### PR TITLE
SizedType: Change "type" member to private

### DIFF
--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -166,7 +166,7 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype)
       return getInt8Ty();
     default:
       LOG(FATAL) << "Cannot generate debug info for type "
-                 << typestr(stype.type) << " (" << stype.GetSize()
+                 << typestr(stype.GetTy()) << " (" << stype.GetSize()
                  << " is not a valid type size)";
       return nullptr;
   }

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1630,7 +1630,7 @@ void CodegenLLVM::unop_int(Unop &unop)
     }
     case Operator::MUL: {
       // When dereferencing a 32-bit integer, only read in 32-bits, etc.
-      auto dst_type = SizedType(type.type, type.GetSize());
+      auto dst_type = SizedType(type.GetTy(), type.GetSize());
       AllocaInst *dst = b_.CreateAllocaBPF(dst_type, "deref");
       b_.CreateProbeRead(ctx_, dst, type, expr_, unop.loc);
       expr_ = b_.CreateIntCast(b_.CreateLoad(b_.GetType(dst_type), dst),
@@ -3225,8 +3225,8 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int &id)
 
   auto elements = AsyncEvent::PrintNonMap().asLLVMType(b_, arg.type.GetSize());
   std::ostringstream struct_name;
-  struct_name << call.func << "_" << arg.type.type << "_" << arg.type.GetSize()
-              << "_t";
+  struct_name << call.func << "_" << arg.type.GetTy() << "_"
+              << arg.type.GetSize() << "_t";
   StructType *print_struct = b_.GetStructType(struct_name.str(),
                                               elements,
                                               true);

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -24,8 +24,8 @@ void ConfigAnalyser::log_type_error(SizedType &type,
                                     AssignConfigVarStatement &assignment)
 {
   LOG(ERROR, assignment.loc, err_)
-      << "Invalid type for " << assignment.config_var << ". Type: " << type.type
-      << ". Expected Type: " << expected_type;
+      << "Invalid type for " << assignment.config_var
+      << ". Type: " << type.GetTy() << ". Expected Type: " << expected_type;
 }
 
 void ConfigAnalyser::set_uint64_config(AssignConfigVarStatement &assignment,

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -635,7 +635,7 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
   std::vector<std::unique_ptr<IPrintable>> arg_values;
 
   for (auto arg : args) {
-    switch (arg.type.type) {
+    switch (arg.type.GetTy()) {
       case Type::integer:
         if (arg.type.IsSigned()) {
           int64_t val = 0;

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -385,7 +385,7 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
     auto *array = btf_array(t);
     const auto &elem_type = get_stype(
         BTFId{ .btf = btf_id.btf, .id = array->type });
-    if (elem_type.type == Type::integer && elem_type.GetSize() == 1) {
+    if (elem_type.IsIntTy() && elem_type.GetSize() == 1) {
       stype = CreateString(array->nelems);
     } else {
       stype = CreateArray(array->nelems, elem_type);

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -73,7 +73,7 @@ std::string validate_format_string(const std::string &fmt,
 
   auto token_iter = tokens_begin;
   for (int i = 0; i < num_args; i++, token_iter++) {
-    Type arg_type = args.at(i).type.type;
+    Type arg_type = args.at(i).type.GetTy();
     if (arg_type == Type::ksym || arg_type == Type::usym ||
         arg_type == Type::probe || arg_type == Type::username ||
         arg_type == Type::kstack || arg_type == Type::ustack ||

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -62,7 +62,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
 {
   auto arg_data = static_cast<const uint8_t *>(data);
   std::ostringstream ptr;
-  switch (arg.type) {
+  switch (arg.GetTy()) {
     case Type::integer:
       switch (arg.GetSize()) {
         case 1:

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -18,7 +18,7 @@ namespace bpftrace {
 namespace {
 bool is_quoted_type(const SizedType &ty)
 {
-  switch (ty.type) {
+  switch (ty.GetTy()) {
     case Type::buffer:
     case Type::cgroup_path:
     case Type::inet:
@@ -669,9 +669,8 @@ std::string TextOutput::map_keyval_to_str(IMap &map,
 
 std::string TextOutput::map_elem_delim_to_str(IMap &map) const
 {
-  if (map.type_.type != Type::kstack && map.type_.type != Type::ustack &&
-      map.type_.type != Type::ksym && map.type_.type != Type::usym &&
-      map.type_.type != Type::inet)
+  if (!map.type_.IsKstackTy() && !map.type_.IsUstackTy() &&
+      !map.type_.IsKsymTy() && !map.type_.IsUsymTy() && !map.type_.IsInetTy())
     return "\n";
 
   return "";

--- a/src/types.h
+++ b/src/types.h
@@ -116,20 +116,19 @@ struct Field;
 
 class SizedType {
 public:
-  SizedType() : type(Type::none)
+  SizedType() : type_(Type::none)
   {
   }
   SizedType(Type type, size_t size_, bool is_signed)
-      : type(type), size_bits_(size_ * 8), is_signed_(is_signed)
+      : type_(type), size_bits_(size_ * 8), is_signed_(is_signed)
   {
   }
-  SizedType(Type type, size_t size_) : type(type), size_bits_(size_ * 8)
+  SizedType(Type type, size_t size_) : type_(type), size_bits_(size_ * 8)
   {
   }
 
   StackType stack_type;
   int funcarg_idx = -1;
-  Type type;
   bool is_internal = false;
   bool is_tparg = false;
   bool is_funcarg = false;
@@ -137,6 +136,7 @@ public:
   TimestampMode ts_mode = TimestampMode::boot;
 
 private:
+  Type type_;
   size_t size_bits_ = 0;                    // size in bits
   std::shared_ptr<SizedType> element_type_; // for "container" and pointer
                                             // (like) types
@@ -152,7 +152,7 @@ private:
   template <typename Archive>
   void serialize(Archive &archive)
   {
-    archive(type,
+    archive(type_,
             stack_type,
             is_internal,
             is_tparg,
@@ -221,8 +221,8 @@ public:
 
   bool IsPrintableTy()
   {
-    return type != Type::none && type != Type::stack_mode &&
-           type != Type::timestamp_mode &&
+    return type_ != Type::none && type_ != Type::stack_mode &&
+           type_ != Type::timestamp_mode &&
            (!IsCtxAccess() || is_funcarg); // args builtin is printable
   }
 
@@ -260,6 +260,11 @@ public:
     return name_;
   }
 
+  Type GetTy() const
+  {
+    return type_;
+  }
+
   const SizedType *GetElementTy() const
   {
     assert(IsArrayTy());
@@ -274,127 +279,127 @@ public:
 
   bool IsBoolTy() const
   {
-    return type == Type::integer && size_bits_ == 1;
+    return type_ == Type::integer && size_bits_ == 1;
   };
   bool IsPtrTy() const
   {
-    return type == Type::pointer;
+    return type_ == Type::pointer;
   };
   bool IsIntTy() const
   {
-    return type == Type::integer;
+    return type_ == Type::integer;
   };
   bool IsNoneTy(void) const
   {
-    return type == Type::none;
+    return type_ == Type::none;
   };
   bool IsIntegerTy(void) const
   {
-    return type == Type::integer;
+    return type_ == Type::integer;
   };
   bool IsHistTy(void) const
   {
-    return type == Type::hist;
+    return type_ == Type::hist;
   };
   bool IsLhistTy(void) const
   {
-    return type == Type::lhist;
+    return type_ == Type::lhist;
   };
   bool IsCountTy(void) const
   {
-    return type == Type::count;
+    return type_ == Type::count;
   };
   bool IsSumTy(void) const
   {
-    return type == Type::sum;
+    return type_ == Type::sum;
   };
   bool IsMinTy(void) const
   {
-    return type == Type::min;
+    return type_ == Type::min;
   };
   bool IsMaxTy(void) const
   {
-    return type == Type::max;
+    return type_ == Type::max;
   };
   bool IsAvgTy(void) const
   {
-    return type == Type::avg;
+    return type_ == Type::avg;
   };
   bool IsStatsTy(void) const
   {
-    return type == Type::stats;
+    return type_ == Type::stats;
   };
   bool IsKstackTy(void) const
   {
-    return type == Type::kstack;
+    return type_ == Type::kstack;
   };
   bool IsUstackTy(void) const
   {
-    return type == Type::ustack;
+    return type_ == Type::ustack;
   };
   bool IsStringTy(void) const
   {
-    return type == Type::string;
+    return type_ == Type::string;
   };
   bool IsKsymTy(void) const
   {
-    return type == Type::ksym;
+    return type_ == Type::ksym;
   };
   bool IsUsymTy(void) const
   {
-    return type == Type::usym;
+    return type_ == Type::usym;
   };
   bool IsProbeTy(void) const
   {
-    return type == Type::probe;
+    return type_ == Type::probe;
   };
   bool IsUsernameTy(void) const
   {
-    return type == Type::username;
+    return type_ == Type::username;
   };
   bool IsInetTy(void) const
   {
-    return type == Type::inet;
+    return type_ == Type::inet;
   };
   bool IsStackModeTy(void) const
   {
-    return type == Type::stack_mode;
+    return type_ == Type::stack_mode;
   };
   bool IsArrayTy(void) const
   {
-    return type == Type::array;
+    return type_ == Type::array;
   };
   bool IsRecordTy(void) const
   {
-    return type == Type::record;
+    return type_ == Type::record;
   };
   bool IsBufferTy(void) const
   {
-    return type == Type::buffer;
+    return type_ == Type::buffer;
   };
   bool IsTupleTy(void) const
   {
-    return type == Type::tuple;
+    return type_ == Type::tuple;
   };
   bool IsTimestampTy(void) const
   {
-    return type == Type::timestamp;
+    return type_ == Type::timestamp;
   };
   bool IsMacAddressTy(void) const
   {
-    return type == Type::mac_address;
+    return type_ == Type::mac_address;
   };
   bool IsCgroupPathTy(void) const
   {
-    return type == Type::cgroup_path;
+    return type_ == Type::cgroup_path;
   };
   bool IsStrerrorTy(void) const
   {
-    return type == Type::strerror;
+    return type_ == Type::strerror;
   };
   bool IsTimestampModeTy(void) const
   {
-    return type == Type::timestamp_mode;
+    return type_ == Type::timestamp_mode;
   }
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -43,15 +43,15 @@ TEST(clang_parser, integers)
   ASSERT_EQ(foo->HasField("y"), true);
   ASSERT_EQ(foo->HasField("z"), true);
 
-  EXPECT_EQ(foo->GetField("x").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("x").type.IsIntTy());
   EXPECT_EQ(foo->GetField("x").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("x").offset, 0);
 
-  EXPECT_EQ(foo->GetField("y").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("y").type.IsIntTy());
   EXPECT_EQ(foo->GetField("y").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("y").offset, 4);
 
-  EXPECT_EQ(foo->GetField("z").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("z").type.IsIntTy());
   EXPECT_EQ(foo->GetField("z").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("z").offset, 8);
 }
@@ -71,19 +71,19 @@ TEST(clang_parser, c_union)
   ASSERT_TRUE(foo->HasField("i"));
   ASSERT_TRUE(foo->HasField("l"));
 
-  EXPECT_EQ(foo->GetField("c").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("c").type.IsIntTy());
   EXPECT_EQ(foo->GetField("c").type.GetSize(), 1U);
   EXPECT_EQ(foo->GetField("c").offset, 0);
 
-  EXPECT_EQ(foo->GetField("s").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("s").type.IsIntTy());
   EXPECT_EQ(foo->GetField("s").type.GetSize(), 2U);
   EXPECT_EQ(foo->GetField("s").offset, 0);
 
-  EXPECT_EQ(foo->GetField("i").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("i").type.IsIntTy());
   EXPECT_EQ(foo->GetField("i").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("i").offset, 0);
 
-  EXPECT_EQ(foo->GetField("l").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("l").type.IsIntTy());
   EXPECT_EQ(foo->GetField("l").type.GetSize(), 8U);
   EXPECT_EQ(foo->GetField("l").offset, 0);
 }
@@ -100,7 +100,7 @@ TEST(clang_parser, c_enum)
   ASSERT_EQ(foo->fields.size(), 1U);
   ASSERT_TRUE(foo->HasField("e"));
 
-  EXPECT_EQ(foo->GetField("e").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("e").type.IsIntTy());
   EXPECT_EQ(foo->GetField("e").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("e").offset, 0);
 }
@@ -154,7 +154,7 @@ TEST(clang_parser, string_array)
   ASSERT_EQ(foo->fields.size(), 1U);
   ASSERT_TRUE(foo->HasField("str"));
 
-  EXPECT_EQ(foo->GetField("str").type.type, Type::string);
+  EXPECT_TRUE(foo->GetField("str").type.IsStringTy());
   EXPECT_EQ(foo->GetField("str").type.GetSize(), 32U);
   EXPECT_EQ(foo->GetField("str").offset, 0);
 }
@@ -232,7 +232,7 @@ TEST(clang_parser, nested_struct_no_type)
   ASSERT_EQ(bar->fields.size(), 1U);
   ASSERT_TRUE(bar->HasField("x"));
 
-  EXPECT_EQ(bar->GetField("x").type.type, Type::integer);
+  EXPECT_TRUE(bar->GetField("x").type.IsIntTy());
   EXPECT_EQ(bar->GetField("x").type.GetSize(), 4U);
   EXPECT_EQ(bar->GetField("x").offset, 0);
 
@@ -240,7 +240,7 @@ TEST(clang_parser, nested_struct_no_type)
   ASSERT_EQ(baz->fields.size(), 1U);
   ASSERT_TRUE(baz->HasField("y"));
 
-  EXPECT_EQ(baz->GetField("y").type.type, Type::integer);
+  EXPECT_TRUE(baz->GetField("y").type.IsIntTy());
   EXPECT_EQ(baz->GetField("y").type.GetSize(), 4U);
   EXPECT_EQ(baz->GetField("y").offset, 0);
 
@@ -279,13 +279,13 @@ TEST(clang_parser, nested_struct_unnamed_fields)
   ASSERT_TRUE(foo->HasField("y"));
   ASSERT_TRUE(foo->HasField("a"));
 
-  EXPECT_EQ(foo->GetField("x").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("x").type.IsIntTy());
   EXPECT_EQ(foo->GetField("x").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("x").offset, 0);
-  EXPECT_EQ(foo->GetField("y").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("y").type.IsIntTy());
   EXPECT_EQ(foo->GetField("y").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("y").offset, 4);
-  EXPECT_EQ(foo->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("a").offset, 8);
 
@@ -293,7 +293,7 @@ TEST(clang_parser, nested_struct_unnamed_fields)
   EXPECT_EQ(bar->fields.size(), 1U);
   EXPECT_TRUE(bar->HasField("z"));
 
-  EXPECT_EQ(bar->GetField("z").type.type, Type::integer);
+  EXPECT_TRUE(bar->GetField("z").type.IsIntTy());
   EXPECT_EQ(bar->GetField("z").type.GetSize(), 4U);
   EXPECT_EQ(bar->GetField("z").offset, 0);
 }
@@ -324,23 +324,23 @@ TEST(clang_parser, nested_struct_anon_union_struct)
   ASSERT_TRUE(foo->HasField("a"));
   ASSERT_TRUE(foo->HasField("z"));
 
-  EXPECT_EQ(foo->GetField("_xy").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("_xy").type.IsIntTy());
   EXPECT_EQ(foo->GetField("_xy").type.GetSize(), 8U);
   EXPECT_EQ(foo->GetField("_xy").offset, 0);
 
-  EXPECT_EQ(foo->GetField("x").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("x").type.IsIntTy());
   EXPECT_EQ(foo->GetField("x").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("x").offset, 0);
 
-  EXPECT_EQ(foo->GetField("y").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("y").type.IsIntTy());
   EXPECT_EQ(foo->GetField("y").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("y").offset, 4);
 
-  EXPECT_EQ(foo->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("a").offset, 8);
 
-  EXPECT_EQ(foo->GetField("z").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("z").type.IsIntTy());
   EXPECT_EQ(foo->GetField("z").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("z").offset, 12);
 }
@@ -359,7 +359,7 @@ TEST(clang_parser, bitfields)
   ASSERT_TRUE(foo->HasField("b"));
   ASSERT_TRUE(foo->HasField("c"));
 
-  EXPECT_EQ(foo->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("a").offset, 0);
   EXPECT_TRUE(foo->GetField("a").bitfield.has_value());
@@ -367,7 +367,7 @@ TEST(clang_parser, bitfields)
   EXPECT_EQ(foo->GetField("a").bitfield->access_rshift, 0U);
   EXPECT_EQ(foo->GetField("a").bitfield->mask, 0xFFU);
 
-  EXPECT_EQ(foo->GetField("b").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("b").type.IsIntTy());
   EXPECT_EQ(foo->GetField("b").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("b").offset, 1);
   EXPECT_TRUE(foo->GetField("b").bitfield.has_value());
@@ -375,7 +375,7 @@ TEST(clang_parser, bitfields)
   EXPECT_EQ(foo->GetField("b").bitfield->access_rshift, 0U);
   EXPECT_EQ(foo->GetField("b").bitfield->mask, 0xFFU);
 
-  EXPECT_EQ(foo->GetField("c").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("c").type.IsIntTy());
   EXPECT_EQ(foo->GetField("c").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("c").offset, 2);
   EXPECT_TRUE(foo->GetField("c").bitfield.has_value());
@@ -400,7 +400,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   ASSERT_TRUE(foo->HasField("d"));
   ASSERT_TRUE(foo->HasField("e"));
 
-  EXPECT_EQ(foo->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("a").offset, 0);
   EXPECT_TRUE(foo->GetField("a").bitfield.has_value());
@@ -408,7 +408,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(foo->GetField("a").bitfield->access_rshift, 0U);
   EXPECT_EQ(foo->GetField("a").bitfield->mask, 0x1U);
 
-  EXPECT_EQ(foo->GetField("b").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("b").type.IsIntTy());
   EXPECT_EQ(foo->GetField("b").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("b").offset, 0);
   EXPECT_TRUE(foo->GetField("b").bitfield.has_value());
@@ -416,7 +416,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(foo->GetField("b").bitfield->access_rshift, 1U);
   EXPECT_EQ(foo->GetField("b").bitfield->mask, 0x1U);
 
-  EXPECT_EQ(foo->GetField("c").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("c").type.IsIntTy());
   EXPECT_EQ(foo->GetField("c").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("c").offset, 0);
   EXPECT_TRUE(foo->GetField("c").bitfield.has_value());
@@ -424,7 +424,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(foo->GetField("c").bitfield->access_rshift, 2U);
   EXPECT_EQ(foo->GetField("c").bitfield->mask, 0x7U);
 
-  EXPECT_EQ(foo->GetField("d").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("d").type.IsIntTy());
   EXPECT_EQ(foo->GetField("d").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("d").offset, 0);
   EXPECT_TRUE(foo->GetField("d").bitfield.has_value());
@@ -432,7 +432,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(foo->GetField("d").bitfield->access_rshift, 5U);
   EXPECT_EQ(foo->GetField("d").bitfield->mask, 0xFFFFFU);
 
-  EXPECT_EQ(foo->GetField("e").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("e").type.IsIntTy());
   EXPECT_EQ(foo->GetField("e").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("e").offset, 3);
   EXPECT_TRUE(foo->GetField("e").bitfield.has_value());
@@ -456,7 +456,7 @@ TEST(clang_parser, bitfields_with_padding)
   ASSERT_TRUE(foo->HasField("b"));
   ASSERT_TRUE(foo->HasField("end"));
 
-  EXPECT_EQ(foo->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("a").offset, 4);
   EXPECT_TRUE(foo->GetField("a").bitfield.has_value());
@@ -464,7 +464,7 @@ TEST(clang_parser, bitfields_with_padding)
   EXPECT_EQ(foo->GetField("a").bitfield->access_rshift, 0U);
   EXPECT_EQ(foo->GetField("a").bitfield->mask, 0xFFFFFFFU);
 
-  EXPECT_EQ(foo->GetField("b").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("b").type.IsIntTy());
   EXPECT_EQ(foo->GetField("b").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("b").offset, 7);
   EXPECT_TRUE(foo->GetField("b").bitfield.has_value());
@@ -488,15 +488,15 @@ TEST(clang_parser, builtin_headers)
   ASSERT_TRUE(foo->HasField("y"));
   ASSERT_TRUE(foo->HasField("z"));
 
-  EXPECT_EQ(foo->GetField("x").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("x").type.IsIntTy());
   EXPECT_EQ(foo->GetField("x").type.GetSize(), 8U);
   EXPECT_EQ(foo->GetField("x").offset, 0);
 
-  EXPECT_EQ(foo->GetField("y").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("y").type.IsIntTy());
   EXPECT_EQ(foo->GetField("y").type.GetSize(), 8U);
   EXPECT_EQ(foo->GetField("y").offset, 8);
 
-  EXPECT_EQ(foo->GetField("z").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("z").type.IsIntTy());
   EXPECT_EQ(foo->GetField("z").type.GetSize(), 8U);
   EXPECT_EQ(foo->GetField("z").offset, 16);
 }
@@ -551,15 +551,15 @@ TEST_F(clang_parser_btf, btf)
   ASSERT_TRUE(foo1->HasField("b"));
   ASSERT_TRUE(foo1->HasField("c"));
 
-  EXPECT_EQ(foo1->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(foo1->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo1->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo1->GetField("a").offset, 0);
 
-  EXPECT_EQ(foo1->GetField("b").type.type, Type::integer);
+  EXPECT_TRUE(foo1->GetField("b").type.IsIntTy());
   EXPECT_EQ(foo1->GetField("b").type.GetSize(), 1U);
   EXPECT_EQ(foo1->GetField("b").offset, 4);
 
-  EXPECT_EQ(foo1->GetField("c").type.type, Type::integer);
+  EXPECT_TRUE(foo1->GetField("c").type.IsIntTy());
   EXPECT_EQ(foo1->GetField("c").type.GetSize(), 8U);
   EXPECT_EQ(foo1->GetField("c").offset, 8);
 
@@ -569,15 +569,15 @@ TEST_F(clang_parser_btf, btf)
   ASSERT_TRUE(foo2->HasField("f"));
   ASSERT_TRUE(foo2->HasField("g"));
 
-  EXPECT_EQ(foo2->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(foo2->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo2->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo2->GetField("a").offset, 0);
 
-  EXPECT_EQ(foo2->GetField("f").type.type, Type::record);
+  EXPECT_TRUE(foo2->GetField("f").type.IsRecordTy());
   EXPECT_EQ(foo2->GetField("f").type.GetSize(), 16U);
   EXPECT_EQ(foo2->GetField("f").offset, 8);
 
-  EXPECT_EQ(foo2->GetField("g").type.type, Type::integer);
+  EXPECT_TRUE(foo2->GetField("g").type.IsIntTy());
   EXPECT_EQ(foo2->GetField("g").type.GetSize(), 1U);
   EXPECT_EQ(foo2->GetField("g").offset, 8);
 
@@ -624,7 +624,7 @@ TEST(clang_parser, btf_unresolved_typedef)
   ASSERT_EQ(foo->fields.size(), 1U);
   ASSERT_TRUE(foo->HasField("x"));
 
-  EXPECT_EQ(foo->GetField("x").type.type, Type::integer);
+  EXPECT_TRUE(foo->GetField("x").type.IsIntTy());
   EXPECT_EQ(foo->GetField("x").type.GetSize(), 8U);
   EXPECT_EQ(foo->GetField("x").offset, 0);
 }
@@ -680,7 +680,7 @@ TEST(clang_parser, struct_typedef)
   ASSERT_EQ(max_align_struct->fields.size(), 1U);
   ASSERT_TRUE(max_align_struct->HasField("x"));
 
-  EXPECT_EQ(max_align_struct->GetField("x").type.type, Type::integer);
+  EXPECT_TRUE(max_align_struct->GetField("x").type.IsIntTy());
   EXPECT_EQ(max_align_struct->GetField("x").type.GetSize(), 4U);
   EXPECT_EQ(max_align_struct->GetField("x").offset, 0);
 
@@ -690,16 +690,16 @@ TEST(clang_parser, struct_typedef)
   ASSERT_TRUE(max_align_typedef->HasField("__clang_max_align_nonce1"));
   ASSERT_TRUE(max_align_typedef->HasField("__clang_max_align_nonce2"));
 
-  EXPECT_EQ(max_align_typedef->GetField("__clang_max_align_nonce1").type.type,
-            Type::integer);
+  EXPECT_TRUE(
+      max_align_typedef->GetField("__clang_max_align_nonce1").type.IsIntTy());
   EXPECT_EQ(
       max_align_typedef->GetField("__clang_max_align_nonce1").type.GetSize(),
       8U);
   EXPECT_EQ(max_align_typedef->GetField("__clang_max_align_nonce1").offset, 0);
 
   // double are not parsed correctly yet so these fields are junk for now
-  EXPECT_EQ(max_align_typedef->GetField("__clang_max_align_nonce2").type.type,
-            Type::none);
+  EXPECT_TRUE(
+      max_align_typedef->GetField("__clang_max_align_nonce2").type.IsNoneTy());
   EXPECT_EQ(
       max_align_typedef->GetField("__clang_max_align_nonce2").type.GetSize(),
       0U);

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -87,19 +87,19 @@ TEST(codegen, printf_offsets)
 
   // Note that scalar types are promoted to 64-bits when put into
   // a perf event buffer
-  EXPECT_EQ(args[0].type.type, Type::integer);
+  EXPECT_TRUE(args[0].type.IsIntTy());
   EXPECT_EQ(args[0].type.GetSize(), 8U);
   EXPECT_EQ(args[0].offset, 8);
 
-  EXPECT_EQ(args[1].type.type, Type::integer);
+  EXPECT_TRUE(args[1].type.IsIntTy());
   EXPECT_EQ(args[1].type.GetSize(), 8U);
   EXPECT_EQ(args[1].offset, 16);
 
-  EXPECT_EQ(args[2].type.type, Type::string);
+  EXPECT_TRUE(args[2].type.IsStringTy());
   EXPECT_EQ(args[2].type.GetSize(), 10U);
   EXPECT_EQ(args[2].offset, 24);
 
-  EXPECT_EQ(args[3].type.type, Type::integer);
+  EXPECT_TRUE(args[3].type.IsIntTy());
   EXPECT_EQ(args[3].type.GetSize(), 8U);
   EXPECT_EQ(args[3].offset, 40);
 }

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -79,15 +79,15 @@ TEST_F(field_analyser_btf, btf_types)
   ASSERT_TRUE(foo1->HasField("b"));
   ASSERT_TRUE(foo1->HasField("c"));
 
-  EXPECT_EQ(foo1->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(foo1->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo1->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo1->GetField("a").offset, 0);
 
-  EXPECT_EQ(foo1->GetField("b").type.type, Type::integer);
+  EXPECT_TRUE(foo1->GetField("b").type.IsIntTy());
   EXPECT_EQ(foo1->GetField("b").type.GetSize(), 1U);
   EXPECT_EQ(foo1->GetField("b").offset, 4);
 
-  EXPECT_EQ(foo1->GetField("c").type.type, Type::integer);
+  EXPECT_TRUE(foo1->GetField("c").type.IsIntTy());
   EXPECT_EQ(foo1->GetField("c").type.GetSize(), 8U);
   EXPECT_EQ(foo1->GetField("c").offset, 8);
 
@@ -97,15 +97,15 @@ TEST_F(field_analyser_btf, btf_types)
   ASSERT_TRUE(foo2->HasField("f"));
   ASSERT_TRUE(foo2->HasField("g"));
 
-  EXPECT_EQ(foo2->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(foo2->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo2->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo2->GetField("a").offset, 0);
 
-  EXPECT_EQ(foo2->GetField("f").type.type, Type::record);
+  EXPECT_TRUE(foo2->GetField("f").type.IsRecordTy());
   EXPECT_EQ(foo2->GetField("f").type.GetSize(), 16U);
   EXPECT_EQ(foo2->GetField("f").offset, 8);
 
-  EXPECT_EQ(foo2->GetField("g").type.type, Type::integer);
+  EXPECT_TRUE(foo2->GetField("g").type.IsIntTy());
   EXPECT_EQ(foo2->GetField("g").type.GetSize(), 1U);
   EXPECT_EQ(foo2->GetField("g").offset, 8);
 
@@ -147,39 +147,37 @@ TEST_F(field_analyser_btf, btf_arrays)
   ASSERT_TRUE(arrs->HasField("zero"));
   ASSERT_TRUE(arrs->HasField("flexible"));
 
-  EXPECT_EQ(arrs->GetField("int_arr").type.type, Type::array);
+  EXPECT_TRUE(arrs->GetField("int_arr").type.IsArrayTy());
   EXPECT_EQ(arrs->GetField("int_arr").type.GetNumElements(), 4);
-  EXPECT_EQ(arrs->GetField("int_arr").type.GetElementTy()->type, Type::integer);
+  EXPECT_TRUE(arrs->GetField("int_arr").type.GetElementTy()->IsIntTy());
   EXPECT_EQ(arrs->GetField("int_arr").type.GetSize(), 16U);
   EXPECT_EQ(arrs->GetField("int_arr").offset, 0);
 
-  EXPECT_EQ(arrs->GetField("char_arr").type.type, Type::string);
+  EXPECT_TRUE(arrs->GetField("char_arr").type.IsStringTy());
   EXPECT_EQ(arrs->GetField("char_arr").type.GetSize(), 8U);
   EXPECT_EQ(arrs->GetField("char_arr").offset, 16);
 
-  EXPECT_EQ(arrs->GetField("ptr_arr").type.type, Type::array);
+  EXPECT_TRUE(arrs->GetField("ptr_arr").type.IsArrayTy());
   EXPECT_EQ(arrs->GetField("ptr_arr").type.GetNumElements(), 2);
-  EXPECT_EQ(arrs->GetField("ptr_arr").type.GetElementTy()->type, Type::pointer);
+  EXPECT_TRUE(arrs->GetField("ptr_arr").type.GetElementTy()->IsPtrTy());
   EXPECT_EQ(arrs->GetField("ptr_arr").type.GetSize(), 2 * sizeof(uintptr_t));
   EXPECT_EQ(arrs->GetField("ptr_arr").offset, 24);
 
-  EXPECT_EQ(arrs->GetField("multi_dim").type.type, Type::array);
+  EXPECT_TRUE(arrs->GetField("multi_dim").type.IsArrayTy());
   EXPECT_EQ(arrs->GetField("multi_dim").type.GetNumElements(), 6);
-  EXPECT_EQ(arrs->GetField("multi_dim").type.GetElementTy()->type,
-            Type::integer);
+  EXPECT_TRUE(arrs->GetField("multi_dim").type.GetElementTy()->IsIntTy());
   EXPECT_EQ(arrs->GetField("multi_dim").type.GetSize(), 24U);
   EXPECT_EQ(arrs->GetField("multi_dim").offset, 40);
 
-  EXPECT_EQ(arrs->GetField("zero").type.type, Type::array);
+  EXPECT_TRUE(arrs->GetField("zero").type.IsArrayTy());
   EXPECT_EQ(arrs->GetField("zero").type.GetNumElements(), 0);
-  EXPECT_EQ(arrs->GetField("zero").type.GetElementTy()->type, Type::integer);
+  EXPECT_TRUE(arrs->GetField("zero").type.GetElementTy()->IsIntTy());
   EXPECT_EQ(arrs->GetField("zero").type.GetSize(), 0U);
   EXPECT_EQ(arrs->GetField("zero").offset, 64);
 
-  EXPECT_EQ(arrs->GetField("flexible").type.type, Type::array);
+  EXPECT_TRUE(arrs->GetField("flexible").type.IsArrayTy());
   EXPECT_EQ(arrs->GetField("flexible").type.GetNumElements(), 0);
-  EXPECT_EQ(arrs->GetField("flexible").type.GetElementTy()->type,
-            Type::integer);
+  EXPECT_TRUE(arrs->GetField("flexible").type.GetElementTy()->IsIntTy());
   EXPECT_EQ(arrs->GetField("flexible").type.GetSize(), 0U);
   EXPECT_EQ(arrs->GetField("flexible").offset, 64);
 }
@@ -220,7 +218,7 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   auto task_struct = bpftrace.structs.Lookup("struct task_struct").lock();
 
   ASSERT_TRUE(task_struct->HasField("a"));
-  EXPECT_EQ(task_struct->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(task_struct->GetField("a").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(task_struct->GetField("a").offset, 9);
   EXPECT_TRUE(task_struct->GetField("a").bitfield.has_value());
@@ -229,7 +227,7 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   EXPECT_EQ(task_struct->GetField("a").bitfield->mask, 0xFFU);
 
   ASSERT_TRUE(task_struct->HasField("b"));
-  EXPECT_EQ(task_struct->GetField("b").type.type, Type::integer);
+  EXPECT_TRUE(task_struct->GetField("b").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("b").type.GetSize(), 4U);
   EXPECT_EQ(task_struct->GetField("b").offset, 10);
   EXPECT_TRUE(task_struct->GetField("b").bitfield.has_value());
@@ -238,7 +236,7 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   EXPECT_EQ(task_struct->GetField("b").bitfield->mask, 0x1U);
 
   ASSERT_TRUE(task_struct->HasField("c"));
-  EXPECT_EQ(task_struct->GetField("c").type.type, Type::integer);
+  EXPECT_TRUE(task_struct->GetField("c").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("c").type.GetSize(), 4U);
   EXPECT_EQ(task_struct->GetField("c").offset, 10);
   EXPECT_TRUE(task_struct->GetField("c").bitfield.has_value());
@@ -247,7 +245,7 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   EXPECT_EQ(task_struct->GetField("c").bitfield->mask, 0x7U);
 
   ASSERT_TRUE(task_struct->HasField("d"));
-  EXPECT_EQ(task_struct->GetField("d").type.type, Type::integer);
+  EXPECT_TRUE(task_struct->GetField("d").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("d").type.GetSize(), 4U);
   EXPECT_EQ(task_struct->GetField("d").offset, 12);
   EXPECT_TRUE(task_struct->GetField("d").bitfield.has_value());
@@ -267,17 +265,17 @@ TEST_F(field_analyser_btf, btf_anon_union_first_in_struct)
       bpftrace.structs.Lookup("struct FirstFieldsAreAnonUnion").lock();
 
   ASSERT_TRUE(record->HasField("a"));
-  EXPECT_EQ(record->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(record->GetField("a").type.IsIntTy());
   EXPECT_EQ(record->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(record->GetField("a").offset, 0);
 
   ASSERT_TRUE(record->HasField("b"));
-  EXPECT_EQ(record->GetField("b").type.type, Type::integer);
+  EXPECT_TRUE(record->GetField("b").type.IsIntTy());
   EXPECT_EQ(record->GetField("b").type.GetSize(), 4U);
   EXPECT_EQ(record->GetField("b").offset, 0);
 
   ASSERT_TRUE(record->HasField("c"));
-  EXPECT_EQ(record->GetField("c").type.type, Type::integer);
+  EXPECT_TRUE(record->GetField("c").type.IsIntTy());
   EXPECT_EQ(record->GetField("c").type.GetSize(), 4U);
   EXPECT_EQ(record->GetField("c").offset, 4);
 }
@@ -356,7 +354,7 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   auto task_struct = bpftrace.structs.Lookup("struct task_struct").lock();
 
   ASSERT_TRUE(task_struct->HasField("a"));
-  EXPECT_EQ(task_struct->GetField("a").type.type, Type::integer);
+  EXPECT_TRUE(task_struct->GetField("a").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("a").type.GetSize(), 4U);
   EXPECT_TRUE(task_struct->GetField("a").bitfield.has_value());
 
@@ -373,7 +371,7 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   }
 
   ASSERT_TRUE(task_struct->HasField("b"));
-  EXPECT_EQ(task_struct->GetField("b").type.type, Type::integer);
+  EXPECT_TRUE(task_struct->GetField("b").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("b").type.GetSize(), 4U);
   EXPECT_TRUE(task_struct->GetField("b").bitfield.has_value());
 
@@ -390,7 +388,7 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   }
 
   ASSERT_TRUE(task_struct->HasField("c"));
-  EXPECT_EQ(task_struct->GetField("c").type.type, Type::integer);
+  EXPECT_TRUE(task_struct->GetField("c").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("c").type.GetSize(), 4U);
   EXPECT_TRUE(task_struct->GetField("c").bitfield.has_value());
 
@@ -408,7 +406,7 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   }
 
   ASSERT_TRUE(task_struct->HasField("d"));
-  EXPECT_EQ(task_struct->GetField("d").type.type, Type::integer);
+  EXPECT_TRUE(task_struct->GetField("d").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("d").type.GetSize(), 4U);
   EXPECT_EQ(task_struct->GetField("d").offset, 12);
   EXPECT_TRUE(task_struct->GetField("d").bitfield.has_value());


### PR DESCRIPTION
The "type" member of the SizedType class is currently public, making it  possible to modify it without updating required fields. This commit changes  it to private "type_", and you can access it through the "GetTy()" getter.

Resolves #1397

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
