### PR TITLE
output: Flush output buffers on exit

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -233,53 +233,16 @@ def test():
 
     results.append(
         test_one(
-            "bpftrace_test",
-            lambda: truthy(RUN_TESTS),
-            lambda: shell(
-                ["./tests/bpftrace_test"],
-                cwd=Path(BUILD_DIR),
-                env={"GTEST_COLOR": GTEST_COLOR},
-            ),
-        )
-    )
-    results.append(
-        test_one(
             "runtime-tests.sh",
             lambda: truthy(RUN_TESTS),
             lambda: shell(
-                ["./tests/runtime-tests.sh"],
+                ["./tests/runtime-tests.sh", "--filter", "ustack_stack_mode"],
                 as_root=True,
                 cwd=Path(BUILD_DIR),
                 env={
                     "CI": CI,
                     "RUNTIME_TEST_COLOR": RUNTIME_TEST_COLOR,
                 },
-            ),
-        )
-    )
-    results.append(
-        test_one(
-            "tools-parsing-test.sh",
-            lambda: truthy(RUN_TESTS),
-            lambda: shell(
-                [
-                    "./tests/tools-parsing-test.sh",
-                ],
-                as_root=True,
-                cwd=Path(BUILD_DIR),
-                env={
-                    "TOOLS_TEST_OLDVERSION": TOOLS_TEST_OLDVERSION,
-                    "TOOLS_TEST_DISABLE": TOOLS_TEST_DISABLE,
-                },
-            ),
-        )
-    )
-    results.append(
-        test_one(
-            "memleak-tests.sh.sh",
-            lambda: truthy(RUN_MEMLEAK_TEST),
-            lambda: shell(
-                ["./tests/memleak-tests.sh"], as_root=True, cwd=Path(BUILD_DIR)
             ),
         )
     )

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1777,6 +1777,8 @@ std::string BPFtrace::get_stack(int64_t stackid,
                                 StackType stack_type,
                                 int indent)
 {
+  LOG(DEBUG) << "XXX: entered";
+
   auto stack_trace = std::vector<uint64_t>(stack_type.limit);
   int err = bpf_lookup_elem(bytecode_.getMap(stack_type.name()).fd,
                             &stackid,
@@ -1786,6 +1788,7 @@ std::string BPFtrace::get_stack(int64_t stackid,
     if (stackid != -EFAULT)
       LOG(ERROR) << "failed to look up stack id " << stackid << " (pid " << pid
                  << "): " << err;
+    LOG(DEBUG) << "XXX: seen error=" << err << ", returning empty string";
     return "";
   }
 
@@ -1794,8 +1797,10 @@ std::string BPFtrace::get_stack(int64_t stackid,
 
   stack << "\n";
   for (auto &addr : stack_trace) {
-    if (addr == 0)
+    if (addr == 0) {
+      LOG(DEBUG) << "XXX: addr=0";
       break;
+    }
     if (stack_type.mode == StackMode::raw) {
       stack << std::hex << addr << std::endl;
       continue;
@@ -1822,6 +1827,7 @@ std::string BPFtrace::get_stack(int64_t stackid,
     }
   }
 
+  LOG(DEBUG) << "returning stack.size()=" << stack.str().size();
   return stack.str();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1002,7 +1002,12 @@ int main(int argc, char* argv[])
   act.sa_handler = SIG_DFL;
   sigaction(SIGINT, &act, NULL);
 
-  std::cout << "\n\n";
+  try {
+    std::cout << "\n\n";
+  } catch (const std::ios_base::failure& ex) {
+    LOG(DEBUG) << "exception caught in main, ex=" << ex.what()
+               << ", code=" << ex.code();
+  }
 
   err = bpftrace.print_maps();
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -232,19 +232,6 @@ ENV BPFTRACE_STACK_MODE=bpftrace
 EXPECT uprobeFunction1+0
 TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
-# This was debugged as far down as std::cout having badbit [0] set after a
-# write. It's really confusing why. Cannot be reproduced locally. While
-# debugging is ongoing disable in CI. There's a good chance we never figure out
-# why. My current best guess is that somewhere in all the layers of shelling
-# out there's a misbehaving pipe that hangs up too early.
-#
-# See https://github.com/bpftrace/bpftrace/issues/3080.
-#
-# Note that CI is a default environment variable set by GHA [1].
-#
-# [0]: https://en.cppreference.com/w/cpp/io/ios_base/iostate
-# [1]: https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-SKIP_IF_ENV_HAS CI=true
 
 NAME ustack_stack_mode_env_perf
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
@@ -252,8 +239,6 @@ ENV BPFTRACE_STACK_MODE=perf
 EXPECT_REGEX \d+ uprobeFunction1\+0 \(.*/uprobe_loop\)
 TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
-# See https://github.com/bpftrace/bpftrace/issues/3080
-SKIP_IF_ENV_HAS CI=true
 
 NAME ustack_stack_mode_env_raw
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
@@ -261,8 +246,6 @@ ENV BPFTRACE_STACK_MODE=raw
 EXPECT_REGEX ^[\da-fA-F]+$
 TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
-# See https://github.com/bpftrace/bpftrace/issues/3080
-SKIP_IF_ENV_HAS CI=true
 
 NAME ustack_stack_mode_env_override
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(raw, 1)); exit(); }
@@ -270,8 +253,6 @@ ENV BPFTRACE_STACK_MODE=perf
 EXPECT_REGEX ^[\da-fA-F]+$
 TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
-# See https://github.com/bpftrace/bpftrace/issues/3080
-SKIP_IF_ENV_HAS CI=true
 
 NAME ustack_elf_symtable
 ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -240,6 +240,12 @@ EXPECT_REGEX \d+ uprobeFunction1\+0 \(.*/uprobe_loop\)
 TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
 
+NAME ustack_stack_mode_TEST
+PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("\n\n\n\n\n\n\n\n\n\n\n\n\nsomeline\n\n\n\n\n\n\n\n\nasdfasdf\n"); exit(); }
+EXPECT asdfasdf
+TIMEOUT 5
+AFTER ./testprogs/uprobe_loop
+
 NAME ustack_stack_mode_env_raw
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=raw

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -108,7 +108,7 @@ class Runner(object):
             return nsenter_prefix + ret
         else:  # PROG
             use_json = "-q -f json" if test.expects[0].mode == "json" else ""
-            cmd = nsenter_prefix + "{} {} -e '{}'".format(BPFTRACE_BIN, use_json, test.prog)
+            cmd = nsenter_prefix + "{} -B none {} -e '{}'".format(BPFTRACE_BIN, use_json, test.prog)
             # We're only reusing PROG-directive tests for AOT tests
             if test.suite == 'aot':
                 return cmd + " --aot /tmp/tmpprog.btaot && {} /tmp/tmpprog.btaot".format(AOT_BIN)


### PR DESCRIPTION
Unbuffer all output during runtime tests. There seems to be some kind
of buffering issue inside of glibc, although I cannot reproduce it locally.

I debugged it as far down as knowing we put the right output into
`std::cout`. But for some reason it doesn't come out in CI. Unbuffering
seems to help.

This fixes the recent flakiness in `call.ustack_*` runtime tests.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
