### PR TITLE
Support BTF-based pretty printing

### DIFF
--- a/src/ast/async_event_types.cpp
+++ b/src/ast/async_event_types.cpp
@@ -103,5 +103,14 @@ std::vector<llvm::Type*> SkbOutput::asLLVMType(ast::IRBuilderBPF& b)
   };
 }
 
+std::vector<llvm::Type*> PrintBTF::asLLVMType(ast::IRBuilderBPF& b, size_t size)
+{
+  return {
+    b.getInt64Ty(),                            // asyncid
+    b.getInt64Ty(),                            // printb_id
+    llvm::ArrayType::get(b.getInt8Ty(), size), // content
+  };
+}
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -126,5 +126,14 @@ struct SkbOutput
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
+// BTF-based pretty printing
+struct PrintBTF
+{
+  uint64_t action_id;
+  uint64_t printb_id;
+  uint8_t content[0];
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t size);
+} __attribute__((packed));
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -367,6 +367,17 @@ CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx, const location &loc)
   return call;
 }
 
+CallInst *IRBuilderBPF::CreateGetPrintBTFMap(Value *ctx, const location &loc)
+{
+  AllocaInst *key = CreateAllocaBPF(getInt32Ty(), "key");
+  CreateStore(getInt32(0), key);
+
+  CallInst *call = createMapLookup(
+      bpftrace_.maps[MapManager::Type::PrintBTF].value()->id, key);
+  CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_map_lookup_elem, loc, true);
+  return call;
+}
+
 Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
                                          Map &map,
                                          Value *key,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -169,6 +169,7 @@ public:
   CallInst *CreateGetRandom(const location &loc);
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
   CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  CallInst *CreateGetPrintBTFMap(Value *ctx, const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
                              FunctionType *helper_type,
                              ArrayRef<Value *> args,

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -243,6 +243,7 @@ private:
   uint64_t watchpoint_id_ = 0;
   int cgroup_path_id_ = 0;
   int skb_output_id_ = 0;
+  int printb_id_ = 0;
 
   Function *linear_func_ = nullptr;
   Function *log2_func_ = nullptr;

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -201,6 +201,12 @@ void ResourceAnalyser::visit(Call &call)
     resources_.skboutput_args_.emplace_back(file.str, offset.n);
     resources_.needs_perf_event_map = true;
   }
+  else if (call.func == "printb")
+  {
+    resources_.printb_args.push_back(call.type);
+    resources_.needs_printb_map = true;
+    resources_.needs_perf_event_map = true;
+  }
 
   if (uses_usym_table(call.func))
   {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -596,6 +596,17 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
         hdr->id, hdr->ns, hdr->pkt + offset, size - sizeof(*hdr));
     return;
   }
+  else if (printf_id == asyncactionint(AsyncAction::printbtf))
+  {
+    auto printb = static_cast<AsyncEvent::PrintBTF *>(data);
+    const auto &info =
+        bpftrace->resources.printb_args.at(printb->printb_id).printb;
+
+    bpftrace->btf_->dump_typed_data(
+        info.dump_id, info.type_id, printb->content, info.size);
+
+    return;
+  }
   else if ( printf_id >= asyncactionint(AsyncAction::syscall) &&
             printf_id < asyncactionint(AsyncAction::syscall) + RESERVED_IDS_PER_ASYNCACTION)
   {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -216,6 +216,7 @@ public:
   std::optional<struct timespec> boottime_;
   static constexpr uint32_t rb_loss_cnt_key_ = 0;
   static constexpr uint64_t rb_loss_cnt_val_ = 0;
+  size_t max_printb_map_size_ = 0;
 
   static void sort_by_key(
       std::vector<SizedType> key_args,

--- a/src/btf.h
+++ b/src/btf.h
@@ -13,6 +13,7 @@
 
 struct btf;
 struct btf_type;
+struct btf_dump;
 
 namespace bpftrace {
 
@@ -41,6 +42,12 @@ class BTF
   {
     struct btf* btf;
     __u32 id;
+  };
+
+  struct BTFDump
+  {
+    struct btf* btf;
+    struct btf_dump* dump;
   };
 
 public:
@@ -72,6 +79,12 @@ public:
 
   std::pair<int, int> get_btf_id_fd(const std::string& func,
                                     const std::string& mod) const;
+  // get dump id and type id
+  std::pair<int, int> get_dumpid_typeid(const std::string& type_name);
+  void dump_typed_data(uint32_t dump_id,
+                       uint32_t type_id,
+                       uint8_t* data,
+                       int data_size);
 
 private:
   void load_kernel_btfs(const std::set<std::string>& modules);
@@ -103,6 +116,7 @@ private:
   std::vector<BTFObj> btf_objects;
   enum state state = NODATA;
   BPFtrace* bpftrace_ = nullptr;
+  std::vector<BTFDump> btf_dumps;
 };
 
 inline bool BTF::has_data(void) const

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf|printb
 
 simple_type     bool|(u)?int(8|16|32|64)|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp_t|macaddr_t|cgroup_path_t|strerror_t
 sized_type      str_t|inet_t|buf_t

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -283,6 +283,8 @@ std::string to_string(MapManager::Type t)
       return "ringbuf";
     case MapManager::Type::RingbufLossCounter:
       return "ringbuf_loss_counter";
+    case MapManager::Type::PrintBTF:
+      return "printb";
   }
   return {}; // unreached
 }

--- a/src/mapmanager.h
+++ b/src/mapmanager.h
@@ -63,6 +63,7 @@ public:
     MappedPrintfData,
     Ringbuf,
     RingbufLossCounter,
+    PrintBTF,
   };
 
   void Set(Type t, std::unique_ptr<IMap> map);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -30,6 +30,9 @@ std::ostream& operator<<(std::ostream& out, MessageType type) {
     case MessageType::syscall: out << "syscall"; break;
     case MessageType::attached_probes: out << "attached_probes"; break;
     case MessageType::lost_events: out << "lost_events"; break;
+    case MessageType::printb:
+      out << "printb";
+      break;
     default: out << "?";
   }
   return out;

--- a/src/output.h
+++ b/src/output.h
@@ -26,6 +26,7 @@ enum class MessageType
   attached_probes,
   lost_events,
   helper_error,
+  printb,
 };
 
 std::ostream& operator<<(std::ostream& out, MessageType type);

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -130,6 +130,18 @@ int RequiredResources::create_maps_impl(BPFtrace &bpftrace, bool fake)
                       std::move(rb_loss_cnt));
   }
 
+  if (needs_printb_map)
+  {
+    auto map = std::make_unique<T>("printb",
+                                   libbpf::BPF_MAP_TYPE_PERCPU_ARRAY,
+                                   4,
+                                   bpftrace.max_printb_map_size_,
+                                   1,
+                                   0);
+    failed_maps += is_invalid_map(map->mapfd_);
+    bpftrace.maps.Set(MapManager::Type::PrintBTF, std::move(map));
+  }
+
   if (failed_maps > 0)
   {
     std::cerr << "Creation of the required BPF maps has failed." << std::endl;

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -10,6 +10,7 @@
 
 #include <cereal/access.hpp>
 
+#include "btf.h"
 #include "format_string.h"
 #include "location.hh"
 #include "mapkey.h"
@@ -104,10 +105,12 @@ public:
   std::map<std::string, LinearHistogramArgs> lhist_args;
   std::map<std::string, MapKey> map_keys;
   std::unordered_set<StackType> stackid_maps;
+  std::vector<SizedType> printb_args;
   bool needs_join_map = false;
   bool needs_elapsed_map = false;
   bool needs_data_map = false;
   bool needs_perf_event_map = false;
+  bool needs_printb_map = false;
 
   // Probe metadata
   //
@@ -148,10 +151,12 @@ private:
             lhist_args,
             map_keys,
             stackid_maps,
+            printb_args,
             needs_join_map,
             needs_elapsed_map,
             needs_data_map,
             needs_perf_event_map,
+            needs_printb_map,
             probes,
             special_probes);
   }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -186,6 +186,7 @@ std::string typestr(Type t)
     case Type::mac_address: return "mac_address"; break;
     case Type::cgroup_path: return "cgroup_path"; break;
     case Type::strerror: return "strerror"; break;
+    case Type::printb: return "printb"; break;
       // clang-format on
   }
 
@@ -482,6 +483,13 @@ SizedType CreateStrerror()
   return SizedType(Type::strerror, 8);
 }
 
+SizedType CreatePrintBTF(int dump_id, int type_id, size_t size)
+{
+  auto st = SizedType(Type::printb, 0);
+  st.printb = PrintBTF{ .dump_id = dump_id, .type_id = type_id, .size = size };
+  return st;
+}
+
 bool SizedType::IsSigned(void) const
 {
   return is_signed_;
@@ -630,6 +638,7 @@ size_t hash<bpftrace::SizedType>::operator()(
     case bpftrace::Type::mac_address:
     case bpftrace::Type::cgroup_path:
     case bpftrace::Type::strerror:
+    case bpftrace::Type::printb:
       break;
   }
 

--- a/src/types.h
+++ b/src/types.h
@@ -591,6 +591,7 @@ enum class AsyncAction
   watchpoint_attach,
   watchpoint_detach,
   skboutput,
+  printbtf,
   // clang-format on
 };
 

--- a/src/types.h
+++ b/src/types.h
@@ -48,7 +48,8 @@ enum class Type
   timestamp,
   mac_address,
   cgroup_path,
-  strerror
+  strerror,
+  printb,
   // clang-format on
 };
 
@@ -93,6 +94,21 @@ private:
   }
 };
 
+struct PrintBTF
+{
+  int dump_id = -1;
+  int type_id = -1;
+  size_t size = 0;
+
+private:
+  friend class cereal::access;
+  template <typename Archive>
+  void serialize(Archive &archive)
+  {
+    archive(dump_id, type_id, size);
+  }
+};
+
 struct Struct;
 struct Field;
 
@@ -117,6 +133,7 @@ public:
   bool is_funcarg = false;
   bool is_btftype = false;
   int funcarg_idx = -1;
+  PrintBTF printb;
 
 private:
   size_t size_ = -1; // in bytes
@@ -440,6 +457,7 @@ SizedType CreateTimestamp();
 SizedType CreateMacAddress();
 SizedType CreateCgroupPath();
 SizedType CreateStrerror();
+SizedType CreatePrintBTF(int dump_id, int type_id, size_t size);
 
 std::ostream &operator<<(std::ostream &os, const SizedType &type);
 


### PR DESCRIPTION
A short example: `bpftrace -e 'kprobe:kfree_skb {printb((struct sk_buff *)arg0)}'`. It will display complete struct sk_buff information, which can improve debugging efficiency. Part of the output is shown below:
```
(struct sk_buff){
        (union){
                (struct){
                        .next = (struct sk_buff *)(nil),
                        .prev = (struct sk_buff *)(nil),
                        (union){
                                .dev = (struct net_device *)(nil),
                                .dev_scratch = (long unsigned int)0,
                        },
                },
...
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
