### PR TITLE
Do not produce empty stack strings for error stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 - Support for 32-bit ARM systems
   - [#2360](https://github.com/iovisor/bpftrace/pull/2360)
 #### Changed
+- Output for error stacks has been improved to include the error code and pid
+  - [#2392](https://github.com/iovisor/bpftrace/pull/2392)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -61,9 +61,15 @@ void ResourceAnalyser::visit(Builtin &builtin)
   {
     resources_.needs_elapsed_map = true;
   }
-  else if (builtin.ident == "kstack" || builtin.ident == "ustack")
+  else if (builtin.ident == "kstack")
   {
-    resources_.stackid_maps.insert(StackType{});
+    resources_.stackid_maps.insert(
+        StackType{ .type = StackType::ukstack::kstack });
+  }
+  else if (builtin.ident == "ustack")
+  {
+    resources_.stackid_maps.insert(
+        StackType{ .type = StackType::ukstack::ustack });
   }
 }
 

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -336,10 +336,12 @@ void SemanticAnalyser::visit(Builtin &builtin)
     builtin.type.SetAS(find_addrspace(type));
   }
   else if (builtin.ident == "kstack") {
-    builtin.type = CreateStack(true, StackType());
+    builtin.type = CreateStack(true,
+                               StackType{ .type = StackType::ukstack::kstack });
   }
   else if (builtin.ident == "ustack") {
-    builtin.type = CreateStack(false, StackType());
+    builtin.type = CreateStack(false,
+                               StackType{ .type = StackType::ukstack::ustack });
   }
   else if (builtin.ident == "comm") {
     builtin.type = CreateString(COMM_SIZE);
@@ -1365,7 +1367,8 @@ void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
     return;
   }
 
-  StackType stack_type;
+  StackType stack_type{ .type = kernel ? StackType::ukstack::kstack
+                                       : StackType::ukstack::ustack };
   if (call.vargs)
   {
     switch (call.vargs->size())

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -65,9 +65,8 @@ int RequiredResources::create_maps_impl(BPFtrace &bpftrace, bool fake)
 
   for (StackType stack_type : stackid_maps)
   {
-    // The stack type doesn't matter here, so we use kstack to force SizedType
-    // to set stack_size.
-    auto map = std::make_unique<T>(CreateStack(true, stack_type));
+    auto map = std::make_unique<T>(
+        CreateStack(stack_type.type == StackType::ukstack::kstack, stack_type));
     failed_maps += is_invalid_map(map->mapfd_);
     bpftrace.maps.Set(stack_type, std::move(map));
   }

--- a/src/types.h
+++ b/src/types.h
@@ -71,8 +71,14 @@ enum class StackMode
 
 struct StackType
 {
+  enum class ukstack
+  {
+    ustack = 1,
+    kstack = 2,
+  };
   size_t limit = DEFAULT_STACK_SIZE;
   StackMode mode = StackMode::bpftrace;
+  ukstack type;
 
   bool operator ==(const StackType &obj) const {
     return limit == obj.limit && mode == obj.mode;


### PR DESCRIPTION
Currently the following output is possible:
```
^C
...
@[]: 1234
```

This is incredibly misleading and hard to diagnose. What's worse, the error LOG is printed _before_ any map output, so it gets immediately lost in the scrollback.

This PR changes the output format to contain the error value and pid:

```
@[
    <error: -17, pid: -1>
]: 14
```

(pid: -1 is a bug, will be fixed separately)

I'm open to ideas on how to write a deterministic runtime test for this behavior.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
