### PR TITLE
BTF: Fix loading BTF from kernel modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to
   - [#2708](https://github.com/iovisor/bpftrace/pull/2708)
 - Add access to `CLOCK_MONOTONIC` with `nsecs(monotonic)`
   - [#2718](https://github.com/iovisor/bpftrace/pull/2718)
+- Fix loading BTF from kernel modules
+  - [#2723](https://github.com/iovisor/bpftrace/pull/2723)
 
 
 ## [0.18.0] 2023-05-15

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -132,7 +132,7 @@ void BTF::load_kernel_btfs(const std::set<std::string> &modules)
     {
       btf_objects.front().id = id;
     }
-    else if (modules.find(mod_name) != modules.end())
+    else
     {
       btf_objects.push_back(
           BTFObj{ .btf = btf__load_from_kernel_by_id_split(id, vmlinux_btf),


### PR DESCRIPTION
I was in a rush making this, on looking again it's definitely not the right fix. There is a bug in this code though.

Before:
```
$ sudo ./bpftrace -l 'kfunc:autofs4:autofs_wait*'
$
```

After:
```
$ sudo ./bpftrace -l 'kfunc:autofs4:autofs_wait*'
kfunc:autofs4:autofs_wait
kfunc:autofs4:autofs_wait_release
$
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
