### PR TITLE
Move probe expansion into codegen

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -62,6 +62,17 @@ enum class Operator {
   BNOT,
 };
 
+// There are 2 kinds of attach point expansion:
+// - full expansion  - separate LLVM function is generated for each match
+// - multi expansion - one LLVM function and BPF program is generated for all
+//                     matches, the list of expanded functions is attached to
+//                     the BPF program using the k(u)probe.multi mechanism
+enum class ExpansionType {
+  NONE,
+  FULL,
+  MULTI,
+};
+
 class Node {
 public:
   Node() = default;
@@ -627,7 +638,9 @@ public:
   uint64_t len = 0;   // for watchpoint probes, the width of watched addr
   std::string mode;   // for watchpoint probes, the watch mode
   bool async = false; // for watchpoint probes, if it's an async watchpoint
-  bool need_expansion = false;
+
+  ExpansionType expansion = ExpansionType::NONE;
+
   uint64_t address = 0;
   uint64_t func_offset = 0;
   bool ignore_invalid = false;

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -29,6 +29,10 @@ using CallArgs = std::vector<std::tuple<FormatString, std::vector<Field>>>;
 class CodegenLLVM : public Visitor {
 public:
   explicit CodegenLLVM(Node *root, BPFtrace &bpftrace, bool is_aot = false);
+  explicit CodegenLLVM(Node *root,
+                       BPFtrace &bpftrace,
+                       bool is_aot,
+                       std::unique_ptr<USDTHelper> usdt_helper);
 
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;
@@ -154,6 +158,12 @@ private:
                      std::optional<int> usdt_location_index = std::nullopt,
                      bool dummy = false);
 
+  // Generate a probe and register it to the BPFtrace class.
+  void add_probe(AttachPoint &ap,
+                 Probe &probe,
+                 const std::string &name,
+                 FunctionType *func_type);
+
   [[nodiscard]] ScopedExprDeleter accept(Node *node);
   [[nodiscard]] std::tuple<Value *, ScopedExprDeleter> getMapKey(Map &map);
   AllocaInst *getMultiMapKey(Map &map, const std::vector<Value *> &extra_keys);
@@ -238,6 +248,7 @@ private:
   Node *root_ = nullptr;
 
   BPFtrace &bpftrace_;
+  std::unique_ptr<USDTHelper> usdt_helper_;
   std::unique_ptr<LLVMContext> context_;
   std::unique_ptr<TargetMachine> target_machine_;
   std::unique_ptr<Module> module_;

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -175,7 +175,7 @@ void FieldAnalyser::resolve_args(Probe &probe)
         probe_type != ProbeType::uprobe)
       continue;
 
-    if (ap->need_expansion) {
+    if (ap->expansion != ExpansionType::NONE) {
       std::set<std::string> matches;
 
       // Find all the matches for the wildcard..

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -434,7 +434,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
       ProbeType type = probetype(attach_point->provider);
 
       if (type == ProbeType::tracepoint) {
-        probe->need_expansion = true;
+        attach_point->expansion = ExpansionType::FULL;
         builtin_args_tracepoint(attach_point, builtin);
       }
     }

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1298,7 +1298,7 @@ void AttachedProbe::attach_usdt(int pid, BPFfeature &feature)
   }
 
   // Resolve location of usdt probe
-  auto u = USDTHelper::find(pid, probe_.path, probe_.ns, probe_.attach_point);
+  auto u = usdt_helper.find(pid, probe_.path, probe_.ns, probe_.attach_point);
   if (!u.has_value())
     throw FatalUserException("Failed to find usdt probe: " + eventname());
   probe_.path = u->path;

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -89,6 +89,7 @@ private:
   uint64_t offset_ = 0;
   int tracing_fd_ = -1;
   std::function<void()> usdt_destructor_;
+  USDTHelper usdt_helper;
 
   BTF &btf_;
 };

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -103,7 +103,9 @@ public:
   {
   }
   virtual ~BPFtrace();
-  virtual int add_probe(ast::Probe &p);
+  virtual int add_probe(const ast::AttachPoint &ap,
+                        const ast::Probe &p,
+                        int usdt_location_idx = 0);
   Probe generateWatchpointSetupProbe(const ast::AttachPoint &ap,
                                      const ast::Probe &probe);
   int num_probes() const;
@@ -265,7 +267,9 @@ private:
   static uint64_t read_address_from_output(std::string output);
   std::optional<std::vector<uint8_t>> find_empty_key(const BpfMap &map) const;
   struct bcc_symbol_option &get_symbol_opts();
-  Probe generate_probe(const ast::AttachPoint &ap, const ast::Probe &p);
+  Probe generate_probe(const ast::AttachPoint &ap,
+                       const ast::Probe &p,
+                       int usdt_location_idx = 0);
   bool has_iter_ = false;
   int epollfd_ = -1;
   struct ring_buffer *ringbuf_ = nullptr;

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -88,7 +88,7 @@ std::set<std::string> Driver::list_modules() const
           ((probe_type == ProbeType::kprobe ||
             probe_type == ProbeType::kretprobe) &&
            !ap->target.empty())) {
-        if (ap->need_expansion) {
+        if (ap->expansion != ast::ExpansionType::NONE) {
           for (auto &match :
                bpftrace_.probe_matcher_->get_matches_for_ap(*ap)) {
             std::string func = match;

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -127,7 +127,7 @@ public:
   std::vector<Probe> watchpoint_probes;
 
   // List of probes using userspace symbol resolution
-  std::unordered_set<ast::Probe *> probes_using_usym;
+  std::unordered_set<const ast::Probe *> probes_using_usym;
 
 private:
   friend class cereal::access;

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -19,10 +19,12 @@ typedef std::vector<usdt_probe_entry> usdt_probe_list;
 // pointer callback without a context variable. So we must keep global state.
 class USDTHelper {
 public:
-  static std::optional<usdt_probe_entry> find(int pid,
-                                              const std::string &target,
-                                              const std::string &provider,
-                                              const std::string &name);
+  virtual ~USDTHelper() = default;
+
+  virtual std::optional<usdt_probe_entry> find(int pid,
+                                               const std::string &target,
+                                               const std::string &provider,
+                                               const std::string &name);
   static usdt_probe_list probes_for_pid(int pid, bool print_error = true);
   static usdt_probe_list probes_for_all_pids();
   static usdt_probe_list probes_for_path(const std::string &path);

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -15,7 +15,8 @@ public:
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
-  MOCK_METHOD1(add_probe, int(ast::Probe &p));
+  MOCK_METHOD3(add_probe,
+               int(const ast::AttachPoint &, const ast::Probe &, int));
 #pragma GCC diagnostic pop
 
   int resolve_uname(const std::string &name,
@@ -110,7 +111,7 @@ TEST(codegen, printf_offsets)
 TEST(codegen, probe_count)
 {
   MockBPFtrace bpftrace;
-  EXPECT_CALL(bpftrace, add_probe(_)).Times(2);
+  EXPECT_CALL(bpftrace, add_probe(_, _, _)).Times(2);
 
   Driver driver(bpftrace);
 

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -23,6 +23,16 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
         return myval;
       });
 
+  ON_CALL(matcher, get_symbols_from_traceable_funcs(true))
+      .WillByDefault([](void) {
+        std::string ksyms = "kernel_mod:func_in_mod\n"
+                            "kernel_mod:other_func_in_mod\n"
+                            "other_kernel_mod:func_in_mod\n";
+        auto myval = std::unique_ptr<std::istream>(
+            new std::istringstream(ksyms));
+        return myval;
+      });
+
   ON_CALL(matcher, get_symbols_from_file(tracefs::available_events()))
       .WillByDefault([](const std::string &) {
         std::string tracepoints = "sched:sched_one\n"

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -163,5 +163,24 @@ public:
   }
 };
 
+class MockUSDTHelper : public USDTHelper {
+public:
+  MockUSDTHelper()
+  {
+  }
+#pragma GCC diagnostic push
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+#endif
+  MOCK_METHOD4(find,
+               std::optional<usdt_probe_entry>(int pid,
+                                               const std::string &target,
+                                               const std::string &provider,
+                                               const std::string &name));
+#pragma GCC diagnostic pop
+};
+
+std::unique_ptr<MockUSDTHelper> get_mock_usdt_helper(int num_locations);
+
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
The previous probe expansion approach tried to minimize the amount of LLVM functions generated by emitting a single function for all probe matches in most cases. While this was efficient, it came with a couple of drawbacks:
- It is necessary to generate a separate LLVM function for each match (e.g. when the `probe` builtin is used). This leads to having two very similar loops for iterating matches in `BPFtrace::add_probe` and in `CodegenLLVM::visit(Probe)` which is quite confusing and hard to maintain.
- libbpf needs one BPF program (i.e. one LLVM function) per probe so if we want to delegate program loading (and possibly attachment) to libbpf (which we do), we cannot use this approach. See #3005 for more details.

This refactors probe expansion by moving most of it into codegen. Overall, we now distinguish two types of probe expansion:

- **Full expansion** - A separate LLVM function is generated for each match. This is used for most expansions now.
- **Multi expansion** - Used for k(u)probes when k(u)probe_multi is available. Generates one LLVM function and one BPF program for all matches and attaches the expanded functions via `bpf_link_create_opts`.

This allows to drop a lot of duplicated code. The expansion for "full" is done in `CodegenLLVM::visit(Probe)`, the expansion for "multi" is done in `BPFtrace::add_probe`.

A drawback of this approach is that we generate substantially larger ELF objects for expansions of probe types which do not support multi-probes (e.g. kfuncs and tracepoints) as we generate duplicate LLVM functions. This is something we can live with for now since multi-attachment is not the main use-case for these probe types (e.g. attaching to many kfuncs is very slow) and there's usually an alternative to use multi-kprobes. In addition, we will probably add a third expansion type using LLVM symbol aliases but that requires libbpf changes.

One particular area where this refactoring caused problems is unit tests in `tests/bpftrace.cpp`. Previously, it was sufficient to generate a simple `ast::Probe` and pass it to `BPFtrace::add_probe` since that was where most of the expansion was done. Now that the expansion was moved to codegen, we need to do full parser -> field analyser -> clang parser -> semantic analyser -> codegen sequence.

Also, the problem comes with USDT probes as it is not possible to easily mock `USDTHelper` which is a fully static class. Since we need to override `AttachPoint::usdt::num_locations` from tests, we allow to do that via a new internal env variable `BPFTRACE_TEST_USDT_NUM_LOCATIONS`.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
