### PR TITLE
[#3058] fix bpftrace -l test.bt

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -669,9 +669,13 @@ Args parse_args(int argc, char* argv[])
     if (optind == argc) {
       args.search = "*:*";
     } else if (optind == argc - 1) {
-      args.search = argv[optind];
-      if (args.search == "*") {
+      std::string_view val(argv[optind]);
+      if (val == "*") {
         args.search = "*:*";
+      } else if (val.find_first_of(":*") != std::string::npos) {
+        args.search = val;
+      } else {
+        args.filename = val;
       }
       optind++;
     } else {

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -158,6 +158,19 @@ EXPECT hardware:cache-misses:
 EXPECT tracepoint:xdp:mem_connect
 TIMEOUT 5
 
+NAME it lists probes in a given file
+RUN {{BPFTRACE}} -l runtime/scripts/interval_order.bt
+EXPECT interval:ms:
+EXPECT interval:ms:
+EXPECT interval:ms:
+TIMEOUT 5
+
+NAME errors on non existent file
+RUN {{BPFTRACE}} -l non_existent_file.bt
+EXPECT ERROR: failed to open file 'non_existent_file.bt': No such file or directory
+TIMEOUT 1
+WILL_FAIL
+
 NAME errors on invalid character in search expression
 RUN {{BPFTRACE}} -l '\n'
 EXPECT stdin:1:1-2: ERROR: invalid character '\'

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -171,12 +171,6 @@ EXPECT ERROR: failed to open file 'non_existent_file.bt': No such file or direct
 TIMEOUT 1
 WILL_FAIL
 
-NAME errors on invalid character in search expression
-RUN {{BPFTRACE}} -l '\n'
-EXPECT stdin:1:1-2: ERROR: invalid character '\'
-TIMEOUT 1
-WILL_FAIL
-
 NAME pid fails validation with leading non-number
 RUN {{BPFTRACE}} -p a1111 file.bt
 EXPECT FATAL: Failed to parse pid: pid 'a1111' is not a valid decimal number


### PR DESCRIPTION
Fix for #3058.

The fix involves some heuristic because there is a conflict:

```
USAGE:
    bpftrace [options] filename
    ...

OPTIONS:
    ...
    -l [search]    list kernel probes or probes in a program
```

Based on the snippet above, a command `bpftrace -l foo` is ambiguous.
Because, `foo` can be either search pattern or a file name.

The PR resolves this via the following logic:
1. assume that `foo` is a file.
2. check the file existence. If yes, proceed accordingly
3. if not, treat `foo` as search command.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
