### PR TITLE
tests: runtime: Fix broken USDT semaphore test

### DIFF
--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -236,7 +236,7 @@ WILL_FAIL
 # if the kernel handles the semaphore
 NAME usdt probes - file based semaphore activation no process, kernel usdt semaphore
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
-EXPECT Attaching 1 probe
+EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 REQUIRES_FEATURE uprobe_refcount


### PR DESCRIPTION
GHA is now getting runners which support kernel usdt semaphores. It's not 100% yet, which is why re-running the test suite helps.

The test is (or was) broken. Probably when EXPECT was changed to be an exact match on a line.

Fix by changing the expected text to include "...".

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
