### PR TITLE
tests: dwarf: Remove uprobeFunction3

### DIFF
--- a/tests/testprogs/uprobe_test.c
+++ b/tests/testprogs/uprobe_test.c
@@ -22,15 +22,33 @@ struct Foo *uprobeFunction2(struct Foo *foo1,
   return foo1;
 }
 
-int uprobeFunction3(
-    enum { A, B, C } e,
-    union {
-      int a;
-      char b;
-    } u __attribute__((unused)))
-{
-  return e;
-}
+// clang-format off
+/*
+ * Anonymous types inside parameter lists are not legal until C23 [0][1][2].
+ * On a non-C23 build, we get unsilencable compiler warnings:
+ *
+ *     /home/dxu/dev/bpftrace/tests/testprogs/uprobe_test.c:26:10: warning: anonymous enum declared inside parameter list will not be visible outside of this definition or declaration
+ *        26 |     enum { A, B, C } e,
+ *           |          ^
+ *     [4/5] Linking C executable tests/testprogs/uprobe_test
+ *
+ * So for now, leave this commented out until C23 is more widely available.
+ *
+ * [0]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108189
+ * [1]: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3037.pdf
+ * [2]: https://www.reddit.com/r/C_Programming/comments/w5hl80/comment/ih8jxi6/?context=3
+ *
+ * int uprobeFunction3(
+ *     enum { A, B, C } e,
+ *     union {
+ *       int a;
+ *       char b;
+ *     } u __attribute__((unused)))
+ * {
+ *   return e;
+ * }
+ */
+// clang-format on
 
 int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
 {


### PR DESCRIPTION
The intent behind uprobeFunction3 was to test parsing of anonymous types defined inside parameter lists. However, it was generating the following un-silenceable compiler warning:

```
/home/dxu/dev/bpftrace/tests/testprogs/uprobe_test.c:26:10: warning:
anonymous enum declared inside parameter list will not be visible outside
of this definition or declaration
   26 |     enum { A, B, C } e,
      |          ^
[4/5] Linking C executable tests/testprogs/uprobe_test
```

Looking closer, it seems like anon types inside parameter lists is not even supported by C standard until C23 [0][1][2].

Since the warning is un-silencable, I suggest implenting support when C23 is more widely available.

[0]: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=108189
[1]: https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3037.pdf
[2]: https://www.reddit.com/r/C_Programming/comments/w5hl80/comment/ih8jxi6/?context=3

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
