### PR TITLE
Replace std::runtime_error with LOG(FATAL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
   - [#3047](https://github.com/bpftrace/bpftrace/pull/3047)
 - Reproducible Builds: Do not store timestamps in gzip header
   - [#3096](https://github.com/bpftrace/bpftrace/pull/3096)
+- Replace instances of std::runtime_error with LOG(FATAL)
+  - [#3091](https://github.com/bpftrace/bpftrace/pull/3091)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/docs/coding_guidelines.md
+++ b/docs/coding_guidelines.md
@@ -29,9 +29,9 @@ Appropriate language features for this include:
 * `int`
 * `bool`
 
-If an error is **not** recoverable, prefer throwing an exception. Broadly
+If an error is **not** recoverable, prefer using `LOG(FATAL)`. Broadly
 speaking, if you want to immediately terminate and show a message to the
-user, use an exception. Exceptions **should not** be used for recoverable
+user, use `LOG(FATAL)`. Exceptions **should not** be used for recoverable
 errors.
 
 ### Examples

--- a/src/arch/loongarch64.cpp
+++ b/src/arch/loongarch64.cpp
@@ -149,8 +149,7 @@ std::string name()
 
 std::vector<std::string> invalid_watchpoint_modes()
 {
-  throw std::runtime_error(
-      "Watchpoints are not supported on this architecture");
+  LOG(FATAL) << "Watchpoints are not supported on this architecture";
 }
 
 int get_kernel_ptr_width()

--- a/src/arch/mips64.cpp
+++ b/src/arch/mips64.cpp
@@ -78,7 +78,7 @@ static std::array<std::string, 32> ptrace_registers = {
   "regs[28]",
   "regs[29]",
   "regs[30]",
-  "regs[31]", 
+  "regs[31]",
 };
 
 static std::array<std::string, 8> arg_registers = {
@@ -161,8 +161,7 @@ std::string name()
 
 std::vector<std::string> invalid_watchpoint_modes()
 {
-  throw std::runtime_error(
-      "Watchpoints are not supported on this architecture");
+  LOG(FATAL) << "Watchpoints are not supported on this architecture";
 }
 
 int get_kernel_ptr_width()

--- a/src/arch/riscv64.cpp
+++ b/src/arch/riscv64.cpp
@@ -103,8 +103,7 @@ std::string name()
 
 std::vector<std::string> invalid_watchpoint_modes()
 {
-  throw std::runtime_error(
-      "Watchpoints are not supported on this architecture");
+  LOG(FATAL) << "Watchpoints are not supported on this architecture";
 }
 
 int get_kernel_ptr_width()

--- a/src/arch/s390.cpp
+++ b/src/arch/s390.cpp
@@ -93,8 +93,7 @@ std::string name()
 
 std::vector<std::string> invalid_watchpoint_modes()
 {
-  throw std::runtime_error(
-      "Watchpoints are not supported on this architecture");
+  LOG(FATAL) << "Watchpoints are not supported on this architecture";
 }
 
 int get_kernel_ptr_width()

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -14,7 +14,7 @@ BpfBytecode::BpfBytecode(const void *elf, size_t elf_size)
   bpf_object_ = std::unique_ptr<struct bpf_object, bpf_object_deleter>(
       bpf_object__open_mem(elf, elf_size, nullptr));
   if (!bpf_object_)
-    throw std::runtime_error("The produced ELF is not a valid BPF object");
+    LOG(FATAL) << "The produced ELF is not a valid BPF object";
 
   struct bpf_map *m;
   bpf_map__for_each (m, bpf_object_.get()) {
@@ -39,7 +39,7 @@ const std::vector<uint8_t> &BpfBytecode::getSection(
     const std::string &name) const
 {
   if (!hasSection(name)) {
-    throw std::runtime_error("Bytecode is missing section " + name);
+    LOG(FATAL) << "Bytecode is missing section: " << name;
   }
   return sections_.at(name);
 }
@@ -88,7 +88,7 @@ const BpfMap &BpfBytecode::getMap(const std::string &name) const
 {
   auto map = maps_.find(name);
   if (map == maps_.end()) {
-    throw std::runtime_error("Unknown map: " + name);
+    LOG(FATAL) << "Unknown map: " << name;
   }
   return map->second;
 }
@@ -102,7 +102,7 @@ const BpfMap &BpfBytecode::getMap(int map_id) const
 {
   auto map = maps_by_id_.find(map_id);
   if (map == maps_by_id_.end()) {
-    throw std::runtime_error("Unknown map id: " + std::to_string(map_id));
+    LOG(FATAL) << "Unknown map id: " << std::to_string(map_id);
   }
   return *map->second;
 }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -258,7 +258,7 @@ private:
   int print_map_hist(const BpfMap &map, uint32_t top, uint32_t div);
   int print_map_stats(const BpfMap &map, uint32_t top, uint32_t div);
   static uint64_t read_address_from_output(std::string output);
-  std::vector<uint8_t> find_empty_key(const BpfMap &map) const;
+  std::optional<std::vector<uint8_t>> find_empty_key(const BpfMap &map) const;
   struct bcc_symbol_option &get_symbol_opts();
   bool has_iter_ = false;
   int epollfd_ = -1;

--- a/src/btf.h
+++ b/src/btf.h
@@ -74,7 +74,9 @@ public:
   std::map<std::string, std::vector<std::string>> get_params(
       const std::set<std::string>& funcs) const;
 
-  Struct resolve_args(const std::string& func, bool ret);
+  std::optional<Struct> resolve_args(const std::string& func,
+                                     bool ret,
+                                     std::string& err);
   void resolve_fields(SizedType& type);
 
   std::pair<int, int> get_btf_id_fd(const std::string& func,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -785,8 +785,13 @@ int main(int argc, char* argv[])
   bpftrace.delta_taitime_ = get_delta_taitime();
 
   if (!args.pid_str.empty()) {
+    std::string errmsg;
+    auto maybe_pid = parse_pid(args.pid_str, errmsg);
+    if (!maybe_pid.has_value()) {
+      LOG(FATAL) << "Failed to parse pid: " + errmsg;
+    }
     try {
-      bpftrace.procmon_ = std::make_unique<ProcMon>(args.pid_str);
+      bpftrace.procmon_ = std::make_unique<ProcMon>(*maybe_pid);
     } catch (const std::exception& e) {
       LOG(ERROR) << e.what();
       return 1;

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -120,11 +120,11 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
       break;
     }
     case ProbeType::tracepoint: {
-      symbol_stream = get_symbols_from_file_safe(tracefs::available_events());
+      symbol_stream = get_symbols_from_file(tracefs::available_events());
       break;
     }
     case ProbeType::rawtracepoint: {
-      symbol_stream = get_symbols_from_file_safe(tracefs::available_events());
+      symbol_stream = get_symbols_from_file(tracefs::available_events());
       symbol_stream = adjust_rawtracepoint(*symbol_stream);
       break;
     }
@@ -212,8 +212,9 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_file(
 {
   auto file = std::make_unique<std::ifstream>(path);
   if (file->fail()) {
-    throw std::runtime_error("Could not read symbols from " + path + ": " +
-                             strerror(errno));
+    LOG(WARNING) << "Could not read symbols from " << path << ": "
+                 << strerror(errno);
+    return nullptr;
   }
 
   return file;
@@ -232,17 +233,6 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_traceable_funcs(
     }
   }
   return std::make_unique<std::istringstream>(funcs);
-}
-
-std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_file_safe(
-    const std::string& path) const
-{
-  try {
-    return get_symbols_from_file(path);
-  } catch (const std::runtime_error& e) {
-    LOG(WARNING) << e.what();
-  }
-  return NULL;
 }
 
 std::unique_ptr<std::istream> ProbeMatcher::get_func_symbols_from_file(

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -94,11 +94,9 @@ private:
   std::set<std::string> get_matches_in_set(const std::string &search_input,
                                            const std::set<std::string> &set);
 
-  virtual std::unique_ptr<std::istream> get_symbols_from_file(
-      const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_traceable_funcs(
       bool with_modules = false) const;
-  virtual std::unique_ptr<std::istream> get_symbols_from_file_safe(
+  virtual std::unique_ptr<std::istream> get_symbols_from_file(
       const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_func_symbols_from_file(
       int pid,

--- a/src/procmon.cpp
+++ b/src/procmon.cpp
@@ -25,11 +25,6 @@ static inline int pidfd_open(int pid, unsigned int flags)
   return syscall(__NR_pidfd_open, pid, flags);
 }
 
-ProcMon::ProcMon(const std::string& pid)
-{
-  setup(parse_pid(pid));
-}
-
 ProcMon::ProcMon(pid_t pid)
 {
   setup(pid);

--- a/src/procmon.h
+++ b/src/procmon.h
@@ -29,7 +29,6 @@ protected:
 class ProcMon : public ProcMonBase {
 public:
   ProcMon(pid_t pid);
-  ProcMon(const std::string& pid);
   ~ProcMon() override;
 
   // Disallow copying as the internal state will get out of sync which will

--- a/src/resolve_cgroupid.cpp
+++ b/src/resolve_cgroupid.cpp
@@ -21,6 +21,7 @@
 #include <stdexcept>
 
 #include "act_helpers.h"
+#include "log.h"
 #include "resolve_cgroupid.h"
 
 namespace {
@@ -91,8 +92,8 @@ std::uint64_t resolve_cgroupid(const std::string &path)
       AT_FDCWD, path.c_str(), cfh.as_file_handle_ptr(), &mount_id, 0);
   if (err < 0) {
     auto emsg = std::strerror(errno);
-    throw std::runtime_error("Failed to get `cgroupid` for path: \"" + path +
-                             "\": " + emsg);
+    LOG(FATAL) << "Failed to get `cgroupid` for path: \"" << path
+               << "\": " << emsg;
   }
 
   return cfh.cgid;

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -163,8 +163,8 @@ void StructManager::Add(const std::string &name,
                         bool allow_override)
 {
   if (struct_map_.find(name) != struct_map_.end())
-    throw std::runtime_error("Type redefinition: type with name \'" + name +
-                             "\' already exists");
+    LOG(FATAL) << "Type redefinition: type with name \'" << name
+               << "\' already exists";
   struct_map_[name] = std::make_unique<Struct>(size, allow_override);
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -488,7 +488,7 @@ Field &SizedType::GetField(ssize_t n) const
 {
   assert(IsTupleTy() || IsRecordTy());
   if (n >= GetFieldCount())
-    throw std::runtime_error("Getfield(): out of bound");
+    LOG(FATAL) << "Getfield(): out of bounds";
   return inner_struct_.lock()->fields[n];
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -40,22 +40,6 @@ private:
   std::string msg_;
 };
 
-class InvalidPIDException : public std::exception {
-public:
-  InvalidPIDException(const std::string &pid, const std::string &msg)
-  {
-    msg_ = "pid '" + pid + "' " + msg;
-  }
-
-  const char *what() const noexcept override
-  {
-    return msg_.c_str();
-  }
-
-private:
-  std::string msg_;
-};
-
 class EnospcException : public std::runtime_error {
 public:
   // C++11 feature: bring base class constructor into scope to automatically
@@ -203,7 +187,7 @@ std::string str_join(const std::vector<std::string> &list,
                      const std::string &delim);
 bool is_numeric(const std::string &str);
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
-pid_t parse_pid(const std::string &str);
+std::optional<pid_t> parse_pid(const std::string &str, std::string &err);
 std::string hex_format_buffer(const char *buf,
                               size_t size,
                               bool keep_ascii = true,

--- a/tests/procmon.cpp
+++ b/tests/procmon.cpp
@@ -7,6 +7,7 @@
 #include "procmon.h"
 
 #include "childhelper.h"
+#include "utils.h"
 
 namespace bpftrace {
 namespace test {
@@ -34,13 +35,6 @@ TEST(procmon, child_terminates)
   EXPECT_FALSE(child->is_alive());
   EXPECT_FALSE(procmon->is_alive());
   EXPECT_FALSE(procmon->is_alive());
-}
-
-TEST(procmon, pid_string)
-{
-  auto child = getChild("/bin/ls");
-  auto procmon = std::make_unique<ProcMon>(std::to_string(child->pid()));
-  EXPECT_TRUE(procmon->is_alive());
 }
 
 } // namespace procmon

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -166,25 +166,25 @@ WILL_FAIL
 
 NAME pid fails validation with leading non-number
 RUN {{BPFTRACE}} -p a1111 file.bt
-EXPECT ERROR: pid 'a1111' is not a valid decimal number
+EXPECT FATAL: Failed to parse pid: pid 'a1111' is not a valid decimal number
 TIMEOUT 1
 WILL_FAIL
 
 NAME pid fails validation with non-number in between
 RUN {{BPFTRACE}} -p 111a1 file.bt
-EXPECT ERROR: pid '111a1' is not a valid decimal number
+EXPECT FATAL: Failed to parse pid: pid '111a1' is not a valid decimal number
 TIMEOUT 1
 WILL_FAIL
 
 NAME pid fails validation with non-numeric argument
 RUN {{BPFTRACE}} -p not_a_pid file.bt
-EXPECT ERROR: pid 'not_a_pid' is not a valid decimal number
+EXPECT FATAL: Failed to parse pid: pid 'not_a_pid' is not a valid decimal number
 TIMEOUT 1
 WILL_FAIL
 
 NAME pid outside of valid pid range
 RUN {{BPFTRACE}} -p 5000000 file.bt
-EXPECT ERROR: pid '5000000' out of valid pid range [1,4194304]
+EXPECT FATAL: Failed to parse pid: pid '5000000' out of valid pid range [1,4194304]
 TIMEOUT 1
 WILL_FAIL
 
@@ -270,6 +270,6 @@ WILL_FAIL
 
 NAME kaddr fails
 PROG BEGIN { print(kaddr("asdfzzzzzzz")) }
-EXPECT ERROR: Failed to compile: Failed to resolve kernel symbol: asdfzzzzzzz
+EXPECT FATAL: Failed to resolve kernel symbol: asdfzzzzzzz
 TIMEOUT 1
 WILL_FAIL

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -184,7 +184,7 @@ TIMEOUT 5
 NAME log size too small
 ENV BPFTRACE_LOG_SIZE=0
 RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
-EXPECT ERROR: Error loading program: BEGIN (try -v)
+EXPECT FATAL: Error loading program: BEGIN (try -v)
 TIMEOUT 5
 WILL_FAIL
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -135,13 +135,13 @@ AFTER ./testprogs/syscall read
 
 NAME kprobe_module_missing
 PROG kprobe:nonsense:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT ERROR: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
+EXPECT FATAL: Error attaching probe: kprobe:nonsense:vfs_read: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
 TIMEOUT 5
 WILL_FAIL
 
 NAME kprobe_func_missing
 PROG kprobe:vmlinux:nonsense { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT ERROR: Error attaching probe: 'kprobe:vmlinux:nonsense'
+EXPECT FATAL: Error attaching probe: kprobe:vmlinux:nonsense
 TIMEOUT 5
 WILL_FAIL
 
@@ -208,7 +208,7 @@ WILL_FAIL
 
 NAME kprobe_offset_module_error
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
-EXPECT Invalid argument
+EXPECT cannot attach kprobe, Invalid argument
 ARCH aarch64
 TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
@@ -287,7 +287,7 @@ WILL_FAIL
 
 NAME uprobe_address_fail_resolve
 PROG uprobe:/bin/bash:10 { printf("arg0: %d\n", arg0); exit();}
-EXPECT ERROR: Could not resolve address: /bin/bash:0xa
+EXPECT FATAL: Could not resolve address: /bin/bash:0xa
 TIMEOUT 5
 WILL_FAIL
 
@@ -306,7 +306,7 @@ AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 
 NAME uprobe_zero_size
 PROG uprobe:./testprogs/uprobe_test:_init { printf("arg0: %d\n", arg0); exit();}
-EXPECT ERROR: Could not determine boundary for _init (symbol has size 0). Use --unsafe to force attachment.
+EXPECT FATAL: Could not determine boundary for _init (symbol has size 0). Use --unsafe to force attachment.
 TIMEOUT 5
 WILL_FAIL
 
@@ -397,7 +397,7 @@ TIMEOUT 5
 
 NAME rawtracepoint_missing
 PROG rawtracepoint:nonsense { printf("hit"); exit(); }
-EXPECT ERROR: Probe does not exist: rawtracepoint:nonsense
+EXPECT FATAL: Probe does not exist: rawtracepoint:nonsense
 TIMEOUT 5
 WILL_FAIL
 
@@ -483,7 +483,7 @@ TIMEOUT 2
 # match and so we should fail on exceeding BPFTRACE_MAX_BPF_PROGS.
 NAME bpf_programs_limit
 PROG k:* { @[probe] = count(); }
-EXPECT_REGEX ERROR: Failed to compile: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 512.\nYou can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
+EXPECT_REGEX FATAL: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 512.\nYou can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
 WILL_FAIL
 TIMEOUT 2
 


### PR DESCRIPTION
There are still some cases where std::runtime_errors are thrown but I didn't change them because either:
- the linter got angry because the function wasn't returning a value
- the throw/catching behavior wasn't obvious enough that I felt comfortable changing it here (e.g. child.cpp)
- we are testing that an error gets thrown in a constructor - LOG(FATAL) doesn't work here because we can't catch it

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
