### PR TITLE
log: Display internal source location for LOG(DEBUG) logs

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -91,6 +91,8 @@ public:
   virtual ~LogStream();
 
 protected:
+  std::string internal_location();
+
   Log& sink_;
   LogType type_;
   const std::optional<location> loc_;


### PR DESCRIPTION
Helps with debugging. A slightly more powerful printf.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
