### PR TITLE
Allow multiple arguments for delete()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#3027](https://github.com/bpftrace/bpftrace/pull/3027)
 - Add LLVM 18 support
   - [#3051](https://github.com/bpftrace/bpftrace/pull/3051)
+- Add ability to call delete() with multiple arguments
+  - [#3046](https://github.com/bpftrace/bpftrace/pull/3046)
 #### Changed
 #### Deprecated
 #### Removed

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2292,8 +2292,8 @@ Functions that are marked *async* are asynchronous which can lead to unexpected 
 | Count how often this function is called.
 | Sync
 
-| <<map-functions-delete, `delete(mapkey k)`>>
-| Delete a single key from a map. For a single value map this deletes the only element. For an associative-array the key to delete has to be specified.
+| <<map-functions-delete, `delete(mapkey k, ...)`>>
+| Delete a single key from a map. For a single value map this deletes the only element. For an associative-array the key to delete has to be specified. Multiple arguments can be passed to delete many keys at once.
 | Sync
 
 | <<map-functions-hist, `hist(int64 n[, int k])`>>
@@ -2399,11 +2399,12 @@ i:s:10 {
 === delete
 
 .variants
-* `delete(mapkey k)`
+* `delete(mapkey k, ...)`
 
 Delete a single key from a map.
 For a single value map this deletes the only element.
 For an associative-array the key to delete has to be specified.
+Multiple arguments can be passed to delete many keys at once.
 
 ```
 k:dummy {
@@ -2411,6 +2412,8 @@ k:dummy {
   @associative[1,2] = 1;
   delete(@scalar);
   delete(@associative[1,2]);
+  // alternatively, you can delete both at once
+  delete(@scalar, @associative[1,2]);
 
   delete(@associative); // error
 }

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -606,12 +606,13 @@ void SemanticAnalyser::visit(Call &call)
     call.type = CreateStats(true);
   } else if (call.func == "delete") {
     check_assignment(call, false, false, false);
-    if (check_nargs(call, 1)) {
-      auto &arg = *call.vargs->at(0);
-      if (!arg.is_map)
-        LOG(ERROR, call.loc, err_) << "delete() expects a map to be provided";
+    if (check_varargs(call, 1, std::numeric_limits<size_t>::max())) {
+      for (const auto &arg : *call.vargs) {
+        if (!arg->is_map)
+          LOG(ERROR, arg->loc, err_)
+              << "delete() only expects maps to be provided";
+      }
     }
-
     call.type = CreateNone();
   } else if (call.func == "str") {
     if (check_varargs(call, 1, 2)) {

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -220,6 +220,12 @@ PROG BEGIN { @ = 1; @a[1] = 1; delete(@); delete(@a[1]); printf("ok\n"); exit();
 EXPECT ok
 TIMEOUT 1
 
+NAME delete multiple-map
+PROG BEGIN { @ = 1; @a[1] = 1; delete(@, @a[1]); exit(); }
+EXPECT_NONE @: 1
+EXPECT_NONE @a[1]: 1
+TIMEOUT 1
+
 NAME delete count-map
 PROG BEGIN { @ = count(); @a[1] = count(); delete(@); delete(@a[1]); exit(); }
 EXPECT @: 0


### PR DESCRIPTION
Implements passing of multiple arguments to delete().

E.g. you can now do

```
@x[1] = 1;
@x[2] = 2;
@c = 5;
delete(@x[1], @x[2], @c);
```
instead of having to call delete() separately for each individual map element.

Closes  #947.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
