### PR TITLE
Config Syntax: Allow trailing semicolons and empty blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
   - [#3033](https://github.com/bpftrace/bpftrace/pull/3033)
 - Fix alignment of atomic map counter update
   - [#3045](https://github.com/bpftrace/bpftrace/pull/3045)
+- Allow trailing semicolons and empty blocks in config syntax
+  - [#3077](https://github.com/bpftrace/bpftrace/pull/3077)
 #### Docs
 #### Tools
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -391,6 +391,7 @@ stmt_list:
 config_assign_stmt_list:
                 config_assign_stmt ";" config_assign_stmt_list { $$ = $3; $3->insert($3->begin(), $1); }
         |       config_assign_stmt                             { $$ = new ast::StatementList; $$->push_back($1); }
+        |       %empty                                         { $$ = new ast::StatementList; }
                 ;
 
 block_stmt:

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2466,6 +2466,45 @@ uprobe:asdf:Stream {} tracepoint:only_one_arg {}
 )");
 }
 
+TEST(Parser, config)
+{
+  test("config = { blah = 5 } BEGIN {}", R"(
+Program
+ config
+  =
+   config var: blah
+   int: 5
+ BEGIN
+)");
+
+  test("config = { blah = 5; } BEGIN {}", R"(
+Program
+ config
+  =
+   config var: blah
+   int: 5
+ BEGIN
+)");
+
+  test("config = { blah = 5; zoop = \"a\"; } BEGIN {}", R"(
+Program
+ config
+  =
+   config var: blah
+   int: 5
+  =
+   config var: zoop
+   string: a
+ BEGIN
+)");
+
+  test("config = {} BEGIN {}", R"(
+Program
+ config
+ BEGIN
+)");
+}
+
 TEST(Parser, config_error)
 {
   test_parse_failure("i:s:1 { exit(); } config = { BPFTRACE_STACK_MODE=perf }",
@@ -2476,13 +2515,13 @@ i:s:1 { exit(); } config = { BPFTRACE_STACK_MODE=perf }
 )");
 
   test_parse_failure("config = { exit(); } i:s:1 { exit(); }", R"(
-stdin:1:12-16: ERROR: syntax error, unexpected call, expecting identifier
+stdin:1:12-16: ERROR: syntax error, unexpected call, expecting }
 config = { exit(); } i:s:1 { exit(); }
            ~~~~
 )");
 
   test_parse_failure("config = { @start = nsecs; } i:s:1 { exit(); }", R"(
-stdin:1:12-18: ERROR: syntax error, unexpected map, expecting identifier
+stdin:1:12-18: ERROR: syntax error, unexpected map, expecting }
 config = { @start = nsecs; } i:s:1 { exit(); }
            ~~~~~~
 )");


### PR DESCRIPTION
This makes it easier to add or remove entries from a config block. Also makes it consistent with the syntax for probe blocks.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
