### PR TITLE
Remove more stat/fstat calls 

### DIFF
--- a/src/bfd-disasm.cpp
+++ b/src/bfd-disasm.cpp
@@ -20,10 +20,13 @@ BfdDisasm::BfdDisasm(std::string &path) : size_(0)
   fd_ = open(path.c_str(), O_RDONLY);
 
   if (fd_ >= 0) {
-    struct stat st;
+    std::error_code ec;
+    std_filesystem::path fs_path{ path };
+    std::uintmax_t file_size = std::filesystem::file_size(fs_path, ec);
 
-    if (fstat(fd_, &st) == 0)
-      size_ = st.st_size;
+    if (file_size != static_cast<std::uintmax_t>(-1)) {
+      size_ = file_size;
+    }
   }
 }
 

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -390,10 +390,11 @@ bool BPFfeature::has_uprobe_refcnt()
   if (has_uprobe_refcnt_.has_value())
     return *has_uprobe_refcnt_;
 
-  struct stat sb;
-  has_uprobe_refcnt_ =
-      ::stat("/sys/bus/event_source/devices/uprobe/format/ref_ctr_offset",
-             &sb) == 0;
+  std::error_code ec;
+  std_filesystem::path path{
+    "/sys/bus/event_source/devices/uprobe/format/ref_ctr_offset"
+  };
+  has_uprobe_refcnt_ = std_filesystem::exists(path, ec);
 
   return *has_uprobe_refcnt_;
 }


### PR DESCRIPTION
Replace with std::filesystem.

https://github.com/bpftrace/bpftrace/issues/1263

There are still a few in utils.cpp but I think
we need to keep those because they access st_ino
and there doesn't seem to be a way to get that
from std::filesystem.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
