### PR TITLE
Fix bpftrace for older kernels: Fallback to no func_infos, no BTF

### DIFF
--- a/src/ast/elf_parser.cpp
+++ b/src/ast/elf_parser.cpp
@@ -1,5 +1,8 @@
 #include "elf_parser.h"
 #include <elf.h>
+#ifndef EM_BPF     // EM_BPF may not be defined in older containers, e.g. RHEL7
+#define EM_BPF 247 // Could be in linux/elf.h, but it can cause conflicts
+#endif
 
 namespace bpftrace {
 namespace elf {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -47,9 +47,12 @@ static bool try_load_(const char* name,
                       size_t logbuf_size,
                       int* outfd = nullptr)
 {
-  for (int attempt = 0; attempt < 3; attempt++) {
-    auto version = kernel_version(attempt);
-    if (version == 0 && attempt > 0) {
+  const KernelVersionMethod methods[] = { vDSO, UTS, File };
+
+  for (KernelVersionMethod method : methods) {
+    auto version = kernel_version(method);
+
+    if (method != vDSO && !version) {
       // Recent kernels don't check the version so we should try to call
       // bpf_prog_load during first iteration even if we failed to determine
       // the version. We should not do that in subsequent iterations to avoid

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1289,28 +1289,27 @@ static uint32_t kernel_version_from_khdr(void)
  * may not match if bpftrace is compiled on a different Linux version than it's
  * used on, e.g. if built with Docker.
  */
-uint32_t kernel_version(int attempt)
+uint32_t kernel_version(KernelVersionMethod method)
 {
   static std::optional<uint32_t> a0, a1, a2;
-  switch (attempt) {
-    case 0: {
+  switch (method) {
+    case vDSO: {
       if (!a0)
         a0 = kernel_version_from_vdso();
       return *a0;
     }
-    case 1: {
+    case UTS: {
       if (!a1)
         a1 = kernel_version_from_uts();
       return *a1;
     }
-    case 2: {
+    case File: {
       if (!a2)
         a2 = kernel_version_from_khdr();
       return *a2;
     }
-    default:
-      LOG(BUG) << "kernel_version(): Invalid attempt: "
-               << std::to_string(attempt);
+    case None:
+      return 0;
   }
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -280,7 +280,8 @@ T read_data(const void *src)
   return v;
 }
 
-uint32_t kernel_version(int attempt);
+enum KernelVersionMethod { vDSO, UTS, File, None };
+uint32_t kernel_version(KernelVersionMethod);
 
 template <typename T>
 T reduce_value(const std::vector<uint8_t> &value, int nvalues)


### PR DESCRIPTION
Fix #3011:

In https://github.com/bpftrace/bpftrace/issues/2913#issuecomment-1888962724, @viktormalik said:
> So the problem is that the older kernel doesn't cope well with BTF and func_infos.

He detailed the problem in https://github.com/bpftrace/bpftrace/issues/2913#issuecomment-1892053795:
> So, I was able to find the problem - older kernels do not have https://github.com/torvalds/linux/commit/51c39bb1d5d105a02e29aa7960f0a395086e6342 and therefore do not support BTF_KIND_FUNC entries with global linkage. Libbpf sanitizes this for older kernels since https://github.com/torvalds/linux/commit/2d3eb67f64ec317bbfe340cfcc8325d40a6ff317 (same series) but it only does that when the program is loaded via bpf_object (which we don't at this point).

He implemented an initial interim fix in #2934 (as loaded via bpf_object) might be a bigger change, but #3011 shows that this is not enough. In it, @giorio94 bisected that #2804 causes `bpftrace` to fail on all kernels that do not support the types that LLVM now generates. And func_infos fail with 4.19 fail too.

I now found that the issue is that current code skips loading the BPF program when loading the BTF into the kernel failed: https://github.com/bpftrace/bpftrace/blob/c8fd334f55e6b04a7eb3fc9a06822fc6b2a6344b/src/attached_probe.cpp#L831
```py
        // Don't attempt to load the program if the BTF load failed.
        // This will fall back to the error handling for failed program load,
        // which is more robust.
```
But there is no such fall back to handle this error yet, so add it. And, I found:
- As @viktormalik said, I also found that older kernels don't cope well with func_infos, so fall back no  func_infos relocation on the 2nd attempt.
- I was able to fix loading the BTF load on for my setup, but 4.19 still rejects loading the BPF program, so even if loading the BTF succeeds, loading the BPF it does not work, fall back to not loading the BTF (as a last resort) in the 3rd attempt.

These changes fix bpftrace to work on 4.19 again.

I plan also submit my BTF fixup changes to fix BTF load on 4.19, they add converting the kinds FUNC, FUNC_PROTO, VAR, and DATASEC. But as said, these only fix BTF load but passing the btf_fd for the loaded BTF still makes the BPF load fail on 4.19.

For now, this is the smallest change and only adds fallbacks for older kernels, that have issues with BTF and func_infos so it does not affect newer kernels at all.

Of course, the best solution is to load everything by using libbpf as bpf_object, but that is a bigger change.

And, I'd also like showing the error code and error message when BPF load fails (added as well).