### PR TITLE
WIP: Index anonymous structs

### DIFF
--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -17,7 +17,7 @@ struct FuncInfo
 };
 
 Dwarf::Dwarf(BPFtrace *bpftrace, const std::string &file_path)
-    : bpftrace_(bpftrace), file_path_(file_path)
+    : bpftrace_(bpftrace), file_path_(file_path), anon_idx(1)
 {
   callbacks.find_debuginfo = dwfl_standard_find_debuginfo;
   callbacks.section_address = dwfl_offline_section_address;
@@ -181,7 +181,9 @@ SizedType Dwarf::get_stype(Dwarf_Die &type_die, bool resolve_structs) const
     }
     case DW_TAG_structure_type:
     case DW_TAG_union_type: {
-      std::string name = dwarf_diename(&type_die);
+      std::string name = dwarf_hasattr_integrate(&type_die, DW_AT_name)
+                             ? dwarf_diename(&type_die)
+                             : "__anon_" + std::to_string(anon_idx++);
       name = (tag == DW_TAG_structure_type ? "struct " : "union ") + name;
       auto result = CreateRecord(
           name, bpftrace_->structs.LookupOrAdd(name, bit_size / 8));

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -60,6 +60,7 @@ private:
 
   BPFtrace *bpftrace_;
   std::string file_path_;
+  mutable int anon_idx;
 };
 
 } // namespace bpftrace

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -41,6 +41,11 @@ struct Foo3 *func_3(int a, int *b, struct Foo1 *foo1)
   return 0;
 }
 
+void *func_4(const struct Foo2 *p)
+{
+  return 0;
+}
+
 struct task_struct
 {
   int pid;

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -225,6 +225,12 @@ TEST_F(field_analyser_dwarf, uprobe_args)
   test(uprobe + ":func_2, " + uprobe + ":func_3 { }", 0);
   test(uprobe + ":func_2, " + uprobe + ":func_3 { $x = args.a; }", 0);
 
+  // func_1 has a parameter that contains an anonymous struct
+  // test(uprobe + ":func_1 { $x = args.foo2->a; }", 0);
+  // test(uprobe + ":func_1 { $x = args.foo2->g; }", 0);
+  // func_4 has a parameter with a const qualifier
+  test(uprobe + ":func_4 { $x = args.p->a; }", 0);
+
   // Probes with wildcards (need non-mock BPFtrace)
   BPFtrace bpftrace;
   // func_* have different args, but none of them


### PR DESCRIPTION
In #2863 I tried to use a fixed name for anonymous structs. That was no good so it was suggested to generate unique names for them. This does basically fix my original use case, but it doesn't seem to have the intended effect. I can still reproduce the crash in some of the test cases though I'm not sure why yet.

Also, some types that I don't think should be anonymous are identified as such:

```
$ sudo ./src/bpftrace -e 'uprobe:libc:getaddrinfo {printf("%d\n", args.hints->ai_protocol);}'
stdin:1:41-64: ERROR: Struct/union of type 'struct __anon_1' does not contain a field named 'ai_protocol'
uprobe:libc:getaddrinfo {printf("%d\n", args.hints->ai_protocol);}
```
but hints should have type `struct addrinfo *` [1].

Intended for #2867

[1] https://debuginfod.archlinux.org/buildid/8bfe03f6bf9b6a6e2591babd0bbc266837d8f658/debuginfo