### PR TITLE
Update log messages

### DIFF
--- a/docs/coding_guidelines.md
+++ b/docs/coding_guidelines.md
@@ -29,7 +29,7 @@ Appropriate language features for this include:
 * `int`
 * `bool`
 
-If an error is **not** recoverable, prefer using `LOG(FATAL)`. Broadly
+If an error is **not** recoverable, prefer using `LOG(FATAL)` or `LOG(ERROR)` and `exit(1)` if there are multiple, separate errors. Broadly
 speaking, if you want to immediately terminate and show a message to the
 user, use `LOG(FATAL)`. Exceptions **should not** be used for recoverable
 errors.
@@ -89,3 +89,14 @@ struct Bar {
   int tailing_;        // bad
 };
 ```
+
+## Log Messages
+
+Below are details about when to use each kind of log level:
+
+- `DEBUG`: log info regardless of log level; like using stdout (comes with file and line number)
+- `V1`: log info only if verbose logging is enabled (-v)
+- `WARNING`: log info that might affect bpftrace behavior or output but allows the run to continue; like using stderr
+- `ERROR`: log info to indicate that the user did something invalid, which will (eventually) cause bpftrace to exit (via `exit(1)` or `LOG(FATAL)`); this should get used if there are multiple errors, otherwise use `FATAL `
+- `FATAL`: similar to `ERROR` but exits immediately after logging
+- `BUG`: exit and log info to indicate that there is an internal/unexpected issue (not caused by invalid user program code or CLI use)

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -156,9 +156,9 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype)
     case 1:
       return getInt8Ty();
     default:
-      LOG(FATAL) << "Cannot generate debug info for type "
-                 << typestr(stype.GetTy()) << " (" << stype.GetSize()
-                 << " is not a valid type size)";
+      LOG(BUG) << "Cannot generate debug info for type "
+               << typestr(stype.GetTy()) << " (" << stype.GetSize()
+               << " is not a valid type size)";
       return nullptr;
   }
 }

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -143,7 +143,7 @@ void CodegenLLVM::visit(Identifier &identifier)
   if (bpftrace_.enums_.count(identifier.ident) != 0) {
     expr_ = b_.getInt64(bpftrace_.enums_[identifier.ident]);
   } else {
-    LOG(FATAL) << "unknown identifier \"" << identifier.ident << "\"";
+    LOG(BUG) << "unknown identifier \"" << identifier.ident << "\"";
   }
 }
 
@@ -424,7 +424,7 @@ void CodegenLLVM::visit(Builtin &builtin)
              builtin.ident.at(4) <= '9') {
     int sp_offset = arch::sp_offset();
     if (sp_offset == -1) {
-      LOG(FATAL) << "negative offset for stack pointer";
+      LOG(BUG) << "negative offset for stack pointer";
     }
 
     int arg_num = atoi(builtin.ident.substr(4).c_str());
@@ -466,7 +466,7 @@ void CodegenLLVM::visit(Builtin &builtin)
   } else if (builtin.ident == "jiffies") {
     expr_ = b_.CreateJiffies64(builtin.loc);
   } else {
-    LOG(FATAL) << "unknown builtin \"" << builtin.ident << "\"";
+    LOG(BUG) << "unknown builtin \"" << builtin.ident << "\"";
   }
 }
 
@@ -1176,7 +1176,7 @@ void CodegenLLVM::visit(Call &call)
 
     int id = bpftrace_.resources.maps_info.at(map.ident).id;
     if (id == -1) {
-      LOG(FATAL) << "map id for map \"" << map.ident << "\" not found";
+      LOG(BUG) << "map id for map \"" << map.ident << "\" not found";
     }
     auto *ident_ptr = b_.CreateGEP(event_struct,
                                    buf,
@@ -1386,7 +1386,7 @@ void CodegenLLVM::visit(Call &call)
       expr_ = b_.CreateGetNs(call.type.ts_mode, call.loc);
     }
   } else {
-    LOG(FATAL) << "missing codegen for function \"" << call.func << "\"";
+    LOG(BUG) << "missing codegen for function \"" << call.func << "\"";
   }
 }
 
@@ -1442,8 +1442,7 @@ std::pair<Value *, uint64_t> CodegenLLVM::getString(Expression *expr)
 void CodegenLLVM::binop_string(Binop &binop)
 {
   if (binop.op != Operator::EQ && binop.op != Operator::NE) {
-    LOG(FATAL) << "missing codegen to string operator \"" << opstr(binop)
-               << "\"";
+    LOG(BUG) << "missing codegen to string operator \"" << opstr(binop) << "\"";
   }
 
   std::string string_literal;
@@ -1506,8 +1505,7 @@ void CodegenLLVM::binop_integer_array(Binop &binop)
 void CodegenLLVM::binop_buf(Binop &binop)
 {
   if (binop.op != Operator::EQ && binop.op != Operator::NE) {
-    LOG(FATAL) << "missing codegen to buffer operator \"" << opstr(binop)
-               << "\"";
+    LOG(BUG) << "missing codegen to buffer operator \"" << opstr(binop) << "\"";
   }
 
   std::string string_literal("");
@@ -1823,8 +1821,8 @@ void CodegenLLVM::visit(Unop &unop)
   {
     unop_ptr(unop);
   } else {
-    LOG(FATAL) << "invalid type (" << type << ") passed to unary operator \""
-               << opstr(unop) << "\"";
+    LOG(BUG) << "invalid type (" << type << ") passed to unary operator \""
+             << opstr(unop) << "\"";
   }
 }
 
@@ -2599,7 +2597,7 @@ void CodegenLLVM::createRet(Value *value)
   // Fall back to default return value
   switch (probetype(current_attach_point_->provider)) {
     case ProbeType::invalid:
-      LOG(FATAL) << "Returning from invalid probetype";
+      LOG(BUG) << "Returning from invalid probetype";
       break;
     case ProbeType::tracepoint:
       // Classic (ie. *not* raw) tracepoints have a kernel quirk stopping perf
@@ -2712,7 +2710,7 @@ void CodegenLLVM::visit(Probe &probe)
           auto usdt = USDTHelper::find(
               bpftrace_.pid(), match_ap.target, match_ap.ns, match_ap.func);
           if (!usdt.has_value())
-            LOG(FATAL) << "Failed to find usdt probe: " << probefull_;
+            LOG(BUG) << "Failed to find usdt probe: " << probefull_;
           match_ap.usdt = *usdt;
 
           // A "unique" USDT probe can be present in a binary in multiple
@@ -3360,7 +3358,7 @@ void CodegenLLVM::createPrintMapCall(Call &call)
 
   int id = bpftrace_.resources.maps_info.at(map.ident).id;
   if (id == -1) {
-    LOG(FATAL) << "map id for map \"" << map.ident << "\" not found";
+    LOG(BUG) << "map id for map \"" << map.ident << "\" not found";
   }
   auto *ident_ptr = b_.CreateGEP(print_struct,
                                  buf,
@@ -3699,7 +3697,7 @@ void CodegenLLVM::emit(raw_pwrite_stream &stream)
 #endif
 
   if (target_machine_->addPassesToEmitFile(PM, stream, nullptr, type))
-    LOG(FATAL) << "Cannot emit a file of this type";
+    LOG(BUG) << "Cannot emit a file of this type";
   PM.run(*module_.get());
 }
 
@@ -3920,7 +3918,7 @@ void CodegenLLVM::createIncDec(Unop &unop)
     else
       expr_ = newval;
   } else {
-    LOG(FATAL) << "invalid expression passed to " << opstr(unop);
+    LOG(BUG) << "invalid expression passed to " << opstr(unop);
   }
 }
 

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -43,7 +43,7 @@ public:
   int analyse();
 
 private:
-  bool resolve_args(Probe &probe);
+  void resolve_args(Probe &probe);
   void resolve_fields(SizedType &type);
   void resolve_type(SizedType &type);
 

--- a/src/ast/passes/node_counter.h
+++ b/src/ast/passes/node_counter.h
@@ -33,9 +33,7 @@ inline Pass CreateCounterPass()
     c.Visit(n);
     auto node_count = c.get_count();
     auto max = ctx.b.max_ast_nodes_;
-    if (bt_verbose) {
-      LOG(INFO) << "node count: " << node_count;
-    }
+    LOG(V1) << "node count: " << node_count;
     if (node_count >= max) {
       LOG(ERROR) << "node count (" << node_count << ") exceeds the limit ("
                  << max << ")";

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -27,7 +27,7 @@ bool ReturnPathAnalyser::visit(Subprog &subprog)
     if (Visit(*stmt))
       return true;
   }
-  LOG(ERROR, subprog.loc, err_) << "Not all code paths return a value";
+  LOG(ERROR, subprog.loc, err_) << "Not all code paths returned a value";
   return false;
 }
 

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -33,7 +33,7 @@ public:
   bool hasSection(const std::string &name) const;
   const std::vector<uint8_t> &getSection(const std::string &name) const;
 
-  int create_maps();
+  bool create_maps();
   bool hasMap(MapType internal_type) const;
   bool hasMap(const StackType &stack_type) const;
   const BpfMap &getMap(const std::string &name) const;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -53,7 +53,6 @@ enum class DebugLevel;
 extern DebugLevel bt_debug;
 extern bool bt_quiet;
 extern bool bt_verbose;
-extern bool bt_verbose2;
 
 enum class DebugLevel { kNone, kDebug, kFullDebug };
 

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -491,8 +491,7 @@ std::string BTF::get_all_funcs_from_btf(const BTFObj &btf_obj) const
     t = btf__type_by_id(btf_obj.btf, t->type);
     if (!t || !btf_is_func_proto(t)) {
       /* bad.. */
-      if (!bt_verbose)
-        LOG(ERROR) << func_name << " function does not have FUNC_PROTO record";
+      LOG(ERROR) << func_name << " function does not have FUNC_PROTO record";
       break;
     }
 

--- a/src/child.cpp
+++ b/src/child.cpp
@@ -287,9 +287,9 @@ void ChildProc::check_child(bool block)
     if (errno == EINVAL)
       LOG(BUG) << "waitpid() EINVAL";
     else {
-      LOG(ERROR) << "waitpid(" << child_pid_
-                 << ") returned unexpected error: " << errno
-                 << ". Marking the child as dead";
+      LOG(WARNING) << "waitpid(" << child_pid_
+                   << ") returned unexpected error: " << errno
+                   << ". Marking the child as dead";
       state_ = State::DIED;
       return;
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -49,8 +49,7 @@ bool Config::is_aslr_enabled()
   {
     std::ifstream file(randomize_va_space_file);
     if (file.fail()) {
-      if (bt_verbose_)
-        LOG(ERROR) << std::strerror(errno) << ": " << randomize_va_space_file;
+      LOG(V1) << std::strerror(errno) << ": " << randomize_va_space_file;
       // conservatively return true
       return true;
     }

--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -75,7 +75,6 @@ int fuzz_main(const char* data, size_t sz)
     return 1;
 
   DISABLE_LOG(DEBUG);
-  DISABLE_LOG(INFO);
   DISABLE_LOG(WARNING);
   // We can't disable error logs because some functions use a length of error
   // log to see if an error occurs. Instead, suppress error log output at each
@@ -176,9 +175,6 @@ int fuzz_main(const char* data, size_t sz)
     // failed to compile
     return 1;
   }
-
-  // for debug
-  // LOG(INFO) << "ok";
 
   return 0;
 }

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -6,12 +6,12 @@ std::string logtype_str(LogType t)
 {
   switch (t) {
     // clang-format off
-    case LogType::DEBUG   : return "DEBUG";
-    case LogType::INFO    : return "INFO";
-    case LogType::WARNING : return "WARNING";
-    case LogType::ERROR   : return "ERROR";
-    case LogType::FATAL   : return "FATAL";
-    case LogType::BUG     : return "BUG";
+    case LogType::DEBUG   : return "";
+    case LogType::V1      : return "";
+    case LogType::WARNING : return "WARNING: ";
+    case LogType::ERROR   : return "ERROR: ";
+    case LogType::FATAL   : return "ERROR: ";
+    case LogType::BUG     : return "BUG: ";
       // clang-format on
   }
 
@@ -22,7 +22,7 @@ Log::Log()
 {
   enabled_map_[LogType::ERROR] = true;
   enabled_map_[LogType::WARNING] = true;
-  enabled_map_[LogType::INFO] = true;
+  enabled_map_[LogType::V1] = false;
   enabled_map_[LogType::DEBUG] = true;
   enabled_map_[LogType::FATAL] = true;
   enabled_map_[LogType::BUG] = true;
@@ -39,9 +39,7 @@ void Log::take_input(LogType type,
                      std::ostream& out,
                      std::string&& input)
 {
-  auto print_out = [&]() {
-    out << logtype_str(type) << ": " << input << std::endl;
-  };
+  auto print_out = [&]() { out << logtype_str(type) << input << std::endl; };
 
   if (loc) {
     if (src_.empty()) {
@@ -99,7 +97,7 @@ void Log::log_with_location(LogType type,
      <filename>:<start_line>-<end_line>: ERROR: <message>
   */
   if (l.begin.line < l.end.line) {
-    out << l.begin.line << "-" << l.end.line << ": " << typestr << ": " << msg
+    out << l.begin.line << "-" << l.end.line << ": " << typestr << msg
         << std::endl;
     return;
   }
@@ -118,7 +116,7 @@ void Log::log_with_location(LogType type,
             ~~~~~~~~~~
   */
   out << l.begin.line << ":" << l.begin.column << "-" << l.end.column;
-  out << ": " << typestr << ": " << msg << std::endl;
+  out << ": " << typestr << msg << std::endl;
 
   // for bpftrace::position, valid line# starts from 1
   std::string srcline = get_source_line(l.begin.line - 1);

--- a/src/log.h
+++ b/src/log.h
@@ -14,7 +14,7 @@ namespace bpftrace {
 enum class LogType
 {
   DEBUG,
-  INFO,
+  V1,
   WARNING,
   ERROR,
   FATAL,
@@ -50,7 +50,8 @@ public:
   }
   inline void disable(LogType type)
   {
-    assert(type != LogType::FATAL);
+    assert(type != LogType::FATAL && type != LogType::BUG &&
+           type != LogType::ERROR);
     enabled_map_[type] = false;
   }
   inline bool is_enabled(LogType type)
@@ -143,7 +144,7 @@ public:
 // clang-format off
 #define LOGSTREAM_COMMON(...) bpftrace::LogStream(__FILE__, __LINE__, __VA_ARGS__)
 #define LOGSTREAM_DEBUG(...) LOGSTREAM_COMMON(__VA_ARGS__)
-#define LOGSTREAM_INFO(...) LOGSTREAM_COMMON(__VA_ARGS__)
+#define LOGSTREAM_V1(...) LOGSTREAM_COMMON(__VA_ARGS__)
 #define LOGSTREAM_WARNING(...) LOGSTREAM_COMMON(__VA_ARGS__)
 #define LOGSTREAM_ERROR(...) LOGSTREAM_COMMON(__VA_ARGS__)
 #define LOGSTREAM_FATAL(...) bpftrace::LogStreamFatal(__FILE__, __LINE__, __VA_ARGS__)
@@ -153,5 +154,6 @@ public:
 #define LOG(type, ...) LOGSTREAM_##type(bpftrace::LogType::type, ##__VA_ARGS__)
 
 #define DISABLE_LOG(type) bpftrace::Log::get().disable(LogType::type)
+#define ENABLE_LOG(type) bpftrace::Log::get().enable(LogType::type)
 
 }; // namespace bpftrace

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -147,7 +147,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       return bpftrace.resolve_mac_address(p);
     }
     default:
-      LOG(ERROR) << "invalid mapkey argument type";
+      LOG(BUG) << "invalid mapkey argument type";
   }
   abort();
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -331,8 +331,8 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
         return std::to_string(reduce_value<uint8_t>(value, nvalues) / div);
         // clang-format on
       default:
-        LOG(FATAL) << "value_to_str: Invalid int bitwidth: "
-                   << type.GetIntBitWidth() << "provided";
+        LOG(BUG) << "value_to_str: Invalid int bitwidth: "
+                 << type.GetIntBitWidth() << "provided";
         return {};
     }
   } else if (type.IsSumTy() || type.IsIntTy()) {

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -480,7 +480,7 @@ void ProbeMatcher::list_probes(ast::Program* prog)
         std::cout << probe_type << ":" << match_print << std::endl;
         if (bt_verbose) {
           for (auto& param : param_lists[match])
-            std::cout << "    " << param << std::endl;
+            LOG(V1) << "    " << param;
         }
       }
     }

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -51,9 +51,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
               if (category == "syscall")
                 LOG(ERROR, ap->loc, std::cerr)
                     << "Did you mean syscalls:" << event_name << "?";
-              if (bt_verbose) {
-                LOG(ERROR) << strerror(errno) << ": " << format_file_path;
-              }
+              LOG(V1) << strerror(errno) << ": " << format_file_path;
               return false;
             } else {
               // unexpected error

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -216,23 +216,22 @@ KConfig::KConfig()
   }
 }
 
-bool get_uint64_env_var(const ::std::string &str,
+void get_uint64_env_var(const ::std::string &str,
                         const std::function<void(uint64_t)> &cb)
 {
   uint64_t dest;
   if (const char *env_p = std::getenv(str.c_str())) {
     std::istringstream stringstream(env_p);
     if (!(stringstream >> dest)) {
-      LOG(ERROR) << "Env var '" << str
+      LOG(FATAL) << "Env var '" << str
                  << "' did not contain a valid uint64_t, or was zero-valued.";
-      return false;
+      return;
     }
     cb(dest);
   }
-  return true;
 }
 
-bool get_bool_env_var(const ::std::string &str,
+void get_bool_env_var(const ::std::string &str,
                       const std::function<void(bool)> &cb)
 {
   if (const char *env_p = std::getenv(str.c_str())) {
@@ -243,14 +242,13 @@ bool get_bool_env_var(const ::std::string &str,
     else if (s == "0")
       dest = false;
     else {
-      LOG(ERROR) << "Env var '" << str
+      LOG(FATAL) << "Env var '" << str
                  << "' did not contain a "
                     "valid value (0 or 1).";
-      return false;
     }
     cb(dest);
   }
-  return true;
+  return;
 }
 
 std::optional<std_filesystem::path> find_in_path(const std::string &name)

--- a/src/utils.h
+++ b/src/utils.h
@@ -133,9 +133,9 @@ static std::vector<std::string> COMPILE_TIME_FUNCS = { "cgroupid" };
 
 static std::vector<std::string> UPROBE_LANGS = { "cpp" };
 
-bool get_uint64_env_var(const ::std::string &str,
+void get_uint64_env_var(const ::std::string &str,
                         const std::function<void(uint64_t)> &cb);
-bool get_bool_env_var(const ::std::string &str,
+void get_bool_env_var(const ::std::string &str,
                       const std::function<void(bool)> &cb);
 // Tries to find a file in $PATH
 std::optional<std_filesystem::path> find_in_path(const std::string &name);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -74,9 +74,9 @@ static void test(BPFtrace &bpftrace,
   codegen.emit();
 
   uint64_t update_tests = 0;
-  if (get_uint64_env_var("BPFTRACE_UPDATE_TESTS",
-                         [&](uint64_t x) { update_tests = x; }) &&
-      update_tests >= 1) {
+  get_uint64_env_var("BPFTRACE_UPDATE_TESTS",
+                     [&](uint64_t x) { update_tests = x; });
+  if (update_tests >= 1) {
     std::cerr << "Running in update mode, test is skipped" << std::endl;
     std::ofstream file(TEST_CODEGEN_LOCATION + name + ".ll");
     file << out.str();

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -26,9 +26,10 @@ TEST(LogStream, basic)
   ss.str({});
 
   // test macro with 1 argument
+  ENABLE_LOG(V1);
   auto cerr_buf = std::cerr.rdbuf(ss.rdbuf());
-  LOG(INFO) << content_1 << content_2;
-  EXPECT_EQ(ss.str(), "INFO: " + content_1 + content_2 + "\n");
+  LOG(V1) << content_1 << content_2;
+  EXPECT_EQ(ss.str(), content_1 + content_2 + "\n");
   std::cerr.rdbuf(cerr_buf);
 }
 

--- a/tests/runtime/banned_probes
+++ b/tests/runtime/banned_probes
@@ -1,23 +1,23 @@
 NAME kretprobe:_raw_spin_lock is banned
 PROG kretprobe:_raw_spin_lock { exit(); }
-EXPECT ERROR: error: kretprobe:_raw_spin_lock can't be used as it might lock up your system.
+EXPECT ERROR: kretprobe:_raw_spin_lock can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL
 
 NAME kretprobe:queued_spin_lock_slowpath is banned
 PROG kretprobe:queued_spin_lock_slowpath { exit(); }
-EXPECT ERROR: error: kretprobe:queued_spin_lock_slowpath can't be used as it might lock up your system.
+EXPECT ERROR: kretprobe:queued_spin_lock_slowpath can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL
 
 NAME kretprobe:_raw_spin_unlock_irqrestore is banned
 PROG kretprobe:_raw_spin_unlock_irqrestore { exit(); }
-EXPECT ERROR: error: kretprobe:_raw_spin_unlock_irqrestore can't be used as it might lock up your system.
+EXPECT ERROR: kretprobe:_raw_spin_unlock_irqrestore can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL
 
 NAME kretprobe:_raw_spin_lock_irqsave is banned
 PROG kretprobe:_raw_spin_lock_irqsave { exit(); }
-EXPECT ERROR: error: kretprobe:_raw_spin_lock_irqsave can't be used as it might lock up your system.
+EXPECT ERROR: kretprobe:_raw_spin_lock_irqsave can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -178,25 +178,25 @@ WILL_FAIL
 
 NAME pid fails validation with leading non-number
 RUN {{BPFTRACE}} -p a1111 file.bt
-EXPECT FATAL: Failed to parse pid: pid 'a1111' is not a valid decimal number
+EXPECT ERROR: Failed to parse pid: pid 'a1111' is not a valid decimal number
 TIMEOUT 1
 WILL_FAIL
 
 NAME pid fails validation with non-number in between
 RUN {{BPFTRACE}} -p 111a1 file.bt
-EXPECT FATAL: Failed to parse pid: pid '111a1' is not a valid decimal number
+EXPECT ERROR: Failed to parse pid: pid '111a1' is not a valid decimal number
 TIMEOUT 1
 WILL_FAIL
 
 NAME pid fails validation with non-numeric argument
 RUN {{BPFTRACE}} -p not_a_pid file.bt
-EXPECT FATAL: Failed to parse pid: pid 'not_a_pid' is not a valid decimal number
+EXPECT ERROR: Failed to parse pid: pid 'not_a_pid' is not a valid decimal number
 TIMEOUT 1
 WILL_FAIL
 
 NAME pid outside of valid pid range
 RUN {{BPFTRACE}} -p 5000000 file.bt
-EXPECT FATAL: Failed to parse pid: pid '5000000' out of valid pid range [1,4194304]
+EXPECT ERROR: Failed to parse pid: pid '5000000' out of valid pid range [1,4194304]
 TIMEOUT 1
 WILL_FAIL
 
@@ -282,6 +282,6 @@ WILL_FAIL
 
 NAME kaddr fails
 PROG BEGIN { print(kaddr("asdfzzzzzzz")) }
-EXPECT FATAL: Failed to resolve kernel symbol: asdfzzzzzzz
+EXPECT ERROR: Failed to resolve kernel symbol: asdfzzzzzzz
 TIMEOUT 1
 WILL_FAIL

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -200,7 +200,7 @@ TIMEOUT 5
 NAME log size too small
 ENV BPFTRACE_LOG_SIZE=0
 RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
-EXPECT FATAL: Error loading program: BEGIN (try -v)
+EXPECT ERROR: Error loading program: BEGIN (try -v)
 TIMEOUT 5
 WILL_FAIL
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -137,13 +137,13 @@ AFTER ./testprogs/syscall read
 
 NAME kprobe_module_missing
 PROG kprobe:nonsense:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT FATAL: Error attaching probe: kprobe:nonsense:vfs_read: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
+EXPECT ERROR: Error attaching probe: kprobe:nonsense:vfs_read: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
 TIMEOUT 5
 WILL_FAIL
 
 NAME kprobe_func_missing
 PROG kprobe:vmlinux:nonsense { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT FATAL: Error attaching probe: kprobe:vmlinux:nonsense
+EXPECT ERROR: Error attaching probe: kprobe:vmlinux:nonsense
 TIMEOUT 5
 WILL_FAIL
 
@@ -289,7 +289,7 @@ WILL_FAIL
 
 NAME uprobe_address_fail_resolve
 PROG uprobe:/bin/bash:10 { printf("arg0: %d\n", arg0); exit();}
-EXPECT FATAL: Could not resolve address: /bin/bash:0xa
+EXPECT ERROR: Could not resolve address: /bin/bash:0xa
 TIMEOUT 5
 WILL_FAIL
 
@@ -308,7 +308,7 @@ AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 
 NAME uprobe_zero_size
 PROG uprobe:./testprogs/uprobe_test:_init { printf("arg0: %d\n", arg0); exit();}
-EXPECT FATAL: Could not determine boundary for _init (symbol has size 0). Use --unsafe to force attachment.
+EXPECT ERROR: Could not determine boundary for _init (symbol has size 0). Use --unsafe to force attachment.
 TIMEOUT 5
 WILL_FAIL
 
@@ -399,7 +399,7 @@ TIMEOUT 5
 
 NAME rawtracepoint_missing
 PROG rawtracepoint:nonsense { printf("hit"); exit(); }
-EXPECT FATAL: Probe does not exist: rawtracepoint:nonsense
+EXPECT ERROR: Probe does not exist: rawtracepoint:nonsense
 TIMEOUT 5
 WILL_FAIL
 
@@ -486,7 +486,7 @@ TIMEOUT 2
 # match and so we should fail on exceeding BPFTRACE_MAX_BPF_PROGS.
 NAME bpf_programs_limit
 PROG k:* { @[probe] = count(); }
-EXPECT_REGEX FATAL: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 512.\nYou can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
+EXPECT_REGEX ERROR: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 512.\nYou can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
 WILL_FAIL
 TIMEOUT 2
 


### PR DESCRIPTION
- `DEBUG`: log info to the user regardless of log level
(like using stdout and comes with file and line number).
No prefix.
- `V1`: log info to the user only if verbose logging is
enabled (bt_verbose or -v) Note: -vv will be deleted as
it's only used in two places in one file. No prefix.
- `WARNING`: log info that might affect bpftrace behavior
or output but allows the run to continue (like using
stderr). Prefix: "WARNING:"
- `ERROR`: log info to indicate that the user did
something invalid which will (eventually) cause bpftrace
to exit (via `exit(1)` or `LOG(FATAL)`). This should get
used if there a multiple errors that need to get logged
to the user otherwise use `FATAL`. Prefix: "ERROR:"
- `FATAL`: abort run and log info to indicate that the
user did something invalid which caused bpftrace to exit.
Prefix: "ERROR:"
- `BUG`: abort run and log info to indicate that there
is an internal/unexpected issue (not caused by invalid
user program code or CLI use). Prefix: "BUG:"

Also update many sites in accordance with the above
schema.

However, there are still many places that utilize
LOG(ERROR) that could be switched to LOG(FATAL) or
LOG(WARNING) but some changes seemed beyond this PR.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
