### PR TITLE
Remove some dead functions

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -139,8 +139,6 @@ public:
   std::string resolve_mac_address(const uint8_t *mac_addr) const;
   std::string resolve_cgroup_path(uint64_t cgroup_path_id,
                                   uint64_t cgroup_id) const;
-  virtual std::string extract_func_symbols_from_path(
-      const std::string &path) const;
   std::string resolve_probe(uint64_t probe_id) const;
   uint64_t resolve_cgroupid(const std::string &path) const;
   std::vector<std::unique_ptr<IPrintable>> get_arg_values(


### PR DESCRIPTION
'extract_func_symbols_from_path' isn't being called and by extension neither is 'add_symbol'

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
