### PR TITLE
docs: Rework release process to have a stable release branch

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -137,6 +137,16 @@ can be used to easily format commits, e.g. `git clang-format upstream/master`
 We want to avoid `fix formatting` commits. Instead every commit should be
 formatted correctly.
 
+## Merging pull requests
+
+Please squash + rebase all pull requests (with no merge commit). In other words,
+there should be one commit in master per pull request. This makes generating
+changelogs both trivial and precise with the least amount of noise.
+
+The exception to this is PRs with complicated changes. If this is the case and
+the commits are well structured, a rebase + merge (no merge commit) is acceptable.
+The rule of thumb is the commit titles should make sense in a changelog.
+
 ## Changelog
 
 The changelog is for end users. It should provide them with a quick summary of

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,17 +1,20 @@
 # Release procedure
 
-This document describes how to release a new bpftrace version.
-
-The "release manager" (RM) can be one or more person. Usually whoever is motivated
-enough to drive a release.
+This document describes the bpftrace release process.
 
 ## Branching model
 
-In the usual case, we release directly from master. Reasoning is that bpftrace
-isn't a huge project yet so complicated branching models and release strategies
-more get in the way than provide order. If master is really busy or really buggy,
-the RM can choose to cut a release branch (titled `X.Y.Z_release`) to try and
-stabilize the code without including work in progress into the release.
+There should be one release branch per "major release" (we are currently
+pre-1.0, "major" refers to semver minor version). The name should follow the
+format `release/<major>.<minor>.x`.
+
+Example branch names:
+
+    * release/0.21.x
+    * release/1.0.x
+    * release/1.1.x
+
+Backport PRs should be opened against the relevant release branch.
 
 ## Merging pull requests
 
@@ -34,6 +37,7 @@ See https://semver.org/ .
 
 You must do these things to formally release a version:
 
+1. Create a new release branch if one does not already exist.
 1. Mark the release in the CHANGELOG by replacing the `## Unreleased` header
    with `## [VERSION] date`.
 1. Update `bpftrace_VERSION_MAJOR`, `bpftrace_VERSION_MINOR`, and

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -16,16 +16,6 @@ Example branch names:
 
 Backport PRs should be opened against the relevant release branch.
 
-## Merging pull requests
-
-Please squash + rebase all pull requests (with no merge commit). In other words,
-there should be one commit in master per pull request. This makes generating
-changelogs both trivial and precise with the least amount of noise.
-
-The exception to this is PRs with complicated changes. If this is the case and
-the commits are well structured, a rebase + merge (no merge commit) is acceptable.
-The rule of thumb is the commit titles should make sense in a changelog.
-
 ## Semantic versioning
 
 We choose to follow semantic versioning. Note that this doesn't matter much for

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -2,6 +2,13 @@
 
 This document describes the bpftrace release process.
 
+## Semantic versioning
+
+We choose to follow semantic versioning. Note that this doesn't matter much for
+major version < 1 but will matter a lot for >= 1.0.0 releases.
+
+See https://semver.org/ .
+
 ## Branching model
 
 There should be one release branch per "major release" (we are currently
@@ -15,13 +22,6 @@ Example branch names:
     * release/1.1.x
 
 Backport PRs should be opened against the relevant release branch.
-
-## Semantic versioning
-
-We choose to follow semantic versioning. Note that this doesn't matter much for
-major version < 1 but will matter a lot for >= 1.0.0 releases.
-
-See https://semver.org/ .
 
 ## Tagging a release
 


### PR DESCRIPTION
This makes it easier for non-committers to request backports.

Also some minor doc cleanups.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
