### PR TITLE
Remove LOG(FATAL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,6 @@ and this project adheres to
   - [#3047](https://github.com/bpftrace/bpftrace/pull/3047)
 - Reproducible Builds: Do not store timestamps in gzip header
   - [#3096](https://github.com/bpftrace/bpftrace/pull/3096)
-- Replace instances of std::runtime_error with LOG(FATAL)
-  - [#3091](https://github.com/bpftrace/bpftrace/pull/3091)
 - Parse DWARF using liblldb instead of libdw
   - [#3042](https://github.com/bpftrace/bpftrace/pull/3042)
 - Replace native 'bpf_get_stackid'

--- a/docs/coding_guidelines.md
+++ b/docs/coding_guidelines.md
@@ -29,10 +29,8 @@ Appropriate language features for this include:
 * `int`
 * `bool`
 
-If an error is **not** recoverable, prefer using `LOG(FATAL)` or `LOG(ERROR)` and `exit(1)` if there are multiple, separate errors. Broadly
-speaking, if you want to immediately terminate and show a message to the
-user, use `LOG(FATAL)`. Exceptions **should not** be used for recoverable
-errors.
+If an error is **not** recoverable, prefer throwing `FatalUserException`.
+Exceptions **should not** be used for recoverable errors.
 
 ### Examples
 
@@ -94,9 +92,14 @@ struct Bar {
 
 Below are details about when to use each kind of log level:
 
-- `DEBUG`: log info regardless of log level; like using stdout (comes with file and line number)
+- `DEBUG`: log info regardless of log level; like using stdout (comes with file
+and line number)
 - `V1`: log info only if verbose logging is enabled (-v)
-- `WARNING`: log info that might affect bpftrace behavior or output but allows the run to continue; like using stderr
-- `ERROR`: log info to indicate that the user did something invalid, which will (eventually) cause bpftrace to exit (via `exit(1)` or `LOG(FATAL)`); this should get used if there are multiple errors, otherwise use `FATAL `
-- `FATAL`: similar to `ERROR` but exits immediately after logging
-- `BUG`: exit and log info to indicate that there is an internal/unexpected issue (not caused by invalid user program code or CLI use)
+- `WARNING`: log info that might affect bpftrace behavior or output but allows
+the run to continue; like using stderr
+- `ERROR`: log info to indicate that the user did something invalid, which will
+(eventually) cause bpftrace to exit (via `exit(1)`); this should primarily get
+used in main.cpp after catching `FatalUserException` from deeper parts of the
+code base
+- `BUG`: abort and log info to indicate that there is an internal/unexpected
+issue (not caused by invalid user program code or CLI use)

--- a/src/arch/loongarch64.cpp
+++ b/src/arch/loongarch64.cpp
@@ -1,4 +1,5 @@
 #include "arch.h"
+#include "utils.h"
 
 #include <algorithm>
 #include <array>
@@ -149,7 +150,8 @@ std::string name()
 
 std::vector<std::string> invalid_watchpoint_modes()
 {
-  LOG(FATAL) << "Watchpoints are not supported on this architecture";
+  throw FatalUserException(
+      "Watchpoints are not supported on this architecture");
 }
 
 int get_kernel_ptr_width()

--- a/src/arch/mips64.cpp
+++ b/src/arch/mips64.cpp
@@ -1,4 +1,5 @@
 #include "arch.h"
+#include "utils.h"
 
 #include <algorithm>
 #include <array>
@@ -161,7 +162,8 @@ std::string name()
 
 std::vector<std::string> invalid_watchpoint_modes()
 {
-  LOG(FATAL) << "Watchpoints are not supported on this architecture";
+  throw FatalUserException(
+      "Watchpoints are not supported on this architecture");
 }
 
 int get_kernel_ptr_width()

--- a/src/arch/riscv64.cpp
+++ b/src/arch/riscv64.cpp
@@ -1,4 +1,5 @@
 #include "arch.h"
+#include "utils.h"
 
 #include <algorithm>
 #include <array>
@@ -103,7 +104,8 @@ std::string name()
 
 std::vector<std::string> invalid_watchpoint_modes()
 {
-  LOG(FATAL) << "Watchpoints are not supported on this architecture";
+  throw FatalUserException(
+      "Watchpoints are not supported on this architecture");
 }
 
 int get_kernel_ptr_width()

--- a/src/arch/s390.cpp
+++ b/src/arch/s390.cpp
@@ -1,4 +1,5 @@
 #include "arch.h"
+#include "utils.h"
 
 #include <algorithm>
 #include <array>
@@ -93,7 +94,8 @@ std::string name()
 
 std::vector<std::string> invalid_watchpoint_modes()
 {
-  LOG(FATAL) << "Watchpoints are not supported on this architecture";
+  throw FatalUserException(
+      "Watchpoints are not supported on this architecture");
 }
 
 int get_kernel_ptr_width()

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -253,8 +253,7 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
         ty = getInt8Ty();
         break;
       default:
-        LOG(FATAL) << stype.GetSize()
-                   << " is not a valid type size for GetType";
+        LOG(BUG) << stype.GetSize() << " is not a valid type size for GetType";
     }
   }
   return ty;
@@ -666,8 +665,8 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
     int offset = 0;
     offset = arch::offset(argument->base_register_name);
     if (offset < 0) {
-      LOG(FATAL) << "offset for register " << argument->base_register_name
-                 << " not known";
+      LOG(BUG) << "offset for register " << argument->base_register_name
+               << " not known";
     }
 
     // bpftrace's args are internally represented as 64 bit integers. However,
@@ -682,8 +681,8 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
     if (argument->valid & BCC_USDT_ARGUMENT_INDEX_REGISTER_NAME) {
       int ioffset = arch::offset(argument->index_register_name);
       if (ioffset < 0) {
-        LOG(FATAL) << "offset for register " << argument->index_register_name
-                   << " not known";
+        LOG(BUG) << "offset for register " << argument->index_register_name
+                 << " not known";
       }
       index_offset = CreateGEP(getInt8Ty(),
                                ctx,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -61,7 +61,8 @@ CodegenLLVM::CodegenLLVM(Node *root, BPFtrace &bpftrace)
   std::string error_str;
   auto target = llvm::TargetRegistry::lookupTarget(LLVMTargetTriple, error_str);
   if (!target)
-    LOG(FATAL) << "Could not find bpf llvm target, does your llvm support it?";
+    throw FatalUserException(
+        "Could not find bpf llvm target, does your llvm support it?");
 
   target_machine_.reset(
       target->createTargetMachine(LLVMTargetTriple,
@@ -837,7 +838,7 @@ void CodegenLLVM::visit(Call &call)
     auto name = bpftrace_.get_string_literal(call.vargs->at(0));
     addr = bpftrace_.resolve_kname(name);
     if (!addr)
-      LOG(FATAL) << "Failed to resolve kernel symbol: " << name;
+      throw FatalUserException("Failed to resolve kernel symbol: " + name);
     expr_ = b_.getInt64(addr);
   } else if (call.func == "uaddr") {
     auto name = bpftrace_.get_string_literal(call.vargs->at(0));
@@ -846,8 +847,8 @@ void CodegenLLVM::visit(Call &call)
                                       &sym,
                                       current_attach_point_->target);
     if (err < 0 || sym.address == 0)
-      LOG(FATAL) << "Could not resolve symbol: "
-                 << current_attach_point_->target << ":" << name;
+      throw FatalUserException("Could not resolve symbol: " +
+                               current_attach_point_->target + ":" + name);
     expr_ = b_.getInt64(sym.address);
   } else if (call.func == "cgroupid") {
     uint64_t cgroupid;
@@ -999,7 +1000,8 @@ void CodegenLLVM::visit(Call &call)
     Value *octet;
     auto ret = inet_pton(af_type, addr.c_str(), &dst);
     if (ret != 1) {
-      LOG(FATAL) << "inet_pton() call returns " << ret;
+      throw FatalUserException("inet_pton() call returns " +
+                               std::to_string(ret));
     }
     for (int i = 0; i < addr_size; i++) {
       octet = b_.getInt8(dst[i]);
@@ -1014,7 +1016,7 @@ void CodegenLLVM::visit(Call &call)
     auto reg_name = bpftrace_.get_string_literal(call.vargs->at(0));
     int offset = arch::offset(reg_name);
     if (offset == -1) {
-      LOG(FATAL) << "negative offset on reg() call";
+      throw FatalUserException("negative offset on reg() call");
     }
 
     expr_ = b_.CreateRegisterRead(ctx_, offset, call.func + "_" + reg_name);
@@ -2697,13 +2699,13 @@ void CodegenLLVM::visit(Probe &probe)
       uint64_t max_bpf_progs = bpftrace_.config_.get(
           ConfigKeyInt::max_bpf_progs);
       if (probe_count_ > max_bpf_progs) {
-        LOG(FATAL) << "Your program is trying to generate more than "
-                   << std::to_string(probe_count_)
-                   << " BPF programs, which exceeds the current limit of "
-                   << std::to_string(max_bpf_progs)
-                   << ".\nYou can increase the limit through the "
-                      "BPFTRACE_MAX_BPF_PROGS "
-                      "environment variable.";
+        throw FatalUserException(
+            "Your program is trying to generate more than " +
+            std::to_string(probe_count_) +
+            " BPF programs, which exceeds the current limit of " +
+            std::to_string(max_bpf_progs) +
+            ".\nYou can increase the limit through the BPFTRACE_MAX_BPF_PROGS "
+            "environment variable.");
       }
 
       tracepoint_struct_ = "";

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -1,6 +1,7 @@
 #include "format_string.h"
 #include "log.h"
 #include "struct.h"
+#include "utils.h"
 
 #include <unordered_map>
 
@@ -148,7 +149,9 @@ void FormatString::format(std::ostream &out,
   auto buffer = std::vector<char>(FMT_BUF_SZ);
   auto check_snprintf_ret = [](int r) {
     if (r < 0) {
-      LOG(FATAL) << "format() error occurred: " << std::strerror(errno);
+      char *e = std::strerror(errno);
+      throw FatalUserException("format() error occurred: " +
+                               std::string(e ? e : ""));
     }
   };
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -10,7 +10,6 @@ std::string logtype_str(LogType t)
     case LogType::V1      : return "";
     case LogType::WARNING : return "WARNING: ";
     case LogType::ERROR   : return "ERROR: ";
-    case LogType::FATAL   : return "ERROR: ";
     case LogType::BUG     : return "BUG: ";
       // clang-format on
   }
@@ -24,7 +23,6 @@ Log::Log()
   enabled_map_[LogType::WARNING] = true;
   enabled_map_[LogType::V1] = false;
   enabled_map_[LogType::DEBUG] = true;
-  enabled_map_[LogType::FATAL] = true;
   enabled_map_[LogType::BUG] = true;
 }
 
@@ -200,12 +198,6 @@ std::string LogStream::internal_location()
   std::ostringstream ss;
   ss << "[" << log_file_ << ":" << log_line_ << "] ";
   return ss.str();
-}
-
-[[noreturn]] LogStreamFatal::~LogStreamFatal()
-{
-  sink_.take_input(type_, loc_, out_, buf_.str());
-  abort();
 }
 
 [[noreturn]] LogStreamBug::~LogStreamBug()

--- a/src/log.h
+++ b/src/log.h
@@ -17,7 +17,6 @@ enum class LogType
   V1,
   WARNING,
   ERROR,
-  FATAL,
   BUG,
 };
 // clang-format on
@@ -50,8 +49,7 @@ public:
   }
   inline void disable(LogType type)
   {
-    assert(type != LogType::FATAL && type != LogType::BUG &&
-           type != LogType::ERROR);
+    assert(type != LogType::BUG && type != LogType::ERROR);
     enabled_map_[type] = false;
   }
   inline bool is_enabled(LogType type)
@@ -103,22 +101,6 @@ protected:
   std::ostringstream buf_;
 };
 
-class LogStreamFatal : public LogStream {
-public:
-  LogStreamFatal(const std::string& file,
-                 int line,
-                 __attribute__((unused)) LogType,
-                 std::ostream& out = std::cerr)
-      : LogStream(file, line, LogType::FATAL, out){};
-  LogStreamFatal(const std::string& file,
-                 int line,
-                 __attribute__((unused)) LogType,
-                 const location& loc,
-                 std::ostream& out = std::cerr)
-      : LogStream(file, line, LogType::FATAL, loc, out){};
-  [[noreturn]] ~LogStreamFatal();
-};
-
 class LogStreamBug : public LogStream {
 public:
   LogStreamBug(const std::string& file,
@@ -147,7 +129,6 @@ public:
 #define LOGSTREAM_V1(...) LOGSTREAM_COMMON(__VA_ARGS__)
 #define LOGSTREAM_WARNING(...) LOGSTREAM_COMMON(__VA_ARGS__)
 #define LOGSTREAM_ERROR(...) LOGSTREAM_COMMON(__VA_ARGS__)
-#define LOGSTREAM_FATAL(...) bpftrace::LogStreamFatal(__FILE__, __LINE__, __VA_ARGS__)
 #define LOGSTREAM_BUG(...) bpftrace::LogStreamBug(__FILE__, __LINE__, __VA_ARGS__)
 // clang-format on
 

--- a/src/resolve_cgroupid.cpp
+++ b/src/resolve_cgroupid.cpp
@@ -23,6 +23,7 @@
 #include "act_helpers.h"
 #include "log.h"
 #include "resolve_cgroupid.h"
+#include "utils.h"
 
 namespace {
 
@@ -91,9 +92,9 @@ std::uint64_t resolve_cgroupid(const std::string &path)
   int err = name_to_handle_at(
       AT_FDCWD, path.c_str(), cfh.as_file_handle_ptr(), &mount_id, 0);
   if (err < 0) {
-    auto emsg = std::strerror(errno);
-    LOG(FATAL) << "Failed to get `cgroupid` for path: \"" << path
-               << "\": " << emsg;
+    char *e = std::strerror(errno);
+    throw bpftrace::FatalUserException("Failed to get `cgroupid` for path: \"" +
+                                       path + "\": " + std::string(e ? e : ""));
   }
 
   return cfh.cgid;

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -4,6 +4,7 @@
 #include <limits>
 
 #include "log.h"
+#include "utils.h"
 
 namespace bpftrace {
 
@@ -131,7 +132,7 @@ const Field &Struct::GetField(const std::string &name) const
     if (field.name == name)
       return field;
   }
-  throw std::runtime_error("struct has no field named " + name);
+  throw FatalUserException("struct has no field named " + name);
 }
 
 void Struct::AddField(const std::string &field_name,
@@ -163,8 +164,8 @@ void StructManager::Add(const std::string &name,
                         bool allow_override)
 {
   if (struct_map_.find(name) != struct_map_.end())
-    LOG(FATAL) << "Type redefinition: type with name \'" << name
-               << "\' already exists";
+    throw FatalUserException("Type redefinition: type with name \'" + name +
+                             "\' already exists");
   struct_map_[name] = std::make_unique<Struct>(size, allow_override);
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -6,6 +6,7 @@
 #include "log.h"
 #include "struct.h"
 #include "types.h"
+#include "utils.h"
 
 namespace bpftrace {
 
@@ -491,7 +492,7 @@ Field &SizedType::GetField(ssize_t n) const
 {
   assert(IsTupleTy() || IsRecordTy());
   if (n >= GetFieldCount())
-    LOG(FATAL) << "Getfield(): out of bounds";
+    throw FatalUserException("Getfield(): out of bounds");
   return inner_struct_.lock()->fields[n];
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -67,7 +67,7 @@ std::vector<std::string> expand_wildcard_path(const std::string &path)
 
   if (glob(path.c_str(), GLOB_NOCHECK, nullptr, &glob_result)) {
     globfree(&glob_result);
-    LOG(FATAL) << "glob() failed";
+    throw bpftrace::FatalUserException("glob() failed");
   }
 
   std::vector<std::string> matching_paths;
@@ -139,7 +139,8 @@ void StdioSilencer::silence()
     close(new_stdio);
   } catch (const std::system_error &e) {
     if (errno == EMFILE)
-      LOG(FATAL) << e.what() << ": please raise NOFILE";
+      throw bpftrace::FatalUserException(std::string(e.what()) +
+                                         ": please raise NOFILE");
     else
       LOG(BUG) << e.what();
   }
@@ -221,8 +222,9 @@ void get_uint64_env_var(const ::std::string &str,
   if (const char *env_p = std::getenv(str.c_str())) {
     std::istringstream stringstream(env_p);
     if (!(stringstream >> dest)) {
-      LOG(FATAL) << "Env var '" << str
-                 << "' did not contain a valid uint64_t, or was zero-valued.";
+      throw bpftrace::FatalUserException(
+          "Env var '" + str +
+          "' did not contain a valid uint64_t, or was zero-valued.");
       return;
     }
     cb(dest);
@@ -240,9 +242,8 @@ void get_bool_env_var(const ::std::string &str,
     else if (s == "0")
       dest = false;
     else {
-      LOG(FATAL) << "Env var '" << str
-                 << "' did not contain a "
-                    "valid value (0 or 1).";
+      throw bpftrace::FatalUserException(
+          "Env var '" + str + "' did not contain a valid value (0 or 1).");
     }
     cb(dest);
   }
@@ -803,7 +804,7 @@ std::string exec_system(const char *cmd)
   std::string result;
   std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
   if (!pipe)
-    throw std::runtime_error("popen() failed!");
+    throw bpftrace::FatalUserException("popen() failed!");
   while (!feof(pipe.get())) {
     if (fgets(buffer.data(), 128, pipe.get()) != nullptr)
       result += buffer.data();

--- a/src/utils.h
+++ b/src/utils.h
@@ -47,6 +47,15 @@ public:
   using std::runtime_error::runtime_error;
 };
 
+// Use this to end bpftrace execution due to a user error.
+// These should be caught at a high level only e.g. main.cpp or bpftrace.cpp
+class FatalUserException : public std::runtime_error {
+public:
+  // C++11 feature: bring base class constructor into scope to automatically
+  // forward constructor calls to base class
+  using std::runtime_error::runtime_error;
+};
+
 class StdioSilencer {
 public:
   StdioSilencer() = default;

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -282,7 +282,7 @@ WILL_FAIL
 
 NAME kaddr fails
 PROG BEGIN { print(kaddr("asdfzzzzzzz")) }
-EXPECT ERROR: Failed to resolve kernel symbol: asdfzzzzzzz
+EXPECT ERROR: Failed to compile: Failed to resolve kernel symbol: asdfzzzzzzz
 TIMEOUT 1
 WILL_FAIL
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -486,7 +486,7 @@ TIMEOUT 2
 # match and so we should fail on exceeding BPFTRACE_MAX_BPF_PROGS.
 NAME bpf_programs_limit
 PROG k:* { @[probe] = count(); }
-EXPECT_REGEX ERROR: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 512.\nYou can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
+EXPECT_REGEX ERROR: Failed to compile: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 512.\nYou can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
 WILL_FAIL
 TIMEOUT 2
 


### PR DESCRIPTION
Replace these with either LOG(BUG), LOG(ERROR) and exit(1) in main.cpp, or `throw std::runtime_error`.

This is to avoid calling `abort` for user errors and removes the confusion between `LOG(ERROR)` and `LOG(FATAL)`.

Issue: https://github.com/bpftrace/bpftrace/issues/3163

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
