### PR TITLE
fix bpftrace_fuzz error for call to 'get_kernel…_cflags'

### DIFF
--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -137,7 +137,8 @@ int fuzz_main(const char* data, size_t sz)
     kobj = std::get<1>(kdirs);
 
     if (ksrc != "")
-      extra_flags = get_kernel_cflags(utsname.machine, ksrc, kobj, bpftrace.kconfig);
+      extra_flags = get_kernel_cflags(
+          utsname.machine, ksrc, kobj, bpftrace.kconfig);
   }
   extra_flags.push_back("-include");
   extra_flags.push_back(CLANG_WORKAROUNDS_H);

--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -137,7 +137,7 @@ int fuzz_main(const char* data, size_t sz)
     kobj = std::get<1>(kdirs);
 
     if (ksrc != "")
-      extra_flags = get_kernel_cflags(utsname.machine, ksrc, kobj);
+      extra_flags = get_kernel_cflags(utsname.machine, ksrc, kobj, bpftrace.kconfig);
   }
   extra_flags.push_back("-include");
   extra_flags.push_back(CLANG_WORKAROUNDS_H);


### PR DESCRIPTION
When compiling bpftrace_fuzz we run into the following issue where 1 argument is missing, adding the required argument

```
src/fuzz_main.cpp:140:21: error: no matching function for call to 'get_kernel_cflags'
      extra_flags = get_kernel_cflags(utsname.machine, ksrc, kobj);
                    ^~~~~~~~~~~~~~~~~
src/utils.h:180:26: note: candidate function not viable: requires 4 arguments, but 3 were provided std::vector<std::string> get_kernel_cflags(const char *uname_machine,
                         ^
```
Seems fourth argument was added via 4bcee640636e268de4b938a1007fb29a8836f049


<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
