### PR TITLE
Replace 'bpf_get_stackid'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
   - [#3091](https://github.com/bpftrace/bpftrace/pull/3091)
 - Parse DWARF using liblldb instead of libdw
   - [#3042](https://github.com/bpftrace/bpftrace/pull/3042)
+- Replace native 'bpf_get_stackid'
+  - [#3060](https://github.com/bpftrace/bpftrace/pull/3060)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -90,7 +90,7 @@ public:
                              SizedType &type,
                              const location &loc);
   void CreateMapUpdateElem(Value *ctx,
-                           Map &map,
+                           const std::string &map_ident,
                            Value *key,
                            Value *val,
                            const location &loc,
@@ -185,12 +185,16 @@ public:
   CallInst *CreateGetCpuId(const location &loc);
   CallInst *CreateGetCurrentTask(const location &loc);
   CallInst *CreateGetRandom(const location &loc);
-  CallInst *CreateGetStackId(Value *ctx,
-                             bool ustack,
-                             StackType stack_type,
-                             const location &loc);
+  CallInst *CreateGetStack(Value *ctx,
+                           bool ustack,
+                           Value *buf,
+                           StackType stack_type,
+                           const location &loc);
   CallInst *CreateGetFuncIp(const location &loc);
   CallInst *CreateGetJoinMap(BasicBlock *failure_callback, const location &loc);
+  CallInst *CreateGetStackScratchMap(StackType stack_type,
+                                     BasicBlock *failure_callback,
+                                     const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
                              FunctionType *helper_type,
                              ArrayRef<Value *> args,

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -223,6 +223,7 @@ private:
   Function *createMapLenCallback();
   Function *createForEachMapCallback(const Variable &decl,
                                      const std::vector<Statement *> &stmts);
+  Function *createMurmurHash2Func();
 
   // Return a lambda that has captured-by-value CodegenLLVM's async id state
   // (ie `printf_id_`, `mapped_printf_id_`, etc.).  Running the returned lambda
@@ -276,6 +277,7 @@ private:
 
   Function *linear_func_ = nullptr;
   Function *log2_func_ = nullptr;
+  Function *murmur_hash_2_func_ = nullptr;
   MDNode *loop_metadata_ = nullptr;
 
   size_t getStructSize(StructType *s)

--- a/src/types.h
+++ b/src/types.h
@@ -96,6 +96,12 @@ struct StackType {
            std::to_string(limit);
   }
 
+  static const std::string &scratch_name()
+  {
+    static const std::string scratch_name = "stack_scratch";
+    return scratch_name;
+  }
+
 private:
   friend class cereal::access;
   template <typename Archive>

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -38,8 +38,8 @@ TEST(codegen, call_kstack_mapids)
   ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
-  ASSERT_EQ(bpftrace->bytecode_.maps().size(), 7);
-  ASSERT_EQ(bpftrace->bytecode_.countStackMaps(), 2U);
+  ASSERT_EQ(bpftrace->bytecode_.maps().size(), 8);
+  ASSERT_EQ(bpftrace->bytecode_.countStackMaps(), 3U);
 
   StackType stack_type;
   stack_type.limit = 5;
@@ -74,8 +74,8 @@ TEST(codegen, call_kstack_modes_mapids)
   ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
-  ASSERT_EQ(bpftrace->bytecode_.maps().size(), 9);
-  ASSERT_EQ(bpftrace->bytecode_.countStackMaps(), 3U);
+  ASSERT_EQ(bpftrace->bytecode_.maps().size(), 10);
+  ASSERT_EQ(bpftrace->bytecode_.countStackMaps(), 4U);
 
   StackType stack_type;
   stack_type.mode = StackMode::perf;

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -38,8 +38,8 @@ TEST(codegen, call_ustack_mapids)
   ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
-  ASSERT_EQ(bpftrace->bytecode_.maps().size(), 7);
-  ASSERT_EQ(bpftrace->bytecode_.countStackMaps(), 2U);
+  ASSERT_EQ(bpftrace->bytecode_.maps().size(), 8);
+  ASSERT_EQ(bpftrace->bytecode_.countStackMaps(), 3U);
 
   StackType stack_type;
   stack_type.limit = 5;
@@ -75,8 +75,8 @@ TEST(codegen, call_ustack_modes_mapids)
   bpftrace->bytecode_ = codegen.compile();
 
   bpftrace->bytecode_.create_maps();
-  ASSERT_EQ(bpftrace->bytecode_.maps().size(), 9);
-  ASSERT_EQ(bpftrace->bytecode_.countStackMaps(), 3U);
+  ASSERT_EQ(bpftrace->bytecode_.maps().size(), 10);
+  ASSERT_EQ(bpftrace->bytecode_.countStackMaps(), 4U);
 
   StackType stack_type;
   stack_type.mode = StackMode::perf;

--- a/tests/codegen/llvm/builtin_kstack.ll
+++ b/tests/codegen/llvm/builtin_kstack.ll
@@ -5,47 +5,182 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8*, i8*, i8* }
-%"struct map_t.1" = type { i8*, i8* }
-%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.2" = type { i8*, i8* }
+%"struct map_t.3" = type { i8*, i8*, i8*, i8* }
 
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @stack_bpftrace_127 = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !42
-@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !56
+@stack_scratch = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@ringbuf = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !52
+@ringbuf_loss_counter = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !66
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !70 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !79 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, %"struct map_t.0"*, i64)*)(i8* %0, %"struct map_t.0"* @stack_bpftrace_127, i64 0)
-  %1 = bitcast i64* %"@x_key" to i8*
+  %lookup_stack_scratch_key = alloca i32, align 4
+  %stackid = alloca i64, align 8
+  %1 = bitcast i64* %stackid to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key", align 8
-  %2 = bitcast i64* %"@x_val" to i8*
+  %2 = bitcast i32* %lookup_stack_scratch_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 %get_stackid, i64* %"@x_val", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_val" to i8*
+  store i32 0, i32* %lookup_stack_scratch_key, align 4
+  %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @stack_scratch, i32* %lookup_stack_scratch_key)
+  %3 = bitcast i32* %lookup_stack_scratch_key to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %4 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %4, null
+  br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
+
+stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+
+merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
+  %5 = load i64, i64* %stackid, align 8
+  %6 = bitcast i64* %stackid to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@x_key", align 8
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %5, i64* %"@x_val", align 8
+  %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %9 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
+
+lookup_stack_scratch_failure:                     ; preds = %entry
+  br label %stack_scratch_failure
+
+lookup_stack_scratch_merge:                       ; preds = %entry
+  %11 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 1016, i1 false)
+  %12 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %12, i32 1016, i64 0)
+  %13 = icmp sge i32 %get_stack, 0
+  br i1 %13, label %get_stack_success, label %get_stack_fail
+
+get_stack_success:                                ; preds = %lookup_stack_scratch_merge
+  %14 = udiv i32 %get_stack, 8
+  %15 = trunc i32 %14 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %12, i8 %15, i64 1)
+  store i64 %murmur_hash_2, i64* %stackid, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.0"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  br label %merge_block
+
+get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+}
+
+; Function Attrs: alwaysinline
+define internal i64 @murmur_hash_2(i8* %0, i8 %1, i64 %2) #1 section "helpers" {
+entry:
+  %k = alloca i64, align 8
+  %i = alloca i8, align 1
+  %id = alloca i64, align 8
+  %seed_addr = alloca i64, align 8
+  %nr_stack_frames_addr = alloca i8, align 1
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %3 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %i)
+  %5 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i8* %0 to i64*
+  store i8 %1, i8* %nr_stack_frames_addr, align 1
+  store i64 %2, i64* %seed_addr, align 8
+  %7 = load i8, i8* %nr_stack_frames_addr, align 1
+  %8 = zext i8 %7 to i64
+  %9 = mul i64 %8, -4132994306676758123
+  %10 = load i64, i64* %seed_addr, align 8
+  %11 = xor i64 %10, %9
+  store i64 %11, i64* %id, align 8
+  store i8 0, i8* %i, align 1
+  br label %while_cond
+
+while_cond:                                       ; preds = %while_body, %entry
+  %12 = load i8, i8* %nr_stack_frames_addr, align 1
+  %13 = load i8, i8* %i, align 1
+  %length.cmp = icmp ult i8 %13, %12
+  br i1 %length.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %14 = load i8, i8* %i, align 1
+  %15 = getelementptr i64, i64* %6, i8 %14
+  %16 = load i64, i64* %15, align 8
+  store i64 %16, i64* %k, align 8
+  %17 = load i64, i64* %k, align 8
+  %18 = mul i64 %17, -4132994306676758123
+  store i64 %18, i64* %k, align 8
+  %19 = load i64, i64* %k, align 8
+  %20 = lshr i64 %19, 47
+  %21 = load i64, i64* %k, align 8
+  %22 = xor i64 %21, %20
+  store i64 %22, i64* %k, align 8
+  %23 = load i64, i64* %k, align 8
+  %24 = mul i64 %23, -4132994306676758123
+  store i64 %24, i64* %k, align 8
+  %25 = load i64, i64* %k, align 8
+  %26 = load i64, i64* %id, align 8
+  %27 = xor i64 %26, %25
+  store i64 %27, i64* %id, align 8
+  %28 = load i64, i64* %id, align 8
+  %29 = mul i64 %28, -4132994306676758123
+  store i64 %29, i64* %id, align 8
+  %30 = load i8, i8* %i, align 1
+  %31 = add i8 %30, 1
+  store i8 %31, i8* %i, align 1
+  br label %while_cond
+
+while_end:                                        ; preds = %while_cond
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %32 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %i)
+  %33 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %34 = load i64, i64* %id, align 8
+  %zero_cond = icmp eq i64 %34, 0
+  br i1 %zero_cond, label %if_zero, label %if_end
+
+if_zero:                                          ; preds = %while_end
+  store i64 1, i64* %id, align 8
+  br label %if_end
+
+if_end:                                           ; preds = %if_zero, %while_end
+  %35 = load i64, i64* %id, align 8
+  %36 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
+  ret i64 %35
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 attributes #0 = { nounwind }
-attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #1 = { alwaysinline }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }
+attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!66}
-!llvm.module.flags = !{!69}
+!llvm.dbg.cu = !{!75}
+!llvm.module.flags = !{!78}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -70,58 +205,67 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
 !21 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
 !22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !23)
-!23 = !{!24, !29, !34, !37}
+!23 = !{!24, !29, !16, !34}
 !24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
 !25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 224, elements: !27)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !27)
 !27 = !{!28}
-!28 = !DISubrange(count: 7, lowerBound: 0)
+!28 = !DISubrange(count: 9, lowerBound: 0)
 !29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
 !30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
 !31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !32)
 !32 = !{!33}
 !33 = !DISubrange(count: 131072, lowerBound: 0)
-!34 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !35, size: 64, offset: 128)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !35, size: 64, offset: 192)
 !35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!36 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!37 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !38, size: 64, offset: 192)
-!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !39, size: 64)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !40)
-!40 = !{!41}
-!41 = !DISubrange(count: 127, lowerBound: 0)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !44, isLocal: false, isDefinition: true)
-!44 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !45)
-!45 = !{!46, !51}
-!46 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !47, size: 64)
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !49)
-!49 = !{!50}
-!50 = !DISubrange(count: 27, lowerBound: 0)
-!51 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !52, size: 64, offset: 64)
-!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !54)
-!54 = !{!55}
-!55 = !DISubrange(count: 262144, lowerBound: 0)
-!56 = !DIGlobalVariableExpression(var: !57, expr: !DIExpression())
-!57 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !58, isLocal: false, isDefinition: true)
-!58 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !59)
-!59 = !{!60, !65, !34, !19}
-!60 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !61, size: 64)
-!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
-!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !63)
-!63 = !{!64}
-!64 = !DISubrange(count: 2, lowerBound: 0)
-!65 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
-!66 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !67, globals: !68)
-!67 = !{}
-!68 = !{!0, !20, !42, !56}
-!69 = !{i32 2, !"Debug Info Version", i32 3}
-!70 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !71, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !66, retainedNodes: !75)
-!71 = !DISubroutineType(types: !72)
-!72 = !{!18, !73}
-!73 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !74, size: 64)
-!74 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!75 = !{!76, !77}
-!76 = !DILocalVariable(name: "var0", scope: !70, file: !2, type: !18)
-!77 = !DILocalVariable(name: "var1", arg: 1, scope: !70, file: !2, type: !73)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 127, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
+!42 = !{!43, !48, !49, !34}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 6, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !50, size: 64, offset: 128)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
+!53 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !54, isLocal: false, isDefinition: true)
+!54 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !55)
+!55 = !{!56, !61}
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !57, size: 64)
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
+!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !59)
+!59 = !{!60}
+!60 = !DISubrange(count: 27, lowerBound: 0)
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !62, size: 64, offset: 64)
+!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !64)
+!64 = !{!65}
+!65 = !DISubrange(count: 262144, lowerBound: 0)
+!66 = !DIGlobalVariableExpression(var: !67, expr: !DIExpression())
+!67 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !68, isLocal: false, isDefinition: true)
+!68 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !69)
+!69 = !{!70, !48, !49, !19}
+!70 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !71, size: 64)
+!71 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !72, size: 64)
+!72 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !73)
+!73 = !{!74}
+!74 = !DISubrange(count: 2, lowerBound: 0)
+!75 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !76, globals: !77)
+!76 = !{}
+!77 = !{!0, !20, !39, !52, !66}
+!78 = !{i32 2, !"Debug Info Version", i32 3}
+!79 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !80, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !75, retainedNodes: !84)
+!80 = !DISubroutineType(types: !81)
+!81 = !{!18, !82}
+!82 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !83, size: 64)
+!83 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!84 = !{!85, !86}
+!85 = !DILocalVariable(name: "var0", scope: !79, file: !2, type: !18)
+!86 = !DILocalVariable(name: "var1", arg: 1, scope: !79, file: !2, type: !82)

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -5,53 +5,188 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8*, i8*, i8* }
-%"struct map_t.1" = type { i8*, i8* }
-%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.2" = type { i8*, i8* }
+%"struct map_t.3" = type { i8*, i8*, i8*, i8* }
 %stack_t = type { i64, i32, i32 }
 
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @stack_bpftrace_127 = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !47
-@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !61
+@stack_scratch = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !44
+@ringbuf = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
+@ringbuf_loss_counter = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !71
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !76 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !85 {
 entry:
   %"@x_key" = alloca i64, align 8
   %stack_args = alloca %stack_t, align 8
-  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, %"struct map_t.0"*, i64)*)(i8* %0, %"struct map_t.0"* @stack_bpftrace_127, i64 256)
-  %1 = bitcast %stack_t* %stack_args to i8*
+  %lookup_stack_scratch_key = alloca i32, align 4
+  %stackid = alloca i64, align 8
+  %1 = bitcast i64* %stackid to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
-  store i64 %get_stackid, i64* %2, align 8
-  %3 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %2 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %lookup_stack_scratch_key, align 4
+  %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @stack_scratch, i32* %lookup_stack_scratch_key)
+  %3 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %4, null
+  br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
+
+stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+
+merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
+  %5 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  %7 = load i64, i64* %stackid, align 8
+  store i64 %7, i64* %6, align 8
+  %8 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %4 = trunc i64 %get_pid_tgid to i32
-  store i32 %4, i32* %3, align 4
-  %5 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
-  store i32 0, i32* %5, align 4
-  %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %9 = trunc i64 %get_pid_tgid to i32
+  store i32 %9, i32* %8, align 4
+  %10 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
+  store i32 0, i32* %10, align 4
+  %11 = bitcast i64* %stackid to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 0, i64* %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %stack_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %stack_t* %stack_args, i64 0)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %stack_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %stack_t* %stack_args, i64 0)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
+
+lookup_stack_scratch_failure:                     ; preds = %entry
+  br label %stack_scratch_failure
+
+lookup_stack_scratch_merge:                       ; preds = %entry
+  %14 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 1016, i1 false)
+  %15 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %15, i32 1016, i64 256)
+  %16 = icmp sge i32 %get_stack, 0
+  br i1 %16, label %get_stack_success, label %get_stack_fail
+
+get_stack_success:                                ; preds = %lookup_stack_scratch_merge
+  %17 = udiv i32 %get_stack, 8
+  %18 = trunc i32 %17 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %15, i8 %18, i64 1)
+  store i64 %murmur_hash_2, i64* %stackid, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.0"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  br label %merge_block
+
+get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+}
+
+; Function Attrs: alwaysinline
+define internal i64 @murmur_hash_2(i8* %0, i8 %1, i64 %2) #1 section "helpers" {
+entry:
+  %k = alloca i64, align 8
+  %i = alloca i8, align 1
+  %id = alloca i64, align 8
+  %seed_addr = alloca i64, align 8
+  %nr_stack_frames_addr = alloca i8, align 1
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %3 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %i)
+  %5 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i8* %0 to i64*
+  store i8 %1, i8* %nr_stack_frames_addr, align 1
+  store i64 %2, i64* %seed_addr, align 8
+  %7 = load i8, i8* %nr_stack_frames_addr, align 1
+  %8 = zext i8 %7 to i64
+  %9 = mul i64 %8, -4132994306676758123
+  %10 = load i64, i64* %seed_addr, align 8
+  %11 = xor i64 %10, %9
+  store i64 %11, i64* %id, align 8
+  store i8 0, i8* %i, align 1
+  br label %while_cond
+
+while_cond:                                       ; preds = %while_body, %entry
+  %12 = load i8, i8* %nr_stack_frames_addr, align 1
+  %13 = load i8, i8* %i, align 1
+  %length.cmp = icmp ult i8 %13, %12
+  br i1 %length.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %14 = load i8, i8* %i, align 1
+  %15 = getelementptr i64, i64* %6, i8 %14
+  %16 = load i64, i64* %15, align 8
+  store i64 %16, i64* %k, align 8
+  %17 = load i64, i64* %k, align 8
+  %18 = mul i64 %17, -4132994306676758123
+  store i64 %18, i64* %k, align 8
+  %19 = load i64, i64* %k, align 8
+  %20 = lshr i64 %19, 47
+  %21 = load i64, i64* %k, align 8
+  %22 = xor i64 %21, %20
+  store i64 %22, i64* %k, align 8
+  %23 = load i64, i64* %k, align 8
+  %24 = mul i64 %23, -4132994306676758123
+  store i64 %24, i64* %k, align 8
+  %25 = load i64, i64* %k, align 8
+  %26 = load i64, i64* %id, align 8
+  %27 = xor i64 %26, %25
+  store i64 %27, i64* %id, align 8
+  %28 = load i64, i64* %id, align 8
+  %29 = mul i64 %28, -4132994306676758123
+  store i64 %29, i64* %id, align 8
+  %30 = load i8, i8* %i, align 1
+  %31 = add i8 %30, 1
+  store i8 %31, i8* %i, align 1
+  br label %while_cond
+
+while_end:                                        ; preds = %while_cond
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %32 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %i)
+  %33 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %34 = load i64, i64* %id, align 8
+  %zero_cond = icmp eq i64 %34, 0
+  br i1 %zero_cond, label %if_zero, label %if_end
+
+if_zero:                                          ; preds = %while_end
+  store i64 1, i64* %id, align 8
+  br label %if_end
+
+if_end:                                           ; preds = %if_zero, %while_end
+  %35 = load i64, i64* %id, align 8
+  %36 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
+  ret i64 %35
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 attributes #0 = { nounwind }
-attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #1 = { alwaysinline }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }
+attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!72}
-!llvm.module.flags = !{!75}
+!llvm.dbg.cu = !{!81}
+!llvm.module.flags = !{!84}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -81,58 +216,67 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
 !26 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
 !27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !28)
-!28 = !{!29, !34, !39, !42}
+!28 = !{!29, !34, !16, !39}
 !29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
 !30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 224, elements: !32)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !32)
 !32 = !{!33}
-!33 = !DISubrange(count: 7, lowerBound: 0)
+!33 = !DISubrange(count: 9, lowerBound: 0)
 !34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
 !35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
 !36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !37)
 !37 = !{!38}
 !38 = !DISubrange(count: 131072, lowerBound: 0)
-!39 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !40, size: 64, offset: 128)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !40, size: 64, offset: 192)
 !40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
-!41 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!42 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !43, size: 64, offset: 192)
-!43 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !44, size: 64)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !45)
-!45 = !{!46}
-!46 = !DISubrange(count: 127, lowerBound: 0)
-!47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
-!48 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !49, isLocal: false, isDefinition: true)
-!49 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !50)
-!50 = !{!51, !56}
-!51 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !52, size: 64)
-!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !54)
-!54 = !{!55}
-!55 = !DISubrange(count: 27, lowerBound: 0)
-!56 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !57, size: 64, offset: 64)
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
-!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !59)
-!59 = !{!60}
-!60 = !DISubrange(count: 262144, lowerBound: 0)
-!61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
-!62 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !63, isLocal: false, isDefinition: true)
-!63 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !64)
-!64 = !{!65, !70, !39, !71}
-!65 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !66, size: 64)
-!66 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !67, size: 64)
-!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !68)
-!68 = !{!69}
-!69 = !DISubrange(count: 2, lowerBound: 0)
-!70 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
-!71 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!72 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !73, globals: !74)
-!73 = !{}
-!74 = !{!0, !25, !47, !61}
-!75 = !{i32 2, !"Debug Info Version", i32 3}
-!76 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !77, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !72, retainedNodes: !80)
-!77 = !DISubroutineType(types: !78)
-!78 = !{!18, !79}
-!79 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!80 = !{!81, !82}
-!81 = !DILocalVariable(name: "var0", scope: !76, file: !2, type: !18)
-!82 = !DILocalVariable(name: "var1", arg: 1, scope: !76, file: !2, type: !79)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !42)
+!42 = !{!43}
+!43 = !DISubrange(count: 127, lowerBound: 0)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
+!46 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !47)
+!47 = !{!48, !53, !54, !39}
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !49, size: 64)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 6, lowerBound: 0)
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
+!56 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !60)
+!60 = !{!61, !66}
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
+!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !64)
+!64 = !{!65}
+!65 = !DISubrange(count: 27, lowerBound: 0)
+!66 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !67, size: 64, offset: 64)
+!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
+!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !69)
+!69 = !{!70}
+!70 = !DISubrange(count: 262144, lowerBound: 0)
+!71 = !DIGlobalVariableExpression(var: !72, expr: !DIExpression())
+!72 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !73, isLocal: false, isDefinition: true)
+!73 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !74)
+!74 = !{!75, !53, !54, !80}
+!75 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !76, size: 64)
+!76 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !77, size: 64)
+!77 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !78)
+!78 = !{!79}
+!79 = !DISubrange(count: 2, lowerBound: 0)
+!80 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!81 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !82, globals: !83)
+!82 = !{}
+!83 = !{!0, !25, !44, !57, !71}
+!84 = !{i32 2, !"Debug Info Version", i32 3}
+!85 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !86, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !81, retainedNodes: !89)
+!86 = !DISubroutineType(types: !87)
+!87 = !{!18, !88}
+!88 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!89 = !{!90, !91}
+!90 = !DILocalVariable(name: "var0", scope: !85, file: !2, type: !18)
+!91 = !DILocalVariable(name: "var1", arg: 1, scope: !85, file: !2, type: !88)

--- a/tests/codegen/llvm/call_kstack.ll
+++ b/tests/codegen/llvm/call_kstack.ll
@@ -9,79 +9,302 @@ target triple = "bpf-pc-linux"
 %"struct map_t.2" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.3" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.4" = type { i8*, i8*, i8*, i8* }
-%"struct map_t.5" = type { i8*, i8* }
-%"struct map_t.6" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.5" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.6" = type { i8*, i8* }
+%"struct map_t.7" = type { i8*, i8*, i8*, i8* }
 
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @AT_z = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !22
 @stack_perf_127 = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !24
-@stack_bpftrace_6 = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !46
-@stack_bpftrace_127 = dso_local global %"struct map_t.4" zeroinitializer, section ".maps", !dbg !55
-@ringbuf = dso_local global %"struct map_t.5" zeroinitializer, section ".maps", !dbg !57
-@ringbuf_loss_counter = dso_local global %"struct map_t.6" zeroinitializer, section ".maps", !dbg !71
+@stack_bpftrace_6 = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !43
+@stack_bpftrace_127 = dso_local global %"struct map_t.4" zeroinitializer, section ".maps", !dbg !52
+@stack_scratch = dso_local global %"struct map_t.5" zeroinitializer, section ".maps", !dbg !54
+@ringbuf = dso_local global %"struct map_t.6" zeroinitializer, section ".maps", !dbg !65
+@ringbuf_loss_counter = dso_local global %"struct map_t.7" zeroinitializer, section ".maps", !dbg !79
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !85 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !92 {
 entry:
   %"@z_val" = alloca i64, align 8
   %"@z_key" = alloca i64, align 8
+  %lookup_stack_scratch_key19 = alloca i32, align 4
+  %stackid16 = alloca i64, align 8
   %"@y_val" = alloca i64, align 8
   %"@y_key" = alloca i64, align 8
+  %lookup_stack_scratch_key5 = alloca i32, align 4
+  %stackid2 = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, %"struct map_t.4"*, i64)*)(i8* %0, %"struct map_t.4"* @stack_bpftrace_127, i64 0)
-  %1 = bitcast i64* %"@x_key" to i8*
+  %lookup_stack_scratch_key = alloca i32, align 4
+  %stackid = alloca i64, align 8
+  %1 = bitcast i64* %stackid to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key", align 8
-  %2 = bitcast i64* %"@x_val" to i8*
+  %2 = bitcast i32* %lookup_stack_scratch_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 %get_stackid, i64* %"@x_val", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_val" to i8*
+  store i32 0, i32* %lookup_stack_scratch_key, align 4
+  %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key)
+  %3 = bitcast i32* %lookup_stack_scratch_key to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %get_stackid1 = call i64 inttoptr (i64 27 to i64 (i8*, %"struct map_t.3"*, i64)*)(i8* %0, %"struct map_t.3"* @stack_bpftrace_6, i64 0)
-  %5 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %4 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %4, null
+  br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
+
+stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+
+merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
+  %5 = load i64, i64* %stackid, align 8
+  %6 = bitcast i64* %stackid to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@x_key", align 8
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %5, i64* %"@x_val", align 8
+  %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %9 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %stackid2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i32* %lookup_stack_scratch_key5 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i32 0, i32* %lookup_stack_scratch_key5, align 4
+  %lookup_stack_scratch_map6 = call [6 x i64]* inttoptr (i64 1 to [6 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key5)
+  %13 = bitcast i32* %lookup_stack_scratch_key5 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  %lookup_stack_scratch_cond9 = icmp ne i8* %14, null
+  br i1 %lookup_stack_scratch_cond9, label %lookup_stack_scratch_merge8, label %lookup_stack_scratch_failure7
+
+lookup_stack_scratch_failure:                     ; preds = %entry
+  br label %stack_scratch_failure
+
+lookup_stack_scratch_merge:                       ; preds = %entry
+  %15 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %15, i8 0, i64 1016, i1 false)
+  %16 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %16, i32 1016, i64 0)
+  %17 = icmp sge i32 %get_stack, 0
+  br i1 %17, label %get_stack_success, label %get_stack_fail
+
+get_stack_success:                                ; preds = %lookup_stack_scratch_merge
+  %18 = udiv i32 %get_stack, 8
+  %19 = trunc i32 %18 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %16, i8 %19, i64 1)
+  store i64 %murmur_hash_2, i64* %stackid, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.4"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.4"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  br label %merge_block
+
+get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+
+stack_scratch_failure3:                           ; preds = %lookup_stack_scratch_failure7
+  store i64 0, i64* %stackid2, align 8
+  br label %merge_block4
+
+merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
+  %20 = load i64, i64* %stackid2, align 8
+  %21 = bitcast i64* %stackid2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
   store i64 0, i64* %"@y_key", align 8
-  %6 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store i64 %get_stackid1, i64* %"@y_val", align 8
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, i64*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %7 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %get_stackid3 = call i64 inttoptr (i64 27 to i64 (i8*, %"struct map_t.2"*, i64)*)(i8* %0, %"struct map_t.2"* @stack_perf_127, i64 0)
-  %9 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %23 = bitcast i64* %"@y_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  store i64 %20, i64* %"@y_val", align 8
+  %update_elem15 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, i64*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", i64* %"@y_val", i64 0)
+  %24 = bitcast i64* %"@y_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
+  %26 = bitcast i64* %stackid16 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %27 = bitcast i32* %lookup_stack_scratch_key19 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
+  store i32 0, i32* %lookup_stack_scratch_key19, align 4
+  %lookup_stack_scratch_map20 = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key19)
+  %28 = bitcast i32* %lookup_stack_scratch_key19 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %28)
+  %29 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
+  %lookup_stack_scratch_cond23 = icmp ne i8* %29, null
+  br i1 %lookup_stack_scratch_cond23, label %lookup_stack_scratch_merge22, label %lookup_stack_scratch_failure21
+
+lookup_stack_scratch_failure7:                    ; preds = %merge_block
+  br label %stack_scratch_failure3
+
+lookup_stack_scratch_merge8:                      ; preds = %merge_block
+  %30 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %30, i8 0, i64 48, i1 false)
+  %31 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  %get_stack12 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %31, i32 48, i64 0)
+  %32 = icmp sge i32 %get_stack12, 0
+  br i1 %32, label %get_stack_success10, label %get_stack_fail11
+
+get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
+  %33 = udiv i32 %get_stack12, 8
+  %34 = trunc i32 %33 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(i8* %31, i8 %34, i64 1)
+  store i64 %murmur_hash_213, i64* %stackid2, align 8
+  %update_elem14 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.3"*, i64*, [6 x i64]*, i64)*)(%"struct map_t.3"* @stack_bpftrace_6, i64* %stackid2, [6 x i64]* %lookup_stack_scratch_map6, i64 0)
+  br label %merge_block4
+
+get_stack_fail11:                                 ; preds = %lookup_stack_scratch_merge8
+  store i64 0, i64* %stackid2, align 8
+  br label %merge_block4
+
+stack_scratch_failure17:                          ; preds = %lookup_stack_scratch_failure21
+  store i64 0, i64* %stackid16, align 8
+  br label %merge_block18
+
+merge_block18:                                    ; preds = %stack_scratch_failure17, %get_stack_success24, %get_stack_fail25
+  %35 = load i64, i64* %stackid16, align 8
+  %36 = bitcast i64* %stackid16 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
+  %37 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
   store i64 0, i64* %"@z_key", align 8
-  %10 = bitcast i64* %"@z_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 %get_stackid3, i64* %"@z_val", align 8
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, i64*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", i64* %"@z_val", i64 0)
-  %11 = bitcast i64* %"@z_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %38 = bitcast i64* %"@z_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %38)
+  store i64 %35, i64* %"@z_val", align 8
+  %update_elem29 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, i64*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", i64* %"@z_val", i64 0)
+  %39 = bitcast i64* %"@z_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %39)
+  %40 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
   ret i64 0
+
+lookup_stack_scratch_failure21:                   ; preds = %merge_block4
+  br label %stack_scratch_failure17
+
+lookup_stack_scratch_merge22:                     ; preds = %merge_block4
+  %41 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %41, i8 0, i64 1016, i1 false)
+  %42 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
+  %get_stack26 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %42, i32 1016, i64 0)
+  %43 = icmp sge i32 %get_stack26, 0
+  br i1 %43, label %get_stack_success24, label %get_stack_fail25
+
+get_stack_success24:                              ; preds = %lookup_stack_scratch_merge22
+  %44 = udiv i32 %get_stack26, 8
+  %45 = trunc i32 %44 to i8
+  %murmur_hash_227 = call i64 @murmur_hash_2(i8* %42, i8 %45, i64 1)
+  store i64 %murmur_hash_227, i64* %stackid16, align 8
+  %update_elem28 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.2"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.2"* @stack_perf_127, i64* %stackid16, [127 x i64]* %lookup_stack_scratch_map20, i64 0)
+  br label %merge_block18
+
+get_stack_fail25:                                 ; preds = %lookup_stack_scratch_merge22
+  store i64 0, i64* %stackid16, align 8
+  br label %merge_block18
+}
+
+; Function Attrs: alwaysinline
+define internal i64 @murmur_hash_2(i8* %0, i8 %1, i64 %2) #1 section "helpers" {
+entry:
+  %k = alloca i64, align 8
+  %i = alloca i8, align 1
+  %id = alloca i64, align 8
+  %seed_addr = alloca i64, align 8
+  %nr_stack_frames_addr = alloca i8, align 1
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %3 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %i)
+  %5 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i8* %0 to i64*
+  store i8 %1, i8* %nr_stack_frames_addr, align 1
+  store i64 %2, i64* %seed_addr, align 8
+  %7 = load i8, i8* %nr_stack_frames_addr, align 1
+  %8 = zext i8 %7 to i64
+  %9 = mul i64 %8, -4132994306676758123
+  %10 = load i64, i64* %seed_addr, align 8
+  %11 = xor i64 %10, %9
+  store i64 %11, i64* %id, align 8
+  store i8 0, i8* %i, align 1
+  br label %while_cond
+
+while_cond:                                       ; preds = %while_body, %entry
+  %12 = load i8, i8* %nr_stack_frames_addr, align 1
+  %13 = load i8, i8* %i, align 1
+  %length.cmp = icmp ult i8 %13, %12
+  br i1 %length.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %14 = load i8, i8* %i, align 1
+  %15 = getelementptr i64, i64* %6, i8 %14
+  %16 = load i64, i64* %15, align 8
+  store i64 %16, i64* %k, align 8
+  %17 = load i64, i64* %k, align 8
+  %18 = mul i64 %17, -4132994306676758123
+  store i64 %18, i64* %k, align 8
+  %19 = load i64, i64* %k, align 8
+  %20 = lshr i64 %19, 47
+  %21 = load i64, i64* %k, align 8
+  %22 = xor i64 %21, %20
+  store i64 %22, i64* %k, align 8
+  %23 = load i64, i64* %k, align 8
+  %24 = mul i64 %23, -4132994306676758123
+  store i64 %24, i64* %k, align 8
+  %25 = load i64, i64* %k, align 8
+  %26 = load i64, i64* %id, align 8
+  %27 = xor i64 %26, %25
+  store i64 %27, i64* %id, align 8
+  %28 = load i64, i64* %id, align 8
+  %29 = mul i64 %28, -4132994306676758123
+  store i64 %29, i64* %id, align 8
+  %30 = load i8, i8* %i, align 1
+  %31 = add i8 %30, 1
+  store i8 %31, i8* %i, align 1
+  br label %while_cond
+
+while_end:                                        ; preds = %while_cond
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %32 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %i)
+  %33 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %34 = load i64, i64* %id, align 8
+  %zero_cond = icmp eq i64 %34, 0
+  br i1 %zero_cond, label %if_zero, label %if_end
+
+if_zero:                                          ; preds = %while_end
+  store i64 1, i64* %id, align 8
+  br label %if_end
+
+if_end:                                           ; preds = %if_zero, %while_end
+  %35 = load i64, i64* %id, align 8
+  %36 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
+  ret i64 %35
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 attributes #0 = { nounwind }
-attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #1 = { alwaysinline }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }
+attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!81}
-!llvm.module.flags = !{!84}
+!llvm.dbg.cu = !{!88}
+!llvm.module.flags = !{!91}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -110,69 +333,76 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
 !25 = distinct !DIGlobalVariable(name: "stack_perf_127", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
 !26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !27)
-!27 = !{!28, !33, !38, !41}
+!27 = !{!28, !33, !16, !38}
 !28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
 !29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 224, elements: !31)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !31)
 !31 = !{!32}
-!32 = !DISubrange(count: 7, lowerBound: 0)
+!32 = !DISubrange(count: 9, lowerBound: 0)
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !36)
 !36 = !{!37}
 !37 = !DISubrange(count: 131072, lowerBound: 0)
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !39, size: 64, offset: 128)
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !39, size: 64, offset: 192)
 !39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!41 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !42, size: 64, offset: 192)
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !44)
-!44 = !{!45}
-!45 = !DISubrange(count: 127, lowerBound: 0)
-!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
-!47 = distinct !DIGlobalVariable(name: "stack_bpftrace_6", linkageName: "global", scope: !2, file: !2, type: !48, isLocal: false, isDefinition: true)
-!48 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !49)
-!49 = !{!28, !33, !38, !50}
-!50 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !51, size: 64, offset: 192)
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 384, elements: !53)
-!53 = !{!54}
-!54 = !DISubrange(count: 6, lowerBound: 0)
-!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
-!56 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
-!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !60)
-!60 = !{!61, !66}
-!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !64)
-!64 = !{!65}
-!65 = !DISubrange(count: 27, lowerBound: 0)
-!66 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !67, size: 64, offset: 64)
-!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
-!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !69)
-!69 = !{!70}
-!70 = !DISubrange(count: 262144, lowerBound: 0)
-!71 = !DIGlobalVariableExpression(var: !72, expr: !DIExpression())
-!72 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !73, isLocal: false, isDefinition: true)
-!73 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !74)
-!74 = !{!75, !80, !38, !19}
-!75 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !76, size: 64)
-!76 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !77, size: 64)
-!77 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !78)
-!78 = !{!79}
-!79 = !DISubrange(count: 2, lowerBound: 0)
-!80 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
-!81 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !82, globals: !83)
-!82 = !{}
-!83 = !{!0, !20, !22, !24, !46, !55, !57, !71}
-!84 = !{i32 2, !"Debug Info Version", i32 3}
-!85 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !86, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !81, retainedNodes: !90)
-!86 = !DISubroutineType(types: !87)
-!87 = !{!18, !88}
-!88 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !89, size: 64)
-!89 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!90 = !{!91, !92}
-!91 = !DILocalVariable(name: "var0", scope: !85, file: !2, type: !18)
-!92 = !DILocalVariable(name: "var1", arg: 1, scope: !85, file: !2, type: !88)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 127, lowerBound: 0)
+!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
+!44 = distinct !DIGlobalVariable(name: "stack_bpftrace_6", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!45 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !46)
+!46 = !{!28, !33, !16, !47}
+!47 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !48, size: 64, offset: 192)
+!48 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !49, size: 64)
+!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 384, elements: !50)
+!50 = !{!51}
+!51 = !DISubrange(count: 6, lowerBound: 0)
+!52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
+!53 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
+!55 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !56, isLocal: false, isDefinition: true)
+!56 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !57)
+!57 = !{!58, !61, !62, !38}
+!58 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !59, size: 64)
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !50)
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!62 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !63, size: 64, offset: 128)
+!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
+!64 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!65 = !DIGlobalVariableExpression(var: !66, expr: !DIExpression())
+!66 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !67, isLocal: false, isDefinition: true)
+!67 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !68)
+!68 = !{!69, !74}
+!69 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !70, size: 64)
+!70 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !71, size: 64)
+!71 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !72)
+!72 = !{!73}
+!73 = !DISubrange(count: 27, lowerBound: 0)
+!74 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !75, size: 64, offset: 64)
+!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !76, size: 64)
+!76 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !77)
+!77 = !{!78}
+!78 = !DISubrange(count: 262144, lowerBound: 0)
+!79 = !DIGlobalVariableExpression(var: !80, expr: !DIExpression())
+!80 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !81, isLocal: false, isDefinition: true)
+!81 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !82)
+!82 = !{!83, !61, !62, !19}
+!83 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !84, size: 64)
+!84 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !85, size: 64)
+!85 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !86)
+!86 = !{!87}
+!87 = !DISubrange(count: 2, lowerBound: 0)
+!88 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !89, globals: !90)
+!89 = !{}
+!90 = !{!0, !20, !22, !24, !43, !52, !54, !65, !79}
+!91 = !{i32 2, !"Debug Info Version", i32 3}
+!92 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !93, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !88, retainedNodes: !97)
+!93 = !DISubroutineType(types: !94)
+!94 = !{!18, !95}
+!95 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !96, size: 64)
+!96 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!97 = !{!98, !99}
+!98 = !DILocalVariable(name: "var0", scope: !92, file: !2, type: !18)
+!99 = !DILocalVariable(name: "var1", arg: 1, scope: !92, file: !2, type: !95)

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -9,95 +9,318 @@ target triple = "bpf-pc-linux"
 %"struct map_t.2" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.3" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.4" = type { i8*, i8*, i8*, i8* }
-%"struct map_t.5" = type { i8*, i8* }
-%"struct map_t.6" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.5" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.6" = type { i8*, i8* }
+%"struct map_t.7" = type { i8*, i8*, i8*, i8* }
 %stack_t = type { i64, i32, i32 }
 
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
 @AT_z = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !27
 @stack_perf_127 = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !29
-@stack_bpftrace_6 = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !51
-@stack_bpftrace_127 = dso_local global %"struct map_t.4" zeroinitializer, section ".maps", !dbg !60
-@ringbuf = dso_local global %"struct map_t.5" zeroinitializer, section ".maps", !dbg !62
-@ringbuf_loss_counter = dso_local global %"struct map_t.6" zeroinitializer, section ".maps", !dbg !76
+@stack_bpftrace_6 = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !48
+@stack_bpftrace_127 = dso_local global %"struct map_t.4" zeroinitializer, section ".maps", !dbg !57
+@stack_scratch = dso_local global %"struct map_t.5" zeroinitializer, section ".maps", !dbg !59
+@ringbuf = dso_local global %"struct map_t.6" zeroinitializer, section ".maps", !dbg !70
+@ringbuf_loss_counter = dso_local global %"struct map_t.7" zeroinitializer, section ".maps", !dbg !84
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !91 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !98 {
 entry:
   %"@z_key" = alloca i64, align 8
-  %stack_args6 = alloca %stack_t, align 8
+  %stack_args31 = alloca %stack_t, align 8
+  %lookup_stack_scratch_key21 = alloca i32, align 4
+  %stackid18 = alloca i64, align 8
   %"@y_key" = alloca i64, align 8
-  %stack_args2 = alloca %stack_t, align 8
+  %stack_args15 = alloca %stack_t, align 8
+  %lookup_stack_scratch_key5 = alloca i32, align 4
+  %stackid2 = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %stack_args = alloca %stack_t, align 8
-  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, %"struct map_t.4"*, i64)*)(i8* %0, %"struct map_t.4"* @stack_bpftrace_127, i64 256)
-  %1 = bitcast %stack_t* %stack_args to i8*
+  %lookup_stack_scratch_key = alloca i32, align 4
+  %stackid = alloca i64, align 8
+  %1 = bitcast i64* %stackid to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
-  store i64 %get_stackid, i64* %2, align 8
-  %3 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %2 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %lookup_stack_scratch_key, align 4
+  %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key)
+  %3 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %4, null
+  br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
+
+stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+
+merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
+  %5 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  %7 = load i64, i64* %stackid, align 8
+  store i64 %7, i64* %6, align 8
+  %8 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %4 = trunc i64 %get_pid_tgid to i32
-  store i32 %4, i32* %3, align 4
-  %5 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
-  store i32 0, i32* %5, align 4
-  %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %9 = trunc i64 %get_pid_tgid to i32
+  store i32 %9, i32* %8, align 4
+  %10 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
+  store i32 0, i32* %10, align 4
+  %11 = bitcast i64* %stackid to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 0, i64* %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %stack_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %stack_t* %stack_args, i64 0)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %get_stackid1 = call i64 inttoptr (i64 27 to i64 (i8*, %"struct map_t.3"*, i64)*)(i8* %0, %"struct map_t.3"* @stack_bpftrace_6, i64 256)
-  %8 = bitcast %stack_t* %stack_args2 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = getelementptr %stack_t, %stack_t* %stack_args2, i64 0, i32 0
-  store i64 %get_stackid1, i64* %9, align 8
-  %10 = getelementptr %stack_t, %stack_t* %stack_args2, i64 0, i32 1
-  %get_pid_tgid3 = call i64 inttoptr (i64 14 to i64 ()*)()
-  %11 = trunc i64 %get_pid_tgid3 to i32
-  store i32 %11, i32* %10, align 4
-  %12 = getelementptr %stack_t, %stack_t* %stack_args2, i64 0, i32 2
-  store i32 0, i32* %12, align 4
-  %13 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 0, i64* %"@y_key", align 8
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, %stack_t*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", %stack_t* %stack_args2, i64 0)
-  %14 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %get_stackid5 = call i64 inttoptr (i64 27 to i64 (i8*, %"struct map_t.2"*, i64)*)(i8* %0, %"struct map_t.2"* @stack_perf_127, i64 256)
-  %15 = bitcast %stack_t* %stack_args6 to i8*
+  %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %stack_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %stack_t* %stack_args, i64 0)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %stackid2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i32* %lookup_stack_scratch_key5 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  %16 = getelementptr %stack_t, %stack_t* %stack_args6, i64 0, i32 0
-  store i64 %get_stackid5, i64* %16, align 8
-  %17 = getelementptr %stack_t, %stack_t* %stack_args6, i64 0, i32 1
-  %get_pid_tgid7 = call i64 inttoptr (i64 14 to i64 ()*)()
-  %18 = trunc i64 %get_pid_tgid7 to i32
-  store i32 %18, i32* %17, align 4
-  %19 = getelementptr %stack_t, %stack_t* %stack_args6, i64 0, i32 2
-  store i32 0, i32* %19, align 4
-  %20 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  store i32 0, i32* %lookup_stack_scratch_key5, align 4
+  %lookup_stack_scratch_map6 = call [6 x i64]* inttoptr (i64 1 to [6 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key5)
+  %16 = bitcast i32* %lookup_stack_scratch_key5 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  %lookup_stack_scratch_cond9 = icmp ne i8* %17, null
+  br i1 %lookup_stack_scratch_cond9, label %lookup_stack_scratch_merge8, label %lookup_stack_scratch_failure7
+
+lookup_stack_scratch_failure:                     ; preds = %entry
+  br label %stack_scratch_failure
+
+lookup_stack_scratch_merge:                       ; preds = %entry
+  %18 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 1016, i1 false)
+  %19 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %19, i32 1016, i64 256)
+  %20 = icmp sge i32 %get_stack, 0
+  br i1 %20, label %get_stack_success, label %get_stack_fail
+
+get_stack_success:                                ; preds = %lookup_stack_scratch_merge
+  %21 = udiv i32 %get_stack, 8
+  %22 = trunc i32 %21 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %19, i8 %22, i64 1)
+  store i64 %murmur_hash_2, i64* %stackid, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.4"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.4"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  br label %merge_block
+
+get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+
+stack_scratch_failure3:                           ; preds = %lookup_stack_scratch_failure7
+  store i64 0, i64* %stackid2, align 8
+  br label %merge_block4
+
+merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
+  %23 = bitcast %stack_t* %stack_args15 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %24 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 0
+  %25 = load i64, i64* %stackid2, align 8
+  store i64 %25, i64* %24, align 8
+  %26 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 1
+  %get_pid_tgid16 = call i64 inttoptr (i64 14 to i64 ()*)()
+  %27 = trunc i64 %get_pid_tgid16 to i32
+  store i32 %27, i32* %26, align 4
+  %28 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 2
+  store i32 0, i32* %28, align 4
+  %29 = bitcast i64* %stackid2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
+  %30 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %30)
+  store i64 0, i64* %"@y_key", align 8
+  %update_elem17 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, %stack_t*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", %stack_t* %stack_args15, i64 0)
+  %31 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
+  %32 = bitcast i64* %stackid18 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %32)
+  %33 = bitcast i32* %lookup_stack_scratch_key21 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  store i32 0, i32* %lookup_stack_scratch_key21, align 4
+  %lookup_stack_scratch_map22 = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key21)
+  %34 = bitcast i32* %lookup_stack_scratch_key21 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  %35 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
+  %lookup_stack_scratch_cond25 = icmp ne i8* %35, null
+  br i1 %lookup_stack_scratch_cond25, label %lookup_stack_scratch_merge24, label %lookup_stack_scratch_failure23
+
+lookup_stack_scratch_failure7:                    ; preds = %merge_block
+  br label %stack_scratch_failure3
+
+lookup_stack_scratch_merge8:                      ; preds = %merge_block
+  %36 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %36, i8 0, i64 48, i1 false)
+  %37 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  %get_stack12 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %37, i32 48, i64 256)
+  %38 = icmp sge i32 %get_stack12, 0
+  br i1 %38, label %get_stack_success10, label %get_stack_fail11
+
+get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
+  %39 = udiv i32 %get_stack12, 8
+  %40 = trunc i32 %39 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(i8* %37, i8 %40, i64 1)
+  store i64 %murmur_hash_213, i64* %stackid2, align 8
+  %update_elem14 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.3"*, i64*, [6 x i64]*, i64)*)(%"struct map_t.3"* @stack_bpftrace_6, i64* %stackid2, [6 x i64]* %lookup_stack_scratch_map6, i64 0)
+  br label %merge_block4
+
+get_stack_fail11:                                 ; preds = %lookup_stack_scratch_merge8
+  store i64 0, i64* %stackid2, align 8
+  br label %merge_block4
+
+stack_scratch_failure19:                          ; preds = %lookup_stack_scratch_failure23
+  store i64 0, i64* %stackid18, align 8
+  br label %merge_block20
+
+merge_block20:                                    ; preds = %stack_scratch_failure19, %get_stack_success26, %get_stack_fail27
+  %41 = bitcast %stack_t* %stack_args31 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %41)
+  %42 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 0
+  %43 = load i64, i64* %stackid18, align 8
+  store i64 %43, i64* %42, align 8
+  %44 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 1
+  %get_pid_tgid32 = call i64 inttoptr (i64 14 to i64 ()*)()
+  %45 = trunc i64 %get_pid_tgid32 to i32
+  store i32 %45, i32* %44, align 4
+  %46 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 2
+  store i32 0, i32* %46, align 4
+  %47 = bitcast i64* %stackid18 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %47)
+  %48 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %48)
   store i64 0, i64* %"@z_key", align 8
-  %update_elem8 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, %stack_t*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", %stack_t* %stack_args6, i64 0)
-  %21 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %update_elem33 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, %stack_t*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", %stack_t* %stack_args31, i64 0)
+  %49 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
   ret i64 0
+
+lookup_stack_scratch_failure23:                   ; preds = %merge_block4
+  br label %stack_scratch_failure19
+
+lookup_stack_scratch_merge24:                     ; preds = %merge_block4
+  %50 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %50, i8 0, i64 1016, i1 false)
+  %51 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
+  %get_stack28 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %51, i32 1016, i64 256)
+  %52 = icmp sge i32 %get_stack28, 0
+  br i1 %52, label %get_stack_success26, label %get_stack_fail27
+
+get_stack_success26:                              ; preds = %lookup_stack_scratch_merge24
+  %53 = udiv i32 %get_stack28, 8
+  %54 = trunc i32 %53 to i8
+  %murmur_hash_229 = call i64 @murmur_hash_2(i8* %51, i8 %54, i64 1)
+  store i64 %murmur_hash_229, i64* %stackid18, align 8
+  %update_elem30 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.2"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.2"* @stack_perf_127, i64* %stackid18, [127 x i64]* %lookup_stack_scratch_map22, i64 0)
+  br label %merge_block20
+
+get_stack_fail27:                                 ; preds = %lookup_stack_scratch_merge24
+  store i64 0, i64* %stackid18, align 8
+  br label %merge_block20
+}
+
+; Function Attrs: alwaysinline
+define internal i64 @murmur_hash_2(i8* %0, i8 %1, i64 %2) #1 section "helpers" {
+entry:
+  %k = alloca i64, align 8
+  %i = alloca i8, align 1
+  %id = alloca i64, align 8
+  %seed_addr = alloca i64, align 8
+  %nr_stack_frames_addr = alloca i8, align 1
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %3 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %i)
+  %5 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i8* %0 to i64*
+  store i8 %1, i8* %nr_stack_frames_addr, align 1
+  store i64 %2, i64* %seed_addr, align 8
+  %7 = load i8, i8* %nr_stack_frames_addr, align 1
+  %8 = zext i8 %7 to i64
+  %9 = mul i64 %8, -4132994306676758123
+  %10 = load i64, i64* %seed_addr, align 8
+  %11 = xor i64 %10, %9
+  store i64 %11, i64* %id, align 8
+  store i8 0, i8* %i, align 1
+  br label %while_cond
+
+while_cond:                                       ; preds = %while_body, %entry
+  %12 = load i8, i8* %nr_stack_frames_addr, align 1
+  %13 = load i8, i8* %i, align 1
+  %length.cmp = icmp ult i8 %13, %12
+  br i1 %length.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %14 = load i8, i8* %i, align 1
+  %15 = getelementptr i64, i64* %6, i8 %14
+  %16 = load i64, i64* %15, align 8
+  store i64 %16, i64* %k, align 8
+  %17 = load i64, i64* %k, align 8
+  %18 = mul i64 %17, -4132994306676758123
+  store i64 %18, i64* %k, align 8
+  %19 = load i64, i64* %k, align 8
+  %20 = lshr i64 %19, 47
+  %21 = load i64, i64* %k, align 8
+  %22 = xor i64 %21, %20
+  store i64 %22, i64* %k, align 8
+  %23 = load i64, i64* %k, align 8
+  %24 = mul i64 %23, -4132994306676758123
+  store i64 %24, i64* %k, align 8
+  %25 = load i64, i64* %k, align 8
+  %26 = load i64, i64* %id, align 8
+  %27 = xor i64 %26, %25
+  store i64 %27, i64* %id, align 8
+  %28 = load i64, i64* %id, align 8
+  %29 = mul i64 %28, -4132994306676758123
+  store i64 %29, i64* %id, align 8
+  %30 = load i8, i8* %i, align 1
+  %31 = add i8 %30, 1
+  store i8 %31, i8* %i, align 1
+  br label %while_cond
+
+while_end:                                        ; preds = %while_cond
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %32 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %i)
+  %33 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %34 = load i64, i64* %id, align 8
+  %zero_cond = icmp eq i64 %34, 0
+  br i1 %zero_cond, label %if_zero, label %if_end
+
+if_zero:                                          ; preds = %while_end
+  store i64 1, i64* %id, align 8
+  br label %if_end
+
+if_end:                                           ; preds = %if_zero, %while_end
+  %35 = load i64, i64* %id, align 8
+  %36 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
+  ret i64 %35
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 attributes #0 = { nounwind }
-attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #1 = { alwaysinline }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn }
+attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!87}
-!llvm.module.flags = !{!90}
+!llvm.dbg.cu = !{!94}
+!llvm.module.flags = !{!97}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -131,69 +354,76 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
 !30 = distinct !DIGlobalVariable(name: "stack_perf_127", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
 !31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !32)
-!32 = !{!33, !38, !43, !46}
+!32 = !{!33, !38, !16, !43}
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !34, size: 64)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 224, elements: !36)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !36)
 !36 = !{!37}
-!37 = !DISubrange(count: 7, lowerBound: 0)
+!37 = !DISubrange(count: 9, lowerBound: 0)
 !38 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !39, size: 64, offset: 64)
 !39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
 !40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !41)
 !41 = !{!42}
 !42 = !DISubrange(count: 131072, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !44, size: 64, offset: 128)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !44, size: 64, offset: 192)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!46 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !47, size: 64, offset: 192)
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !49)
-!49 = !{!50}
-!50 = !DISubrange(count: 127, lowerBound: 0)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "stack_bpftrace_6", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !54)
-!54 = !{!33, !38, !43, !55}
-!55 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !56, size: 64, offset: 192)
-!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !57, size: 64)
-!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 384, elements: !58)
-!58 = !{!59}
-!59 = !DISubrange(count: 6, lowerBound: 0)
-!60 = !DIGlobalVariableExpression(var: !61, expr: !DIExpression())
-!61 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
-!62 = !DIGlobalVariableExpression(var: !63, expr: !DIExpression())
-!63 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !64, isLocal: false, isDefinition: true)
-!64 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !65)
-!65 = !{!66, !71}
-!66 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !67, size: 64)
-!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
-!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !69)
-!69 = !{!70}
-!70 = !DISubrange(count: 27, lowerBound: 0)
-!71 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !72, size: 64, offset: 64)
-!72 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !73, size: 64)
-!73 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !74)
-!74 = !{!75}
-!75 = !DISubrange(count: 262144, lowerBound: 0)
-!76 = !DIGlobalVariableExpression(var: !77, expr: !DIExpression())
-!77 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !78, isLocal: false, isDefinition: true)
-!78 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !79)
-!79 = !{!80, !85, !43, !86}
-!80 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !81, size: 64)
-!81 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !82, size: 64)
-!82 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !83)
-!83 = !{!84}
-!84 = !DISubrange(count: 2, lowerBound: 0)
-!85 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
-!86 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!87 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !88, globals: !89)
-!88 = !{}
-!89 = !{!0, !25, !27, !29, !51, !60, !62, !76}
-!90 = !{i32 2, !"Debug Info Version", i32 3}
-!91 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !92, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !87, retainedNodes: !95)
-!92 = !DISubroutineType(types: !93)
-!93 = !{!18, !94}
-!94 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!95 = !{!96, !97}
-!96 = !DILocalVariable(name: "var0", scope: !91, file: !2, type: !18)
-!97 = !DILocalVariable(name: "var1", arg: 1, scope: !91, file: !2, type: !94)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 127, lowerBound: 0)
+!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
+!49 = distinct !DIGlobalVariable(name: "stack_bpftrace_6", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!50 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !51)
+!51 = !{!33, !38, !16, !52}
+!52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !53, size: 64, offset: 192)
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 384, elements: !55)
+!55 = !{!56}
+!56 = !DISubrange(count: 6, lowerBound: 0)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
+!61 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !62)
+!62 = !{!63, !66, !67, !43}
+!63 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !64, size: 64)
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !55)
+!66 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!67 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !68, size: 64, offset: 128)
+!68 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
+!69 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!70 = !DIGlobalVariableExpression(var: !71, expr: !DIExpression())
+!71 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !72, isLocal: false, isDefinition: true)
+!72 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !73)
+!73 = !{!74, !79}
+!74 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !75, size: 64)
+!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !76, size: 64)
+!76 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !77)
+!77 = !{!78}
+!78 = !DISubrange(count: 27, lowerBound: 0)
+!79 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !80, size: 64, offset: 64)
+!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !81, size: 64)
+!81 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !82)
+!82 = !{!83}
+!83 = !DISubrange(count: 262144, lowerBound: 0)
+!84 = !DIGlobalVariableExpression(var: !85, expr: !DIExpression())
+!85 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !86, isLocal: false, isDefinition: true)
+!86 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !87)
+!87 = !{!88, !66, !67, !93}
+!88 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !89, size: 64)
+!89 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !90, size: 64)
+!90 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !91)
+!91 = !{!92}
+!92 = !DISubrange(count: 2, lowerBound: 0)
+!93 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!94 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !95, globals: !96)
+!95 = !{}
+!96 = !{!0, !25, !27, !29, !48, !57, !59, !70, !84}
+!97 = !{i32 2, !"Debug Info Version", i32 3}
+!98 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !99, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !94, retainedNodes: !102)
+!99 = !DISubroutineType(types: !100)
+!100 = !{!18, !101}
+!101 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!102 = !{!103, !104}
+!103 = !DILocalVariable(name: "var0", scope: !98, file: !2, type: !18)
+!104 = !DILocalVariable(name: "var1", arg: 1, scope: !98, file: !2, type: !101)

--- a/tests/codegen/llvm/struct_semicolon_1.ll
+++ b/tests/codegen/llvm/struct_semicolon_1.ll
@@ -4,22 +4,26 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
-%"struct map_t.0" = type { i8*, i8* }
-%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.1" = type { i8*, i8* }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
 %stack_t = type { i64, i32, i32 }
 %printf_t = type { i64, [16 x i8] }
 
 @stack_bpftrace_127 = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@stack_scratch = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !41
+@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !55
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !59 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !69 {
 entry:
   %key = alloca i32, align 4
   %stack_args = alloca %stack_t, align 8
+  %lookup_stack_scratch_key = alloca i32, align 4
+  %stackid = alloca i64, align 8
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -27,49 +31,91 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
   %3 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
   store i64 0, i64* %3, align 8
-  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, %"struct map_t"*, i64)*)(i8* %0, %"struct map_t"* @stack_bpftrace_127, i64 256)
-  %4 = bitcast %stack_t* %stack_args to i8*
+  %4 = bitcast i64* %stackid to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
-  store i64 %get_stackid, i64* %5, align 8
-  %6 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %5 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i32 0, i32* %lookup_stack_scratch_key, align 4
+  %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.0"*, i32*)*)(%"struct map_t.0"* @stack_scratch, i32* %lookup_stack_scratch_key)
+  %6 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %7, null
+  br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
+
+stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+
+merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
+  %8 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  %10 = load i64, i64* %stackid, align 8
+  store i64 %10, i64* %9, align 8
+  %11 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %7 = trunc i64 %get_pid_tgid to i32
-  store i32 %7, i32* %6, align 4
-  %8 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
-  store i32 0, i32* %8, align 4
-  %9 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  %10 = bitcast [16 x i8]* %9 to i8*
-  %11 = bitcast %stack_t* %stack_args to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %10, i8* align 1 %11, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %printf_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %printf_t* %printf_args, i64 24, i64 0)
+  %12 = trunc i64 %get_pid_tgid to i32
+  store i32 %12, i32* %11, align 4
+  %13 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
+  store i32 0, i32* %13, align 4
+  %14 = bitcast i64* %stackid to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  %16 = bitcast [16 x i8]* %15 to i8*
+  %17 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %16, i8* align 1 %17, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.1"*, %printf_t*, i64, i64)*)(%"struct map_t.1"* @ringbuf, %printf_t* %printf_args, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
-  %12 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+lookup_stack_scratch_failure:                     ; preds = %entry
+  br label %stack_scratch_failure
+
+lookup_stack_scratch_merge:                       ; preds = %entry
+  %18 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 1016, i1 false)
+  %19 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %19, i32 1016, i64 256)
+  %20 = icmp sge i32 %get_stack, 0
+  br i1 %20, label %get_stack_success, label %get_stack_fail
+
+get_stack_success:                                ; preds = %lookup_stack_scratch_merge
+  %21 = udiv i32 %get_stack, 8
+  %22 = trunc i32 %21 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %19, i8 %22, i64 1)
+  store i64 %murmur_hash_2, i64* %stackid, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [127 x i64]*, i64)*)(%"struct map_t"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  br label %merge_block
+
+get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+
+event_loss_counter:                               ; preds = %merge_block
+  %23 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
   store i32 0, i32* %key, align 4
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @ringbuf_loss_counter, i32* %key)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.2"*, i32*)*)(%"struct map_t.2"* @ringbuf_loss_counter, i32* %key)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  %13 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+counter_merge:                                    ; preds = %lookup_merge, %merge_block
+  %24 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %14 = bitcast i8* %lookup_elem to i64*
-  %15 = atomicrmw add i64* %14, i64 1 seq_cst
+  %25 = bitcast i8* %lookup_elem to i64*
+  %26 = atomicrmw add i64* %25, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %16 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %27 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
   br label %counter_merge
 }
 
@@ -79,18 +125,103 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
+; Function Attrs: alwaysinline
+define internal i64 @murmur_hash_2(i8* %0, i8 %1, i64 %2) #3 section "helpers" {
+entry:
+  %k = alloca i64, align 8
+  %i = alloca i8, align 1
+  %id = alloca i64, align 8
+  %seed_addr = alloca i64, align 8
+  %nr_stack_frames_addr = alloca i8, align 1
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %3 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %i)
+  %5 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i8* %0 to i64*
+  store i8 %1, i8* %nr_stack_frames_addr, align 1
+  store i64 %2, i64* %seed_addr, align 8
+  %7 = load i8, i8* %nr_stack_frames_addr, align 1
+  %8 = zext i8 %7 to i64
+  %9 = mul i64 %8, -4132994306676758123
+  %10 = load i64, i64* %seed_addr, align 8
+  %11 = xor i64 %10, %9
+  store i64 %11, i64* %id, align 8
+  store i8 0, i8* %i, align 1
+  br label %while_cond
+
+while_cond:                                       ; preds = %while_body, %entry
+  %12 = load i8, i8* %nr_stack_frames_addr, align 1
+  %13 = load i8, i8* %i, align 1
+  %length.cmp = icmp ult i8 %13, %12
+  br i1 %length.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %14 = load i8, i8* %i, align 1
+  %15 = getelementptr i64, i64* %6, i8 %14
+  %16 = load i64, i64* %15, align 8
+  store i64 %16, i64* %k, align 8
+  %17 = load i64, i64* %k, align 8
+  %18 = mul i64 %17, -4132994306676758123
+  store i64 %18, i64* %k, align 8
+  %19 = load i64, i64* %k, align 8
+  %20 = lshr i64 %19, 47
+  %21 = load i64, i64* %k, align 8
+  %22 = xor i64 %21, %20
+  store i64 %22, i64* %k, align 8
+  %23 = load i64, i64* %k, align 8
+  %24 = mul i64 %23, -4132994306676758123
+  store i64 %24, i64* %k, align 8
+  %25 = load i64, i64* %k, align 8
+  %26 = load i64, i64* %id, align 8
+  %27 = xor i64 %26, %25
+  store i64 %27, i64* %id, align 8
+  %28 = load i64, i64* %id, align 8
+  %29 = mul i64 %28, -4132994306676758123
+  store i64 %29, i64* %id, align 8
+  %30 = load i8, i8* %i, align 1
+  %31 = add i8 %30, 1
+  store i8 %31, i8* %i, align 1
+  br label %while_cond
+
+while_end:                                        ; preds = %while_cond
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %32 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %i)
+  %33 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %34 = load i64, i64* %id, align 8
+  %zero_cond = icmp eq i64 %34, 0
+  br i1 %zero_cond, label %if_zero, label %if_end
+
+if_zero:                                          ; preds = %while_end
+  store i64 1, i64* %id, align 8
+  br label %if_end
+
+if_end:                                           ; preds = %if_zero, %while_end
+  %35 = load i64, i64* %id, align 8
+  %36 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
+  ret i64 %35
+}
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
+
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #3 = { alwaysinline }
 
-!llvm.dbg.cu = !{!55}
-!llvm.module.flags = !{!58}
+!llvm.dbg.cu = !{!65}
+!llvm.module.flags = !{!68}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -99,10 +230,10 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !4 = !{!5, !11, !16, !19}
 !5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
 !6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
-!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 224, elements: !9)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !9)
 !8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 !9 = !{!10}
-!10 = !DISubrange(count: 7, lowerBound: 0)
+!10 = !DISubrange(count: 9, lowerBound: 0)
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !14)
@@ -110,52 +241,62 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !15 = !DISubrange(count: 131072, lowerBound: 0)
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
-!18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 8128, elements: !23)
-!22 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!23 = !{!24}
-!24 = !DISubrange(count: 127, lowerBound: 0)
-!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
-!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
-!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
-!28 = !{!29, !34}
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 27, lowerBound: 0)
-!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
-!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !37)
-!37 = !{!38}
-!38 = !DISubrange(count: 262144, lowerBound: 0)
-!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
-!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !48, !16, !53}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 2, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !49, size: 64, offset: 64)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !51)
-!51 = !{!52}
-!52 = !DISubrange(count: 1, lowerBound: 0)
-!53 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !54, size: 64, offset: 192)
-!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !56, globals: !57)
-!56 = !{}
-!57 = !{!0, !25, !39}
-!58 = !{i32 2, !"Debug Info Version", i32 3}
-!59 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !60, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !64)
-!60 = !DISubroutineType(types: !61)
-!61 = !{!22, !62}
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!63 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!64 = !{!65, !66}
-!65 = !DILocalVariable(name: "var0", scope: !59, file: !2, type: !22)
-!66 = !DILocalVariable(name: "var1", arg: 1, scope: !59, file: !2, type: !62)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !22)
+!22 = !{!23}
+!23 = !DISubrange(count: 127, lowerBound: 0)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !27)
+!27 = !{!28, !33, !38, !19}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 6, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 1, lowerBound: 0)
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !39, size: 64, offset: 128)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !44)
+!44 = !{!45, !50}
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !46, size: 64)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !48)
+!48 = !{!49}
+!49 = !DISubrange(count: 27, lowerBound: 0)
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !51, size: 64, offset: 64)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !53)
+!53 = !{!54}
+!54 = !DISubrange(count: 262144, lowerBound: 0)
+!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
+!56 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !57, isLocal: false, isDefinition: true)
+!57 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !58)
+!58 = !{!59, !33, !38, !64}
+!59 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !60, size: 64)
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !62)
+!62 = !{!63}
+!63 = !DISubrange(count: 2, lowerBound: 0)
+!64 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!65 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !66, globals: !67)
+!66 = !{}
+!67 = !{!0, !24, !41, !55}
+!68 = !{i32 2, !"Debug Info Version", i32 3}
+!69 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !70, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !65, retainedNodes: !74)
+!70 = !DISubroutineType(types: !71)
+!71 = !{!18, !72}
+!72 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !73, size: 64)
+!73 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!74 = !{!75, !76}
+!75 = !DILocalVariable(name: "var0", scope: !69, file: !2, type: !18)
+!76 = !DILocalVariable(name: "var1", arg: 1, scope: !69, file: !2, type: !72)

--- a/tests/codegen/llvm/struct_semicolon_2.ll
+++ b/tests/codegen/llvm/struct_semicolon_2.ll
@@ -4,22 +4,26 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
-%"struct map_t.0" = type { i8*, i8* }
-%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.1" = type { i8*, i8* }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
 %stack_t = type { i64, i32, i32 }
 %printf_t = type { i64, [16 x i8] }
 
 @stack_bpftrace_127 = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@stack_scratch = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !41
+@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !55
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !59 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !69 {
 entry:
   %key = alloca i32, align 4
   %stack_args = alloca %stack_t, align 8
+  %lookup_stack_scratch_key = alloca i32, align 4
+  %stackid = alloca i64, align 8
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -27,49 +31,91 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
   %3 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
   store i64 0, i64* %3, align 8
-  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, %"struct map_t"*, i64)*)(i8* %0, %"struct map_t"* @stack_bpftrace_127, i64 256)
-  %4 = bitcast %stack_t* %stack_args to i8*
+  %4 = bitcast i64* %stackid to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
-  store i64 %get_stackid, i64* %5, align 8
-  %6 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %5 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i32 0, i32* %lookup_stack_scratch_key, align 4
+  %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.0"*, i32*)*)(%"struct map_t.0"* @stack_scratch, i32* %lookup_stack_scratch_key)
+  %6 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %7, null
+  br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
+
+stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+
+merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
+  %8 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  %10 = load i64, i64* %stackid, align 8
+  store i64 %10, i64* %9, align 8
+  %11 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %7 = trunc i64 %get_pid_tgid to i32
-  store i32 %7, i32* %6, align 4
-  %8 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
-  store i32 0, i32* %8, align 4
-  %9 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  %10 = bitcast [16 x i8]* %9 to i8*
-  %11 = bitcast %stack_t* %stack_args to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %10, i8* align 1 %11, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %printf_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %printf_t* %printf_args, i64 24, i64 0)
+  %12 = trunc i64 %get_pid_tgid to i32
+  store i32 %12, i32* %11, align 4
+  %13 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
+  store i32 0, i32* %13, align 4
+  %14 = bitcast i64* %stackid to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  %16 = bitcast [16 x i8]* %15 to i8*
+  %17 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %16, i8* align 1 %17, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.1"*, %printf_t*, i64, i64)*)(%"struct map_t.1"* @ringbuf, %printf_t* %printf_args, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
-  %12 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+lookup_stack_scratch_failure:                     ; preds = %entry
+  br label %stack_scratch_failure
+
+lookup_stack_scratch_merge:                       ; preds = %entry
+  %18 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 1016, i1 false)
+  %19 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %19, i32 1016, i64 256)
+  %20 = icmp sge i32 %get_stack, 0
+  br i1 %20, label %get_stack_success, label %get_stack_fail
+
+get_stack_success:                                ; preds = %lookup_stack_scratch_merge
+  %21 = udiv i32 %get_stack, 8
+  %22 = trunc i32 %21 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %19, i8 %22, i64 1)
+  store i64 %murmur_hash_2, i64* %stackid, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [127 x i64]*, i64)*)(%"struct map_t"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  br label %merge_block
+
+get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
+  store i64 0, i64* %stackid, align 8
+  br label %merge_block
+
+event_loss_counter:                               ; preds = %merge_block
+  %23 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
   store i32 0, i32* %key, align 4
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @ringbuf_loss_counter, i32* %key)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.2"*, i32*)*)(%"struct map_t.2"* @ringbuf_loss_counter, i32* %key)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  %13 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+counter_merge:                                    ; preds = %lookup_merge, %merge_block
+  %24 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %14 = bitcast i8* %lookup_elem to i64*
-  %15 = atomicrmw add i64* %14, i64 1 seq_cst
+  %25 = bitcast i8* %lookup_elem to i64*
+  %26 = atomicrmw add i64* %25, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %16 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %27 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
   br label %counter_merge
 }
 
@@ -79,18 +125,103 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
+; Function Attrs: alwaysinline
+define internal i64 @murmur_hash_2(i8* %0, i8 %1, i64 %2) #3 section "helpers" {
+entry:
+  %k = alloca i64, align 8
+  %i = alloca i8, align 1
+  %id = alloca i64, align 8
+  %seed_addr = alloca i64, align 8
+  %nr_stack_frames_addr = alloca i8, align 1
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %3 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %i)
+  %5 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i8* %0 to i64*
+  store i8 %1, i8* %nr_stack_frames_addr, align 1
+  store i64 %2, i64* %seed_addr, align 8
+  %7 = load i8, i8* %nr_stack_frames_addr, align 1
+  %8 = zext i8 %7 to i64
+  %9 = mul i64 %8, -4132994306676758123
+  %10 = load i64, i64* %seed_addr, align 8
+  %11 = xor i64 %10, %9
+  store i64 %11, i64* %id, align 8
+  store i8 0, i8* %i, align 1
+  br label %while_cond
+
+while_cond:                                       ; preds = %while_body, %entry
+  %12 = load i8, i8* %nr_stack_frames_addr, align 1
+  %13 = load i8, i8* %i, align 1
+  %length.cmp = icmp ult i8 %13, %12
+  br i1 %length.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %14 = load i8, i8* %i, align 1
+  %15 = getelementptr i64, i64* %6, i8 %14
+  %16 = load i64, i64* %15, align 8
+  store i64 %16, i64* %k, align 8
+  %17 = load i64, i64* %k, align 8
+  %18 = mul i64 %17, -4132994306676758123
+  store i64 %18, i64* %k, align 8
+  %19 = load i64, i64* %k, align 8
+  %20 = lshr i64 %19, 47
+  %21 = load i64, i64* %k, align 8
+  %22 = xor i64 %21, %20
+  store i64 %22, i64* %k, align 8
+  %23 = load i64, i64* %k, align 8
+  %24 = mul i64 %23, -4132994306676758123
+  store i64 %24, i64* %k, align 8
+  %25 = load i64, i64* %k, align 8
+  %26 = load i64, i64* %id, align 8
+  %27 = xor i64 %26, %25
+  store i64 %27, i64* %id, align 8
+  %28 = load i64, i64* %id, align 8
+  %29 = mul i64 %28, -4132994306676758123
+  store i64 %29, i64* %id, align 8
+  %30 = load i8, i8* %i, align 1
+  %31 = add i8 %30, 1
+  store i8 %31, i8* %i, align 1
+  br label %while_cond
+
+while_end:                                        ; preds = %while_cond
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %nr_stack_frames_addr)
+  %32 = bitcast i64* %seed_addr to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %i)
+  %33 = bitcast i64* %k to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %34 = load i64, i64* %id, align 8
+  %zero_cond = icmp eq i64 %34, 0
+  br i1 %zero_cond, label %if_zero, label %if_end
+
+if_zero:                                          ; preds = %while_end
+  store i64 1, i64* %id, align 8
+  br label %if_end
+
+if_end:                                           ; preds = %if_zero, %while_end
+  %35 = load i64, i64* %id, align 8
+  %36 = bitcast i64* %id to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
+  ret i64 %35
+}
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
+
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+attributes #3 = { alwaysinline }
 
-!llvm.dbg.cu = !{!55}
-!llvm.module.flags = !{!58}
+!llvm.dbg.cu = !{!65}
+!llvm.module.flags = !{!68}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -99,10 +230,10 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !4 = !{!5, !11, !16, !19}
 !5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
 !6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
-!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 224, elements: !9)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !9)
 !8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 !9 = !{!10}
-!10 = !DISubrange(count: 7, lowerBound: 0)
+!10 = !DISubrange(count: 9, lowerBound: 0)
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !14)
@@ -110,52 +241,62 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !15 = !DISubrange(count: 131072, lowerBound: 0)
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
-!18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 8128, elements: !23)
-!22 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!23 = !{!24}
-!24 = !DISubrange(count: 127, lowerBound: 0)
-!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
-!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
-!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
-!28 = !{!29, !34}
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 27, lowerBound: 0)
-!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
-!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !37)
-!37 = !{!38}
-!38 = !DISubrange(count: 262144, lowerBound: 0)
-!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
-!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !48, !16, !53}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 2, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !49, size: 64, offset: 64)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !51)
-!51 = !{!52}
-!52 = !DISubrange(count: 1, lowerBound: 0)
-!53 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !54, size: 64, offset: 192)
-!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !56, globals: !57)
-!56 = !{}
-!57 = !{!0, !25, !39}
-!58 = !{i32 2, !"Debug Info Version", i32 3}
-!59 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !60, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !64)
-!60 = !DISubroutineType(types: !61)
-!61 = !{!22, !62}
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!63 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!64 = !{!65, !66}
-!65 = !DILocalVariable(name: "var0", scope: !59, file: !2, type: !22)
-!66 = !DILocalVariable(name: "var1", arg: 1, scope: !59, file: !2, type: !62)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !22)
+!22 = !{!23}
+!23 = !DISubrange(count: 127, lowerBound: 0)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !27)
+!27 = !{!28, !33, !38, !19}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 6, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 1, lowerBound: 0)
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !39, size: 64, offset: 128)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !44)
+!44 = !{!45, !50}
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !46, size: 64)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !48)
+!48 = !{!49}
+!49 = !DISubrange(count: 27, lowerBound: 0)
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !51, size: 64, offset: 64)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !53)
+!53 = !{!54}
+!54 = !DISubrange(count: 262144, lowerBound: 0)
+!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
+!56 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !57, isLocal: false, isDefinition: true)
+!57 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !58)
+!58 = !{!59, !33, !38, !64}
+!59 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !60, size: 64)
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !62)
+!62 = !{!63}
+!63 = !DISubrange(count: 2, lowerBound: 0)
+!64 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!65 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !66, globals: !67)
+!66 = !{}
+!67 = !{!0, !24, !41, !55}
+!68 = !{i32 2, !"Debug Info Version", i32 3}
+!69 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !70, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !65, retainedNodes: !74)
+!70 = !DISubroutineType(types: !71)
+!71 = !{!18, !72}
+!72 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !73, size: 64)
+!73 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!74 = !{!75, !76}
+!75 = !DILocalVariable(name: "var0", scope: !69, file: !2, type: !18)
+!76 = !DILocalVariable(name: "var1", arg: 1, scope: !69, file: !2, type: !72)


### PR DESCRIPTION
The native `bpf_get_stackid` function is broken by design.

First, stacks can suffer from hash collisions and we can lose stacks.
We receive collision errors in userspace b/c we do not set
BPF_F_REUSE_STACKID.

Second, there is not a great way to reduce the frequency of collision
(other than increasing map size) b/c multiple probes can be sharing
the same stack (remember they are hashed). As a result, we cannot
delete entries in this map b/c we don't know when all the sharers
are gone.

This diff implements our own get_stack_id function utilizing the
quick hash function murmurhash2:
https://github.com/aappleby/smhasher/blob/92cf3702fcfaadc84eb7bef59825a23e0cd84f56/src/MurmurHash2.cpp

This involves:
- creating a scratch map (the stack is too large as a stack var)
- calling `bpf_get_stack` to populate the stack
- calling `murmur_hash_2_func_` to get the stack id
- storing the stackid and stack as a key/value in a hash map

More details:
https://github.com/bpftrace/bpftrace/issues/2962

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
