### PR TITLE
Semantic Analyser: Don't analyse for-loop's body when map is not defined

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2083,16 +2083,17 @@ void SemanticAnalyser::visit(For &f)
         << "Maps used as for-loop expressions must have keys to iterate over";
   }
 
-  if (mapval && mapkey) {
-    auto keytype = CreateNone();
-    if (mapkey->args_.size() == 1) {
-      keytype = mapkey->args_[0];
-    } else {
-      keytype = CreateTuple(bpftrace_.structs.AddTuple(mapkey->args_));
-    }
-    f.decl->type = CreateTuple(
-        bpftrace_.structs.AddTuple({ keytype, *mapval }));
+  if (!mapval || !mapkey)
+    return;
+
+  auto keytype = CreateNone();
+  if (mapkey->args_.size() == 1) {
+    keytype = mapkey->args_[0];
+  } else {
+    keytype = CreateTuple(bpftrace_.structs.AddTuple(mapkey->args_));
   }
+  f.decl->type = CreateTuple(bpftrace_.structs.AddTuple({ keytype, *mapval }));
+
   variable_val_[scope_][decl_name] = f.decl->type;
 
   loop_depth_++;

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3386,6 +3386,13 @@ TEST(semantic_analyser, for_loop_map)
   test("BEGIN { @map[0] = 1; for ($kv : @map) { print($kv.1); } }");
 }
 
+TEST(semantic_analyser, for_loop_map_declared_after)
+{
+  // Regression test: What happens with @map[$kv.0] when @map hasn't been
+  // defined yet?
+  test("BEGIN { for ($kv : @map) { @map[$kv.0] } @map[0] = 1; }");
+}
+
 TEST(semantic_analyser, for_loop_map_no_key)
 {
   // Error location is incorrect: #3063


### PR DESCRIPTION
This script would previously crash bpftrace with a floating point exception:
```
BEGIN { for ($kv : @map) { @map[$kv.0] } @map[0] = 1; }
```

On the first pass:
- `@map` is undefined and so `$kv.0` has type "none".
- `@map`'s key type is recorded as "none" in the loop body
- `@map`'s value type is then recorded as "int" outside the loop

On the second pass:
- `@map` is defined, `$kv`'s type will be set to "(none, int)"
- Creating a tuple containing a "none" type results in arithmetic problems attempting to calculate padding

Resolve the issue by simply not analysing a loop's body until the map is fully defined. This slightly changes the ordering of some error messages, but results in no other changes.

With the plans to split type propagation out of SemanticAnalyser, the future logic will be similar to this new behaviour, in that we won't analyse code until types are fully defined.

##### Checklist

No changelog necessary as the for-loop feature has not yet made it to a released version.

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
