### PR TITLE
Report correct helper for error messages

### DIFF
--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -95,15 +95,12 @@ private:
 
 class HelperVerifierError : public std::runtime_error {
 public:
-  const libbpf::bpf_func_id func_id_;
-  const std::string helper_name_;
-  explicit HelperVerifierError(libbpf::bpf_func_id func_id,
-                               std::string helper_name)
-      : std::runtime_error("helper invalid in probe"),
-        func_id_(func_id),
-        helper_name_(helper_name)
+  HelperVerifierError(const std::string &msg, libbpf::bpf_func_id func_id_)
+      : std::runtime_error(msg), func_id(func_id_)
   {
   }
+
+  const libbpf::bpf_func_id func_id;
 };
 
 } // namespace bpftrace

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -960,11 +960,10 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_probe(
     // Caller will handle
     throw e;
   } catch (const HelperVerifierError &e) {
-    if (helper_use_loc_.find(e.func_id_) != helper_use_loc_.end()) {
-      LOG(ERROR, helper_use_loc_[e.func_id_], std::cerr)
-          << "helper " << e.helper_name_ << " not supported in probe";
+    if (helper_use_loc_.find(e.func_id) != helper_use_loc_.end()) {
+      LOG(ERROR, helper_use_loc_[e.func_id], std::cerr) << e.what();
     } else {
-      LOG(ERROR) << "helper " << e.helper_name_ << " not supported in probe";
+      LOG(ERROR) << e.what();
     }
   } catch (const std::runtime_error &e) {
     LOG(ERROR) << e.what();

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -449,9 +449,13 @@ RUN {{BPFTRACE}} -e 'BEGIN { if (strcontains("abc", "a")) { printf("OK\n"); exit
 EXPECT OK
 TIMEOUT 1
 
+# The extra prints are here to confirm that we report on the correct helper, not
+# just the first or the last one.
 NAME path_in_unsupported_kfunc
-PROG kfunc:vfs_read { print(path(args.file->f_path)); }
-EXPECT stdin:1:18-47: ERROR: helper bpf_d_path not supported in probe
+PROG kfunc:vfs_read { print("a"); print(path(args.file->f_path)); print("b"); }
+EXPECT stdin:1:30-59: ERROR: helper bpf_d_path not allowed in probe
+EXPECT kfunc:vfs_read { print("a"); print(path(args.file->f_path)); print("b"); }
+EXPECT                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 REQUIRES_FEATURE dpath
 REQUIRES_FEATURE kfunc
 TIMEOUT 5


### PR DESCRIPTION
Previously, the first helper in a script would always be reported as the issue, even if it was not the cause of the verifier error.

The logic has been wrapped in a function (maybe_throw_helper_verifier_error) to allow it to be reused for other helper errors in the future.