### PR TITLE
tests: runtime: Fix flaky ustack() tests

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -227,32 +227,32 @@ TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack_stack_mode_env_bpftrace
-PROG k:do_nanosleep { printf("%s", ustack(1)); exit(); }
+PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=bpftrace
-EXPECT_REGEX ^\s+[a-zA-Z0-9_]+
+EXPECT uprobeFunction1+0
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep  1e8
+AFTER ./testprogs/uprobe_loop
 
 NAME ustack_stack_mode_env_perf
-PROG k:do_nanosleep { printf("%s", ustack(1)); exit(); }
+PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=perf
-EXPECT_REGEX ^\s+[0-9a-f]+ [a-zA-Z0-9_]+
+EXPECT_REGEX \d+ uprobeFunction1\+0 \(.*/uprobe_loop\)
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep  1e8
+AFTER ./testprogs/uprobe_loop
 
 NAME ustack_stack_mode_env_raw
-PROG k:do_nanosleep { printf("%s", ustack(1)); exit(); }
+PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=raw
-EXPECT_REGEX ^\s+[0-9a-f]+$
+EXPECT_REGEX ^[\da-fA-F]+$
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep  1e8
+AFTER ./testprogs/uprobe_loop
 
 NAME ustack_stack_mode_env_override
-PROG k:do_nanosleep { printf("%s", ustack(raw, 1)); exit(); }
+PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(raw, 1)); exit(); }
 ENV BPFTRACE_STACK_MODE=perf
-EXPECT_REGEX ^\s+[0-9a-f]+$
+EXPECT_REGEX ^[\da-fA-F]+$
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep  1e8
+AFTER ./testprogs/uprobe_loop
 
 NAME ustack_elf_symtable
 ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM

--- a/tests/testprogs/uprobe_loop.c
+++ b/tests/testprogs/uprobe_loop.c
@@ -1,0 +1,22 @@
+#include <unistd.h>
+
+int uprobeFunction1(int *n, char c __attribute__((unused)))
+{
+  return *n;
+}
+
+void spin()
+{
+  while (1) {
+    int n = 13;
+    char c = 'x';
+    uprobeFunction1(&n, c);
+    usleep(500);
+  }
+}
+
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
+{
+  spin();
+  return 0;
+}


### PR DESCRIPTION
Before, the tests were hooking into k:do_nanosleep() and then executing a nanosleep() syscall. This doesn't work quite right -- the kernel could be executing do_nanosleep() without a corresponding userspace task. We could add a pid filter, but it's cleaner to test ustack behavior from a uprobe anyways.

This commit fixes the test to be more reliable and narrows down the regex more.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
