### PR TITLE
Better error message for args in mixed probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 - Add for-each loops for iterating over map elements
   - [#3003](https://github.com/bpftrace/bpftrace/pull/3003)
 #### Changed
+- Better error message for args in mixed probes
+  - [#3047](https://github.com/bpftrace/bpftrace/pull/3047)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -423,8 +423,13 @@ void SemanticAnalyser::visit(Builtin &builtin)
 
     ProbeType type = single_provider_type(probe);
 
-    if (type == ProbeType::kfunc || type == ProbeType::kretfunc ||
-        type == ProbeType::uprobe) {
+    if (type == ProbeType::invalid) {
+      LOG(ERROR, builtin.loc, err_)
+          << "The args builtin can only be used within the context of a single "
+             "probe type, e.g. \"probe1 {args}\" is valid while "
+             "\"probe1,probe2 {args}\" is not.";
+    } else if (type == ProbeType::kfunc || type == ProbeType::kretfunc ||
+               type == ProbeType::uprobe) {
       auto type_name = probe->args_typename();
       builtin.type = CreateRecord(type_name,
                                   bpftrace_.structs.Lookup(type_name));

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3596,6 +3596,15 @@ BEGIN { @map[0] = 1; for ($kv : @map) { print($kv); } }
              false);
 }
 
+TEST_F(semantic_analyser_btf, args_builtin_mixed_probes)
+{
+  test_error("kfunc:func_1,tracepoint:sched:sched_one { args }", R"(
+stdin:1:43-47: ERROR: The args builtin can only be used within the context of a single probe type, e.g. "probe1 {args}" is valid while "probe1,probe2 {args}" is not.
+kfunc:func_1,tracepoint:sched:sched_one { args }
+                                          ~~~~
+)");
+}
+
 } // namespace semantic_analyser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
It is not possible to use the `args` builtin in probes with mixed probe types (e.g. tracepoints and kfuncs). When trying that, bpftrace correctly fails but the error message is not very clear:

    # bpftrace -e 'tracepoint:syscalls:sys_enter_read,kfunc:vfs_read { print(args.count); }'
    stdin:1:53-63: ERROR: The args builtin can only be used with tracepoint/kfunc/uprobeprobes (invalid used here)
    tracepoint:syscalls:sys_enter_read,kfunc:vfs_read { print(args.count); }
                                                        ~~~~~~~~~~

Improve the error message:

    # bpftrace -e 'tracepoint:syscalls:sys_enter_read,kfunc:vfs_read { print(args.count); }'
    stdin:1:53-63: ERROR: The args builtin must be used in probes with a single probe type
    tracepoint:syscalls:sys_enter_read,kfunc:vfs_read { print(args.count); }
                                                        ~~~~~~~~~~

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
