### PR TITLE
ast.cpp: Include required header

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1,6 +1,6 @@
 #include "ast/ast.h"
 
-#include <iostream>
+#include <algorithm>
 
 #include "ast/visitors.h"
 #include "log.h"


### PR DESCRIPTION
Broken Fedora build on master: https://github.com/bpftrace/bpftrace/actions/runs/8798819655/job/24146582079

`std::transform` is defined in `<algorithm>` and the build was failing on some platforms because it was not included.

Also remove `<iostream>` while I'm here, as it hasn't been required in this file for a long time.