### PR TITLE
CMake: Re-generate codegen_includes.cpp when test files are added or removed

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,16 +2,21 @@ add_compile_options("-Werror=undef")
 
 # Regenerate codegen_includes.cpp whenever anything in the tests/codegen
 # directory changes
-file(GLOB_RECURSE CODEGEN_SOURCES codegen/*.cpp codegen/*.h)
-add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/tests/codegen_includes.cpp
+file(GLOB_RECURSE CODEGEN_SOURCES CONFIGURE_DEPENDS codegen/*.cpp codegen/*.h)
+set(CODEGEN_INCLUDES_CPP codegen_includes.cpp)
+add_custom_command(
+  OUTPUT
+    ${CODEGEN_INCLUDES_CPP}
   COMMAND
     ${CMAKE_COMMAND}
-    -DTEST_SRC_DIR="${CMAKE_SOURCE_DIR}/tests/codegen"
+    -DCODEGEN_INCLUDES_CPP="${CODEGEN_INCLUDES_CPP}"
+    -DCODEGEN_SOURCES="${CODEGEN_SOURCES}"
     -P ${CMAKE_SOURCE_DIR}/tests/codegen/generate_codegen_includes.cmake
-  DEPENDS ${CODEGEN_SOURCES})
+  DEPENDS
+    ${CODEGEN_SOURCES})
 
 if(${LLVM_VERSION_MAJOR} VERSION_EQUAL 12)
-  set(CODEGEN_SRC ${CMAKE_BINARY_DIR}/tests/codegen_includes.cpp)
+  set(CODEGEN_SRC ${CODEGEN_INCLUDES_CPP})
 else()
   set(CODEGEN_SRC "")
   message(STATUS "Disabled codegen test for LLVM != 12 (found ${LLVM_VERSION_MAJOR})")

--- a/tests/codegen/generate_codegen_includes.cmake
+++ b/tests/codegen/generate_codegen_includes.cmake
@@ -1,12 +1,12 @@
 # Combine all codegen tests into a single compilation unit to improve build
 # performance. https://github.com/bpftrace/bpftrace/issues/229
-function(generate_codegen_includes output)
+function(generate_codegen_includes output tests)
   file(REMOVE ${output})
-  file(GLOB tests ${TEST_SRC_DIR}/*.cpp)
   file(WRITE ${output} "")
   foreach(test ${tests})
     file(APPEND ${output} "#include \"${test}\"\n")
   endforeach()
 endfunction()
 
-generate_codegen_includes(${CMAKE_BINARY_DIR}/codegen_includes.cpp)
+separate_arguments(CODEGEN_SOURCES NATIVE_COMMAND ${CODEGEN_SOURCES})
+generate_codegen_includes("${CODEGEN_INCLUDES_CPP}" "${CODEGEN_SOURCES}")


### PR DESCRIPTION
- CONFIGURE_DEPENDS triggers re-generation of the list of source files as necessary
- Pass list of source files through to the sub command so we only have a single glob to deal with
- Correctly set up the custom command's OUTPUT parameter so that codegen_includes.cpp is re-generated before it is compiled into bpftrace_test


##### Checklist

- ~[ ]~ Language changes are updated in `man/adoc/bpftrace.adoc`
- ~[ ]~ User-visible and non-trivial changes updated in `CHANGELOG.md`
- ~[ ]~ The new behaviour is covered by tests
