### PR TITLE
Add user function definition support

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(ast
   passes/resource_analyser.cpp
   passes/semantic_analyser.cpp
   passes/codegen_llvm.cpp
+  passes/return_path_analyser.cpp
 )
 
 target_include_directories(ast_defs PUBLIC ${CMAKE_SOURCE_DIR}/src)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -233,6 +233,8 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
     ty = GetStructType(ty_name.str(), llvm_elems, false);
   } else if (stype.IsPtrTy()) {
     ty = getInt64Ty();
+  } else if (stype.IsVoidTy()) {
+    ty = getVoidTy();
   } else {
     switch (stype.GetSize()) {
       case 16:

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -58,7 +58,9 @@ public:
   void visit(Predicate &pred) override;
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
+  void visit(Subprog &subprog) override;
   void visit(Program &program) override;
+
   AllocaInst *getHistMapKey(Map &map, Value *log2);
   int getNextIndexForProbe();
   Value *createLogicalAnd(Binop &binop);
@@ -175,7 +177,7 @@ private:
 
   // Create return instruction
   //
-  // If null, return value will depend on current attach point
+  // If null, return value will depend on current attach point (void in subprog)
   void createRet(Value *value = nullptr);
 
   // Every time we see a watchpoint that specifies a function + arg pair, we
@@ -248,6 +250,7 @@ private:
   int next_probe_index_ = 1;
   // Used if there are duplicate USDT entries
   int current_usdt_location_index_{ 0 };
+  bool inside_subprog_ = false;
 
   std::map<std::string, AllocaInst *> variables_;
   int printf_id_ = 0;

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -38,6 +38,7 @@ public:
   void visit(AssignVarStatement &assignment) override;
   void visit(Unop &unop) override;
   void visit(Probe &probe) override;
+  void visit(Subprog &subprog) override;
 
   int analyse();
 

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -45,6 +45,7 @@ public:
   void visit(Predicate &pred) override;
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
+  void visit(Subprog &subprog) override;
   void visit(Program &program) override;
 
   int depth_ = 0;

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -53,6 +53,12 @@ void ResourceAnalyser::visit(Probe &probe)
   Visitor::visit(probe);
 }
 
+void ResourceAnalyser::visit(Subprog &subprog)
+{
+  probe_ = nullptr;
+  Visitor::visit(subprog);
+}
+
 void ResourceAnalyser::visit(Builtin &builtin)
 {
   if (builtin.ident == "elapsed") {
@@ -92,7 +98,8 @@ void ResourceAnalyser::visit(Call &call)
 
     auto fmtstr = get_literal_string(*call.vargs->at(0));
     if (call.func == "printf") {
-      if (single_provider_type_postsema(probe_) == ProbeType::iter) {
+      if (probe_ != nullptr &&
+          single_provider_type_postsema(probe_) == ProbeType::iter) {
         resources_.mapped_printf_args.emplace_back(fmtstr, args);
         resources_.needs_data_map = true;
       } else {

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -27,6 +27,7 @@ public:
 
 private:
   void visit(Probe &probe) override;
+  void visit(Subprog &subprog) override;
   void visit(Builtin &map) override;
   void visit(Call &call) override;
   void visit(Map &map) override;

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -1,0 +1,94 @@
+#include "return_path_analyser.h"
+#include "log.h"
+
+namespace bpftrace {
+namespace ast {
+
+ReturnPathAnalyser::ReturnPathAnalyser(Node *root, std::ostream &out)
+    : root_(root), out_(out)
+{
+}
+
+bool ReturnPathAnalyser::visit(Program &prog)
+{
+  for (Subprog *subprog : *prog.functions) {
+    if (!visit(*subprog))
+      return false;
+  }
+  return true;
+}
+
+bool ReturnPathAnalyser::visit(Subprog &subprog)
+{
+  if (subprog.return_type.IsVoidTy())
+    return true;
+
+  for (Statement *stmt : *subprog.stmts) {
+    if (Visit(*stmt))
+      return true;
+  }
+  LOG(ERROR, subprog.loc, err_) << "Not all code paths return a value";
+  return false;
+}
+
+bool ReturnPathAnalyser::visit(Jump &jump)
+{
+  return jump.ident == JumpType::RETURN;
+}
+
+bool ReturnPathAnalyser::visit(If &if_stmt)
+{
+  bool result = false;
+  for (Statement *stmt : *if_stmt.stmts) {
+    if (Visit(*stmt))
+      result = true;
+  }
+  if (!result) {
+    // if block has no return
+    return false;
+  }
+
+  if (if_stmt.else_stmts) {
+    for (Statement *stmt : *if_stmt.else_stmts) {
+      if (Visit(*stmt)) {
+        // both blocks have a return
+        return true;
+      }
+    }
+    // else block has no return
+    return false;
+  } else {
+    // if without else always requires another return in the code after it
+    return false;
+  }
+}
+
+bool ReturnPathAnalyser::default_visitor(__attribute__((unused)) Node &node)
+{
+  // not a return instruction
+  return false;
+}
+
+int ReturnPathAnalyser::analyse()
+{
+  int result = Visit(*root_) ? 0 : 1;
+  if (result)
+    out_ << err_.str();
+  return result;
+}
+
+Pass CreateReturnPathPass()
+{
+  auto fn = [](Node &n, __attribute__((unused)) PassContext &ctx) {
+    auto return_path = ReturnPathAnalyser(&n);
+    int err = return_path.analyse();
+    if (err)
+      return PassResult::Error("ReturnPath");
+    return PassResult::Success();
+  };
+
+  return Pass("ReturnPath", fn);
+}
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/passes/return_path_analyser.h
+++ b/src/ast/passes/return_path_analyser.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+#include "ast/visitors.h"
+
+namespace bpftrace {
+namespace ast {
+
+class ReturnPathAnalyser : public Dispatcher<bool> {
+public:
+  explicit ReturnPathAnalyser(Node *root, std::ostream &out = std::cerr);
+
+  // visit methods return true iff all return paths of the analyzed code
+  // (represented by the given node) return a value
+  // For details for concrete node type see the implementations
+  bool visit(Program &prog) override;
+  bool visit(Subprog &subprog) override;
+  bool visit(Jump &jump) override;
+  bool visit(If &if_stmt) override;
+
+  // For nodes that neither directly return a value or have children with
+  // semantics such that the code represented by the node always returns
+  // a value, false is returned
+  bool default_visitor(Node &node) override;
+
+  int analyse();
+
+private:
+  Node *root_;
+  std::ostream &out_;
+  std::ostringstream err_;
+};
+
+Pass CreateReturnPathPass();
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -72,6 +72,7 @@ public:
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
   void visit(Config &config) override;
+  void visit(Subprog &subprog) override;
   void visit(Program &program) override;
 
   int analyse();
@@ -103,6 +104,10 @@ private:
 
   void check_stack_call(Call &call, bool kernel);
 
+  Probe *get_probe_from_scope(Scope *scope,
+                              const location &loc,
+                              std::string name = "");
+
   SizedType *get_map_type(const Map &map);
   void assign_map_type(const Map &map, const SizedType &type);
   void update_key_type(const Map &map, const MapKey &new_key);
@@ -110,7 +115,7 @@ private:
   void resolve_struct_type(SizedType &type, const location &loc);
 
   void builtin_args_tracepoint(AttachPoint *attach_point, Builtin &builtin);
-  ProbeType single_provider_type(void);
+  ProbeType single_provider_type(Probe *probe);
   AddrSpace find_addrspace(ProbeType pt);
 
   void binop_ptr(Binop &op);
@@ -123,7 +128,7 @@ private:
   };
   void accept_statements(StatementList *stmts);
 
-  Probe *probe_;
+  Scope *scope_;
 
   // Holds the function currently being visited by this SemanticAnalyser.
   std::string func_;
@@ -131,7 +136,7 @@ private:
   // SemanticAnalyser.
   int func_arg_idx_ = -1;
 
-  std::map<Probe *, std::map<std::string, SizedType>> variable_val_;
+  std::map<Scope *, std::map<std::string, SizedType>> variable_val_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, MapKey> map_key_;
 

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -157,8 +157,10 @@ void Visitor::visit(While &while_block)
   }
 }
 
-void Visitor::visit(Jump &jump __attribute__((__unused__)))
+void Visitor::visit(Jump &jump)
 {
+  if (jump.return_value)
+    Visit(*jump.return_value);
 }
 
 void Visitor::visit(Predicate &pred)
@@ -191,8 +193,25 @@ void Visitor::visit(Config &config)
   }
 }
 
+void Visitor::visit(SubprogArg &subprog_arg __attribute__((__unused__)))
+{
+}
+
+void Visitor::visit(Subprog &subprog)
+{
+  for (SubprogArg *arg : *subprog.args) {
+    Visit(*arg);
+  }
+  for (Statement *stmt : *subprog.stmts) {
+    Visit(*stmt);
+  }
+}
+
 void Visitor::visit(Program &program)
 {
+  if (program.functions)
+    for (Subprog *subprog : *program.functions)
+      Visit(*subprog);
   for (Probe *probe : *program.probes)
     Visit(*probe);
   if (program.config)
@@ -412,9 +431,21 @@ Node *Mutator::visit(Config &config)
   return c;
 }
 
+Node *Mutator::visit(Subprog &subprog)
+{
+  auto s = subprog.leafcopy();
+
+  s->stmts = mutateStmtList(subprog.stmts);
+  return s;
+}
+
 Node *Mutator::visit(Program &program)
 {
   auto p = program.leafcopy();
+  p->functions = new SubprogList;
+  if (program.functions)
+    for (Subprog *subprog : *program.functions)
+      p->functions->push_back(Value<Subprog>(subprog));
   p->probes = new ProbeList;
   for (Probe *probe : *program.probes)
     p->probes->push_back(Value<Probe>(probe));

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -44,6 +44,8 @@ public:
   virtual void visit(AttachPoint &ap) = 0;
   virtual void visit(Probe &probe) = 0;
   virtual void visit(Config &config) = 0;
+  virtual void visit(SubprogArg &subprog_arg) = 0;
+  virtual void visit(Subprog &subprog) = 0;
   virtual void visit(Program &program) = 0;
 };
 
@@ -109,6 +111,8 @@ public:
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
   void visit(Config &config) override;
+  void visit(SubprogArg &subprog_arg) override;
+  void visit(Subprog &subprog) override;
   void visit(Program &program) override;
 };
 
@@ -173,6 +177,8 @@ public:
   virtual R visit(AttachPoint &node) DEFAULT_FN;
   virtual R visit(Probe &node) DEFAULT_FN;
   virtual R visit(Config &node) DEFAULT_FN;
+  virtual R visit(SubprogArg &node) DEFAULT_FN;
+  virtual R visit(Subprog &node) DEFAULT_FN;
   virtual R visit(Program &node) DEFAULT_FN;
 
   virtual R default_visitor(Node &node)
@@ -220,6 +226,8 @@ private:
     DEFINE_DISPATCH(Ternary);
     DEFINE_DISPATCH(While);
     DEFINE_DISPATCH(AttachPoint);
+    DEFINE_DISPATCH(SubprogArg);
+    DEFINE_DISPATCH(Subprog);
     DEFINE_DISPATCH(Probe);
     DEFINE_DISPATCH(Config);
     DEFINE_DISPATCH(Program);
@@ -273,6 +281,7 @@ public:
   Node *visit(AttachPoint &) override;
   Node *visit(Probe &) override;
   Node *visit(Config &) override;
+  Node *visit(Subprog &) override;
   Node *visit(Program &) override;
 
 protected:

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -41,8 +41,9 @@ builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|
 call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|len|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
 
 int_type        bool|(u)?int(8|16|32|64)
-builtin_type    (u)?(min|max|sum|count|avg|stats)_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp_t|macaddr_t|cgroup_path_t|strerror_t
+builtin_type    void|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp_t|macaddr_t|cgroup_path_t|strerror_t
 sized_type      str_t|inet_t|buf_t
+subprog         fn
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack|nsecs
@@ -56,6 +57,8 @@ oct_esc  [0-7]{1,3}
 %x ENUM
 %x BRACE
 %x COMMENT
+%x AFTER_COLON
+%x STRUCT_AFTER_COLON
 
 %%
 
@@ -76,6 +79,7 @@ bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, loc); }
 {builtin}               { return Parser::make_BUILTIN(yytext, loc); }
 {call}                  { return Parser::make_CALL(yytext, loc); }
 {call_and_builtin}      { return Parser::make_CALL_BUILTIN(yytext, loc); }
+{subprog}               { return Parser::make_SUBPROG(yytext, loc); }
 {int}|{hex}|{exponent}  {
                           try
                           {
@@ -90,7 +94,12 @@ bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, loc); }
 {path}                  { return Parser::make_PATH(yytext, loc); }
 {map}                   { return Parser::make_MAP(yytext, loc); }
 {var}                   { return Parser::make_VAR(yytext, loc); }
-":"                     { return Parser::make_COLON(loc); }
+":"                     {
+                          /* For handling "struct x" in "fn name(...): struct x {  }" as a type rather than
+                            a beginning of a struct definition; see AFTER_COLON rules below */
+                          yy_push_state(AFTER_COLON, yyscanner);
+                          return Parser::make_COLON(loc);
+                        }
 ";"                     { return Parser::make_SEMI(loc); }
 "{"                     { return Parser::make_LBRACE(loc); }
 "}"                     { return Parser::make_RBRACE(loc); }
@@ -186,6 +195,27 @@ struct|union|enum       {
                             struct_type = yytext;
                             return Parser::make_STRUCT(loc);
                         }
+<AFTER_COLON>{
+  {hspace}+             { loc.step(); }
+  {vspace}+             { loc.lines(yyleng); loc.step(); }
+  struct|union|enum     {
+                          yy_pop_state(yyscanner);
+                          yy_push_state(STRUCT_AFTER_COLON, yyscanner);
+                          buffer.clear();
+                          struct_type = yytext;
+                          return Parser::make_STRUCT(loc);
+                        }
+  .                     { unput(yytext[0]); yy_pop_state(yyscanner); }
+}
+<STRUCT_AFTER_COLON>{
+  "{"|","|")"           {
+                          yy_pop_state(yyscanner);
+                          unput(yytext[0]);
+                          return Parser::make_IDENT(struct_type + " " + trim(buffer), loc);
+                        }
+  .                     { buffer += yytext[0]; }
+  \n                    buffer += '\n'; loc.lines(1); loc.step();
+}
 <STRUCT,BRACE>{
   "*"|")"|","           {
                           if (YY_START == STRUCT)
@@ -194,7 +224,8 @@ struct|union|enum       {
                             // Put the cast type into a canonical form by trimming
                             // and then inserting a single space.
                             yy_pop_state(yyscanner);
-                            unput(yytext[0]);
+                            for (int i = yyleng - 1; i >= 0; i--)
+                              unput(yytext[i]);
                             return Parser::make_IDENT(struct_type + " " + trim(buffer), loc);
                           }
                           buffer += yytext[0];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "ast/passes/node_counter.h"
 #include "ast/passes/portability_analyser.h"
 #include "ast/passes/resource_analyser.h"
+#include "ast/passes/return_path_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 
 #include "bpffeature.h"
@@ -456,6 +457,7 @@ ast::PassManager CreateDynamicPM()
   pm.AddPass(ast::CreateSemanticPass());
   pm.AddPass(ast::CreateCounterPass());
   pm.AddPass(ast::CreateResourcePass());
+  pm.AddPass(ast::CreateReturnPathPass());
 
   return pm;
 }
@@ -466,6 +468,7 @@ ast::PassManager CreateAotPM()
   pm.AddPass(ast::CreateSemanticPass());
   pm.AddPass(ast::CreatePortabilityPass());
   pm.AddPass(ast::CreateResourcePass());
+  pm.AddPass(ast::CreateReturnPathPass());
 
   return pm;
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -49,6 +49,7 @@ bool is_quoted_type(const SizedType &ty)
     case Type::timestamp:
     case Type::timestamp_mode:
     case Type::tuple:
+    case Type::voidtype:
       return false;
   }
   return false;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -102,6 +102,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> CALL_BUILTIN "call_builtin"
 %token <std::string> INT_TYPE "integer type"
 %token <std::string> BUILTIN_TYPE "builtin type"
+%token <std::string> SUBPROG "subprog"
 %token <std::string> SIZED_TYPE "sized type"
 %token <std::string> IDENT "identifier"
 %token <std::string> PATH "path"
@@ -138,12 +139,15 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::Expression *> and_expr addi_expr primary_expr cast_expr conditional_expr equality_expr expr logical_and_expr muli_expr
 %type <ast::Expression *> logical_or_expr map_or_var or_expr postfix_expr relational_expr shift_expr tuple_access_expr unary_expr xor_expr
 %type <ast::ExpressionList *> vargs
+%type <ast::Subprog *> subprog
+%type <ast::SubprogArg *> subprog_arg
+%type <ast::SubprogArgList *> subprog_args
 %type <ast::Integer *> int
 %type <ast::Map *> map
 %type <ast::PositionalParameter *> param
 %type <ast::Predicate *> pred
 %type <ast::Probe *> probe
-%type <ast::ProbeList *> probes
+%type <std::pair<ast::ProbeList *, ast::SubprogList *>> probes_and_subprogs
 %type <ast::Config *> config
 %type <ast::Statement *> assign_stmt block_stmt expr_stmt if_stmt jump_stmt loop_stmt config_assign_stmt
 %type <ast::StatementList *> block block_or_if stmt_list config_block config_assign_stmt_list
@@ -172,7 +176,9 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %%
 
 program:
-                c_definitions config probes END { driver.root = std::make_unique<ast::Program>($1, $2, $3); }
+                c_definitions config probes_and_subprogs END {
+                    driver.root = std::make_unique<ast::Program>($1, $2, $3.second, $3.first);
+                }
                 ;
 
 c_definitions:
@@ -186,6 +192,7 @@ type:
                 int_type { $$ = $1; }
         |       BUILTIN_TYPE {
                     static std::unordered_map<std::string, SizedType> type_map = {
+                        {"void", CreateVoid()},
                         {"min_t", CreateMin(true)},
                         {"max_t", CreateMax(true)},
                         {"sum_t", CreateSum(true)},
@@ -253,9 +260,29 @@ config:
         |        %empty                        { $$ = nullptr; }
                 ;
 
-probes:
-                probes probe { $$ = $1; $1->push_back($2); }
-        |       probe        { $$ = new ast::ProbeList; $$->push_back($1); }
+subprog:
+                SUBPROG IDENT "(" subprog_args ")" ":" type block {
+                    $$ = new ast::Subprog($2, $7, $4, $8);
+                }
+        |       SUBPROG IDENT "(" ")" ":" type block {
+                    $$ = new ast::Subprog($2, $6, new ast::SubprogArgList, $7);
+                }
+                ;
+
+subprog_args:
+                subprog_args "," subprog_arg { $1->push_back($3); $$ = $1; }
+        |       subprog_arg                  { $$ = new ast::SubprogArgList; $$->push_back($1); }
+                ;
+
+subprog_arg:
+                VAR ":" type { $$ = new ast::SubprogArg($1, $3); }
+                ;
+
+probes_and_subprogs:
+                probes_and_subprogs probe   { $$ = $1; $1.first->push_back($2); }
+        |       probes_and_subprogs subprog { $$ = $1; $1.second->push_back($2); }
+        |       probe        { $$ = { new ast::ProbeList, new ast::SubprogList}; $$.first->push_back($1); }
+        |       subprog      { $$ = { new ast::ProbeList, new ast::SubprogList}; $$.second->push_back($1); }
                 ;
 
 probe:
@@ -382,9 +409,10 @@ expr_stmt:
                 ;
 
 jump_stmt:
-                BREAK    { $$ = new ast::Jump(ast::JumpType::BREAK, @$); }
-        |       CONTINUE { $$ = new ast::Jump(ast::JumpType::CONTINUE, @$); }
-        |       RETURN   { $$ = new ast::Jump(ast::JumpType::RETURN, @$); }
+                BREAK       { $$ = new ast::Jump(ast::JumpType::BREAK, @$); }
+        |       CONTINUE    { $$ = new ast::Jump(ast::JumpType::CONTINUE, @$); }
+        |       RETURN      { $$ = new ast::Jump(ast::JumpType::RETURN, @$); }
+        |       RETURN expr { $$ = new ast::Jump(ast::JumpType::RETURN, $2, @$); }
                 ;
 
 loop_stmt:

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -143,6 +143,7 @@ std::string typestr(Type t)
   switch (t) {
     // clang-format off
     case Type::none:     return "none";     break;
+    case Type::voidtype: return "void";     break;
     case Type::integer:  return "integer";  break;
     case Type::pointer:  return "pointer";  break;
     case Type::record:   return "record";   break;
@@ -322,6 +323,11 @@ SizedType CreateString(size_t size)
 SizedType CreateNone()
 {
   return SizedType(Type::none, 0);
+}
+
+SizedType CreateVoid()
+{
+  return SizedType(Type::voidtype, 0);
 }
 
 SizedType CreateStackMode()
@@ -592,6 +598,7 @@ size_t hash<bpftrace::SizedType>::operator()(
     // No default case (explicitly skip all remaining types instead) to get
     // a compiler warning when we add a new type
     case bpftrace::Type::none:
+    case bpftrace::Type::voidtype:
     case bpftrace::Type::hist:
     case bpftrace::Type::lhist:
     case bpftrace::Type::count:

--- a/src/types.h
+++ b/src/types.h
@@ -22,6 +22,7 @@ const int COMM_SIZE = 16;
 enum class Type : uint8_t {
   // clang-format off
   none,
+  voidtype,
   integer,
   pointer,
   record, // struct/union, as struct is a protected keyword
@@ -293,6 +294,10 @@ public:
   {
     return type_ == Type::none;
   };
+  bool IsVoidTy(void) const
+  {
+    return type_ == Type::voidtype;
+  };
   bool IsIntegerTy(void) const
   {
     return type_ == Type::integer;
@@ -419,6 +424,7 @@ public:
 // Type helpers
 
 SizedType CreateNone();
+SizedType CreateVoid();
 SizedType CreateBool();
 SizedType CreateInteger(size_t bits, bool is_signed);
 SizedType CreateInt(size_t bits);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(bpftrace_test
   config_analyser.cpp
   resource_analyser.cpp
   required_resources.cpp
+  return_path_analyser.cpp
   semantic_analyser.cpp
   tracepoint_format_parser.cpp
   utils.cpp

--- a/tests/codegen/llvm/subprog_arguments.ll
+++ b/tests/codegen/llvm/subprog_arguments.ll
@@ -1,0 +1,79 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8* }
+%"struct map_t.0" = type { i8*, i8*, i8*, i8* }
+
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define internal i64 @add(i8* %0, i64 %1, i64 %2) {
+entry:
+  %"$b" = alloca i64, align 8
+  %"$a" = alloca i64, align 8
+  %3 = bitcast i64* %"$a" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 %1, i64* %"$a", align 8
+  %4 = bitcast i64* %"$b" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %2, i64* %"$b", align 8
+  %5 = load i64, i64* %"$a", align 8
+  %6 = load i64, i64* %"$b", align 8
+  %7 = add i64 %5, %6
+  ret i64 %7
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!39}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !37, globals: !38)
+!37 = !{}
+!38 = !{!0, !16}
+!39 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/subprog.cpp
+++ b/tests/codegen/subprog.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, subprog_arguments)
+{
+  test("fn add($a : int64, $b : int64): int64 { return $a + $b; }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -415,6 +415,11 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   EXPECT_EQ(task_struct->GetField("d").bitfield->mask, 0xFFFFFU);
 }
 
+TEST(field_analyser_subprog, struct_cast)
+{
+  test("struct x { int a; } fn f(): void { $s = (struct x *)0; }", 0);
+}
+
 #endif // HAVE_LIBDW
 
 } // namespace field_analyser

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2167,6 +2167,114 @@ TEST(Parser, keywords_as_identifiers)
   }
 }
 
+TEST(Parser, subprog_probe_mixed)
+{
+  test("i:s:1 {} fn f1(): void {} i:s:1 {} fn f2(): void {}",
+       "Program\n"
+       " f1: void()\n"
+       " f2: void()\n"
+       " interval:s:1\n"
+       " interval:s:1\n");
+}
+
+TEST(Parser, subprog_void_no_args)
+{
+  test("fn f(): void {}",
+       "Program\n"
+       " f: void()\n");
+}
+
+TEST(Parser, subprog_invalid_return_type)
+{
+  test_parse_failure("fn f(): nonexistent {}");
+}
+
+TEST(Parser, subprog_one_arg)
+{
+  test("fn f($a : uint8): void {}",
+       "Program\n"
+       " f: void($a : unsigned int8)\n");
+}
+
+TEST(Parser, subprog_two_args)
+{
+  test("fn f($a : uint8, $b : uint8): void {}",
+       "Program\n"
+       " f: void($a : unsigned int8, $b : unsigned int8)\n");
+}
+
+TEST(Parser, subprog_string_arg)
+{
+  test("fn f($a : str_t[16]): void {}",
+       "Program\n"
+       " f: void($a : string[16])\n");
+}
+
+TEST(Parser, subprog_struct_arg)
+{
+  test("fn f($a: struct x): void {}",
+       "Program\n"
+       " f: void($a : struct x)\n");
+}
+
+TEST(Parser, subprog_union_arg)
+{
+  test("fn f($a : union x): void {}",
+       "Program\n"
+       " f: void($a : union x)\n");
+}
+
+TEST(Parser, subprog_enum_arg)
+{
+  test("fn f($a : enum x): void {}",
+       "Program\n"
+       " f: void($a : enum x)\n");
+}
+
+TEST(Parser, subprog_invalid_arg)
+{
+  test_parse_failure("fn f($x : invalid): void {}");
+}
+
+TEST(Parser, subprog_return)
+{
+  test("fn f(): void { return 1 + 1; }",
+       "Program\n"
+       " f: void()\n"
+       "  return\n"
+       "   +\n"
+       "    int: 1\n"
+       "    int: 1\n");
+}
+
+TEST(Parser, subprog_string)
+{
+  test("fn f(): str_t[16] {}",
+       "Program\n"
+       " f: string[16]()\n");
+}
+
+TEST(Parser, subprog_struct)
+{
+  test("fn f(): struct x {}",
+       "Program\n"
+       " f: struct x()\n");
+}
+
+TEST(Parser, subprog_union)
+{
+  test("fn f(): union x {}",
+       "Program\n"
+       " f: union x()\n");
+}
+
+TEST(Parser, subprog_enum)
+{
+  test("fn f(): enum x {}",
+       "Program\n"
+       " f: enum x()\n");
+}
+
 } // namespace parser
 } // namespace test
 } // namespace bpftrace

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -61,6 +61,11 @@ TEST(resource_analyser, multiple_lhist_bounds_in_single_map)
        false);
 }
 
+TEST(resource_analyser, printf_in_subprog)
+{
+  test("fn greet(): void { printf(\"Hello, world\\n\"); }", true);
+}
+
 } // namespace resource_analyser
 } // namespace test
 } // namespace bpftrace

--- a/tests/return_path_analyser.cpp
+++ b/tests/return_path_analyser.cpp
@@ -1,0 +1,115 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "ast/passes/field_analyser.h"
+#include "ast/passes/return_path_analyser.h"
+#include "ast/passes/semantic_analyser.h"
+#include "clang_parser.h"
+#include "driver.h"
+#include "mocks.h"
+
+namespace bpftrace {
+namespace test {
+namespace return_path_analyser {
+
+using ::testing::_;
+
+void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
+{
+  Driver driver(bpftrace);
+  std::stringstream out;
+  std::stringstream msg;
+  msg << "\nInput:\n" << input << "\n\nOutput:\n";
+
+  ASSERT_EQ(driver.parse_str(input), 0);
+
+  ast::FieldAnalyser fields(driver.root.get(), bpftrace, out);
+  ASSERT_EQ(fields.analyse(), 0) << msg.str() << out.str();
+
+  ClangParser clang;
+  ASSERT_TRUE(clang.parse(driver.root.get(), bpftrace));
+
+  ASSERT_EQ(driver.parse_str(input), 0);
+  out.str("");
+  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, out, false);
+  ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
+
+  ast::ReturnPathAnalyser return_path(driver.root.get(), out);
+  EXPECT_EQ(return_path.analyse(), expected_result) << msg.str() << out.str();
+}
+
+void test(const std::string &input, int expected_result = 0)
+{
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  test(*bpftrace, input, expected_result);
+}
+
+TEST(return_path_analyser, simple_return)
+{
+  test("fn test(): int64 { $x = 0; return 0; }", 0);
+}
+
+TEST(return_path_analyser, simple_no_return)
+{
+  test("fn test(): int64 { $x = 0; }", 1);
+}
+
+TEST(return_path_analyser, if_else)
+{
+  test("fn test($x: int64): int64 {"
+       "  if ($x > 0) { return 0; } else { return 1; }"
+       "}",
+       0);
+}
+
+TEST(return_path_analyser, if_else_no_return)
+{
+  test("fn test($x: int64): int64 {"
+       "  if ($x > 0) { return 0; } else { $x = 0; }"
+       "}",
+       1);
+}
+
+TEST(return_path_analyser, if_without_else)
+{
+  test("fn test($x: int64): int64 { if ($x > 0) { return 0; } }", 1);
+}
+
+TEST(return_path_analyser, while_loop)
+{
+  test("fn test($x: int64): int64 { while ($x) { return 0; } }", 1);
+}
+
+TEST(return_path_analyser, if_branches)
+{
+  test("fn test($x: int64): int64 {"
+       "  if ($x > 0) {"
+       "    if ($x > 0) { return 1; } else { return 0; }"
+       "  } else {"
+       "    if ($x > 0) { return 1; } else { return 0; }"
+       "  }"
+       "}",
+       0);
+}
+
+TEST(return_path_analyser, if_branches_fail)
+{
+  test("fn test($x: int64): int64 {"
+       "  if ($x > 0) {"
+       "    if ($x > 0) { return 1; } else { return 0; }"
+       "  } else {"
+       "    if ($x > 0) { return 1; } else { $x = 1; }"
+       "  }"
+       "}",
+       1);
+}
+
+TEST(return_path_analyser, void_return_type)
+{
+  test("fn test() : void {}", 0);
+}
+
+} // namespace return_path_analyser
+} // namespace test
+} // namespace bpftrace

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2950,6 +2950,40 @@ TEST(semantic_analyser, config)
        0);
 }
 
+TEST(semantic_analyser, subprog_return)
+{
+  test("fn f(): void { return; }", 0);
+  test("fn f(): void { return 1; }", 1);
+  test("fn f(): int64 { return; }", 1);
+  test("fn f(): int64 { return 1; }", 0);
+}
+
+TEST(semantic_analyser, subprog_arguments)
+{
+  test("fn f($a : int64): int64 { return $a; }", 0);
+  test("fn f($a : int64): str_t[16] { return $a; }", 1);
+}
+
+TEST(semantic_analyser, subprog_map)
+{
+  test("fn f(): void { @a = 0; }", 0);
+  test("fn f(): int64 { @a = 0; return @a + 1; }", 0);
+  test("fn f(): void { @a[0] = 0; }", 0);
+  test("fn f(): int64 { @a[0] = 0; return @a[0] + 1; }", 0);
+}
+
+TEST(semantic_analyser, subprog_builtin)
+{
+  test("fn f(): void { print(\"Hello world\"); }", 0);
+  test("fn f(): uint64 { return sizeof(int64); }", 0);
+  test("fn f(): uint64 { return nsecs; }", 0);
+}
+
+TEST(semantic_analyser, subprog_buildin_disallowed)
+{
+  test("fn f(): int64 { return func; }", 1);
+}
+
 class semantic_analyser_btf : public test_btf {};
 
 TEST_F(semantic_analyser_btf, kfunc)


### PR DESCRIPTION
A new structure for defining subprograms is added on the same level as probes:
```
fn <function_name>(<type0> <arg0>, ...): <return_type> {
  <body>
}
```
The existing return statement is extended to also allow returning a specified value. SemanticAnalyser checks if the type is correct, while CodegenLLVM goes through the generated code to ensure all code flow paths return a value in a non-void function.

Only a limited number of builtins are allowed to be used inside functions due to current implementation restrictions; these can be addressed in later development.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

----

This is the first step in implementing #2516 that can be either merged separately or together with the rest of the implementation. Note that this does not implement a way to call the functions nor a way to generate the correct BPF code for that.

(I'm opening this draft PR, since I believe there is quite a few non-trivial changes that it makes sense to review while I work on the rest.)

##### Checklist

Note: this checklist is only for the function definition part, excluding the BPF code generator and function calls.

- [x] Tests for parser
- [x] Tests for semantic analyser
- [x] Tests for codegen
- [x] Function argument support
