### PR TITLE
Allow more than one call to len()

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1141,7 +1141,10 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *len = b_.CreateAllocaBPF(b_.getInt64Ty(), "len");
     b_.CreateStore(b_.getInt64(0), len);
 
-    b_.CreateForEachMapElem(ctx_, map, createMapLenCallback(), len, call.loc);
+    if (!map_len_func_)
+      map_len_func_ = createMapLenCallback();
+
+    b_.CreateForEachMapElem(ctx_, map, map_len_func_, len, call.loc);
 
     expr_ = b_.CreateLoad(b_.getInt64Ty(), len);
     b_.CreateLifetimeEnd(len);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -278,6 +278,7 @@ private:
   Function *linear_func_ = nullptr;
   Function *log2_func_ = nullptr;
   Function *murmur_hash_2_func_ = nullptr;
+  Function *map_len_func_ = nullptr;
   MDNode *loop_metadata_ = nullptr;
 
   size_t getStructSize(StructType *s)


### PR DESCRIPTION
Specifically from different probes.
The issue here is the duplicated, unused subprog
in the probe text section.

Issue: https://github.com/bpftrace/bpftrace/issues/3021

This is a temporary fix just for len().

This didn't work before:
```
BEGIN {
  @map[0] = 1;
  print(len(@map))
}
END { 
  @map[1] = 2;
  print(len(@map));
}
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
