### PR TITLE
use 64bit alignment for map counter atomic add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   - [#2964](https://github.com/bpftrace/bpftrace/pull/2964)
 - Fix security hole checking unpacked kernel headers
   - [#3033](https://github.com/bpftrace/bpftrace/pull/3033)
+- Fix alignment of atomic map counter update
+  - [#3045](https://github.com/bpftrace/bpftrace/pull/3045)
 #### Docs
 #### Tools
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1472,7 +1472,7 @@ void IRBuilderBPF::CreateAtomicIncCounter(const std::string &map_name,
   CREATE_ATOMIC_RMW(AtomicRMWInst::BinOp::Add,
                     val,
                     getInt64(1),
-                    1,
+                    8,
                     AtomicOrdering::SequentiallyConsistent);
   CreateBr(lookup_merge_block);
 


### PR DESCRIPTION
For an atomic inc of a map counter (ringbuf loss counter), generate IR with 64bit alignment. This is more correct, and will avoid problems with upcoming LLVM versions, as they will emit a function call for a potentially unaligned atomicrmw. This will lead to an error like this:

# bpftrace -e 'BEGIN { print("hello")}'
error: <unknown>:0:0: in function BEGIN i64 (ptr): t15: i64 = GlobalAddress<ptr @__atomic_compare_exchange> 0 too many arguments

