### PR TITLE
Runtime Tests: Make EXPECT_NONE operate on plain text (not regex) patterns

### DIFF
--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -135,9 +135,11 @@ class TestParser(object):
                 prog = line
             elif item_name == 'EXPECT':
                 expects.append(Expect(line, 'text'))
+            elif item_name == 'EXPECT_NONE':
+                expects.append(Expect(line, 'text_none'))
             elif item_name == 'EXPECT_REGEX':
                 expects.append(Expect(line, 'regex'))
-            elif item_name == 'EXPECT_NONE':
+            elif item_name == 'EXPECT_REGEX_NONE':
                 expects.append(Expect(line, 'regex_none'))
             elif item_name == 'EXPECT_FILE':
                 has_exact_expect = True

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -207,6 +207,8 @@ class Runner(object):
                 if expect.mode == "text":
                     # Raw text match on an entire line, ignoring leading/trailing whitespace
                     return re.search(f"^\s*{re.escape(expect.expect)}\s*$", output, re.M)
+                elif expect.mode == "text_none":
+                    return not re.search(f"^\s*{re.escape(expect.expect)}\s*$", output, re.M)
                 elif expect.mode == "regex":
                     return re.search(expect.expect, output, re.M)
                 elif expect.mode == "regex_none":
@@ -457,6 +459,9 @@ class Runner(object):
             for failed_expect in failed_expects:
                 if failed_expect.mode == "text":
                     print('\tExpected: ' + failed_expect.expect)
+                    print('\tFound:\n' + to_utf8(output))
+                elif failed_expect.mode == "text_none":
+                    print('\tExpected no: ' + failed_expect.expect)
                     print('\tFound:\n' + to_utf8(output))
                 elif failed_expect.mode == "regex":
                     print('\tExpected REGEX: ' + failed_expect.expect)


### PR DESCRIPTION
`EXPECT_REGEX_NONE` is introduced to preserve the old behaviour.

Related to #2997

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
