### PR TITLE
Fix: specific types in tuples

### DIFF
--- a/src/output.h
+++ b/src/output.h
@@ -193,8 +193,11 @@ protected:
   virtual std::string field_to_str(const std::string &name,
                                    const std::string &value) const = 0;
   // Convert tuple to string
-  virtual std::string tuple_to_str(
-      const std::vector<std::string> &elems) const = 0;
+  virtual std::string tuple_to_str(BPFtrace &bpftrace,
+                                   const SizedType &type,
+                                   std::vector<uint8_t> &value,
+                                   bool is_per_cpu,
+                                   uint32_t div) const = 0;
   // Convert a vector of (key, value) pairs into string
   // keys are strings
   // values are 64-bit integers
@@ -267,8 +270,11 @@ protected:
   std::string map_elem_delim_to_str(const SizedType &map_type) const override;
   std::string field_to_str(const std::string &name,
                            const std::string &value) const override;
-  std::string tuple_to_str(
-      const std::vector<std::string> &elems) const override;
+  std::string tuple_to_str(BPFtrace &bpftrace,
+                           const SizedType &type,
+                           std::vector<uint8_t> &value,
+                           bool is_per_cpu,
+                           uint32_t div) const override;
   std::string key_value_pairs_to_str(
       std::vector<std::pair<std::string, int64_t>> &keyvals) const override;
 };
@@ -346,8 +352,11 @@ protected:
   std::string map_elem_delim_to_str(const SizedType &map_type) const override;
   std::string field_to_str(const std::string &name,
                            const std::string &value) const override;
-  std::string tuple_to_str(
-      const std::vector<std::string> &elems) const override;
+  std::string tuple_to_str(BPFtrace &bpftrace,
+                           const SizedType &type,
+                           std::vector<uint8_t> &value,
+                           bool is_per_cpu,
+                           uint32_t div) const override;
   std::string key_value_pairs_to_str(
       std::vector<std::pair<std::string, int64_t>> &keyvals) const override;
 };

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -324,7 +324,7 @@ TIMEOUT 1
 
 NAME print_non_map_tuple
 PROG BEGIN { $t = (1, 2, "string"); print($t); exit() }
-EXPECT (1, 2, string)
+EXPECT (1, 2, "string")
 TIMEOUT 1
 
 NAME print_non_map_array
@@ -359,7 +359,7 @@ TIMEOUT 1
 
 NAME print_map_item_tuple
 PROG BEGIN { @x[1] = "hi"; print((1, 2, @x[1])); exit() }
-EXPECT (1, 2, hi)
+EXPECT (1, 2, "hi")
 TIMEOUT 1
 
 NAME strftime

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -25,7 +25,7 @@ TIMEOUT 5
 
 NAME complex tuple 1
 PROG BEGIN { print(((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555)); exit(); }
-EXPECT (-100, 100, abcdef, 3, 1, -10, 10, -555)
+EXPECT (-100, 100, "abcdef", 3, 1, -10, 10, -555)
 TIMEOUT 5
 
 NAME tuple struct sizing 1
@@ -80,8 +80,8 @@ TIMEOUT 5
 # Careful with '(' and ')', they are read by the test engine as a regex group,
 # so make sure to escape them.
 NAME tuple print
-PROG BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }
-EXPECT @: (1, 2, string, (4, 5))
+PROG BEGIN { @ = (1, 2, "string", (4, 5), strerror(22)); exit(); }
+EXPECT @: (1, 2, "string", (4, 5), "Invalid argument")
 TIMEOUT 5
 
 NAME tuple strftime type is packed

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -76,5 +76,5 @@ TIMEOUT 2
 
 NAME tuple string resize
 PROG BEGIN { @ = ("hello", 0); } i:ms:1 { @ = ("hi", 1); exit(); }
-EXPECT @: (hi, 1)
+EXPECT @: ("hi", 1)
 TIMEOUT 2


### PR DESCRIPTION
Fixes Issue: https://github.com/bpftrace/bpftrace/issues/2998

```
BEGIN { $t = (1, 2, "string"); print($t); exit() }
```
Should print: `(1, 2, "string")` instead of `(1, 2, string)`

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
