### PR TITLE
Materialise a header file containing version info

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -1,0 +1,30 @@
+# This file generates the file "version.h", containing an up-to-date version
+# string on each build.
+
+# Inputs:
+#   File names:
+#     VERSION_H_IN - name of template source file
+#     VERSION_H    - name of populated file to be generated
+#   Fallback version numbers when not building in a Git repository:
+#     bpftrace_VERSION_MAJOR
+#     bpftrace_VERSION_MINOR
+#     bpftrace_VERSION_PATCH
+
+# Try and get a version string from Git tags
+execute_process(
+  COMMAND git describe --abbrev=4 --dirty --tags
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE BPFTRACE_VERSION
+  ERROR_VARIABLE GIT_DESCRIBE_ERROR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE retcode
+)
+
+# If the build is not done from a git repo, get the version information from
+# the version variables in main CMakeLists.txt
+if(NOT ${retcode} EQUAL 0)
+  set(BPFTRACE_VERSION "v${bpftrace_VERSION_MAJOR}.${bpftrace_VERSION_MINOR}.${bpftrace_VERSION_PATCH}")
+  message(STATUS "Could not obtain version string from Git. Falling back to CMake version string.")
+endif()
+
+configure_file(${VERSION_H_IN} ${VERSION_H} @ONLY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,6 +61,7 @@ set_target_properties(libbpftrace PROPERTIES PREFIX "")
 add_executable(${BPFTRACE}
   ${MAIN_SRC}
 )
+target_include_directories(${BPFTRACE} PUBLIC ${CMAKE_BINARY_DIR}/src)
 
 install(TARGETS ${BPFTRACE} DESTINATION ${CMAKE_INSTALL_BINDIR})
 target_link_libraries(${BPFTRACE} libbpftrace)
@@ -94,22 +95,20 @@ if (KERNEL_HEADERS_DIR)
   target_compile_definitions(runtime PUBLIC KERNEL_HEADERS_DIR="${KERNEL_HEADERS_DIR}")
 endif()
 
-execute_process(
-  COMMAND git describe --abbrev=4 --dirty --tags
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-  OUTPUT_VARIABLE BPFTRACE_VERSION
-  ERROR_VARIABLE GIT_DESCRIBE_ERROR
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-  RESULT_VARIABLE retcode
+add_custom_command(
+  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version.h
+  DEPENDS ${PROJECT_SOURCE_DIR}/.git/index
+  COMMAND ${CMAKE_COMMAND}
+    -DVERSION_H_IN=${CMAKE_CURRENT_SOURCE_DIR}/version.h.in
+    -DVERSION_H=${CMAKE_CURRENT_BINARY_DIR}/version.h
+    -Dbpftrace_VERSION_MAJOR=${bpftrace_VERSION_MAJOR}
+    -Dbpftrace_VERSION_MINOR=${bpftrace_VERSION_MINOR}
+    -Dbpftrace_VERSION_PATCH=${bpftrace_VERSION_PATCH}
+    -P ${CMAKE_SOURCE_DIR}/cmake/Version.cmake
 )
-
-# If the build is not done from a git repo, get the version information from
-# the version variables in main CMakeLists.txt
-if(NOT "${retcode}" STREQUAL "0")
-  set(BPFTRACE_VERSION "v${bpftrace_VERSION_MAJOR}.${bpftrace_VERSION_MINOR}.${bpftrace_VERSION_PATCH}")
-endif()
-
-add_definitions("-DBPFTRACE_VERSION=\"${BPFTRACE_VERSION}\"")
+add_custom_target(version_h DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/version.h)
+add_dependencies(${BPFTRACE} version_h)
+add_dependencies(libbpftrace version_h)
 
 target_include_directories(runtime PRIVATE ${CMAKE_BINARY_DIR})
 target_include_directories(runtime PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/src/aot/CMakeLists.txt
+++ b/src/aot/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(aot aot.cpp)
-add_dependencies(aot parser)
+add_dependencies(aot parser version_h)
 target_include_directories(aot PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(aot PUBLIC ${CMAKE_BINARY_DIR}/src)
 target_include_directories(aot PUBLIC ${CMAKE_BINARY_DIR})
 target_compile_definitions(aot PRIVATE ${BPFTRACE_FLAGS})
 

--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -22,6 +22,7 @@
 #include "filesystem.h"
 #include "log.h"
 #include "utils.h"
+#include "version.h"
 
 #define AOT_ELF_SECTION ".btaot"
 static constexpr auto AOT_MAGIC = 0xA07;
@@ -51,7 +52,7 @@ namespace bpftrace {
 namespace aot {
 namespace {
 
-uint32_t rs_hash(const std::string &str)
+uint32_t rs_hash(std::string_view str)
 {
   unsigned int b = 378551;
   unsigned int a = 63689;

--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -7,6 +7,7 @@
 #include "bpftrace.h"
 #include "log.h"
 #include "output.h"
+#include "version.h"
 
 using namespace bpftrace;
 

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -3,6 +3,8 @@
 
 #include "build_info.h"
 
+#include "version.h"
+
 namespace bpftrace {
 
 std::string BuildInfo::report()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "probe_matcher.h"
 #include "procmon.h"
 #include "tracepoint_format_parser.h"
+#include "version.h"
 
 using namespace bpftrace;
 

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <string_view>
+
+constexpr std::string_view BPFTRACE_VERSION = "@BPFTRACE_VERSION@";


### PR DESCRIPTION
This approach makes the bpftrace build easier to integrate into non-CMake build systems.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
