### PR TITLE
config: Specify the type of str_trunc_trailer explicitly

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -23,7 +23,7 @@ Config::Config(bool has_cmd, bool bt_verbose) : bt_verbose_(bt_verbose)
     { ConfigKeyInt::max_type_res_iterations, { .value = (uint64_t)0 } },
     { ConfigKeyInt::perf_rb_pages, { .value = (uint64_t)64 } },
     { ConfigKeyStackMode::default_, { .value = StackMode::bpftrace } },
-    { ConfigKeyString::str_trunc_trailer, { .value = ".." } },
+    { ConfigKeyString::str_trunc_trailer, { .value = std::string("..") } },
     // by default, cache user symbols per program if ASLR is disabled on system
     // or `-c` option is given
     { ConfigKeyUserSymbolCacheType::default_,


### PR DESCRIPTION
Built bpftrace with LLVM/clang 16 and ran some random scripts, I got the following error:

    $ sudo bpftrace -e '...'
    Attaching 1 probe...
    terminate called after throwing an instance of 'std::runtime_error'
      what():  Type mismatch for config key
    [1]    1297304 abort      sudo ./bpftrace -e

The coredump reveals a failed type deduction:

    (gdb) p config_map_
    ...
      [std::variant<bpftrace::ConfigKeyBool, bpftrace::ConfigKeyInt, bpftrace::ConfigKeyString, bpftrace::ConfigKeyStackMode, bpftrace::ConfigKeyUserSymbolCacheType> [index 2] = {bpftrace::ConfigKeyString::str_trunc_trailer}] = {source = bpftrace::ConfigSource::default_,
        value = std::variant<bool, unsigned long, std::string, bpftrace::StackMode, bpftrace::UserSymbolCacheType> [index 0] = {true}},
    ...

Let's specify the type of str_trunc_trailer to avoid such error.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
