### PR TITLE
Fixes for watchpoint probes and runtime tests

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2547,7 +2547,7 @@ void CodegenLLVM::generateProbe(Probe &probe,
   if ((pt == ProbeType::watchpoint || pt == ProbeType::asyncwatchpoint) &&
       current_attach_point_->func.size())
     generateWatchpointSetupProbe(
-        func_type, func_name, current_attach_point_->address, index);
+        func_type, name, current_attach_point_->address, index);
 }
 
 void CodegenLLVM::visit(Subprog &subprog)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -123,14 +123,15 @@ add_custom_target(
 )
 add_test(NAME runtime_tests COMMAND ./runtime-tests.sh)
 
-file(GLOB_RECURSE runtime_test_files
+file(GLOB_RECURSE runtime_test_src_files
   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
   CONFIGURE_DEPENDS
   runtime/*
 )
-list(REMOVE_ITEM runtime_test_files runtime/engine/cmake_vars.py)
+list(REMOVE_ITEM runtime_test_src_files runtime/engine/cmake_vars.py)
 
-foreach(runtime_test_file ${runtime_test_files})
+set(runtime_test_files)
+foreach(runtime_test_file ${runtime_test_src_files})
   add_custom_command(
     OUTPUT
       ${CMAKE_CURRENT_BINARY_DIR}/${runtime_test_file}
@@ -139,6 +140,10 @@ foreach(runtime_test_file ${runtime_test_files})
       ${CMAKE_CURRENT_BINARY_DIR}/${runtime_test_file}
     DEPENDS
       ${CMAKE_CURRENT_SOURCE_DIR}/${runtime_test_file}
+  )
+  list(APPEND
+    runtime_test_files
+    ${CMAKE_CURRENT_BINARY_DIR}/${runtime_test_file}
   )
 endforeach()
 add_custom_target(runtime_test_files ALL DEPENDS ${runtime_test_files})

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -37,7 +37,7 @@ REQUIRES_FEATURE signal
 
 NAME many_function_probes
 RUN {{BPFTRACE}} -e 'watchpoint:increment+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_many_probes
-EXPECT You are out of watchpoint registers
+EXPECT Failed to attach watchpoint probe. You are out of watchpoint registers.
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
@@ -58,7 +58,7 @@ REQUIRES_FEATURE signal
 
 NAME wildcarded_function
 RUN {{BPFTRACE}} -e 'watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
-EXPECT You are out of watchpoint registers
+EXPECT Failed to attach watchpoint probe. You are out of watchpoint registers.
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Fix two issues with watchpoint probes/tests introduced by recent PRs:
- #2997 forgot to update the `EXPECT` clauses for watchpoint runtime tests,
- #3153 broke the name of the LLVM functions/sections for watchpoint setup probes and bpftrace was not able to associate the generated BPF programs to probes.

The reason why neither of these was captured is a strange issue in CMake. During CMake run, we copy files from `tests/runtime/` to `build/tests/runtime`, however, the last file (in our case `tests/runtime/watchpoint`) is never copied. Due to this, watchpoint tests are not run in the CI and also do not get updated in local builds (it seems to have worked in the past b/c I had the file in my build directory but it was never updated).

I'm not sure if this is caused by our change or by a CMake update, however, our approach is IMHO not correct as it makes the `runtime_tests` target depend on the runtime tests files from the source directory. Changing it to depend on the (newly copied) files from the build directory eliminates the above issue. This is done by the last commit in the PR. 

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
