### PR TITLE
Runtime tests: Make EXPECT only match exact lines of output

### DIFF
--- a/tests/runtime/addrspace
+++ b/tests/runtime/addrspace
@@ -1,5 +1,5 @@
 NAME openat uptr
 RUN {{BPFTRACE}} -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { print(str(uptr(args.filename))) }' -c "./testprogs/syscall openat"
-EXPECT bpftrace_runtime_test_syscall
+EXPECT_REGEX ^.*/bpftrace_runtime_test_syscall_gen_open_temp$
 REQUIRES_FEATURE probe_read_kernel
 TIMEOUT 5

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -12,7 +12,7 @@ AFTER ./testprogs/array_access
 
 NAME array element access - out of bounds
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[5]; printf("%d\n", $x); exit(); }
-EXPECT the index 5 is out of bounds for array of size 4
+EXPECT stdin:1:100-108: ERROR: the index 5 is out of bounds for array of size 4
 TIMEOUT 5
 AFTER ./testprogs/array_access
 WILL_FAIL
@@ -37,31 +37,31 @@ AFTER ./testprogs/array_access
 
 NAME array assignment into map
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; exit(); }
-EXPECT @a: \[1,2,3,4\]
+EXPECT @a: [1,2,3,4]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a map key
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x] = 0; exit(); }
-EXPECT @x\[\[1,2,3,4\]\]: 0
+EXPECT @x[[1,2,3,4]]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a part of map multikey
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x, 42] = 0; exit(); }
-EXPECT @x\[\[1,2,3,4\], 42\]: 0
+EXPECT @x[[1,2,3,4], 42]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a map key assigned from another map
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; @x[@a] = 0; exit(); }
-EXPECT @x\[\[1,2,3,4\]\]: 0
+EXPECT @x[[1,2,3,4]]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array in a tuple
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x = (1, ((struct A *) arg0)->x); exit(); }
-EXPECT @x: \(1, \[1,2,3,4\]\)
+EXPECT @x: (1, [1,2,3,4])
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
@@ -91,19 +91,19 @@ AFTER ./testprogs/array_access
 
 NAME multi-dimensional array assignment into map
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; exit(); }
-EXPECT @b: \[\[5,6\],\[7,8\]\]
+EXPECT @b: [[5,6],[7,8]]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array as a map key
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @x[((struct B *) arg1)->y] = 0; exit(); }
-EXPECT @x\[\[\[5,6\],\[7,8\]\]]: 0
+EXPECT @x[[[5,6],[7,8]]]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array as a map key assigned from another map
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; @x[@b] = 0; exit(); }
-EXPECT @x\[\[\[5,6\],\[7,8\]\]]: 0
+EXPECT @x[[[5,6],[7,8]]]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 

--- a/tests/runtime/banned_probes
+++ b/tests/runtime/banned_probes
@@ -1,23 +1,23 @@
 NAME kretprobe:_raw_spin_lock is banned
 PROG kretprobe:_raw_spin_lock { exit(); }
-EXPECT error: kretprobe:_raw_spin_lock can't be used as it might lock up your system.
+EXPECT ERROR: error: kretprobe:_raw_spin_lock can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL
 
 NAME kretprobe:queued_spin_lock_slowpath is banned
 PROG kretprobe:queued_spin_lock_slowpath { exit(); }
-EXPECT error: kretprobe:queued_spin_lock_slowpath can't be used as it might lock up your system.
+EXPECT ERROR: error: kretprobe:queued_spin_lock_slowpath can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL
 
 NAME kretprobe:_raw_spin_unlock_irqrestore is banned
 PROG kretprobe:_raw_spin_unlock_irqrestore { exit(); }
-EXPECT error: kretprobe:_raw_spin_unlock_irqrestore can't be used as it might lock up your system.
+EXPECT ERROR: error: kretprobe:_raw_spin_unlock_irqrestore can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL
 
 NAME kretprobe:_raw_spin_lock_irqsave is banned
 PROG kretprobe:_raw_spin_lock_irqsave { exit(); }
-EXPECT error: kretprobe:_raw_spin_lock_irqsave can't be used as it might lock up your system.
+EXPECT ERROR: error: kretprobe:_raw_spin_lock_irqsave can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -1,16 +1,16 @@
 NAME it shows version
 RUN {{BPFTRACE}} --version
-EXPECT bpftrace v
+EXPECT_REGEX ^bpftrace v\d
 TIMEOUT 1
 
 NAME it shows usage with help flag
 RUN {{BPFTRACE}} -h
-EXPECT USAGE
+EXPECT USAGE:
 TIMEOUT 1
 
 NAME it shows usage with bad flag
 RUN {{BPFTRACE}} -idonotexist
-EXPECT USAGE
+EXPECT USAGE:
 TIMEOUT 1
 WILL_FAIL
 
@@ -27,61 +27,61 @@ TIMEOUT 1
 
 NAME it lists kprobes
 RUN {{BPFTRACE}} -l | grep kprobes
-EXPECT kprobe
+EXPECT_REGEX kprobe:.*
 TIMEOUT 1
 
 NAME it lists tracepoints
 RUN {{BPFTRACE}} -l | grep tracepoint
-EXPECT tracepoint
+EXPECT_REGEX tracepoint:.*
 TIMEOUT 1
 
 NAME it lists software events
 RUN {{BPFTRACE}} -l | grep software
-EXPECT software
+EXPECT_REGEX software:.*
 TIMEOUT 1
 
 NAME it lists hardware events
 RUN {{BPFTRACE}} -l | grep hardware
-EXPECT hardware
+EXPECT_REGEX hardware:.*
 TIMEOUT 1
 
 NAME it lists kfuncs
 RUN {{BPFTRACE}} -l | grep kfunc
-EXPECT kfunc
+EXPECT_REGEX kfunc:.*
 REQUIRES_FEATURE btf
 REQUIRES_FEATURE kfunc
 TIMEOUT 1
 
 NAME it lists rawtracepoints
 RUN {{BPFTRACE}} -l | grep rawtracepoint
-EXPECT rawtracepoint
+EXPECT_REGEX rawtracepoint:.*
 TIMEOUT 1
 
 NAME it lists kfunc params
 RUN {{BPFTRACE}} -lv "kfunc:*"
-EXPECT [ ]+[a-zA-Z_\*\s]+
+EXPECT_REGEX [ ]+[a-zA-Z_\*\s]+
 REQUIRES_FEATURE btf
 REQUIRES_FEATURE kfunc
 TIMEOUT 1
 
 NAME it lists kprobes with regex filter
 RUN {{BPFTRACE}} -l "kprobe:*"
-EXPECT kprobe:
+EXPECT_REGEX kprobe:.*
 TIMEOUT 1
 
 NAME it lists kretprobes with regex filter
 RUN {{BPFTRACE}} -l "kretprobe:*"
-EXPECT kretprobe:
+EXPECT_REGEX kretprobe:.*
 TIMEOUT 1
 
 NAME it lists uprobes with regex filter
 RUN {{BPFTRACE}} -l "uprobe:./testprogs/syscall:*"
-EXPECT uprobe:
+EXPECT_REGEX uprobe:.*
 TIMEOUT 1
 
 NAME it lists uretprobes with regex filter
 RUN {{BPFTRACE}} -l "uretprobe:./testprogs/syscall:*"
-EXPECT uretprobe:
+EXPECT_REGEX uretprobe:.*
 TIMEOUT 1
 
 NAME it lists tracepoints with regex filter
@@ -91,47 +91,53 @@ TIMEOUT 1
 
 NAME it lists software events with regex filter
 RUN {{BPFTRACE}} -l "software:*"
-EXPECT software:cpu
+EXPECT software:cpu:
 TIMEOUT 1
 
 NAME it lists hardware events with regex filter
 RUN {{BPFTRACE}} -l "hardware:*"
-EXPECT hardware:cpu
+EXPECT hardware:cpu-cycles:
 TIMEOUT 1
 
 NAME it lists kfuncs events with regex filter
 RUN {{BPFTRACE}} -l "kfunc:*"
-EXPECT kfunc
+EXPECT_REGEX kfunc:.*
 REQUIRES_FEATURE btf
 REQUIRES_FEATURE kfunc
 TIMEOUT 1
 
 NAME it lists kretfuncs events with regex filter
 RUN {{BPFTRACE}} -l "kretfunc:*"
-EXPECT kretfunc
+EXPECT_REGEX kretfunc:.*
 REQUIRES_FEATURE btf
 REQUIRES_FEATURE kfunc
 TIMEOUT 1
 
 NAME it lists interval probes with regex filter
 RUN {{BPFTRACE}} -l "interval:*"
-EXPECT interval:s
+EXPECT interval:hz:
+EXPECT interval:us:
+EXPECT interval:ms:
+EXPECT interval:s:
 TIMEOUT 1
 
 NAME it lists profile probes with regex filter
 RUN {{BPFTRACE}} -l "profile:*"
-EXPECT profile:*
+EXPECT profile:hz:
+EXPECT profile:us:
+EXPECT profile:ms:
+EXPECT profile:s:
 TIMEOUT 1
 
 NAME listing with wildcarded probe type
 RUN {{BPFTRACE}} -l "*ware:*"
-EXPECT hardware:
-EXPECT software:
+EXPECT_REGEX hardware:.*
+EXPECT_REGEX software:.*
 TIMEOUT 1
 
 NAME it lists rawtracepoint with regex filter
 RUN {{BPFTRACE}} -l "rawtracepoint:*"
-EXPECT rawtracepoint:
+EXPECT_REGEX rawtracepoint:.*
 TIMEOUT 1
 
 NAME it only lists probes in the program
@@ -142,18 +148,19 @@ TIMEOUT 5
 
 NAME it lists uprobes in the program
 RUN {{BPFTRACE}} -l -e 'uretprobe:*:uprobeFunction* { exit(); }' -p {{BEFORE_PID}}
-EXPECT uretprobe:[\S]+uprobe_test:uprobeFunction1
+EXPECT_REGEX uretprobe:[\S]+uprobe_test:uprobeFunction1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME it lists multiple probes in the program
 RUN {{BPFTRACE}} -l -e 'hardware:cache-misses:10 { exit(); } tracepoint:xdp:mem_connect { exit(); }'
-EXPECT hardware:cache-misses:\ntracepoint:xdp:mem_connect
+EXPECT hardware:cache-misses:
+EXPECT tracepoint:xdp:mem_connect
 TIMEOUT 5
 
 NAME errors on invalid character in search expression
 RUN {{BPFTRACE}} -l '\n'
-EXPECT ERROR: invalid character
+EXPECT stdin:1:1-2: ERROR: invalid character '\'
 TIMEOUT 1
 WILL_FAIL
 
@@ -177,24 +184,24 @@ WILL_FAIL
 
 NAME pid outside of valid pid range
 RUN {{BPFTRACE}} -p 5000000 file.bt
-EXPECT ERROR: pid '5000000' out of valid pid range \[1,4194304\]
+EXPECT ERROR: pid '5000000' out of valid pid range [1,4194304]
 TIMEOUT 1
 WILL_FAIL
 
 NAME libraries under /usr/include are in the search path
 RUN {{BPFTRACE}} -e "$(echo "#include <sys/xattr.h>"; echo "BEGIN { exit(); }")" 2>&1
-EXPECT ^((?!file not found).)*$
+EXPECT_NONE file not found
 REQUIRES ls /usr/include/sys/xattr.h
 TIMEOUT 1
 
 NAME non existent library include fails
 RUN {{BPFTRACE}} -e "$(echo "#include <lol/no.h>"; echo "BEGIN { exit(); }")" 2>&1
-EXPECT file not found
+EXPECT definitions.h:2:10: fatal error: 'lol/no.h' file not found
 TIMEOUT 1
 WILL_FAIL
 
 NAME defines work
-RUN {{BPFTRACE}} -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\\n", _UNDERSCORE); exit(); }')"
+RUN {{BPFTRACE}} -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\n", _UNDERSCORE); exit(); }')"
 EXPECT 314
 TIMEOUT 1
 
@@ -235,7 +242,7 @@ TIMEOUT 1
 
 NAME spawn child
 RUN {{BPFTRACE}} -e 'i:ms:500 { printf("%d\n", cpid); }' -c './testprogs/syscall nanosleep 1e9'
-EXPECT [0-9]+
+EXPECT_REGEX [0-9]+
 TIMEOUT 3
 
 NAME info flag
@@ -251,12 +258,12 @@ REQUIRES_FEATURE loop
 
 NAME disable warnings
 RUN {{BPFTRACE}} --no-warnings -e 'BEGIN { @x = stats(10); print(@x, 2); clear(@x); exit();}' 2>&1| grep -c -E "WARNING|invalid option"
-EXPECT ^0$
+EXPECT_REGEX ^0$
 TIMEOUT 1
 WILL_FAIL
 
 NAME kaddr fails
 PROG BEGIN { print(kaddr("asdfzzzzzzz")) }
-EXPECT Failed to resolve kernel symbol
+EXPECT ERROR: Failed to compile: Failed to resolve kernel symbol: asdfzzzzzzz
 TIMEOUT 1
 WILL_FAIL

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -18,19 +18,19 @@ REQUIRES_FEATURE btf
 
 NAME enum_value_reference
 PROG BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }
-EXPECT ^8$
+EXPECT_REGEX ^8$
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME redefine_btf_type
 PROG struct task_struct { int x; } BEGIN { printf("%d\n", curtask->x); exit() }
-EXPECT -?[0-9][0-9]*
+EXPECT_REGEX -?[0-9][0-9]*
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME redefine_btf_type_missing_def
 PROG struct task_struct { struct thread_info x; } BEGIN { printf("%d\n", curtask->x.status); }
-EXPECT error:.*'struct thread_info'
+EXPECT_REGEX error:.*'struct thread_info'
 TIMEOUT 5
 REQUIRES_FEATURE btf
 WILL_FAIL
@@ -58,7 +58,7 @@ CLEANUP nft delete table bpftrace
 NAME kernel_module_args
 RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("size: %d\n", args.size); exit(); }'
 AFTER /usr/sbin/nft add table bpftrace
-EXPECT size: [0-9]+
+EXPECT_REGEX size: [0-9]+
 TIMEOUT 5
 REQUIRES_FEATURE kfunc
 REQUIRES lsmod | grep '^nf_tables'
@@ -68,7 +68,7 @@ CLEANUP nft delete table bpftrace
 NAME kernel_module_types
 RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("portid: %d\n", args.ctx->portid); exit(); }'
 AFTER /usr/sbin/nft add table bpftrace
-EXPECT portid: [0-9]+
+EXPECT_REGEX portid: [0-9]+
 TIMEOUT 5
 REQUIRES_FEATURE kfunc
 REQUIRES lsmod | grep '^nf_tables'

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -1,41 +1,41 @@
 NAME pid
 PROG i:ms:1 { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 
 NAME tid
 PROG i:ms:1 { printf("SUCCESS %d\n", tid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 
 NAME uid
 PROG i:ms:1 { printf("SUCCESS %d\n", uid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 
 NAME gid
 PROG i:ms:1 { printf("SUCCESS %d\n", gid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 
 NAME nsecs
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME elapsed
 PROG i:ms:1 { printf("SUCCESS %llu\n", elapsed); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME numaid
 PROG i:ms:1 { printf("SUCCESS %lu\n", numaid); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME cpu
 PROG i:ms:1 { printf("SUCCESS %lu\n", cpu); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME comm
@@ -45,17 +45,17 @@ TIMEOUT 5
 
 NAME kstack
 PROG BEGIN { printf("%s\n", kstack); exit(); }
-EXPECT Attaching 1 probe
+EXPECT Attaching 1 probe...
 TIMEOUT 5
 
 NAME ustack
 PROG BEGIN { printf("%s\n", ustack); exit(); }
-EXPECT Attaching 1 probe
+EXPECT Attaching 1 probe...
 TIMEOUT 5
 
 NAME arg
 PROG k:vfs_read { printf("SUCCESS %p\n", arg0); exit(); }
-EXPECT SUCCESS 0x[0-9a-f]+
+EXPECT_REGEX ^SUCCESS 0x[0-9a-f]+$
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
@@ -89,19 +89,19 @@ AFTER ./testprogs/stack_args
 
 NAME retval
 PROG kretprobe:vfs_read { printf("SUCCESS %d\n", retval); exit(); }
-EXPECT SUCCESS .*
+EXPECT_REGEX SUCCESS .*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME func
 PROG k:vfs_read { printf("SUCCESS %s\n", func); exit(); }
-EXPECT SUCCESS .*
+EXPECT_REGEX SUCCESS .*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME func_uprobe
 PROG uprobe:./testprogs/uprobe_negative_retval:function1 { printf("SUCCESS %s\n", func); exit(); }
-EXPECT SUCCESS .*
+EXPECT_REGEX SUCCESS .*
 AFTER ./testprogs/uprobe_negative_retval
 TIMEOUT 5
 
@@ -124,7 +124,7 @@ TIMEOUT 5
 
 NAME username
 PROG i:ms:1 { printf("SUCCESS %s\n", username); exit(); }
-EXPECT SUCCESS .*
+EXPECT_REGEX SUCCESS .*
 TIMEOUT 5
 
 NAME probe
@@ -135,127 +135,128 @@ AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME begin probe
 PROG BEGIN { printf("%s", probe);exit(); } END{printf("-%s\n", probe); }
-EXPECT ^BEGIN-END$
+EXPECT_REGEX ^BEGIN-END$
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME curtask
 PROG i:ms:1 { printf("SUCCESS %p\n", curtask); exit(); }
-EXPECT SUCCESS 0x[0-9a-f]+
+EXPECT_REGEX SUCCESS 0x[0-9a-f]+
 TIMEOUT 5
 
 NAME curtask_field
 PROG struct task_struct {int x;} i:ms:1 { printf("SUCCESS %d\n", curtask->x); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+EXPECT_REGEX SUCCESS -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME rand
 PROG i:ms:1 { printf("SUCCESS %lu\n", rand); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME cgroup
 PROG i:ms:1 { printf("SUCCESS %llu\n", cgroup); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 MIN_KERNEL 4.18
 
 NAME ctx
 PROG struct x {unsigned long x}; i:ms:1 { printf("SUCCESS %lu\n", ((struct x*)ctx)->x); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME cat
 PROG i:ms:1 { cat("/proc/loadavg"); exit(); }
-EXPECT ^([0-9]+\.[0-9]+ ?)+.*$
+EXPECT_REGEX ^([0-9]+\.[0-9]+ ?)+.*$
 TIMEOUT 5
 
 NAME cat limited output
 ENV BPFTRACE_MAX_CAT_BYTES=1
 PROG i:ms:1 { cat("/proc/loadavg"); exit(); }
-EXPECT ^[0-9]$
+EXPECT_REGEX ^[0-9]$
 TIMEOUT 5
 
 NAME cat format str
 PROG i:ms:1 { $s = "loadavg"; cat("/proc/%s", $s); exit(); }
-EXPECT ^([0-9]+\.[0-9]+ ?)+.*$
+EXPECT_REGEX ^([0-9]+\.[0-9]+ ?)+.*$
 TIMEOUT 5
 
 NAME log size too small
 ENV BPFTRACE_LOG_SIZE=0
 RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
-EXPECT Error loading program: BEGIN
+EXPECT ERROR: Error loading program: BEGIN (try -v)
 TIMEOUT 5
 WILL_FAIL
 
 NAME increase log size
+ENV BPFTRACE_LOG_SIZE=10000000
 RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
-EXPECT ^Attaching 1 probe
+EXPECT hello
 TIMEOUT 5
 
 NAME cat "no such file"
 PROG i:ms:1 { cat("/does/not/exist/file"); exit(); }
-EXPECT ^ERROR: failed to open file '/does/not/exist/file': No such file or directory$
+EXPECT ERROR: failed to open file '/does/not/exist/file': No such file or directory
 TIMEOUT 5
 
 NAME sizeof
 PROG struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x)); exit(); }
-EXPECT ^8 4 1 8 8$
+EXPECT 8 4 1 8 8
 TIMEOUT 5
 
 NAME sizeof_ints
 PROG BEGIN { printf("%d %d %d %d %d %d\n", sizeof(uint8), sizeof(int8), sizeof(uint16), sizeof(int16), sizeof(uint32), sizeof(int32)); exit(); }
-EXPECT ^1 1 2 2 4 4$
+EXPECT 1 1 2 2 4 4
 TIMEOUT 5
 
 # printf only takes 7 args
 NAME sizeof_ints_pt2
 PROG BEGIN { printf("%d %d\n", sizeof(uint64), sizeof(int64)); exit(); }
-EXPECT ^8 8$
+EXPECT 8 8
 TIMEOUT 5
 
 NAME sizeof_btf
 PROG BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }
-EXPECT ^size=
+EXPECT_REGEX ^size=
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME offsetof
 PROG struct Foo { int x; long l; char c; } BEGIN { printf("%ld\n", offsetof(struct Foo, x)); exit(); }
-EXPECT ^0$
+EXPECT_REGEX ^0$
 TIMEOUT 5
 
 NAME print args in kfunc
 PROG kfunc:vfs_open { print(args); exit(); }
-EXPECT { .path = 0x[0-9a-f]+, .file = 0x[0-9a-f]+ }
+EXPECT_REGEX { .path = 0x[0-9a-f]+, .file = 0x[0-9a-f]+ }
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall open
 
 NAME args in kfunc store in map
 PROG kfunc:vfs_open { @= args; exit(); }
-EXPECT @: { .path = 0x[0-9a-f]+, .file = 0x[0-9a-f]+ }
+EXPECT_REGEX @: { .path = 0x[0-9a-f]+, .file = 0x[0-9a-f]+ }
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall open
 
 NAME args in kfunc as a map key
 PROG kfunc:vfs_open { @[args] = 1; exit(); }
-EXPECT @[{.path=0x[0-9a-f]+,.file=0x[0-9a-f]+}]: 1
+EXPECT_REGEX @[{.path=0x[0-9a-f]+,.file=0x[0-9a-f]+}]: 1
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall open
 
 NAME args in uprobe print
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { print(args); exit(); }
-EXPECT { .n = 0x[0-9a-f]+, .c = 120 }
+EXPECT_REGEX { .n = 0x[0-9a-f]+, .c = 120 }
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME args in uprobe store in map
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = args; exit(); }
-EXPECT @: { .n = 0x[0-9a-f]+, .c = 120 }
+EXPECT_REGEX @: { .n = 0x[0-9a-f]+, .c = 120 }
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
@@ -269,14 +270,14 @@ BEFORE ./testprogs/uprobe_test
 
 NAME args in uprobe as a map key
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @[args] = 1; exit(); }
-EXPECT @[{.n=0x[0-9a-f]+,.c=120}]: 1
+EXPECT_REGEX @[{.n=0x[0-9a-f]+,.c=120}]: 1
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME jiffies
 PROG i:ms:1 { printf("SUCCESS %llu\n", jiffies); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 REQUIRES_FEATURE jiffies64
 TIMEOUT 5
 MIN_KERNEL 5.9

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -5,7 +5,7 @@ TIMEOUT 5
 
 NAME printf_long_fmt
 PROG i:ms:1 { printf("hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!\n"); exit();}
-EXPECT ^hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!
+EXPECT hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!
 TIMEOUT 5
 
 NAME printf_argument
@@ -24,7 +24,7 @@ EXPECT 123 hello 456 world
 TIMEOUT 5
 
 NAME printf_more_arguments
-PROG BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd"); exit(); }
+PROG BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd"); exit(); }
 EXPECT 1st: aa; 2nd: abb;; 3rd: abcc;;; 4th: abcdd;;;;
 TIMEOUT 5
 
@@ -40,12 +40,12 @@ TIMEOUT 5
 
 NAME time
 PROG i:ms:1 { time("%H:%M:%S\n"); exit();}
-EXPECT [0-9]*:[0-9]*:[0-9]*
+EXPECT_REGEX [0-9]*:[0-9]*:[0-9]*
 TIMEOUT 5
 
 NAME time_short
 PROG i:ms:1 { time("%H-%M:%S\n"); exit();}
-EXPECT [0-9]*-[0-9]*
+EXPECT_REGEX [0-9]*-[0-9]*
 TIMEOUT 5
 
 NAME join
@@ -61,48 +61,48 @@ TIMEOUT 5
 NAME str
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
 AFTER ./testprogs/syscall execve /bin/ls
-EXPECT P: /*.
+EXPECT_REGEX P: /*.
 TIMEOUT 5
 
 NAME str_truncated
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
 ENV BPFTRACE_MAX_STRLEN=5
 AFTER ./testprogs/syscall execve /bin/ls &>/dev/null
-EXPECT P: /...\.\.
+EXPECT_REGEX P: /...\.\.
 TIMEOUT 5
 
 NAME str_truncated_custom
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
 ENV BPFTRACE_MAX_STRLEN=5 BPFTRACE_STR_TRUNC_TRAILER=_xxx
 AFTER ./testprogs/syscall execve /bin/ls &>/dev/null
-EXPECT P: /..._xxx
+EXPECT_REGEX P: /..._xxx
 TIMEOUT 5
 
 NAME buf
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
-EXPECT P: \\x09\\x08\\x07\\x06-\\x05\\x04\\x03\\x02-\\x01\\x02\\x03\\x04-\\x05\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x08\\x00\\x00\\x00-\\x09\\x00\\x0a\\x00\\x0b\\x00\\x0c\\x00-\\x0d\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0e\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00
+EXPECT P: \x09\x08\x07\x06-\x05\x04\x03\x02-\x01\x02\x03\x04-\x05\x00\x00\x00\x06\x00\x00\x00\x07\x00\x00\x00\x08\x00\x00\x00-\x09\x00\x0a\x00\x0b\x00\x0c\x00-\x0d\x00\x00\x00\x00\x00\x00\x00\x0e\x00\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00
 TIMEOUT 5
 ARCH x86_64|ppc64le|aarch64|armv7l
 
 NAME buf
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
-EXPECT P: \\x09\\x08\\x07\\x06-\\x05\\x04\\x03\\x02-\\x01\\x02\\x03\\x04-\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x08-\\x00\\x09\\x00\\x0a\\x00\\x0b\\x00\\x0c-\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0d\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0e\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x10
+EXPECT P: \x09\x08\x07\x06-\x05\x04\x03\x02-\x01\x02\x03\x04-\x00\x00\x00\x05\x00\x00\x00\x06\x00\x00\x00\x07\x00\x00\x00\x08-\x00\x09\x00\x0a\x00\x0b\x00\x0c-\x00\x00\x00\x00\x00\x00\x00\x0d\x00\x00\x00\x00\x00\x00\x00\x0e\x00\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x10
 TIMEOUT 5
 ARCH s390x|ppc64
 
 NAME buf_map_key
 PROG i:ms:100 { @[buf("ok_key", 6)] = 1; exit(); }
-EXPECT @\[ok_key\]: 1
+EXPECT @[ok_key]: 1
 TIMEOUT 5
 
 NAME buf_map_multikey
 PROG BEGIN { @[buf("ok_key", 8), 1] = hist(1); exit(); }
-EXPECT @\[ok_key\\x00\\x00\, 1]
+EXPECT @[ok_key\x00\x00, 1]:
 TIMEOUT 5
 
 NAME buf_hist_map_key
 PROG BEGIN { @[buf("ok_key", 8)] = hist(1); exit(); }
-EXPECT @\[ok_key\\x00\\x00\]
+EXPECT @[ok_key\x00\x00]:
 TIMEOUT 5
 
 NAME buf_map_value
@@ -112,7 +112,7 @@ TIMEOUT 5
 
 NAME buf_no_ascii
 PROG BEGIN { printf("%rx", buf("Hello\0", 6)); exit(); }
-EXPECT \\x48\\x65\\x6c\\x6c\\x6f\\x00
+EXPECT \x48\x65\x6c\x6c\x6f\x00
 TIMEOUT 5
 
 NAME buf_no_ascii_no_escaping
@@ -160,7 +160,7 @@ TIMEOUT 5
 
 NAME count
 PROG i:ms:100 { @ = count(); exit();}
-EXPECT @:\s[0-9]+
+EXPECT_REGEX @:\s[0-9]+
 TIMEOUT 5
 
 NAME sum
@@ -210,54 +210,54 @@ TIMEOUT 5
 
 NAME kstack
 PROG k:do_nanosleep { printf("%s\n%s\n", kstack(), kstack(1)); exit(); }
-EXPECT Attaching 1 probe
+EXPECT Attaching 1 probe...
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME kstack perf mode
 PROG k:do_nanosleep { printf("%s\n", kstack(perf, 1)); exit(); }
-EXPECT Attaching 1 probe
+EXPECT Attaching 1 probe...
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack
 PROG k:do_nanosleep { printf("%s\n%s\n", ustack(), ustack(1)); exit(); }
-EXPECT Attaching 1 probe
+EXPECT Attaching 1 probe...
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack_stack_mode_env_bpftrace
 PROG k:do_nanosleep { printf("%s", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=bpftrace
-EXPECT ^\s+[a-zA-Z0-9_]+
+EXPECT_REGEX ^\s+[a-zA-Z0-9_]+
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack_stack_mode_env_perf
 PROG k:do_nanosleep { printf("%s", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=perf
-EXPECT ^\s+[0-9a-f]+ [a-zA-Z0-9_]+
+EXPECT_REGEX ^\s+[0-9a-f]+ [a-zA-Z0-9_]+
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack_stack_mode_env_raw
 PROG k:do_nanosleep { printf("%s", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=raw
-EXPECT ^\s+[0-9a-f]+$
+EXPECT_REGEX ^\s+[0-9a-f]+$
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack_stack_mode_env_override
 PROG k:do_nanosleep { printf("%s", ustack(raw, 1)); exit(); }
 ENV BPFTRACE_STACK_MODE=perf
-EXPECT ^\s+[0-9a-f]+$
+EXPECT_REGEX ^\s+[0-9a-f]+$
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack_elf_symtable
 ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM
 PROG uprobe:./testprogs/uprobe_symres_exited_process:test { print(ustack); exit(); }
-EXPECT ^\s+test\+0\s+main\+[1-9][0-9]*
+EXPECT_REGEX ^\s+test\+0\s+main\+[1-9][0-9]*
 AFTER ./testprogs/disable_aslr ./testprogs/uprobe_symres_exited_process
 ARCH x86_64
 TIMEOUT 5
@@ -265,19 +265,19 @@ TIMEOUT 5
 NAME ustack_elf_symtable
 ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM
 PROG uprobe:./testprogs/uprobe_symres_exited_process:test { print(ustack); exit(); }
-EXPECT ^\s+test\+0\s+test2\+[1-9][0-9]*\s+main\+[1-9][0-9]*
+EXPECT_REGEX ^\s+test\+0\s+test2\+[1-9][0-9]*\s+main\+[1-9][0-9]*
 AFTER ./testprogs/disable_aslr ./testprogs/uprobe_symres_exited_process
 ARCH ppc64le
 TIMEOUT 5
 
 NAME cat
 PROG i:ms:1 { cat("/proc/uptime"); exit();}
-EXPECT [0-9]*.[0-9]* [0-9]*.[0-9]*
+EXPECT_REGEX [0-9]*.[0-9]* [0-9]*.[0-9]*
 TIMEOUT 5
 
 NAME cat_more_args
 PROG i:ms:1 { cat("/%s%s%s%s/%s%s%s", "p", "r", "o", "c", "u", "p", "time"); exit();}
-EXPECT [0-9]*.[0-9]* [0-9]*.[0-9]*
+EXPECT_REGEX [0-9]*.[0-9]* [0-9]*.[0-9]*
 TIMEOUT 5
 
 NAME uaddr
@@ -309,7 +309,7 @@ TIMEOUT 5
 
 NAME usym
 PROG i:ms:100 { @=usym(1); @a=@; exit(); }
-EXPECT ^@a: 0x1$
+EXPECT @a: 0x1
 TIMEOUT 5
 
 NAME print_non_map
@@ -329,13 +329,13 @@ TIMEOUT 1
 
 NAME print_non_map_array
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; print($a); exit(); }
-EXPECT \[1,2,3,4\]
+EXPECT [1,2,3,4]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME print_non_map_multi_dimensional_array
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; print($b); exit(); }
-EXPECT \[\[5,6\],\[7,8\]\]
+EXPECT [[5,6],[7,8]]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
@@ -347,24 +347,24 @@ AFTER ./testprogs/simple_struct
 
 NAME print_non_map_struct_kfunc
 PROG kfunc:vfs_open { print(*args.path); exit(); }
-EXPECT { .mnt = 0x[0-9a-f]+, .dentry = 0x[0-9a-f]+ }
+EXPECT_REGEX { .mnt = 0x[0-9a-f]+, .dentry = 0x[0-9a-f]+ }
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall open
 
 NAME strftime
 PROG BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts); exit(); }
-EXPECT [0-9]{2}\/[0-9]{2}\/[0-9]{2}
+EXPECT_REGEX [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 TIMEOUT 5
 
 NAME strftime_as_map_key
 PROG BEGIN { @[strftime("%m/%d/%y", nsecs)] = 1; exit();}
-EXPECT \[[0-9]{2}\/[0-9]{2}\/[0-9]{2}\]: 1
+EXPECT_REGEX \[[0-9]{2}\/[0-9]{2}\/[0-9]{2}\]: 1
 TIMEOUT 5
 
 NAME strftime_as_map_value
 PROG BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}
-EXPECT @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
+EXPECT_REGEX @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 TIMEOUT 5
 
 # Output two microsecond timestamps, 123000 nsecs apart. Use python to evaluate and verify there's a 123us delta
@@ -383,22 +383,22 @@ TIMEOUT 1
 
 NAME print_avg_map_args
 PROG BEGIN { print("BEGIN"); @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); print("END"); clear(@); exit(); }
-EXPECT BEGIN\n@\[c\]: 3\n@\[d\]: 4\n\nEND
+EXPECT_REGEX BEGIN\n@\[c\]: 3\n@\[d\]: 4\n\nEND
 TIMEOUT 1
 
 NAME print_avg_map_with_large_top
 PROG BEGIN { print("BEGIN"); @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); print("END"); clear(@); exit(); }
-EXPECT BEGIN\n@\[a\]: 1\n@\[b\]: 2\n@\[c\]: 3\n@\[d\]: 4\n\nEND
+EXPECT_REGEX BEGIN\n@\[a\]: 1\n@\[b\]: 2\n@\[c\]: 3\n@\[d\]: 4\n\nEND
 TIMEOUT 1
 
 NAME print_hist_with_top_arg
 PROG BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); print("END"); clear(@); exit(); }
-EXPECT BEGIN\n@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
+EXPECT_REGEX BEGIN\n@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
 TIMEOUT 1
 
 NAME print_hist_with_large_top_arg
 PROG BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); print("END"); clear(@); exit(); }
-EXPECT BEGIN\n@\[1\]:(.*\n)+@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
+EXPECT_REGEX BEGIN\n@\[1\]:(.*\n)+@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
 TIMEOUT 1
 
 NAME path
@@ -422,7 +422,7 @@ TIMEOUT 1
 
 NAME path_in_unsupported_kfunc
 PROG kfunc:vfs_read { print(path(args.file->f_path)); }
-EXPECT \nstdin:1:18-47: ERROR: helper bpf_d_path not supported in probe\n
+EXPECT stdin:1:18-47: ERROR: helper bpf_d_path not supported in probe
 REQUIRES_FEATURE dpath
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
@@ -436,12 +436,12 @@ TIMEOUT 5
 
 NAME macaddr as map key
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[macaddr($s->mac)] = 1; exit(); }' -c ./testprogs/complex_struct
-EXPECT @\[05:04:03:02:01:02\]: 1
+EXPECT @[05:04:03:02:01:02]: 1
 TIMEOUT 5
 
 NAME macaddr as map value
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[1] = macaddr($s->mac); exit(); }' -c ./testprogs/complex_struct
-EXPECT \[1\]: 05:04:03:02:01:02
+EXPECT @[1]: 05:04:03:02:01:02
 TIMEOUT 5
 
 NAME iter:task
@@ -464,14 +464,14 @@ TIMEOUT 5
 
 NAME cgroup_path
 PROG BEGIN { print(cgroup_path(cgroup & ((1 << 32) - 1))); exit(); }
-EXPECT ([a-z]*:\/.*;)*[a-z]*:\/.*
+EXPECT_REGEX ([a-z]*:\/.*;)*[a-z]*:\/.*
 REQUIRES grep -q '^cgroup2' /proc/mounts
 TIMEOUT 5
 MIN_KERNEL 4.18
 
 NAME cgroup_path printf
 PROG BEGIN { printf("path: %s", cgroup_path(cgroup & ((1 << 32) - 1))); exit(); }
-EXPECT path: ([a-z]*:\/.*;)*[a-z]*:\/.*
+EXPECT_REGEX path: ([a-z]*:\/.*;)*[a-z]*:\/.*
 REQUIRES grep -q '^cgroup2' /proc/mounts
 TIMEOUT 5
 MIN_KERNEL 4.18
@@ -522,44 +522,44 @@ MIN_KERNEL 5.5
 
 NAME debugf
 RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { debugf("debugf"); exit();}'; cat /sys/kernel/debug/tracing/trace
-EXPECT bpf_trace_printk: debugf
+EXPECT_REGEX bpf_trace_printk: debugf
 TIMEOUT 3
 
 NAME debugf_with_arguments
 RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { debugf("debugf %s %d %x", "a", 1, 16); exit();}'; cat /sys/kernel/debug/tracing/trace
-EXPECT bpf_trace_printk: debugf a 1 10
+EXPECT_REGEX bpf_trace_printk: debugf a 1 10
 TIMEOUT 3
 
 NAME debugf_with_seq_printf
 RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { printf("printf %d", 0); debugf("debugf %d", 1); exit();}'; cat /sys/kernel/debug/tracing/trace
-EXPECT bpf_trace_printk: debugf 1
+EXPECT_REGEX bpf_trace_printk: debugf 1
 TIMEOUT 3
 
 NAME nsecs
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs()); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME nsecs_monotonic
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(monotonic)); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME nsecs_boot
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(boot)); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME nsecs_tai
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(tai)); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 REQUIRES_FEATURE get_tai_ns
 MIN_KERNEL 6.1
 
 NAME nsecs_sw_tai
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(sw_tai)); exit(); }
-EXPECT SUCCESS [0-9]+
+EXPECT_REGEX SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME map len

--- a/tests/runtime/config
+++ b/tests/runtime/config
@@ -1,32 +1,32 @@
 NAME config as env var
 RUN {{BPFTRACE}} -e 'config = { BPFTRACE_STACK_MODE=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
-EXPECT ^\s+[0-9a-f]+$
+EXPECT_REGEX ^\s+[0-9a-f]+$
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME config short name
 RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
-EXPECT ^\s+[0-9a-f]+$
+EXPECT_REGEX ^\s+[0-9a-f]+$
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME env var takes precedence
 RUN {{BPFTRACE}} -e 'config = { BPFTRACE_STACK_MODE=perf } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
 ENV BPFTRACE_STACK_MODE=raw
-EXPECT ^\s+[0-9a-f]+$
+EXPECT_REGEX ^\s+[0-9a-f]+$
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME bad config
 RUN {{BPFTRACE}} -e 'config = { bad_config=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
-EXPECT ERROR: Unrecognized config variable: bad_config
+EXPECT stdin:1:12-23: ERROR: Unrecognized config variable: bad_config
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 WILL_FAIL
 
 NAME env only config
 RUN {{BPFTRACE}} -e 'config = { debug_output=1 } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
-EXPECT ERROR: debug_output can only be set as an environment variable
+EXPECT stdin:1:12-25: ERROR: debug_output can only be set as an environment variable
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 WILL_FAIL

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -6,13 +6,13 @@ TIMEOUT 5
 
 NAME list uprobe args - pointer type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:uprobeFunction1'
-EXPECT int\* n
+EXPECT int* n
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME list uprobe args - struct pointer type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:uprobeFunction2'
-EXPECT struct Foo\* foo1
+EXPECT struct Foo* foo1
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
@@ -54,7 +54,7 @@ BEFORE ./testprogs/uprobe_test
 
 NAME struct field array
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { print(args.foo1->c); exit(); }
-EXPECT \[1,2,3\]
+EXPECT [1,2,3]
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -134,6 +134,8 @@ class TestParser(object):
             elif item_name == "PROG":
                 prog = line
             elif item_name == 'EXPECT':
+                expects.append(Expect(line, 'text'))
+            elif item_name == 'EXPECT_REGEX':
                 expects.append(Expect(line, 'regex'))
             elif item_name == 'EXPECT_NONE':
                 expects.append(Expect(line, 'regex_none'))

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -201,10 +201,13 @@ class Runner(object):
 
         def get_pid_ns_cmd(cmd):
             return nsenter + [os.path.abspath(x) for x in cmd.split()]
-            
+
         def check_expect(expect, output):
             try:
-                if expect.mode == "regex":
+                if expect.mode == "text":
+                    # Raw text match on an entire line, ignoring leading/trailing whitespace
+                    return re.search(f"^\s*{re.escape(expect.expect)}\s*$", output, re.M)
+                elif expect.mode == "regex":
                     return re.search(expect.expect, output, re.M)
                 elif expect.mode == "regex_none":
                     return not re.search(expect.expect, output, re.M)
@@ -452,7 +455,10 @@ class Runner(object):
             print(fail("[  FAILED  ] ") + "%s.%s" % (test.suite, test.name))
             print('\tCommand: ' + bpf_call)
             for failed_expect in failed_expects:
-                if failed_expect.mode == "regex":
+                if failed_expect.mode == "text":
+                    print('\tExpected: ' + failed_expect.expect)
+                    print('\tFound:\n' + to_utf8(output))
+                elif failed_expect.mode == "regex":
                     print('\tExpected REGEX: ' + failed_expect.expect)
                     print('\tFound:\n' + to_utf8(output))
                 elif failed_expect.mode == "regex_none":

--- a/tests/runtime/file-output
+++ b/tests/runtime/file-output
@@ -1,19 +1,19 @@
 NAME printf to file
 RUN {{BPFTRACE}} -e 'i:ms:10 { printf("%s %d\n", "SUCCESS", 1); exit() }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
-EXPECT ^SUCCESS 1$
+EXPECT SUCCESS 1
 TIMEOUT 5
 
 NAME cat to file
 RUN {{BPFTRACE}} -e 'i:ms:10 { cat("/proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
-EXPECT ^([0-9]+\.[0-9]+ )+.*$
+EXPECT_REGEX ^([0-9]+\.[0-9]+ )+.*$
 TIMEOUT 5
 
 NAME print map to file
 RUN {{BPFTRACE}} -e 'i:ms:10 { @=lhist(50, 0, 100, 10); exit();}' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
-EXPECT ^\[50, 60\).*\@+\|$
+EXPECT_REGEX ^\[50, 60\).*\@+\|$
 TIMEOUT 5
 
 NAME system stdout to file
 RUN {{BPFTRACE}} --unsafe -e 'i:ms:10 { system("cat /proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
-EXPECT ^([0-9]+\.[0-9]+ )+.*$
+EXPECT_REGEX ^([0-9]+\.[0-9]+ )+.*$
 TIMEOUT 5

--- a/tests/runtime/intcast
+++ b/tests/runtime/intcast
@@ -1,16 +1,16 @@
 NAME Casting retval should work
 PROG ur:./testprogs/uprobe_negative_retval:main   /(int32)retval < 0/ { @[(int32)retval]=count(); exit();}
 AFTER ./testprogs/uprobe_negative_retval
-EXPECT ^@\[-100\]: 1$
+EXPECT @[-100]: 1
 TIMEOUT 5
 
 NAME Sum casted retval
 PROG ur:./testprogs/uprobe_negative_retval:function1 { @=stats((int32)retval); exit();} ur:./testprogs/uprobe_negative_retval:main { exit() }
 AFTER ./testprogs/uprobe_negative_retval
-EXPECT ^@: count 221, average -10, total -2210$
+EXPECT @: count 221, average -10, total -2210
 TIMEOUT 5
 
 NAME Casting ints
 PROG BEGIN{printf("Values: %d %d\n", (uint8) -10, (uint16) 131087); exit(); }
-EXPECT Values: 246 15$
+EXPECT Values: 246 15
 TIMEOUT 5

--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -1,41 +1,41 @@
 NAME Sum casted value
 PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+8)); exit();}
-EXPECT ^@: 3258
+EXPECT @: 3258
 TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
 PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+0)); exit();}
-EXPECT ^@: 3258
+EXPECT @: 3258
 TIMEOUT 5
 ARCH aarch64
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
 PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+0)); exit();}
-EXPECT ^@: 3567
+EXPECT @: 3567
 TIMEOUT 5
 ARCH armv7l
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
 PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+96)); exit();}
-EXPECT ^@: 3258
+EXPECT @: 3258
 TIMEOUT 5
 ARCH ppc64le
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
 PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+112)); exit();}
-EXPECT ^@: 3258
+EXPECT @: 3258
 TIMEOUT 5
 ARCH ppc64
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
 PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r15")+160)); exit();}
-EXPECT ^@: 4660
+EXPECT @: 4660
 TIMEOUT 5
 ARCH s390x
 AFTER ./testprogs/intptrcast

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -1,6 +1,6 @@
 NAME invalid_format
 RUN {{BPFTRACE}} -q -f jsonx -e 'BEGIN { @scalar = 5; exit(); }'
-EXPECT ^ERROR: Invalid output format "jsonx"$
+EXPECT ERROR: Invalid output format "jsonx"
 TIMEOUT 5
 WILL_FAIL
 
@@ -72,102 +72,102 @@ TIMEOUT 5
 
 NAME printf
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { printf("test %d", 5); exit(); }'
-EXPECT ^{"type": "printf", "data": "test 5"}$
+EXPECT {"type": "printf", "data": "test 5"}
 TIMEOUT 5
 
 NAME printf_escaping
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { printf("test \r \n \t \\ \" bar"); exit(); }'
-EXPECT ^{"type": "printf", "data": "test \\r \\n \\t \\\\ \\\" bar"}$
+EXPECT {"type": "printf", "data": "test \r \n \t \\ \" bar"}
 TIMEOUT 5
 
 NAME time
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { time(); exit(); }'
-EXPECT ^{"type": "time", "data": "[0-9]*:[0-9]*:[0-9]*\\n"}$
+EXPECT_REGEX ^{"type": "time", "data": "[0-9]*:[0-9]*:[0-9]*\\n"}$
 TIMEOUT 5
 
 NAME syscall
 RUN {{BPFTRACE}} --unsafe -f json -e 'BEGIN { system("echo a b c"); exit(); }'
-EXPECT ^{"type": "syscall", "data": "a b c\\n"}$
+EXPECT {"type": "syscall", "data": "a b c\n"}
 TIMEOUT 5
 
 NAME join_delim
 RUN {{BPFTRACE}} --unsafe -f json -e 'tracepoint:syscalls:sys_enter_execve { join(args.argv, ","); }' -c "./testprogs/syscall execve /bin/echo 'A'"
-EXPECT ^{"type": "join", "data": "/bin/echo,'A'"}
+EXPECT {"type": "join", "data": "/bin/echo,'A'"}
 TIMEOUT 5
 
 NAME cat
 RUN {{BPFTRACE}} -f json -e 'BEGIN { cat("/proc/uptime"); exit(); }'
-EXPECT ^{"type": "cat", "data": "[0-9]*.[0-9]* [0-9]*.[0-9]*\\n"}$
+EXPECT_REGEX ^{"type": "cat", "data": "[0-9]*.[0-9]* [0-9]*.[0-9]*\\n"}$
 TIMEOUT 5
 
 NAME strerror
 RUN {{BPFTRACE}} -f json -e 'BEGIN { print((strerror(7))); exit(); }'
-EXPECT ^{"type": "value", "data": "Argument list too long"}$
+EXPECT {"type": "value", "data": "Argument list too long"}
 TIMEOUT 5
 
 # Careful with '[' and ']', they are read by the test engine as a regex
 # character class, so make sure to escape them.
 NAME tuple
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
-EXPECT ^{"type": "map", "data": {"@": \[1,2,"string",\[4,5\]\]}}$
+EXPECT {"type": "map", "data": {"@": [1,2,"string",[4,5]]}}
 TIMEOUT 5
 
 NAME tuple_with_struct
 RUN {{BPFTRACE}} -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); @ = (0, $f); exit(); }'
-EXPECT ^{"type": "map", "data": {"@": \[0,{ "m": 2, "n": 3 }\]}}$
+EXPECT {"type": "map", "data": {"@": [0,{ "m": 2, "n": 3 }]}}
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME tuple_with_escaped_string
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @ = (1, 2, "string with \"quotes\""); exit(); }'
-EXPECT ^{"type": "map", "data": {"@": \[1,2,"string with \\"quotes\\""\]}}$
+EXPECT {"type": "map", "data": {"@": [1,2,"string with \"quotes\""]}}
 TIMEOUT 5
 
 NAME print_non_map
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { $x = 5; print($x); exit() }'
-EXPECT ^{"type": "value", "data": 5}$
+EXPECT {"type": "value", "data": 5}
 TIMEOUT 1
 
 NAME print_non_map_builtin
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print(comm); exit() }'
-EXPECT ^{"type": "value", "data": "bpftrace"}$
+EXPECT {"type": "value", "data": "bpftrace"}
 TIMEOUT 1
 
 NAME print_non_map_tuple
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { $t = (1, 2, "string"); print($t); exit() }'
-EXPECT ^{"type": "value", "data": \[1,2,"string"\]}$
+EXPECT {"type": "value", "data": [1,2,"string"]}
 TIMEOUT 1
 
 NAME print_non_map_struct
 RUN {{BPFTRACE}} -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
-EXPECT ^{"type": "value", "data": { "m": 2, "n": 3 }}$
+EXPECT {"type": "value", "data": { "m": 2, "n": 3 }}
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME print_non_map_nested_struct
 RUN {{BPFTRACE}} -f json -e 'struct Foo { struct { int m[1] } y; struct { int n; } a; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
-EXPECT ^{"type": "value", "data": { "y": { "m": \[2\] }, "a": { "n": 3 } }}$
+EXPECT {"type": "value", "data": { "y": { "m": [2] }, "a": { "n": 3 } }}
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME print_avg_map_args
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@); exit(); }'
-EXPECT {"type": "stats", "data": {"@": { *"c": 3, *"d": 4}}}
+EXPECT {"type": "stats", "data": {"@": {"c": 3, "d": 4}}}
 TIMEOUT 1
 
 NAME print_avg_map_with_large_top
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@); exit(); }'
-EXPECT {"type": "stats", "data": {"@": { *"a": 1, *"b": 2, *"c": 3, *"d": 4}}}
+EXPECT {"type": "stats", "data": {"@": {"a": 1, "b": 2, "c": 3, "d": 4}}}
 TIMEOUT 1
 
 NAME print_hist_with_top_arg
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); clear(@); exit(); }'
-EXPECT {"type": "hist", "data": {"@": {"2": \[{"min": 16, "max": 31, "count": 1}\], "3": \[{"min": 16, "max": 31, "count": 1}\]}}}
+EXPECT {"type": "hist", "data": {"@": {"2": [{"min": 16, "max": 31, "count": 1}], "3": [{"min": 16, "max": 31, "count": 1}]}}}
 TIMEOUT 1
 
 NAME print_hist_with_large_top_arg
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); clear(@); exit(); }'
-EXPECT {"type": "hist", "data": {"@": {"1": \[{"min": 8, "max": 15, "count": 1}\], "2": \[{"min": 16, "max": 31, "count": 1}\], "3": \[{"min": 16, "max": 31, "count": 1}\]}}}
+EXPECT {"type": "hist", "data": {"@": {"1": [{"min": 8, "max": 15, "count": 1}], "2": [{"min": 16, "max": 31, "count": 1}], "3": [{"min": 16, "max": 31, "count": 1}]}}}
 TIMEOUT 1
 
 NAME helper_error
@@ -177,5 +177,5 @@ TIMEOUT 1
 
 NAME cgroup_path
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print(cgroup_path(cgroup)); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin))'
-EXPECT ^{'type': 'value', 'data': '.*'}$
+EXPECT_REGEX ^{'type': 'value', 'data': '.*'}$
 TIMEOUT 5

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -60,13 +60,17 @@ TIMEOUT 5
 
 NAME unroll_max_value
 PROG i:ms:1 {$a = 1; unroll (101) { $a = $a + 2; } printf("a=%d\n", $a); exit();}
-EXPECT unroll maximum value is 100
+EXPECT stdin:1:17-29: ERROR: unroll maximum value is 100
+EXPECT i:ms:1 {$a = 1; unroll (101) { $a = $a + 2; } printf("a=%d\n", $a); exit();}
+EXPECT                 ~~~~~~~~~~~~
 TIMEOUT 5
 WILL_FAIL
 
 NAME unroll_min_value
 PROG i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}
-EXPECT unroll minimum value is 1
+EXPECT stdin:1:17-27: ERROR: unroll minimum value is 1
+EXPECT i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}
+EXPECT                 ~~~~~~~~~~
 TIMEOUT 5
 WILL_FAIL
 
@@ -77,7 +81,7 @@ TIMEOUT 5
 
 NAME unroll_printf
 PROG BEGIN { unroll (1) { printf("a"); } printf("b\n"); exit(); }
-EXPECT ab\n
+EXPECT ab
 TIMEOUT 5
 
 NAME if_compare_and_print_string
@@ -127,7 +131,7 @@ TIMEOUT 1
 
 NAME string compare map lookup
 RUN {{BPFTRACE}} -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { @[comm] = 1; }' -c "./testprogs/syscall openat"
-EXPECT @\[syscall\]: 1
+EXPECT @[syscall]: 1
 TIMEOUT 5
 
 NAME struct partial string compare - pass
@@ -192,7 +196,7 @@ TIMEOUT 1
 
 NAME positional lhist
 RUN {{BPFTRACE}} -e 'BEGIN { @ = lhist(0, $1, $2, $3); exit()}' 0 10000 1000
-EXPECT @: *\n[\[(].*
+EXPECT_REGEX @: *\n[\[(].*
 TIMEOUT 5
 
 NAME positional buf
@@ -214,22 +218,22 @@ AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME lhist can be cleared
 PROG BEGIN{ @[1] = lhist(3,0,10,1); clear(@); exit() }
-EXPECT .*
+EXPECT_REGEX .*
 TIMEOUT 1
 
 NAME hist can be cleared
 PROG BEGIN{ @[1] = hist(1); clear(@); exit() }
-EXPECT .*
+EXPECT_REGEX .*
 TIMEOUT 1
 
 NAME stats can be cleared
 PROG BEGIN{ @[1] = stats(1); clear(@); exit() }
-EXPECT .*
+EXPECT_REGEX .*
 TIMEOUT 1
 
 NAME avg can be cleared
 PROG BEGIN{ @[1] = avg(1); clear(@); exit() }
-EXPECT .*
+EXPECT_REGEX .*
 TIMEOUT 1
 
 NAME sigint under heavy load
@@ -257,15 +261,21 @@ TIMEOUT 1
 
 NAME map_assign_map_ptr
 PROG i:ms:100 { @ = curtask; @a = @; printf("%p\n", @a); exit(); }
-EXPECT 0x[0-9a-f]+
+EXPECT_REGEX 0x[0-9a-f]+
 TIMEOUT 1
 
 NAME runtime_error_check_delete
 RUN {{BPFTRACE}} -k -e 'i:ms:100 { @[1] = 1; delete(@[2]); exit(); }'
-EXPECT WARNING: Can't delete map element because it does not exist.
+EXPECT stdin:1:22-34: WARNING: Can't delete map element because it does not exist.
+EXPECT Additional Info - helper: map_delete_elem, retcode: -2
+EXPECT i:ms:100 { @[1] = 1; delete(@[2]); exit(); }
+EXPECT                      ~~~~~~~~~~~~
 TIMEOUT 1
 
 NAME runtime_error_check_lookup
 RUN {{BPFTRACE}} -kk -e 'i:ms:100 { @[1] = 1; printf("%d\n", @[2]); exit(); }'
-EXPECT WARNING: Can't lookup map element because it does not exist.
+EXPECT stdin:1:37-41: WARNING: Can't lookup map element because it does not exist.
+EXPECT Additional Info - helper: map_lookup_elem, retcode: 0
+EXPECT i:ms:100 { @[1] = 1; printf("%d\n", @[2]); exit(); }
+EXPECT                                     ~~~~
 TIMEOUT 1

--- a/tests/runtime/pointers
+++ b/tests/runtime/pointers
@@ -1,81 +1,81 @@
 NAME u8 pointer increment
 PROG BEGIN { @=(int8*) 0x32; @+=1; exit(); }
-EXPECT ^@: 0x33
+EXPECT @: 0x33
 TIMEOUT 5
 
 NAME u16 pointer increment
 PROG BEGIN { @=(int16*) 0x32; @+=1; exit(); }
-EXPECT ^@: 0x34
+EXPECT @: 0x34
 TIMEOUT 5
 
 NAME u32 pointer increment
 PROG BEGIN { @=(int32*) 0x32; @+=1; exit(); }
-EXPECT ^@: 0x36
+EXPECT @: 0x36
 TIMEOUT 5
 
 NAME u64 pointer increment
 PROG BEGIN { @=(int64*) 0x32; @+=1; exit(); }
-EXPECT ^@: 0x3a
+EXPECT @: 0x3a
 TIMEOUT 5
 
 NAME u8 pointer unop post increment
 PROG BEGIN { @=(int8*) 0x32; @++; exit(); }
-EXPECT ^@: 0x33
+EXPECT @: 0x33
 TIMEOUT 5
 
 NAME u16 pointer unop post increment
 PROG BEGIN { @=(int16*) 0x32; @++; exit(); }
-EXPECT ^@: 0x34
+EXPECT @: 0x34
 TIMEOUT 5
 
 NAME u32 pointer unop post increment
 PROG BEGIN { @=(int32*) 0x32; @++; exit(); }
-EXPECT ^@: 0x36
+EXPECT @: 0x36
 TIMEOUT 5
 
 NAME u64 pointer unop post increment
 PROG BEGIN { @=(int64*) 0x32; @++; exit(); }
-EXPECT ^@: 0x3a
+EXPECT @: 0x3a
 TIMEOUT 5
 
 NAME u8 pointer unop pre increment
 PROG BEGIN { @=(int8*) 0x32; @++; exit(); }
-EXPECT ^@: 0x33
+EXPECT @: 0x33
 TIMEOUT 5
 
 NAME u16 pointer unop pre increment
 PROG BEGIN { @=(int16*) 0x32; @++; exit(); }
-EXPECT ^@: 0x34
+EXPECT @: 0x34
 TIMEOUT 5
 
 NAME u32 pointer unop pre increment
 PROG BEGIN { @=(int32*) 0x32; @++; exit(); }
-EXPECT ^@: 0x36
+EXPECT @: 0x36
 TIMEOUT 5
 
 NAME u64 pointer unop pre increment
 PROG BEGIN { @=(int64*) 0x32; @++; exit(); }
-EXPECT ^@: 0x3a
+EXPECT @: 0x3a
 TIMEOUT 5
 
 NAME Pointer decrement 1
 PROG BEGIN { @=(int32*) 0x32; @-=1; exit(); }
-EXPECT ^@: 0x2e
+EXPECT @: 0x2e
 TIMEOUT 5
 
 NAME Pointer decrement
 PROG BEGIN { @=(int32*) 0x32; @--; exit(); }
-EXPECT ^@: 0x2e
+EXPECT @: 0x2e
 TIMEOUT 5
 
 NAME Pointer increment 6
 PROG BEGIN { @=(int32*) 0x32; @+=6; exit(); }
-EXPECT ^@: 0x4a
+EXPECT @: 0x4a
 TIMEOUT 5
 
 NAME Pointer decrement 6
 PROG BEGIN { @=(int32*) 0x32; @-=6; exit(); }
-EXPECT ^@: 0x1a
+EXPECT @: 0x1a
 TIMEOUT 5
 
 NAME Struct pointer math
@@ -85,18 +85,18 @@ TIMEOUT 5
 
 NAME Pointer decrement with map
 PROG BEGIN { @dec = 4; @=(int32*) 0x32; @-=@dec; exit(); }
-EXPECT ^@: 0x22
+EXPECT @: 0x22
 TIMEOUT 5
 
 NAME Pointer walk through struct
 RUN {{BPFTRACE}} runtime/scripts/struct_walk.bt -c ./testprogs/struct_walk
-EXPECT ^a: 45 b: 1000
+EXPECT a: 45 b: 1000
 TIMEOUT 5
 
 NAME Pointer arith with int32
 PROG struct C { uint32_t a; }; uprobe:./testprogs/struct_walk:clear { $c = (struct C *)arg0; printf("ptr: %p\n", $c + $c->a); exit() }
 AFTER ./testprogs/struct_walk
-EXPECT ^ptr: 0x[0-9a-z]+
+EXPECT_REGEX ^ptr: 0x[0-9a-z]+
 TIMEOUT 5
 
 NAME Pointer to pointer arithmetic and dereference

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -1,34 +1,34 @@
 NAME kfunc
 PROG kfunc:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretfunc
 PROG kretfunc:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kfunc_wildcard
 PROG kfunc:vfs_re*ad { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kfunc_module
 PROG kfunc:vmlinux:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kfunc_module_wildcard
 PROG kfunc:vmlinu*:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
@@ -36,7 +36,7 @@ AFTER ./testprogs/syscall read
 # https://github.com/bpftrace/bpftrace/issues/2447
 NAME kfunc_multiple_attach_point_multiple_functions
 PROG BEGIN { @a = 2; @b = 1; @c = 1 } i:s:1 { exit() } kfunc:vfs_read, kfunc:vfs_open /@a != 0/ { @a -= 1 } kfunc:vfs_read /@b == 1/ { @b = 0 } kfunc:vfs_open /@c == 1/ { @c = 0 }
-EXPECT @a: 0\n@b: 0\n@c: 0
+EXPECT_REGEX @a: 0\n@b: 0\n@c: 0
 TIMEOUT 5
 REQUIRES_FEATURE kfunc
 # Note: this calls both vfs_read and vfs_open
@@ -44,7 +44,7 @@ AFTER ./testprogs/syscall read
 
 NAME kfunc args
 PROG kfunc:vfs_read { printf("%d\n", args.count); exit(); }
-EXPECT [0-9][0-9]*
+EXPECT_REGEX [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 REQUIRES_FEATURE btf
 TIMEOUT 5
@@ -53,7 +53,7 @@ AFTER ./testprogs/syscall read
 # Checking backwards compatibility
 NAME kfunc args as a pointer
 PROG kfunc:vfs_read { printf("%d\n", args->count); exit(); }
-EXPECT [0-9][0-9]*
+EXPECT_REGEX [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 REQUIRES_FEATURE btf
 TIMEOUT 5
@@ -70,7 +70,7 @@ AFTER ./testprogs/syscall read
 
 NAME kretfunc large args
 PROG kretfunc:__sys_bpf { if (args.cmd == 1111 && args.size == 2222 && (int64)retval == -7) { printf("SUCCESS %d\n", pid); exit(); }}
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 REQUIRES_FEATURE btf
 TIMEOUT 5
@@ -79,27 +79,27 @@ AFTER ./testprogs/kfunc_args 1111 2222
 # Sanity check for fentry/fexit alias
 NAME fentry
 PROG fentry:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME fexit
 PROG fexit:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe
 PROG kprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_short_name
 PROG k:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
@@ -111,7 +111,7 @@ AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testpro
 
 NAME kprobe_offset
 PROG kprobe:vfs_read+0 { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
@@ -123,13 +123,13 @@ REQUIRES /usr/sbin/bpftool
 
 NAME kprobe_module
 PROG kprobe:vmlinux:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_module_wildcard
 PROG kprobe:vmlinu*:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
@@ -162,7 +162,7 @@ AFTER ./testprogs/uprobe_test
 
 NAME kprobe_wildcard probe builtin
 RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { @ = probe; printf("progs: "); system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
-EXPECT progs: [1-9][0-9]+
+EXPECT_REGEX progs: [1-9][0-9]+
 TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 
@@ -171,7 +171,7 @@ REQUIRES /usr/sbin/bpftool
 # version.
 NAME kprobe_offset_fail_size
 PROG kprobe:vfs_read+1000000 { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT Offset outside the function bounds \('vfs_read' size is*
+EXPECT_REGEX Offset outside the function bounds \('vfs_read' size is*
 TIMEOUT 5
 WILL_FAIL
 
@@ -198,7 +198,7 @@ CLEANUP /usr/sbin/nft delete table bpftrace
 
 NAME kprobe_offset_module_error
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
-EXPECT Possible attachment attempt in the middle of an instruction, try a different offset.
+EXPECT ERROR: Possible attachment attempt in the middle of an instruction, try a different offset.
 ARCH x86_64
 TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
@@ -214,13 +214,13 @@ WILL_FAIL
 
 NAME kretprobe
 PROG kretprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretprobe_short_name
 PROG kr:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
@@ -261,37 +261,37 @@ BEFORE ./testprogs/uprobe_test
 
 NAME uprobe
 PROG uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}
-EXPECT arg0: [0-9]*
+EXPECT_REGEX arg0: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset
 PROG uprobe:/bin/bash:echo_builtin+0 { printf("arg0: %d\n", arg0); exit();}
-EXPECT arg0: [0-9]*
+EXPECT_REGEX arg0: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset
 PROG uprobe:/bin/bash:"echo_builtin"+0 { printf("arg0: %d\n", arg0); exit();}
-EXPECT arg0: [0-9]*
+EXPECT_REGEX arg0: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset_fail_size
 PROG uprobe:/bin/bash:echo_builtin+1000000 { printf("arg0: %d\n", arg0); exit();}
-EXPECT Offset outside the function bounds \('echo_builtin' size is*
+EXPECT_REGEX Offset outside the function bounds \('echo_builtin' size is*
 TIMEOUT 5
 WILL_FAIL
 
 NAME uprobe_address_fail_resolve
 PROG uprobe:/bin/bash:10 { printf("arg0: %d\n", arg0); exit();}
-EXPECT Could not resolve address: /bin/bash:0xa
+EXPECT ERROR: Could not resolve address: /bin/bash:0xa
 TIMEOUT 5
 WILL_FAIL
 
 NAME uprobe_library
 PROG uprobe:libc:fread { printf("size: %d\n", arg1); exit(); }
-EXPECT size: [0-9]+
+EXPECT_REGEX size: [0-9]+
 TIMEOUT 5
 AFTER ./testprogs/uprobe_library
 REQUIRES_FEATURE libpath_resolv
@@ -304,19 +304,19 @@ AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 
 NAME uprobe_zero_size
 PROG uprobe:./testprogs/uprobe_test:_init { printf("arg0: %d\n", arg0); exit();}
-EXPECT Could not determine boundary for _init
+EXPECT ERROR: Could not determine boundary for _init (symbol has size 0). Use --unsafe to force attachment.
 TIMEOUT 5
 WILL_FAIL
 
 NAME uprobe_zero_size_unsafe
 RUN {{BPFTRACE}} --unsafe -e 'uprobe:./testprogs/uprobe_test:_init { printf("arg0: %d\n", arg0); exit();}'
-EXPECT arg0: [0-9]*
+EXPECT_REGEX arg0: [0-9]*
 TIMEOUT 5
 AFTER ./testprogs/uprobe_test
 
 NAME uretprobe
 PROG uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}
-EXPECT readline: [0-9]*
+EXPECT_REGEX readline: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
@@ -328,13 +328,13 @@ AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 
 NAME tracepoint
 PROG tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS %d\n", gid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
 TIMEOUT 5
 
 NAME tracepoint_short_name
 PROG t:syscalls:sys_exit_nanosleep { printf("SUCCESS %d\n", gid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
 TIMEOUT 5
 
@@ -345,13 +345,13 @@ TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8; ./testprogs/syscall nanosleep 1e8
 
 NAME tracepoint_expansion
-RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c "./testprogs/syscall nanosleep 1e8"
-EXPECT hit hit
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit\n"); }' -c "./testprogs/syscall nanosleep 1e8"
+EXPECT hit
 TIMEOUT 5
 
 NAME tracepoint_missing
 PROG t:syscalls:nonsense { printf("hit"); exit(); }
-EXPECT ERROR: tracepoint not found: syscalls:nonsense
+EXPECT stdin:1:1-20: ERROR: tracepoint not found: syscalls:nonsense
 TIMEOUT 5
 WILL_FAIL
 
@@ -364,32 +364,32 @@ WILL_FAIL
 
 NAME tracepoint args
 PROG tracepoint:syscalls:sys_enter_read { printf("%d\n", args.count); exit(); }
-EXPECT [0-9][0-9]*
+EXPECT_REGEX [0-9][0-9]*
 AFTER ./testprogs/syscall read
 TIMEOUT 5
 
 # Checking backwards compatibility
 NAME tracepoint args as pointer
 PROG tracepoint:syscalls:sys_enter_read { printf("%d\n", args->count); exit(); }
-EXPECT [0-9][0-9]*
+EXPECT_REGEX [0-9][0-9]*
 AFTER ./testprogs/syscall read
 TIMEOUT 5
 
 # Test that we get at least two characters out
 NAME tracepoint_data_loc
 PROG tracepoint:irq:irq_handler_entry { print(str(args.name)); exit(); }
-EXPECT ..+
+EXPECT_REGEX ..+
 TIMEOUT 5
 
 NAME rawtracepoint
 PROG rawtracepoint:sys_exit { printf("SUCCESS %d\n", gid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
 TIMEOUT 5
 
 NAME rawtracepoint_short_name
 PROG rt:sys_exit { printf("SUCCESS %d\n", gid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
 TIMEOUT 5
 
@@ -401,18 +401,18 @@ WILL_FAIL
 
 NAME rawtracepoint_wildcard
 PROG rawtracepoint:sys_* { printf("SUCCESS %d\n", gid); exit(); }
-EXPECT SUCCESS [0-9][0-9]*
+EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep
 TIMEOUT 5
 
 NAME profile
-PROG profile:hz:599 { @[tid] = count(); exit();}
-EXPECT \@\[[0-9]*\]\:\s[0-9]
+PROG profile:hz:599 { print("hit"); exit(); }
+EXPECT hit
 TIMEOUT 5
 
 NAME profile_short_name
-PROG p:hz:599 { @[tid] = count(); exit();}
-EXPECT \@\[[0-9]*\]\:\s[0-9]
+PROG p:hz:599 { print("hit"); exit(); }
+EXPECT hit
 TIMEOUT 5
 
 NAME profile_probe_builtin
@@ -421,13 +421,13 @@ EXPECT profile:hz:599
 TIMEOUT 5
 
 NAME interval
-PROG t:raw_syscalls:sys_enter { @syscalls = count(); } interval:ms:1{ print(@syscalls); clear(@syscalls); exit();}
-EXPECT @syscalls\:\s[0-9]*
+PROG interval:ms:1 { print("hit"); exit(); }
+EXPECT hit
 TIMEOUT 5
 
 NAME interval_short_name
-PROG t:raw_syscalls:sys_enter { @syscalls = count(); } i:ms:1{ print(@syscalls); clear(@syscalls); exit();}
-EXPECT @syscalls\:\s[0-9]*
+PROG i:ms:1{ print("hit"); exit();}
+EXPECT hit
 TIMEOUT 5
 
 NAME interval_probe_builtin
@@ -436,8 +436,8 @@ EXPECT interval:ms:1
 TIMEOUT 5
 
 NAME software
-PROG software:cpu-clock:1 { @[comm] = count(); exit();}
-EXPECT @\[.*\]\:\s[0-9]*
+PROG software:cpu-clock:1 { print("hit"); exit();}
+EXPECT hit
 TIMEOUT 5
 
 NAME software_probe_builtin
@@ -452,8 +452,8 @@ TIMEOUT 5
 
 NAME hardware
 REQUIRES ls /sys/devices/cpu/events/cache-misses
-PROG hardware:cache-misses:10 { @[pid] = count(); exit(); }
-EXPECT @\[.*\]\:\s[0-9]*
+PROG hardware:cache-misses:10 { print("hit"); exit(); }
+EXPECT hit
 TIMEOUT 5
 
 NAME hardware_probe_builtin
@@ -474,19 +474,19 @@ TIMEOUT 2
 
 NAME BEGIN,END
 PROG BEGIN,END { printf("Hello\n"); exit(); }
-EXPECT Hello\nHello
+EXPECT_REGEX Hello\nHello
 TIMEOUT 2
 
 # The "probe" builtin forces bpftrace to generate one BPF function for each
 # match and so we should fail on exceeding BPFTRACE_MAX_BPF_PROGS.
 NAME bpf_programs_limit
 PROG k:* { @[probe] = count(); }
-EXPECT BPFTRACE_MAX_BPF_PROGS
+EXPECT_REGEX ERROR: Failed to compile: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 512.\nYou can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
 WILL_FAIL
 TIMEOUT 2
 
 NAME sanitise probe name
 PROG uprobe:./testprogs/uprobe_namesan:fn* { printf("ok\n"); exit(); }
-EXPECT ^ok
+EXPECT ok
 AFTER ./testprogs/uprobe_namesan
 TIMEOUT 5

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -74,11 +74,11 @@ TIMEOUT 3
 # ctx+const is ok, but ctx+const+const is not ok.
 NAME access ctx struct field twice
 PROG tracepoint:sched:sched_wakeup { if (args.comm == "asdf") { print(args.comm) } exit(); }
-EXPECT Attaching 1 probe
+EXPECT Attaching 1 probe...
 TIMEOUT 1
 
 # https://github.com/bpftrace/bpftrace/issues/2135
 NAME address_probe_invalid_expansion
 RUN {{BPFTRACE}} -e "uprobe:./testprogs/uprobe_test:0x$(nm ./testprogs/uprobe_test | awk '$3 == "uprobeFunction1" {print $1}') { @[probe] = count(); exit() }"
-EXPECT Attaching 1 probe
+EXPECT Attaching 1 probe...
 TIMEOUT 1

--- a/tests/runtime/signals
+++ b/tests/runtime/signals
@@ -6,11 +6,11 @@ TIMEOUT 3
 
 NAME sigint quit
 RUN {{BPFTRACE}} -e 'END { printf("%s %d", "SUCCESS", 1) }' & (./testprogs/syscall nanosleep 1e9 && /usr/bin/env kill -s SIGINT $!)
-EXPECT ^SUCCESS 1$
+EXPECT SUCCESS 1
 TIMEOUT 2
 
 NAME print all maps on sigusr1
-RUN {{BPFTRACE}} -f json -e 'BEGIN { @scalar = 5; } interval:s:2 { exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @scalar = 5; } interval:s:2 { delete(@scalar); exit(); }'
 AFTER kill -s USR1 $(pidof bpftrace)
-EXPECT @scalar[\s\S]+@scalar
+EXPECT @scalar: 5
 TIMEOUT 5

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -1,34 +1,34 @@
 NAME stats with negative values
 PROG BEGIN { @=stats(-10); @=stats(-5); @=stats(5); exit() }
-EXPECT ^@:\scount\s3,\saverage\s-3+,\stotal\s-10$
+EXPECT @: count 3, average -3, total -10
 TIMEOUT 5
 
 NAME avg with negative values
 PROG BEGIN { @=avg(-30); @=avg(-10); exit(); }
-EXPECT ^@:\s-20$
+EXPECT @: -20
 TIMEOUT 5
 
 NAME negative map value
 PROG BEGIN { @ = -11; exit(); }
-EXPECT @: -11$
+EXPECT @: -11
 TIMEOUT 1
 
 NAME sum negative maps
 PROG BEGIN { @ = -11; @+=@; exit() }
-EXPECT @: -22$
+EXPECT @: -22
 TIMEOUT 1
 
 NAME Comparison should print as 0 or 1
 PROG struct x { uint64_t x; }; BEGIN { $a = (*(struct x*)0).x; printf("%d %d\n", $a > -1, $a < 1); exit(); }
-EXPECT ^0 1$
+EXPECT 0 1
 TIMEOUT 1
 
 NAME sum with negative value
 PROG BEGIN { @=sum(10); @=sum(-20); exit(); }
-EXPECT ^@: -10$
+EXPECT @: -10
 TIMEOUT 1
 
 NAME mixed values
 PROG BEGIN { printf("%d %d %d %d\n", (int8) -10, -5555, (int16)-123, 100); exit(); }
-EXPECT ^-10 -5555 -123 100$
+EXPECT -10 -5555 -123 100
 TIMEOUT 5

--- a/tests/runtime/struct
+++ b/tests/runtime/struct
@@ -18,30 +18,30 @@ AFTER ./testprogs/simple_struct
 
 NAME nested struct assignment into map
 PROG struct Foo { struct { int m[1] } y; struct { int n } a; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }
-EXPECT @s: { .y = { .m = \[2\] }, .a = { .n = 3 } }
+EXPECT @s: { .y = { .m = [2] }, .a = { .n = 3 } }
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct as a map key
 PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s[*((struct Foo *)arg0)] = 0; exit(); }
-EXPECT @s\[{.m=2,.n=3}\]: 0
+EXPECT @s[{.m=2,.n=3}]: 0
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct as a part of multikey
 PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s[*((struct Foo *)arg0), 42] = 0; exit(); }
-EXPECT @s\[{.m=2,.n=3}, 42\]: 0
+EXPECT @s[{.m=2,.n=3}, 42]: 0
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct as a map key assigned from another map
 PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @x = *((struct Foo *)arg0); @s[@x] = 0; exit(); }
-EXPECT @s\[{.m=2,.n=3}\]: 0
+EXPECT @s[{.m=2,.n=3}]: 0
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct in a tuple
 PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s = (1, *((struct Foo *)arg0)); exit(); }
-EXPECT @s: \(1, { .m = 2, .n = 3 }\)
+EXPECT @s: (1, { .m = 2, .n = 3 })
 TIMEOUT 4
 AFTER ./testprogs/simple_struct

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -10,22 +10,22 @@ TIMEOUT 5
 
 NAME mixed int tuple map
 PROG BEGIN { @ = ( (int32) -100, (int8) 10, 50 ); exit();}
-EXPECT @: \(-100, 10, 50\)
+EXPECT @: (-100, 10, 50)
 TIMEOUT 5
 
 NAME mixed int tuple map 2
 PROG BEGIN { @ = ( -100, (int8) 10, (int32) 50 ); exit();}
-EXPECT @: \(-100, 10, 50\)
+EXPECT @: (-100, 10, 50)
 TIMEOUT 5
 
 NAME mixed int tuple map 3
 PROG BEGIN { @ = ( -100, (int8) 10, (int32) 50, 100 ); exit();}
-EXPECT @: \(-100, 10, 50, 100\)
+EXPECT @: (-100, 10, 50, 100)
 TIMEOUT 5
 
 NAME complex tuple 1
 PROG BEGIN { print(((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555)); exit(); }
-EXPECT \(-100, 100, abcdef, 3, 1, -10, 10, -555\)
+EXPECT (-100, 100, abcdef, 3, 1, -10, 10, -555)
 TIMEOUT 5
 
 NAME tuple struct sizing 1
@@ -50,7 +50,7 @@ TIMEOUT 5
 
 NAME struct in tuple
 PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @t = (1, *((struct Foo *)arg0)); exit(); }
-EXPECT @t: \(1, \{ .m = 2, .n = 3 \}\)
+EXPECT @t: (1, { .m = 2, .n = 3 })
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
@@ -62,7 +62,7 @@ AFTER ./testprogs/simple_struct
 
 NAME array in tuple
 PROG struct A { int x[4]; } u:./testprogs/array_access:test_struct { @t = (1, ((struct A *)arg0)->x); exit(); }
-EXPECT @t: \(1, \[1,2,3,4\]\)
+EXPECT @t: (1, [1,2,3,4])
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
@@ -74,31 +74,31 @@ AFTER ./testprogs/array_access
 
 NAME nested tuple
 PROG BEGIN{ @ = ((int8)1, ((int8)-20, (int8)30)); exit(); }
-EXPECT @: \(1, \(-20, 30\)\)
+EXPECT @: (1, (-20, 30))
 TIMEOUT 5
 
 # Careful with '(' and ')', they are read by the test engine as a regex group,
 # so make sure to escape them.
 NAME tuple print
 PROG BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }
-EXPECT ^@: \(1, 2, string, \(4, 5\)\)$
+EXPECT @: (1, 2, string, (4, 5))
 TIMEOUT 5
 
 NAME tuple strftime type is packed
 PROG BEGIN { @ = (nsecs, strftime("%M:%S", nsecs)); exit(); }
-EXPECT ^@: \(\d+, \d+:\d+\)$
+EXPECT_REGEX ^@: \(\d+, \d+:\d+\)$
 TIMEOUT 5
 
 NAME bytearray in tuple
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = ((int8)1, usym(reg("ip")), 10); exit(); }
-EXPECT ^@: \(1, 0x[0-9a-f]+, 10\)$
+EXPECT_REGEX ^@: \(1, 0x[0-9a-f]+, 10\)$
 TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/uprobe_test
 
 NAME bytearray in tuple
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = ((int8)1, usym(reg("nip")), 10); exit(); }
-EXPECT ^@: \(1, 0x[0-9a-f]+, 10\)$
+EXPECT_REGEX ^@: \(1, 0x[0-9a-f]+, 10\)$
 TIMEOUT 5
 ARCH ppc64|ppc64le
 AFTER ./testprogs/uprobe_test

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -30,19 +30,19 @@ TIMEOUT 5
 
 NAME uprobes - list probes by pid
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^uprobe'
-EXPECT uprobe:.*/testprogs/uprobe_test:uprobeFunction1
+EXPECT_REGEX uprobe:.*/testprogs/uprobe_test:uprobeFunction1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - list probes by pid; uprobes only
 RUN {{BPFTRACE}} -l 'uprobe:*' -p {{BEFORE_PID}}
-EXPECT uprobe:.*/testprogs/uprobe_test:uprobeFunction1
+EXPECT_REGEX uprobe:.*/testprogs/uprobe_test:uprobeFunction1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - list probes by pid in separate mount namespace
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^uprobe'
-EXPECT uprobe:.*/bpftrace-unshare-mountns-test/uprobe_test:uprobeFunction1
+EXPECT_REGEX uprobe:.*/bpftrace-unshare-mountns-test/uprobe_test:uprobeFunction1
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
@@ -58,7 +58,7 @@ BEFORE ./testprogs/mountns_wrapper uprobe_test
 # pid namespace, not that of the docker container's namespace.
 NAME uprobes - attach to probe for executable in a pivot_root'd mount namespace
 RUN {{BPFTRACE}} -e 'uprobe:/proc/{{BEFORE_PID}}/root/uprobe_test:uprobeFunction1 { printf("func %s\n", func); exit(); }'
-EXPECT ^func (0x[0-9a-f]+|function1)$
+EXPECT_REGEX ^func (0x[0-9a-f]+|function1)$
 TIMEOUT 5
 BEFORE ./testprogs/mountns_pivot_wrapper uprobe_test
 

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -11,21 +11,21 @@ TIMEOUT 5
 
 NAME usdt probes - list probes by pid
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^usdt:'
-EXPECT usdt:.*/testprogs/usdt_test:tracetest:testprobe
+EXPECT_REGEX ^usdt:.*/testprogs/usdt_test:tracetest:testprobe$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - list probes by pid; usdt only
 RUN {{BPFTRACE}} -l 'usdt:*' -p {{BEFORE_PID}}
-EXPECT usdt_test:tracetest:testprobe
+EXPECT_REGEX ^usdt:.*/testprogs/usdt_test:tracetest:testprobe$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - lists linked library probes by pid
 RUN {{BPFTRACE}} -l 'usdt:*' -p $(pidof usdt_lib)
-EXPECT libusdt_tp.so:tracetestlib:lib_probe_1
+EXPECT_REGEX usdt:.*/libusdt_tp.so:tracetestlib:lib_probe_1$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_lib
 REQUIRES ./testprogs/systemtap_sys_sdt_check
@@ -38,7 +38,7 @@ REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - filter probes by pid on provider
 RUN {{BPFTRACE}} -l 'usdt:*:tracetest2:*' -p {{BEFORE_PID}}
-EXPECT usdt_test:tracetest2:testprobe2
+EXPECT_REGEX ^usdt:.*/usdt_test:tracetest2:testprobe2$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
@@ -57,7 +57,8 @@ REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - filter probes by pid and wildcard probe name
 RUN {{BPFTRACE}} -l 'usdt:*:tracetest:test*' -p {{BEFORE_PID}}
-EXPECT usdt_test:tracetest:testprobe2
+EXPECT_REGEX ^usdt:.*/usdt_test:tracetest:testprobe$
+EXPECT_REGEX ^usdt:.*/usdt_test:tracetest:testprobe2$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
@@ -192,33 +193,33 @@ REQUIRES bash -c "exit 1"
 
 NAME usdt probes - attach to probe with probe builtin and args by file
 PROG usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }
-EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
+EXPECT_REGEX ^\d+ usdt:./testprogs/usdt_test:tracetest.?:testprobe.?$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - attach to probe with probe builtin and args by file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -c ./testprogs/usdt_test
-EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
+EXPECT_REGEX ^\d+ usdt:./testprogs/usdt_test:tracetest.?:testprobe.?$
 TIMEOUT 5
 
 NAME usdt probes - attach to probe with probe builtin and args by pid
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -p {{BEFORE_PID}}
-EXPECT usdt_test:tracetest:testprobe
+EXPECT_REGEX ^\d+ usdt:.*/testprogs/usdt_test:tracetest.?:testprobe.?$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - attach to probe with semaphore
 RUN {{BPFTRACE}} -e 'usdt::tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
-EXPECT tracetest_testprobe_semaphore: [1-9]
+EXPECT tracetest_testprobe_semaphore: 1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - file based semaphore activation
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' --usdt-file-activation
-EXPECT tracetest_testprobe_semaphore: [1-9]
+EXPECT tracetest_testprobe_semaphore: 1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
@@ -244,7 +245,7 @@ REQUIRES_FEATURE uprobe_refcount
 # --usdt-file-activation if the kernel handles the semaphore
 NAME usdt probes - file based semaphore activation
 PROG usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }
-EXPECT tracetest_testprobe_semaphore: [1-9]
+EXPECT tracetest_testprobe_semaphore: 1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
@@ -260,7 +261,7 @@ REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - list probes by pid in separate mountns
 RUN {{BPFTRACE}} -l 'usdt:*' -p {{BEFORE_PID}}
-EXPECT usdt:.*/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe
+EXPECT_REGEX ^usdt:.*/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe$
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper usdt_test
 
@@ -283,15 +284,13 @@ REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt sized arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_sized_args:test:probe2 { printf("%ld\n", arg0); exit(); }' -p {{BEFORE_PID}}
-EXPECT ^1$
+EXPECT 1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_sized_args
 
 NAME usdt constant arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:const_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
-EXPECT 4092785136 -202182160 61936 -3600 240 -16
-#EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
-# Bug in bcc, constants are stored in a 32-bit int, so 64-bit values are truncated
+EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
 TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
@@ -317,12 +316,12 @@ REQUIRES ./testprogs/systemtap_sys_sdt_check
 # attach to all of them
 NAME usdt duplicated markers
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_inlined:tracetest:testprobe { printf("%d\n", arg1); @a += 1; if (@a >= 2) {exit();} }' -c ./testprogs/usdt_inlined
-EXPECT Attaching 2 probes.*\n.*\s999\s*100
+EXPECT_REGEX 999\n100
 TIMEOUT 1
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes in multiple modules
 RUN {{BPFTRACE}} runtime/scripts/usdt_multi_modules.bt
-EXPECT Attaching 2 probes
+EXPECT Attaching 2 probes...
 TIMEOUT 1
 REQUIRES ./testprogs/systemtap_sys_sdt_check

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -1,6 +1,6 @@
 NAME global_int
 PROG i:ms:1 {@a = 10; printf("%d\n", @a); exit();}
-EXPECT \@a: 10
+EXPECT @a: 10
 TIMEOUT 5
 
 NAME global_string
@@ -66,15 +66,15 @@ TIMEOUT 2
 
 NAME map key string type resize
 PROG BEGIN { @["hello"] = 0; } i:ms:1 { @["hi"] = 1; exit(); }
-EXPECT @\[hi\]: 1
+EXPECT @[hi]: 1
 TIMEOUT 2
 
 NAME map multi-key string type resize
 PROG BEGIN { @["hello", 0] = 0; } i:ms:1 { @["hi", 1] = 1; exit(); }
-EXPECT @\[hi, 1\]: 1
+EXPECT @[hi, 1]: 1
 TIMEOUT 2
 
 NAME tuple string resize
 PROG BEGIN { @ = ("hello", 0); } i:ms:1 { @ = ("hi", 1); exit(); }
-EXPECT @: \(hi, 1\)
+EXPECT @: (hi, 1)
 TIMEOUT 2

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -65,7 +65,7 @@ REQUIRES_FEATURE signal
 
 NAME unique_probe_bodies
 RUN {{BPFTRACE}} -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
-EXPECT .*increment_0:4:w!
+EXPECT_REGEX .*increment_0:4:w!
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal


### PR DESCRIPTION
The old behaviour is preserved with the new keyword: EXPECT_REGEX

Regexes make the tests harder to read and write, with special characters needing to be escaped, and are being misused in quite a number of places.

Switch the tests which use regex features over to EXPECT_REGEX. A lot of these will need to be looked at in the future as they're accepting basically any output, right or wrong.