### PR TITLE
Fix builtin includes to #include using /bpftrace/include

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -663,7 +663,8 @@ bool ClangParser::parse(ast::Program *program,
   if (program->c_definitions.empty() && bpftrace.btf_set_.empty())
     return true;
 
-  input = "#include <__btf_generated_header.h>\n" + program->c_definitions;
+  input = "#include </bpftrace/include/__btf_generated_header.h>\n" +
+          program->c_definitions;
 
   input_files = getTranslationUnitFiles(CXUnsavedFile{
       .Filename = "definitions.h",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -423,7 +423,7 @@ static std::optional<struct timespec> get_delta_taitime()
           utsname.machine, ksrc, kobj, bpftrace.kconfig);
   }
   extra_flags.push_back("-include");
-  extra_flags.push_back(CLANG_WORKAROUNDS_H);
+  extra_flags.push_back("/bpftrace/include/" CLANG_WORKAROUNDS_H);
 
   for (auto dir : include_dirs) {
     extra_flags.push_back("-I");


### PR DESCRIPTION
When testing bpftrace-0.19.1 on an old system based on CentOS 7, the included libclang-16.0.6 was not able to find `__btf_generated_header.h` and `clang_workarounds.h`

Prepending their directory `/bpftrace/include` (including them using their full path) fixed the issue. I wonder why this is, but I figured it might also make things clearer for the tip:

- Makes it clear that those are built-in headers
- Leaves no ambiguity which files are included.