### PR TITLE
Parse C++ class and inheritance from Debug Info

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,6 +24,7 @@ BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterFunction: true
+BreakAfterAttributes: Leave
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon
@@ -88,4 +89,3 @@ UseTab: Never
 Language: Json
 DisableFormat: true
 ...
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#3285](https://github.com/bpftrace/bpftrace/pull/3285)
 - For-loops: Allow sharing variables between the main probe and the loop's body
   - [#3014](https://github.com/bpftrace/bpftrace/pull/3014)
+- Parse C++ Class and Inheritance from Debug Info
+  - [#3094](https://github.com/bpftrace/bpftrace/pull/3094)
 #### Changed
 - Merge output into `stdout` when `-lv`
   - [#3383](https://github.com/bpftrace/bpftrace/pull/3383)

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -207,7 +207,7 @@ void Printer::visit(Ternary &ternary)
 void Printer::visit(FieldAccess &acc)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "." << std::endl;
+  out_ << indent << "." << type(acc.type) << std::endl;
 
   ++depth_;
   acc.expr->accept(*this);

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -42,6 +42,23 @@ public:
   {
   }
 
+  [[deprecated("Use Visit(Node *const &n) instead.")]]
+  virtual inline void Visit(Node &n) override
+  {
+    n.accept(*this);
+  }
+
+  virtual inline void Visit(Node *const &n)
+  {
+    n->accept(*this);
+  }
+
+  virtual inline void Visit(Expression *&expr)
+  {
+    expr->accept(*this);
+    dereference_if_needed(expr);
+  }
+
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;
   void visit(String &string) override;
@@ -125,6 +142,7 @@ private:
   void binop_ptr(Binop &op);
   void binop_int(Binop &op);
   void binop_array(Binop &op);
+  void dereference_if_needed(Expression *&expr);
 
   bool has_error() const;
   bool in_loop(void)

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -150,6 +150,10 @@ public:
   bool has_btf_data() const;
   Dwarf *get_dwarf(const std::string &filename);
   Dwarf *get_dwarf(const ast::AttachPoint &attachpoint);
+  bool has_dwarf_data() const
+  {
+    return !dwarves_.empty();
+  }
   void kfunc_recursion_check(ast::Program *prog);
 
   std::string cmd_;

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -181,18 +181,13 @@ SizedType Dwarf::get_stype(lldb::SBType type, bool resolve_structs)
         default:
           return CreateNone();
       }
-      break;
     }
     case lldb::eTypeClassEnumeration:
       return CreateUInt(bit_size);
     case lldb::eTypeClassPointer:
-    case lldb::eTypeClassReference: {
-      if (auto inner_type = type.GetPointeeType()) {
-        return CreatePointer(get_stype(inner_type, false));
-      }
-      // void *
-      return CreatePointer(CreateNone());
-    }
+      return CreatePointer(get_stype(type.GetPointeeType(), false));
+    case lldb::eTypeClassReference:
+      return CreatePointer(get_stype(type.GetDereferencedType(), false));
     case lldb::eTypeClassClass:
     case lldb::eTypeClassStruct:
     case lldb::eTypeClassUnion: {

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -40,6 +40,7 @@ private:
 
   std::string get_type_name(lldb::SBType type);
   SizedType get_stype(lldb::SBType type, bool resolve_structs = true);
+  void resolve_fields(std::shared_ptr<Struct> str, lldb::SBType type);
   std::optional<Bitfield> resolve_bitfield(lldb::SBTypeMember field);
 
   BPFtrace *bpftrace_;

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -40,7 +40,6 @@ private:
 
   std::string get_type_name(lldb::SBType type);
   SizedType get_stype(lldb::SBType type, bool resolve_structs = true);
-  void resolve_fields(std::shared_ptr<Struct> str, lldb::SBType type);
   std::optional<Bitfield> resolve_bitfield(lldb::SBTypeMember field);
 
   BPFtrace *bpftrace_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -881,6 +881,13 @@ int main(int argc, char* argv[])
       pm = CreateDynamicPM();
       break;
     case BuildMode::AHEAD_OF_TIME:
+      if (bpftrace.has_dwarf_data()) {
+        // See #3392 to learn why AOT does not yet support uprobe+DebugInfo.
+        LOG(ERROR) << "AOT does not yet support uprobe probes using DebugInfo.";
+        if (std::getenv("__BPFTRACE_NOTIFY_AOT_PORTABILITY_DISABLED"))
+          std::cout << "__BPFTRACE_NOTIFY_AOT_PORTABILITY_DISABLED"
+                    << std::endl;
+      }
       pm = CreateAotPM();
       break;
   }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -43,6 +43,7 @@ bool is_quoted_type(const SizedType &ty)
     case Type::min:
     case Type::none:
     case Type::pointer:
+    case Type::reference:
     case Type::record:
     case Type::stack_mode:
     case Type::stats:
@@ -382,7 +383,7 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
         reinterpret_cast<AsyncEvent::CgroupPath *>(value.data())->cgroup_id);
   else if (type.IsStrerrorTy())
     return strerror(read_data<uint64_t>(value.data()));
-  else if (type.IsPtrTy()) {
+  else if (type.IsPtrTy() || type.IsRefTy()) {
     std::ostringstream res;
     res << "0x" << std::hex << read_data<uint64_t>(value.data());
     return res.str();

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -156,10 +156,10 @@ void Struct::AddField(const std::string &field_name,
 {
   if (!HasField(field_name))
     fields.push_back(Field{ .name = field_name,
-                               .type = type,
-                               .offset = offset,
-                               .bitfield = bitfield,
-                               .is_data_loc = is_data_loc });
+                            .type = type,
+                            .offset = offset,
+                            .bitfield = bitfield,
+                            .is_data_loc = is_data_loc });
 }
 
 bool Struct::HasFields() const

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -155,7 +155,7 @@ void Struct::AddField(const std::string &field_name,
                       bool is_data_loc)
 {
   if (!HasField(field_name))
-    fields.emplace_back(Field{ .name = field_name,
+    fields.push_back(Field{ .name = field_name,
                                .type = type,
                                .offset = offset,
                                .bitfield = bitfield,

--- a/src/types.h
+++ b/src/types.h
@@ -26,6 +26,7 @@ enum class Type : uint8_t {
   voidtype,
   integer,
   pointer,
+  reference,
   record, // struct/union, as struct is a protected keyword
   hist,
   lhist,
@@ -314,6 +315,12 @@ public:
     return element_type_.get();
   }
 
+  const SizedType *GetDereferencedTy() const
+  {
+    assert(IsRefTy());
+    return element_type_.get();
+  }
+
   bool IsBoolTy() const
   {
     return type_ == Type::integer && size_bits_ == 1;
@@ -321,6 +328,10 @@ public:
   bool IsPtrTy() const
   {
     return type_ == Type::pointer;
+  };
+  bool IsRefTy() const
+  {
+    return type_ == Type::reference;
   };
   bool IsIntTy() const
   {
@@ -458,12 +469,19 @@ public:
   friend std::ostream &operator<<(std::ostream &, const SizedType &);
   friend std::ostream &operator<<(std::ostream &, Type);
 
+  void IntoPointer()
+  {
+    assert(IsRefTy());
+    type_ = Type::pointer;
+  }
+
   // Factories
 
   friend SizedType CreateArray(size_t num_elements,
                                const SizedType &element_type);
 
   friend SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as);
+  friend SizedType CreateReference(const SizedType &pointee_type, AddrSpace as);
   friend SizedType CreateRecord(const std::string &name,
                                 std::weak_ptr<Struct> record);
   friend SizedType CreateInteger(size_t bits, bool is_signed);
@@ -490,6 +508,8 @@ SizedType CreateString(size_t size);
 SizedType CreateArray(size_t num_elements, const SizedType &element_type);
 SizedType CreatePointer(const SizedType &pointee_type,
                         AddrSpace as = AddrSpace::none);
+SizedType CreateReference(const SizedType &referred_type,
+                          AddrSpace as = AddrSpace::none);
 
 SizedType CreateRecord(const std::string &name, std::weak_ptr<Struct> record);
 SizedType CreateTuple(std::weak_ptr<Struct> tuple);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -429,6 +429,29 @@ std::string erase_prefix(std::string &str)
   return prefix;
 }
 
+void erase_parameter_list(std::string &demangled_name)
+{
+  size_t args_start = std::string::npos;
+  ssize_t stack = 0;
+  // Look for the parenthesis closing the parameter list, then find
+  // the matching parenthesis at the start of the parameter list...
+  for (ssize_t it = demangled_name.find_last_of(')'); it >= 0; --it) {
+    if (demangled_name[it] == ')')
+      stack++;
+    if (demangled_name[it] == '(')
+      stack--;
+    if (stack == 0) {
+      args_start = it;
+      break;
+    }
+  }
+
+  // If we found the start of the parameter list,
+  // remove the parameters from the match line.
+  if (args_start != std::string::npos)
+    demangled_name.resize(args_start);
+}
+
 bool wildcard_match(std::string_view str,
                     const std::vector<std::string> &tokens,
                     bool start_wildcard,

--- a/src/utils.h
+++ b/src/utils.h
@@ -183,6 +183,7 @@ std::vector<std::string> split_string(const std::string &str,
                                       char delimiter,
                                       bool remove_empty = false);
 std::string erase_prefix(std::string &str);
+void erase_parameter_list(std::string &demangled_name);
 bool wildcard_match(std::string_view str,
                     const std::vector<std::string> &tokens,
                     bool start_wildcard,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ add_executable(bpftrace_test
 add_subdirectory(data)
 if(${LLDB_FOUND})
   add_dependencies(bpftrace_test debuginfo_dwarf_data)
+  add_dependencies(bpftrace_test data_source_cxx)
 endif()
 add_dependencies(bpftrace_test debuginfo_btf_data)
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})

--- a/tests/README.md
+++ b/tests/README.md
@@ -126,9 +126,9 @@ not known until test time. The following runtime variables are available for the
 
 ### Test programs
 
-You can add test programs for your runtime tests by placing a `.c` file corresponding to your test program in `tests/testprogs`.
+You can add test programs for your runtime tests by placing a `.c` or `.cpp` file corresponding to your test program in `tests/testprogs`.
 
-You can add test libraries for your runtime tests by placing a `.c` file corresponding to your test library in `tests/testlibs`.
+You can add test libraries for your runtime tests by placing a `.c` or `.cpp` file corresponding to your test library in `tests/testlibs`.
 
 The test file `tests/testprogs/my_test.c` will result in an executable that you can call and probe in your runtime test at `./testprogs/my_test`
 

--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -71,6 +71,7 @@ if(${LLDB_FOUND})
       -DDWARF_DATA_HEX=${DWARF_DATA_HEX}
       -DDWARF_DATA_H_IN=${DWARF_DATA_H_IN}
       -DDWARF_DATA_H=${DWARF_DATA_H}
+      -DDWARF_DATA_CXX_PATH=${CMAKE_CURRENT_BINARY_DIR}/data_source_cxx
       -P ${CONFIGURE_DWARF_HEADERS}
     DEPENDS ${FUNC_LIST_HEX} ${DWARF_DATA_HEX} ${CONFIGURE_DWARF_HEADERS})
 
@@ -92,3 +93,6 @@ add_custom_command(
   DEPENDS ${BTF_DATA_HEX} ${FUNC_LIST_HEX} ${CONFIGURE_BTF_HEADERS})
 
 add_custom_target(debuginfo_btf_data DEPENDS ${BTF_DATA_H})
+
+add_executable(data_source_cxx data_source_cxx.cpp)
+target_compile_options(data_source_cxx PRIVATE -g)

--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -94,5 +94,7 @@ add_custom_command(
 
 add_custom_target(debuginfo_btf_data DEPENDS ${BTF_DATA_H})
 
+# BTF doesn't support C++, so we only generate a data_source_cxx executable
+# to run the field_analyser tests on.
 add_executable(data_source_cxx data_source_cxx.cpp)
 target_compile_options(data_source_cxx PRIVATE -g)

--- a/tests/data/data_source_cxx.cpp
+++ b/tests/data/data_source_cxx.cpp
@@ -1,49 +1,105 @@
 class Parent {
-  private:
-    int a;
-  protected:
-    int b;
-  public:
-    int c;
-    int d; // Shadowed by Child::d, but should be reachable with a cast
+private:
+  int a;
 
-  Parent(int a, int b, int c, int d) : a(a), b(b), c(c), d(d) {}
+protected:
+  int b;
+
+public:
+  int c;
+  int d; // Shadowed by Child::d, but should be reachable with a cast
+
+  Parent(int a, int b, int c, int d) : a(a), b(b), c(c), d(d)
+  {
+  }
 };
 
 class Child : public Parent {
-  public:
-    int d;
-    int e;
-    int f;
+public:
+  int d;
+  int e;
+  int f;
 
-  Child(int a, int b, int c, int d, int e, int f) : Parent(a, b, c, d), d(d + 1), e(e), f(f) {}
+  Child(int a, int b, int c, int d, int e, int f)
+      : Parent(a, b, c, d), d(d + 1), e(e), f(f)
+  {
+  }
 };
 
 class LittleChild : public Child {
-  public:
-    int g;
+public:
+  int g;
 
-  LittleChild(int a, int b, int c, int d, int e, int f, int g) : Child(a, b, c, d, e, f), g(g) {}
+  LittleChild(int a, int b, int c, int d, int e, int f, int g)
+      : Child(a, b, c, d, e, f), g(g)
+  {
+  }
+};
+
+struct Top {
+  int x;
+};
+
+struct Left : public Top {
+  int y;
+};
+
+struct Right : public Top {
+  int z;
+};
+
+struct Bottom : public Left, public Right {
+  int w;
+};
+
+struct Multi : public Parent, public Top {
+  int abc;
+
+  Multi(int a, int b, int c, int d, int e)
+      : Parent{ a, b, c, d }, Top{ e }, abc{ e + 1 }
+  {
+  }
 };
 
 int func_1(Child &c, Parent &p __attribute__((unused)))
 {
-  return dynamic_cast<Parent&>(c).d;
+  return dynamic_cast<Parent &>(c).d;
 }
 
 int func_2(LittleChild &lc)
 {
-  return dynamic_cast<Parent&>(lc).d;
+  return dynamic_cast<Parent &>(lc).d;
+}
+
+int func_3(Multi &m, Bottom &b __attribute__((unused)))
+{
+  return m.abc;
 }
 
 int main(void)
 {
-  Parent p{1, 2, 3, 4};
-  Child c{1, 2, 3, 4, 5, 6};
+  Parent p{ 1, 2, 3, 4 };
+  Child c{ 1, 2, 3, 4, 5, 6 };
   func_1(c, p);
 
-  LittleChild lc{1, 2, 3, 4, 5, 6, 7};
+  LittleChild lc{ 1, 2, 3, 4, 5, 6, 7 };
   func_2(lc);
+
+  Multi m{ 1, 2, 3, 4, 5 };
+  Bottom b{
+    {
+        // Left
+        { 1 }, // Left's Top
+        2      // Left's y
+    },
+    {
+        // Right
+        { 3 }, // Right's Top
+        4      // Right's z
+    },
+    5 // Bottom's w
+  };
+  func_3(m, b);
 
   return 0;
 }

--- a/tests/data/data_source_cxx.cpp
+++ b/tests/data/data_source_cxx.cpp
@@ -19,9 +19,21 @@ class Child : public Parent {
   Child(int a, int b, int c, int d, int e, int f) : Parent(a, b, c, d), d(d + 1), e(e), f(f) {}
 };
 
+class LittleChild : public Child {
+  public:
+    int g;
+
+  LittleChild(int a, int b, int c, int d, int e, int f, int g) : Child(a, b, c, d, e, f), g(g) {}
+};
+
 int func_1(Child &c, Parent &p __attribute__((unused)))
 {
   return dynamic_cast<Parent&>(c).d;
+}
+
+int func_2(LittleChild &lc)
+{
+  return dynamic_cast<Parent&>(lc).d;
 }
 
 int main(void)
@@ -29,5 +41,9 @@ int main(void)
   Parent p{1, 2, 3, 4};
   Child c{1, 2, 3, 4, 5, 6};
   func_1(c, p);
+
+  LittleChild lc{1, 2, 3, 4, 5, 6, 7};
+  func_2(lc);
+
   return 0;
 }

--- a/tests/data/data_source_cxx.cpp
+++ b/tests/data/data_source_cxx.cpp
@@ -26,11 +26,11 @@ public:
   }
 };
 
-class LittleChild : public Child {
+class GrandChild : public Child {
 public:
   int g;
 
-  LittleChild(int a, int b, int c, int d, int e, int f, int g)
+  GrandChild(int a, int b, int c, int d, int e, int f, int g)
       : Child(a, b, c, d, e, f), g(g)
   {
   }
@@ -54,9 +54,10 @@ struct Bottom : public Left, public Right {
 
 struct Multi : public Parent, public Top {
   int abc;
+  int &rabc;
 
   Multi(int a, int b, int c, int d, int e)
-      : Parent{ a, b, c, d }, Top{ e }, abc{ e + 1 }
+      : Parent{ a, b, c, d }, Top{ e }, abc{ e + 1 }, rabc{ abc }
   {
   }
 };
@@ -66,7 +67,7 @@ int func_1(Child &c, Parent &p __attribute__((unused)))
   return dynamic_cast<Parent &>(c).d;
 }
 
-int func_2(LittleChild &lc)
+int func_2(GrandChild &lc)
 {
   return dynamic_cast<Parent &>(lc).d;
 }
@@ -82,7 +83,7 @@ int main(void)
   Child c{ 1, 2, 3, 4, 5, 6 };
   func_1(c, p);
 
-  LittleChild lc{ 1, 2, 3, 4, 5, 6, 7 };
+  GrandChild lc{ 1, 2, 3, 4, 5, 6, 7 };
   func_2(lc);
 
   Multi m{ 1, 2, 3, 4, 5 };

--- a/tests/data/data_source_cxx.cpp
+++ b/tests/data/data_source_cxx.cpp
@@ -1,0 +1,33 @@
+class Parent {
+  private:
+    int a;
+  protected:
+    int b;
+  public:
+    int c;
+    int d; // Shadowed by Child::d, but should be reachable with a cast
+
+  Parent(int a, int b, int c, int d) : a(a), b(b), c(c), d(d) {}
+};
+
+class Child : public Parent {
+  public:
+    int d;
+    int e;
+    int f;
+
+  Child(int a, int b, int c, int d, int e, int f) : Parent(a, b, c, d), d(d + 1), e(e), f(f) {}
+};
+
+int func_1(Child &c, Parent &p __attribute__((unused)))
+{
+  return dynamic_cast<Parent&>(c).d;
+}
+
+int main(void)
+{
+  Parent p{1, 2, 3, 4};
+  Child c{1, 2, 3, 4, 5, 6};
+  func_1(c, p);
+  return 0;
+}

--- a/tests/data/dwarf_data.h.in
+++ b/tests/data/dwarf_data.h.in
@@ -1,8 +1,8 @@
 #pragma once
 
-unsigned char dwarf_data[] = {
+constexpr inline unsigned char dwarf_data[] = {
 ${DWARF_DATA}
 };
-unsigned int dwarf_data_len = sizeof(dwarf_data) / sizeof(dwarf_data[0]);
+constexpr inline unsigned int dwarf_data_len = sizeof(dwarf_data) / sizeof(dwarf_data[0]);
 
-static constexpr const char *dwarf_data_cxx_path = "${DWARF_DATA_CXX_PATH}";
+constexpr inline const char *dwarf_data_cxx_path = "${DWARF_DATA_CXX_PATH}";

--- a/tests/data/dwarf_data.h.in
+++ b/tests/data/dwarf_data.h.in
@@ -4,3 +4,5 @@ unsigned char dwarf_data[] = {
 ${DWARF_DATA}
 };
 unsigned int dwarf_data_len = sizeof(dwarf_data) / sizeof(dwarf_data[0]);
+
+static constexpr const char *dwarf_data_cxx_path = "${DWARF_DATA_CXX_PATH}";

--- a/tests/dwarf_common.h
+++ b/tests/dwarf_common.h
@@ -4,6 +4,7 @@
 
 #include <cstdio>
 #include <fcntl.h>
+#include <fstream>
 #include <stdexcept>
 
 #include "data/dwarf_data.h"

--- a/tests/dwarf_common.h
+++ b/tests/dwarf_common.h
@@ -32,4 +32,5 @@ protected:
   }
 
   static constexpr const char *bin_ = "/tmp/bpftrace-test-dwarf-data";
+  static constexpr const char *cxx_bin_ = dwarf_data_cxx_path;
 };

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -478,6 +478,40 @@ TEST_F(field_analyser_dwarf, parse_arrays)
   EXPECT_EQ(arrs->GetField("flexible").offset, 64);
 }
 
+TEST_F(field_analyser_dwarf, parse_class)
+{
+  BPFtrace bpftrace;
+  std::string uprobe = "uprobe:" + std::string(cxx_bin_);
+  test(bpftrace, uprobe + ":_Z6func_1R5ChildR6Parent { $x = args.p->a; }", 0);
+
+  ASSERT_TRUE(bpftrace.structs.Has("Parent"));
+  auto cls = bpftrace.structs.Lookup("Parent").lock();
+
+  ASSERT_TRUE(cls->HasFields());
+  ASSERT_EQ(cls->fields.size(), 4);
+  ASSERT_EQ(cls->size, 16);
+
+  ASSERT_TRUE(cls->HasField("a"));
+  ASSERT_TRUE(cls->GetField("a").type.IsIntTy());
+  ASSERT_EQ(cls->GetField("a").type.GetSize(), 4);
+  ASSERT_EQ(cls->GetField("a").offset, 0);
+
+  ASSERT_TRUE(cls->HasField("b"));
+  ASSERT_TRUE(cls->GetField("b").type.IsIntTy());
+  ASSERT_EQ(cls->GetField("b").type.GetSize(), 4);
+  ASSERT_EQ(cls->GetField("b").offset, 4);
+
+  ASSERT_TRUE(cls->HasField("c"));
+  ASSERT_TRUE(cls->GetField("c").type.IsIntTy());
+  ASSERT_EQ(cls->GetField("c").type.GetSize(), 4);
+  ASSERT_EQ(cls->GetField("c").offset, 8);
+
+  ASSERT_TRUE(cls->HasField("d"));
+  ASSERT_TRUE(cls->GetField("d").type.IsIntTy());
+  ASSERT_EQ(cls->GetField("d").type.GetSize(), 4);
+  ASSERT_EQ(cls->GetField("d").offset, 12);
+}
+
 TEST_F(field_analyser_dwarf, parse_struct_anonymous_fields)
 {
   GTEST_SKIP() << "Anonymous fields not supported #3084";

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -511,7 +511,7 @@ static void CheckParentFields(const std::shared_ptr<Struct> &cls,
   EXPECT_EQ(cls->GetField("c").offset, 8);
 
   // The Child class also has a field 'd', which shadows the Parent's.
-  if (is_d_shadowed == false) {
+  if (!is_d_shadowed) {
     EXPECT_TRUE(cls->HasField("d"));
     EXPECT_TRUE(cls->GetField("d").type.IsIntTy());
     EXPECT_EQ(cls->GetField("d").type.GetSize(), 4);

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -33,7 +33,7 @@ REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME list uprobe args - array reference type
-RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test_cxx:_Z11uprobeArrayRA10_i'
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeArray'
 EXPECT int (&)[10] array
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
@@ -187,7 +187,7 @@ TIMEOUT 5
 AFTER ./testprogs/uprobe_test_cxx
 
 NAME uprobe arg as reference - array
-PROG uprobe:./testprogs/uprobe_test_cxx:_Z11uprobeArrayRA10_i {
+PROG uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeArray {
        printf("arr[0] = %d, arr[1] = %d, arr[9] = %d\n",
          args.array[0], args.array[1], args.array[9]);
        exit();

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -19,15 +19,16 @@ TIMEOUT 5
 NAME list uprobe args - anonymous param type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:uprobeFunction3'
 EXPECT enum { A, B, C } e
-EXPECT union { int a; char b; } u
+       union { int a; char b; } u
 REQUIRES bash -c "exit 1" # SKIP: anonymous parameter type not supported #3083
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME list uprobe args - class reference type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeFunction1'
-EXPECT     int x
-           struct Foo foo
+EXPECT     int & x
+           Foo & foo
+           Bar & bar
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
@@ -140,6 +141,61 @@ EXPECT_REGEX ^\n[ ]+square\+\d+\n[ ]+main\+\d+$
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 AFTER ./testprogs/inline_function
+
+NAME print uprobe arg as deref pointer - struct
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 {
+       print(*args.foo1);
+       exit();
+     }
+EXPECT { .a = 123, .b = hello, .c = [1,2,3], .d = 1311768467463790320 }
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+AFTER ./testprogs/uprobe_test
+
+NAME uprobe arg as reference - int
+PROG uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeFunction1 {
+       printf("x = %d\n", args.x);
+       exit();
+     }
+EXPECT x = 42
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+AFTER ./testprogs/uprobe_test_cxx
+
+NAME print uprobe arg as reference - struct
+PROG uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeFunction1 {
+       print(args.foo);
+       exit();
+     }
+EXPECT_REGEX ^\{ \.a = 1, \.b = 2, \.c = 3, \.x = 0x[0-9a-f]{1,16} \}$
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+AFTER ./testprogs/uprobe_test_cxx
+
+NAME uprobe arg as reference - struct member
+PROG uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeFunction1 {
+       printf("foo.a = %d\nfoo.b = %d\nfoo.c = %d\nfoo.x = %d\n",
+         args.foo.a, args.foo.b, args.foo.c, args.foo.x);
+       exit();
+     }
+EXPECT foo.a = 1
+       foo.b = 2
+       foo.c = 3
+       foo.x = 42
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+AFTER ./testprogs/uprobe_test_cxx
+
+NAME uprobe arg as reference - array
+PROG uprobe:./testprogs/uprobe_test_cxx:_Z11uprobeArrayRA10_i {
+       printf("arr[0] = %d, arr[1] = %d, arr[9] = %d\n",
+         args.array[0], args.array[1], args.array[9]);
+       exit();
+     }
+EXPECT arr[0] = 1, arr[1] = 2, arr[9] = 10
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+AFTER ./testprogs/uprobe_test_cxx
 
 # Checking backwards compatibility
 NAME uprobe args as pointer

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -25,9 +25,9 @@ REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME list uprobe args - class reference type
-RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test_cxx:_Z15uprobeFunction3R5ChildR6Parent'
-EXPECT Child & c
-EXPECT Parent & p
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeFunction1'
+EXPECT     int x
+           struct Foo foo
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -24,6 +24,19 @@ REQUIRES bash -c "exit 1" # SKIP: anonymous parameter type not supported #3083
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
+NAME list uprobe args - class reference type
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test_cxx:_Z15uprobeFunction3R5ChildR6Parent'
+EXPECT Child & c
+EXPECT Parent & p
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+
+NAME list uprobe args - array reference type
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test_cxx:_Z11uprobeArrayRA10_i'
+EXPECT int (&)[10] array
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+
 NAME uprobe arg by name - char
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("c = %c\n", args.c); exit(); }
 EXPECT c = x

--- a/tests/testlibs/CMakeLists.txt
+++ b/tests/testlibs/CMakeLists.txt
@@ -1,4 +1,4 @@
-file(GLOB testlib_sources CONFIGURE_DEPENDS *.c)
+file(GLOB testlib_sources CONFIGURE_DEPENDS *.c *.cpp)
 set(testlibtargets "")
 foreach(testlib_source ${testlib_sources})
   get_filename_component(testlib_name ${testlib_source} NAME_WE)

--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -18,7 +18,7 @@ test_and_add_testprog_cflag("-fno-omit-frame-pointer")
 test_and_add_testprog_cflag("-mno-omit-leaf-frame-pointer")
 get_property(testprog_cflags GLOBAL PROPERTY testprog_cflags)
 
-file(GLOB testprog_sources CONFIGURE_DEPENDS *.c)
+file(GLOB testprog_sources CONFIGURE_DEPENDS *.c *.cpp)
 set(testprogtargets "")
 foreach(testprog_source ${testprog_sources})
   get_filename_component(testprog_name ${testprog_source} NAME_WE)

--- a/tests/testprogs/uprobe_test_cxx.cpp
+++ b/tests/testprogs/uprobe_test_cxx.cpp
@@ -1,0 +1,27 @@
+#include <unistd.h>
+
+struct Foo {
+  int a, b, c;
+  int *x;
+};
+
+int uprobeFunction1(int x, Foo foo)
+{
+  return x + foo.c;
+}
+
+int uprobeArray(int (&array)[10])
+{
+  return array[0];
+}
+
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
+{
+  // usleep(1000000);
+
+  int x = 42;
+  Foo foo{ 1, 2, 3, &x };
+  uprobeFunction1(x, foo);
+
+  return 0;
+}

--- a/tests/testprogs/uprobe_test_cxx.cpp
+++ b/tests/testprogs/uprobe_test_cxx.cpp
@@ -2,10 +2,15 @@
 
 struct Foo {
   int a, b, c;
-  int *x;
+  int &x;
 };
 
-int uprobeFunction1(int x, Foo foo)
+class Bar {
+public:
+  int x, y, z;
+};
+
+int uprobeFunction1(int &x, Foo &foo, Bar &bar __attribute__((unused)))
 {
   return x + foo.c;
 }
@@ -17,11 +22,13 @@ int uprobeArray(int (&array)[10])
 
 int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
 {
-  // usleep(1000000);
-
   int x = 42;
-  Foo foo{ 1, 2, 3, &x };
-  uprobeFunction1(x, foo);
+  Foo foo{ 1, 2, 3, x };
+  Bar bar{ 10, 11, 12 };
+  uprobeFunction1(x, foo, bar);
+
+  int arr[10] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+  uprobeArray(arr);
 
   return 0;
 }


### PR DESCRIPTION
Extend the Dwarf parser to make class members and parents' members accessible.

This patch handles any shape of inheritance hierarchy, but does provide access to parents' shadowed members:
```
struct Parent { int abc, xyz; };
struct Child : Parent { int abc; };
...
child->abc          // Access the child's member
child->xyz          // Access the parent's member
child->Parent::abc  // Not implemented: access the parent's shadowed member
```

Multiple inheritance suffer from a similar problem: when a parent shadows the member of another parent.
```
struct GrandChild : Parent, Child {};
g_child->xyz // Access Parent's member
g_child->abc // Ambiguous! Will access Parent::abc, but it should reject and require a qualified name instead
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
