### PR TITLE
include <algorithm> explicitly in files that use it

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <arpa/inet.h>
 #include <cassert>
 #include <cerrno>

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -6,6 +6,7 @@
 #include "tracefs.h"
 #include "types.h"
 #include "utils.h"
+#include <algorithm>
 #include <cmath>
 #include <cstring>
 #include <fcntl.h>

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <dirent.h>
 #include <fstream>
 #include <iomanip>


### PR DESCRIPTION
A few files use methods defined in <algorithm>, such as std::sort and std::all_of. Instead of relying on these being included transitively, include <algorithm> explicitly.


##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` (N/A)
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md` (N/A)
- [ ] The new behaviour is covered by tests (N/A)
