### PR TITLE
man: Clarify ++/-- operators can lose updates

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -804,6 +804,8 @@ $b = --$a; // a = 9; b = 9
 Note that maps will be implicitly declared and initialized to 0 if not already declared or defined.
 Scratch variables must be initialized before using these operators.
 
+Note `++`/`--` on a shared global variable can lose updates. See <<map-functions-count, `count()`>> for more details.
+
 === Pointers
 
 Pointers in bpftrace are similar to those found in `C`.


### PR DESCRIPTION
We already call this out in count() docs. Let's do it for ++/-- as well.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
