### PR TITLE
print: Print single map values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
   - [#2958](https://github.com/bpftrace/bpftrace/pull/2958)
 - Add ability to list all probes in a program
   - [#2969](https://github.com/bpftrace/bpftrace/pull/2969)
+- Add ability to call print() with indexed maps to print single map values
+  - [#3027](https://github.com/bpftrace/bpftrace/pull/3027)
 #### Changed
 #### Deprecated
 #### Removed

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -983,9 +983,14 @@ void CodegenLLVM::visit(Call &call)
                                               b_.GetInsertBlock()->getParent());
     b_.SetInsertPoint(deadcode);
   } else if (call.func == "print") {
-    if (call.vargs->at(0)->is_map)
-      createPrintMapCall(call);
-    else
+    if (call.vargs->at(0)->is_map) {
+      auto &arg = *call.vargs->at(0);
+      auto &map = static_cast<Map &>(arg);
+      if (!map.vargs)
+        createPrintMapCall(call);
+      else
+        createPrintNonMapCall(call, non_map_print_id_);
+    } else
       createPrintNonMapCall(call, non_map_print_id_);
   } else if (call.func == "cgroup_path") {
     auto elements = AsyncEvent::CgroupPath().asLLVMType(b_);

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -154,6 +154,11 @@ void ResourceAnalyser::visit(Call &call)
     auto &arg = *call.vargs->at(0);
     if (!arg.is_map)
       resources_.non_map_print_args.push_back(arg.type);
+    else {
+      auto &map = static_cast<Map &>(arg);
+      if (map.vargs)
+        resources_.non_map_print_args.push_back(map.type);
+    }
   } else if (call.func == "kstack" || call.func == "ustack") {
     resources_.stackid_maps.insert(call.type.stack_type);
   } else if (call.func == "cgroup_path") {

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -352,6 +352,16 @@ REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall open
 
+NAME print_map_item
+PROG BEGIN { @x[1] = 5; print(@x[1]); exit() }
+EXPECT 5
+TIMEOUT 1
+
+NAME print_map_item_tuple
+PROG BEGIN { @x[1] = "hi"; print((1, 2, @x[1])); exit() }
+EXPECT (1, 2, hi)
+TIMEOUT 1
+
 NAME strftime
 PROG BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts); exit(); }
 EXPECT_REGEX [0-9]{2}\/[0-9]{2}\/[0-9]{2}


### PR DESCRIPTION
Allows indexing a map with key(s) to print single map values while using the print() function.

Resolves #2779.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
