### PR TITLE
Ensure pcap writers are always closed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1014,9 +1014,7 @@ int main(int argc, char* argv[])
       std::cout << "Child exited with code: " << val << std::endl;
   }
 
-  if (err)
-    return err;
-
   bpftrace.close_pcaps();
-  return 0;
+
+  return err;
 }


### PR DESCRIPTION
Before, if we encountered an error, we could miss closing the pcap writers.

Also remove an unnecessary conditional.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
