### PR TITLE
Fixing build error when libdw is not present

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,7 +43,10 @@ add_executable(bpftrace_test
 )
 
 add_subdirectory(data)
-add_dependencies(bpftrace_test debuginfo_data)
+if(${LIBDW_FOUND})
+  add_dependencies(bpftrace_test debuginfo_dwarf_data)
+endif()
+add_dependencies(bpftrace_test debuginfo_btf_data)
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 target_compile_definitions(bpftrace_test PRIVATE TEST_CODEGEN_LOCATION="${CMAKE_SOURCE_DIR}/tests/codegen/llvm/")

--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -20,13 +20,14 @@ add_custom_command(
   # We must hack it like this b/c cmake does not support setting env vars at build time
   COMMAND bash -c "LLVM_OBJCOPY=${LLVM_OBJCOPY} pahole -J ${DATA_SOURCE_O}"
   DEPENDS ${DATA_SOURCE_C})
+add_custom_target(data_source_o DEPENDS ${DATA_SOURCE_O})
 
 # Generate btf_data from BTF in data_source.o
 set(BTF_DATA_FILE ${CMAKE_CURRENT_BINARY_DIR}/btf_data)
 add_custom_command(
   OUTPUT ${BTF_DATA_FILE}
   COMMAND ${LLVM_OBJCOPY} --dump-section .BTF=${BTF_DATA_FILE} ${DATA_SOURCE_O}
-  DEPENDS ${DATA_SOURCE_O})
+  DEPENDS data_source_o)
 
 # Generate btf_data.hex from btf_data
 set(BTF_DATA_HEX ${CMAKE_CURRENT_BINARY_DIR}/btf_data.hex)
@@ -41,7 +42,7 @@ add_custom_command(
   OUTPUT ${FUNC_LIST_HEX}
   COMMAND nm ${DATA_SOURCE_O} | awk -v ORS=\\\\n "$2 == \"T\" { print $3 }" > ${FUNC_LIST_HEX}
   VERBATIM
-  DEPENDS ${DATA_SOURCE_O})
+  DEPENDS data_source_o)
 
 if(${LIBDW_FOUND})
   # Generate dwarf_data from data_source.o
@@ -49,7 +50,7 @@ if(${LIBDW_FOUND})
   add_custom_command(
     OUTPUT ${DWARF_DATA_FILE}
     COMMAND strip --only-keep-debug -o ${DWARF_DATA_FILE} ${DATA_SOURCE_O}
-    DEPENDS ${DATA_SOURCE_O})
+    DEPENDS data_source_o)
 
   # Generate dwarf_data.hex from dwarf_data
   set(DWARF_DATA_HEX ${CMAKE_CURRENT_BINARY_DIR}/dwarf_data.hex)
@@ -57,25 +58,37 @@ if(${LIBDW_FOUND})
     OUTPUT ${DWARF_DATA_HEX}
     COMMAND xxd -i < ${DWARF_DATA_FILE} > ${DWARF_DATA_HEX}
     DEPENDS ${DWARF_DATA_FILE})
+    
+  set(CONFIGURE_DWARF_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/configure_dwarf_headers.cmake)
+  set(DWARF_DATA_H_IN ${CMAKE_CURRENT_SOURCE_DIR}/dwarf_data.h.in)
+  set(DWARF_DATA_H ${CMAKE_CURRENT_BINARY_DIR}/dwarf_data.h)
+  
+  add_custom_command(
+    OUTPUT ${DWARF_DATA_H}
+    COMMAND
+      ${CMAKE_COMMAND}
+      -DFUNC_LIST_HEX=${FUNC_LIST_HEX}
+      -DDWARF_DATA_HEX=${DWARF_DATA_HEX}
+      -DDWARF_DATA_H_IN=${DWARF_DATA_H_IN}
+      -DDWARF_DATA_H=${DWARF_DATA_H}
+      -P ${CONFIGURE_DWARF_HEADERS}
+    DEPENDS ${FUNC_LIST_HEX} ${DWARF_DATA_HEX} ${CONFIGURE_DWARF_HEADERS})
+    
+  add_custom_target(debuginfo_dwarf_data DEPENDS ${DWARF_DATA_H})
 endif()
 
-set(CONFIGURE_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/configure_headers.cmake)
+set(CONFIGURE_BTF_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/configure_btf_headers.cmake)
 set(BTF_DATA_H_IN ${CMAKE_CURRENT_SOURCE_DIR}/btf_data.h.in)
 set(BTF_DATA_H ${CMAKE_CURRENT_BINARY_DIR}/btf_data.h)
-set(DWARF_DATA_H_IN ${CMAKE_CURRENT_SOURCE_DIR}/dwarf_data.h.in)
-set(DWARF_DATA_H ${CMAKE_CURRENT_BINARY_DIR}/dwarf_data.h)
 add_custom_command(
-  OUTPUT ${BTF_DATA_H} ${DWARF_DATA_H}
+  OUTPUT ${BTF_DATA_H}
   COMMAND
     ${CMAKE_COMMAND}
     -DBTF_DATA_HEX=${BTF_DATA_HEX}
     -DFUNC_LIST_HEX=${FUNC_LIST_HEX}
-    -DDWARF_DATA_HEX=${DWARF_DATA_HEX}
     -DBTF_DATA_H_IN=${BTF_DATA_H_IN}
     -DBTF_DATA_H=${BTF_DATA_H}
-    -DDWARF_DATA_H_IN=${DWARF_DATA_H_IN}
-    -DDWARF_DATA_H=${DWARF_DATA_H}
-    -P ${CONFIGURE_HEADERS}
-  DEPENDS ${BTF_DATA_HEX} ${FUNC_LIST_HEX} ${DWARF_DATA_HEX} ${CONFIGURE_HEADERS})
+    -P ${CONFIGURE_BTF_HEADERS}
+  DEPENDS ${BTF_DATA_HEX} ${FUNC_LIST_HEX} ${CONFIGURE_BTF_HEADERS})
 
-add_custom_target(debuginfo_data DEPENDS ${BTF_DATA_H} ${DWARF_DATA_H})
+add_custom_target(debuginfo_btf_data DEPENDS ${BTF_DATA_H})

--- a/tests/data/configure_btf_headers.cmake
+++ b/tests/data/configure_btf_headers.cmake
@@ -1,0 +1,8 @@
+# This logic needs to be in a separate cmake script b/c file() runs
+# at cmake configuration stage and _not_ during build. So this script
+# is wrapped in a custom command so that it's only run when necessary.
+
+file(READ ${BTF_DATA_HEX} BTF_DATA)
+file(READ ${FUNC_LIST_HEX} FUNC_LIST)
+
+configure_file(${BTF_DATA_H_IN} ${BTF_DATA_H})

--- a/tests/data/configure_dwarf_headers.cmake
+++ b/tests/data/configure_dwarf_headers.cmake
@@ -2,9 +2,6 @@
 # at cmake configuration stage and _not_ during build. So this script
 # is wrapped in a custom command so that it's only run when necessary.
 
-file(READ ${BTF_DATA_HEX} BTF_DATA)
-file(READ ${FUNC_LIST_HEX} FUNC_LIST)
 file(READ ${DWARF_DATA_HEX} DWARF_DATA)
 
-configure_file(${BTF_DATA_H_IN} ${BTF_DATA_H})
 configure_file(${DWARF_DATA_H_IN} ${DWARF_DATA_H})


### PR DESCRIPTION
Fixes #2789, only generates Dwarf test data if libdw is present. We don't need libdw to generate the data, but it's only used when `HAVE_LIBDW` is set.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
