### PR TITLE
Update PR template to warn against outdated change

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,10 @@ Please provide a description of your change below this comment.
 Then please complete the checklist.
 
 Useful contribution guidelines and tips are in docs/developers.md.
+
+Warning: please make sure that you have implemented and tested your
+         change against the latest version of bpftrace (unless opening a
+         PR for a release branch).
 -->
 
 ##### Checklist


### PR DESCRIPTION
Recently, we've been receiving a lot of PRs which fix bugs occurring only on older versions of bpftrace, especially changing `args.xxx` to `args->xxx` in the one-liners tutorial (just two of those #3121 and #3122 opened today).

While the root cause may need more work to resolve (having documentation for older versions), I think that we may be able to eliminate a part of such PRs by adding a warning to the GitHub PR template that warns people to check that they implement and test the change against the last version of bpftrace.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
