### PR TITLE
Add nr_stack_frames to stack key

### DIFF
--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -13,8 +13,9 @@ inline bool needMemcpy(const SizedType &stype)
 inline bool shouldBeOnStackAlready(const SizedType &type)
 {
   return type.IsStringTy() || type.IsBufferTy() || type.IsInetTy() ||
-         type.IsUsymTy() || type.IsUstackTy() || type.IsTupleTy() ||
-         type.IsTimestampTy() || type.IsMacAddressTy() || type.IsCgroupPathTy();
+         type.IsUsymTy() || type.IsKstackTy() || type.IsUstackTy() ||
+         type.IsTupleTy() || type.IsTimestampTy() || type.IsMacAddressTy() ||
+         type.IsCgroupPathTy();
 }
 
 inline bool onStack(const SizedType &type)

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -42,6 +42,11 @@ struct symbol {
   uint64_t address;
 };
 
+struct stack_key {
+  int64_t stackid;
+  uint32_t nr_stack_frames;
+};
+
 enum class DebugLevel;
 
 // globals
@@ -115,6 +120,7 @@ public:
   int zero_map(const BpfMap &map);
   int print_map(const BpfMap &map, uint32_t top, uint32_t div);
   std::string get_stack(int64_t stackid,
+                        uint32_t nr_stack_frames,
                         int pid,
                         int probe_id,
                         bool ustack,

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -78,12 +78,18 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       }
       break;
     case Type::kstack:
-      return bpftrace.get_stack(
-          read_data<int64_t>(data), -1, -1, false, arg.stack_type, 4);
+      return bpftrace.get_stack(read_data<int64_t>(data),
+                                read_data<uint32_t>(arg_data + 8),
+                                -1,
+                                -1,
+                                false,
+                                arg.stack_type,
+                                4);
     case Type::ustack:
       return bpftrace.get_stack(read_data<int64_t>(data),
-                                read_data<int32_t>(arg_data + 8),
+                                read_data<uint32_t>(arg_data + 8),
                                 read_data<int32_t>(arg_data + 12),
+                                read_data<int32_t>(arg_data + 16),
                                 true,
                                 arg.stack_type,
                                 4);

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -241,12 +241,18 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
 {
   uint32_t nvalues = is_per_cpu ? bpftrace.ncpus_ : 1;
   if (type.IsKstackTy())
-    return bpftrace.get_stack(
-        read_data<uint64_t>(value.data()), -1, -1, false, type.stack_type, 8);
+    return bpftrace.get_stack(read_data<uint64_t>(value.data()),
+                              read_data<uint32_t>(value.data() + 8),
+                              -1,
+                              -1,
+                              false,
+                              type.stack_type,
+                              8);
   else if (type.IsUstackTy())
     return bpftrace.get_stack(read_data<int64_t>(value.data()),
-                              read_data<int32_t>(value.data() + 8),
+                              read_data<uint32_t>(value.data() + 8),
                               read_data<int32_t>(value.data() + 12),
+                              read_data<int32_t>(value.data() + 16),
                               true,
                               type.stack_type,
                               8);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -107,9 +107,10 @@ bool SizedType::operator==(const SizedType &t) const
 bool SizedType::IsByteArray() const
 {
   return type_ == Type::string || type_ == Type::usym ||
-         type_ == Type::ustack || type_ == Type::inet ||
-         type_ == Type::buffer || type_ == Type::timestamp ||
-         type_ == Type::mac_address || type_ == Type::cgroup_path;
+         type_ == Type::kstack || type_ == Type::ustack ||
+         type_ == Type::inet || type_ == Type::buffer ||
+         type_ == Type::timestamp || type_ == Type::mac_address ||
+         type_ == Type::cgroup_path;
 }
 
 bool SizedType::IsAggregate() const
@@ -363,7 +364,8 @@ SizedType CreateRecord(const std::string &name, std::weak_ptr<Struct> record)
 
 SizedType CreateStack(bool kernel, StackType stack)
 {
-  auto st = SizedType(kernel ? Type::kstack : Type::ustack, kernel ? 8 : 16);
+  // These sizes are based on the stack key (see CodegenLLVM::kstack_ustack)
+  auto st = SizedType(kernel ? Type::kstack : Type::ustack, kernel ? 12 : 20);
   st.stack_type = stack;
   return st;
 }

--- a/tests/codegen/llvm/builtin_kstack.ll
+++ b/tests/codegen/llvm/builtin_kstack.ll
@@ -8,76 +8,73 @@ target triple = "bpf-pc-linux"
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.2" = type { i8*, i8* }
 %"struct map_t.3" = type { i8*, i8*, i8*, i8* }
+%stack_key = type { i64, i32 }
 
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@stack_bpftrace_127 = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@stack_scratch = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
-@ringbuf = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !52
-@ringbuf_loss_counter = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !66
+@stack_bpftrace_127 = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
+@stack_scratch = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !45
+@ringbuf = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !58
+@ringbuf_loss_counter = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !72
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !79 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !86 {
 entry:
-  %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stackid = alloca i64, align 8
-  %1 = bitcast i64* %stackid to i8*
+  %stack_key = alloca %stack_key, align 8
+  %1 = bitcast %stack_key* %stack_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %2 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 0, i64* %2, align 8
+  %3 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 0, i32* %3, align 4
+  %4 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i32 0, i32* %lookup_stack_scratch_key, align 4
   %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @stack_scratch, i32* %lookup_stack_scratch_key)
-  %3 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %lookup_stack_scratch_cond = icmp ne i8* %4, null
+  %5 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %6, null
   br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
 
 stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
-  %5 = load i64, i64* %stackid, align 8
-  %6 = bitcast i64* %stackid to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@x_key", align 8
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 %5, i64* %"@x_val", align 8
-  %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %stack_key*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %stack_key* %stack_key, i64 0)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
 
 lookup_stack_scratch_failure:                     ; preds = %entry
   br label %stack_scratch_failure
 
 lookup_stack_scratch_merge:                       ; preds = %entry
-  %11 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 1016, i1 false)
-  %12 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %12, i32 1016, i64 0)
-  %13 = icmp sge i32 %get_stack, 0
-  br i1 %13, label %get_stack_success, label %get_stack_fail
+  %9 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 1016, i1 false)
+  %10 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %10, i32 1016, i64 0)
+  %11 = icmp sge i32 %get_stack, 0
+  br i1 %11, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %14 = udiv i32 %get_stack, 8
-  %15 = trunc i32 %14 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %12, i8 %15, i64 1)
-  store i64 %murmur_hash_2, i64* %stackid, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.0"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  %12 = udiv i32 %get_stack, 8
+  %13 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 %12, i32* %13, align 4
+  %14 = trunc i32 %12 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %10, i8 %14, i64 1)
+  %15 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, i64* %15, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.0"* @stack_bpftrace_127, %stack_key* %stack_key, [127 x i64]* %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
 get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 }
 
@@ -179,8 +176,8 @@ attributes #1 = { alwaysinline }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
 attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!75}
-!llvm.module.flags = !{!78}
+!llvm.dbg.cu = !{!82}
+!llvm.module.flags = !{!85}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -201,71 +198,77 @@ attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !23)
-!23 = !{!24, !29, !16, !34}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 9, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 96, elements: !23)
+!22 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!23 = !{!24}
+!24 = !DISubrange(count: 12, lowerBound: 0)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !28)
+!28 = !{!29, !34, !39, !40}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
 !30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !32)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !32)
 !32 = !{!33}
-!33 = !DISubrange(count: 131072, lowerBound: 0)
-!34 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !35, size: 64, offset: 192)
+!33 = !DISubrange(count: 9, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
 !35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !37)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !37)
 !37 = !{!38}
-!38 = !DISubrange(count: 127, lowerBound: 0)
-!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
-!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !48, !49, !34}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 6, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
-!49 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !50, size: 64, offset: 128)
+!38 = !DISubrange(count: 131072, lowerBound: 0)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !20, size: 64, offset: 128)
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !41, size: 64, offset: 192)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 127, lowerBound: 0)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
+!47 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !48)
+!48 = !{!49, !54, !55, !40}
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !50, size: 64)
 !50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
-!51 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
-!53 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !54, isLocal: false, isDefinition: true)
-!54 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !55)
-!55 = !{!56, !61}
-!56 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !57, size: 64)
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
-!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !59)
-!59 = !{!60}
-!60 = !DISubrange(count: 27, lowerBound: 0)
-!61 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !62, size: 64, offset: 64)
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !64)
-!64 = !{!65}
-!65 = !DISubrange(count: 262144, lowerBound: 0)
-!66 = !DIGlobalVariableExpression(var: !67, expr: !DIExpression())
-!67 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !68, isLocal: false, isDefinition: true)
-!68 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !69)
-!69 = !{!70, !48, !49, !19}
-!70 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !71, size: 64)
-!71 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !72, size: 64)
-!72 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !73)
-!73 = !{!74}
-!74 = !DISubrange(count: 2, lowerBound: 0)
-!75 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !76, globals: !77)
-!76 = !{}
-!77 = !{!0, !20, !39, !52, !66}
-!78 = !{i32 2, !"Debug Info Version", i32 3}
-!79 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !80, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !75, retainedNodes: !84)
-!80 = !DISubroutineType(types: !81)
-!81 = !{!18, !82}
-!82 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !83, size: 64)
-!83 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!84 = !{!85, !86}
-!85 = !DILocalVariable(name: "var0", scope: !79, file: !2, type: !18)
-!86 = !DILocalVariable(name: "var1", arg: 1, scope: !79, file: !2, type: !82)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 6, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!55 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !56, size: 64, offset: 128)
+!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !57, size: 64)
+!57 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!58 = !DIGlobalVariableExpression(var: !59, expr: !DIExpression())
+!59 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !60, isLocal: false, isDefinition: true)
+!60 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !61)
+!61 = !{!62, !67}
+!62 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !63, size: 64)
+!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
+!64 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !65)
+!65 = !{!66}
+!66 = !DISubrange(count: 27, lowerBound: 0)
+!67 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !68, size: 64, offset: 64)
+!68 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
+!69 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !70)
+!70 = !{!71}
+!71 = !DISubrange(count: 262144, lowerBound: 0)
+!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
+!73 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !74, isLocal: false, isDefinition: true)
+!74 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !75)
+!75 = !{!76, !54, !55, !81}
+!76 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !77, size: 64)
+!77 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !78, size: 64)
+!78 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !79)
+!79 = !{!80}
+!80 = !DISubrange(count: 2, lowerBound: 0)
+!81 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!82 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !83, globals: !84)
+!83 = !{}
+!84 = !{!0, !25, !45, !58, !72}
+!85 = !{i32 2, !"Debug Info Version", i32 3}
+!86 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !87, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !82, retainedNodes: !90)
+!87 = !DISubroutineType(types: !88)
+!88 = !{!18, !89}
+!89 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!90 = !{!91, !92}
+!91 = !DILocalVariable(name: "var0", scope: !86, file: !2, type: !18)
+!92 = !DILocalVariable(name: "var1", arg: 1, scope: !86, file: !2, type: !89)

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -8,82 +8,93 @@ target triple = "bpf-pc-linux"
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.2" = type { i8*, i8* }
 %"struct map_t.3" = type { i8*, i8*, i8*, i8* }
-%stack_t = type { i64, i32, i32 }
+%stack_t = type { i64, i32, i32, i32 }
+%stack_key = type { i64, i32 }
 
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @stack_bpftrace_127 = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@stack_scratch = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !44
-@ringbuf = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
-@ringbuf_loss_counter = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !71
+@stack_scratch = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !49
+@ringbuf = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !62
+@ringbuf_loss_counter = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !76
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !85 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !90 {
 entry:
   %"@x_key" = alloca i64, align 8
   %stack_args = alloca %stack_t, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stackid = alloca i64, align 8
-  %1 = bitcast i64* %stackid to i8*
+  %stack_key = alloca %stack_key, align 8
+  %1 = bitcast %stack_key* %stack_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %2 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 0, i64* %2, align 8
+  %3 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 0, i32* %3, align 4
+  %4 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i32 0, i32* %lookup_stack_scratch_key, align 4
   %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @stack_scratch, i32* %lookup_stack_scratch_key)
-  %3 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %lookup_stack_scratch_cond = icmp ne i8* %4, null
+  %5 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %6, null
   br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
 
 stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
-  %5 = bitcast %stack_t* %stack_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
-  %7 = load i64, i64* %stackid, align 8
-  store i64 %7, i64* %6, align 8
-  %8 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %7 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  %9 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  %10 = load i64, i64* %8, align 8
+  store i64 %10, i64* %9, align 8
+  %11 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  %12 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %13 = load i32, i32* %11, align 4
+  store i32 %13, i32* %12, align 4
+  %14 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %9 = trunc i64 %get_pid_tgid to i32
-  store i32 %9, i32* %8, align 4
-  %10 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
-  store i32 0, i32* %10, align 4
-  %11 = bitcast i64* %stackid to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %15 = trunc i64 %get_pid_tgid to i32
+  store i32 %15, i32* %14, align 4
+  %16 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 3
+  store i32 0, i32* %16, align 4
+  %17 = bitcast %stack_key* %stack_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
   store i64 0, i64* %"@x_key", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %stack_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %stack_t* %stack_args, i64 0)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %19 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
 
 lookup_stack_scratch_failure:                     ; preds = %entry
   br label %stack_scratch_failure
 
 lookup_stack_scratch_merge:                       ; preds = %entry
-  %14 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 1016, i1 false)
-  %15 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %15, i32 1016, i64 256)
-  %16 = icmp sge i32 %get_stack, 0
-  br i1 %16, label %get_stack_success, label %get_stack_fail
+  %20 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %20, i8 0, i64 1016, i1 false)
+  %21 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %21, i32 1016, i64 256)
+  %22 = icmp sge i32 %get_stack, 0
+  br i1 %22, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %17 = udiv i32 %get_stack, 8
-  %18 = trunc i32 %17 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %15, i8 %18, i64 1)
-  store i64 %murmur_hash_2, i64* %stackid, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.0"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  %23 = udiv i32 %get_stack, 8
+  %24 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 %23, i32* %24, align 4
+  %25 = trunc i32 %23 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %21, i8 %25, i64 1)
+  %26 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, i64* %26, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.0"* @stack_bpftrace_127, %stack_key* %stack_key, [127 x i64]* %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
 get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 }
 
@@ -185,8 +196,8 @@ attributes #1 = { alwaysinline }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
 attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!81}
-!llvm.module.flags = !{!84}
+!llvm.dbg.cu = !{!86}
+!llvm.module.flags = !{!89}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -209,14 +220,14 @@ attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 128, elements: !23)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 160, elements: !23)
 !22 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !23 = !{!24}
-!24 = !DISubrange(count: 16, lowerBound: 0)
+!24 = !DISubrange(count: 20, lowerBound: 0)
 !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
 !26 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
 !27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !28)
-!28 = !{!29, !34, !16, !39}
+!28 = !{!29, !34, !39, !44}
 !29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
 !30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
 !31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !32)
@@ -227,56 +238,61 @@ attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !37)
 !37 = !{!38}
 !38 = !DISubrange(count: 131072, lowerBound: 0)
-!39 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !40, size: 64, offset: 192)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !40, size: 64, offset: 128)
 !40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !42)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 96, elements: !42)
 !42 = !{!43}
-!43 = !DISubrange(count: 127, lowerBound: 0)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
-!46 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !47)
-!47 = !{!48, !53, !54, !39}
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !49, size: 64)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !51)
-!51 = !{!52}
-!52 = !DISubrange(count: 6, lowerBound: 0)
-!53 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
-!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
-!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
-!56 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
-!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !60)
-!60 = !{!61, !66}
-!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !64)
-!64 = !{!65}
-!65 = !DISubrange(count: 27, lowerBound: 0)
-!66 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !67, size: 64, offset: 64)
+!43 = !DISubrange(count: 12, lowerBound: 0)
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !45, size: 64, offset: 192)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 127, lowerBound: 0)
+!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
+!50 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !51, isLocal: false, isDefinition: true)
+!51 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !52)
+!52 = !{!53, !58, !59, !44}
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !54, size: 64)
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !56)
+!56 = !{!57}
+!57 = !DISubrange(count: 6, lowerBound: 0)
+!58 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!59 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !60, size: 64, offset: 128)
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!62 = !DIGlobalVariableExpression(var: !63, expr: !DIExpression())
+!63 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !64, isLocal: false, isDefinition: true)
+!64 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !65)
+!65 = !{!66, !71}
+!66 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !67, size: 64)
 !67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
-!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !69)
+!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !69)
 !69 = !{!70}
-!70 = !DISubrange(count: 262144, lowerBound: 0)
-!71 = !DIGlobalVariableExpression(var: !72, expr: !DIExpression())
-!72 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !73, isLocal: false, isDefinition: true)
-!73 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !74)
-!74 = !{!75, !53, !54, !80}
-!75 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !76, size: 64)
-!76 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !77, size: 64)
-!77 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !78)
-!78 = !{!79}
-!79 = !DISubrange(count: 2, lowerBound: 0)
-!80 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!81 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !82, globals: !83)
-!82 = !{}
-!83 = !{!0, !25, !44, !57, !71}
-!84 = !{i32 2, !"Debug Info Version", i32 3}
-!85 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !86, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !81, retainedNodes: !89)
-!86 = !DISubroutineType(types: !87)
-!87 = !{!18, !88}
-!88 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!89 = !{!90, !91}
-!90 = !DILocalVariable(name: "var0", scope: !85, file: !2, type: !18)
-!91 = !DILocalVariable(name: "var1", arg: 1, scope: !85, file: !2, type: !88)
+!70 = !DISubrange(count: 27, lowerBound: 0)
+!71 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !72, size: 64, offset: 64)
+!72 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !73, size: 64)
+!73 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !74)
+!74 = !{!75}
+!75 = !DISubrange(count: 262144, lowerBound: 0)
+!76 = !DIGlobalVariableExpression(var: !77, expr: !DIExpression())
+!77 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !78, isLocal: false, isDefinition: true)
+!78 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !79)
+!79 = !{!80, !58, !59, !85}
+!80 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !81, size: 64)
+!81 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !82, size: 64)
+!82 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !83)
+!83 = !{!84}
+!84 = !DISubrange(count: 2, lowerBound: 0)
+!85 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!86 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !87, globals: !88)
+!87 = !{}
+!88 = !{!0, !25, !49, !62, !76}
+!89 = !{i32 2, !"Debug Info Version", i32 3}
+!90 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !91, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !86, retainedNodes: !94)
+!91 = !DISubroutineType(types: !92)
+!92 = !{!18, !93}
+!93 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!94 = !{!95, !96}
+!95 = !DILocalVariable(name: "var0", scope: !90, file: !2, type: !18)
+!96 = !DILocalVariable(name: "var1", arg: 1, scope: !90, file: !2, type: !93)

--- a/tests/codegen/llvm/call_kstack.ll
+++ b/tests/codegen/llvm/call_kstack.ll
@@ -12,67 +12,64 @@ target triple = "bpf-pc-linux"
 %"struct map_t.5" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.6" = type { i8*, i8* }
 %"struct map_t.7" = type { i8*, i8*, i8*, i8* }
+%stack_key = type { i64, i32 }
 
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@AT_z = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !22
-@stack_perf_127 = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !24
-@stack_bpftrace_6 = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !43
-@stack_bpftrace_127 = dso_local global %"struct map_t.4" zeroinitializer, section ".maps", !dbg !52
-@stack_scratch = dso_local global %"struct map_t.5" zeroinitializer, section ".maps", !dbg !54
-@ringbuf = dso_local global %"struct map_t.6" zeroinitializer, section ".maps", !dbg !65
-@ringbuf_loss_counter = dso_local global %"struct map_t.7" zeroinitializer, section ".maps", !dbg !79
+@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
+@AT_z = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !27
+@stack_perf_127 = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !29
+@stack_bpftrace_6 = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !49
+@stack_bpftrace_127 = dso_local global %"struct map_t.4" zeroinitializer, section ".maps", !dbg !58
+@stack_scratch = dso_local global %"struct map_t.5" zeroinitializer, section ".maps", !dbg !60
+@ringbuf = dso_local global %"struct map_t.6" zeroinitializer, section ".maps", !dbg !71
+@ringbuf_loss_counter = dso_local global %"struct map_t.7" zeroinitializer, section ".maps", !dbg !85
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !92 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !99 {
 entry:
-  %"@z_val" = alloca i64, align 8
   %"@z_key" = alloca i64, align 8
   %lookup_stack_scratch_key19 = alloca i32, align 4
-  %stackid16 = alloca i64, align 8
-  %"@y_val" = alloca i64, align 8
+  %stack_key16 = alloca %stack_key, align 8
   %"@y_key" = alloca i64, align 8
   %lookup_stack_scratch_key5 = alloca i32, align 4
-  %stackid2 = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %stack_key2 = alloca %stack_key, align 8
   %"@x_key" = alloca i64, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stackid = alloca i64, align 8
-  %1 = bitcast i64* %stackid to i8*
+  %stack_key = alloca %stack_key, align 8
+  %1 = bitcast %stack_key* %stack_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %2 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 0, i64* %2, align 8
+  %3 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 0, i32* %3, align 4
+  %4 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i32 0, i32* %lookup_stack_scratch_key, align 4
   %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key)
-  %3 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %lookup_stack_scratch_cond = icmp ne i8* %4, null
+  %5 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %6, null
   br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
 
 stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
-  %5 = load i64, i64* %stackid, align 8
-  %6 = bitcast i64* %stackid to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@x_key", align 8
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 %5, i64* %"@x_val", align 8
-  %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %stackid2 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %stack_key*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %stack_key* %stack_key, i64 0)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast %stack_key* %stack_key2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
+  store i64 0, i64* %10, align 8
+  %11 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
+  store i32 0, i32* %11, align 4
   %12 = bitcast i32* %lookup_stack_scratch_key5 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i32 0, i32* %lookup_stack_scratch_key5, align 4
@@ -96,37 +93,34 @@ lookup_stack_scratch_merge:                       ; preds = %entry
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
   %18 = udiv i32 %get_stack, 8
-  %19 = trunc i32 %18 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %16, i8 %19, i64 1)
-  store i64 %murmur_hash_2, i64* %stackid, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.4"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.4"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  %19 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 %18, i32* %19, align 4
+  %20 = trunc i32 %18 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %16, i8 %20, i64 1)
+  %21 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, i64* %21, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.4"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.4"* @stack_bpftrace_127, %stack_key* %stack_key, [127 x i64]* %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
 get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 
 stack_scratch_failure3:                           ; preds = %lookup_stack_scratch_failure7
-  store i64 0, i64* %stackid2, align 8
   br label %merge_block4
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
-  %20 = load i64, i64* %stackid2, align 8
-  %21 = bitcast i64* %stackid2 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   %22 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
   store i64 0, i64* %"@y_key", align 8
-  %23 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
-  store i64 %20, i64* %"@y_val", align 8
-  %update_elem15 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, i64*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %24 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
-  %25 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
-  %26 = bitcast i64* %stackid16 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %update_elem15 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, %stack_key*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", %stack_key* %stack_key2, i64 0)
+  %23 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  %24 = bitcast %stack_key* %stack_key16 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
+  %25 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 0
+  store i64 0, i64* %25, align 8
+  %26 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 1
+  store i32 0, i32* %26, align 4
   %27 = bitcast i32* %lookup_stack_scratch_key19 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
   store i32 0, i32* %lookup_stack_scratch_key19, align 4
@@ -150,58 +144,53 @@ lookup_stack_scratch_merge8:                      ; preds = %merge_block
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
   %33 = udiv i32 %get_stack12, 8
-  %34 = trunc i32 %33 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(i8* %31, i8 %34, i64 1)
-  store i64 %murmur_hash_213, i64* %stackid2, align 8
-  %update_elem14 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.3"*, i64*, [6 x i64]*, i64)*)(%"struct map_t.3"* @stack_bpftrace_6, i64* %stackid2, [6 x i64]* %lookup_stack_scratch_map6, i64 0)
+  %34 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
+  store i32 %33, i32* %34, align 4
+  %35 = trunc i32 %33 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(i8* %31, i8 %35, i64 1)
+  %36 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, i64* %36, align 8
+  %update_elem14 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.3"*, %stack_key*, [6 x i64]*, i64)*)(%"struct map_t.3"* @stack_bpftrace_6, %stack_key* %stack_key2, [6 x i64]* %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
 get_stack_fail11:                                 ; preds = %lookup_stack_scratch_merge8
-  store i64 0, i64* %stackid2, align 8
   br label %merge_block4
 
 stack_scratch_failure17:                          ; preds = %lookup_stack_scratch_failure21
-  store i64 0, i64* %stackid16, align 8
   br label %merge_block18
 
 merge_block18:                                    ; preds = %stack_scratch_failure17, %get_stack_success24, %get_stack_fail25
-  %35 = load i64, i64* %stackid16, align 8
-  %36 = bitcast i64* %stackid16 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
   %37 = bitcast i64* %"@z_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
   store i64 0, i64* %"@z_key", align 8
-  %38 = bitcast i64* %"@z_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %38)
-  store i64 %35, i64* %"@z_val", align 8
-  %update_elem29 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, i64*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", i64* %"@z_val", i64 0)
-  %39 = bitcast i64* %"@z_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %39)
-  %40 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
+  %update_elem29 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, %stack_key*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", %stack_key* %stack_key16, i64 0)
+  %38 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %38)
   ret i64 0
 
 lookup_stack_scratch_failure21:                   ; preds = %merge_block4
   br label %stack_scratch_failure17
 
 lookup_stack_scratch_merge22:                     ; preds = %merge_block4
-  %41 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %41, i8 0, i64 1016, i1 false)
-  %42 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
-  %get_stack26 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %42, i32 1016, i64 0)
-  %43 = icmp sge i32 %get_stack26, 0
-  br i1 %43, label %get_stack_success24, label %get_stack_fail25
+  %39 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %39, i8 0, i64 1016, i1 false)
+  %40 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
+  %get_stack26 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %40, i32 1016, i64 0)
+  %41 = icmp sge i32 %get_stack26, 0
+  br i1 %41, label %get_stack_success24, label %get_stack_fail25
 
 get_stack_success24:                              ; preds = %lookup_stack_scratch_merge22
-  %44 = udiv i32 %get_stack26, 8
-  %45 = trunc i32 %44 to i8
-  %murmur_hash_227 = call i64 @murmur_hash_2(i8* %42, i8 %45, i64 1)
-  store i64 %murmur_hash_227, i64* %stackid16, align 8
-  %update_elem28 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.2"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.2"* @stack_perf_127, i64* %stackid16, [127 x i64]* %lookup_stack_scratch_map20, i64 0)
+  %42 = udiv i32 %get_stack26, 8
+  %43 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 1
+  store i32 %42, i32* %43, align 4
+  %44 = trunc i32 %42 to i8
+  %murmur_hash_227 = call i64 @murmur_hash_2(i8* %40, i8 %44, i64 1)
+  %45 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 0
+  store i64 %murmur_hash_227, i64* %45, align 8
+  %update_elem28 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.2"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.2"* @stack_perf_127, %stack_key* %stack_key16, [127 x i64]* %lookup_stack_scratch_map20, i64 0)
   br label %merge_block18
 
 get_stack_fail25:                                 ; preds = %lookup_stack_scratch_merge22
-  store i64 0, i64* %stackid16, align 8
   br label %merge_block18
 }
 
@@ -303,8 +292,8 @@ attributes #1 = { alwaysinline }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
 attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!88}
-!llvm.module.flags = !{!91}
+!llvm.dbg.cu = !{!95}
+!llvm.module.flags = !{!98}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -325,84 +314,90 @@ attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_z", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
-!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "stack_perf_127", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !27)
-!27 = !{!28, !33, !16, !38}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 9, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 96, elements: !23)
+!22 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!23 = !{!24}
+!24 = !DISubrange(count: 12, lowerBound: 0)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "AT_z", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
+!30 = distinct !DIGlobalVariable(name: "stack_perf_127", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
+!31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !32)
+!32 = !{!33, !38, !43, !44}
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !34, size: 64)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !36)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !36)
 !36 = !{!37}
-!37 = !DISubrange(count: 131072, lowerBound: 0)
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !39, size: 64, offset: 192)
+!37 = !DISubrange(count: 9, lowerBound: 0)
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !39, size: 64, offset: 64)
 !39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !41)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !41)
 !41 = !{!42}
-!42 = !DISubrange(count: 127, lowerBound: 0)
-!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
-!44 = distinct !DIGlobalVariable(name: "stack_bpftrace_6", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
-!45 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !46)
-!46 = !{!28, !33, !16, !47}
-!47 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !48, size: 64, offset: 192)
-!48 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !49, size: 64)
-!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 384, elements: !50)
-!50 = !{!51}
-!51 = !DISubrange(count: 6, lowerBound: 0)
-!52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
-!53 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
-!55 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !56, isLocal: false, isDefinition: true)
-!56 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !57)
-!57 = !{!58, !61, !62, !38}
-!58 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !59, size: 64)
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
-!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !50)
-!61 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
-!62 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !63, size: 64, offset: 128)
-!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
-!64 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!65 = !DIGlobalVariableExpression(var: !66, expr: !DIExpression())
-!66 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !67, isLocal: false, isDefinition: true)
-!67 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !68)
-!68 = !{!69, !74}
-!69 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !70, size: 64)
-!70 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !71, size: 64)
-!71 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !72)
-!72 = !{!73}
-!73 = !DISubrange(count: 27, lowerBound: 0)
-!74 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !75, size: 64, offset: 64)
-!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !76, size: 64)
-!76 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !77)
-!77 = !{!78}
-!78 = !DISubrange(count: 262144, lowerBound: 0)
-!79 = !DIGlobalVariableExpression(var: !80, expr: !DIExpression())
-!80 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !81, isLocal: false, isDefinition: true)
-!81 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !82)
-!82 = !{!83, !61, !62, !19}
-!83 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !84, size: 64)
-!84 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !85, size: 64)
-!85 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !86)
-!86 = !{!87}
-!87 = !DISubrange(count: 2, lowerBound: 0)
-!88 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !89, globals: !90)
-!89 = !{}
-!90 = !{!0, !20, !22, !24, !43, !52, !54, !65, !79}
-!91 = !{i32 2, !"Debug Info Version", i32 3}
-!92 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !93, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !88, retainedNodes: !97)
-!93 = !DISubroutineType(types: !94)
-!94 = !{!18, !95}
-!95 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !96, size: 64)
-!96 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!97 = !{!98, !99}
-!98 = !DILocalVariable(name: "var0", scope: !92, file: !2, type: !18)
-!99 = !DILocalVariable(name: "var1", arg: 1, scope: !92, file: !2, type: !95)
+!42 = !DISubrange(count: 131072, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !20, size: 64, offset: 128)
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !45, size: 64, offset: 192)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 127, lowerBound: 0)
+!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
+!50 = distinct !DIGlobalVariable(name: "stack_bpftrace_6", linkageName: "global", scope: !2, file: !2, type: !51, isLocal: false, isDefinition: true)
+!51 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !52)
+!52 = !{!33, !38, !43, !53}
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !54, size: 64, offset: 192)
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 384, elements: !56)
+!56 = !{!57}
+!57 = !DISubrange(count: 6, lowerBound: 0)
+!58 = !DIGlobalVariableExpression(var: !59, expr: !DIExpression())
+!59 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
+!60 = !DIGlobalVariableExpression(var: !61, expr: !DIExpression())
+!61 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !62, isLocal: false, isDefinition: true)
+!62 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !63)
+!63 = !{!64, !67, !68, !44}
+!64 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !65, size: 64)
+!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
+!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !56)
+!67 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!68 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !69, size: 64, offset: 128)
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !70, size: 64)
+!70 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!71 = !DIGlobalVariableExpression(var: !72, expr: !DIExpression())
+!72 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !73, isLocal: false, isDefinition: true)
+!73 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !74)
+!74 = !{!75, !80}
+!75 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !76, size: 64)
+!76 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !77, size: 64)
+!77 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !78)
+!78 = !{!79}
+!79 = !DISubrange(count: 27, lowerBound: 0)
+!80 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !81, size: 64, offset: 64)
+!81 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !82, size: 64)
+!82 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !83)
+!83 = !{!84}
+!84 = !DISubrange(count: 262144, lowerBound: 0)
+!85 = !DIGlobalVariableExpression(var: !86, expr: !DIExpression())
+!86 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !87, isLocal: false, isDefinition: true)
+!87 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !88)
+!88 = !{!89, !67, !68, !94}
+!89 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !90, size: 64)
+!90 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !91, size: 64)
+!91 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !92)
+!92 = !{!93}
+!93 = !DISubrange(count: 2, lowerBound: 0)
+!94 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!95 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !96, globals: !97)
+!96 = !{}
+!97 = !{!0, !25, !27, !29, !49, !58, !60, !71, !85}
+!98 = !{i32 2, !"Debug Info Version", i32 3}
+!99 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !100, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !95, retainedNodes: !103)
+!100 = !DISubroutineType(types: !101)
+!101 = !{!18, !102}
+!102 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!103 = !{!104, !105}
+!104 = !DILocalVariable(name: "var0", scope: !99, file: !2, type: !18)
+!105 = !DILocalVariable(name: "var1", arg: 1, scope: !99, file: !2, type: !102)

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -12,212 +12,243 @@ target triple = "bpf-pc-linux"
 %"struct map_t.5" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.6" = type { i8*, i8* }
 %"struct map_t.7" = type { i8*, i8*, i8*, i8* }
-%stack_t = type { i64, i32, i32 }
+%stack_t = type { i64, i32, i32, i32 }
+%stack_key = type { i64, i32 }
 
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
 @AT_z = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !27
 @stack_perf_127 = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !29
-@stack_bpftrace_6 = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !48
-@stack_bpftrace_127 = dso_local global %"struct map_t.4" zeroinitializer, section ".maps", !dbg !57
-@stack_scratch = dso_local global %"struct map_t.5" zeroinitializer, section ".maps", !dbg !59
-@ringbuf = dso_local global %"struct map_t.6" zeroinitializer, section ".maps", !dbg !70
-@ringbuf_loss_counter = dso_local global %"struct map_t.7" zeroinitializer, section ".maps", !dbg !84
+@stack_bpftrace_6 = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !53
+@stack_bpftrace_127 = dso_local global %"struct map_t.4" zeroinitializer, section ".maps", !dbg !62
+@stack_scratch = dso_local global %"struct map_t.5" zeroinitializer, section ".maps", !dbg !64
+@ringbuf = dso_local global %"struct map_t.6" zeroinitializer, section ".maps", !dbg !75
+@ringbuf_loss_counter = dso_local global %"struct map_t.7" zeroinitializer, section ".maps", !dbg !89
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !98 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !103 {
 entry:
   %"@z_key" = alloca i64, align 8
   %stack_args31 = alloca %stack_t, align 8
   %lookup_stack_scratch_key21 = alloca i32, align 4
-  %stackid18 = alloca i64, align 8
+  %stack_key18 = alloca %stack_key, align 8
   %"@y_key" = alloca i64, align 8
   %stack_args15 = alloca %stack_t, align 8
   %lookup_stack_scratch_key5 = alloca i32, align 4
-  %stackid2 = alloca i64, align 8
+  %stack_key2 = alloca %stack_key, align 8
   %"@x_key" = alloca i64, align 8
   %stack_args = alloca %stack_t, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stackid = alloca i64, align 8
-  %1 = bitcast i64* %stackid to i8*
+  %stack_key = alloca %stack_key, align 8
+  %1 = bitcast %stack_key* %stack_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %2 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 0, i64* %2, align 8
+  %3 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 0, i32* %3, align 4
+  %4 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i32 0, i32* %lookup_stack_scratch_key, align 4
   %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key)
-  %3 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %lookup_stack_scratch_cond = icmp ne i8* %4, null
+  %5 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %6, null
   br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
 
 stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
-  %5 = bitcast %stack_t* %stack_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
-  %7 = load i64, i64* %stackid, align 8
-  store i64 %7, i64* %6, align 8
-  %8 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %7 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  %9 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  %10 = load i64, i64* %8, align 8
+  store i64 %10, i64* %9, align 8
+  %11 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  %12 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %13 = load i32, i32* %11, align 4
+  store i32 %13, i32* %12, align 4
+  %14 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %9 = trunc i64 %get_pid_tgid to i32
-  store i32 %9, i32* %8, align 4
-  %10 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
-  store i32 0, i32* %10, align 4
-  %11 = bitcast i64* %stackid to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %15 = trunc i64 %get_pid_tgid to i32
+  store i32 %15, i32* %14, align 4
+  %16 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 3
+  store i32 0, i32* %16, align 4
+  %17 = bitcast %stack_key* %stack_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
   store i64 0, i64* %"@x_key", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %stack_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %stack_t* %stack_args, i64 0)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %stackid2 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i32* %lookup_stack_scratch_key5 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %19 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = bitcast %stack_key* %stack_key2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  %21 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
+  store i64 0, i64* %21, align 8
+  %22 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
+  store i32 0, i32* %22, align 4
+  %23 = bitcast i32* %lookup_stack_scratch_key5 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
   store i32 0, i32* %lookup_stack_scratch_key5, align 4
   %lookup_stack_scratch_map6 = call [6 x i64]* inttoptr (i64 1 to [6 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key5)
-  %16 = bitcast i32* %lookup_stack_scratch_key5 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
-  %lookup_stack_scratch_cond9 = icmp ne i8* %17, null
+  %24 = bitcast i32* %lookup_stack_scratch_key5 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  %lookup_stack_scratch_cond9 = icmp ne i8* %25, null
   br i1 %lookup_stack_scratch_cond9, label %lookup_stack_scratch_merge8, label %lookup_stack_scratch_failure7
 
 lookup_stack_scratch_failure:                     ; preds = %entry
   br label %stack_scratch_failure
 
 lookup_stack_scratch_merge:                       ; preds = %entry
-  %18 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 1016, i1 false)
-  %19 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %19, i32 1016, i64 256)
-  %20 = icmp sge i32 %get_stack, 0
-  br i1 %20, label %get_stack_success, label %get_stack_fail
+  %26 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %26, i8 0, i64 1016, i1 false)
+  %27 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %27, i32 1016, i64 256)
+  %28 = icmp sge i32 %get_stack, 0
+  br i1 %28, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %21 = udiv i32 %get_stack, 8
-  %22 = trunc i32 %21 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %19, i8 %22, i64 1)
-  store i64 %murmur_hash_2, i64* %stackid, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.4"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.4"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  %29 = udiv i32 %get_stack, 8
+  %30 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 %29, i32* %30, align 4
+  %31 = trunc i32 %29 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %27, i8 %31, i64 1)
+  %32 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, i64* %32, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.4"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.4"* @stack_bpftrace_127, %stack_key* %stack_key, [127 x i64]* %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
 get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 
 stack_scratch_failure3:                           ; preds = %lookup_stack_scratch_failure7
-  store i64 0, i64* %stackid2, align 8
   br label %merge_block4
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
-  %23 = bitcast %stack_t* %stack_args15 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
-  %24 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 0
-  %25 = load i64, i64* %stackid2, align 8
-  store i64 %25, i64* %24, align 8
-  %26 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 1
+  %33 = bitcast %stack_t* %stack_args15 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %34 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
+  %35 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 0
+  %36 = load i64, i64* %34, align 8
+  store i64 %36, i64* %35, align 8
+  %37 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
+  %38 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 1
+  %39 = load i32, i32* %37, align 4
+  store i32 %39, i32* %38, align 4
+  %40 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 2
   %get_pid_tgid16 = call i64 inttoptr (i64 14 to i64 ()*)()
-  %27 = trunc i64 %get_pid_tgid16 to i32
-  store i32 %27, i32* %26, align 4
-  %28 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 2
-  store i32 0, i32* %28, align 4
-  %29 = bitcast i64* %stackid2 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
-  %30 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %30)
+  %41 = trunc i64 %get_pid_tgid16 to i32
+  store i32 %41, i32* %40, align 4
+  %42 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 3
+  store i32 0, i32* %42, align 4
+  %43 = bitcast %stack_key* %stack_key2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
+  %44 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %44)
   store i64 0, i64* %"@y_key", align 8
   %update_elem17 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, %stack_t*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", %stack_t* %stack_args15, i64 0)
-  %31 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
-  %32 = bitcast i64* %stackid18 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %32)
-  %33 = bitcast i32* %lookup_stack_scratch_key21 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %45 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %45)
+  %46 = bitcast %stack_key* %stack_key18 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %46)
+  %47 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 0
+  store i64 0, i64* %47, align 8
+  %48 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 1
+  store i32 0, i32* %48, align 4
+  %49 = bitcast i32* %lookup_stack_scratch_key21 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %49)
   store i32 0, i32* %lookup_stack_scratch_key21, align 4
   %lookup_stack_scratch_map22 = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key21)
-  %34 = bitcast i32* %lookup_stack_scratch_key21 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
-  %35 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
-  %lookup_stack_scratch_cond25 = icmp ne i8* %35, null
+  %50 = bitcast i32* %lookup_stack_scratch_key21 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %50)
+  %51 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
+  %lookup_stack_scratch_cond25 = icmp ne i8* %51, null
   br i1 %lookup_stack_scratch_cond25, label %lookup_stack_scratch_merge24, label %lookup_stack_scratch_failure23
 
 lookup_stack_scratch_failure7:                    ; preds = %merge_block
   br label %stack_scratch_failure3
 
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
-  %36 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %36, i8 0, i64 48, i1 false)
-  %37 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
-  %get_stack12 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %37, i32 48, i64 256)
-  %38 = icmp sge i32 %get_stack12, 0
-  br i1 %38, label %get_stack_success10, label %get_stack_fail11
+  %52 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %52, i8 0, i64 48, i1 false)
+  %53 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  %get_stack12 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %53, i32 48, i64 256)
+  %54 = icmp sge i32 %get_stack12, 0
+  br i1 %54, label %get_stack_success10, label %get_stack_fail11
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
-  %39 = udiv i32 %get_stack12, 8
-  %40 = trunc i32 %39 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(i8* %37, i8 %40, i64 1)
-  store i64 %murmur_hash_213, i64* %stackid2, align 8
-  %update_elem14 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.3"*, i64*, [6 x i64]*, i64)*)(%"struct map_t.3"* @stack_bpftrace_6, i64* %stackid2, [6 x i64]* %lookup_stack_scratch_map6, i64 0)
+  %55 = udiv i32 %get_stack12, 8
+  %56 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
+  store i32 %55, i32* %56, align 4
+  %57 = trunc i32 %55 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(i8* %53, i8 %57, i64 1)
+  %58 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, i64* %58, align 8
+  %update_elem14 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.3"*, %stack_key*, [6 x i64]*, i64)*)(%"struct map_t.3"* @stack_bpftrace_6, %stack_key* %stack_key2, [6 x i64]* %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
 get_stack_fail11:                                 ; preds = %lookup_stack_scratch_merge8
-  store i64 0, i64* %stackid2, align 8
   br label %merge_block4
 
 stack_scratch_failure19:                          ; preds = %lookup_stack_scratch_failure23
-  store i64 0, i64* %stackid18, align 8
   br label %merge_block20
 
 merge_block20:                                    ; preds = %stack_scratch_failure19, %get_stack_success26, %get_stack_fail27
-  %41 = bitcast %stack_t* %stack_args31 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %41)
-  %42 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 0
-  %43 = load i64, i64* %stackid18, align 8
-  store i64 %43, i64* %42, align 8
-  %44 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 1
+  %59 = bitcast %stack_t* %stack_args31 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %59)
+  %60 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 0
+  %61 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 0
+  %62 = load i64, i64* %60, align 8
+  store i64 %62, i64* %61, align 8
+  %63 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 1
+  %64 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 1
+  %65 = load i32, i32* %63, align 4
+  store i32 %65, i32* %64, align 4
+  %66 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 2
   %get_pid_tgid32 = call i64 inttoptr (i64 14 to i64 ()*)()
-  %45 = trunc i64 %get_pid_tgid32 to i32
-  store i32 %45, i32* %44, align 4
-  %46 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 2
-  store i32 0, i32* %46, align 4
-  %47 = bitcast i64* %stackid18 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %47)
-  %48 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %48)
+  %67 = trunc i64 %get_pid_tgid32 to i32
+  store i32 %67, i32* %66, align 4
+  %68 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 3
+  store i32 0, i32* %68, align 4
+  %69 = bitcast %stack_key* %stack_key18 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %69)
+  %70 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %70)
   store i64 0, i64* %"@z_key", align 8
   %update_elem33 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, %stack_t*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", %stack_t* %stack_args31, i64 0)
-  %49 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
+  %71 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %71)
   ret i64 0
 
 lookup_stack_scratch_failure23:                   ; preds = %merge_block4
   br label %stack_scratch_failure19
 
 lookup_stack_scratch_merge24:                     ; preds = %merge_block4
-  %50 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %50, i8 0, i64 1016, i1 false)
-  %51 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
-  %get_stack28 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %51, i32 1016, i64 256)
-  %52 = icmp sge i32 %get_stack28, 0
-  br i1 %52, label %get_stack_success26, label %get_stack_fail27
+  %72 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %72, i8 0, i64 1016, i1 false)
+  %73 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
+  %get_stack28 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %73, i32 1016, i64 256)
+  %74 = icmp sge i32 %get_stack28, 0
+  br i1 %74, label %get_stack_success26, label %get_stack_fail27
 
 get_stack_success26:                              ; preds = %lookup_stack_scratch_merge24
-  %53 = udiv i32 %get_stack28, 8
-  %54 = trunc i32 %53 to i8
-  %murmur_hash_229 = call i64 @murmur_hash_2(i8* %51, i8 %54, i64 1)
-  store i64 %murmur_hash_229, i64* %stackid18, align 8
-  %update_elem30 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.2"*, i64*, [127 x i64]*, i64)*)(%"struct map_t.2"* @stack_perf_127, i64* %stackid18, [127 x i64]* %lookup_stack_scratch_map22, i64 0)
+  %75 = udiv i32 %get_stack28, 8
+  %76 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 1
+  store i32 %75, i32* %76, align 4
+  %77 = trunc i32 %75 to i8
+  %murmur_hash_229 = call i64 @murmur_hash_2(i8* %73, i8 %77, i64 1)
+  %78 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 0
+  store i64 %murmur_hash_229, i64* %78, align 8
+  %update_elem30 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.2"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.2"* @stack_perf_127, %stack_key* %stack_key18, [127 x i64]* %lookup_stack_scratch_map22, i64 0)
   br label %merge_block20
 
 get_stack_fail27:                                 ; preds = %lookup_stack_scratch_merge24
-  store i64 0, i64* %stackid18, align 8
   br label %merge_block20
 }
 
@@ -319,8 +350,8 @@ attributes #1 = { alwaysinline }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
 attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!94}
-!llvm.module.flags = !{!97}
+!llvm.dbg.cu = !{!99}
+!llvm.module.flags = !{!102}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -343,10 +374,10 @@ attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 128, elements: !23)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 160, elements: !23)
 !22 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !23 = !{!24}
-!24 = !DISubrange(count: 16, lowerBound: 0)
+!24 = !DISubrange(count: 20, lowerBound: 0)
 !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
 !26 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
 !27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
@@ -354,7 +385,7 @@ attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
 !30 = distinct !DIGlobalVariable(name: "stack_perf_127", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
 !31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !32)
-!32 = !{!33, !38, !16, !43}
+!32 = !{!33, !38, !43, !48}
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !34, size: 64)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !36)
@@ -365,65 +396,70 @@ attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !41)
 !41 = !{!42}
 !42 = !DISubrange(count: 131072, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !44, size: 64, offset: 192)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !44, size: 64, offset: 128)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !46)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 96, elements: !46)
 !46 = !{!47}
-!47 = !DISubrange(count: 127, lowerBound: 0)
-!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "stack_bpftrace_6", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
-!50 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !51)
-!51 = !{!33, !38, !16, !52}
-!52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !53, size: 64, offset: 192)
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 384, elements: !55)
-!55 = !{!56}
-!56 = !DISubrange(count: 6, lowerBound: 0)
-!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
-!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
-!60 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
-!61 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !62)
-!62 = !{!63, !66, !67, !43}
-!63 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !64, size: 64)
-!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
-!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !55)
-!66 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
-!67 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !68, size: 64, offset: 128)
-!68 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
-!69 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!70 = !DIGlobalVariableExpression(var: !71, expr: !DIExpression())
-!71 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !72, isLocal: false, isDefinition: true)
-!72 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !73)
-!73 = !{!74, !79}
-!74 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !75, size: 64)
-!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !76, size: 64)
-!76 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !77)
-!77 = !{!78}
-!78 = !DISubrange(count: 27, lowerBound: 0)
-!79 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !80, size: 64, offset: 64)
+!47 = !DISubrange(count: 12, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !49, size: 64, offset: 192)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 127, lowerBound: 0)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "stack_bpftrace_6", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !56)
+!56 = !{!33, !38, !43, !57}
+!57 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !58, size: 64, offset: 192)
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 384, elements: !60)
+!60 = !{!61}
+!61 = !DISubrange(count: 6, lowerBound: 0)
+!62 = !DIGlobalVariableExpression(var: !63, expr: !DIExpression())
+!63 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
+!64 = !DIGlobalVariableExpression(var: !65, expr: !DIExpression())
+!65 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !66, isLocal: false, isDefinition: true)
+!66 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !67)
+!67 = !{!68, !71, !72, !48}
+!68 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !69, size: 64)
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !70, size: 64)
+!70 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !60)
+!71 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!72 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !73, size: 64, offset: 128)
+!73 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !74, size: 64)
+!74 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!75 = !DIGlobalVariableExpression(var: !76, expr: !DIExpression())
+!76 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !77, isLocal: false, isDefinition: true)
+!77 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !78)
+!78 = !{!79, !84}
+!79 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !80, size: 64)
 !80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !81, size: 64)
-!81 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !82)
+!81 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !82)
 !82 = !{!83}
-!83 = !DISubrange(count: 262144, lowerBound: 0)
-!84 = !DIGlobalVariableExpression(var: !85, expr: !DIExpression())
-!85 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !86, isLocal: false, isDefinition: true)
-!86 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !87)
-!87 = !{!88, !66, !67, !93}
-!88 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !89, size: 64)
-!89 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !90, size: 64)
-!90 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !91)
-!91 = !{!92}
-!92 = !DISubrange(count: 2, lowerBound: 0)
-!93 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!94 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !95, globals: !96)
-!95 = !{}
-!96 = !{!0, !25, !27, !29, !48, !57, !59, !70, !84}
-!97 = !{i32 2, !"Debug Info Version", i32 3}
-!98 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !99, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !94, retainedNodes: !102)
-!99 = !DISubroutineType(types: !100)
-!100 = !{!18, !101}
-!101 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!102 = !{!103, !104}
-!103 = !DILocalVariable(name: "var0", scope: !98, file: !2, type: !18)
-!104 = !DILocalVariable(name: "var1", arg: 1, scope: !98, file: !2, type: !101)
+!83 = !DISubrange(count: 27, lowerBound: 0)
+!84 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !85, size: 64, offset: 64)
+!85 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !86, size: 64)
+!86 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !87)
+!87 = !{!88}
+!88 = !DISubrange(count: 262144, lowerBound: 0)
+!89 = !DIGlobalVariableExpression(var: !90, expr: !DIExpression())
+!90 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !91, isLocal: false, isDefinition: true)
+!91 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !92)
+!92 = !{!93, !71, !72, !98}
+!93 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !94, size: 64)
+!94 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !95, size: 64)
+!95 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !96)
+!96 = !{!97}
+!97 = !DISubrange(count: 2, lowerBound: 0)
+!98 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!99 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !100, globals: !101)
+!100 = !{}
+!101 = !{!0, !25, !27, !29, !53, !62, !64, !75, !89}
+!102 = !{i32 2, !"Debug Info Version", i32 3}
+!103 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !104, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !99, retainedNodes: !107)
+!104 = !DISubroutineType(types: !105)
+!105 = !{!18, !106}
+!106 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!107 = !{!108, !109}
+!108 = !DILocalVariable(name: "var0", scope: !103, file: !2, type: !18)
+!109 = !DILocalVariable(name: "var1", arg: 1, scope: !103, file: !2, type: !106)

--- a/tests/codegen/llvm/struct_semicolon_1.ll
+++ b/tests/codegen/llvm/struct_semicolon_1.ll
@@ -7,65 +7,74 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.1" = type { i8*, i8* }
 %"struct map_t.2" = type { i8*, i8*, i8*, i8* }
-%stack_t = type { i64, i32, i32 }
-%printf_t = type { i64, [16 x i8] }
+%stack_t = type { i64, i32, i32, i32 }
+%stack_key = type { i64, i32 }
+%printf_t = type { i64, [20 x i8] }
 
 @stack_bpftrace_127 = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@stack_scratch = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !24
-@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !41
-@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !55
+@stack_scratch = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !28
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !45
+@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !59
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !69 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !74 {
 entry:
   %key = alloca i32, align 4
   %stack_args = alloca %stack_t, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stackid = alloca i64, align 8
+  %stack_key = alloca %stack_key, align 8
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 32, i1 false)
   %3 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
   store i64 0, i64* %3, align 8
-  %4 = bitcast i64* %stackid to i8*
+  %4 = bitcast %stack_key* %stack_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %5 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 0, i64* %5, align 8
+  %6 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 0, i32* %6, align 4
+  %7 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i32 0, i32* %lookup_stack_scratch_key, align 4
   %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.0"*, i32*)*)(%"struct map_t.0"* @stack_scratch, i32* %lookup_stack_scratch_key)
-  %6 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %lookup_stack_scratch_cond = icmp ne i8* %7, null
+  %8 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %9, null
   br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
 
 stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
-  %8 = bitcast %stack_t* %stack_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
-  %10 = load i64, i64* %stackid, align 8
-  store i64 %10, i64* %9, align 8
-  %11 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %10 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  %12 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  %13 = load i64, i64* %11, align 8
+  store i64 %13, i64* %12, align 8
+  %14 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  %15 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %16 = load i32, i32* %14, align 4
+  store i32 %16, i32* %15, align 4
+  %17 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %12 = trunc i64 %get_pid_tgid to i32
-  store i32 %12, i32* %11, align 4
-  %13 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
-  store i32 0, i32* %13, align 4
-  %14 = bitcast i64* %stackid to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  %16 = bitcast [16 x i8]* %15 to i8*
-  %17 = bitcast %stack_t* %stack_args to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %16, i8* align 1 %17, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.1"*, %printf_t*, i64, i64)*)(%"struct map_t.1"* @ringbuf, %printf_t* %printf_args, i64 24, i64 0)
+  %18 = trunc i64 %get_pid_tgid to i32
+  store i32 %18, i32* %17, align 4
+  %19 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 3
+  store i32 0, i32* %19, align 4
+  %20 = bitcast %stack_key* %stack_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  %22 = bitcast [20 x i8]* %21 to i8*
+  %23 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %22, i8* align 1 %23, i64 20, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.1"*, %printf_t*, i64, i64)*)(%"struct map_t.1"* @ringbuf, %printf_t* %printf_args, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -73,49 +82,51 @@ lookup_stack_scratch_failure:                     ; preds = %entry
   br label %stack_scratch_failure
 
 lookup_stack_scratch_merge:                       ; preds = %entry
-  %18 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 1016, i1 false)
-  %19 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %19, i32 1016, i64 256)
-  %20 = icmp sge i32 %get_stack, 0
-  br i1 %20, label %get_stack_success, label %get_stack_fail
+  %24 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %24, i8 0, i64 1016, i1 false)
+  %25 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %25, i32 1016, i64 256)
+  %26 = icmp sge i32 %get_stack, 0
+  br i1 %26, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %21 = udiv i32 %get_stack, 8
-  %22 = trunc i32 %21 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %19, i8 %22, i64 1)
-  store i64 %murmur_hash_2, i64* %stackid, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [127 x i64]*, i64)*)(%"struct map_t"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  %27 = udiv i32 %get_stack, 8
+  %28 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 %27, i32* %28, align 4
+  %29 = trunc i32 %27 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %25, i8 %29, i64 1)
+  %30 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, i64* %30, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t"* @stack_bpftrace_127, %stack_key* %stack_key, [127 x i64]* %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
 get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 
 event_loss_counter:                               ; preds = %merge_block
-  %23 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %31 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
   store i32 0, i32* %key, align 4
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.2"*, i32*)*)(%"struct map_t.2"* @ringbuf_loss_counter, i32* %key)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 counter_merge:                                    ; preds = %lookup_merge, %merge_block
-  %24 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %32 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %25 = bitcast i8* %lookup_elem to i64*
-  %26 = atomicrmw add i64* %25, i64 1 seq_cst
+  %33 = bitcast i8* %lookup_elem to i64*
+  %34 = atomicrmw add i64* %33, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %27 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
+  %35 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %35)
   br label %counter_merge
 }
 
@@ -220,14 +231,14 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 attributes #3 = { alwaysinline }
 
-!llvm.dbg.cu = !{!65}
-!llvm.module.flags = !{!68}
+!llvm.dbg.cu = !{!70}
+!llvm.module.flags = !{!73}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
 !2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
 !3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
-!4 = !{!5, !11, !16, !19}
+!4 = !{!5, !11, !16, !22}
 !5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
 !6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
 !7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !9)
@@ -241,62 +252,66 @@ attributes #3 = { alwaysinline }
 !15 = !DISubrange(count: 131072, lowerBound: 0)
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
-!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
-!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !22)
-!22 = !{!23}
-!23 = !DISubrange(count: 127, lowerBound: 0)
-!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !27)
-!27 = !{!28, !33, !38, !19}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 6, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 1, lowerBound: 0)
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !39, size: 64, offset: 128)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
-!42 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
-!43 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !44)
-!44 = !{!45, !50}
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !46, size: 64)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !48)
-!48 = !{!49}
-!49 = !DISubrange(count: 27, lowerBound: 0)
-!50 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !51, size: 64, offset: 64)
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !53)
-!53 = !{!54}
-!54 = !DISubrange(count: 262144, lowerBound: 0)
-!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
-!56 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !57, isLocal: false, isDefinition: true)
-!57 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !58)
-!58 = !{!59, !33, !38, !64}
-!59 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !60, size: 64)
-!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
-!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !62)
-!62 = !{!63}
-!63 = !DISubrange(count: 2, lowerBound: 0)
-!64 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!65 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !66, globals: !67)
-!66 = !{}
-!67 = !{!0, !24, !41, !55}
-!68 = !{i32 2, !"Debug Info Version", i32 3}
-!69 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !70, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !65, retainedNodes: !74)
-!70 = !DISubroutineType(types: !71)
-!71 = !{!18, !72}
-!72 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !73, size: 64)
-!73 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!74 = !{!75, !76}
-!75 = !DILocalVariable(name: "var0", scope: !69, file: !2, type: !18)
-!76 = !DILocalVariable(name: "var1", arg: 1, scope: !69, file: !2, type: !72)
+!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 96, elements: !20)
+!19 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!20 = !{!21}
+!21 = !DISubrange(count: 12, lowerBound: 0)
+!22 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 8128, elements: !26)
+!25 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!26 = !{!27}
+!27 = !DISubrange(count: 127, lowerBound: 0)
+!28 = !DIGlobalVariableExpression(var: !29, expr: !DIExpression())
+!29 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !30, isLocal: false, isDefinition: true)
+!30 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !31)
+!31 = !{!32, !37, !42, !22}
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !33, size: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 6, lowerBound: 0)
+!37 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !38, size: 64, offset: 64)
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !39, size: 64)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !40)
+!40 = !{!41}
+!41 = !DISubrange(count: 1, lowerBound: 0)
+!42 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !43, size: 64, offset: 128)
+!43 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !44, size: 64)
+!44 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
+!47 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !48)
+!48 = !{!49, !54}
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !50, size: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 27, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !55, size: 64, offset: 64)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !57)
+!57 = !{!58}
+!58 = !DISubrange(count: 262144, lowerBound: 0)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
+!61 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !62)
+!62 = !{!63, !37, !42, !68}
+!63 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !64, size: 64)
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !66)
+!66 = !{!67}
+!67 = !DISubrange(count: 2, lowerBound: 0)
+!68 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !69, size: 64, offset: 192)
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!70 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !71, globals: !72)
+!71 = !{}
+!72 = !{!0, !28, !45, !59}
+!73 = !{i32 2, !"Debug Info Version", i32 3}
+!74 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !75, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !70, retainedNodes: !78)
+!75 = !DISubroutineType(types: !76)
+!76 = !{!25, !77}
+!77 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!78 = !{!79, !80}
+!79 = !DILocalVariable(name: "var0", scope: !74, file: !2, type: !25)
+!80 = !DILocalVariable(name: "var1", arg: 1, scope: !74, file: !2, type: !77)

--- a/tests/codegen/llvm/struct_semicolon_2.ll
+++ b/tests/codegen/llvm/struct_semicolon_2.ll
@@ -7,65 +7,74 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.1" = type { i8*, i8* }
 %"struct map_t.2" = type { i8*, i8*, i8*, i8* }
-%stack_t = type { i64, i32, i32 }
-%printf_t = type { i64, [16 x i8] }
+%stack_t = type { i64, i32, i32, i32 }
+%stack_key = type { i64, i32 }
+%printf_t = type { i64, [20 x i8] }
 
 @stack_bpftrace_127 = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@stack_scratch = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !24
-@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !41
-@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !55
+@stack_scratch = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !28
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !45
+@ringbuf_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !59
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !69 {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" !dbg !74 {
 entry:
   %key = alloca i32, align 4
   %stack_args = alloca %stack_t, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stackid = alloca i64, align 8
+  %stack_key = alloca %stack_key, align 8
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 32, i1 false)
   %3 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
   store i64 0, i64* %3, align 8
-  %4 = bitcast i64* %stackid to i8*
+  %4 = bitcast %stack_key* %stack_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %5 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 0, i64* %5, align 8
+  %6 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 0, i32* %6, align 4
+  %7 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i32 0, i32* %lookup_stack_scratch_key, align 4
   %lookup_stack_scratch_map = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.0"*, i32*)*)(%"struct map_t.0"* @stack_scratch, i32* %lookup_stack_scratch_key)
-  %6 = bitcast i32* %lookup_stack_scratch_key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %lookup_stack_scratch_cond = icmp ne i8* %7, null
+  %8 = bitcast i32* %lookup_stack_scratch_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %lookup_stack_scratch_cond = icmp ne i8* %9, null
   br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
 
 stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
-  %8 = bitcast %stack_t* %stack_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
-  %10 = load i64, i64* %stackid, align 8
-  store i64 %10, i64* %9, align 8
-  %11 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %10 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  %12 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  %13 = load i64, i64* %11, align 8
+  store i64 %13, i64* %12, align 8
+  %14 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  %15 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
+  %16 = load i32, i32* %14, align 4
+  store i32 %16, i32* %15, align 4
+  %17 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %12 = trunc i64 %get_pid_tgid to i32
-  store i32 %12, i32* %11, align 4
-  %13 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
-  store i32 0, i32* %13, align 4
-  %14 = bitcast i64* %stackid to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  %16 = bitcast [16 x i8]* %15 to i8*
-  %17 = bitcast %stack_t* %stack_args to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %16, i8* align 1 %17, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.1"*, %printf_t*, i64, i64)*)(%"struct map_t.1"* @ringbuf, %printf_t* %printf_args, i64 24, i64 0)
+  %18 = trunc i64 %get_pid_tgid to i32
+  store i32 %18, i32* %17, align 4
+  %19 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 3
+  store i32 0, i32* %19, align 4
+  %20 = bitcast %stack_key* %stack_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  %22 = bitcast [20 x i8]* %21 to i8*
+  %23 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %22, i8* align 1 %23, i64 20, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.1"*, %printf_t*, i64, i64)*)(%"struct map_t.1"* @ringbuf, %printf_t* %printf_args, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -73,49 +82,51 @@ lookup_stack_scratch_failure:                     ; preds = %entry
   br label %stack_scratch_failure
 
 lookup_stack_scratch_merge:                       ; preds = %entry
-  %18 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 1016, i1 false)
-  %19 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %19, i32 1016, i64 256)
-  %20 = icmp sge i32 %get_stack, 0
-  br i1 %20, label %get_stack_success, label %get_stack_fail
+  %24 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %24, i8 0, i64 1016, i1 false)
+  %25 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %25, i32 1016, i64 256)
+  %26 = icmp sge i32 %get_stack, 0
+  br i1 %26, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %21 = udiv i32 %get_stack, 8
-  %22 = trunc i32 %21 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %19, i8 %22, i64 1)
-  store i64 %murmur_hash_2, i64* %stackid, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [127 x i64]*, i64)*)(%"struct map_t"* @stack_bpftrace_127, i64* %stackid, [127 x i64]* %lookup_stack_scratch_map, i64 0)
+  %27 = udiv i32 %get_stack, 8
+  %28 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 %27, i32* %28, align 4
+  %29 = trunc i32 %27 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %25, i8 %29, i64 1)
+  %30 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, i64* %30, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t"* @stack_bpftrace_127, %stack_key* %stack_key, [127 x i64]* %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
 get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
-  store i64 0, i64* %stackid, align 8
   br label %merge_block
 
 event_loss_counter:                               ; preds = %merge_block
-  %23 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %31 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
   store i32 0, i32* %key, align 4
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.2"*, i32*)*)(%"struct map_t.2"* @ringbuf_loss_counter, i32* %key)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 counter_merge:                                    ; preds = %lookup_merge, %merge_block
-  %24 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %32 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %25 = bitcast i8* %lookup_elem to i64*
-  %26 = atomicrmw add i64* %25, i64 1 seq_cst
+  %33 = bitcast i8* %lookup_elem to i64*
+  %34 = atomicrmw add i64* %33, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %27 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
+  %35 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %35)
   br label %counter_merge
 }
 
@@ -220,14 +231,14 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 attributes #3 = { alwaysinline }
 
-!llvm.dbg.cu = !{!65}
-!llvm.module.flags = !{!68}
+!llvm.dbg.cu = !{!70}
+!llvm.module.flags = !{!73}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
 !2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
 !3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
-!4 = !{!5, !11, !16, !19}
+!4 = !{!5, !11, !16, !22}
 !5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
 !6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
 !7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !9)
@@ -241,62 +252,66 @@ attributes #3 = { alwaysinline }
 !15 = !DISubrange(count: 131072, lowerBound: 0)
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
-!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
-!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8128, elements: !22)
-!22 = !{!23}
-!23 = !DISubrange(count: 127, lowerBound: 0)
-!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !27)
-!27 = !{!28, !33, !38, !19}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 6, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 1, lowerBound: 0)
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !39, size: 64, offset: 128)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
-!42 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
-!43 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !44)
-!44 = !{!45, !50}
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !46, size: 64)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !48)
-!48 = !{!49}
-!49 = !DISubrange(count: 27, lowerBound: 0)
-!50 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !51, size: 64, offset: 64)
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !53)
-!53 = !{!54}
-!54 = !DISubrange(count: 262144, lowerBound: 0)
-!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
-!56 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !57, isLocal: false, isDefinition: true)
-!57 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !58)
-!58 = !{!59, !33, !38, !64}
-!59 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !60, size: 64)
-!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
-!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !62)
-!62 = !{!63}
-!63 = !DISubrange(count: 2, lowerBound: 0)
-!64 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!65 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !66, globals: !67)
-!66 = !{}
-!67 = !{!0, !24, !41, !55}
-!68 = !{i32 2, !"Debug Info Version", i32 3}
-!69 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !70, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !65, retainedNodes: !74)
-!70 = !DISubroutineType(types: !71)
-!71 = !{!18, !72}
-!72 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !73, size: 64)
-!73 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!74 = !{!75, !76}
-!75 = !DILocalVariable(name: "var0", scope: !69, file: !2, type: !18)
-!76 = !DILocalVariable(name: "var1", arg: 1, scope: !69, file: !2, type: !72)
+!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 96, elements: !20)
+!19 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!20 = !{!21}
+!21 = !DISubrange(count: 12, lowerBound: 0)
+!22 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 8128, elements: !26)
+!25 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!26 = !{!27}
+!27 = !DISubrange(count: 127, lowerBound: 0)
+!28 = !DIGlobalVariableExpression(var: !29, expr: !DIExpression())
+!29 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !30, isLocal: false, isDefinition: true)
+!30 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !31)
+!31 = !{!32, !37, !42, !22}
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !33, size: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 6, lowerBound: 0)
+!37 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !38, size: 64, offset: 64)
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !39, size: 64)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !40)
+!40 = !{!41}
+!41 = !DISubrange(count: 1, lowerBound: 0)
+!42 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !43, size: 64, offset: 128)
+!43 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !44, size: 64)
+!44 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
+!47 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !48)
+!48 = !{!49, !54}
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !50, size: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 27, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !55, size: 64, offset: 64)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !57)
+!57 = !{!58}
+!58 = !DISubrange(count: 262144, lowerBound: 0)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
+!61 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !62)
+!62 = !{!63, !37, !42, !68}
+!63 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !64, size: 64)
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !66)
+!66 = !{!67}
+!67 = !DISubrange(count: 2, lowerBound: 0)
+!68 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !69, size: 64, offset: 192)
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!70 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !71, globals: !72)
+!71 = !{}
+!72 = !{!0, !28, !45, !59}
+!73 = !{i32 2, !"Debug Info Version", i32 3}
+!74 = distinct !DISubprogram(name: "kprobe_f", linkageName: "kprobe_f", scope: !2, file: !2, type: !75, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !70, retainedNodes: !78)
+!75 = !DISubroutineType(types: !76)
+!76 = !{!25, !77}
+!77 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!78 = !{!79, !80}
+!79 = !DILocalVariable(name: "var0", scope: !74, file: !2, type: !25)
+!80 = !DILocalVariable(name: "var1", arg: 1, scope: !74, file: !2, type: !77)


### PR DESCRIPTION
This will further decrease the chances of collision because even if two stacks of different sizes hash to the same id, if they are of different sizes the stack key will be different. So now two stacks of the same size will have have to hash to the same id for there to be a collision.

This also has the small benefit of being able to use the this number when iterating over the stack in userspace.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
