### PR TITLE
ClangParser: fix builtin includes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -414,7 +414,7 @@ static void parse_env(BPFtrace& bpftrace)
       }
     }
     extra_flags.push_back("-include");
-    extra_flags.push_back(CLANG_WORKAROUNDS_H);
+    extra_flags.push_back("/bpftrace/include/" CLANG_WORKAROUNDS_H);
 
     for (auto dir : include_dirs) {
       extra_flags.push_back("-I");


### PR DESCRIPTION
#3135 added the `/bpftrace/include` prefix to headers generated by bpftrace (`__btf_generated_header.h`, `clang_workarounds.h`), however, #3156 broke the latter when moving code around in `main.cpp.

Reintroduce the dropped prefix.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
