### PR TITLE
Add optional support for sending systemd readiness notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   - [#3046](https://github.com/bpftrace/bpftrace/pull/3046)
 - Add for-each loops for iterating over map elements
   - [#3003](https://github.com/bpftrace/bpftrace/pull/3003)
+- Add optional systemd support
+  - [#3158](https://github.com/bpftrace/bpftrace/pull/3158)
 #### Changed
 - Better error message for args in mixed probes
   - [#3047](https://github.com/bpftrace/bpftrace/pull/3047)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ set(VENDOR_GTEST OFF CACHE BOOL "Clone gtest from github")
 set(BUILD_FUZZ OFF CACHE BOOL "Build bpftrace for fuzzing")
 set(USE_LIBFUZZER OFF CACHE BOOL "Use libfuzzer for fuzzing")
 set(FUZZ_TARGET "codegen" CACHE STRING "Fuzzing target")
+set(ENABLE_SYSTEMD OFF CACHE BOOL "Enable systemd integration")
 
 set(ENABLE_SKB_OUTPUT ON CACHE BOOL "Enable skb_output, will include libpcap")
 
@@ -118,6 +119,11 @@ if(ENABLE_SKB_OUTPUT)
   find_package(LibPcap)
 endif()
 
+if(ENABLE_SYSTEMD)
+  find_package(PkgConfig)
+  pkg_check_modules(libsystemd REQUIRED IMPORTED_TARGET libsystemd)
+endif()
+
 if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)
 endif()
@@ -187,6 +193,10 @@ endif(LIBPCAP_FOUND)
 if (HAVE_LIBBPF_UPROBE_MULTI)
   set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_LIBBPF_UPROBE_MULTI)
 endif(HAVE_LIBBPF_UPROBE_MULTI)
+
+if(ENABLE_SYSTEMD)
+  set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_LIBSYSTEMD)
+endif()
 
 add_subdirectory(src)
 if (BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ find_package(LibBfd)
 find_package(LibOpcodes)
 
 if(ENABLE_SKB_OUTPUT)
-find_package(LibPcap)
+  find_package(LibPcap)
 endif()
 
 if(POLICY CMP0075)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3809,3 +3809,29 @@ Maps are printed by reference not by value and as the value gets updated right a
 ----
 
 Therefore, when you need precise event statistics, it is recommended to use synchronous functions (e.g. count() and hist()) to ensure more reliable and accurate results.
+
+=== Systemd support
+
+To run bpftrace in the background using systemd::
+----
+# systemd-run --unit=bpftrace --service-type=notify bpftrace -e 'kprobe:do_nanosleep { printf("%d sleeping\n", pid); }'
+----
+
+In the above example, systemd-run will not finish until bpftrace has attached
+its probes, so you can be sure that all following commands will be traced. To
+stop tracing, run `systemctl stop bpftrace`.
+
+To debug early boot issues, bpftrace can be invoked via a systemd service
+ordered before the service that needs to be traced. A basic unit file to run
+bpftrace before another service looks as follows::
+----
+[Unit]
+Before=service-i-want-to-trace.service
+
+[Service]
+Type=notify
+ExecStart=bpftrace -e 'kprobe:do_nanosleep { printf("%d sleeping\n", pid); }'
+----
+
+Similarly to the systemd-run example, the service to be traced will not start
+until bpftrace started by the systemd unit has attached its probes.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -222,6 +222,10 @@ if (STATIC_LINKING)
   endif()
 endif()
 
+if (ENABLE_SYSTEMD)
+  target_link_libraries(runtime PkgConfig::libsystemd)
+endif()
+
 unset(MAIN_SRC)
 unset(BPFTRACE)
 

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -33,6 +33,12 @@ std::string BuildInfo::report()
 #else
       << "no" << std::endl;
 #endif
+  buf << "  libsystemd (systemd notify support): "
+#ifdef HAVE_LIBSYSTEMD
+      << "yes" << std::endl;
+#else
+      << "no" << std::endl;
+#endif
 
   return buf.str();
 }


### PR DESCRIPTION
When ENABLE_SYSTEMD is enabled, we'll link against libsystemd and send readiness notifications using sd_notify() as documented in https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html.

These will only be sent if the NOTIFY_$SOCKET environment variable is set to a unix socket where systemd expects to receive readiness notifications.

This allows running bpftrace in a systemd service which will only be considered started once bpftrace has finished allocation its probes. This allows starting bpftrace from scripts and ensuring that its probes are registered before continuing.

For example, currently one has to do something like this:

"""
bpftrace <script> &
PID=$!
sleep 2 # How many seconds should we sleep???
<stuff that needs tracing>
kill $PID
"""

With the problem being that we never know how long we should sleep. Either we don't sleep long enough and miss messages, or we sleep too long and waste time doing nothing useful.

With this PR, we can do the following instead:

"""
systemd-run --unit=bpftrace --service-type=notify bpftrace <script> <stuff that needs tracing>
systemctl stop bpftrace
"""

The systemd-run command will only finish once bpftrace has sent the READY=1 notification, which is only send after probes have been registered, thus guaranteeing that we wait just long enough for the probes to be registered but not any longer.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
