### PR TITLE
Add packages required for test build

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,10 +1,17 @@
 # This Dockerfile is used to both document and test building bpftrace on the
 # development version of ubuntu. We attempt to catch bugs as early as possible
 # which is why we are using devel.
-
+#
+# To invoke the build, run the following command in top directory:
+# docker build -f docker/Dockerfile.ubuntu .
+# and for Test Build:
+# docker build  --build-arg BUILD_TESTING=ON -f docker/Dockerfile.ubuntu .
+#
 FROM ubuntu:devel
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG BUILD_TESTING=OFF
+
 RUN apt-get update && apt-get install -y \
     asciidoctor \
     binutils-dev \
@@ -25,9 +32,14 @@ RUN apt-get update && apt-get install -y \
     systemtap-sdt-dev \
     zlib1g-dev
 
+# Conditionally install few packages if BUILD_TESTING is ON
+RUN if [ "$BUILD_TESTING" = "ON" ]; then \
+    apt-get install -y xxd libgtest-dev libgmock-dev dwarves; \
+    fi
+
 COPY . /src
 WORKDIR /src
-RUN cmake -B /build -DBUILD_TESTING=OFF
+RUN cmake -B /build -DBUILD_TESTING=${BUILD_TESTING}
 RUN make -C /build -j$(nproc)
 
 ENTRYPOINT ["/build/src/bpftrace"]


### PR DESCRIPTION
Modified Ubuntu docker file for test builds.

To invoke the build, run the following command in top directory:
(with dot at end)
$ docker build -f docker/Dockerfile.ubuntu .