### PR TITLE
aot: Give preference to local build shim

### DIFF
--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -143,7 +143,7 @@ bool build_binary(const std_filesystem::path &shim,
   secdata.close();
 
   // Respect user provided BPFTRACE_OBJCOPY if present
-  std::string objcopy = "objcopy";
+  std::string_view objcopy = "objcopy";
   if (auto c = std::getenv("BPFTRACE_OBJCOPY"))
     objcopy = c;
 
@@ -189,7 +189,7 @@ int generate(const RequiredResources &resources,
   if (!section)
     return 1;
 
-  auto shim = find_in_path(AOT_SHIM_NAME.data());
+  auto shim = find_in_path(AOT_SHIM_NAME);
   if (!shim) {
     LOG(ERROR) << "Failed to locate " << AOT_SHIM_NAME
                << " shim binary. Is it in $PATH?";

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -268,6 +268,26 @@ std::optional<std_filesystem::path> find_in_path(std::string_view name)
   return std::nullopt;
 }
 
+std::optional<std_filesystem::path> find_near_self(std::string_view filename)
+{
+  std::error_code ec;
+  auto exe = std_filesystem::read_symlink("/proc/self/exe", ec);
+  if (ec) {
+    LOG(WARNING) << "Failed to resolve /proc/self/exe: " << ec;
+    return std::nullopt;
+  }
+
+  exe.replace_filename(filename);
+  bool exists = std_filesystem::exists(exe, ec);
+  if (!exists) {
+    if (ec)
+      LOG(WARNING) << "Failed to resolve stat " << exe << ": " << ec;
+    return std::nullopt;
+  }
+
+  return exe;
+}
+
 std::string get_pid_exe(const std::string &pid)
 {
   std::error_code ec;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -250,7 +250,7 @@ void get_bool_env_var(const ::std::string &str,
   return;
 }
 
-std::optional<std_filesystem::path> find_in_path(const std::string &name)
+std::optional<std_filesystem::path> find_in_path(std::string_view name)
 {
   std::error_code ec;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <sys/utsname.h>
 #include <tuple>
 #include <unordered_map>
@@ -161,7 +162,7 @@ void get_uint64_env_var(const ::std::string &str,
 void get_bool_env_var(const ::std::string &str,
                       const std::function<void(bool)> &cb);
 // Tries to find a file in $PATH
-std::optional<std_filesystem::path> find_in_path(const std::string &name);
+std::optional<std_filesystem::path> find_in_path(std::string_view name);
 std::string get_pid_exe(pid_t pid);
 std::string get_pid_exe(const std::string &pid);
 std::string get_proc_maps(const std::string &pid);

--- a/src/utils.h
+++ b/src/utils.h
@@ -163,6 +163,8 @@ void get_bool_env_var(const ::std::string &str,
                       const std::function<void(bool)> &cb);
 // Tries to find a file in $PATH
 std::optional<std_filesystem::path> find_in_path(std::string_view name);
+// Finds a file in the same directory as running binary
+std::optional<std_filesystem::path> find_near_self(std::string_view name);
 std::string get_pid_exe(pid_t pid);
 std::string get_pid_exe(const std::string &pid);
 std::string get_proc_maps(const std::string &pid);

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -347,6 +347,22 @@ TEST(utils, find_in_path)
   EXPECT_TRUE(std_filesystem::remove_all(path));
 }
 
+// These tests are a bit hacky and rely on repository structure.
+//
+// They rely on the fact that the test binary is in the same directory
+// as some of the other test binaries.
+//
+// Hopefully they are easy to maintain. If not, please delete.
+TEST(utils, find_near_self)
+{
+  auto runtime_tests = find_near_self("runtime-tests.sh");
+  ASSERT_TRUE(runtime_tests.has_value());
+  EXPECT_TRUE(runtime_tests->filename() == "runtime-tests.sh");
+  EXPECT_TRUE(std_filesystem::exists(*runtime_tests));
+
+  EXPECT_FALSE(find_near_self("SHOULD_NOT_EXIST").has_value());
+}
+
 TEST(utils, get_pids_for_program)
 {
   auto pids = get_pids_for_program("/proc/self/exe");


### PR DESCRIPTION
This helps with development such that we don't need to mess with $PATH
when running --aot commands. Now we can just run it like a prod
invocation and it will "just work".

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
