### PR TITLE
Process SIGINT during probe attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix ability to interrupt bpftrace during probe attach
+  - [#3053](https://github.com/bpftrace/bpftrace/pull/3053)
 - Fix field resolution on structs with anon union as first field
   - [#2964](https://github.com/bpftrace/bpftrace/pull/2964)
 - Fix security hole checking unpacked kernel headers

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1178,6 +1178,10 @@ int BPFtrace::run(BpfBytecode bytecode)
   // iterate in reverse and attach the rest.
   for (auto probes = resources.probes.begin(); probes != resources.probes.end();
        ++probes) {
+    if (BPFtrace::exitsig_recv) {
+      request_finalize();
+      return -1;
+    }
     if (!attach_reverse(*probes)) {
       auto aps = attach_probe(*probes, bytecode_);
 
@@ -1192,6 +1196,10 @@ int BPFtrace::run(BpfBytecode bytecode)
   for (auto r_probes = resources.probes.rbegin();
        r_probes != resources.probes.rend();
        ++r_probes) {
+    if (BPFtrace::exitsig_recv) {
+      request_finalize();
+      return -1;
+    }
     if (attach_reverse(*r_probes)) {
       auto aps = attach_probe(*r_probes, bytecode_);
 


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

Currently it isn't possible to manually interrupt the probe attach phase with a Ctrl-C. Some probe types can take a reasonable amount of type to attach especially on older kernels - the example I'm working with here is 'kfunc/fentry' probes. This isn't a problem when working with a small number of probes but it becomes a real issue when working with many thousands of probes. For example, it currently takes me ~17 seconds to enable 2800 kfunc probes on a 5-19 based kernel (and over 5 minutes to detach them but that's another thing). A user should have the ability to interrupt this process.

This fix simply checks for a signal being delivered in the attach loops. There are two loops, one for forward and one for reverse attaching and I'm performing the same check in both for uniformity.

Manual test runs look OK although they are quite noisy and I'll see what the CI says :-) . As far as i can see, this isn;t suitable for a new test addition.

This has been manually tested on 5.19 kernel and a current bpf-next kernel.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
