### PR TITLE
List program probes when -l is also provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 #### Added
 - Add 'lazy_symbolication' config
   - [#2958](https://github.com/bpftrace/bpftrace/pull/2958)
+- Add ability to list all probes in a program
+  - [#2969](https://github.com/bpftrace/bpftrace/pull/2969)
 #### Changed
 #### Deprecated
 #### Removed

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -159,7 +159,7 @@ OPTIONS:
     -h             show this help message
     -I DIR         add the specified DIR to the search path for include files.
     --include FILE adds an implicit #include which is read before the source file is preprocessed.
-    -l [search]    list probes
+    -l [search]    list kernel probes or probes in a program
     -p PID         enable USDT probes or search for uprobes/uretprobes in PID address space
     -c 'CMD'       run CMD and enable USDT probes on resulting process
     -q             keep messages quiet
@@ -282,7 +282,9 @@ iscsid is sleeping.
 
 ## 4. `-l`: Listing Probes
 
-Probes from the tracepoint and kprobe libraries can be listed with `-l`.
+Probe listing is the method to discover which probes are supported by the current system.
+Listing supports the same syntax as normal attachment does and alternatively can be 
+combined with `-e` or filename args to see all the probes that a program would attach to.
 
 ```
 # bpftrace -l | more
@@ -309,6 +311,15 @@ tracepoint:syscalls:sys_exit_nanosleep
 kprobe:nanosleep_copyout
 kprobe:hrtimer_nanosleep
 [...]
+```
+
+Seeing the probes a program would attach to:
+```
+# bpftrace -l -e 'kprobe:xprt_switch_get { exit(); } tracepoint:xdp:mem_* { exit(); }'
+kprobe:xprt_switch_get
+tracepoint:xdp:mem_connect
+tracepoint:xdp:mem_disconnect
+tracepoint:xdp:mem_return_failed
 ```
 
 The `-v` option when listing tracepoints will show their arguments for use from the args builtin. For

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2755,13 +2755,15 @@ int main()
 == Listing Probes
 
 Probe listing is the method to discover which probes are supported by the current system.
-Listing supports the same syntax as normal attachment does:
+Listing supports the same syntax as normal attachment does and alternatively can be
+combined with `-e` or filename args to see all the probes that a program would attach to.
 
 ----
 # bpftrace -l 'kprobe:*'
 # bpftrace -l 't:syscalls:*openat*
 # bpftrace -l 'kprobe:tcp*,trace
 # bpftrace -l 'k:*socket*,tracepoint:syscalls:*tcp*'
+# bpftrace -l -e 'tracepoint:xdp:mem_* { exit(); }'
 ----
 
 The verbose flag (`-v`) can be specified to inspect arguments (`args`) for providers that support it:

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -134,6 +134,22 @@ RUN {{BPFTRACE}} -l "rawtracepoint:*"
 EXPECT rawtracepoint:
 TIMEOUT 1
 
+NAME it only lists probes in the program
+RUN {{BPFTRACE}} -l -e 'kfunc:vmlinux:vfs_read { exit(); }' | grep kfunc | wc -l
+EXPECT 1
+TIMEOUT 5
+
+NAME it lists uprobes in the program
+RUN {{BPFTRACE}} -l -e 'uretprobe:*:uprobeFunction* { exit(); }' -p {{BEFORE_PID}}
+EXPECT uretprobe:[\S]+uprobe_test:uprobeFunction1
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME it lists multiple probes in the program
+RUN {{BPFTRACE}} -l -e 'hardware:cache-misses:10 { exit(); } tracepoint:xdp:mem_connect { exit(); }'
+EXPECT hardware:cache-misses:\ntracepoint:xdp:mem_connect
+TIMEOUT 5
+
 NAME errors on invalid character in search expression
 RUN {{BPFTRACE}} -l '\n'
 EXPECT ERROR: invalid character


### PR DESCRIPTION
Extend listing functionality to also list all the probes a program would attach to when '-l' arg is provided.

e.g.
```
$ sudo bpftrace -l -e 'kfunc:vmlinux:vfs_* { exit(); }'
kfunc:vmlinux:vfs_cancel_lock
kfunc:vmlinux:vfs_clean_context
kfunc:vmlinux:vfs_cleanup_quota_inode
kfunc:vmlinux:vfs_clone_file_range
kfunc:vmlinux:vfs_cmd_create
kfunc:vmlinux:vfs_copy_file_range
kfunc:vmlinux:vfs_create
kfunc:vmlinux:vfs_create_mount
kfunc:vmlinux:vfs_dedupe_file_range
kfunc:vmlinux:vfs_dedupe_file_range_one
kfunc:vmlinux:vfs_dentry_acceptable
kfunc:vmlinux:vfs_dup_fs_context
kfunc:vmlinux:vfs_fadvise
...
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
