### PR TITLE
Add implicit cast for 'sum' and 'count'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to
   - [#3195](https://github.com/bpftrace/bpftrace/pull/3195)
 - Semantic analyser: fix checking record map types
   - [#3220](https://github.com/bpftrace/bpftrace/pull/3220)
+- Fix count/sum map reads in kernel space (implict casting)
+  - [#3189](https://github.com/bpftrace/bpftrace/pull/3189)
 #### Docs
 #### Tools
 

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2415,9 +2415,12 @@ i:s:10 {
 Count how often this function is called.
 
 Using `@=count()` is conceptually similar to `@++`.
-The difference is that the `count()` function uses a map type optimized for this (PER_CPU), increasing performance and correctness.
-Multiple writers to a shared global var might lose counts as bpftrace doesn't update them atomically.
-Due to this the map cannot be accessed as a regular integer.
+The difference is that the `count()` function uses a map type optimized for 
+writing (PER_CPU), increasing performance and correctness. However, sync reads 
+can be expensive as bpftrace needs to iterate over all the cpus to collect and 
+sum these values.
+Note: In contrast to hash maps (e.g. `@++`), multiple writers to a shared 
+global var might lose counts as bpftrace doesn't update them atomically.
 
 ----
 i:ms:100 {
@@ -2425,7 +2428,12 @@ i:ms:100 {
 }
 
 i:s:10 {
+  // async read
   print(@);
+  // sync read
+  if (@ > 10) {
+    print(("hello"));
+  }
   clear(@);
 }
 ----
@@ -2574,6 +2582,30 @@ kprobe:vfs_read {
 * `sum(int64 n)`
 
 Calculate the sum of all `n` passed.
+
+Using `@=sum(5)` is conceptually similar to `@+=5`.
+The difference is that the `sum()` function uses a map type optimized for 
+writing (PER_CPU), increasing performance and correctness. However, sync reads 
+can be expensive as bpftrace needs to iterate over all the cpus to collect and 
+sum these values.
+Note: In contrast to hash maps (e.g. `@+=5`), multiple writers to a shared 
+global var might lose updates as bpftrace doesn't update them atomically.
+
+----
+i:ms:100 {
+  @ = sum(5);
+}
+
+i:s:10 {
+  // async read
+  print(@);
+  // sync read
+  if (@ > 10) {
+    print(("hello"));
+  }
+  clear(@);
+}
+----
 
 [#map-functions-zero]
 === zero

--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -116,6 +116,16 @@ int main(int argc, char* argv[])
     return 1;
 
   BPFtrace bpftrace(std::move(output));
+
+  // TODO: remove this once we move to libbpf or move to open-coded iterators
+  auto num_cpus = bpftrace.get_num_possible_cpus();
+  if (num_cpus > 1024) {
+    LOG(WARNING) << "Detected " << num_cpus
+                 << " cpus. For ahead-of-time compilation there is a max of "
+                    "1024 cpus so there may be incorrect data for 'count' "
+                    "and 'sum' aggregations.";
+  }
+
   int err = aot::load(bpftrace, argv[0]);
   if (err) {
     LOG(ERROR) << "Failed to load AOT script";

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -89,6 +89,12 @@ public:
                              Value *key,
                              SizedType &type,
                              const location &loc);
+
+  Value *CreatePerCpuMapSumElems(Value *ctx,
+                                 Map &map,
+                                 Value *key,
+                                 const location &loc,
+                                 bool is_aot);
   void CreateMapUpdateElem(Value *ctx,
                            const std::string &map_ident,
                            Value *key,
@@ -303,6 +309,17 @@ private:
                             Value *key,
                             PointerType *val_ptr_ty,
                             const std::string &name = "lookup_elem");
+  CallInst *createPerCpuMapLookup(
+      const std::string &map_name,
+      Value *key,
+      Value *cpu,
+      const std::string &name = "lookup_percpu_elem");
+  CallInst *createPerCpuMapLookup(
+      const std::string &map_name,
+      Value *key,
+      Value *cpu,
+      PointerType *val_ptr_ty,
+      const std::string &name = "lookup_percpu_elem");
   CallInst *createGetScratchMap(const std::string &map_name,
                                 const std::string &name,
                                 PointerType *val_ptr_ty,

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1796,7 +1796,8 @@ void SemanticAnalyser::visit(Binop &binop)
     return;
   }
 
-  if (lht.IsIntTy() && rht.IsIntTy()) {
+  if ((lht.IsCastableMapTy() || lht.IsIntTy()) &&
+      (rht.IsCastableMapTy() || rht.IsIntTy())) {
     binop_int(binop);
   } else if (lht.IsArrayTy() && rht.IsArrayTy()) {
     binop_array(binop);
@@ -2333,7 +2334,7 @@ void SemanticAnalyser::visit(Cast &cast)
   }
 
   if ((cast.type.IsIntTy() && !rhs.IsIntTy() && !rhs.IsPtrTy() &&
-       !rhs.IsCtxAccess() && !(rhs.IsArrayTy())) ||
+       !rhs.IsCtxAccess() && !rhs.IsArrayTy() && !rhs.IsCastableMapTy()) ||
       // casting from/to int arrays must respect the size
       (cast.type.IsArrayTy() &&
        (!rhs.IsIntTy() || cast.type.GetSize() != rhs.GetSize())) ||

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1,3 +1,4 @@
+#include "btf.h"
 #include <algorithm>
 #include <arpa/inet.h>
 #include <cassert>
@@ -2337,6 +2338,11 @@ struct bcc_symbol_option &BPFtrace::get_symbol_opts()
   };
 
   return symopts;
+}
+
+int BPFtrace::get_num_possible_cpus() const
+{
+  return libbpf_num_possible_cpus();
 }
 
 } // namespace bpftrace

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -156,6 +156,7 @@ public:
   std::optional<int64_t> get_int_literal(const ast::Expression *expr) const;
   std::optional<std::string> get_watchpoint_binary_path() const;
   virtual bool is_traceable_func(const std::string &func_name) const;
+  virtual int get_num_possible_cpus() const;
   virtual std::unordered_set<std::string> get_func_modules(
       const std::string &func_name) const;
   int create_pcaps(void);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -907,7 +907,9 @@ int main(int argc, char* argv[])
     return err;
   }
 
-  ast::CodegenLLVM llvm(&*ast_root, bpftrace);
+  ast::CodegenLLVM llvm(&*ast_root,
+                        bpftrace,
+                        args.build_mode == BuildMode::AHEAD_OF_TIME);
   BpfBytecode bytecode;
   try {
     llvm.generate_ir();

--- a/src/types.h
+++ b/src/types.h
@@ -412,6 +412,10 @@ public:
   {
     return type_ == Type::timestamp_mode;
   }
+  bool IsCastableMapTy() const
+  {
+    return type_ == Type::count || type_ == Type::sum;
+  }
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);
   friend std::ostream &operator<<(std::ostream &, Type);

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -44,6 +44,11 @@ public:
   {
     return feature_->has_loop();
   }
+
+  int get_num_possible_cpus() const override
+  {
+    return 20;
+  }
 };
 
 TEST(codegen, printf_offsets)

--- a/tests/codegen/llvm/count_cast.ll
+++ b/tests/codegen/llvm/count_cast.ll
@@ -1,0 +1,234 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8* }
+%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
+@ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !49 {
+entry:
+  %key = alloca i32, align 4
+  %print_integer_8_t = alloca %print_integer_8_t, align 8
+  %i = alloca i32, align 4
+  %sum = alloca i64, align 8
+  %"@x_key1" = alloca i64, align 8
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@x_key", align 8
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
+  %2 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %3 = load i64, i64* %cast, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, i64* %cast, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  %5 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 1, i64* %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@x_key1", align 8
+  %10 = bitcast i64* %sum to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i32 0, i32* %i, align 4
+  store i64 0, i64* %sum, align 8
+  br label %while_cond
+
+if_body:                                          ; preds = %while_end
+  %12 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
+  store i64 30007, i64* %13, align 8
+  %14 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
+  store i64 0, i64* %14, align 8
+  %15 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
+  %16 = bitcast [8 x i8]* %15 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 8, i1 false)
+  %17 = bitcast [8 x i8]* %15 to i64*
+  store i64 6, i64* %17, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_integer_8_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_integer_8_t* %print_integer_8_t, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+if_end:                                           ; preds = %counter_merge, %while_end
+  ret i64 0
+
+while_cond:                                       ; preds = %lookup_success2, %lookup_merge
+  %18 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %18, 20
+  br i1 %num_cpu.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %19 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %19)
+  %map_lookup_cond4 = icmp ne i8* %lookup_percpu_elem, null
+  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+
+while_end:                                        ; preds = %error_failure, %error_success, %while_cond
+  %20 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = load i64, i64* %sum, align 8
+  %22 = bitcast i64* %sum to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  %24 = icmp sgt i64 %21, 5
+  %25 = zext i1 %24 to i64
+  %true_cond = icmp ne i64 %25, 0
+  br i1 %true_cond, label %if_body, label %if_end
+
+lookup_success2:                                  ; preds = %while_body
+  %cast5 = bitcast i8* %lookup_percpu_elem to i64*
+  %26 = load i64, i64* %sum, align 8
+  %27 = load i64, i64* %cast5, align 8
+  %28 = add i64 %27, %26
+  store i64 %28, i64* %sum, align 8
+  %29 = load i32, i32* %i, align 4
+  %30 = add i32 %29, 1
+  store i32 %30, i32* %i, align 4
+  br label %while_cond
+
+lookup_failure3:                                  ; preds = %while_body
+  %31 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %31, 0
+  br i1 %error_lookup_cond, label %error_success, label %error_failure
+
+error_success:                                    ; preds = %lookup_failure3
+  br label %while_end
+
+error_failure:                                    ; preds = %lookup_failure3
+  %32 = load i32, i32* %i, align 4
+  br label %while_end
+
+event_loss_counter:                               ; preds = %if_body
+  %33 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  store i32 0, i32* %key, align 4
+  %lookup_elem6 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @ringbuf_loss_counter, i32* %key)
+  %map_lookup_cond10 = icmp ne i8* %lookup_elem6, null
+  br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
+
+counter_merge:                                    ; preds = %lookup_merge9, %if_body
+  %34 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  br label %if_end
+
+lookup_success7:                                  ; preds = %event_loss_counter
+  %35 = bitcast i8* %lookup_elem6 to i64*
+  %36 = atomicrmw add i64* %35, i64 1 seq_cst
+  br label %lookup_merge9
+
+lookup_failure8:                                  ; preds = %event_loss_counter
+  br label %lookup_merge9
+
+lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
+  %37 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+  br label %counter_merge
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+
+!llvm.dbg.cu = !{!45}
+!llvm.module.flags = !{!48}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 6, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 1, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
+!25 = !{!26, !31}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !29)
+!29 = !{!30}
+!30 = !DISubrange(count: 27, lowerBound: 0)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 262144, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !11, !16, !19}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 2, lowerBound: 0)
+!45 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !46, globals: !47)
+!46 = !{}
+!47 = !{!0, !22, !36}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !45, retainedNodes: !54)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!21, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
+!53 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -1,0 +1,267 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8* }
+%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
+%"unsigned int64_count__tuple_t" = type { i64, i64 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+entry:
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 1, i64* %"@x_key", align 8
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
+  %2 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %3 = load i64, i64* %cast, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, i64* %cast, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  %5 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 1, i64* %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %for_each_map_elem = call i64 inttoptr (i64 164 to i64 (%"struct map_t"*, i64 (i8*, i8*, i8*, i8*)*, i8*, i64)*)(%"struct map_t"* @AT_x, i64 (i8*, i8*, i8*, i8*)* @map_for_each_cb, i8* null, i64 0)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !62 {
+  %key1 = alloca i32, align 4
+  %print_tuple_16_t = alloca %print_tuple_16_t, align 8
+  %tuple = alloca %"unsigned int64_count__tuple_t", align 8
+  %"$kv" = alloca %"unsigned int64_count__tuple_t", align 8
+  %i = alloca i32, align 4
+  %sum = alloca i64, align 8
+  %lookup_key = alloca i64, align 8
+  %key = load i64, i8* %1, align 8
+  %5 = bitcast i64* %lookup_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 %key, i64* %lookup_key, align 8
+  %6 = bitcast i64* %sum to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %i, align 4
+  store i64 0, i64* %sum, align 8
+  br label %while_cond
+
+while_cond:                                       ; preds = %lookup_success, %4
+  %8 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %8, 20
+  br i1 %num_cpu.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %9 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %9)
+  %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+while_end:                                        ; preds = %error_failure, %error_success, %while_cond
+  %10 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = load i64, i64* %sum, align 8
+  %12 = bitcast i64* %sum to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast %"unsigned int64_count__tuple_t"* %"$kv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = bitcast %"unsigned int64_count__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
+  %15 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 0
+  store i64 %key, i64* %15, align 8
+  %16 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %11, i64* %16, align 8
+  %17 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 0
+  %18 = load i64, i64* %17, align 8
+  %19 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 1
+  %20 = load i64, i64* %19, align 8
+  %21 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  %22 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
+  %23 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %tuple, i32 0, i32 0
+  store i64 %18, i64* %23, align 8
+  %24 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %tuple, i32 0, i32 1
+  store i64 %20, i64* %24, align 8
+  %25 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
+  %26 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, i64* %26, align 8
+  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
+  store i64 0, i64* %27, align 8
+  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %29 = bitcast [16 x i8]* %28 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 16, i1 false)
+  %30 = bitcast [16 x i8]* %28 to i8*
+  %31 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %30, i8* align 1 %31, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_tuple_16_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+lookup_success:                                   ; preds = %while_body
+  %cast = bitcast i8* %lookup_percpu_elem to i64*
+  %32 = load i64, i64* %sum, align 8
+  %33 = load i64, i64* %cast, align 8
+  %34 = add i64 %33, %32
+  store i64 %34, i64* %sum, align 8
+  %35 = load i32, i32* %i, align 4
+  %36 = add i32 %35, 1
+  store i32 %36, i32* %i, align 4
+  br label %while_cond
+
+lookup_failure:                                   ; preds = %while_body
+  %37 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %37, 0
+  br i1 %error_lookup_cond, label %error_success, label %error_failure
+
+error_success:                                    ; preds = %lookup_failure
+  br label %while_end
+
+error_failure:                                    ; preds = %lookup_failure
+  %38 = load i32, i32* %i, align 4
+  br label %while_end
+
+event_loss_counter:                               ; preds = %while_end
+  %39 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  store i32 0, i32* %key1, align 4
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @ringbuf_loss_counter, i32* %key1)
+  %map_lookup_cond4 = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+
+counter_merge:                                    ; preds = %lookup_merge, %while_end
+  %40 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
+  %41 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  ret i64 0
+
+lookup_success2:                                  ; preds = %event_loss_counter
+  %42 = bitcast i8* %lookup_elem to i64*
+  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure3:                                  ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
+  %44 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  br label %counter_merge
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!54}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 160, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 5, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
+!23 = !{!24, !29}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
+!27 = !{!28}
+!28 = !DISubrange(count: 27, lowerBound: 0)
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 262144, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
+!37 = !{!38, !43, !48, !19}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 2, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 1, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
+!52 = !{}
+!53 = !{!0, !20, !34}
+!54 = !{i32 2, !"Debug Info Version", i32 3}
+!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!18, !58}
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
+!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!60 = !{!61}
+!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!62 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !63)
+!63 = !{!64}
+!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !58)

--- a/tests/codegen/llvm/count_no_cast_for_print.ll
+++ b/tests/codegen/llvm/count_no_cast_for_print.ll
@@ -1,0 +1,164 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8* }
+%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%print_t = type <{ i64, i32, i32, i32 }>
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
+@ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(i8* %0) section "s_BEGIN_1" !dbg !49 {
+entry:
+  %key = alloca i32, align 4
+  %"print_@" = alloca %print_t, align 8
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@_key", align 8
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_, i64* %"@_key")
+  %2 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %3 = load i64, i64* %cast, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, i64* %cast, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  %5 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 1, i64* %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_, i64* %"@_key", i64* %initial_value, i64 1)
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast %print_t* %"print_@" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = getelementptr %print_t, %print_t* %"print_@", i64 0, i32 0
+  store i64 30001, i64* %10, align 8
+  %11 = getelementptr %print_t, %print_t* %"print_@", i64 0, i32 1
+  store i32 0, i32* %11, align 4
+  %12 = getelementptr %print_t, %print_t* %"print_@", i64 0, i32 2
+  store i32 0, i32* %12, align 4
+  %13 = getelementptr %print_t, %print_t* %"print_@", i64 0, i32 3
+  store i32 0, i32* %13, align 4
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_t* %"print_@", i64 20, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_merge
+  %14 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i32 0, i32* %key, align 4
+  %lookup_elem1 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @ringbuf_loss_counter, i32* %key)
+  %map_lookup_cond5 = icmp ne i8* %lookup_elem1, null
+  br i1 %map_lookup_cond5, label %lookup_success2, label %lookup_failure3
+
+counter_merge:                                    ; preds = %lookup_merge4, %lookup_merge
+  %15 = bitcast %print_t* %"print_@" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+
+lookup_success2:                                  ; preds = %event_loss_counter
+  %16 = bitcast i8* %lookup_elem1 to i64*
+  %17 = atomicrmw add i64* %16, i64 1 seq_cst
+  br label %lookup_merge4
+
+lookup_failure3:                                  ; preds = %event_loss_counter
+  br label %lookup_merge4
+
+lookup_merge4:                                    ; preds = %lookup_failure3, %lookup_success2
+  %18 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  br label %counter_merge
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+
+!llvm.dbg.cu = !{!45}
+!llvm.module.flags = !{!48}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 6, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 1, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
+!25 = !{!26, !31}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !29)
+!29 = !{!30}
+!30 = !DISubrange(count: 27, lowerBound: 0)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 262144, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !11, !16, !19}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 2, lowerBound: 0)
+!45 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !46, globals: !47)
+!46 = !{}
+!47 = !{!0, !22, !36}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !45, retainedNodes: !54)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!21, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
+!53 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/sum_cast.ll
+++ b/tests/codegen/llvm/sum_cast.ll
@@ -1,0 +1,240 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8* }
+%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+entry:
+  %key = alloca i32, align 4
+  %print_integer_8_t = alloca %print_integer_8_t, align 8
+  %i = alloca i32, align 4
+  %sum = alloca i64, align 8
+  %"@x_key1" = alloca i64, align 8
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@x_key", align 8
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
+  %2 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %3 = load i64, i64* %cast, align 8
+  %4 = add i64 %3, 2
+  store i64 %4, i64* %cast, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  %5 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 2, i64* %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@x_key1", align 8
+  %10 = bitcast i64* %sum to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i32 0, i32* %i, align 4
+  store i64 0, i64* %sum, align 8
+  br label %while_cond
+
+if_body:                                          ; preds = %while_end
+  %12 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
+  store i64 30007, i64* %13, align 8
+  %14 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
+  store i64 0, i64* %14, align 8
+  %15 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
+  %16 = bitcast [8 x i8]* %15 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 8, i1 false)
+  %17 = bitcast [8 x i8]* %15 to i64*
+  store i64 6, i64* %17, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_integer_8_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_integer_8_t* %print_integer_8_t, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+if_end:                                           ; preds = %counter_merge, %while_end
+  ret i64 0
+
+while_cond:                                       ; preds = %lookup_success2, %lookup_merge
+  %18 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %18, 20
+  br i1 %num_cpu.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %19 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %19)
+  %map_lookup_cond4 = icmp ne i8* %lookup_percpu_elem, null
+  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+
+while_end:                                        ; preds = %error_failure, %error_success, %while_cond
+  %20 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = load i64, i64* %sum, align 8
+  %22 = bitcast i64* %sum to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  %24 = icmp sgt i64 %21, 5
+  %25 = zext i1 %24 to i64
+  %true_cond = icmp ne i64 %25, 0
+  br i1 %true_cond, label %if_body, label %if_end
+
+lookup_success2:                                  ; preds = %while_body
+  %cast5 = bitcast i8* %lookup_percpu_elem to i64*
+  %26 = load i64, i64* %sum, align 8
+  %27 = load i64, i64* %cast5, align 8
+  %28 = add i64 %27, %26
+  store i64 %28, i64* %sum, align 8
+  %29 = load i32, i32* %i, align 4
+  %30 = add i32 %29, 1
+  store i32 %30, i32* %i, align 4
+  br label %while_cond
+
+lookup_failure3:                                  ; preds = %while_body
+  %31 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %31, 0
+  br i1 %error_lookup_cond, label %error_success, label %error_failure
+
+error_success:                                    ; preds = %lookup_failure3
+  br label %while_end
+
+error_failure:                                    ; preds = %lookup_failure3
+  %32 = load i32, i32* %i, align 4
+  br label %while_end
+
+event_loss_counter:                               ; preds = %if_body
+  %33 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  store i32 0, i32* %key, align 4
+  %lookup_elem6 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @ringbuf_loss_counter, i32* %key)
+  %map_lookup_cond10 = icmp ne i8* %lookup_elem6, null
+  br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
+
+counter_merge:                                    ; preds = %lookup_merge9, %if_body
+  %34 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  br label %if_end
+
+lookup_success7:                                  ; preds = %event_loss_counter
+  %35 = bitcast i8* %lookup_elem6 to i64*
+  %36 = atomicrmw add i64* %35, i64 1 seq_cst
+  br label %lookup_merge9
+
+lookup_failure8:                                  ; preds = %event_loss_counter
+  br label %lookup_merge9
+
+lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
+  %37 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+  br label %counter_merge
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!54}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 160, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 5, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
+!23 = !{!24, !29}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
+!27 = !{!28}
+!28 = !DISubrange(count: 27, lowerBound: 0)
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 262144, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
+!37 = !{!38, !43, !48, !19}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 2, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 1, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
+!52 = !{}
+!53 = !{!0, !20, !34}
+!54 = !{i32 2, !"Debug Info Version", i32 3}
+!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!18, !58}
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
+!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!60 = !{!61}
+!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -1,0 +1,267 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8* }
+%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
+%"unsigned int64_sum__tuple_t" = type { i64, i64 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+entry:
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 1, i64* %"@x_key", align 8
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
+  %2 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %3 = load i64, i64* %cast, align 8
+  %4 = add i64 %3, 2
+  store i64 %4, i64* %cast, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  %5 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 2, i64* %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %for_each_map_elem = call i64 inttoptr (i64 164 to i64 (%"struct map_t"*, i64 (i8*, i8*, i8*, i8*)*, i8*, i64)*)(%"struct map_t"* @AT_x, i64 (i8*, i8*, i8*, i8*)* @map_for_each_cb, i8* null, i64 0)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !62 {
+  %key1 = alloca i32, align 4
+  %print_tuple_16_t = alloca %print_tuple_16_t, align 8
+  %tuple = alloca %"unsigned int64_sum__tuple_t", align 8
+  %"$kv" = alloca %"unsigned int64_sum__tuple_t", align 8
+  %i = alloca i32, align 4
+  %sum = alloca i64, align 8
+  %lookup_key = alloca i64, align 8
+  %key = load i64, i8* %1, align 8
+  %5 = bitcast i64* %lookup_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 %key, i64* %lookup_key, align 8
+  %6 = bitcast i64* %sum to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %i, align 4
+  store i64 0, i64* %sum, align 8
+  br label %while_cond
+
+while_cond:                                       ; preds = %lookup_success, %4
+  %8 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %8, 20
+  br i1 %num_cpu.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %9 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %9)
+  %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+while_end:                                        ; preds = %error_failure, %error_success, %while_cond
+  %10 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = load i64, i64* %sum, align 8
+  %12 = bitcast i64* %sum to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast %"unsigned int64_sum__tuple_t"* %"$kv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = bitcast %"unsigned int64_sum__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
+  %15 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 0
+  store i64 %key, i64* %15, align 8
+  %16 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %11, i64* %16, align 8
+  %17 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 0
+  %18 = load i64, i64* %17, align 8
+  %19 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 1
+  %20 = load i64, i64* %19, align 8
+  %21 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  %22 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
+  %23 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %tuple, i32 0, i32 0
+  store i64 %18, i64* %23, align 8
+  %24 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %tuple, i32 0, i32 1
+  store i64 %20, i64* %24, align 8
+  %25 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
+  %26 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, i64* %26, align 8
+  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
+  store i64 0, i64* %27, align 8
+  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %29 = bitcast [16 x i8]* %28 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 16, i1 false)
+  %30 = bitcast [16 x i8]* %28 to i8*
+  %31 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %30, i8* align 1 %31, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_tuple_16_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+lookup_success:                                   ; preds = %while_body
+  %cast = bitcast i8* %lookup_percpu_elem to i64*
+  %32 = load i64, i64* %sum, align 8
+  %33 = load i64, i64* %cast, align 8
+  %34 = add i64 %33, %32
+  store i64 %34, i64* %sum, align 8
+  %35 = load i32, i32* %i, align 4
+  %36 = add i32 %35, 1
+  store i32 %36, i32* %i, align 4
+  br label %while_cond
+
+lookup_failure:                                   ; preds = %while_body
+  %37 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %37, 0
+  br i1 %error_lookup_cond, label %error_success, label %error_failure
+
+error_success:                                    ; preds = %lookup_failure
+  br label %while_end
+
+error_failure:                                    ; preds = %lookup_failure
+  %38 = load i32, i32* %i, align 4
+  br label %while_end
+
+event_loss_counter:                               ; preds = %while_end
+  %39 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  store i32 0, i32* %key1, align 4
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @ringbuf_loss_counter, i32* %key1)
+  %map_lookup_cond4 = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+
+counter_merge:                                    ; preds = %lookup_merge, %while_end
+  %40 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
+  %41 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  ret i64 0
+
+lookup_success2:                                  ; preds = %event_loss_counter
+  %42 = bitcast i8* %lookup_elem to i64*
+  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure3:                                  ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
+  %44 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  br label %counter_merge
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!54}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 160, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 5, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
+!23 = !{!24, !29}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
+!27 = !{!28}
+!28 = !DISubrange(count: 27, lowerBound: 0)
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 262144, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
+!37 = !{!38, !43, !48, !19}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 2, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 1, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
+!52 = !{}
+!53 = !{!0, !20, !34}
+!54 = !{i32 2, !"Debug Info Version", i32 3}
+!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!18, !58}
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
+!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!60 = !{!61}
+!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!62 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !63)
+!63 = !{!64}
+!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !58)

--- a/tests/codegen/per_cpu_map_cast.cpp
+++ b/tests/codegen/per_cpu_map_cast.cpp
@@ -1,0 +1,37 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, count_cast)
+{
+  test("kprobe:f { @x = count(); if (@x > 5) { print((6)); } }", NAME);
+}
+
+TEST(codegen, sum_cast)
+{
+  test("kprobe:f { @x = sum(2); if (@x > 5) { print((6)); } }", NAME);
+}
+
+TEST(codegen, count_cast_loop)
+{
+  test(
+      "kprobe:f { @x[1] = count(); for ($kv : @x) { print(($kv.0, $kv.1)); } }",
+      NAME);
+}
+
+TEST(codegen, sum_cast_loop)
+{
+  test("kprobe:f { @x[1] = sum(2); for ($kv : @x) { print(($kv.0, $kv.1)); } }",
+       NAME);
+}
+
+TEST(codegen, count_no_cast_for_print)
+{
+  test("BEGIN { @ = count(); print(@) }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -81,6 +81,11 @@ public:
     mock_probe_matcher = dynamic_cast<MockProbeMatcher *>(probe_matcher_.get());
   }
 
+  int get_num_possible_cpus() const override
+  {
+    return 20;
+  }
+
   MockProbeMatcher *mock_probe_matcher;
 };
 

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -279,3 +279,18 @@ EXPECT stdin:1:37-41: WARNING: Can't lookup map element because it does not exis
        i:ms:100 { @[1] = 1; printf("%d\n", @[2]); exit(); }
                                            ~~~~
 TIMEOUT 1
+
+NAME per_cpu_map_if_lt
+PROG i:ms:1 { @ = count(); if (@ > 5) { printf("done\n"); exit(); }}
+EXPECT done
+TIMEOUT 5
+
+NAME per_cpu_map_arithmetic
+PROG BEGIN { @a = sum(10); @b = count(); $c = @a + @b; if ($c == 11) { printf("done\n"); } exit();}
+EXPECT done
+TIMEOUT 5
+
+NAME per_cpu_map_cast
+PROG BEGIN { @a = count(); @b = sum(10); printf("%d-%d\n", (uint64)@a, (int64)@b); exit();}
+EXPECT 1-10
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2058,6 +2058,35 @@ TEST(semantic_analyser, map_cast_types)
        1);
 }
 
+TEST(semantic_analyser, map_aggregations_implicit_cast)
+{
+  test("kprobe:f { @ = count(); if (@ > 0) { print((1)); } }");
+  test("kprobe:f { @ = sum(5); if (@ > 0) { print((1)); } }");
+
+  test_error("kprobe:f { @ = avg(5); if (@ > 0) { print((1)); } }", R"(
+stdin:1:27-33: ERROR: Type mismatch for '>': comparing 'avg' with 'int64'
+kprobe:f { @ = avg(5); if (@ > 0) { print((1)); } }
+                          ~~~~~~
+)");
+  test_error("kprobe:f { @ = count(); @ += 5 }", R"(
+stdin:1:25-26: ERROR: Type mismatch for @: trying to assign value of type 'int64' when map already contains a value of type 'count'
+kprobe:f { @ = count(); @ += 5 }
+                        ~
+)");
+}
+
+TEST(semantic_analyser, map_aggregations_explicit_cast)
+{
+  test("kprobe:f { @ = count(); print((1, (uint16)@)); }");
+  test("kprobe:f { @ = sum(5); print((1, (uint16)@)); }");
+
+  test_error("kprobe:f { @ = avg(5); print((1, (uint16)@)); }", R"(
+stdin:1:34-42: ERROR: Cannot cast from "avg" to "unsigned int16"
+kprobe:f { @ = avg(5); print((1, (uint16)@)); }
+                                 ~~~~~~~~
+)");
+}
+
 TEST(semantic_analyser, variable_casts_are_local)
 {
   std::string structs =


### PR DESCRIPTION
This utilizes 'map_lookup_percpu_elem' to iterate over the per-cpu maps that 'sum' and 'count' use to aggregate the values for each cpu so these maps can be used in kernel space for conditionals and arithmetic.

Additionally, add explicit casting for printing or storing just the value for these types of maps.

Issue: https://github.com/bpftrace/bpftrace/issues/3126

Note: We can do the same to support to 'avg', 'max', 'min' but those require the same user-space logic written in llvm ir.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
