### PR TITLE
Add for-each loops for iterating over map elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
   - [#3051](https://github.com/bpftrace/bpftrace/pull/3051)
 - Add ability to call delete() with multiple arguments
   - [#3046](https://github.com/bpftrace/bpftrace/pull/3046)
+- Add for-each loops for iterating over map elements
+  - [#3003](https://github.com/bpftrace/bpftrace/pull/3003)
 #### Changed
 #### Deprecated
 #### Removed

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -541,6 +541,39 @@ Characters and strings support the following escape sequences:
 
 === Loops
 
+==== For
+
+With Linux 5.13 and later, `for` loops can be used to iterate over elements in a map.
+
+----
+for ($kv : @map) {
+  block;
+}
+----
+
+The variable declared in the `for` loop will be initialised on each iteration with a tuple containing a key and a value from the map, i.e. `$kv = (key, value)`.
+
+----
+@map[10] = 20;
+for ($kv : @map) {
+  print($kv.0); // key
+  print($kv.1); // value
+}
+----
+
+When a map has multiple keys, the loop variable will be initialised with nested tuple of the form: `((key1, key2, ...), value)`
+
+----
+@map[10,11] = 20;
+for ($kv : @map) {
+  print($kv.0.0); // key 1
+  print($kv.0.1); // key 2
+  print($kv.1);   // value
+}
+----
+
+==== While
+
 Since kernel 5.3 BPF supports loops as long as the verifier can prove they're bounded and fit within the instruction limit.
 
 In bpftrace, loops are available through the `while` statement.
@@ -577,6 +610,8 @@ i:s:1 {
   printf("\n");
 }
 ----
+
+==== Unroll
 
 Loop unrolling is also supported with the `unroll` statement.
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -41,6 +41,7 @@ MAKE_ACCEPT(AttachPoint)
 MAKE_ACCEPT(If)
 MAKE_ACCEPT(Unroll)
 MAKE_ACCEPT(While)
+MAKE_ACCEPT(For)
 MAKE_ACCEPT(Config)
 MAKE_ACCEPT(Jump)
 MAKE_ACCEPT(Probe)
@@ -205,6 +206,15 @@ Ternary::~Ternary()
 While::~While()
 {
   delete cond;
+  for (auto *stmt : *stmts)
+    delete stmt;
+  delete stmts;
+}
+
+For::~For()
+{
+  delete decl;
+  delete expr;
   for (auto *stmt : *stmts)
     delete stmt;
   delete stmts;
@@ -756,6 +766,10 @@ bool Probe::has_ap_of_probetype(ProbeType probe_type)
 }
 
 While::While(const While &other) : Statement(other)
+{
+}
+
+For::For(const For &other) : Statement(other)
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -556,6 +556,25 @@ private:
   While(const While &other);
 };
 
+class For : public Statement {
+public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(For)
+
+  For(Variable *decl, Expression *expr, StatementList *stmts, location loc)
+      : Statement(loc), decl(decl), expr(expr), stmts(stmts)
+  {
+  }
+  ~For();
+
+  Variable *decl = nullptr;
+  Expression *expr = nullptr;
+  StatementList *stmts = nullptr;
+
+private:
+  For(const For &other);
+};
+
 class Config : public Statement {
 public:
   DEFINE_ACCEPT

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -54,6 +54,7 @@ public:
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
+  void visit(For &f) override;
   void visit(Jump &jump) override;
   void visit(Predicate &pred) override;
   void visit(AttachPoint &ap) override;
@@ -84,6 +85,10 @@ public:
                            uint64_t max_entries,
                            const MapKey &key,
                            const SizedType &value_type);
+  AllocaInst *createTuple(
+      const SizedType &tuple_type,
+      const std::vector<std::pair<llvm::Value *, const location *>> &vals,
+      const std::string &name);
 
   void generate_ir(void);
   void generate_maps(const RequiredResources &resources);
@@ -216,6 +221,8 @@ private:
   void createIncDec(Unop &unop);
 
   Function *createMapLenCallback();
+  Function *createForEachMapCallback(const Variable &decl,
+                                     const std::vector<Statement *> &stmts);
 
   // Return a lambda that has captured-by-value CodegenLLVM's async id state
   // (ie `printf_id_`, `mapped_printf_id_`, etc.).  Running the returned lambda

--- a/src/ast/passes/collect_nodes.h
+++ b/src/ast/passes/collect_nodes.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <functional>
+#include <vector>
+
+#include "ast/visitors.h"
+
+namespace bpftrace::ast {
+
+/*
+ * CollectNodes
+ *
+ * Recurses into the provided node and builds a list of all descendants of the
+ * requested type which match a predicate.
+ */
+template <typename NodeT>
+class CollectNodes : public Visitor {
+public:
+  void run(
+      Node &node,
+      std::function<bool(const NodeT &)> pred = [](const auto &) {
+        return true;
+      })
+  {
+    pred_ = pred;
+    node.accept(*this);
+  }
+  const std::vector<std::reference_wrapper<NodeT>> nodes() const
+  {
+    return nodes_;
+  }
+
+private:
+  void visit(NodeT &node) override
+  {
+    if (pred_(node)) {
+      nodes_.push_back(node);
+    }
+  }
+
+  std::vector<std::reference_wrapper<NodeT>> nodes_;
+  std::function<bool(const NodeT &)> pred_;
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/collect_nodes.h
+++ b/src/ast/passes/collect_nodes.h
@@ -25,7 +25,7 @@ public:
     pred_ = pred;
     node.accept(*this);
   }
-  const std::vector<std::reference_wrapper<NodeT>> nodes() const
+  const std::vector<std::reference_wrapper<NodeT>> &nodes() const
   {
     return nodes_;
   }

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -12,8 +12,9 @@ namespace ast {
 
 void Printer::print(Node *root)
 {
-  depth_ = 0;
+  ++depth_;
   Visit(*root);
+  --depth_;
 }
 
 std::string Printer::type(const SizedType &ty)
@@ -348,6 +349,24 @@ void Printer::visit(While &while_block)
   for (Statement *stmt : *while_block.stmts) {
     stmt->accept(*this);
   }
+}
+
+void Printer::visit(For &for_loop)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "for" << std::endl;
+
+  ++depth_;
+  out_ << indent << " decl\n";
+  print(for_loop.decl);
+  out_ << indent << " expr\n";
+  print(for_loop.expr);
+
+  out_ << indent << " stmts\n";
+  for (Statement *stmt : *for_loop.stmts) {
+    print(stmt);
+  }
+  --depth_;
 }
 
 void Printer::visit(Config &config)

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -40,6 +40,7 @@ public:
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
+  void visit(For &for_loop) override;
   void visit(Config &config) override;
   void visit(Jump &jump) override;
   void visit(Predicate &pred) override;
@@ -48,7 +49,7 @@ public:
   void visit(Subprog &subprog) override;
   void visit(Program &program) override;
 
-  int depth_ = 0;
+  int depth_ = -1;
 
 private:
   std::ostream &out_;

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -56,6 +56,7 @@ public:
   void visit(Binop &binop) override;
   void visit(Unop &unop) override;
   void visit(While &while_block) override;
+  void visit(For &f) override;
   void visit(Jump &jump) override;
   void visit(Ternary &ternary) override;
   void visit(FieldAccess &acc) override;
@@ -109,6 +110,7 @@ private:
                               std::string name = "");
 
   SizedType *get_map_type(const Map &map);
+  MapKey *get_map_key_type(const Map &map);
   void assign_map_type(const Map &map, const SizedType &type);
   void update_key_type(const Map &map, const MapKey &new_key);
   bool update_string_size(SizedType &type, const SizedType &new_type);
@@ -122,6 +124,7 @@ private:
   void binop_int(Binop &op);
   void binop_array(Binop &op);
 
+  bool has_error() const;
   bool in_loop(void)
   {
     return loop_depth_ > 0;

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -157,6 +157,16 @@ void Visitor::visit(While &while_block)
   }
 }
 
+void Visitor::visit(For &for_loop)
+{
+  Visit(*for_loop.decl);
+  Visit(*for_loop.expr);
+
+  for (Statement *stmt : *for_loop.stmts) {
+    Visit(*stmt);
+  }
+}
+
 void Visitor::visit(Jump &jump)
 {
   if (jump.return_value)
@@ -408,6 +418,16 @@ Node *Mutator::visit(While &while_block)
 
   w->stmts = mutateStmtList(while_block.stmts);
   return w;
+}
+
+Node *Mutator::visit(For &for_loop)
+{
+  auto f = for_loop.leafcopy();
+  f->decl = Value<Variable>(for_loop.decl);
+  f->expr = Value<Expression>(for_loop.expr);
+
+  f->stmts = mutateStmtList(for_loop.stmts);
+  return f;
 }
 
 Node *Mutator::visit(Probe &probe)

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -40,6 +40,7 @@ public:
   virtual void visit(Jump &jump) = 0;
   virtual void visit(Unroll &unroll) = 0;
   virtual void visit(While &while_block) = 0;
+  virtual void visit(For &for_loop) = 0;
   virtual void visit(Predicate &pred) = 0;
   virtual void visit(AttachPoint &ap) = 0;
   virtual void visit(Probe &probe) = 0;
@@ -106,6 +107,7 @@ public:
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
+  void visit(For &for_loop) override;
   void visit(Jump &jump) override;
   void visit(Predicate &pred) override;
   void visit(AttachPoint &ap) override;
@@ -173,6 +175,7 @@ public:
   virtual R visit(Jump &node) DEFAULT_FN;
   virtual R visit(Unroll &node) DEFAULT_FN;
   virtual R visit(While &node) DEFAULT_FN;
+  virtual R visit(For &node) DEFAULT_FN;
   virtual R visit(Predicate &node) DEFAULT_FN;
   virtual R visit(AttachPoint &node) DEFAULT_FN;
   virtual R visit(Probe &node) DEFAULT_FN;
@@ -225,6 +228,7 @@ private:
     DEFINE_DISPATCH(Predicate);
     DEFINE_DISPATCH(Ternary);
     DEFINE_DISPATCH(While);
+    DEFINE_DISPATCH(For);
     DEFINE_DISPATCH(AttachPoint);
     DEFINE_DISPATCH(SubprogArg);
     DEFINE_DISPATCH(Subprog);
@@ -277,6 +281,7 @@ public:
   Node *visit(Jump &) override;
   Node *visit(Unroll &) override;
   Node *visit(While &) override;
+  Node *visit(For &) override;
   Node *visit(Predicate &) override;
   Node *visit(AttachPoint &) override;
   Node *visit(Probe &) override;

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -610,6 +610,7 @@ std::string BPFfeature::report(void)
       << "  get_tai_ns: " << to_str(has_helper_ktime_get_tai_ns())
       << "  get_func_ip: " << to_str(has_helper_get_func_ip())
       << "  jiffies64: " << to_str(has_helper_jiffies64())
+      << "  for_each_map_elem: " << to_str(has_helper_for_each_map_elem())
 
       << std::endl;
 

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -125,6 +125,7 @@ public:
   DEFINE_HELPER_TEST(ktime_get_tai_ns, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(get_func_ip, libbpf::BPF_PROG_TYPE_TRACING);
   DEFINE_HELPER_TEST(jiffies64, libbpf::BPF_PROG_TYPE_KPROBE);
+  DEFINE_HELPER_TEST(for_each_map_elem, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(kprobe, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(tracepoint, libbpf::BPF_PROG_TYPE_TRACEPOINT);
   DEFINE_PROG_TEST(perf_event, libbpf::BPF_PROG_TYPE_PERF_EVENT);

--- a/tests/codegen/for_map_one_key.cpp
+++ b/tests/codegen/for_map_one_key.cpp
@@ -1,0 +1,10 @@
+#include "common.h"
+
+namespace bpftrace::test::codegen {
+
+TEST(codegen, for_map_one_key)
+{
+  test("BEGIN { @map[16] = 32; for ($kv : @map) { @x = $kv; } }", NAME);
+}
+
+} // namespace bpftrace::test::codegen

--- a/tests/codegen/for_map_strings.cpp
+++ b/tests/codegen/for_map_strings.cpp
@@ -1,0 +1,11 @@
+#include "common.h"
+
+namespace bpftrace::test::codegen {
+
+TEST(codegen, for_map_strings)
+{
+  test(R"(BEGIN { @map["abc"] = "xyz"; for ($kv : @map) { @x = $kv; } })",
+       NAME);
+}
+
+} // namespace bpftrace::test::codegen

--- a/tests/codegen/for_map_two_keys.cpp
+++ b/tests/codegen/for_map_two_keys.cpp
@@ -1,0 +1,10 @@
+#include "common.h"
+
+namespace bpftrace::test::codegen {
+
+TEST(codegen, for_map_two_keys)
+{
+  test("BEGIN { @map[16,17] = 32; for ($kv : @map) { @x = $kv; } }", NAME);
+}
+
+} // namespace bpftrace::test::codegen

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -18,17 +18,17 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !40 {
 entry:
   %key = alloca i32, align 4
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
-  %str = alloca [4 x i8], align 1
   %tuple = alloca %"int64_string[4]__tuple_t", align 8
-  %1 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
+  %str = alloca [4 x i8], align 1
+  %1 = bitcast [4 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 16, i1 false)
-  %3 = getelementptr %"int64_string[4]__tuple_t", %"int64_string[4]__tuple_t"* %tuple, i32 0, i32 0
-  store i64 1, i64* %3, align 8
-  %4 = bitcast [4 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store [4 x i8] c"abc\00", [4 x i8]* %str, align 1
+  %2 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %3 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %3, i8 0, i64 16, i1 false)
+  %4 = getelementptr %"int64_string[4]__tuple_t", %"int64_string[4]__tuple_t"* %tuple, i32 0, i32 0
+  store i64 1, i64* %4, align 8
   %5 = getelementptr %"int64_string[4]__tuple_t", %"int64_string[4]__tuple_t"* %tuple, i32 0, i32 1
   %6 = bitcast [4 x i8]* %5 to i8*
   %7 = bitcast [4 x i8]* %str to i8*

--- a/tests/codegen/llvm/for_map_one_key.ll
+++ b/tests/codegen/llvm/for_map_one_key.ll
@@ -1,0 +1,149 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.1" = type { i8*, i8* }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
+%"unsigned int64_int64__tuple_t" = type { i64, i64 }
+
+@AT_map = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_x = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !30
+@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !44
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN(i8* %0) section "s_BEGIN_1" !dbg !61 {
+entry:
+  %"@map_val" = alloca i64, align 8
+  %"@map_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@map_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 16, i64* %"@map_key", align 8
+  %2 = bitcast i64* %"@map_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 32, i64* %"@map_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_map, i64* %"@map_key", i64* %"@map_val", i64 0)
+  %3 = bitcast i64* %"@map_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %"@map_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %for_each_map_elem = call i64 inttoptr (i64 164 to i64 (%"struct map_t"*, i64 (i8*, i8*, i8*, i8*)*, i8*, i64)*)(%"struct map_t"* @AT_map, i64 (i8*, i8*, i8*, i8*)* @map_for_each_cb, i8* null, i64 0)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !69 {
+  %"@x_key" = alloca i64, align 8
+  %"$kv" = alloca %"unsigned int64_int64__tuple_t", align 8
+  %key = load i64, i8* %1, align 8
+  %val = load i64, i8* %2, align 8
+  %5 = bitcast %"unsigned int64_int64__tuple_t"* %"$kv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast %"unsigned int64_int64__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %"unsigned int64_int64__tuple_t", %"unsigned int64_int64__tuple_t"* %"$kv", i32 0, i32 0
+  store i64 %key, i64* %7, align 8
+  %8 = getelementptr %"unsigned int64_int64__tuple_t", %"unsigned int64_int64__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %val, i64* %8, align 8
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@x_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, %"unsigned int64_int64__tuple_t"*, i64)*)(%"struct map_t.0"* @AT_x, i64* %"@x_key", %"unsigned int64_int64__tuple_t"* %"$kv", i64 0)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!60}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !23)
+!23 = !{!5, !11, !16, !24}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !29}
+!28 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64, offset: 64)
+!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
+!31 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !33)
+!33 = !{!34, !39}
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !35, size: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 27, lowerBound: 0)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !40, size: 64, offset: 64)
+!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !42)
+!42 = !{!43}
+!43 = !DISubrange(count: 262144, lowerBound: 0)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
+!46 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !47)
+!47 = !{!48, !53, !54, !19}
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !49, size: 64)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 2, lowerBound: 0)
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
+!56 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !58, globals: !59)
+!58 = !{}
+!59 = !{!0, !20, !30, !44}
+!60 = !{i32 2, !"Debug Info Version", i32 3}
+!61 = distinct !DISubprogram(name: "BEGIN", linkageName: "BEGIN", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !66)
+!62 = !DISubroutineType(types: !63)
+!63 = !{!18, !64}
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!66 = !{!67, !68}
+!67 = !DILocalVariable(name: "var0", scope: !61, file: !2, type: !18)
+!68 = !DILocalVariable(name: "var1", arg: 1, scope: !61, file: !2, type: !64)
+!69 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !57, retainedNodes: !70)
+!70 = !{!71, !72}
+!71 = !DILocalVariable(name: "var0", scope: !69, file: !2, type: !18)
+!72 = !DILocalVariable(name: "var1", arg: 1, scope: !69, file: !2, type: !64)

--- a/tests/codegen/llvm/for_map_strings.ll
+++ b/tests/codegen/llvm/for_map_strings.ll
@@ -1,0 +1,158 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.1" = type { i8*, i8* }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
+%"string[4]_string[4]__tuple_t" = type { [4 x i8], [4 x i8] }
+
+@AT_map = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_x = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !23
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !50
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN(i8* %0) section "s_BEGIN_1" !dbg !68 {
+entry:
+  %str1 = alloca [4 x i8], align 1
+  %str = alloca [4 x i8], align 1
+  %1 = bitcast [4 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store [4 x i8] c"xyz\00", [4 x i8]* %str, align 1
+  %2 = bitcast [4 x i8]* %str1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store [4 x i8] c"abc\00", [4 x i8]* %str1, align 1
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, [4 x i8]*, [4 x i8]*, i64)*)(%"struct map_t"* @AT_map, [4 x i8]* %str1, [4 x i8]* %str, i64 0)
+  %3 = bitcast [4 x i8]* %str1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast [4 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %for_each_map_elem = call i64 inttoptr (i64 164 to i64 (%"struct map_t"*, i64 (i8*, i8*, i8*, i8*)*, i8*, i64)*)(%"struct map_t"* @AT_map, i64 (i8*, i8*, i8*, i8*)* @map_for_each_cb, i8* null, i64 0)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !75 {
+  %"@x_key" = alloca i64, align 8
+  %"$kv" = alloca %"string[4]_string[4]__tuple_t", align 8
+  %5 = bitcast %"string[4]_string[4]__tuple_t"* %"$kv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast %"string[4]_string[4]__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 8, i1 false)
+  %7 = getelementptr %"string[4]_string[4]__tuple_t", %"string[4]_string[4]__tuple_t"* %"$kv", i32 0, i32 0
+  %8 = bitcast [4 x i8]* %7 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %1, i64 4, i1 false)
+  %9 = getelementptr %"string[4]_string[4]__tuple_t", %"string[4]_string[4]__tuple_t"* %"$kv", i32 0, i32 1
+  %10 = bitcast [4 x i8]* %9 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %10, i8* align 1 %2, i64 4, i1 false)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@x_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, %"string[4]_string[4]__tuple_t"*, i64)*)(%"struct map_t.0"* @AT_x, i64* %"@x_key", %"string[4]_string[4]__tuple_t"* %"$kv", i64 0)
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+
+!llvm.dbg.cu = !{!64}
+!llvm.module.flags = !{!67}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !22}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 32, elements: !20)
+!19 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!20 = !{!21}
+!21 = !DISubrange(count: 4, lowerBound: 0)
+!22 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !26)
+!26 = !{!5, !11, !27, !30}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !28, size: 64, offset: 128)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !31, size: 64, offset: 192)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 64, elements: !33)
+!33 = !{!34, !35}
+!34 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 32)
+!35 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 32, offset: 32)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !39)
+!39 = !{!40, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 27, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !46, size: 64, offset: 64)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !48)
+!48 = !{!49}
+!49 = !DISubrange(count: 262144, lowerBound: 0)
+!50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
+!51 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
+!52 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !53)
+!53 = !{!54, !59, !60, !63}
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !55, size: 64)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !57)
+!57 = !{!58}
+!58 = !DISubrange(count: 2, lowerBound: 0)
+!59 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!60 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !61, size: 64, offset: 128)
+!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
+!62 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!63 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !28, size: 64, offset: 192)
+!64 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !65, globals: !66)
+!65 = !{}
+!66 = !{!0, !23, !36, !50}
+!67 = !{i32 2, !"Debug Info Version", i32 3}
+!68 = distinct !DISubprogram(name: "BEGIN", linkageName: "BEGIN", scope: !2, file: !2, type: !69, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !64, retainedNodes: !72)
+!69 = !DISubroutineType(types: !70)
+!70 = !{!29, !71}
+!71 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!72 = !{!73, !74}
+!73 = !DILocalVariable(name: "var0", scope: !68, file: !2, type: !29)
+!74 = !DILocalVariable(name: "var1", arg: 1, scope: !68, file: !2, type: !71)
+!75 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !69, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !64, retainedNodes: !76)
+!76 = !{!77, !78}
+!77 = !DILocalVariable(name: "var0", scope: !75, file: !2, type: !29)
+!78 = !DILocalVariable(name: "var1", arg: 1, scope: !75, file: !2, type: !71)

--- a/tests/codegen/llvm/for_map_two_keys.ll
+++ b/tests/codegen/llvm/for_map_two_keys.ll
@@ -1,0 +1,167 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.1" = type { i8*, i8* }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
+%"(unsigned int64,unsigned int64)_int64__tuple_t" = type { %"unsigned int64_unsigned int64__tuple_t", i64 }
+%"unsigned int64_unsigned int64__tuple_t" = type { i64, i64 }
+
+@AT_map = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_x = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
+@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !54
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN(i8* %0) section "s_BEGIN_1" !dbg !71 {
+entry:
+  %"@map_val" = alloca i64, align 8
+  %"@map_key" = alloca [16 x i8], align 1
+  %1 = bitcast [16 x i8]* %"@map_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %2 = getelementptr [16 x i8], [16 x i8]* %"@map_key", i64 0, i64 0
+  %3 = bitcast i8* %2 to i64*
+  store i64 16, i64* %3, align 8
+  %4 = getelementptr [16 x i8], [16 x i8]* %"@map_key", i64 0, i64 8
+  %5 = bitcast i8* %4 to i64*
+  store i64 17, i64* %5, align 8
+  %6 = bitcast i64* %"@map_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 32, i64* %"@map_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, [16 x i8]*, i64*, i64)*)(%"struct map_t"* @AT_map, [16 x i8]* %"@map_key", i64* %"@map_val", i64 0)
+  %7 = bitcast i64* %"@map_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast [16 x i8]* %"@map_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %for_each_map_elem = call i64 inttoptr (i64 164 to i64 (%"struct map_t"*, i64 (i8*, i8*, i8*, i8*)*, i8*, i64)*)(%"struct map_t"* @AT_map, i64 (i8*, i8*, i8*, i8*)* @map_for_each_cb, i8* null, i64 0)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !78 {
+  %"@x_key" = alloca i64, align 8
+  %"$kv" = alloca %"(unsigned int64,unsigned int64)_int64__tuple_t", align 8
+  %val = load i64, i8* %2, align 8
+  %5 = bitcast %"(unsigned int64,unsigned int64)_int64__tuple_t"* %"$kv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast %"(unsigned int64,unsigned int64)_int64__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 24, i1 false)
+  %7 = getelementptr %"(unsigned int64,unsigned int64)_int64__tuple_t", %"(unsigned int64,unsigned int64)_int64__tuple_t"* %"$kv", i32 0, i32 0
+  %8 = bitcast %"unsigned int64_unsigned int64__tuple_t"* %7 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %1, i64 16, i1 false)
+  %9 = getelementptr %"(unsigned int64,unsigned int64)_int64__tuple_t", %"(unsigned int64,unsigned int64)_int64__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %val, i64* %9, align 8
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@x_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, %"(unsigned int64,unsigned int64)_int64__tuple_t"*, i64)*)(%"struct map_t.0"* @AT_x, i64* %"@x_key", %"(unsigned int64,unsigned int64)_int64__tuple_t"* %"$kv", i64 0)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+
+!llvm.dbg.cu = !{!67}
+!llvm.module.flags = !{!70}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !22}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 128, elements: !20)
+!19 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!20 = !{!21}
+!21 = !DISubrange(count: 16, lowerBound: 0)
+!22 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !28)
+!28 = !{!5, !11, !29, !30}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !31, size: 64, offset: 192)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 192, elements: !33)
+!33 = !{!34, !39}
+!34 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !35, size: 128)
+!35 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !36)
+!36 = !{!37, !38}
+!37 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64)
+!38 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64, offset: 64)
+!39 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64, offset: 128)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !43)
+!43 = !{!44, !49}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 27, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 262144, lowerBound: 0)
+!54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
+!55 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !56, isLocal: false, isDefinition: true)
+!56 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !57)
+!57 = !{!58, !63, !64, !22}
+!58 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !59, size: 64)
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !61)
+!61 = !{!62}
+!62 = !DISubrange(count: 2, lowerBound: 0)
+!63 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!64 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !65, size: 64, offset: 128)
+!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
+!66 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!67 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !68, globals: !69)
+!68 = !{}
+!69 = !{!0, !25, !40, !54}
+!70 = !{i32 2, !"Debug Info Version", i32 3}
+!71 = distinct !DISubprogram(name: "BEGIN", linkageName: "BEGIN", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !67, retainedNodes: !75)
+!72 = !DISubroutineType(types: !73)
+!73 = !{!24, !74}
+!74 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!75 = !{!76, !77}
+!76 = !DILocalVariable(name: "var0", scope: !71, file: !2, type: !24)
+!77 = !DILocalVariable(name: "var1", arg: 1, scope: !71, file: !2, type: !74)
+!78 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !67, retainedNodes: !79)
+!79 = !{!80, !81}
+!80 = !DILocalVariable(name: "var0", scope: !78, file: !2, type: !24)
+!81 = !DILocalVariable(name: "var1", arg: 1, scope: !78, file: !2, type: !74)

--- a/tests/codegen/llvm/tuple.ll
+++ b/tests/codegen/llvm/tuple.ll
@@ -18,19 +18,19 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !62 {
 entry:
   %"@t_key" = alloca i64, align 8
-  %str = alloca [4 x i8], align 1
   %tuple = alloca %"int64_int64_string[4]__tuple_t", align 8
-  %1 = bitcast %"int64_int64_string[4]__tuple_t"* %tuple to i8*
+  %str = alloca [4 x i8], align 1
+  %1 = bitcast [4 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %"int64_int64_string[4]__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
-  %3 = getelementptr %"int64_int64_string[4]__tuple_t", %"int64_int64_string[4]__tuple_t"* %tuple, i32 0, i32 0
-  store i64 1, i64* %3, align 8
-  %4 = getelementptr %"int64_int64_string[4]__tuple_t", %"int64_int64_string[4]__tuple_t"* %tuple, i32 0, i32 1
-  store i64 2, i64* %4, align 8
-  %5 = bitcast [4 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store [4 x i8] c"str\00", [4 x i8]* %str, align 1
+  %2 = bitcast %"int64_int64_string[4]__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %3 = bitcast %"int64_int64_string[4]__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %3, i8 0, i64 24, i1 false)
+  %4 = getelementptr %"int64_int64_string[4]__tuple_t", %"int64_int64_string[4]__tuple_t"* %tuple, i32 0, i32 0
+  store i64 1, i64* %4, align 8
+  %5 = getelementptr %"int64_int64_string[4]__tuple_t", %"int64_int64_string[4]__tuple_t"* %tuple, i32 0, i32 1
+  store i64 2, i64* %5, align 8
   %6 = getelementptr %"int64_int64_string[4]__tuple_t", %"int64_int64_string[4]__tuple_t"* %tuple, i32 0, i32 2
   %7 = bitcast [4 x i8]* %6 to i8*
   %8 = bitcast [4 x i8]* %str to i8*

--- a/tests/codegen/llvm/tuple_array_struct.ll
+++ b/tests/codegen/llvm/tuple_array_struct.ll
@@ -19,21 +19,21 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !64 {
 entry:
   %"@t_key" = alloca i64, align 8
   %tuple = alloca %"struct Foo_int32[4]__tuple_t", align 8
-  %1 = bitcast %"struct Foo_int32[4]__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %"struct Foo_int32[4]__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2, align 8
   %3 = bitcast i8* %0 to i64*
-  %4 = getelementptr i64, i64* %3, i64 14
-  %arg0 = load volatile i64, i64* %4, align 8
-  %5 = getelementptr %"struct Foo_int32[4]__tuple_t", %"struct Foo_int32[4]__tuple_t"* %tuple, i32 0, i32 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([8 x i8]*, i32, i64)*)([8 x i8]* %5, i32 8, i64 %arg0)
-  %6 = bitcast i8* %0 to i64*
-  %7 = getelementptr i64, i64* %6, i64 13
-  %arg1 = load volatile i64, i64* %7, align 8
-  %8 = add i64 %arg1, 0
+  %4 = getelementptr i64, i64* %3, i64 13
+  %arg1 = load volatile i64, i64* %4, align 8
+  %5 = add i64 %arg1, 0
+  %6 = bitcast %"struct Foo_int32[4]__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = bitcast %"struct Foo_int32[4]__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 24, i1 false)
+  %8 = getelementptr %"struct Foo_int32[4]__tuple_t", %"struct Foo_int32[4]__tuple_t"* %tuple, i32 0, i32 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([8 x i8]*, i32, i64)*)([8 x i8]* %8, i32 8, i64 %arg0)
   %9 = getelementptr %"struct Foo_int32[4]__tuple_t", %"struct Foo_int32[4]__tuple_t"* %tuple, i32 0, i32 1
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 ([4 x i32]*, i32, i64)*)([4 x i32]* %9, i32 16, i64 %8)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 ([4 x i32]*, i32, i64)*)([4 x i32]* %9, i32 16, i64 %5)
   %10 = bitcast i64* %"@t_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@t_key", align 8

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -6,8 +6,8 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
-%usym_t = type { i64, i64, i64 }
 %"unsigned int8_usym_int64__tuple_t" = type { i8, [24 x i8], i64 }
+%usym_t = type { i64, i64, i64 }
 
 @AT_t = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !30
@@ -19,27 +19,27 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !62 {
 entry:
   %"@t_key" = alloca i64, align 8
-  %usym = alloca %usym_t, align 8
   %tuple = alloca %"unsigned int8_usym_int64__tuple_t", align 8
-  %1 = bitcast %"unsigned int8_usym_int64__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %"unsigned int8_usym_int64__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 40, i1 false)
-  %3 = getelementptr %"unsigned int8_usym_int64__tuple_t", %"unsigned int8_usym_int64__tuple_t"* %tuple, i32 0, i32 0
-  store i8 1, i8* %3, align 1
-  %4 = bitcast i8* %0 to i64*
-  %5 = getelementptr i64, i64* %4, i64 16
-  %reg_ip = load volatile i64, i64* %5, align 8
-  %6 = bitcast %usym_t* %usym to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %usym = alloca %usym_t, align 8
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 16
+  %reg_ip = load volatile i64, i64* %2, align 8
+  %3 = bitcast %usym_t* %usym to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %7 = lshr i64 %get_pid_tgid, 32
-  %8 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 0
-  %9 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 1
-  %10 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 2
-  store i64 %reg_ip, i64* %8, align 8
-  store i64 %7, i64* %9, align 8
-  store i64 0, i64* %10, align 8
+  %4 = lshr i64 %get_pid_tgid, 32
+  %5 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 0
+  %6 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 1
+  %7 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 2
+  store i64 %reg_ip, i64* %5, align 8
+  store i64 %4, i64* %6, align 8
+  store i64 0, i64* %7, align 8
+  %8 = bitcast %"unsigned int8_usym_int64__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = bitcast %"unsigned int8_usym_int64__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 40, i1 false)
+  %10 = getelementptr %"unsigned int8_usym_int64__tuple_t", %"unsigned int8_usym_int64__tuple_t"* %tuple, i32 0, i32 0
+  store i8 1, i8* %10, align 1
   %11 = getelementptr %"unsigned int8_usym_int64__tuple_t", %"unsigned int8_usym_int64__tuple_t"* %tuple, i32 0, i32 1
   %12 = bitcast [24 x i8]* %11 to i8*
   %13 = bitcast %usym_t* %usym to i8*

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -108,6 +108,7 @@ public:
     has_ktime_get_tai_ns_ = std::make_optional<bool>(has_features);
     has_get_func_ip_ = std::make_optional<bool>(has_features);
     has_jiffies64_ = std::make_optional<bool>(has_features);
+    has_for_each_map_elem_ = std::make_optional<bool>(has_features);
   };
 
   void has_loop(bool has)

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2275,6 +2275,37 @@ TEST(Parser, subprog_enum)
        " f: enum x()\n");
 }
 
+TEST(Parser, for_loop)
+{
+  test("BEGIN { for ($kv : @map) { print($kv) } }", R"(
+Program
+ BEGIN
+  for
+   decl
+    variable: $kv
+   expr
+    map: @map
+   stmts
+    call: print
+     variable: $kv
+)");
+
+  // Error location is incorrect: #3063
+  // No body
+  test_parse_failure("BEGIN { for ($kv : @map) print($kv); }", R"(
+stdin:1:27-32: ERROR: syntax error, unexpected call, expecting {
+BEGIN { for ($kv : @map) print($kv); }
+                          ~~~~~
+)");
+
+  // Map for decl
+  test_parse_failure("BEGIN { for (@kv : @map) { } }", R"(
+stdin:1:13-17: ERROR: syntax error, unexpected map, expecting variable
+BEGIN { for (@kv : @map) { } }
+            ~~~~
+)");
+}
+
 } // namespace parser
 } // namespace test
 } // namespace bpftrace

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -1,0 +1,71 @@
+NAME map one key
+PROG BEGIN { @map[16] = 32; @map[64] = 128; for ($kv : @map) { print($kv); } exit(); }
+EXPECT (16, 32)
+EXPECT (64, 128)
+TIMEOUT 5
+
+NAME map two keys
+PROG BEGIN { @map[16,17] = 32; @map[64,65] = 128; for ($kv : @map) { print($kv); } exit(); }
+EXPECT ((16, 17), 32)
+EXPECT ((64, 65), 128)
+TIMEOUT 5
+
+NAME map one key elements
+PROG BEGIN { @map[16] = 32; for ($kv : @map) { printf("key: %d, val: %d\n", $kv.0, $kv.1); } exit(); }
+EXPECT key: 16, val: 32
+TIMEOUT 5
+
+NAME map two key elements
+PROG BEGIN { @map[16,17] = 32; for ($kv : @map) { printf("key: (%d,%d), val: %d\n", $kv.0.0, $kv.0.1, $kv.1); } exit(); }
+EXPECT key: (16,17), val: 32
+TIMEOUT 5
+
+NAME map strings
+PROG BEGIN { @map["abc"] = "aa"; @map["def"] = "dd"; for ($kv : @map) { print($kv); } exit(); }
+EXPECT (abc, aa)
+EXPECT (def, dd)
+TIMEOUT 5
+
+NAME map create map in body
+PROG BEGIN { @map[16] = 32; @map[64] = 128; for ($kv : @map) { @new[$kv.1] = $kv.0; } print(@new); exit(); }
+EXPECT @new[32]: 16
+EXPECT @new[128]: 64
+TIMEOUT 5
+
+NAME map multiple loops
+PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); } for ($kv : @mapB) { print($kv); } exit(); }
+EXPECT (16, 32)
+EXPECT (17, 33)
+EXPECT (64, 128)
+EXPECT (65, 129)
+TIMEOUT 5
+
+# Disabled due to https://github.com/bpftrace/bpftrace/issues/3021
+NAME map multiple probes
+PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); } exit(); } END { for ($kv : @mapB) { print($kv); } }
+EXPECT (16, 32)
+EXPECT (17, 33)
+EXPECT (64, 128)
+EXPECT (65, 129)
+TIMEOUT 5
+REQUIRES bash -c "exit 1"
+
+NAME map nested vals
+PROG BEGIN { @mapA[16] = 32; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); for ($kv2 : @mapB) { print($kv2); } } exit(); }
+EXPECT (16, 32)
+EXPECT (64, 128)
+EXPECT (65, 129)
+TIMEOUT 5
+
+NAME map nested count
+PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; @mapB[66] = 130; for ($kv : @mapA) { printf("A"); for ($kv2 : @mapB) { printf("B"); } } exit(); }
+EXPECT ABBBABBB
+TIMEOUT 5
+
+NAME map delete
+PROG BEGIN { @[0,0,0] = 1; @[0,0,1] = 1; @[0,1,0] = 1; @[1,0,0] = 1; for ($kv : @) { if ($kv.0.1 == 1) { delete(@[$kv.0.0, $kv.0.1, $kv.0.2]); } } exit(); }
+EXPECT @[0, 0, 0]: 1
+EXPECT @[0, 0, 1]: 1
+EXPECT @[1, 0, 0]: 1
+EXPECT_NONE @[0, 1, 0]: 1
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3080,6 +3080,264 @@ TEST_F(semantic_analyser_btf, fentry)
   test("fentry:func_1 { $x = args->a; }", 0);
 }
 
+TEST(semantic_analyser, for_loop_map_one_key)
+{
+  test("BEGIN { @map[0] = 1; for ($kv : @map) { print($kv); } }", R"(
+Program
+ BEGIN
+  =
+   map: @map :: [int64]
+    int: 0 :: [int64]
+   int: 1 :: [int64]
+  for
+   decl
+    variable: $kv :: [(unsigned int64,int64)]
+   expr
+    map: @map :: [int64]
+   stmts
+    call: print
+     variable: $kv :: [(unsigned int64,int64)]
+)");
+}
+
+TEST(semantic_analyser, for_loop_map_two_keys)
+{
+  test("BEGIN { @map[0,0] = 1; for ($kv : @map) { print($kv); } }", R"(
+Program
+ BEGIN
+  =
+   map: @map :: [int64]
+    int: 0 :: [int64]
+    int: 0 :: [int64]
+   int: 1 :: [int64]
+  for
+   decl
+    variable: $kv :: [((unsigned int64,unsigned int64),int64)]
+   expr
+    map: @map :: [int64]
+   stmts
+    call: print
+     variable: $kv :: [((unsigned int64,unsigned int64),int64)]
+)");
+}
+
+TEST(semantic_analyser, for_loop_map)
+{
+  test("BEGIN { @map[0] = 1; for ($kv : @map) { print($kv); } }");
+  test("BEGIN { @map[0] = 1; for ($kv : @map) { print($kv.0); } }");
+  test("BEGIN { @map[0] = 1; for ($kv : @map) { print($kv.1); } }");
+}
+
+TEST(semantic_analyser, for_loop_map_no_key)
+{
+  // Error location is incorrect: #3063
+  test_error("BEGIN { @map = 1; for ($kv : @map) { } }", R"(
+stdin:1:30-35: ERROR: Maps used as for-loop expressions must have keys to iterate over
+BEGIN { @map = 1; for ($kv : @map) { } }
+                             ~~~~~
+)");
+}
+
+TEST(semantic_analyser, for_loop_map_undefined)
+{
+  // Error location is incorrect: #3063
+  test_error("BEGIN { for ($kv : @map) { } }", R"(
+stdin:1:20-25: ERROR: Undefined map: @map
+BEGIN { for ($kv : @map) { } }
+                   ~~~~~
+)");
+}
+
+TEST(semantic_analyser, for_loop_map_undefined2)
+{
+  // Error location is incorrect: #3063
+  test_error("BEGIN { @map[0] = 1; for ($kv : @undef) { @map[$kv.0]; } }", R"(
+stdin:1:33-40: ERROR: Undefined map: @undef
+BEGIN { @map[0] = 1; for ($kv : @undef) { @map[$kv.0]; } }
+                                ~~~~~~~
+)");
+}
+
+TEST(semantic_analyser, for_loop_shadowed_decl)
+{
+  test_error(R"(
+    BEGIN {
+      $kv = 1;
+      @map[0] = 1;
+      for ($kv : @map) { }
+    })",
+             R"(
+stdin:4:11-15: ERROR: Loop declaration shadows existing variable: $kv
+      for ($kv : @map) { }
+          ~~~~
+)");
+}
+
+TEST(semantic_analyser, for_loop_variables)
+{
+  // Read-only
+  test_error(R"(
+    BEGIN {
+      $var = 0;
+      @map[0] = 1;
+      for ($kv : @map) {
+        print($var);
+      }
+      print($var);
+    })",
+             R"(
+stdin:5:9-19: ERROR: Variables defined outside of a for-loop can not be accessed in the loop's scope
+        print($var);
+        ~~~~~~~~~~
+)");
+
+  // Modified after loop
+  test_error(R"(
+    BEGIN {
+      $var = 0;
+      @map[0] = 1;
+      for ($kv : @map) {
+        print($var);
+      }
+      $var = 1;
+      print($var);
+    })",
+             R"(
+stdin:5:9-19: ERROR: Variables defined outside of a for-loop can not be accessed in the loop's scope
+        print($var);
+        ~~~~~~~~~~
+)");
+
+  // Modified during loop
+  test_error(R"(
+    BEGIN {
+      $var = 0;
+      @map[0] = 1;
+      for ($kv : @map) {
+        $var++;
+      }
+      print($var);
+    })",
+             R"(
+stdin:5:9-13: ERROR: Variables defined outside of a for-loop can not be accessed in the loop's scope
+        $var++;
+        ~~~~
+)");
+
+  // Created in loop
+  test(R"(
+    BEGIN {
+      @map[0] = 1;
+      for ($kv : @map) {
+        $var = 2;
+        print($var);
+      }
+    })");
+}
+
+TEST(semantic_analyser, for_loop_variables_created_in_loop_used_after)
+{
+  test_error(R"(
+    BEGIN {
+      @map[0] = 1;
+      for ($kv : @map) {
+        $var = 2;
+      }
+      print($var);
+    })",
+             R"(
+stdin:6:7-17: ERROR: Undefined or undeclared variable: $var
+      print($var);
+      ~~~~~~~~~~
+)");
+
+  test_error(R"(
+    BEGIN {
+      @map[0] = 1;
+      for ($kv : @map) {
+        print($kv);
+      }
+      print($kv);
+    })",
+             R"(
+stdin:6:7-16: ERROR: Undefined or undeclared variable: $kv
+      print($kv);
+      ~~~~~~~~~
+)");
+}
+
+TEST(semantic_analyser, for_loop_invalid_expr)
+{
+  // Error location is incorrect: #3063
+  test_error("BEGIN { for ($x : $var) { } }", R"(
+stdin:1:19-24: ERROR: Loop expression must be a map
+BEGIN { for ($x : $var) { } }
+                  ~~~~~
+)");
+  test_error("BEGIN { for ($x : 1+2) { } }", R"(
+stdin:1:19-22: ERROR: Loop expression must be a map
+BEGIN { for ($x : 1+2) { } }
+                  ~~~
+)");
+  test_error("BEGIN { for ($x : \"abc\") { } }", R"(
+stdin:1:19-25: ERROR: Loop expression must be a map
+BEGIN { for ($x : "abc") { } }
+                  ~~~~~~
+)");
+}
+
+TEST(semantic_analyser, for_loop_multiple_errors)
+{
+  // Error location is incorrect: #3063
+  test_error(R"(
+    BEGIN {
+      $kv = 1;
+      @map[0] = 1;
+      for ($kv : 1) { }
+    })",
+             R"(
+stdin:4:11-15: ERROR: Loop declaration shadows existing variable: $kv
+      for ($kv : 1) { }
+          ~~~~
+stdin:4:18-20: ERROR: Loop expression must be a map
+      for ($kv : 1) { }
+                 ~~
+)");
+}
+
+TEST(semantic_analyser, for_loop_control_flow)
+{
+  // Error location is incorrect: #3063
+  test_error("BEGIN { @map[0] = 1; for ($kv : @map) { break; } }", R"(
+stdin:1:42-47: ERROR: 'break' statement is not allowed in a for-loop
+BEGIN { @map[0] = 1; for ($kv : @map) { break; } }
+                                         ~~~~~
+)");
+  // Error location is incorrect: #3063
+  test_error("BEGIN { @map[0] = 1; for ($kv : @map) { continue; } }", R"(
+stdin:1:42-50: ERROR: 'continue' statement is not allowed in a for-loop
+BEGIN { @map[0] = 1; for ($kv : @map) { continue; } }
+                                         ~~~~~~~~
+)");
+  // Error location is incorrect: #3063
+  test_error("BEGIN { @map[0] = 1; for ($kv : @map) { return; } }", R"(
+stdin:1:42-48: ERROR: 'return' statement is not allowed in a for-loop
+BEGIN { @map[0] = 1; for ($kv : @map) { return; } }
+                                         ~~~~~~
+)");
+}
+
+TEST(semantic_analyser, for_loop_missing_feature)
+{
+  test_error("BEGIN { @map[0] = 1; for ($kv : @map) { print($kv); } }",
+             R"(
+stdin:1:22-25: ERROR: Missing required kernel feature: for_each_map_elem
+BEGIN { @map[0] = 1; for ($kv : @map) { print($kv); } }
+                     ~~~
+)",
+             false);
+}
+
 } // namespace semantic_analyser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
Basic support for #2955. Support for sharing variables will be added in a separate PR: #3014

For loops are implemented using the bpf_for_each_map_elem helper function, which requires them to be rewritten into a callback style.

In this first implementation, we do not allow any variables to be shared between the main probe and the loop's body. Maps are global so are not a problem.

Pseudo code for the transformation we apply:

Before:
```
PROBE {
  @map[0] = 1;
  for ($kv : @map) {
    [LOOP BODY]
  }
}
```

After:
```
PROBE {
  @map[0] = 1;
  bpf_for_each_map_elem(@map, &map_for_each_cb, 0, 0);
}
long map_for_each_cb(bpf_map *map, const void *key, void *value, void *ctx) {
  $kv = ((uint64)key, (uint64)value);
  [LOOP BODY]
}
```

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
