### PR TITLE
One-liner tutorial: add note on args access change

### DIFF
--- a/docs/tutorial_one_liners.md
+++ b/docs/tutorial_one_liners.md
@@ -4,6 +4,10 @@ This teaches you bpftrace for Linux in 12 easy lessons, where each lesson is a o
 
 Contributed by Brendan Gregg, Netflix (2018), based on his FreeBSD [DTrace Tutorial](https://wiki.freebsd.org/DTrace/Tutorial).
 
+Note: bpftrace 0.19 changed the way probe arguments are accessed (using
+`args.xxx` instead of `args->xxx`). If you are using an older version of
+bpftrace, you will need to use `args->xxx` in the below examples.
+
 # Lesson 1. Listing Probes
 
 ```


### PR DESCRIPTION
#2578 changed the way args fields are accessed. Since then, it is recommended to use `args.xxx` instead of `args->xxx` which is also reflected in the one-liner tutorial.

As many distros still have older versions of bpftrace, people keep stumbling on one-liner tutorial commands throwing errors about `args.xxx` not being a correct expression. Add a note to the one-liner tutorial which highlights this change and warns people to use `args->xxx` for older versions of bpftrace.

It would be good to also update the Chinese and Japanese versions of the tutorial but that's far beyond my capabilities.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
