### PR TITLE
Config: update lexer to match string start

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -73,6 +73,7 @@ oct_esc  [0-7]{1,3}
 }
 
 bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, loc); }
+^{space}*config         { return Parser::make_CONFIG(loc); }
 {builtin}               { return Parser::make_BUILTIN(yytext, loc); }
 {call}                  { return Parser::make_CALL(yytext, loc); }
 {call_and_builtin}      { return Parser::make_CALL_BUILTIN(yytext, loc); }
@@ -143,7 +144,6 @@ bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, loc); }
 "?"                     { return Parser::make_QUES(loc); }
 "unroll"                { return Parser::make_UNROLL(loc); }
 "while"                 { return Parser::make_WHILE(loc); }
-"config"                { return Parser::make_CONFIG(loc); }
 "for"                   { return Parser::make_FOR(loc); }
 "return"                { return Parser::make_RETURN(loc); }
 "continue"              { return Parser::make_CONTINUE(loc); }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2021,6 +2021,13 @@ TEST(Parser, config_error)
                      "BPFTRACE_MAX_PROBES=2; exit(); }");
   test_parse_failure("config { BPFTRACE_STACK_MODE=perf } i:s:1 { exit(); }");
   test_parse_failure("BPFTRACE_STACK_MODE=perf; i:s:1 { exit(); }");
+
+  test("        config = { BPFTRACE_STACK_MODE=perf } i:s:1 { exit(); }",
+       "Program\n config\n  =\n   config var: BPFTRACE_STACK_MODE\n   "
+       "stack_mode: perf\n interval:s:1\n  call: exit\n");
+  test("BEGIN { $x = (struct Foo*)0; $x->config; }",
+       "Program\n BEGIN\n  =\n   variable: $x\n   (struct Foo *)\n    int: 0\n "
+       " .\n   dereference\n    variable: $x\n   config\n");
 }
 
 } // namespace parser


### PR DESCRIPTION
To prevent this error only match against "config"
keyword if it's the start of the string:

```
bpftrace -e 'struct Foo {int config;} BEGIN { $x = (struct Foo*)0; $x->config; }' -d
stdin:1:56-66: ERROR: syntax error, unexpected config
struct Foo {int config;} BEGIN { $x = (struct Foo*)0; $x->config; }
```

This should be fine since the config block needs
to be at the top and start the line.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
