### PR TITLE
aot: Fix distro builds

### DIFF
--- a/src/aot/CMakeLists.txt
+++ b/src/aot/CMakeLists.txt
@@ -6,6 +6,12 @@ target_include_directories(aot PUBLIC ${CMAKE_BINARY_DIR}/src)
 target_include_directories(aot PUBLIC ${CMAKE_BINARY_DIR})
 target_compile_definitions(aot PRIVATE ${BPFTRACE_FLAGS})
 
+if(STATIC_LINKING)
+  target_link_libraries(aot LIBELF)
+else()
+  target_link_libraries(aot ${LIBELF_LIBRARIES})
+endif(STATIC_LINKING)
+
 # Only build aotrt if supported bcc is used
 # (https://github.com/iovisor/bcc/commit/719191867a25ce07dc96f7faf9b8ccedadc7ec44)
 if(NOT LIBBCC_BPF_CONTAINS_RUNTIME)


### PR DESCRIPTION
We need to link aot.o against libelf if aot.cpp wants to actually use the dependency.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
