### PR TITLE
Fix listing type definitions

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -886,6 +886,12 @@ bool is_supported_lang(const std::string &lang)
                      [&](const auto &cand) { return lang == cand; });
 }
 
+bool is_type_name(std::string_view str)
+{
+  return str.find("struct ") == 0 || str.find("union ") == 0 ||
+         str.find("enum ") == 0;
+}
+
 std::string exec_system(const char *cmd)
 {
   std::array<char, 128> buffer;

--- a/src/utils.h
+++ b/src/utils.h
@@ -178,6 +178,7 @@ const std::string &is_deprecated(const std::string &str);
 bool is_unsafe_func(const std::string &func_name);
 bool is_compile_time_func(const std::string &func_name);
 bool is_supported_lang(const std::string &lang);
+bool is_type_name(std::string_view str);
 std::string exec_system(const char *cmd);
 std::vector<std::string> resolve_binary_path(const std::string &cmd);
 std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid);

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -158,6 +158,11 @@ EXPECT hardware:cache-misses:
 EXPECT tracepoint:xdp:mem_connect
 TIMEOUT 5
 
+NAME it lists struct definitions
+RUN {{BPFTRACE}} -lv 'struct task_struct'
+EXPECT struct task_struct {
+TIMEOUT 2
+
 NAME it lists probes in a given file
 RUN {{BPFTRACE}} -l runtime/scripts/interval_order.bt
 EXPECT interval:ms:
@@ -165,9 +170,9 @@ EXPECT interval:ms:
 EXPECT interval:ms:
 TIMEOUT 5
 
-NAME errors on non existent file
+NAME warning on non existent file
 RUN {{BPFTRACE}} -l non_existent_file.bt
-EXPECT ERROR: failed to open file 'non_existent_file.bt': No such file or directory
+EXPECT WARNING: It appears that 'non_existent_file.bt' is a filename but the file does not exist. Treating 'non_existent_file.bt' as a search pattern.
 TIMEOUT 1
 WILL_FAIL
 


### PR DESCRIPTION
#3111 broke listing of struct definitions:

    # bpftrace -l 'struct task_struct'
    ERROR: failed to open file 'struct task_struct': No such file or directory

This fixes the problem and introduces a runtime test to avoid future breakage.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
