### PR TITLE
Add user function call support

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -305,13 +305,19 @@ PositionalParameter::PositionalParameter(PositionalParameterType ptype,
   is_literal = true;
 }
 
-Call::Call(const std::string &func, location loc)
-    : Expression(loc), func(is_deprecated(func)), vargs(nullptr)
+Call::Call(const std::string &func, bool builtin, location loc)
+    : Expression(loc),
+      func(is_deprecated(func)),
+      vargs(nullptr),
+      builtin(builtin)
 {
 }
 
-Call::Call(const std::string &func, ExpressionList *vargs, location loc)
-    : Expression(loc), func(is_deprecated(func)), vargs(vargs)
+Call::Call(const std::string &func,
+           ExpressionList *vargs,
+           bool builtin,
+           location loc)
+    : Expression(loc), func(is_deprecated(func)), vargs(vargs), builtin(builtin)
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -197,12 +197,16 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Call)
 
-  explicit Call(const std::string &func, location loc);
-  Call(const std::string &func, ExpressionList *vargs, location loc);
+  explicit Call(const std::string &func, bool builtin, location loc);
+  Call(const std::string &func,
+       ExpressionList *vargs,
+       bool builtin,
+       location loc);
   ~Call();
 
   std::string func;
   ExpressionList *vargs = nullptr;
+  bool builtin;
 
 private:
   Call(const Call &other);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -79,6 +79,7 @@ public:
 
   void createPrintMapCall(Call &call);
   void createPrintNonMapCall(Call &call, int &id);
+  void createSubprogCall(Call &call);
 
   void createMapDefinition(const std::string &name,
                            libbpf::bpf_map_type map_type,
@@ -260,6 +261,7 @@ private:
   bool inside_subprog_ = false;
 
   std::map<std::string, AllocaInst *> variables_;
+  std::unordered_set<std::string> subprogs_;
   int printf_id_ = 0;
   int mapped_printf_id_ = 0;
   int time_id_ = 0;

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -104,6 +104,7 @@ private:
   bool check_available(const Call &call, const AttachPoint &ap);
 
   void check_stack_call(Call &call, bool kernel);
+  bool check_subprog_call(Call &call);
 
   Probe *get_probe_from_scope(Scope *scope,
                               const location &loc,
@@ -138,6 +139,8 @@ private:
   // Holds the function argument index currently being visited by this
   // SemanticAnalyser.
   int func_arg_idx_ = -1;
+  // Holds the list of processed subprogs used for checking subprog calls.
+  std::unordered_map<std::string, Subprog *> subprogs_;
 
   std::map<Scope *, std::map<std::string, SizedType>> variable_val_;
   std::map<std::string, SizedType> map_val_;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -208,7 +208,7 @@ struct|union|enum       {
   .                     { unput(yytext[0]); yy_pop_state(yyscanner); }
 }
 <STRUCT_AFTER_COLON>{
-  "{"|","|")"           {
+  "{"|","|")"|"*"       {
                           yy_pop_state(yyscanner);
                           unput(yytext[0]);
                           return Parser::make_IDENT(struct_type + " " + trim(buffer), loc);

--- a/src/types.h
+++ b/src/types.h
@@ -229,7 +229,7 @@ public:
   bool IsPrintableTy()
   {
     return type_ != Type::none && type_ != Type::stack_mode &&
-           type_ != Type::timestamp_mode &&
+           type_ != Type::timestamp_mode && type_ != Type::voidtype &&
            (!IsCtxAccess() || is_funcarg); // args builtin is printable
   }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2715,6 +2715,20 @@ TEST(Parser, subprog_enum)
        " f: enum x()\n");
 }
 
+TEST(Parser, subprog_call)
+{
+  test("BEGIN { f(); }",
+       "Program\n"
+       " BEGIN\n"
+       "  call: f\n");
+  test("BEGIN { f(1, \"2\"); }",
+       "Program\n"
+       " BEGIN\n"
+       "  call: f\n"
+       "   int: 1\n"
+       "   string: 2\n");
+}
+
 TEST(Parser, for_loop)
 {
   test("BEGIN { for ($kv : @map) { print($kv) } }", R"(

--- a/tests/runtime/subprogs
+++ b/tests/runtime/subprogs
@@ -1,0 +1,53 @@
+NAME add two numbers
+PROG fn add($a: int64, $b: int64): int64 { return $a + $b; } BEGIN { print(add(5, 11)); exit(); }
+EXPECT 16
+TIMEOUT 5
+
+NAME nested call
+PROG fn f1(): void { printf("1"); f2(); } fn f2(): void { printf("2"); f3(); } fn f3(): void { printf("3\n"); } BEGIN { f1(); exit(); }
+EXPECT 123
+TIMEOUT 5
+
+NAME recursive factorial
+PROG fn fact($x: int64): int64 { if ($x == 0) { return 1; } else { return (int64)($x * fact($x - 1)); } } BEGIN { print(fact(5)); exit(); }
+EXPECT 120
+TIMEOUT 5
+
+NAME recursive factorial with two functions
+RUN {{BPFTRACE}} -ve 'fn fact1($x: int64): int64 { if ($x == 0) { return 1; } else { return (int64)($x * fact2($x - 1)); } } fn fact2($x: int64): int64 { if ($x == 0) { return 1; } else { return (int64)($x * fact1($x - 1)); } } BEGIN { print(fact1(5)); exit(); }'
+#EXPECT 120
+EXPECT_REGEX the call stack of .* frames is too deep
+TIMEOUT 5
+WILL_FAIL # currently rejected by BPF verifier
+
+NAME recursive Fibonacci
+RUN {{BPFTRACE}} -ve 'fn fib($i: int64): int64 { if ($i == 0 || $i == 1) { return 1; } else { return (int64)(fib($i - 1) + fib($i - 2)); } } BEGIN { print(fib(10)); exit(); }'
+#EXPECT 89
+EXPECT_REGEX the call stack of .* frames is too deep
+TIMEOUT 5
+WILL_FAIL # currently rejected by BPF verifier
+
+NAME print from subprog
+PROG fn print_int_twice($x: int64): void { printf("%d %d\n", $x, $x); } BEGIN { print_int_twice(42); exit(); }
+EXPECT 42 42
+TIMEOUT 5
+
+NAME map access from subprog
+PROG fn print_from_map($idx: int64): void { print(@x[$idx]); } BEGIN { @x[0] = 1; @x[1] = 2; print_from_map(1); exit(); }
+EXPECT 2
+TIMEOUT 5
+
+NAME cpu builtin from subprog
+PROG fn print_cpu(): void { printf("cpu: %d", cpu); } BEGIN { print_cpu(); exit(); }
+EXPECT_REGEX cpu: [0-9]*
+TIMEOUT 5
+
+NAME comm builtin from subprog
+PROG fn print_comm(): void { print(comm); } BEGIN { print_comm(); exit(); }
+EXPECT bpftrace
+TIMEOUT 5
+
+NAME cgroup_path builtin from subprog
+PROG fn print_cgroup_path(): void { printf("path: %s", cgroup_path(cgroup)); } BEGIN { print_cgroup_path(); exit() }
+EXPECT_REGEX path: .*
+TIMEOUT 5


### PR DESCRIPTION
Function defined by the user can now be called in the same ways as built-in functions, for example:

fn add($a: int64, $b: int64): int64 {
  return $a + $b;
}

BEGIN {
  print(add(5, 9));
}

If a function of the same name as an existing built-in is defined, it overrides the built-in and a warning is printed.

Implementation-wise, the functionality depends on existing relocations against subprogs implemented in commit d345d06 ("Implement relocations against .text for subprogs").

Functions are generated as separate LLVM IR functions and translated into BPF subprogs via the LLVM bpf backend. Relocations make sure the resulting program can be loaded.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
