### PR TITLE
cmake: Fix nix build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,7 +97,6 @@ endif()
 
 add_custom_command(
   OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version.h
-  DEPENDS ${PROJECT_SOURCE_DIR}/.git/index
   COMMAND ${CMAKE_COMMAND}
     -DVERSION_H_IN=${CMAKE_CURRENT_SOURCE_DIR}/version.h.in
     -DVERSION_H=${CMAKE_CURRENT_BINARY_DIR}/version.h


### PR DESCRIPTION
Nix does the build in a hermetic environment. Git history is not available during the build. This confuses cmake. Fix by removing the explicit dependency on git history.

This should still work OK, as Version.cmake handles git shellout failures gracefully.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
