### PR TITLE
Cleanup: Don't call probetypeName() explicitly

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -448,7 +448,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
     {
       LOG(ERROR, builtin.loc, err_)
           << "The args builtin can only be used with tracepoint/kfunc/uprobe"
-          << "probes (" << probetypeName(type) << " used here)";
+          << "probes (" << type << " used here)";
     }
   } else {
     builtin.type = CreateNone();

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -56,7 +56,7 @@ bpf_probe_attach_type attachtype(ProbeType t)
     case ProbeType::uretprobe: return BPF_PROBE_RETURN; break;
     case ProbeType::usdt:      return BPF_PROBE_ENTRY;  break;
     default:
-      LOG(FATAL) << "invalid probe attachtype \"" << probetypeName(t) << "\"";
+      LOG(FATAL) << "invalid probe attachtype \"" << t << "\"";
   }
   // clang-format on
 }
@@ -221,8 +221,7 @@ AttachedProbe::AttachedProbe(Probe &probe,
       attach_raw_tracepoint();
       break;
     default:
-      LOG(FATAL) << "invalid attached probe type \""
-                 << probetypeName(probe_.type) << "\"";
+      LOG(FATAL) << "invalid attached probe type \"" << probe_.type << "\"";
   }
 }
 
@@ -248,8 +247,7 @@ AttachedProbe::AttachedProbe(Probe &probe,
       attach_uprobe(pid, safe_mode);
       break;
     default:
-      LOG(FATAL) << "invalid attached probe type \""
-                 << probetypeName(probe_.type) << "\"";
+      LOG(FATAL) << "invalid attached probe type \"" << probe_.type << "\"";
   }
 }
 
@@ -300,8 +298,8 @@ AttachedProbe::~AttachedProbe()
       err = detach_raw_tracepoint();
       break;
     case ProbeType::invalid:
-      LOG(FATAL) << "invalid attached probe type \""
-                 << probetypeName(probe_.type) << "\" at destructor";
+      LOG(FATAL) << "invalid attached probe type \"" << probe_.type
+                 << "\" at destructor";
   }
 
   if (err)
@@ -354,8 +352,7 @@ std::string AttachedProbe::eventname() const
     case ProbeType::tracepoint:
       return probe_.attach_point;
     default:
-      LOG(FATAL) << "invalid eventname probe \"" << probetypeName(probe_.type)
-                 << "\"";
+      LOG(FATAL) << "invalid eventname probe \"" << probe_.type << "\"";
   }
 }
 
@@ -419,7 +416,6 @@ static void check_alignment(std::string &path,
 {
   Disasm dasm(path);
   AlignState aligned = dasm.is_aligned(sym_offset, func_offset);
-  std::string probe_name = probetypeName(type);
 
   std::string tmp = path + ":" + symbol + "+" + std::to_string(func_offset);
 
@@ -434,30 +430,29 @@ static void check_alignment(std::string &path,
       return;
     case AlignState::NotAlign:
       if (safe_mode)
-        LOG(FATAL) << "Could not add " << probe_name
+        LOG(FATAL) << "Could not add " << type
                    << " into middle of instruction: " << tmp;
       else
-        LOG(WARNING) << "Unsafe " + probe_name +
-                            " in the middle of the instruction: "
-                     << tmp;
+        LOG(WARNING) << "Unsafe " << type
+                     << " in the middle of the instruction: " << tmp;
       break;
 
     case AlignState::Fail:
       if (safe_mode)
-        LOG(FATAL) << "Failed to check if " << probe_name
+        LOG(FATAL) << "Failed to check if " << type
                    << " is in proper place: " << tmp;
       else
-        LOG(WARNING) << "Unchecked " + probe_name + ": " << tmp;
+        LOG(WARNING) << "Unchecked " << type << ": " << tmp;
       break;
 
     case AlignState::NotSupp:
       if (safe_mode)
-        LOG(FATAL) << "Can't check if " << probe_name
+        LOG(FATAL) << "Can't check if " << type
                    << " is in proper place (compiled without "
                       "(k|u)probe offset support): "
                    << tmp;
       else
-        LOG(WARNING) << "Unchecked " + probe_name + " : " << tmp;
+        LOG(WARNING) << "Unchecked " << type << " : " << tmp;
       break;
   }
 }

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -476,8 +476,7 @@ void ProbeMatcher::list_probes(ast::Program* prog)
           match_print = target + ":" + ap->lang + ":" + func;
         }
 
-        std::cout << probetypeName(probe_type) << ":" << match_print
-                  << std::endl;
+        std::cout << probe_type << ":" << match_print << std::endl;
         if (bt_verbose) {
           for (auto& param : param_lists[match])
             std::cout << "    " << param << std::endl;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -21,6 +21,7 @@ std::ostream &operator<<(std::ostream &os, AddrSpace as)
   return os;
 }
 
+std::string probetypeName(ProbeType t);
 std::ostream &operator<<(std::ostream &os, ProbeType type)
 {
   os << probetypeName(type);

--- a/src/types.h
+++ b/src/types.h
@@ -538,7 +538,6 @@ ProbeType probetype(const std::string &type);
 std::string addrspacestr(AddrSpace as);
 std::string typestr(Type t);
 std::string expand_probe_name(const std::string &orig_name);
-std::string probetypeName(ProbeType t);
 
 struct Probe {
   ProbeType type;


### PR DESCRIPTION
It is only used for logging, where `operator<<` is also available for formatting `ProbeType`. Better to standardise on one formatting method rather than splitting the codebase across two.

No functional change.