### PR TITLE
runtime tests: update EXPECTs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -65,7 +65,8 @@ Each runtime testcase consists of multiple directives. In no particular order:
   `RUN` unless you must pass flags or create a shell pipeline.  This XOR the
   `RUN` field is required
 * `EXPECT`: The expected output. Python regular expressions are supported.
-   One of EXPECT, EXPECT_NONE, EXPECT_FILE or EXPECT_JSON is required.
+   One or more `EXPECT` and `EXPECT_NONE` or a single `EXPECT_FILE` or 
+   `EXPECT_JSON` is required.
 * `EXPECT_NONE`: The negation of `EXPECT`, which also supports Python regular 
    expressions.
 * `EXPECT_FILE`: A file containing the expected output, matched as plain

--- a/tests/README.md
+++ b/tests/README.md
@@ -65,7 +65,9 @@ Each runtime testcase consists of multiple directives. In no particular order:
   `RUN` unless you must pass flags or create a shell pipeline.  This XOR the
   `RUN` field is required
 * `EXPECT`: The expected output. Python regular expressions are supported.
-   One of EXPECT, EXPECT_FILE or EXPECT_JSON is required.
+   One of EXPECT, EXPECT_NONE, EXPECT_FILE or EXPECT_JSON is required.
+* `EXPECT_NONE`: The negation of `EXPECT`, which also supports Python regular 
+   expressions.
 * `EXPECT_FILE`: A file containing the expected output, matched as plain
    text after stripping initial and final empty lines
 * `EXPECT_JSON`: A json file containing the expected output, matched after

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -135,8 +135,9 @@ EXPECT rawtracepoint:
 TIMEOUT 1
 
 NAME it only lists probes in the program
-RUN {{BPFTRACE}} -l -e 'kfunc:vmlinux:vfs_read { exit(); }' | grep kfunc | wc -l
-EXPECT 1
+RUN {{BPFTRACE}} -l -e 'kfunc:vmlinux:vfs_read { exit(); }'
+EXPECT kfunc:vmlinux:vfs_read
+EXPECT_NONE kfunc:vmlinux:vfs_write
 TIMEOUT 5
 
 NAME it lists uprobes in the program

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -132,6 +132,9 @@ class TestParser(object):
             elif item_name == 'EXPECT':
                 expect = line
                 expect_mode = 'regex'
+            elif item_name == 'EXPECT_NONE':
+                expect = line
+                expect_mode = 'regex_none'
             elif item_name == 'EXPECT_FILE':
                 expect = line
                 expect_mode = 'file'

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -205,6 +205,8 @@ class Runner(object):
             try:
                 if test.expect_mode == "regex":
                     return re.search(test.expect, output, re.M)
+                elif test.expect_mode == "regex_none":
+                    return not re.search(test.expect, output, re.M)
                 elif test.expect_mode == "file":
                     # remove leading and trailing empty lines
                     return output.strip() == open(test.expect).read().strip()
@@ -338,7 +340,7 @@ class Runner(object):
                 output += nextline
                 if not attached and nextline == "__BPFTRACE_NOTIFY_PROBES_ATTACHED\n":
                     attached = True
-                    if test.expect_mode != "regex":
+                    if test.expect_mode != "regex" and test.expect_mode != "regex_none":
                         output = ""  # ignore earlier ouput
                     signal.alarm(test.timeout or DEFAULT_TIMEOUT)
                     if test.after:
@@ -440,6 +442,9 @@ class Runner(object):
             print('\tCommand: ' + bpf_call)
             if test.expect_mode == "regex":
                 print('\tExpected REGEX: ' + test.expect)
+                print('\tFound:\n' + to_utf8(output))
+            elif test.expect_mode == "regex_none":
+                print('\tExpected no REGEX: ' + test.expect)
                 print('\tFound:\n' + to_utf8(output))
             elif test.expect_mode == "json":
                 try:


### PR DESCRIPTION
Add
- EXPECT_NONE
- The ability to have multiple EXPECTs and/or EXPECT_NONEs
##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
