### PR TITLE
tests: Use colorized output in GHA

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -40,7 +40,9 @@ RUN_TESTS = os.environ.get("RUN_TESTS", "1")
 RUN_MEMLEAK_TEST = os.environ.get("RUN_MEMLEAK_TEST", "0")
 CC = os.environ.get("CC", "cc")
 CXX = os.environ.get("CXX", "c++")
+GTEST_COLOR = os.environ.get("GTEST_COLOR", "auto")
 RUNTIME_TEST_DISABLE = os.environ.get("RUNTIME_TEST_DISABLE", "")
+RUNTIME_TEST_COLOR = os.environ.get("RUNTIME_TEST_COLOR", "auto")
 TOOLS_TEST_OLDVERSION = os.environ.get("TOOLS_TEST_OLDVERSION", "")
 TOOLS_TEST_DISABLE = os.environ.get("TOOLS_TEST_DISABLE", "")
 
@@ -229,7 +231,11 @@ def test():
         test_one(
             "bpftrace_test",
             lambda: truthy(RUN_TESTS),
-            lambda: shell(["./tests/bpftrace_test"], cwd=Path(BUILD_DIR)),
+            lambda: shell(
+                ["./tests/bpftrace_test"],
+                cwd=Path(BUILD_DIR),
+                env={"GTEST_COLOR": GTEST_COLOR},
+            ),
         )
     )
     results.append(
@@ -240,7 +246,10 @@ def test():
                 ["./tests/runtime-tests.sh"],
                 as_root=True,
                 cwd=Path(BUILD_DIR),
-                env={"RUNTIME_TEST_DISABLE": RUNTIME_TEST_DISABLE},
+                env={
+                    "RUNTIME_TEST_DISABLE": RUNTIME_TEST_DISABLE,
+                    "RUNTIME_TEST_COLOR": RUNTIME_TEST_COLOR,
+                },
             ),
         )
     )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
   build_test:
     runs-on: ubuntu-latest
     continue-on-error: true
+    env:
+      GTEST_COLOR: yes
+      RUNTIME_TEST_COLOR: yes
     strategy:
       matrix:
         env:

--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -79,11 +79,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1703957214,
-        "narHash": "sha256-VBiQAJaGnksf9na2rtOvxliKuK+Bn8LMyz2gzyNowc4=",
+        "lastModified": 1710772095,
+        "narHash": "sha256-NNippyej+t1eWHKMIaz9VClexikhi+545djsEwswPWU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ab3d01706825b1291a77187f2756c8fac3da2ca9",
+        "rev": "0f064344c9c731c47bfb836200a2be922595c88b",
         "type": "github"
       },
       "original": {

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -14,6 +14,7 @@ import cmake_vars
 
 BPFTRACE_BIN = os.environ["BPFTRACE_RUNTIME_TEST_EXECUTABLE"]
 AOT_BIN = os.environ["BPFTRACE_AOT_RUNTIME_TEST_EXECUTABLE"]
+COLOR_SETTING = os.environ.get("RUNTIME_TEST_COLOR", "auto")
 ATTACH_TIMEOUT = 10
 DEFAULT_TIMEOUT = 5
 
@@ -23,9 +24,17 @@ WARN_COLOR = '\033[94m'
 ERROR_COLOR = '\033[91m'
 NO_COLOR = '\033[0m'
 
-# TODO(mmarchini) only add colors if terminal supports it
 def colorify(s, color):
-    return "%s%s%s" % (color, s, NO_COLOR) if sys.stdout.isatty() else s
+    if COLOR_SETTING == "yes":
+        use_color = True
+    elif COLOR_SETTING == "auto":
+        use_color = sys.stdout.isatty()
+    elif COLOR_SETTING == "no":
+        use_color = False
+    else:
+        raise ValueError("Invalid setting for RUNTIME_TEST_COLOR")
+
+    return f"{color}{s}{NO_COLOR}" if use_color else s
 
 def ok(s):
     return colorify(s, OK_COLOR)


### PR DESCRIPTION
Makes it easier to visually parse output. GHA supports ANSI color codes, despite not being a tty.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
