### PR TITLE
Align detect_helper with log message change

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -179,7 +179,8 @@ bool BPFfeature::detect_helper(enum libbpf::bpf_func_id func_id,
     return false;
 
   return (strstr(buf, "invalid func ") == nullptr) &&
-         (strstr(buf, "unknown func ") == nullptr);
+         (strstr(buf, "unknown func ") == nullptr) &&
+         (strstr(buf, "program of this type cannot use helper ") == nullptr);
 }
 
 bool BPFfeature::detect_prog_type(


### PR DESCRIPTION
"unknown func " log message, produced by  BPF verifier may change in future to  "program of this type cannot use helper ". Corresponding kernel change:
 https://lore.kernel.org/all/20240325152210.377548-1-yatsenko@meta.com/

