### PR TITLE
Prevent banned kernel funcs from all probes

### DIFF
--- a/tests/runtime/banned_probes
+++ b/tests/runtime/banned_probes
@@ -1,23 +1,45 @@
+# Check the list of banned functions
+
 NAME kretprobe:_raw_spin_lock is banned
 PROG kretprobe:_raw_spin_lock { exit(); }
-EXPECT ERROR: kretprobe:_raw_spin_lock can't be used as it might lock up your system.
+EXPECT ERROR: kernel function: _raw_spin_lock can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL
 
 NAME kretprobe:queued_spin_lock_slowpath is banned
 PROG kretprobe:queued_spin_lock_slowpath { exit(); }
-EXPECT ERROR: kretprobe:queued_spin_lock_slowpath can't be used as it might lock up your system.
+EXPECT ERROR: kernel function: queued_spin_lock_slowpath can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL
 
 NAME kretprobe:_raw_spin_unlock_irqrestore is banned
 PROG kretprobe:_raw_spin_unlock_irqrestore { exit(); }
-EXPECT ERROR: kretprobe:_raw_spin_unlock_irqrestore can't be used as it might lock up your system.
+EXPECT ERROR: kernel function: _raw_spin_unlock_irqrestore can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL
 
 NAME kretprobe:_raw_spin_lock_irqsave is banned
 PROG kretprobe:_raw_spin_lock_irqsave { exit(); }
-EXPECT ERROR: kretprobe:_raw_spin_lock_irqsave can't be used as it might lock up your system.
+EXPECT ERROR: kernel function: _raw_spin_lock_irqsave can't be used as it might lock up your system.
+TIMEOUT 1
+WILL_FAIL
+
+# Check the list of banned probes for those functions
+
+NAME kprobe:_raw_spin_lock is banned
+PROG kprobe:_raw_spin_lock { exit(); }
+EXPECT ERROR: kernel function: _raw_spin_lock can't be used as it might lock up your system.
+TIMEOUT 1
+WILL_FAIL
+
+NAME kfunc:queued_spin_lock_slowpath is banned
+PROG kfunc:queued_spin_lock_slowpath { exit(); }
+EXPECT ERROR: kernel function: queued_spin_lock_slowpath can't be used as it might lock up your system.
+TIMEOUT 1
+WILL_FAIL
+
+NAME kretfunc:_raw_spin_unlock_irqrestore is banned
+PROG kretfunc:_raw_spin_unlock_irqrestore { exit(); }
+EXPECT ERROR: kernel function: _raw_spin_unlock_irqrestore can't be used as it might lock up your system.
 TIMEOUT 1
 WILL_FAIL


### PR DESCRIPTION
Previously we only banned kretprobes from
using banned kernel functions but a bpftrace
script at Meta saw a crash from utilizing
one of these functions in kfunc/kretfunc.

This changes prevents any probe from attaching
to one of these functions.

Issue: https://github.com/bpftrace/bpftrace/issues/3144

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
