### PR TITLE
Fix runtime tests using ustacks

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -229,7 +229,7 @@ AFTER ./testprogs/uprobe_loop
 NAME ustack_stack_mode_env_bpftrace
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=bpftrace
-EXPECT_REGEX ^uprobeFunction1\+[0-9]+$
+EXPECT_REGEX ^\s+uprobeFunction1\+[0-9]+$
 TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
 # This was debugged as far down as std::cout having badbit [0] set after a
@@ -249,7 +249,7 @@ SKIP_IF_ENV_HAS CI=true
 NAME ustack_stack_mode_env_perf
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=perf
-EXPECT_REGEX ^[0-9a-f]+ uprobeFunction1\+[0-9]+ \(.*/uprobe_loop\)$
+EXPECT_REGEX ^\s+[0-9a-f]+ uprobeFunction1\+[0-9]+ \(.*/uprobe_loop\)$
 TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
 # See https://github.com/bpftrace/bpftrace/issues/3080

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -95,8 +95,8 @@ PROG config = { probe_inline = 1; cache_user_symbols = "PER_PROGRAM"; }
        printf("%s\n", ustack);
        if (++@count == 3) { exit(); }
      }
-EXPECT_REGEX ^\n[ ]+main\+\d+\n[ ]+0x[\da-f]+\n\n$
-EXPECT_REGEX ^\n[ ]+square\+\d+\n[ ]+main\+\d+\n[ ]+0x[\da-f]+\n\n$
+EXPECT_REGEX ^\n[ ]+main\+\d+$
+EXPECT_REGEX ^\n[ ]+square\+\d+\n[ ]+main\+\d+$
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 AFTER ./testprogs/inline_function


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Several tests using the `ustack` builtin fail on my local setup. I found two issues:
- Some tests in `call.ustack*` do not expect the stack entries to be indented by whitespace. These tests happen to be the same as the ones disabled in the CI by #3078 so the issue was never discovered.
- The `dwarf.uprobe inlined function - ustack` gives me a slightly different stack from what is expected. It seems to expect something like:
    ```
        main+21
        0x7fdff76fb14a
    ```
    but I'm getting
    ```
        main+21
        0x7fdff76fb14a
        0x7fdff76fb20b
        _start+37
    ```
    IMHO, the most important part is to check that the "main+21" call occurs at the top of the stack and everything below is not that important.

This fixes the two issues.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
