### PR TITLE
probe listing: fix help and adoc

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -132,7 +132,7 @@ u:lib.so:"fn(char const*)" { printf("arg0:%s\n", str(arg0));}
 
 Same as '-k' but also includes the errors from 'probe_read_*'  BPF helpers.
 
-=== *-l* [_SEARCH_]
+=== *-l* [_SEARCH_|_FILENAME_]
 
 List all probes that match the _SEARCH_ pattern.
 If the pattern is omitted all probes will be listed.
@@ -3526,6 +3526,7 @@ combined with `-e` or filename args to see all the probes that a program would a
 # bpftrace -l 'kprobe:tcp*,trace
 # bpftrace -l 'k:*socket*,tracepoint:syscalls:*tcp*'
 # bpftrace -l -e 'tracepoint:xdp:mem_* { exit(); }'
+# bpftrace -l my_script.bt
 # bpftrace -lv 'enum cpu_usage_stat'
 ----
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,7 +96,8 @@ void usage()
   std::cerr << "    -h, --help     show this help message" << std::endl;
   std::cerr << "    -I DIR         add the directory to the include search path" << std::endl;
   std::cerr << "    --include FILE add an #include file before preprocessing" << std::endl;
-  std::cerr << "    -l [search]    list kernel probes or probes in a program" << std::endl;
+  std::cerr << "    -l [search|filename]" << std::endl;
+  std::cerr << "                   list kernel probes or probes in a program" << std::endl;
   std::cerr << "    -p PID         enable USDT probes on PID" << std::endl;
   std::cerr << "    -c 'CMD'       run CMD and enable USDT probes on resulting process" << std::endl;
   std::cerr << "    --usdt-file-activation" << std::endl;


### PR DESCRIPTION
Specify that the positional param can be
a search or a filename.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
