### PR TITLE
Add ability to specify a script's license

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   - [#3046](https://github.com/bpftrace/bpftrace/pull/3046)
 - Add for-each loops for iterating over map elements
   - [#3003](https://github.com/bpftrace/bpftrace/pull/3003)
+- Add ability to specify a script's license
+  - [#3157](https://github.com/bpftrace/bpftrace/pull/3157)
 #### Changed
 - Better error message for args in mixed probes
   - [#3047](https://github.com/bpftrace/bpftrace/pull/3047)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -53,7 +53,11 @@ x86_64, arm64, s390x, arm32, loongarch64, mips64, ppc64, riscv64
 
 The license of a bpftrace script affects how it can be run, as the Linux kernel limits the functionality available to non-GPL licensed programs.
 
-A license can be specified by setting the <<license>> config variable.
+A license can be specified by setting the <<license>> config variable or by including a single-line comment containing a SPDX License ID:
+
+----
+// SPDX-License-Identifier: GPL-2.0-or-later
+----
 
 If a license is not explicitly declared, bpftrace will assume that the script is GPL v2 compatible.
 

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -49,6 +49,14 @@ List all the probes attached in the program::
 
 x86_64, arm64, s390x, arm32, loongarch64, mips64, ppc64, riscv64
 
+== Script Licenses
+
+The license of a bpftrace script affects how it can be run, as the Linux kernel limits the functionality available to non-GPL licensed programs.
+
+A license can be specified by setting the <<license>> config variable.
+
+If a license is not explicitly declared, bpftrace will assume that the script is GPL v2 compatible.
+
 == Options
 
 === *-B* _MODE_
@@ -3339,6 +3347,16 @@ This feature can be turned off by setting the value of this environment variable
 Default: 0
 
 For user space symbols, symbolicate lazily/on-demand (1) or symbolicate everything ahead of time (0).
+
+=== license
+
+Default: <unset>
+
+The license covering the script's source code.
+
+This license string is passed to the kernel where it is used to determine what functionality can be used.
+
+Licenses recognised by the Linux kernel are listed in link:https://docs.kernel.org/process/license-rules.html#id1[its documentation].
 
 === log_size
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -607,14 +607,12 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
   // int bpf_probe_read_str(void *dst, int size, const void *unsafe_ptr)
   FunctionType *probereadstr_func_type = FunctionType::get(
       getInt64Ty(), { dst->getType(), getInt32Ty(), src->getType() }, false);
-  PointerType *probereadstr_func_ptr_type = PointerType::get(
-      probereadstr_func_type, 0);
-  Constant *probereadstr_callee = ConstantExpr::getCast(
-      Instruction::IntToPtr, getInt64(read_fn), probereadstr_func_ptr_type);
-  CallInst *call = createCall(probereadstr_func_type,
-                              probereadstr_callee,
-                              { dst, size_i32, src },
-                              probeReadHelperName(read_fn));
+
+  CallInst *call = CreateHelperCall(read_fn,
+                                    probereadstr_func_type,
+                                    { dst, size_i32, src },
+                                    probeReadHelperName(read_fn),
+                                    &loc);
   CreateHelperErrorCond(ctx, call, read_fn, loc);
   return call;
 }

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -96,12 +96,16 @@ CodegenLLVM::CodegenLLVM(Node *root, BPFtrace &bpftrace)
                          llvm::DEBUG_METADATA_VERSION);
 
   // Set license of BPF programs
-  const std::string license = "GPL";
+  const auto &license = bpftrace_.get_license();
   auto license_var = llvm::dyn_cast<GlobalVariable>(module_->getOrInsertGlobal(
       "LICENSE", ArrayType::get(b_.getInt8Ty(), license.size() + 1)));
   license_var->setInitializer(
       ConstantDataArray::getString(module_->getContext(), license.c_str()));
   license_var->setSection("license");
+
+  // XXX: Set licenses for manually loaded programs. Remove once libbpf is used
+  // instead:
+  bpftrace_.resources.license = license;
 }
 
 void CodegenLLVM::visit(Integer &integer)

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -8,6 +8,7 @@
 #include "bpffeature.h"
 #include "bpfprogram.h"
 #include "btf.h"
+#include "container/cstring_view.h"
 #include "types.h"
 
 #include <bcc/libbpf.h>
@@ -24,12 +25,14 @@ public:
                 BpfProgram &&prog,
                 bool safe_mode,
                 BPFfeature &feature,
-                BTF &btf);
+                BTF &btf,
+                cstring_view license);
   AttachedProbe(Probe &probe,
                 BpfProgram &&prog,
                 int pid,
                 BPFfeature &feature,
                 BTF &btf,
+                cstring_view license,
                 bool safe_mode = true);
   ~AttachedProbe();
   AttachedProbe(const AttachedProbe &) = delete;
@@ -44,7 +47,7 @@ private:
   std::string eventname() const;
   void resolve_offset_kprobe(bool safe_mode);
   bool resolve_offset_uprobe(bool safe_mode);
-  void load_prog(BPFfeature &feature);
+  void load_prog(BPFfeature &feature, cstring_view license);
   void attach_multi_kprobe(void);
   void attach_multi_uprobe(int pid);
   void attach_kprobe(bool safe_mode);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -166,6 +166,7 @@ public:
   bool has_btf_data() const;
   Dwarf *get_dwarf(const std::string &filename);
   Dwarf *get_dwarf(const ast::AttachPoint &attachpoint);
+  std::string get_license() const;
 
   std::string cmd_;
   bool finalize_ = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -13,6 +13,7 @@ Config::Config(bool has_cmd, bool bt_verbose) : bt_verbose_(bt_verbose)
   config_map_ = {
     { ConfigKeyBool::cpp_demangle, { .value = true } },
     { ConfigKeyBool::lazy_symbolication, { .value = false } },
+    { ConfigKeyString::license, { .value = std::nullopt } },
     { ConfigKeyInt::log_size, { .value = (uint64_t)1000000 } },
     { ConfigKeyInt::max_bpf_progs, { .value = (uint64_t)512 } },
     { ConfigKeyInt::max_cat_bytes, { .value = (uint64_t)10240 } },

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -85,6 +85,8 @@ public:
   void load_state(std::istream &in);
   void load_state(const uint8_t *ptr, size_t len);
 
+  std::string license;
+
   // Async argument metadata
   std::vector<std::tuple<FormatString, std::vector<Field>>> system_args;
   // mapped_printf_args stores seq_printf, debugf arguments

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,7 @@ add_executable(bpftrace_test
   mocks.cpp
   output.cpp
   parser.cpp
+  parser_licenses.cpp
   portability_analyser.cpp
   procmon.cpp
   probe.cpp

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -72,6 +72,17 @@ TEST(Config, get_config_key)
             "max_ast_nodes can only be set as an environment variable");
 }
 
+TEST(Config, try_get)
+{
+  auto config = Config();
+  auto config_setter = ConfigSetter(config, ConfigSource::env_var);
+
+  EXPECT_EQ(config.try_get(ConfigKeyString::license), std::nullopt);
+
+  config_setter.set(ConfigKeyString::license, "abc");
+  EXPECT_EQ(config.try_get(ConfigKeyString::license), "abc");
+}
+
 TEST(ConfigSetter, set_stack_mode)
 {
   auto config = Config();

--- a/tests/parser_licenses.cpp
+++ b/tests/parser_licenses.cpp
@@ -1,0 +1,65 @@
+#include <optional>
+#include <string>
+#include <string_view>
+
+#include "bpftrace.h"
+#include "driver.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::parser_licenses {
+
+void test(std::string_view input, std::optional<std::string> expected_license)
+{
+  BPFtrace bpftrace;
+  Driver driver{ bpftrace };
+  ASSERT_EQ(0, driver.parse_str(input));
+  EXPECT_EQ(expected_license,
+            bpftrace.config_.try_get(ConfigKeyString::license));
+}
+
+TEST(ParserLicenses, GPL_v2_only)
+{
+  test(R"(
+// SPDX-License-Identifier: GPL-2.0-only
+BEGIN {}
+)",
+       "GPL");
+}
+
+TEST(ParserLicenses, GPL_v2_or_later)
+{
+  test(R"(
+// SPDX-License-Identifier: GPL-2.0-or-later
+BEGIN {}
+)",
+       "GPL");
+}
+
+TEST(ParserLicenses, GPL_v1)
+{
+  test(R"(
+// SPDX-License-Identifier: GPL-1.0-only
+BEGIN {}
+)",
+       "GPL-1.0-only");
+}
+
+TEST(ParserLicenses, GPL_v3)
+{
+  test(R"(
+// SPDX-License-Identifier: GPL-3.0-only
+BEGIN {}
+)",
+       "GPL-3.0-only");
+}
+
+TEST(ParserLicenses, Apache_2)
+{
+  test(R"(
+// SPDX-License-Identifier: Apache-2.0
+BEGIN {}
+)",
+       "Apache-2.0");
+}
+
+} // namespace bpftrace::test::parser_licenses

--- a/tests/runtime/license
+++ b/tests/runtime/license
@@ -16,3 +16,24 @@ EXPECT stdin:1:51-57: ERROR: helper bpf_probe_read_str can only be used in GPL-c
 TIMEOUT 5
 WILL_FAIL
 
+NAME spdx_allowed
+PROG // SPDX-License-Identifier: GPL-2.0-or-later
+     BEGIN { printf("\"%s\"\n", str(0)); exit(); }
+EXPECT ""
+TIMEOUT 5
+
+NAME spdx_not_allowed
+PROG // SPDX-License-Identifier: Apache-2.0
+     BEGIN { printf("%s\n", str(0)); }
+EXPECT stdin:2:24-30: ERROR: helper bpf_probe_read_str can only be used in GPL-compatible programs
+       BEGIN { printf("%s\n", str(0)); }
+                              ~~~~~~
+TIMEOUT 5
+WILL_FAIL
+
+NAME config_override_spdx
+PROG // SPDX-License-Identifier: Some-unknown-GPL-compatible-license
+     config = { license = "GPL" }
+     BEGIN { printf("\"%s\"\n", str(0)); exit(); }
+EXPECT ""
+TIMEOUT 5

--- a/tests/runtime/license
+++ b/tests/runtime/license
@@ -1,0 +1,18 @@
+NAME implicit_allowed
+PROG BEGIN { printf("\"%s\"\n", str(0)); exit(); }
+EXPECT ""
+TIMEOUT 5
+
+NAME config_allowed
+PROG config = { license = "GPL" } BEGIN { printf("\"%s\"\n", str(0)); exit(); }
+EXPECT ""
+TIMEOUT 5
+
+NAME config_not_allowed
+PROG config = { license = "?" } BEGIN { printf("%s\n", str(0)); }
+EXPECT stdin:1:51-57: ERROR: helper bpf_probe_read_str can only be used in GPL-compatible programs
+       config = { license = "?" } BEGIN { printf("%s\n", str(0)); }
+                                                         ~~~~~~
+TIMEOUT 5
+WILL_FAIL
+


### PR DESCRIPTION
Not all code will be GPL-licensed, so provide users with a way to override the assumed GPL license.

1. Use license defined in config if provided
2. Parse SPDX License IDs from scripts

Licenses defined in a BpfScript config block take precedence over SPDX IDs.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
