### PR TITLE
Refactor attach-point expansion and creation of Probe objects

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -676,26 +676,12 @@ void AttachPoint::set_index(int index)
 
 std::string Probe::name() const
 {
-  std::string n;
-  for (auto &attach_point : *attach_points) {
-    if (!n.empty())
-      n += ',';
-    n += attach_point->provider;
-    if (attach_point->target != "")
-      n += ":" + attach_point->target;
-    if (attach_point->ns != "")
-      n += ":" + attach_point->ns;
-    if (attach_point->func != "") {
-      n += ":" + attach_point->func;
-      if (attach_point->func_offset != 0)
-        n += "+" + std::to_string(attach_point->func_offset);
-    }
-    if (attach_point->address != 0)
-      n += ":" + std::to_string(attach_point->address);
-    if (attach_point->freq != 0)
-      n += ":" + std::to_string(attach_point->freq);
-  }
-  return n;
+  std::vector<std::string> ap_names;
+  std::transform(attach_points->begin(),
+                 attach_points->end(),
+                 std::back_inserter(ap_names),
+                 [](const AttachPoint *ap) { return ap->name(); });
+  return str_join(ap_names, ",");
 }
 
 std::string Probe::args_typename() const

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -632,9 +632,9 @@ public:
   uint64_t func_offset = 0;
   bool ignore_invalid = false;
 
-  std::string name(const std::string &attach_point) const;
-  std::string name(const std::string &attach_target,
-                   const std::string &attach_point) const;
+  std::string name() const;
+
+  AttachPoint create_expansion_copy(const std::string &match) const;
 
   int index() const;
   void set_index(int index);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -149,7 +149,6 @@ private:
                      const std::string &full_func_id,
                      const std::string &section_name,
                      FunctionType *func_type,
-                     bool expansion,
                      std::optional<int> usdt_location_index = std::nullopt,
                      bool dummy = false);
 

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -406,7 +406,7 @@ void Printer::visit(Predicate &pred)
 void Printer::visit(AttachPoint &ap)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << ap.name(ap.func) << std::endl;
+  out_ << indent << ap.name() << std::endl;
 }
 
 void Printer::visit(Probe &probe)

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -904,9 +904,9 @@ void SemanticAnalyser::visit(Call &call)
         LOG(ERROR, call.loc, err_)
             << "Symbol size mismatch between probes. Symbol \"" << name
             << "\" has size " << sizes.at(0) << " for probe \""
-            << probe->attach_points->at(0)->name("") << "\" but size "
+            << probe->attach_points->at(0)->name() << "\" but size "
             << sizes.at(i) << " for probe \""
-            << probe->attach_points->at(i)->name("") << "\"";
+            << probe->attach_points->at(i)->name() << "\"";
       }
     }
     size_t pointee_size = 0;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -78,20 +78,37 @@ Probe BPFtrace::generateWatchpointSetupProbe(const ast::AttachPoint &ap,
   return setup_probe;
 }
 
+Probe BPFtrace::generate_probe(const ast::AttachPoint &ap, const ast::Probe &p)
+{
+  Probe probe;
+  probe.path = ap.target;
+  probe.attach_point = ap.func;
+  probe.type = probetype(ap.provider);
+  probe.log_size = config_.get(ConfigKeyInt::log_size);
+  probe.orig_name = p.name();
+  probe.ns = ap.ns;
+  probe.name = ap.name();
+  probe.need_expansion = p.need_expansion;
+  probe.freq = ap.freq;
+  probe.address = ap.address;
+  probe.func_offset = ap.func_offset;
+  probe.loc = 0;
+  probe.index = ap.index() ?: p.index();
+  probe.len = ap.len;
+  probe.mode = ap.mode;
+  probe.async = ap.async;
+  probe.pin = ap.pin;
+  return probe;
+}
+
 int BPFtrace::add_probe(ast::Probe &p)
 {
   for (auto attach_point : *p.attach_points) {
     if (attach_point->provider == "BEGIN" || attach_point->provider == "END") {
-      Probe probe;
+      auto probe = generate_probe(*attach_point, p);
       probe.path = "/proc/self/exe";
       probe.attach_point = attach_point->provider + "_trigger";
-      probe.type = probetype(attach_point->provider);
-      probe.log_size = config_.get(ConfigKeyInt::log_size);
-      probe.orig_name = p.name();
       probe.name = p.name();
-      probe.loc = 0;
-      probe.index = attach_point->index() > 0 ? attach_point->index()
-                                              : p.index();
       resources.special_probes.push_back(probe);
       continue;
     }
@@ -133,15 +150,8 @@ int BPFtrace::add_probe(ast::Probe &p)
           (probetype(attach_point->provider) == ProbeType::kprobe ||
            probetype(attach_point->provider) == ProbeType::kretprobe) &&
           attach_point->target.empty()) {
-        Probe probe;
-        probe.attach_point = attach_point->func;
-        probe.type = probetype(attach_point->provider);
-        probe.log_size = config_.get(ConfigKeyInt::log_size);
-        probe.orig_name = p.name();
-        probe.name = attach_point->name();
-        probe.index = p.index();
-        probe.funcs.assign(attach_funcs.begin(), attach_funcs.end());
-
+        auto probe = generate_probe(*attach_point, p);
+        probe.funcs = attach_funcs;
         resources.probes.push_back(probe);
         continue;
       }
@@ -151,16 +161,8 @@ int BPFtrace::add_probe(ast::Probe &p)
           feature_->has_uprobe_multi() && has_wildcard(attach_point->func) &&
           !p.need_expansion && attach_funcs.size()) {
         if (!has_wildcard(attach_point->target)) {
-          Probe probe;
-          probe.attach_point = attach_point->func;
-          probe.path = attach_point->target;
-          probe.type = probetype(attach_point->provider);
-          probe.log_size = config_.get(ConfigKeyInt::log_size);
-          probe.orig_name = p.name();
-          probe.name = attach_point->name();
-          probe.index = p.index();
+          auto probe = generate_probe(*attach_point, p);
           probe.funcs = attach_funcs;
-
           resources.probes.push_back(probe);
           continue;
         } else {
@@ -175,14 +177,7 @@ int BPFtrace::add_probe(ast::Probe &p)
             if (found != target_map.end()) {
               found->second.funcs.push_back(func);
             } else {
-              Probe probe;
-              probe.attach_point = attach_point->func;
-              probe.path = ap.target;
-              probe.type = probetype(attach_point->provider);
-              probe.log_size = config_.get(ConfigKeyInt::log_size);
-              probe.orig_name = p.name();
-              probe.name = ap.name();
-              probe.index = p.index();
+              auto probe = generate_probe(ap, p);
               probe.funcs.push_back(func);
               target_map.insert({ { ap.target, probe } });
             }
@@ -260,25 +255,7 @@ int BPFtrace::add_probe(ast::Probe &p)
         has_iter_ = true;
       }
 
-      Probe probe;
-      probe.path = match_ap.target;
-      probe.attach_point = match_ap.func;
-      probe.type = probetype(attach_point->provider);
-      probe.log_size = config_.get(ConfigKeyInt::log_size);
-      probe.orig_name = p.name();
-      probe.ns = match_ap.ns;
-      probe.name = match_ap.name();
-      probe.need_expansion = p.need_expansion;
-      probe.freq = attach_point->freq;
-      probe.address = attach_point->address;
-      probe.func_offset = attach_point->func_offset;
-      probe.loc = 0;
-      probe.index = attach_point->index() > 0 ? attach_point->index()
-                                              : p.index();
-      probe.len = attach_point->len;
-      probe.mode = attach_point->mode;
-      probe.async = attach_point->async;
-      probe.pin = attach_point->pin;
+      auto probe = generate_probe(match_ap, p);
 
       if (probetype(attach_point->provider) == ProbeType::usdt) {
         // We must attach to all locations of a USDT marker if duplicates exist

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -64,15 +64,14 @@ BPFtrace::~BPFtrace()
     bcc_free_symcache(ksyms_, -1);
 }
 
-Probe BPFtrace::generateWatchpointSetupProbe(const std::string &func,
-                                             const ast::AttachPoint &ap,
+Probe BPFtrace::generateWatchpointSetupProbe(const ast::AttachPoint &ap,
                                              const ast::Probe &probe)
 {
   Probe setup_probe;
-  setup_probe.name = get_watchpoint_setup_probe_name(ap.name(func));
+  setup_probe.name = get_watchpoint_setup_probe_name(ap.name());
   setup_probe.type = ProbeType::uprobe;
   setup_probe.path = ap.target;
-  setup_probe.attach_point = func;
+  setup_probe.attach_point = ap.func;
   setup_probe.orig_name = get_watchpoint_setup_probe_name(probe.name());
   setup_probe.index = ap.index() > 0 ? ap.index() : probe.index();
 
@@ -120,7 +119,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       }
 
       if (underspecified_usdt_probe && matches.size() > 1) {
-        LOG(ERROR) << "namespace for " << attach_point->name(attach_point->func)
+        LOG(ERROR) << "namespace for " << attach_point->name()
                    << " not specified, matched " << matches.size() << " probes";
         LOG(INFO) << "please specify a unique namespace or use '*' to attach "
                   << "to all matched probes";
@@ -139,8 +138,7 @@ int BPFtrace::add_probe(ast::Probe &p)
         probe.type = probetype(attach_point->provider);
         probe.log_size = config_.get(ConfigKeyInt::log_size);
         probe.orig_name = p.name();
-        probe.name = attach_point->name(attach_point->target,
-                                        attach_point->func);
+        probe.name = attach_point->name();
         probe.index = p.index();
         probe.funcs.assign(attach_funcs.begin(), attach_funcs.end());
 
@@ -159,8 +157,7 @@ int BPFtrace::add_probe(ast::Probe &p)
           probe.type = probetype(attach_point->provider);
           probe.log_size = config_.get(ConfigKeyInt::log_size);
           probe.orig_name = p.name();
-          probe.name = attach_point->name(attach_point->target,
-                                          attach_point->func);
+          probe.name = attach_point->name();
           probe.index = p.index();
           probe.funcs = attach_funcs;
 
@@ -171,22 +168,23 @@ int BPFtrace::add_probe(ast::Probe &p)
           // probe per expanded target.
           std::unordered_map<std::string, Probe> target_map;
           for (const auto &func : attach_funcs) {
-            std::string func_id = func;
-            std::string target = erase_prefix(func_id);
-            auto found = target_map.find(target);
+            ast::AttachPoint ap = attach_point->create_expansion_copy(func);
+            // Use the original (possibly wildcarded) function name
+            ap.func = attach_point->func;
+            auto found = target_map.find(ap.target);
             if (found != target_map.end()) {
               found->second.funcs.push_back(func);
             } else {
               Probe probe;
               probe.attach_point = attach_point->func;
-              probe.path = target;
+              probe.path = ap.target;
               probe.type = probetype(attach_point->provider);
               probe.log_size = config_.get(ConfigKeyInt::log_size);
               probe.orig_name = p.name();
-              probe.name = attach_point->name(target, attach_point->func);
+              probe.name = ap.name();
               probe.index = p.index();
               probe.funcs.push_back(func);
-              target_map.insert({ { target, probe } });
+              target_map.insert({ { ap.target, probe } });
             }
           }
           for (auto &pair : target_map) {
@@ -247,59 +245,29 @@ int BPFtrace::add_probe(ast::Probe &p)
     // There may be a way to refactor and unify the codepaths in a clean manner
     // but so far it has eluded your author.
     for (const auto &f : attach_funcs) {
-      std::string func = f;
-      std::string func_id = func;
-      std::string target = attach_point->target;
+      ast::AttachPoint match_ap = attach_point->create_expansion_copy(f);
 
-      // USDT probes must specify a target binary path, a provider, and
-      // a function name for full id.
-      // So we will extract out the path and the provider namespace to get just
-      // the function name
       if (probetype(attach_point->provider) == ProbeType::usdt) {
-        target = erase_prefix(func_id);
-        std::string ns = erase_prefix(func_id);
-        // Set attach_point target, ns, and func to their resolved values in
-        // case of wildcards.
-        attach_point->target = target;
-        attach_point->ns = ns;
-        attach_point->func = func_id;
         // Necessary for correct number of locations if wildcard expands to
         // multiple probes.
         std::optional<usdt_probe_entry> usdt;
-        if (attach_point->need_expansion &&
-            (usdt = USDTHelper::find(this->pid(), target, ns, func_id))) {
-          attach_point->usdt = *usdt;
+        if ((p.need_expansion || match_ap.need_expansion) &&
+            (usdt = USDTHelper::find(
+                 this->pid(), match_ap.target, match_ap.ns, match_ap.func))) {
+          match_ap.usdt = *usdt;
         }
-      } else if (probetype(attach_point->provider) == ProbeType::tracepoint ||
-                 probetype(attach_point->provider) == ProbeType::uprobe ||
-                 probetype(attach_point->provider) == ProbeType::uretprobe ||
-                 probetype(attach_point->provider) == ProbeType::kfunc ||
-                 probetype(attach_point->provider) == ProbeType::kretfunc ||
-                 ((probetype(attach_point->provider) == ProbeType::kprobe ||
-                   probetype(attach_point->provider) == ProbeType::kretprobe) &&
-                  !attach_point->target.empty())) {
-        // tracepoint, uprobe, k(ret)func, and k(ret)probes specify both a
-        // target and a function name.
-        // We extract the target from func_id so that a resolved target and a
-        // resolved function name are used in the probe.
-        target = erase_prefix(func_id);
-      } else if (probetype(attach_point->provider) == ProbeType::watchpoint ||
-                 probetype(attach_point->provider) ==
-                     ProbeType::asyncwatchpoint) {
-        target = erase_prefix(func_id);
-        erase_prefix(func);
       } else if (probetype(attach_point->provider) == ProbeType::iter) {
         has_iter_ = true;
       }
 
       Probe probe;
-      probe.path = target;
-      probe.attach_point = func_id;
+      probe.path = match_ap.target;
+      probe.attach_point = match_ap.func;
       probe.type = probetype(attach_point->provider);
       probe.log_size = config_.get(ConfigKeyInt::log_size);
       probe.orig_name = p.name();
-      probe.ns = attach_point->ns;
-      probe.name = attach_point->name(target, func_id);
+      probe.ns = match_ap.ns;
+      probe.name = match_ap.name();
       probe.need_expansion = p.need_expansion;
       probe.freq = attach_point->freq;
       probe.address = attach_point->address;
@@ -316,7 +284,7 @@ int BPFtrace::add_probe(ast::Probe &p)
         // We must attach to all locations of a USDT marker if duplicates exist
         // in a target binary. See comment in codegen_llvm.cpp probe generation
         // code for more details.
-        for (int i = 0; i < attach_point->usdt.num_locations; ++i) {
+        for (int i = 0; i < match_ap.usdt.num_locations; ++i) {
           Probe probe_copy = probe;
           probe_copy.usdt_location_idx = i;
           probe_copy.index = attach_point->index() > 0 ? attach_point->index()
@@ -329,7 +297,7 @@ int BPFtrace::add_probe(ast::Probe &p)
                       ProbeType::asyncwatchpoint) &&
                  attach_point->func.size()) {
         resources.probes.emplace_back(
-            generateWatchpointSetupProbe(func_id, *attach_point, p));
+            generateWatchpointSetupProbe(match_ap, p));
 
         resources.watchpoint_probes.emplace_back(std::move(probe));
       } else {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -265,6 +265,7 @@ private:
   static uint64_t read_address_from_output(std::string output);
   std::optional<std::vector<uint8_t>> find_empty_key(const BpfMap &map) const;
   struct bcc_symbol_option &get_symbol_opts();
+  Probe generate_probe(const ast::AttachPoint &ap, const ast::Probe &p);
   bool has_iter_ = false;
   int epollfd_ = -1;
   struct ring_buffer *ringbuf_ = nullptr;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -105,8 +105,7 @@ public:
   }
   virtual ~BPFtrace();
   virtual int add_probe(ast::Probe &p);
-  Probe generateWatchpointSetupProbe(const std::string &func,
-                                     const ast::AttachPoint &ap,
+  Probe generateWatchpointSetupProbe(const ast::AttachPoint &ap,
                                      const ast::Probe &probe);
   int num_probes() const;
   int prerun() const;

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -152,11 +152,11 @@ TEST(ast, attach_point_name)
   ap3->func = "readline";
   auto attach_points = APL({ ap1, ap2, ap3 });
   Probe kprobe(attach_points, nullptr, nullptr);
-  EXPECT_EQ(ap2->name("sys_thisone"), "kprobe:sys_thisone");
+  EXPECT_EQ(ap2->name(), "kprobe:sys_thisone");
 
   attach_points = APL({ ap1, ap2, ap3 });
   Probe uprobe(attach_points, nullptr, nullptr);
-  EXPECT_EQ(ap3->name("readline"), "uprobe:/bin/sh:readline");
+  EXPECT_EQ(ap3->name(), "uprobe:/bin/sh:readline");
 }
 
 } // namespace ast

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -738,26 +738,15 @@ TEST(bpftrace, add_probes_usdt_wildcard)
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(4U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
-  check_usdt(bpftrace->get_probes().at(0),
-             "/bin/bash",
-             "prov1",
-             "tp3",
-             "usdt:/bin/bash:prov1:tp3");
-  check_usdt(bpftrace->get_probes().at(1),
-             "/bin/sh",
-             "prov1",
-             "tp1",
-             "usdt:/bin/sh:prov1:tp1");
-  check_usdt(bpftrace->get_probes().at(2),
-             "/bin/sh",
-             "prov1",
-             "tp2",
-             "usdt:/bin/sh:prov1:tp2");
-  check_usdt(bpftrace->get_probes().at(3),
-             "/bin/sh",
-             "prov2",
-             "tp",
-             "usdt:/bin/sh:prov2:tp");
+
+  const std::string orig_name = "usdt:/bin/*sh:prov*:tp*";
+  check_usdt(
+      bpftrace->get_probes().at(0), "/bin/bash", "prov1", "tp3", orig_name);
+  check_usdt(
+      bpftrace->get_probes().at(1), "/bin/sh", "prov1", "tp1", orig_name);
+  check_usdt(
+      bpftrace->get_probes().at(2), "/bin/sh", "prov1", "tp2", orig_name);
+  check_usdt(bpftrace->get_probes().at(3), "/bin/sh", "prov2", "tp", orig_name);
 }
 
 TEST(bpftrace, add_probes_usdt_wildcard_for_target)
@@ -771,31 +760,20 @@ TEST(bpftrace, add_probes_usdt_wildcard_for_target)
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(5U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
-  check_usdt(bpftrace->get_probes().at(0),
-             "/bin/bash",
-             "prov1",
-             "tp3",
-             "usdt:/bin/bash:prov1:tp3");
-  check_usdt(bpftrace->get_probes().at(1),
-             "/bin/sh",
-             "prov1",
-             "tp1",
-             "usdt:/bin/sh:prov1:tp1");
-  check_usdt(bpftrace->get_probes().at(2),
-             "/bin/sh",
-             "prov1",
-             "tp2",
-             "usdt:/bin/sh:prov1:tp2");
-  check_usdt(bpftrace->get_probes().at(3),
-             "/bin/sh",
-             "prov2",
-             "tp",
-             "usdt:/bin/sh:prov2:tp");
+
+  const std::string orig_name = "usdt:*:prov*:tp*";
+  check_usdt(
+      bpftrace->get_probes().at(0), "/bin/bash", "prov1", "tp3", orig_name);
+  check_usdt(
+      bpftrace->get_probes().at(1), "/bin/sh", "prov1", "tp1", orig_name);
+  check_usdt(
+      bpftrace->get_probes().at(2), "/bin/sh", "prov1", "tp2", orig_name);
+  check_usdt(bpftrace->get_probes().at(3), "/bin/sh", "prov2", "tp", orig_name);
   check_usdt(bpftrace->get_probes().at(4),
              "/proc/1234/exe",
              "prov2",
              "tp4",
-             "usdt:/proc/1234/exe:prov2:tp4");
+             orig_name);
 }
 
 TEST(bpftrace, add_probes_usdt_empty_namespace)
@@ -814,7 +792,7 @@ TEST(bpftrace, add_probes_usdt_empty_namespace)
              "/bin/sh",
              "prov1",
              "tp1",
-             "usdt:/bin/sh:prov1:tp1");
+             "usdt:/bin/sh:tp1");
 }
 
 TEST(bpftrace, add_probes_usdt_empty_namespace_conflict)

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -615,21 +615,20 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
     ASSERT_EQ(0, bpftrace->add_probe(*probe));
     ASSERT_EQ(3U, bpftrace->get_probes().size());
     ASSERT_EQ(0U, bpftrace->get_special_probes().size());
-    const auto orig_name = provider + ":/bin/sh:cpp_mangled";
     check_uprobe(bpftrace->get_probes().at(0),
                  "/bin/sh",
                  "_Z11cpp_mangledi",
-                 orig_name,
+                 provider + ":/bin/sh:cpp:cpp_mangled",
                  provider + ":/bin/sh:cpp:_Z11cpp_mangledi");
     check_uprobe(bpftrace->get_probes().at(1),
                  "/bin/sh",
                  "_Z11cpp_mangledv",
-                 orig_name,
+                 provider + ":/bin/sh:cpp:cpp_mangled",
                  provider + ":/bin/sh:cpp:_Z11cpp_mangledv");
     check_uprobe(bpftrace->get_probes().at(2),
                  "/bin/sh",
                  "cpp_mangled",
-                 orig_name,
+                 provider + ":/bin/sh:cpp:cpp_mangled",
                  provider + ":/bin/sh:cpp:cpp_mangled");
   }
 }
@@ -649,7 +648,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
   check_uprobe(bpftrace->get_probes().at(0),
                "/bin/sh",
                "_Z11cpp_mangledi",
-               "uprobe:/bin/sh:cpp_mangled(int)",
+               "uprobe:/bin/sh:cpp:cpp_mangled(int)",
                "uprobe:/bin/sh:cpp:_Z11cpp_mangledi");
 }
 
@@ -671,22 +670,22 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
   check_uprobe(bpftrace->get_probes().at(0),
                "/bin/sh",
                "_Z11cpp_mangledi",
-               "uprobe:/bin/sh:cpp_man*",
+               "uprobe:/bin/sh:cpp:cpp_man*",
                "uprobe:/bin/sh:cpp:_Z11cpp_mangledi");
   check_uprobe(bpftrace->get_probes().at(1),
                "/bin/sh",
                "_Z11cpp_mangledv",
-               "uprobe:/bin/sh:cpp_man*",
+               "uprobe:/bin/sh:cpp:cpp_man*",
                "uprobe:/bin/sh:cpp:_Z11cpp_mangledv");
   check_uprobe(bpftrace->get_probes().at(2),
                "/bin/sh",
                "_Z18cpp_mangled_suffixv",
-               "uprobe:/bin/sh:cpp_man*",
+               "uprobe:/bin/sh:cpp:cpp_man*",
                "uprobe:/bin/sh:cpp:_Z18cpp_mangled_suffixv");
   check_uprobe(bpftrace->get_probes().at(3),
                "/bin/sh",
                "cpp_mangled",
-               "uprobe:/bin/sh:cpp_man*",
+               "uprobe:/bin/sh:cpp:cpp_man*",
                "uprobe:/bin/sh:cpp:cpp_mangled");
 }
 


### PR DESCRIPTION
Currently, we have two places where wildcard expansion is done:
- codegen for probe expansion (e.g. when the `probe` builtin is used)
- `Probe` generation for attach point expansion (for most cases)

These two places have a lot of repetitive code (both within and between them) and are sometimes very difficult to read. This PR attempts to simplify that. Ideally, we should be able to unify the expansion code eventually, this is just a first step towards that goal.

See individual commit messages for a detailed explanation of the changes.

This is also the first step towards #2334.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
