### PR TITLE
Fix intptrcast runtime tests

### DIFF
--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -1,83 +1,11 @@
 NAME Sum casted value
-PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+8)); exit();}
-EXPECT @: 3258
+PROG uprobe:./testprogs/intptrcast:fn { @=sum(*((uint16*)arg0 + 1)); exit();}
+EXPECT @: 1110
 TIMEOUT 5
-ARCH x86_64
-AFTER ./testprogs/intptrcast
-
-NAME Sum casted value
-PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+0)); exit();}
-EXPECT @: 3258
-TIMEOUT 5
-ARCH aarch64
-AFTER ./testprogs/intptrcast
-
-NAME Sum casted value
-PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+0)); exit();}
-EXPECT @: 3567
-TIMEOUT 5
-ARCH armv7l
-AFTER ./testprogs/intptrcast
-
-NAME Sum casted value
-PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+96)); exit();}
-EXPECT @: 3258
-TIMEOUT 5
-ARCH ppc64le
-AFTER ./testprogs/intptrcast
-
-NAME Sum casted value
-PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+112)); exit();}
-EXPECT @: 3258
-TIMEOUT 5
-ARCH ppc64
-AFTER ./testprogs/intptrcast
-
-NAME Sum casted value
-PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r15")+160)); exit();}
-EXPECT @: 4660
-TIMEOUT 5
-ARCH s390x
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-PROG uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+8); printf("%d\n", $a); exit();}
-EXPECT 3258
+PROG uprobe:./testprogs/intptrcast:fn { $a=*((uint16*)arg0 + 1); printf("%d\n", $a); exit();}
+EXPECT 1110
 TIMEOUT 5
-ARCH x86_64
-AFTER ./testprogs/intptrcast
-
-NAME Casting ints
-PROG uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+0); printf("%d\n", $a); exit();}
-EXPECT 3258
-TIMEOUT 5
-ARCH aarch64
-AFTER ./testprogs/intptrcast
-
-NAME Casting ints
-PROG uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+4); printf("0x%x\n", $a); exit();}
-EXPECT 0x4321
-TIMEOUT 5
-ARCH armv7l
-AFTER ./testprogs/intptrcast
-
-NAME Casting ints
-PROG uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+96); printf("%d\n", $a); exit();}
-EXPECT 3258
-TIMEOUT 5
-ARCH ppc64le
-AFTER ./testprogs/intptrcast
-
-NAME Casting ints
-PROG uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+112); printf("%d\n", $a); exit();}
-EXPECT 3258
-TIMEOUT 5
-ARCH ppc64
-AFTER ./testprogs/intptrcast
-
-NAME Casting ints
-PROG uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r15")+160); printf("%d\n", $a); exit();}
-EXPECT 4660
-TIMEOUT 5
-ARCH s390x
 AFTER ./testprogs/intptrcast

--- a/tests/testprogs/intptrcast.c
+++ b/tests/testprogs/intptrcast.c
@@ -1,26 +1,15 @@
-int fn(short p1,
-       short p2,
-       short p3,
-       short p4,
-       short p5,
-       unsigned long p6,
-       short p7,
-       short p8,
-       short p9)
+#include <stdint.h>
+
+int fn(uint16_t nums[])
 {
-  return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
+  return nums[0] + nums[1];
 }
 
 int main()
 {
-  fn(0x123,
-     0x456,
-     0x789,
-     0xabc,
-     0xdef,
-     0x1234567887654321,
-     0xcba,
-     0xcba,
-     0xcba);
+  uint16_t nums[] = {
+    0x123, 0x456, 0x789, 0xabc, 0xdef, 0xcba,
+  };
+  fn(nums);
   return 0;
 }


### PR DESCRIPTION
Explicitly put numbers into an array on the stack instead of relying on architecture-specific calling conventions for stack-passed parameters.

This removes the dependency on the stack pointer's value (which changed as of #3095) and makes the tests architecture independent.

This fixes the recent test failures on master: https://github.com/bpftrace/bpftrace/actions/runs/9080541080