### PR TITLE
Allow mocking BpfMap for unit tests

### DIFF
--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -4,12 +4,12 @@ namespace bpftrace {
 
 libbpf::bpf_map_type BpfMap::type() const
 {
-  return static_cast<libbpf::bpf_map_type>(bpf_map__type(bpf_map_));
+  return type_;
 }
 
-std::string BpfMap::bpf_name() const
+cstring_view BpfMap::bpf_name() const
 {
-  return bpf_map__name(bpf_map_);
+  return name_;
 }
 
 std::string BpfMap::name() const
@@ -19,17 +19,17 @@ std::string BpfMap::name() const
 
 uint32_t BpfMap::key_size() const
 {
-  return bpf_map__key_size(bpf_map_);
+  return key_size_;
 }
 
 uint32_t BpfMap::value_size() const
 {
-  return bpf_map__value_size(bpf_map_);
+  return value_size_;
 }
 
 uint32_t BpfMap::max_entries() const
 {
-  return bpf_map__max_entries(bpf_map_);
+  return max_entries_;
 }
 
 bool BpfMap::is_stack_map() const

--- a/src/container/cstring_view.h
+++ b/src/container/cstring_view.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+namespace bpftrace {
+
+/*
+ * cstring_view
+ *
+ * A restricted version of std::string_view which guarantees that the underlying
+ * string buffer will be null-terminated. This can be useful when interacting
+ * with C APIs while avoiding the use of char* and unnecessary copies from using
+ * std::string.
+ *
+ * We only allow constructing cstring_view from types which are guaranteed to
+ * store null-terminated strings. All modifiers or operations on cstring_view
+ * will also maintain the null-terminated property.
+ */
+class cstring_view : public std::string_view {
+public:
+  constexpr cstring_view(const char *str) noexcept : std::string_view{ str }
+  {
+  }
+  // This ctor can be made constexpt in C++20:
+  cstring_view(const std::string &str) noexcept : std::string_view{ str }
+  {
+  }
+
+  constexpr const char *c_str() const noexcept
+  {
+    return data();
+  }
+
+private:
+  // Disallow use of functions which can break the null-termination invariant
+  using std::string_view::copy;
+  using std::string_view::remove_suffix;
+  using std::string_view::substr;
+};
+
+} // namespace bpftrace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(bpftrace_test
   child.cpp
   clang_parser.cpp
   config.cpp
+  cstring_view.cpp
   field_analyser.cpp
   log.cpp
   main.cpp

--- a/tests/cstring_view.cpp
+++ b/tests/cstring_view.cpp
@@ -1,0 +1,60 @@
+#include "container/cstring_view.h"
+#include "gtest/gtest.h"
+
+#include <type_traits>
+
+namespace bpftrace::test::cstring_view {
+
+using bpftrace::cstring_view;
+
+TEST(cstring_view, c_string)
+{
+  const char *str = "abc";
+  cstring_view sv{ str };
+
+  EXPECT_EQ("abc", sv);
+
+  EXPECT_EQ('a', sv[0]);
+  EXPECT_EQ('b', sv[1]);
+  EXPECT_EQ('c', sv[2]);
+  EXPECT_EQ('\0', sv[3]);
+}
+
+TEST(cstring_view, std_string)
+{
+  std::string str = "abc";
+  cstring_view sv{ str };
+
+  EXPECT_EQ("abc", sv);
+
+  EXPECT_EQ('a', sv[0]);
+  EXPECT_EQ('b', sv[1]);
+  EXPECT_EQ('c', sv[2]);
+  EXPECT_EQ('\0', sv[3]);
+}
+
+TEST(cstring_view, std_string_view)
+{
+  EXPECT_FALSE((std::is_constructible_v<cstring_view, std::string_view>));
+
+  // Sanity checks:
+  EXPECT_TRUE((std::is_constructible_v<cstring_view, std::string>));
+  EXPECT_TRUE((std::is_constructible_v<cstring_view, const char *>));
+}
+
+TEST(cstring_view, length)
+{
+  cstring_view sv{ "abc" };
+
+  EXPECT_EQ("abc", sv);
+  EXPECT_EQ(3, sv.size());
+  EXPECT_EQ(3, sv.length());
+}
+
+TEST(cstring_view, c_str)
+{
+  cstring_view sv{ "abc" };
+  EXPECT_EQ(0, strcmp(sv.c_str(), "abc"));
+}
+
+} // namespace bpftrace::test::cstring_view


### PR DESCRIPTION
Extract relevant details from libbpf::bpf_map in the BpfMap constructor.

Introduce a new container type `cstring_view` to ease interacting the libbpf's C API.