### PR TITLE
Fix build issue with UAPI header of pre-v5.16 kernel

### DIFF
--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -49,7 +49,16 @@ static int btf_type_size(const struct btf_type *t)
     case BTF_KIND_ENUM:
       return base_size + vlen * sizeof(struct btf_enum);
     case BTF_KIND_ENUM64:
-      return base_size + vlen * sizeof(struct btf_enum64);
+      /* struct btf_enum64 is not available in UAPI header until v6.0,
+       * calculate its size with array instead. Its definition is:
+       *
+       * struct btf_enum64 {
+       *	__u32	name_off;
+       *	__u32	val_lo32;
+       *	__u32	val_hi32;
+       * };
+       */
+      return base_size + vlen * sizeof(__u32[3]);
     case BTF_KIND_ARRAY:
       return base_size + sizeof(struct btf_array);
     case BTF_KIND_STRUCT:
@@ -62,7 +71,14 @@ static int btf_type_size(const struct btf_type *t)
     case BTF_KIND_DATASEC:
       return base_size + vlen * sizeof(struct btf_var_secinfo);
     case BTF_KIND_DECL_TAG:
-      return base_size + sizeof(struct btf_decl_tag);
+      /* struct btf_decl_tag is not available until v5.16. Use the same trick
+       * as btf_enum64 above. Its definition is:
+       *
+       * struct btf_decl_tag {
+       *  __s32   component_idx;
+       * };
+       */
+      return base_size + sizeof(__s32);
     default:
       return -EINVAL;
   }


### PR DESCRIPTION
322cdfa7 ("Fixup generated BTF for older kernels") added with PR #2934 allowed the generated BTF to work stable v5.4 kernel. However, the newly added btf_type_size() requires definition of struct btf_decl_tag (v5.16) and struct btf_enum64 (v6.0), which were not available in UAPI header of v5.4 kernel; which will cause build to fail.

Similar to libbpf/libbpf@85f8b7c, we can fix this by treating the structs as an array, and thus calculate their respective size without require their definition being present in the kernel UAPI header.

(CC @viktormalik)

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests