### PR TITLE
BpfProgram: Relocate .text section

### DIFF
--- a/src/bpfprogram.h
+++ b/src/bpfprogram.h
@@ -37,6 +37,7 @@ private:
                       MapManager &bpftrace);
 
   void relocateInsns();
+  bool relocateSection(const std::string &relsecname, bpf_insn *);
   void relocateFuncInfos();
   void appendFileFuncInfos(const struct btf_ext_info_sec *src,
                            size_t func_info_rec_size,


### PR DESCRIPTION
This is needed for BPF subprograms which use maps (including the ring buffer's map).

It's therefore needed for most uses of bpf_for_each_map_elem and the upcoming for-loop support.

Easiest to view with "ignore whitespace" on - I've pretty much just moved code into a new function and called it twice.

I'm not keen on the "return needs_text" part but couldn't think of a nicer way of doing it.