### PR TITLE
Fix build issue with UAPI header of older kernel (#2977)

### DIFF
--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -51,7 +51,16 @@ static int btf_type_size(const struct btf_type *t)
     case BTF_KIND_ENUM:
       return base_size + vlen * sizeof(struct btf_enum);
     case BTF_KIND_ENUM64:
-      return base_size + vlen * sizeof(struct btf_enum64);
+      /* struct btf_enum64 is not available in UAPI header until v6.0,
+       * calculate its size with array instead. Its definition is:
+       *
+       * struct btf_enum64 {
+       *	__u32	name_off;
+       *	__u32	val_lo32;
+       *	__u32	val_hi32;
+       * };
+       */
+      return base_size + vlen * sizeof(__u32[3]);
     case BTF_KIND_ARRAY:
       return base_size + sizeof(struct btf_array);
     case BTF_KIND_STRUCT:
@@ -64,7 +73,14 @@ static int btf_type_size(const struct btf_type *t)
     case BTF_KIND_DATASEC:
       return base_size + vlen * sizeof(struct btf_var_secinfo);
     case BTF_KIND_DECL_TAG:
-      return base_size + sizeof(struct btf_decl_tag);
+      /* struct btf_decl_tag is not available until v5.16. Use the same trick
+       * as btf_enum64 above. Its definition is:
+       *
+       * struct btf_decl_tag {
+       *  __s32   component_idx;
+       * };
+       */
+      return base_size + sizeof(__s32);
     default:
       return -EINVAL;
   }


### PR DESCRIPTION
This is a backport of #2977 that the fix to build failure due to struct btf_decl_tag (v5.16) and struct btf_enum64 (v6.0) definitions missing in UAPI header of v5.4 kernel.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
