### PR TITLE
Codegen: Don't emit lifetime.end for variables used as map keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to
   - [#3024](https://github.com/bpftrace/bpftrace/pull/3024)
 - Fix error in dereferencing kernel double pointers
   - [#3024](https://github.com/bpftrace/bpftrace/pull/3024)
+- Fix variable corruption when used as map key
+  - [#3195](https://github.com/bpftrace/bpftrace/pull/3195)
 #### Docs
 #### Tools
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2775,6 +2775,7 @@ std::tuple<Value *, CodegenLLVM::ScopedExprDeleter> CodegenLLVM::getMapKey(
     Map &map)
 {
   Value *key;
+  bool alloca_created_here = true;
   if (map.vargs) {
     // A single value as a map key (e.g., @[comm] = 0;)
     if (map.vargs->size() == 1) {
@@ -2791,6 +2792,10 @@ std::tuple<Value *, CodegenLLVM::ScopedExprDeleter> CodegenLLVM::getMapKey(
           key = expr_;
           // Call-ee freed
           scoped_del.disarm();
+
+          // We don't have enough visibility into where key comes from to safely
+          // end its lifetime. It could be a variable, for example.
+          alloca_created_here = false;
         }
       } else {
         key = b_.CreateAllocaBPF(expr->type, map.ident + "_key");
@@ -2813,8 +2818,8 @@ std::tuple<Value *, CodegenLLVM::ScopedExprDeleter> CodegenLLVM::getMapKey(
     b_.CreateStore(b_.getInt64(0), key);
   }
 
-  auto key_deleter = [this, key]() {
-    if (dyn_cast<AllocaInst>(key))
+  auto key_deleter = [this, key, alloca_created_here]() {
+    if (alloca_created_here)
       b_.CreateLifetimeEnd(key);
   };
   return std::make_tuple(key, ScopedExprDeleter(std::move(key_deleter)));
@@ -2830,6 +2835,9 @@ AllocaInst *CodegenLLVM::getMultiMapKey(Map &map,
   for (auto *extra_key : extra_keys) {
     size += module_->getDataLayout().getTypeAllocSize(extra_key->getType());
   }
+
+  // If key ever changes to not be allocated here, be sure to update getMapKey()
+  // as well to take the new lifetime semantics into account.
   AllocaInst *key = b_.CreateAllocaBPF(size, map.ident + "_key");
   auto *key_type = ArrayType::get(b_.getInt8Ty(), size);
 

--- a/tests/codegen/llvm/call_ntop_key.ll
+++ b/tests/codegen/llvm/call_ntop_key.ll
@@ -55,8 +55,6 @@ lookup_failure:                                   ; preds = %entry
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %11 = bitcast i64* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast %inet_t* %inet to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -56,8 +56,6 @@ lookup_failure:                                   ; preds = %entry
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %11 = bitcast i64* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast %usym_t* %usym to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/for_map_strings.ll
+++ b/tests/codegen/llvm/for_map_strings.ll
@@ -29,10 +29,8 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store [4 x i8] c"abc\00", [4 x i8]* %str1, align 1
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, [4 x i8]*, [4 x i8]*, i64)*)(%"struct map_t"* @AT_map, [4 x i8]* %str1, [4 x i8]* %str, i64 0)
-  %3 = bitcast [4 x i8]* %str1 to i8*
+  %3 = bitcast [4 x i8]* %str to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [4 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %for_each_map_elem = call i64 inttoptr (i64 164 to i64 (%"struct map_t"*, i64 (i8*, i8*, i8*, i8*)*, i8*, i64)*)(%"struct map_t"* @AT_map, i64 (i8*, i8*, i8*, i8*)* @map_for_each_cb, i8* null, i64 0)
   ret i64 0
 }

--- a/tests/codegen/llvm/literal_strncmp.ll
+++ b/tests/codegen/llvm/literal_strncmp.ll
@@ -100,8 +100,6 @@ lookup_failure:                                   ; preds = %pred_true
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %19 = bitcast i64* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
-  %20 = bitcast [16 x i8]* %comm5 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -130,8 +130,6 @@ lookup_failure:                                   ; preds = %pred_true
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %25 = bitcast i64* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
-  %26 = bitcast [16 x i8]* %comm17 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -130,8 +130,6 @@ lookup_failure:                                   ; preds = %pred_true
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %25 = bitcast i64* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
-  %26 = bitcast [16 x i8]* %comm17 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/variable_map_key_lifetime.ll
+++ b/tests/codegen/llvm/variable_map_key_lifetime.ll
@@ -1,0 +1,135 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8* }
+%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
+@ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(i8* %0) section "s_BEGIN_1" !dbg !56 {
+entry:
+  %"@x_val1" = alloca i64, align 8
+  %"@x_val" = alloca i64, align 8
+  %"$myvar" = alloca [4 x i8], align 1
+  %1 = bitcast [4 x i8]* %"$myvar" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %2 = bitcast [4 x i8]* %"$myvar" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 4, i1 false)
+  %str = alloca [4 x i8], align 1
+  %3 = bitcast [4 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store [4 x i8] c"abc\00", [4 x i8]* %str, align 1
+  %4 = bitcast [4 x i8]* %"$myvar" to i8*
+  %5 = bitcast [4 x i8]* %str to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %4, i8* align 1 %5, i64 4, i1 false)
+  %6 = bitcast [4 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 1, i64* %"@x_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, [4 x i8]*, i64*, i64)*)(%"struct map_t"* @AT_x, [4 x i8]* %"$myvar", i64* %"@x_val", i64 0)
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [4 x i8]* %"$myvar" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_val1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 1, i64* %"@x_val1", align 8
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, [4 x i8]*, i64*, i64)*)(%"struct map_t"* @AT_x, [4 x i8]* %"$myvar", i64* %"@x_val1", i64 0)
+  %11 = bitcast i64* %"@x_val1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast [4 x i8]* %"$myvar" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+
+!llvm.dbg.cu = !{!52}
+!llvm.module.flags = !{!55}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !22}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 32, elements: !20)
+!19 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!20 = !{!21}
+!21 = !DISubrange(count: 4, lowerBound: 0)
+!22 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "ringbuf_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
+!42 = !{!43, !48, !49, !22}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 2, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !50, size: 64, offset: 128)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!52 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !53, globals: !54)
+!53 = !{}
+!54 = !{!0, !25, !39}
+!55 = !{i32 2, !"Debug Info Version", i32 3}
+!56 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !60)
+!57 = !DISubroutineType(types: !58)
+!58 = !{!24, !59}
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!60 = !{!61}
+!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)

--- a/tests/codegen/llvm/variable_map_key_lifetime.ll
+++ b/tests/codegen/llvm/variable_map_key_lifetime.ll
@@ -39,16 +39,12 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, [4 x i8]*, i64*, i64)*)(%"struct map_t"* @AT_x, [4 x i8]* %"$myvar", i64* %"@x_val", i64 0)
   %8 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast [4 x i8]* %"$myvar" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val1" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %9 = bitcast i64* %"@x_val1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %"@x_val1", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, [4 x i8]*, i64*, i64)*)(%"struct map_t"* @AT_x, [4 x i8]* %"$myvar", i64* %"@x_val1", i64 0)
-  %11 = bitcast i64* %"@x_val1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast [4 x i8]* %"$myvar" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %10 = bitcast i64* %"@x_val1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/variable_map_key_lifetime.cpp
+++ b/tests/codegen/variable_map_key_lifetime.cpp
@@ -1,0 +1,10 @@
+#include "common.h"
+
+namespace bpftrace::test::codegen {
+
+TEST(codegen, variable_map_key_lifetime)
+{
+  test(R"(BEGIN { $myvar = "abc"; @x[$myvar] = 1; @x[$myvar] = 1; })", NAME);
+}
+
+} // namespace bpftrace::test::codegen


### PR DESCRIPTION
Fixes #3000

Previously a lifetime.end was always inserted for expressions used as map keys. This is not correct if the expression is a variable which is used again later in the program.

`$blah` should not be marked as dead after line 4, it should persist at least until after line 5:
```
  1  BEGIN
  2  {
  3    $blah = "abc";
  4    @x[$blah] = 1;
  5    @y[$blah] = 1;
  6  }
```

##### Checklist

- ~[ ]~ Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
