### PR TITLE
tests: runtime: Fix ustack tests probing k:do_nanosleep

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -221,10 +221,10 @@ TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack
-PROG k:do_nanosleep { printf("%s\n%s\n", ustack(), ustack(1)); exit(); }
+PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack(1)); exit(); }
 EXPECT Attaching 1 probe...
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep  1e8
+AFTER ./testprogs/uprobe_loop
 
 NAME ustack_stack_mode_env_bpftrace
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -211,10 +211,10 @@ TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME positional ustack
-RUN {{BPFTRACE}} -e 'k:do_nanosleep { printf("SUCCESS %s\n%s\n", ustack(), ustack($1)); exit(); }' 1
-EXPECT SUCCESS
+RUN {{BPFTRACE}} -e 'u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack($1)); exit(); }' 1
+EXPECT_REGEX .*uprobeFunction1\+0\n\s+main\+\d+\n.*\n\n\n\s+uprobeFunction1\+0
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep  1e8
+AFTER ./testprogs/uprobe_loop
 
 NAME lhist can be cleared
 PROG BEGIN{ @[1] = lhist(3,0,10,1); clear(@); exit() }


### PR DESCRIPTION
k:do_nanosleep may not always have an associated userspace task. Make tests more reliable by probing an existing userspace task.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
