### PR TITLE
aot: Enable aot built bpftrace programs to run on their own

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(runtime
   procmon.cpp
   printf.cpp
   resolve_cgroupid.cpp
+  run_bpftrace.cpp
   struct.cpp
   tracefs.cpp
   debugfs.cpp

--- a/src/aot/CMakeLists.txt
+++ b/src/aot/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT LIBBCC_BPF_CONTAINS_RUNTIME)
 endif()
 
 add_executable(bpftrace-aotrt aot_main.cpp)
-target_link_libraries(bpftrace-aotrt aot runtime arch ast_defs cxxdemangler_stdlib)
+target_link_libraries(bpftrace-aotrt aot runtime arch ast ast_defs cxxdemangler_stdlib)
 install(TARGETS bpftrace-aotrt DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 if(LIBPCAP_FOUND)

--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -6,10 +6,9 @@
 #include <exception>
 #include <fcntl.h>
 #include <fstream>
-#include <istream>
+#include <gelf.h>
+#include <libelf.h>
 #include <optional>
-#include <ostream>
-#include <streambuf>
 #include <sys/mman.h>
 #include <sys/stat.h>
 
@@ -19,6 +18,7 @@
 #include <cereal/types/unordered_map.hpp>
 #include <cereal/types/vector.hpp>
 
+#include "ast/elf_parser.h"
 #include "filesystem.h"
 #include "log.h"
 #include "utils.h"
@@ -41,8 +41,8 @@ struct Header {
   uint64_t version;    // Hash of version string
   uint64_t rr_off;     // RequiredResources offset from start of file
   uint64_t rr_len;     // RequiredResources length
-  uint64_t bc_off;     // Bytecode offset from start of file
-  uint64_t bc_len;     // Bytecode length
+  uint64_t elf_off;    // ELF offset from start of file
+  uint64_t elf_len;    // ELF length
 };
 
 static_assert(sizeof(Header) == 48);
@@ -66,12 +66,6 @@ uint32_t rs_hash(std::string_view str)
   return hash;
 }
 
-void serialize_bytecode(const BpfBytecode &bytecode, std::ostream &out)
-{
-  cereal::BinaryOutputArchive archive(out);
-  archive(bytecode);
-}
-
 int load_required_resources(BPFtrace &bpftrace, uint8_t *ptr, size_t len)
 {
   try {
@@ -84,24 +78,10 @@ int load_required_resources(BPFtrace &bpftrace, uint8_t *ptr, size_t len)
   return 0;
 }
 
-int load_bytecode(BPFtrace &bpftrace, uint8_t *ptr, size_t len)
-{
-  try {
-    Membuf mbuf(ptr, ptr + len);
-    std::istream istream(&mbuf);
-    cereal::BinaryInputArchive archive(istream);
-    archive(bpftrace.bytecode_);
-  } catch (const std::exception &ex) {
-    LOG(ERROR) << "Failed to deserialize metadata: " << ex.what();
-    return 1;
-  }
-
-  return 0;
-}
-
 std::optional<std::vector<uint8_t>> generate_btaot_section(
     const RequiredResources &resources,
-    const BpfBytecode &bytecode)
+    void *const elf,
+    size_t elf_size)
 {
   // Serialize RuntimeResources
   std::string serialized_metadata;
@@ -114,17 +94,6 @@ std::optional<std::vector<uint8_t>> generate_btaot_section(
     return std::nullopt;
   }
 
-  // Serialize bytecode
-  std::string serialized_bytecode;
-  try {
-    std::ostringstream serialized(std::ios::binary);
-    serialize_bytecode(bytecode, serialized);
-    serialized_bytecode = serialized.str();
-  } catch (const std::exception &ex) {
-    LOG(ERROR) << "Failed to serialize bytecode: " << ex.what();
-    return std::nullopt;
-  }
-
   // Construct the header
   auto hdr_len = sizeof(Header);
   Header hdr = {
@@ -134,13 +103,13 @@ std::optional<std::vector<uint8_t>> generate_btaot_section(
     .version = rs_hash(BPFTRACE_VERSION),
     .rr_off = hdr_len,
     .rr_len = serialized_metadata.size(),
-    .bc_off = hdr_len + serialized_metadata.size(),
-    .bc_len = serialized_bytecode.size(),
+    .elf_off = hdr_len + serialized_metadata.size(),
+    .elf_len = elf_size,
   };
 
   // Resize the output buffer appropriately
   std::vector<uint8_t> out;
-  out.resize(sizeof(Header) + hdr.rr_len + hdr.bc_len);
+  out.resize(sizeof(Header) + hdr.rr_len + hdr.elf_len);
   uint8_t *p = out.data();
 
   // Write out header
@@ -151,9 +120,9 @@ std::optional<std::vector<uint8_t>> generate_btaot_section(
   memcpy(p, serialized_metadata.data(), hdr.rr_len);
   p += hdr.rr_len;
 
-  // Write out bytecode
-  memcpy(p, serialized_bytecode.data(), hdr.bc_len);
-  p += hdr.bc_len;
+  // Write out ELF
+  memcpy(p, elf, hdr.elf_len);
+  p += hdr.elf_len;
 
   return out;
 }
@@ -213,10 +182,11 @@ out:
 } // namespace
 
 int generate(const RequiredResources &resources,
-             const BpfBytecode &bytecode,
-             const std::string &out)
+             const std::string &out,
+             void *const elf,
+             size_t elf_size)
 {
-  auto section = generate_btaot_section(resources, bytecode);
+  auto section = generate_btaot_section(resources, elf, elf_size);
   if (!section)
     return 1;
 
@@ -253,16 +223,76 @@ int load(BPFtrace &bpftrace, const std::string &in)
     return 1;
   }
 
-  uint8_t *ptr = static_cast<uint8_t *>(
-      ::mmap(NULL, in_file_size, PROT_READ, MAP_PRIVATE, infd, 0));
-  if (ptr == MAP_FAILED) {
-    auto saved_err = errno;
-    LOG(ERROR) << "Failed to mmap: " << in << ": " << std::strerror(saved_err);
-    return 1;
+  // Find .btaot section
+  Elf *elf = NULL;
+  Elf_Scn *scn = NULL;
+  GElf_Shdr shdr;
+  char *secname = NULL;
+  Elf_Data *data = NULL;
+  uint8_t *btaot_section = NULL;
+  const Header *hdr;
+
+  if (elf_version(EV_CURRENT) == EV_NONE) {
+    LOG(ERROR) << "Cannot set libelf version: " << elf_errmsg(-1);
+    err = 1;
+    goto out;
   }
 
-  // Validate header
-  auto hdr = reinterpret_cast<const Header *>(ptr);
+  elf = elf_begin(infd, ELF_C_READ, NULL);
+  if (!elf) {
+    LOG(ERROR) << "Cannot read ELF file: " << elf_errmsg(-1);
+    err = 1;
+    goto out;
+  }
+
+  size_t strndx;
+  if (elf_getshdrstrndx(elf, &strndx) < 0) {
+    LOG(ERROR) << "Failed to get ELF section index of the string table: "
+               << elf_errmsg(-1);
+    err = 1;
+    goto out;
+  }
+
+  int i;
+  i = 0;
+  while ((scn = elf_nextscn(elf, scn))) {
+    i++;
+    if (!gelf_getshdr(scn, &shdr)) {
+      LOG(ERROR) << "Failed to get ELF section(" << i
+                 << ") hdr: " << elf_errmsg(-1);
+      err = 1;
+      goto out;
+    }
+
+    secname = elf_strptr(elf, strndx, shdr.sh_name);
+    if (!secname) {
+      LOG(ERROR) << "Failed to get ELF section(" << i
+                 << ") hdr name: " << elf_errmsg(-1);
+      err = 1;
+      goto out;
+    }
+
+    if (std::string_view(secname) == AOT_ELF_SECTION) {
+      data = elf_getdata(scn, 0);
+      if (!data) {
+        LOG(ERROR) << "Failed to get BTAOT ELF section(" << i
+                   << ") data: " << elf_errmsg(-1);
+        err = 1;
+        goto out;
+      }
+
+      btaot_section = static_cast<uint8_t *>(data->d_buf);
+      break;
+    }
+  }
+
+  // Validate .btaot header
+  hdr = reinterpret_cast<const Header *>(btaot_section);
+  if (!hdr) {
+    LOG(ERROR) << "Couldn't find " << AOT_ELF_SECTION << " section in " << in;
+    err = 1;
+    goto out;
+  }
   if (hdr->magic != AOT_MAGIC) {
     LOG(ERROR) << "Invalid magic in " << in << ": " << hdr->magic;
     err = 1;
@@ -285,28 +315,30 @@ int load(BPFtrace &bpftrace, const std::string &in)
     goto out;
   }
   if ((hdr->rr_off + hdr->rr_len) > static_cast<uint64_t>(in_file_size) ||
-      (hdr->bc_off + hdr->bc_len) > static_cast<uint64_t>(in_file_size)) {
+      (hdr->elf_off + hdr->elf_len) > static_cast<uint64_t>(in_file_size)) {
     LOG(ERROR) << "Corrupted AOT bpftrace file: incomplete payload";
     err = 1;
     goto out;
   }
 
   // Load payloads
-  err = load_required_resources(bpftrace, ptr + hdr->rr_off, hdr->rr_len);
+  err = load_required_resources(bpftrace,
+                                btaot_section + hdr->rr_off,
+                                hdr->rr_len);
   if (err)
     goto out;
 
-  err = load_bytecode(bpftrace, ptr + hdr->bc_off, hdr->bc_len);
+  bpftrace.bytecode_ = elf::parseBpfBytecodeFromElfObject(btaot_section +
+                                                              hdr->elf_off,
+                                                          hdr->elf_len);
   if (err)
     goto out;
 
 out:
-  if (::munmap(ptr, in_file_size)) {
-    auto saved_err = errno;
-    LOG(ERROR) << "Failed to munmap(): " << in << ": "
-               << std::strerror(saved_err);
-  }
+  if (elf)
+    elf_end(elf);
 
+  close(infd);
   return err;
 }
 

--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -26,7 +26,6 @@
 
 #define AOT_ELF_SECTION ".btaot"
 static constexpr auto AOT_MAGIC = 0xA07;
-static constexpr auto AOT_SHIM_NAME = "bpftrace-aotrt";
 static constexpr auto AOT_SECDATA_TEMPFILE = ".temp_btaot";
 
 // AOT payload will have this header at the beginning. We don't worry about
@@ -190,7 +189,7 @@ int generate(const RequiredResources &resources,
   if (!section)
     return 1;
 
-  auto shim = find_in_path(AOT_SHIM_NAME);
+  auto shim = find_in_path(AOT_SHIM_NAME.data());
   if (!shim) {
     LOG(ERROR) << "Failed to locate " << AOT_SHIM_NAME
                << " shim binary. Is it in $PATH?";

--- a/src/aot/aot.h
+++ b/src/aot/aot.h
@@ -9,6 +9,8 @@
 namespace bpftrace {
 namespace aot {
 
+static constexpr std::string_view AOT_SHIM_NAME = "bpftrace-aotrt";
+
 int generate(const RequiredResources &resources,
              const std::string &out,
              void *const elf,

--- a/src/aot/aot.h
+++ b/src/aot/aot.h
@@ -10,8 +10,9 @@ namespace bpftrace {
 namespace aot {
 
 int generate(const RequiredResources &resources,
-             const BpfBytecode &bytecode,
-             const std::string &out);
+             const std::string &out,
+             void *const elf,
+             size_t elf_size);
 
 int load(BPFtrace &bpftrace, const std::string &in);
 

--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -1,12 +1,12 @@
 #include <fstream>
 #include <getopt.h>
 #include <iostream>
-#include <memory>
 
 #include "aot.h"
 #include "bpftrace.h"
 #include "log.h"
 #include "output.h"
+#include "run_bpftrace.h"
 #include "version.h"
 
 using namespace bpftrace;
@@ -101,6 +101,8 @@ int main(int argc, char* argv[])
     return 1;
   }
 
+  libbpf_set_print(libbpf_print);
+
   auto output = prepare_output(output_file, output_format);
   if (!output)
     return 1;
@@ -112,12 +114,5 @@ int main(int argc, char* argv[])
     return err;
   }
 
-  err = bpftrace.run(std::move(bpftrace.bytecode_));
-  if (err)
-    return err;
-
-  std::cout << "\n\n";
-  return bpftrace.print_maps();
-
-  return 0;
+  return run_bpftrace(bpftrace, bpftrace.bytecode_);
 }

--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include <fstream>
 #include <getopt.h>
 #include <iostream>
@@ -11,10 +12,10 @@
 
 using namespace bpftrace;
 
-void usage()
+void usage(std::string_view filename)
 {
   // clang-format off
-  std::cerr << "USAGE: bpftrace-aotrt filename" << std::endl;
+  std::cerr << "USAGE: " << filename << " [options]" << std::endl;
   std::cerr << std::endl;
   std::cerr << "OPTIONS:" << std::endl;
   std::cerr << "    -f FORMAT      output format ('text', 'json')" << std::endl;
@@ -70,6 +71,13 @@ int main(int argc, char* argv[])
     option{ nullptr, 0, nullptr, 0 }, // Must be last
   };
 
+  std::filesystem::path p(argv[0]);
+  if (p.filename() == aot::AOT_SHIM_NAME) {
+    LOG(ERROR) << "Runtime shim should not be run directly, please generate a "
+                  "binary using --aot option in bpftrace";
+    return 1;
+  }
+
   while ((c = getopt_long(argc, argv, short_opts, long_opts, nullptr)) != -1) {
     switch (c) {
       case 'o':
@@ -79,7 +87,7 @@ int main(int argc, char* argv[])
         output_format = optarg;
         break;
       case 'h':
-        usage();
+        usage(argv[0]);
         return 0;
       case 'V':
         std::cout << "bpftrace " << BPFTRACE_VERSION << std::endl;
@@ -91,13 +99,13 @@ int main(int argc, char* argv[])
         bt_verbose = true;
         break;
       default:
-        usage();
+        usage(argv[0]);
         return 1;
     }
   }
 
-  if (!argv[optind]) {
-    usage();
+  if (argv[optind]) {
+    usage(argv[0]);
     return 1;
   }
 
@@ -108,7 +116,7 @@ int main(int argc, char* argv[])
     return 1;
 
   BPFtrace bpftrace(std::move(output));
-  int err = aot::load(bpftrace, argv[optind]);
+  int err = aot::load(bpftrace, argv[0]);
   if (err) {
     LOG(ERROR) << "Failed to load AOT script";
     return err;

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -62,13 +62,6 @@ private:
 
   std::map<std::string, BpfMap> maps_;
   std::map<int, BpfMap *> maps_by_id_;
-
-  friend class cereal::access;
-  template <typename Archive>
-  void serialize(Archive &archive)
-  {
-    archive(sections_);
-  }
 };
 
 } // namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #include <array>
 #include <bpf/libbpf.h>
-#include <csignal>
 #include <cstdio>
 #include <cstring>
 #include <fstream>
@@ -38,6 +37,7 @@
 #include "output.h"
 #include "probe_matcher.h"
 #include "procmon.h"
+#include "run_bpftrace.h"
 #include "tracepoint_format_parser.h"
 #include "utils.h"
 #include "version.h"
@@ -684,29 +684,6 @@ Args parse_args(int argc, char* argv[])
   return args;
 }
 
-static const char* libbpf_print_level_string(enum libbpf_print_level level)
-{
-  switch (level) {
-    case LIBBPF_WARN:
-      return "WARN";
-    case LIBBPF_INFO:
-      return "INFO";
-    default:
-      return "DEBUG";
-  }
-}
-
-static int libbpf_print(enum libbpf_print_level level,
-                        const char* msg,
-                        va_list ap)
-{
-  if (bt_debug == DebugLevel::kNone)
-    return 0;
-
-  fprintf(stderr, "[%s] ", libbpf_print_level_string(level));
-  return vfprintf(stderr, msg, ap);
-}
-
 int main(int argc, char* argv[])
 {
   int err;
@@ -950,6 +927,14 @@ int main(int argc, char* argv[])
       llvm.emit_elf(args.output_elf);
       return 0;
     }
+    if (args.build_mode == BuildMode::AHEAD_OF_TIME) {
+      llvm::SmallVector<char, 0> aot_output;
+      llvm::raw_svector_ostream aot_os(aot_output);
+      llvm.emit(aot_os);
+
+      return aot::generate(
+          bpftrace.resources, args.aot, aot_output.data(), aot_output.size());
+    }
     bytecode = llvm.emit();
   } catch (const std::system_error& ex) {
     LOG(ERROR) << "failed to write elf: " << ex.what();
@@ -962,41 +947,5 @@ int main(int argc, char* argv[])
   if (bt_debug != DebugLevel::kNone || args.test_mode == TestMode::CODEGEN)
     return 0;
 
-  if (args.build_mode == BuildMode::AHEAD_OF_TIME)
-    return aot::generate(bpftrace.resources, bytecode, args.aot);
-
-  // Signal handler that lets us know an exit signal was received.
-  struct sigaction act = {};
-  act.sa_handler = [](int) { BPFtrace::exitsig_recv = true; };
-  sigaction(SIGINT, &act, NULL);
-  sigaction(SIGTERM, &act, NULL);
-
-  // Signal handler that prints all maps when SIGUSR1 was received.
-  act.sa_handler = [](int) { BPFtrace::sigusr1_recv = true; };
-  sigaction(SIGUSR1, &act, NULL);
-
-  err = bpftrace.run(std::move(bytecode));
-  if (err)
-    return err;
-
-  // We are now post-processing. If we receive another SIGINT,
-  // handle it normally (exit)
-  act.sa_handler = SIG_DFL;
-  sigaction(SIGINT, &act, NULL);
-
-  std::cout << "\n\n";
-
-  err = bpftrace.print_maps();
-
-  if (bpftrace.child_) {
-    auto val = 0;
-    if ((val = bpftrace.child_->term_signal()) > -1)
-      LOG(V1) << "Child terminated by signal: " << val;
-    if ((val = bpftrace.child_->exit_code()) > -1)
-      LOG(V1) << "Child exited with code: " << val;
-  }
-
-  bpftrace.close_pcaps();
-
-  return err;
+  return run_bpftrace(bpftrace, bytecode);
 }

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -1,0 +1,67 @@
+#include <csignal>
+
+#include "log.h"
+#include "run_bpftrace.h"
+
+using namespace bpftrace;
+
+static const char *libbpf_print_level_string(enum libbpf_print_level level)
+{
+  switch (level) {
+    case LIBBPF_WARN:
+      return "WARN";
+    case LIBBPF_INFO:
+      return "INFO";
+    default:
+      return "DEBUG";
+  }
+}
+
+int libbpf_print(enum libbpf_print_level level, const char *msg, va_list ap)
+{
+  if (bt_debug == DebugLevel::kNone)
+    return 0;
+
+  fprintf(stderr, "[%s] ", libbpf_print_level_string(level));
+  return vfprintf(stderr, msg, ap);
+}
+
+int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
+{
+  int err;
+
+  // Signal handler that lets us know an exit signal was received.
+  struct sigaction act = {};
+  act.sa_handler = [](int) { BPFtrace::exitsig_recv = true; };
+  sigaction(SIGINT, &act, NULL);
+  sigaction(SIGTERM, &act, NULL);
+
+  // Signal handler that prints all maps when SIGUSR1 was received.
+  act.sa_handler = [](int) { BPFtrace::sigusr1_recv = true; };
+  sigaction(SIGUSR1, &act, NULL);
+
+  err = bpftrace.run(std::move(bytecode));
+  if (err)
+    return err;
+
+  // We are now post-processing. If we receive another SIGINT,
+  // handle it normally (exit)
+  act.sa_handler = SIG_DFL;
+  sigaction(SIGINT, &act, NULL);
+
+  std::cout << "\n\n";
+
+  err = bpftrace.print_maps();
+
+  if (bpftrace.child_) {
+    auto val = 0;
+    if ((val = bpftrace.child_->term_signal()) > -1)
+      LOG(V1) << "Child terminated by signal: " << val;
+    if ((val = bpftrace.child_->exit_code()) > -1)
+      LOG(V1) << "Child exited with code: " << val;
+  }
+
+  bpftrace.close_pcaps();
+
+  return err;
+}

--- a/src/run_bpftrace.h
+++ b/src/run_bpftrace.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "bpftrace.h"
+
+int libbpf_print(enum libbpf_print_level level, const char *msg, va_list ap);
+
+int run_bpftrace(bpftrace::BPFtrace &bpftrace, bpftrace::BpfBytecode &bytecode);


### PR DESCRIPTION
The first commit fixes a couple issues with aot built binaries that was preventing runtime from functioning.

We now look in the right place in the ELF file for the custom .btaot section that contains the metadata + generated ELF, that we then restore to create BpfBytecode. ~~Second, we now also serialize the map of BpfMaps owned by BpfBytecode into the bytecode as well, which is necessary for runtime. In order to do this, I needed to add a default constructor to BpfMap, as well as a hacky solution to be able to serialize the name of the map which is a cstring_view (which may or may not have defeated the purpose of having the cstring_view in the first place - would appreciate a review of this).~~ Finally, I fixed maps not being printed out correctly when bpftrace exits.

The second commit allows running aot binaries directly without calling having to call runtime shim (e.g. you can now just call ```./a.btaot``` instead of ```bpftrace-aotrt a.btaot```. This is possible because the aot binaries already contain all the info necessary to run themselves.

Address part 1 of #2918.

Example:
```
$ ./bpftrace -e 'profile:hz:599 { @[tid] = count(); exit(); }' --aot a.btaot
$ ./a.btaot
Attaching 1 probe...


@[679916]: 1
@[12686]: 1
@[680061]: 1
@[0]: 4
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
