### PR TITLE
Allow keywords to be used as idents

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -138,18 +138,18 @@ bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, loc); }
 "$"[0-9]+               { return Parser::make_PARAM(yytext, loc); }
 "$"#                    { return Parser::make_PARAMCOUNT(loc); }
 "#"[^!].*               { return Parser::make_CPREPROC(yytext, loc); }
-"if"                    { return Parser::make_IF(loc); }
-"else"                  { return Parser::make_ELSE(loc); }
+"if"                    { return Parser::make_IF(yytext, loc); }
+"else"                  { return Parser::make_ELSE(yytext, loc); }
 "?"                     { return Parser::make_QUES(loc); }
-"unroll"                { return Parser::make_UNROLL(loc); }
-"while"                 { return Parser::make_WHILE(loc); }
-"config"                { return Parser::make_CONFIG(loc); }
-"for"                   { return Parser::make_FOR(loc); }
-"return"                { return Parser::make_RETURN(loc); }
-"continue"              { return Parser::make_CONTINUE(loc); }
-"break"                 { return Parser::make_BREAK(loc); }
-"sizeof"                { return Parser::make_SIZEOF(loc); }
-"offsetof"              { return Parser::make_OFFSETOF(loc); }
+"unroll"                { return Parser::make_UNROLL(yytext, loc); }
+"while"                 { return Parser::make_WHILE(yytext, loc); }
+"config"                { return Parser::make_CONFIG(yytext, loc); }
+"for"                   { return Parser::make_FOR(yytext, loc); }
+"return"                { return Parser::make_RETURN(yytext, loc); }
+"continue"              { return Parser::make_CONTINUE(yytext, loc); }
+"break"                 { return Parser::make_BREAK(yytext, loc); }
+"sizeof"                { return Parser::make_SIZEOF(yytext, loc); }
+"offsetof"              { return Parser::make_OFFSETOF(yytext, loc); }
 
 {int_type}              { return Parser::make_INT_TYPE(yytext, loc); }
 {builtin_type}          { return Parser::make_BUILTIN_TYPE(yytext, loc); }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2141,6 +2141,28 @@ TEST(Parser, config_error)
   test_parse_failure("BPFTRACE_STACK_MODE=perf; i:s:1 { exit(); }");
 }
 
+TEST(Parser, keywords_as_identifiers)
+{
+  std::vector<std::string> keywords = { "break",    "config", "continue",
+                                        "else",     "for",    "if",
+                                        "offsetof", "return", "sizeof",
+                                        "unroll",   "while" };
+  for (const auto &keyword : keywords) {
+    test("BEGIN { $x = (struct Foo*)0; $x->" + keyword + "; }",
+         "Program\n BEGIN\n  =\n   variable: $x\n   (struct Foo *)\n    int: "
+         "0\n "
+         " .\n   dereference\n    variable: $x\n   " +
+             keyword + "\n");
+    test("BEGIN { $x = (struct Foo)0; $x." + keyword + "; }",
+         "Program\n BEGIN\n  =\n   variable: $x\n   (struct Foo)\n    int: 0\n "
+         " .\n   variable: $x\n   " +
+             keyword + "\n");
+    test("BEGIN { $x = offsetof(*curtask, " + keyword + "); }",
+         "Program\n BEGIN\n  =\n   variable: $x\n   offsetof: \n    "
+         "dereference\n     builtin: curtask\n");
+  }
+}
+
 } // namespace parser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
This list of keywords that can now be used for postfix expressions and in the offsetof expression e.g.
```
$x->keyword
$x.keyword
offsetof(*curtask, keyword)
```

List:
- "break"
- "config"
- "continue"
- "else"
- "for"
- "if"
- "offsetof"
- "return"
- "sizeof"
- "unroll"
- "while"

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
