### PR TITLE
BpfProgram: Use correct offset when relocating .text

### DIFF
--- a/src/bpfprogram.h
+++ b/src/bpfprogram.h
@@ -37,7 +37,7 @@ private:
                       MapManager &bpftrace);
 
   void relocateInsns();
-  bool relocateSection(const std::string &relsecname, bpf_insn *);
+  void relocateSection(const std::string &relsecname, bpf_insn *);
   void relocateFuncInfos();
   void appendFileFuncInfos(const struct btf_ext_info_sec *src,
                            size_t func_info_rec_size,


### PR DESCRIPTION
The .text section appears after our main program section:

```
    [Main Program]
    [   .text    ] <- text_offset_
```

When relocating instructions from the main program to point into .text, they must add text_offset_.

When relocating instructions from .text to point to another part of .text, they should not add an offset.


This is needed to allow nested loops in #3003, in which a subprogram calls another subprogram.