### PR TITLE
Update tutorial_one_liners.md

### DIFF
--- a/docs/tutorial_one_liners.md
+++ b/docs/tutorial_one_liners.md
@@ -33,7 +33,7 @@ This prints a welcome message. Run it, then hit Ctrl-C to end.
 # Lesson 3. File Opens
 
 ```
-# bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args.filename)); }'
+# bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args -> filename)); }'
 Attaching 1 probe...
 snmp-pass /proc/cpuinfo
 snmp-pass /proc/stat


### PR DESCRIPTION
The example in Lesson 3 fails with ERROR: Can not access field 'filename' on type '(ctx) struct _tracepoint_syscalls_sys_enter_openat *'. Try dereferencing it first, or using '->'

Corrected to use ->

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
