### PR TITLE
Fix inconsistent lhist bucket labels

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -127,10 +127,13 @@ std::string TextOutput::hist_index_label(uint32_t index, uint32_t k)
   return label.str();
 }
 
-std::string TextOutput::lhist_index_label(int number)
+std::string TextOutput::lhist_index_label(int number, int step)
 {
-  int kilo = 1024;
-  int mega = 1048576;
+  constexpr int kilo = 1024;
+  constexpr int mega = 1024 * 1024;
+
+  if (step % kilo != 0)
+    return std::to_string(number);
 
   std::ostringstream label;
 
@@ -562,12 +565,12 @@ std::string TextOutput::lhist_to_str(const std::vector<uint64_t> &values,
     int bar_width = values.at(i) / (float)max_value * max_width;
     std::ostringstream header;
     if (i == 0) {
-      header << "(..., " << lhist_index_label(min) << ")";
+      header << "(..., " << lhist_index_label(min, step) << ")";
     } else if (i == (buckets + 1)) {
-      header << "[" << lhist_index_label(max) << ", ...)";
+      header << "[" << lhist_index_label(max, step) << ", ...)";
     } else {
-      header << "[" << lhist_index_label((i - 1) * step + min);
-      header << ", " << lhist_index_label(i * step + min) << ")";
+      header << "[" << lhist_index_label((i - 1) * step + min, step);
+      header << ", " << lhist_index_label(i * step + min, step) << ")";
     }
 
     std::string bar(bar_width, '@');

--- a/src/output.h
+++ b/src/output.h
@@ -249,7 +249,7 @@ public:
 
 protected:
   static std::string hist_index_label(uint32_t index, uint32_t bits);
-  static std::string lhist_index_label(int number);
+  static std::string lhist_index_label(int number, int step);
   virtual std::string hist_to_str(const std::vector<uint64_t> &values,
                                   uint32_t div,
                                   uint32_t k) const override;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(bpftrace_test
   log.cpp
   main.cpp
   mocks.cpp
+  output.cpp
   parser.cpp
   portability_analyser.cpp
   procmon.cpp

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -37,11 +37,15 @@ TEST(TextOutput, lhist_no_suffix)
 
   output.map_hist(bpftrace, map, 0, 0, values_by_key, total_counts_by_key);
 
+  // The buckets for this test case have been specifically chosen: 640000 can
+  // also be written as 625K, while the other bucket boundaries can not be
+  // expressed with a suffix. We should only use the suffix representation for a
+  // bucket if all buckets can be expressed with one.
   EXPECT_EQ(R"(@mymap: 
 [610000, 620000)       1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
 [620000, 630000)       1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
-[630000, 625K)         1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
-[625K, 650000)         1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[630000, 640000)       1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[640000, 650000)       1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
 [650000, 660000)       1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
 [660000, 670000)       1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
 

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -1,0 +1,93 @@
+#include "output.h"
+
+#include <gtest/gtest.h>
+#include <sstream>
+
+#include "bpfmap.h"
+#include "bpftrace.h"
+#include "mocks.h"
+
+namespace bpftrace::test::output {
+
+TEST(TextOutput, lhist_no_suffix)
+{
+  std::stringstream out;
+  std::stringstream err;
+  TextOutput output{ out, err };
+
+  MockBPFtrace bpftrace;
+  bpftrace.resources.maps_info["@mymap"] = MapInfo{ MapKey{},
+                                                    SizedType{ Type::lhist, 8 },
+                                                    LinearHistogramArgs{
+                                                        610000, 670000, 10000 },
+                                                    {},
+                                                    {} };
+  BpfMap map{ libbpf::BPF_MAP_TYPE_HASH, "@mymap", 8, 8, 1000 };
+
+  std::map<std::vector<uint8_t>, std::vector<uint64_t>> values_by_key = {
+    {
+        { 0 },
+        { 0, 1, 1, 1, 1, 1, 1, 0 },
+    },
+  };
+
+  std::vector<std::pair<std::vector<uint8_t>, uint64_t>> total_counts_by_key = {
+    { { 0 }, 6 }
+  };
+
+  output.map_hist(bpftrace, map, 0, 0, values_by_key, total_counts_by_key);
+
+  EXPECT_EQ(R"(@mymap: 
+[610000, 620000)       1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[620000, 630000)       1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[630000, 625K)         1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[625K, 650000)         1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[650000, 660000)       1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[660000, 670000)       1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+
+)",
+            out.str());
+  EXPECT_TRUE(err.str().empty());
+}
+
+TEST(TextOutput, lhist_suffix)
+{
+  std::stringstream out;
+  std::stringstream err;
+  TextOutput output{ out, err };
+
+  MockBPFtrace bpftrace;
+  bpftrace.resources.maps_info["@mymap"] = MapInfo{ MapKey{},
+                                                    SizedType{ Type::lhist, 8 },
+                                                    LinearHistogramArgs{
+                                                        0, 5 * 1024, 1024 },
+                                                    {},
+                                                    {} };
+  BpfMap map{ libbpf::BPF_MAP_TYPE_HASH, "@mymap", 8, 8, 1000 };
+
+  std::map<std::vector<uint8_t>, std::vector<uint64_t>> values_by_key = {
+    {
+        { 0 },
+        { 0, 1, 1, 1, 1, 1, 0 },
+    },
+  };
+
+  std::vector<std::pair<std::vector<uint8_t>, uint64_t>> total_counts_by_key = {
+    { { 0 }, 5 }
+  };
+
+  output.map_hist(bpftrace, map, 0, 0, values_by_key, total_counts_by_key);
+
+  EXPECT_EQ(R"(@mymap: 
+[0, 1K)                1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[1K, 2K)               1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[2K, 3K)               1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[3K, 4K)               1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[4K, 5K)               1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+
+)",
+            out.str());
+  EXPECT_TRUE(err.str().empty());
+}
+
+} // namespace bpftrace::test::output


### PR DESCRIPTION
The 'K' and 'M' suffixes should either be applied to all buckets or to none. This can be achieved by only applying the suffixes if the step size is a multiple of 1024.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
