### PR TITLE
ci: Run tests under controlled kernels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,17 @@ jobs:
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
+        - NAME: Latest LLVM + Upstream kernel
+          TYPE: Release
+          LLVM_VERSION: 16
+          RUN_RUNTIME_TESTS: 1
+          RUN_ALL_TESTS: 0
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          BASE: focal
+          VENDOR_GTEST: ON
+          VMTEST_VERSION: 0.5.4
+          KERNEL: https://github.com/danobi/vmtest/releases/download/test_assets/bzImage-v6.2-archlinux
         - NAME: Memleak test (LLVM 11 Debug)
           TYPE: Debug
           LLVM_VERSION: 11
@@ -151,6 +162,7 @@ jobs:
       run: >
         docker build
         --build-arg LLVM_VERSION=$LLVM_VERSION
+        --build-arg VMTEST_VERSION=$VMTEST_VERSION
         -t bpftrace-builder-$BASE-llvm-$LLVM_VERSION
         -f docker/Dockerfile.$BASE
         docker/ &&
@@ -175,8 +187,10 @@ jobs:
         -v /lib/modules:/lib/modules:ro
         -v /usr/src:/usr/src:ro
         -e RUN_TESTS=${RUN_TESTS}
+        -e RUN_RUNTIME_TESTS=${RUN_RUNTIME_TESTS}
         -e RUN_ALL_TESTS=${RUN_ALL_TESTS}
         -e RUN_MEMLEAK_TEST="${RUN_MEMLEAK_TEST}"
+        -e KERNEL="${KERNEL}"
         -e CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}"
         -e RUNTIME_TEST_DISABLE="${RUNTIME_TEST_DISABLE}"
         -e VENDOR_GTEST="${VENDOR_GTEST}"

--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -2,6 +2,7 @@ FROM ubuntu:focal
 
 ARG LLVM_VERSION
 ENV LLVM_VERSION=$LLVM_VERSION
+ARG VMTEST_VERSION=0.5.4
 
 RUN apt-get update && apt-get install -y curl gnupg &&\
     llvmRepository="\n\
@@ -47,6 +48,8 @@ RUN apt-get update && apt-get install -y \
       systemtap-sdt-dev \
       python3 \
       python3-distutils \
+      qemu-system-x86 \
+      qemu-guest-agent \
       xxd \
       libssl-dev
 
@@ -62,6 +65,10 @@ RUN if [ "$LLVM_VERSION" -ge 14 ] ; then \
       apt download libpolly-${LLVM_VERSION}-dev && \
       dpkg --force-all -i libpolly-${LLVM_VERSION}-dev*.deb ; \
     fi
+
+# Install statically linked vmtest binary
+RUN curl -L https://github.com/danobi/vmtest/releases/download/v${VMTEST_VERSION}/vmtest-amd64 -o /usr/local/bin/vmtest
+RUN chmod +x /usr/local/bin/vmtest
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY build.sh /build.sh

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -20,7 +20,7 @@ CXX=${CXX:c++}
 ENABLE_SKB_OUTPUT=${ENABLE_SKB_OUTPUT:-ON}
 USE_SYSTEM_BPF_BCC=${USE_SYSTEM_BPF_BCC:-OFF}
 
-if [[ $LLVM_VERSION -eq 13 ]]; then 
+if [[ $LLVM_VERSION -eq 13 ]]; then
   touch /usr/lib/llvm-13/bin/llvm-omp-device-info
 fi
 
@@ -64,7 +64,7 @@ if [ $RUN_TESTS = 1 ]; then
 fi
 
 # Memleak tests require bpftrace built with -fsanitize=address so it cannot be
-# usually run with unit/runtime tests (RUN_TESTS should be set to 0). 
+# usually run with unit/runtime tests (RUN_TESTS should be set to 0).
 if [ $RUN_MEMLEAK_TEST = 1 ]; then
   ./tests/memleak-tests.sh
 fi

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -9,7 +9,6 @@ LLVM_VERSION=${LLVM_VERSION:-8} # default llvm to latest version
 EMBED_USE_LLVM=${EMBED_USE_LLVM:-OFF}
 EMBED_BUILD_LLVM=${EMBED_BUILD_LLVM:-OFF}
 ALLOW_UNSAFE_PROBE=${ALLOW_UNSAFE_PROBE:-OFF}
-DEPS_ONLY=${DEPS_ONLY:-OFF}
 BUILD_TESTING=${BUILD_TESTING:-ON}
 RUN_TESTS=${RUN_TESTS:-1}
 RUN_MEMLEAK_TEST=${RUN_MEMLEAK_TEST:-0}
@@ -50,9 +49,6 @@ cmake -DCMAKE_BUILD_TYPE="$2" \
       ../
 shift 2
 
-# It is necessary to build embedded llvm and clang targets first,
-# so that their headers can be referenced
-[[ $DEPS_ONLY == "ON" ]] && exit 0
 make "$@" -j $(nproc)
 
 if [ $RUN_TESTS = 1 ]; then


### PR DESCRIPTION
This PR teaches CI how to run tests under different and tightly controlled
kernels. Under the hood it uses `vmtest`.

More details about vmtest can be found here:

* https://github.com/danobi/vmtest
* https://dxuuu.xyz/vmtest.html

Note we use kernels that are built and provided by vmtest. See:

* https://github.com/danobi/vmtest/releases/tag/test_assets
* https://github.com/danobi/vmtest/blob/master/.github/workflows/kernels.yml

While I'm not making any official guarantees about provided kernel stability,
I do promise not to break bpftrace CI if at all possible.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
