### PR TITLE
Fix error in dereferencing kernel double pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to
   - [#3095](https://github.com/bpftrace/bpftrace/pull/3095)
 - Fix storing strings of differing lengths in a variable
   - [#3178](https://github.com/bpftrace/bpftrace/pull/3178)
+- Field analyser: resolve fields for array accesses
+  - [#3024](https://github.com/bpftrace/bpftrace/pull/3024)
 #### Docs
 #### Tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to
   - [#3178](https://github.com/bpftrace/bpftrace/pull/3178)
 - Field analyser: resolve fields for array accesses
   - [#3024](https://github.com/bpftrace/bpftrace/pull/3024)
+- Fix error in dereferencing kernel double pointers
+  - [#3024](https://github.com/bpftrace/bpftrace/pull/3024)
 #### Docs
 #### Tools
 

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -113,6 +113,16 @@ void FieldAnalyser::visit(FieldAccess &acc)
   }
 }
 
+void FieldAnalyser::visit(ArrayAccess &arr)
+{
+  Visit(*arr.indexpr);
+  Visit(*arr.expr);
+  if (sized_type_.IsPtrTy()) {
+    sized_type_ = *sized_type_.GetPointeeTy();
+    resolve_fields(sized_type_);
+  }
+}
+
 void FieldAnalyser::visit(Cast &cast)
 {
   Visit(*cast.expr);

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -31,6 +31,7 @@ public:
   void visit(Map &map) override;
   void visit(Variable &var) override;
   void visit(FieldAccess &acc) override;
+  void visit(ArrayAccess &arr) override;
   void visit(Cast &cast) override;
   void visit(Sizeof &szof) override;
   void visit(Offsetof &ofof) override;

--- a/tests/codegen/llvm/map_args.ll
+++ b/tests/codegen/llvm/map_args.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
-%"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args" = type { i32, i64, i64 }
+%"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args" = type { i32, i64, i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -38,12 +38,17 @@ entry:
   %arg2 = load volatile i64, i64* %10, align 8
   %11 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args"* %args, i64 0, i32 2
   store i64 %arg2, i64* %11, align 8
-  %12 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %12 = bitcast i8* %0 to i64*
+  %13 = getelementptr i64, i64* %12, i64 11
+  %arg3 = load volatile i64, i64* %13, align 8
+  %14 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args"* %args, i64 0, i32 3
+  store i64 %arg3, i64* %14, align 8
+  %15 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   store i64 0, i64* %"@_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args"*, i64)*)(%"struct map_t"* @AT_, i64* %"@_key", %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args"* %args, i64 0)
-  %13 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %16 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
   ret i64 0
 }
 
@@ -80,10 +85,10 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 160, elements: !23)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 224, elements: !23)
 !22 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !23 = !{!24}
-!24 = !DISubrange(count: 20, lowerBound: 0)
+!24 = !DISubrange(count: 28, lowerBound: 0)
 !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
 !26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
 !27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -21,7 +21,10 @@ struct Foo3 {
 
 struct Foo3 foo3;
 
-struct Foo3 *func_1(int a, struct Foo1 *foo1, struct Foo2 *foo2)
+struct Foo3 *func_1(int a,
+                    struct Foo1 *foo1,
+                    struct Foo2 *foo2,
+                    struct Foo3 *foo3)
 {
   return 0;
 }
@@ -31,7 +34,8 @@ struct Foo3 *func_2(int a, int *b, struct Foo1 *foo1)
   return 0;
 }
 
-struct Foo3 *func_3(int a, int *b, struct Foo1 *foo1)
+// __attribute__((noinline)) is needed due to a LLDB/GCC compatibility bug
+struct Foo3 *__attribute__((noinline)) func_3(int a, int *b, struct Foo1 *foo1)
 {
   return 0;
 }
@@ -115,7 +119,7 @@ int main(void)
   struct bpf_iter__task_file iter_task_file;
   struct bpf_iter__task_vma iter_task_vma;
 
-  func_1(0, 0, 0);
+  func_1(0, 0, 0, 0);
 
   bpf_iter_task();
   bpf_iter_task_file();

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -82,3 +82,18 @@ NAME address_probe_invalid_expansion
 RUN {{BPFTRACE}} -e "uprobe:./testprogs/uprobe_test:0x$(nm ./testprogs/uprobe_test | awk '$3 == "uprobeFunction1" {print $1}') { @[probe] = count(); exit() }"
 EXPECT Attaching 1 probe...
 TIMEOUT 1
+
+# The verifier is not able to track BTF info for double pointer dereferences and
+# array accesses so we must use bpf_probe_read_kernel, otherwise the program is
+# rejected. The below two tests make sure that we handle such situations.
+NAME kfunc double pointer dereference
+PROG kfunc:__module_get { print((*args.module->trace_events)->flags); exit(); }
+AFTER lsmod
+EXPECT Attaching 1 probe...
+TIMEOUT 1
+
+NAME kfunc double pointer array access
+PROG kfunc:__module_get { print(args.module->trace_events[1]->flags); exit(); }
+AFTER lsmod
+EXPECT Attaching 1 probe...
+TIMEOUT 1


### PR DESCRIPTION
BPF verifier can detect safety of pointer accesses for BTF-based probes (k(ret)func, iter) and therefore it is not necessary to use `bpf_probe_read_kernel` inside such probes. This feature was enabled in bpftrace by commit c2c3ab96 ("Support identifying btf type").
    
Unfortunately, the verifier is not able to track BTF information for dereferences and array accesses on double pointers so, e.g. the following script fails to load:

    # bpftrace -e 'kfunc:__module_get { print(args.module->trace_events[0]->flags);' } -v
    INFO: node count: 13
    Attaching 1 probe...
   
    Error log:
    reg type unsupported for arg#0 function kfunc_vmlinux___module_get#22
    0: R1=ctx(off=0,imm=0) R10=fp0
    0: (79) r1 = *(u64 *)(r1 +0)
    func '__module_get' arg0 has btf_id 250 type STRUCT 'module'
    1: R1_w=ptr_module(off=0,imm=0)
    1: (79) r1 = *(u64 *)(r1 +1128)       ; R1_w=scalar()
    2: (79) r1 = *(u64 *)(r1 +0)
    R1 invalid mem access 'scalar'
    processed 3 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0

    ERROR: Error loading program: kfunc:vmlinux:__module_get
    
A similar error happens when dereferencing the double pointer with `*`
    
    # bpftrace -e 'kfunc:__module_get { print((*args.module->trace_events)->flags);' } -v
    
 An analogous program fails to load even when written using libbpf.
    
 We need to use `bpf_probe_read_kernel` for such cases so do not propagate the `SizedType::is_btftype` flag when observing a dereference or array access of a double pointer in semantic analyser.

This also fixes another bug related to array access - field analyser was not doing field resolution on array accesses on pointers to structs.

Overall, this resolves #3016.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
