### PR TITLE
Add support for string literal concatenation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
   - [#2315](https://github.com/iovisor/bpftrace/pull/2315)
 - Add %rh option to print buffer as hex without \x
   - [#2445](https://github.com/iovisor/bpftrace/pull/2445)
+- Add support for string literal concatenation
+  - [#2464](https://github.com/iovisor/bpftrace/pull/2464)
 #### Changed
 - Raise minimum versions for libbpf and bcc and vendor them for local builds
   - [#2369](https://github.com/iovisor/bpftrace/pull/2369)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -413,7 +413,7 @@ Integer suffixes as found in the C language are parsed by bpftrace to ensure com
 
 Character constants can be defined by enclosing the character in single quotes, e.g. `$c = 'c';`.
 
-String constants can be defined by enclosing the character string in double quotes, e.g. `$str = "Hello world";`.
+String constants can be defined by enclosing the character string in double quotes, e.g. `$str = "Hello world";`. Multiple string literals in succession will be combined into a single string literal, e.g. `$str = "Hello " "world";` assigns the string literal "Hello world" to `$str`.
 
 Characters and strings support the following escape sequences:
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -120,7 +120,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 
 
 %type <ast::Operator> unary_op compound_op
-%type <std::string> attach_point_def c_definitions ident
+%type <std::string> attach_point_def c_definitions ident string_literal
 
 %type <ast::AttachPoint *> attach_point
 %type <ast::AttachPointList *> attach_points
@@ -331,10 +331,15 @@ assign_stmt:
                 }
         ;
 
+string_literal:
+                STRING                { $$ = std::string($1); }
+        |       string_literal STRING { $$ = $1 + std::string($2); }
+        ;
+
 primary_expr:
                 IDENT              { $$ = new ast::Identifier($1, @$); }
         |       int                { $$ = $1; }
-        |       STRING             { $$ = new ast::String($1, @$); }
+        |       string_literal     { $$ = new ast::String($1, @$); }
         |       STACK_MODE         { $$ = new ast::StackMode($1, @$); }
         |       BUILTIN            { $$ = new ast::Builtin($1, @$); }
         |       CALL_BUILTIN       { $$ = new ast::Builtin($1, @$); }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1640,6 +1640,21 @@ i:s:1 { < }
   EXPECT_EQ(out.str(), expected);
 }
 
+TEST(Parser, string_literal_concat)
+{
+  test("k:f { \"ab\" \"cd\" \"ef\" }",
+       "Program\n"
+       " kprobe:f\n"
+       "  string: abcdef\n"
+       );
+  test("k:f /\"foo\" \"bar\"/ {}",
+       "Program\n"
+       " kprobe:f\n"
+       "  pred\n"
+       "   string: foobar\n"
+       );
+}
+
 TEST(Parser, string_with_tab)
 {
   BPFtrace bpftrace;


### PR DESCRIPTION
Adds support for string literal concatenation. For example, the text `"Foo" "Bar"` will be converted to `"FooBar"` during parsing.

I'm not familiar with the codebase and it's been many years since using flex/bison, so apologies if this isn't the right approach to do this. Let me know if you have any suggestions or feedback.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [X] The new behaviour is covered by tests

Fixes #2458 
