### PR TITLE
Fix runtime tests for aarch64

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -470,7 +470,7 @@ bool AttachedProbe::resolve_offset_uprobe(bool safe_mode)
 
   sym.name = "";
   option.use_debug_file = 1;
-  option.use_symbol_type = 0xffffffff;
+  option.use_symbol_type = BCC_SYM_ALL_TYPES ^ (1 << STT_NOTYPE);
 
   if (symbol.empty()) {
     sym.address = probe_.address;
@@ -550,7 +550,7 @@ static std::string find_vmlinux(const struct vmlinux_location *locs,
 {
   struct bcc_symbol_option option = {};
   option.use_debug_file = 0;
-  option.use_symbol_type = BCC_SYM_ALL_TYPES;
+  option.use_symbol_type = BCC_SYM_ALL_TYPES ^ (1 << STT_NOTYPE);
   struct utsname buf;
 
   uname(&buf);
@@ -1084,7 +1084,7 @@ static void resolve_offset_uprobe_multi(const std::string &path,
   std::sort(std::begin(syms), std::end(syms));
 
   option.use_debug_file = 1;
-  option.use_symbol_type = 0xffffffff;
+  option.use_symbol_type = BCC_SYM_ALL_TYPES ^ (1 << STT_NOTYPE);
 
   std::vector<struct addr_offset> addrs;
   std::set<uint64_t> set;

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -217,6 +217,8 @@ SizedType Dwarf::get_stype(lldb::SBType type, bool resolve_structs)
           return CreateArray(length, inner_stype);
       }
     }
+    case lldb::eTypeClassTypedef:
+      return get_stype(type.GetTypedefedType(), resolve_structs);
     default:
       return CreateNone();
   }

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -208,6 +208,10 @@ SizedType Dwarf::get_stype(lldb::SBType type, bool resolve_structs)
       switch (inner_type.GetBasicType()) {
         case lldb::eBasicTypeChar:
         case lldb::eBasicTypeSignedChar:
+        case lldb::eBasicTypeUnsignedChar:
+#if LLVM_VERSION_MAJOR >= 15
+        case lldb::eBasicTypeChar8:
+#endif
           return CreateString(length);
         default:
           return CreateArray(length, inner_stype);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -144,7 +144,7 @@ std::string addrspacestr(AddrSpace as)
 std::string typestr(Type t)
 {
   switch (t) {
-    // clang-format off
+      // clang-format off
     case Type::none:     return "none";     break;
     case Type::voidtype: return "void";     break;
     case Type::integer:  return "integer";  break;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -252,14 +252,8 @@ uint64_t asyncactionint(AsyncAction a)
 // Type wrappers
 SizedType CreateInteger(size_t bits, bool is_signed)
 {
-  // Zero sized integers are not usually valid. However, during semantic
-  // analysis when we're inferring types, the first pass may not have
-  // enough information to figure out the exact size of the integer. Later
-  // passes infer the exact size.
-  assert(bits == 0 || bits == 1 || bits == 8 || bits == 16 || bits == 32 ||
-         bits == 64);
   auto t = SizedType(Type::integer, 0, is_signed);
-  t.size_bits_ = bits;
+  t.SetIntBitWidth(bits);
   return t;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -240,13 +240,24 @@ public:
     return size_bits_ / 8;
   }
 
-  void SetSize(size_t size)
+  void SetSize(size_t byte_size)
   {
-    size_bits_ = size * 8;
-    if (IsIntTy()) {
-      assert(size == 0 || size == 1 || size == 8 || size == 16 || size == 32 ||
-             size == 64);
-    }
+    if (IsIntTy())
+      SetIntBitWidth(byte_size * 8);
+    else
+      size_bits_ = byte_size * 8;
+  }
+
+  void SetIntBitWidth(size_t bits)
+  {
+    assert(IsIntTy());
+    // Zero sized integers are not usually valid. However, during semantic
+    // analysis when we're inferring types, the first pass may not have
+    // enough information to figure out the exact size of the integer. Later
+    // passes infer the exact size.
+    assert(bits == 0 || bits == 1 || bits == 8 || bits == 16 || bits == 32 ||
+          bits == 64 || bits == 128);
+    size_bits_ = bits;
   }
 
   size_t GetIntBitWidth() const

--- a/src/types.h
+++ b/src/types.h
@@ -251,12 +251,15 @@ public:
   void SetIntBitWidth(size_t bits)
   {
     assert(IsIntTy());
+    // Truncate integers too large to fit in BPF registers (64-bits).
+    if (bits > 64)
+      bits = 64;
     // Zero sized integers are not usually valid. However, during semantic
     // analysis when we're inferring types, the first pass may not have
     // enough information to figure out the exact size of the integer. Later
     // passes infer the exact size.
     assert(bits == 0 || bits == 1 || bits == 8 || bits == 16 || bits == 32 ||
-          bits == 64 || bits == 128);
+           bits == 64);
     size_bits_ = bits;
   }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1376,7 +1376,7 @@ std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
   };
   struct bcc_symbol_option option;
   memset(&option, 0, sizeof(option));
-  option.use_symbol_type = BCC_SYM_ALL_TYPES;
+  option.use_symbol_type = BCC_SYM_ALL_TYPES ^ (1 << STT_NOTYPE);
   bcc_elf_foreach_sym(
       elf_file.c_str(), sym_resolve_callback, &option, &symbol_table);
 

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -45,6 +45,33 @@ REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
+# NAME uprobe arg by index - 128-bits integer
+# PROG uprobe:./testprogs/uprobe_test:uprobeFunctionUint128 { printf("x = %x\ny = %x\nz = %x\nw = %x\n", arg0, arg1, arg2, arg3); exit(); }
+# EXPECT x = 9abcdef0
+#        y = efefefef
+#        z = cdcdcdcd
+#        w = abababab
+# REQUIRES_FEATURE dwarf
+# TIMEOUT 5
+# BEFORE ./testprogs/uprobe_test
+
+# NAME uprobe arg by name - 128-bits integer
+# PROG uprobe:./testprogs/uprobe_test:uprobeFunctionUint128 { printf("x = %x\ny = %x\nz = %x\nw = %x\n", args.x, args.y, args.z, args.w); exit(); }
+# EXPECT x = 9abcdef0
+#        y = efefefef
+#        z = cdcdcdcd
+#        w = abababab
+# REQUIRES_FEATURE dwarf
+# TIMEOUT 5
+# BEFORE ./testprogs/uprobe_test
+
+NAME uprobe arg by name - struct with 128-bits integer
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->d = %x\n", args.foo1->d); exit(); }
+EXPECT foo1->d = 9abcdef0
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
 NAME uprobe skip inlined function
 PROG config = { probe_inline = 0 }
      uprobe:./testprogs/inline_function:square { @count++ }

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -371,6 +371,7 @@ class Runner(object):
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
+                errors='backslashreplace',
                 env=env,
                 start_new_session=True,
                 universal_newlines=True,

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -212,7 +212,7 @@ AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME positional ustack
 RUN {{BPFTRACE}} -e 'u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack($1)); exit(); }' 1
-EXPECT_REGEX .*uprobeFunction1\+[0-9]+\n\s+spin\+[0-9]+\n\s+main\+[0-9]+\n.*\n\n\n\s+uprobeFunction1\+[0-9]+
+EXPECT_REGEX .*uprobeFunction1\+[0-9]+\n\s+spin\+[0-9]+\n\s+main\+[0-9]+\n(?s:.*)\n\n\n\s+uprobeFunction1\+[0-9]+
 TIMEOUT 5
 # Required to skip function prologue
 REQUIRES_FEATURE dwarf

--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(testprog_cflags "-g -O0")
+set(testprog_cflags "-g -O0 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer")
 if(LLVM_VERSION_MAJOR VERSION_LESS 13)
   # CI's GCC compile the testprogs using DWARF version 5
   # LLDB doesn't support DWARF5 before version 13, so we force DWARF4

--- a/tests/testprogs/uprobe_test.c
+++ b/tests/testprogs/uprobe_test.c
@@ -9,6 +9,7 @@ struct Foo {
   int a;
   char b[10];
   int c[3];
+  __int128_t d;
 };
 
 int uprobeFunction1(int *n, char c __attribute__((unused)))
@@ -50,6 +51,14 @@ struct Foo *uprobeFunction2(struct Foo *foo1,
  */
 // clang-format on
 
+__uint128_t uprobeFunctionUint128(__uint128_t x,
+                                  __uint128_t y __attribute__((unused)),
+                                  __uint128_t z __attribute__((unused)),
+                                  __uint128_t w)
+{
+  return x + w;
+}
+
 int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
 {
   usleep(1000000);
@@ -58,9 +67,19 @@ int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
   char c = 'x';
   uprobeFunction1(&n, c);
 
-  struct Foo foo1 = { .a = 123, .b = "hello", .c = { 1, 2, 3 } };
-  struct Foo foo2 = { .a = 456, .b = "world", .c = { 4, 5, 6 } };
+  struct Foo foo1 = {
+    .a = 123, .b = "hello", .c = { 1, 2, 3 }, .d = 0x123456789ABCDEF0
+  };
+  struct Foo foo2 = {
+    .a = 456, .b = "world", .c = { 4, 5, 6 }, .d = 0xFEDCBA9876543210
+  };
   uprobeFunction2(&foo1, &foo2);
+
+  __uint128_t x = 0x123456789ABCDEF0;
+  __uint128_t y = 0xEFEFEFEFEFEFEFEF;
+  __uint128_t z = 0xCDCDCDCDCDCDCDCD;
+  __uint128_t w = 0xABABABABABABABAB;
+  uprobeFunctionUint128(x, y, z, w);
 
   return 0;
 }


### PR DESCRIPTION
This PR fixes the following tests, that are failing when running on ARM:

* Update `CreateInteger` to accept 128-bits integers.
  The ARM specific [`struct user_fpsimd_state`](https://elixir.bootlin.com/linux/latest/source/arch/arm64/include/uapi/asm/ptrace.h#L95) has a 128-bits integers.
* Update DWARF parser to consider arrays of `unsigned char` as strings.
  The `char`s from "tests/data/data_source.c"'s `struct Arrays::char_arr` have the Basic Type `lldb::eBasicTypeUnsignedChar`. Is this valid? Is there a bug in GCC for generating wrong DWARF?
* Force frame pointers for each `testprogs` and `testlibs`.
  The compiler doesn't have to set-up a frame pointer for leaf functions. We enforce their generation with `-fno-omit-frame-pointer` AND `-mno-omit-leaf-frame-pointer`.
* Ignore `STT_NOTYPE` symbols from the symbol table.
  ARM binaries might contain [mapping symbols](https://github.com/ARM-software/abi-aa/blob/main/aaelf64/aaelf64.rst#mapping-symbols), which are not relevant to bpftrace. These symbols messes with symbolication, as they might have the same address as other symbols.
* Fix runtime test `other.positional ustack`.
  The expected regex would not tolerate extra stack trace. By using the `s` flag with `.*`, we accept any number of extra lines, while being strict enough to validate that `uprobeFunction1` is on top of the last stack trace.

After these fixes, the following runtime tests still fail:
* `probe.kprobe_offset_fail_size`: the function `AttachedProbe::resolve_offset_kprobe` cannot locate `vmlinux`, because my machine only has `vmlinuZ`, and thus can't check the boundaries of `vfs_read`. The Kernel didn't reject the probe `vfs_read+100000`. Shouldn't this function use `/proc/kallsyms` instead?
* `call.path`: The `path` builtin function returns path with the form `/dev/pts/4`, but never returns the expected path of the temporary file created for the test. Is this a Kernel bug?
* `call.strcontains`: This test uses the `path` builtin function and fails because of the issue above.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
