### PR TITLE
AST: Various cleanups

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -226,14 +226,14 @@ Integer::Integer(int64_t n, location loc) : Expression(loc), n(n)
   is_literal = true;
 }
 
-String::String(const std::string &str, location loc) : Expression(loc), str(str)
+String::String(std::string str, location loc)
+    : Expression(loc), str(std::move(str))
 {
   is_literal = true;
 }
 
-
-StackMode::StackMode(const std::string &mode, location loc)
-    : Expression(loc), mode(mode)
+StackMode::StackMode(std::string mode, location loc)
+    : Expression(loc), mode(std::move(mode))
 {
   is_literal = true;
 }
@@ -244,9 +244,8 @@ Builtin::Builtin(const std::string &ident, location loc)
 {
 }
 
-
-Identifier::Identifier(const std::string &ident, location loc)
-    : Expression(loc), ident(ident)
+Identifier::Identifier(std::string ident, location loc)
+    : Expression(loc), ident(std::move(ident))
 {
 }
 
@@ -259,9 +258,8 @@ PositionalParameter::PositionalParameter(PositionalParameterType ptype,
   is_literal = true;
 }
 
-
 Call::Call(const std::string &func, location loc)
-    : Expression(loc), func(is_deprecated(func)), vargs(nullptr)
+    : Expression(loc), func(is_deprecated(func))
 {
 }
 
@@ -271,7 +269,7 @@ Call::Call(const std::string &func, ExpressionList *vargs, location loc)
 }
 
 Sizeof::Sizeof(SizedType type, location loc)
-    : Expression(loc), expr(nullptr), argtype(type)
+    : Expression(loc), argtype(std::move(type))
 {
 }
 
@@ -279,24 +277,24 @@ Sizeof::Sizeof(Expression *expr, location loc) : Expression(loc), expr(expr)
 {
 }
 
-Offsetof::Offsetof(SizedType record, std::string &field, location loc)
-    : Expression(loc), record(record), expr(nullptr), field(field)
+Offsetof::Offsetof(SizedType record, std::string field, location loc)
+    : Expression(loc), record(std::move(record)), field(std::move(field))
 {
 }
 
-Offsetof::Offsetof(Expression *expr, std::string &field, location loc)
-    : Expression(loc), expr(expr), field(field)
+Offsetof::Offsetof(Expression *expr, std::string field, location loc)
+    : Expression(loc), expr(expr), field(std::move(field))
 {
 }
 
-Map::Map(const std::string &ident, location loc)
-    : Expression(loc), ident(ident), vargs(nullptr)
+Map::Map(std::string ident, location loc)
+    : Expression(loc), ident(std::move(ident))
 {
   is_map = true;
 }
 
-Map::Map(const std::string &ident, ExpressionList *vargs, location loc)
-    : Expression(loc), ident(ident), vargs(vargs)
+Map::Map(std::string ident, ExpressionList *vargs, location loc)
+    : Expression(loc), ident(std::move(ident)), vargs(vargs)
 {
   is_map = true;
   for (auto expr : *vargs)
@@ -305,8 +303,8 @@ Map::Map(const std::string &ident, ExpressionList *vargs, location loc)
   }
 }
 
-Variable::Variable(const std::string &ident, location loc)
-    : Expression(loc), ident(ident)
+Variable::Variable(std::string ident, location loc)
+    : Expression(loc), ident(std::move(ident))
 {
   is_variable = true;
 }
@@ -335,11 +333,8 @@ Ternary::Ternary(Expression *cond,
 {
 }
 
-
-FieldAccess::FieldAccess(Expression *expr,
-                         const std::string &field,
-                         location loc)
-    : Expression(loc), expr(expr), field(field)
+FieldAccess::FieldAccess(Expression *expr, std::string field, location loc)
+    : Expression(loc), expr(expr), field(std::move(field))
 {
 }
 
@@ -357,7 +352,7 @@ ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr, location loc)
 Cast::Cast(SizedType cast_type, Expression *expr, location loc)
     : Expression(loc), expr(expr)
 {
-  type = cast_type;
+  type = std::move(cast_type);
 }
 
 
@@ -394,9 +389,8 @@ Predicate::Predicate(Expression *expr, location loc) : Node(loc), expr(expr)
 {
 }
 
-
-AttachPoint::AttachPoint(const std::string &raw_input, location loc)
-    : Node(loc), raw_input(raw_input)
+AttachPoint::AttachPoint(std::string raw_input, location loc)
+    : Node(loc), raw_input(std::move(raw_input))
 {
 }
 
@@ -423,9 +417,8 @@ Probe::Probe(AttachPointList *attach_points,
 {
 }
 
-
-Program::Program(const std::string &c_definitions, ProbeList *probes)
-    : c_definitions(c_definitions), probes(probes)
+Program::Program(std::string c_definitions, ProbeList *probes)
+    : c_definitions(std::move(c_definitions)), probes(probes)
 {
 }
 
@@ -607,14 +600,6 @@ Call::Call(const Call &other) : Expression(other)
   func = other.func;
 }
 
-Sizeof::Sizeof(const Sizeof &other) : Expression(other)
-{
-}
-
-Offsetof::Offsetof(const Offsetof &other) : Expression(other)
-{
-}
-
 Binop::Binop(const Binop &other) : Expression(other)
 {
   op = other.op;
@@ -633,7 +618,7 @@ Map::Map(const Map &other) : Expression(other)
 }
 
 FieldAccess::FieldAccess(const FieldAccess &other)
-    : Expression(other), expr(nullptr)
+    : Expression(other) // TODO why not copy expr??
 {
   field = other.field;
   index = other.index;
@@ -649,7 +634,7 @@ Program::Program(const Program &other) : Node(other)
   c_definitions = other.c_definitions;
 }
 
-Cast::Cast(const Cast &other) : Expression(other)
+Cast::Cast(const Cast &other) : Expression(other) // TODO expr isn't copied??
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -112,7 +112,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Integer)
 
-  explicit Integer(int64_t n, location loc);
+  Integer(int64_t n, location loc);
 
   int64_t n;
 
@@ -125,9 +125,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(PositionalParameter)
 
-  explicit PositionalParameter(PositionalParameterType ptype,
-                               long n,
-                               location loc);
+  PositionalParameter(PositionalParameterType ptype, long n, location loc);
   ~PositionalParameter() = default;
 
   PositionalParameterType ptype;
@@ -143,7 +141,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(String)
 
-  explicit String(const std::string &str, location loc);
+  String(std::string str, location loc);
   ~String() = default;
 
   std::string str;
@@ -157,7 +155,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(StackMode)
 
-  explicit StackMode(const std::string &mode, location loc);
+  StackMode(std::string mode, location loc);
   ~StackMode() = default;
 
   std::string mode;
@@ -171,7 +169,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Identifier)
 
-  explicit Identifier(const std::string &ident, location loc);
+  Identifier(std::string ident, location loc);
   ~Identifier() = default;
 
   std::string ident;
@@ -185,7 +183,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Builtin)
 
-  explicit Builtin(const std::string &ident, location loc);
+  Builtin(const std::string &ident, location loc);
   ~Builtin() = default;
 
   std::string ident;
@@ -200,7 +198,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Call)
 
-  explicit Call(const std::string &func, location loc);
+  Call(const std::string &func, location loc);
   Call(const std::string &func, ExpressionList *vargs, location loc);
   ~Call();
 
@@ -221,11 +219,11 @@ public:
   Sizeof(Expression *expr, location loc);
   ~Sizeof();
 
-  Expression *expr;
+  Expression *expr = nullptr;
   SizedType argtype;
 
 private:
-  Sizeof(const Sizeof &other);
+  Sizeof(const Sizeof &other) = default;
 };
 
 class Offsetof : public Expression
@@ -234,16 +232,16 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Offsetof)
 
-  Offsetof(SizedType record, std::string &field, location loc);
-  Offsetof(Expression *expr, std::string &field, location loc);
+  Offsetof(SizedType record, std::string field, location loc);
+  Offsetof(Expression *expr, std::string field, location loc);
   ~Offsetof();
 
   SizedType record;
-  Expression *expr;
+  Expression *expr = nullptr;
   std::string field;
 
 private:
-  Offsetof(const Offsetof &other);
+  Offsetof(const Offsetof &other) = default;
 };
 
 class Map : public Expression {
@@ -251,8 +249,8 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Map)
 
-  explicit Map(const std::string &ident, location loc);
-  Map(const std::string &ident, ExpressionList *vargs, location loc);
+  Map(std::string ident, location loc);
+  Map(std::string ident, ExpressionList *vargs, location loc);
   ~Map();
 
   std::string ident;
@@ -269,7 +267,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Variable)
 
-  explicit Variable(const std::string &ident, location loc);
+  Variable(std::string ident, location loc);
   ~Variable() = default;
 
   std::string ident;
@@ -321,8 +319,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(FieldAccess)
 
-  FieldAccess(Expression *expr, const std::string &field);
-  FieldAccess(Expression *expr, const std::string &field, location loc);
+  FieldAccess(Expression *expr, std::string field, location loc);
   FieldAccess(Expression *expr, ssize_t index, location loc);
   ~FieldAccess();
 
@@ -398,7 +395,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(ExprStatement)
 
-  explicit ExprStatement(Expression *expr, location loc);
+  ExprStatement(Expression *expr, location loc);
   ~ExprStatement();
 
   Expression *expr = nullptr;
@@ -500,7 +497,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Predicate)
 
-  explicit Predicate(Expression *expr, location loc);
+  Predicate(Expression *expr, location loc);
   ~Predicate();
 
   Expression *expr = nullptr;
@@ -546,7 +543,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(AttachPoint)
 
-  explicit AttachPoint(const std::string &raw_input, location loc = location());
+  explicit AttachPoint(std::string raw_input, location loc = location());
   AttachPoint(const std::string &raw_input, bool ignore_invalid)
       : AttachPoint(raw_input)
   {
@@ -620,7 +617,7 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Program)
 
-  Program(const std::string &c_definitions, ProbeList *probes);
+  Program(std::string c_definitions, ProbeList *probes);
 
   ~Program();
 


### PR DESCRIPTION
I'll wait for #2624 to go into master before I merge this, as there'll be conflicts.

- Use move ctors for std::string and SizedType
- Remove explicit keywords on multi-arg ctors (they were a hold-over from when the ctors were single-argument, before locations were added)
- Use in-class initialisers instead of member initialisers for constants