### PR TITLE
Refactor verbose and debug outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,49 +31,40 @@ jobs:
         - NAME: LLVM 12 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm12
-          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 13 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm13
-          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 14 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm14
-          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 15 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm15
-          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 16 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm16
-          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 17 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm17
-          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 18 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm18
-          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 18 Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm18
-          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 18 Clang Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm18
           CC: clang
           CXX: clang++
-          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: Memleak test (LLVM 18 Debug)
           CMAKE_BUILD_TYPE: Debug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Add --dry-run CLI option
+  - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)
 #### Changed
 - Stream output when printing maps
   - [#3264](https://github.com/bpftrace/bpftrace/pull/3264)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,14 @@ and this project adheres to
   - [#3264](https://github.com/bpftrace/bpftrace/pull/3264)
 - Only print kernel headers not found message if parsing fails
   - [#3265](https://github.com/bpftrace/bpftrace/pull/3265)
+- Add mandatory "stage" argument to the -d CLI option
+  - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)
+- Allow simultaneous use of -v and -d
+  - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)
 #### Deprecated
 #### Removed
+- Remove the -dd CLI option
+  - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)
 #### Fixed
 - Fix incorrect buf() size calculation which could lead to verifier errors
   - [#3281](https://github.com/bpftrace/bpftrace/pull/3281)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -75,6 +75,12 @@ The child process runs with the same privileges as bpftrace itself (usually root
 Enable debug mode.
 For more details see the <<Debug Output>> section.
 
+=== *--dry-run*
+
+Terminate execution right after attaching all the probes. Useful for testing
+that the script can be parsed, loaded, and attached, without actually running
+it.
+
 === *-e* _PROGRAM_
 
 Execute _PROGRAM_ instead of reading the program from a file or stdin.

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -70,14 +70,9 @@ To avoid a race condition when using 'USDTs', the child is stopped after 'execve
 The child PID is available to programs as the 'cpid' builtin.
 The child process runs with the same privileges as bpftrace itself (usually root).
 
-=== *-d*
+=== *-d STAGE*
 
 Enable debug mode.
-For more details see the <<Debug Output>> section.
-
-=== *-dd*
-
-Enable verbose debug mode.
 For more details see the <<Debug Output>> section.
 
 === *-e* _PROGRAM_
@@ -3512,52 +3507,38 @@ See src/attached_probe.cpp:find_vmlinux() for details.
 
 === Debug Output
 
-The `-d` option produces debug output and does not run the program. This is mostly useful for debugging issues with bpftrace itself.
-You can also use `-dd` to produce a more verbose debug output, which will also print unoptimized IR.
+The `-d STAGE` option produces debug output. It prints the output of the
+bpftrace execution stage given by the _STAGE_ argument. The option can be used
+multiple times (with different stage names) and the special value `all` prints
+the output of all the supported stages.
 
 Note: This is primarily used for bpftrace developers.
 
-The output begins with `Program` and then an abstract syntax tree (AST) representation of the program.
+The supported options are:
 
-----
-# bpftrace -d -e 'tracepoint:syscalls:sys_enter_nanosleep { printf("%s is sleeping.\n", comm); }'
-Program
- tracepoint:syscalls:sys_enter_nanosleep
-  call: printf
-   string: %s is sleeping.\n
-   builtin: comm
-[...]
-----
+[cols="~,~"]
+|===
 
-Continued:
+| `ast`
+| Prints the Abstract Syntax Tree (AST) after every pass.
 
-----
-[...]
-%printf_t = type { i64, [16 x i8] }
-[...]
-define i64 @"tracepoint:syscalls:sys_enter_nanosleep"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_nanosleep" {
-entry:
-  %comm = alloca [16 x i8], align 1
-  %printf_args = alloca %printf_t, align 8
-  %1 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
-  %3 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 24, i32 8, i1 false)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 16, i32 1, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
-  %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1, i64 0
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %4, i8* nonnull %2, i64 16, i32 1, i1 false)
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  ret i64 0
-[...]
-----
+| `codegen`
+| Prints the unoptimized LLVM IR as produced by `CodegenLLVM`.
 
-This section shows the llvm intermediate representation (IR) assembly, which is then compiled into BPF.
+| `codegen-opt`
+| Prints the optimized LLVM IR, i.e. the code which will be compiled into BPF
+bytecode.
+
+| `libbpf`
+| Captures and prints libbpf log for all libbpf operations that bpftrace uses.
+
+| `verifier`
+| Captures and prints the BPF verifier log.
+
+| `all`
+| Prints the output of all of the above stages.
+
+|===
 
 === Listing Probes
 
@@ -3653,44 +3634,17 @@ The `-v` option prints more information about the program as it is run:
 
 ----
 # bpftrace -v -e 'tracepoint:syscalls:sys_enter_nanosleep { printf("%s is sleeping.\n", comm); }'
+AST node count: 7
 Attaching 1 probe...
 
-The verifier log:
-0: (bf) r6 = r1
-1: (b7) r1 = 0
-2: (7b) *(u64 *)(r10 -24) = r1
-3: (7b) *(u64 *)(r10 -32) = r1
-4: (7b) *(u64 *)(r10 -40) = r1
-5: (7b) *(u64 *)(r10 -8) = r1
-6: (7b) *(u64 *)(r10 -16) = r1
-7: (bf) r1 = r10
-8: (07) r1 += -16
-9: (b7) r2 = 16
-10: (85) call bpf_get_current_comm#16
-11: (79) r1 = *(u64 *)(r10 -16)
-12: (7b) *(u64 *)(r10 -32) = r1
-13: (79) r1 = *(u64 *)(r10 -8)
-14: (7b) *(u64 *)(r10 -24) = r1
-15: (18) r7 = 0xffff9044e65f1000
-17: (85) call bpf_get_smp_processor_id#8
-18: (bf) r4 = r10
-19: (07) r4 += -40
-20: (bf) r1 = r6
-21: (bf) r2 = r7
-22: (bf) r3 = r0
-23: (b7) r5 = 24
-24: (85) call bpf_perf_event_output#25
-25: (b7) r0 = 0
-26: (95) exit
-processed 26 insns (limit 131072), stack depth 40
+load tracepoint:syscalls:sys_enter_nanosleep, with BTF, with func_infos: Success
 
+Program ID: 111
 Attaching tracepoint:syscalls:sys_enter_nanosleep
 iscsid is sleeping.
 iscsid is sleeping.
 [...]
 ----
-
-This includes `The verifier log:` and then the log message from the in-kernel verifier.
 
 == Advanced Topics
 

--- a/src/ast/pass_manager.cpp
+++ b/src/ast/pass_manager.cpp
@@ -27,7 +27,7 @@ void PassManager::AddPass(Pass p)
 PassResult PassManager::Run(std::unique_ptr<Node> node, PassContext &ctx)
 {
   Node *root = node.release();
-  if (bt_debug != DebugLevel::kNone)
+  if (bt_debug.find(DebugStage::Ast) != bt_debug.end())
     print(root, "parser", std::cout);
   for (auto &pass : passes_) {
     auto result = pass.Run(*root, ctx);
@@ -39,7 +39,7 @@ PassResult PassManager::Run(std::unique_ptr<Node> node, PassContext &ctx)
       root = result.Root();
     }
 
-    if (bt_debug != DebugLevel::kNone)
+    if (bt_debug.find(DebugStage::Ast) != bt_debug.end())
       print(root, pass.name, std::cout);
   }
   return PassResult::Success(root);

--- a/src/ast/passes/node_counter.h
+++ b/src/ast/passes/node_counter.h
@@ -33,7 +33,7 @@ inline Pass CreateCounterPass()
     c.Visit(n);
     auto node_count = c.get_count();
     auto max = ctx.b.max_ast_nodes_;
-    LOG(V1) << "node count: " << node_count;
+    LOG(V1) << "AST node count: " << node_count;
     if (node_count >= max) {
       LOG(ERROR) << "node count (" << node_count << ") exceeds the limit ("
                  << max << ")";

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -46,7 +46,7 @@
 
 namespace bpftrace {
 
-DebugLevel bt_debug = DebugLevel::kNone;
+std::set<DebugStage> bt_debug = {};
 bool bt_quiet = false;
 bool bt_verbose = false;
 volatile sig_atomic_t BPFtrace::exitsig_recv = false;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -49,6 +49,7 @@ namespace bpftrace {
 std::set<DebugStage> bt_debug = {};
 bool bt_quiet = false;
 bool bt_verbose = false;
+bool dry_run = false;
 volatile sig_atomic_t BPFtrace::exitsig_recv = false;
 volatile sig_atomic_t BPFtrace::sigusr1_recv = false;
 
@@ -1061,6 +1062,9 @@ int BPFtrace::run(BpfBytecode bytecode)
     LOG(WARNING) << "Failed to send readiness notification, ignoring: "
                  << strerror(-err);
 #endif
+
+  if (dry_run)
+    exitsig_recv = true;
 
   if (has_iter_) {
     int err = run_iter();

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -47,33 +47,14 @@ struct stack_key {
   uint32_t nr_stack_frames;
 };
 
-enum class DebugLevel;
+enum class DebugStage;
 
 // globals
-extern DebugLevel bt_debug;
+extern std::set<DebugStage> bt_debug;
 extern bool bt_quiet;
 extern bool bt_verbose;
 
-enum class DebugLevel { kNone, kDebug, kFullDebug };
-
-inline DebugLevel operator++(DebugLevel &level, int)
-{
-  switch (level) {
-    case DebugLevel::kNone:
-      level = DebugLevel::kDebug;
-      break;
-    case DebugLevel::kDebug:
-      level = DebugLevel::kFullDebug;
-      break;
-    case DebugLevel::kFullDebug:
-      // NOTE (mmarchini): should be handled by the caller
-      level = DebugLevel::kNone;
-      break;
-    default:
-      break;
-  }
-  return level;
-}
+enum class DebugStage { Ast, Codegen, CodegenOpt, Libbpf, Verifier };
 
 class WildcardException : public std::exception {
 public:

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -53,6 +53,7 @@ enum class DebugStage;
 extern std::set<DebugStage> bt_debug;
 extern bool bt_quiet;
 extern bool bt_verbose;
+extern bool dry_run;
 
 enum class DebugStage { Ast, Codegen, CodegenOpt, Libbpf, Verifier };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,6 +79,7 @@ enum Options {
   EMIT_LLVM,
   NO_FEATURE,
   DEBUG,
+  DRY_RUN,
 };
 } // namespace
 
@@ -114,6 +115,7 @@ void usage()
   std::cerr << std::endl;
   std::cerr << "TROUBLESHOOTING OPTIONS:" << std::endl;
   std::cerr << "    -v                      verbose messages" << std::endl;
+  std::cerr << "    --dry-run               terminate execution right after attaching all the probes" << std::endl;
   std::cerr << "    -d STAGE                debug info for various stages of bpftrace execution" << std::endl;
   std::cerr << "                            ('all', 'ast', 'codegen', 'codegen-opt', 'libbpf', 'verifier')" << std::endl;
   std::cerr << "    --emit-elf FILE         (dry run) generate ELF file with bpf programs and write to FILE" << std::endl;
@@ -496,6 +498,7 @@ Args parse_args(int argc, char* argv[])
     option{ "aot", required_argument, nullptr, Options::AOT },
     option{ "no-feature", required_argument, nullptr, Options::NO_FEATURE },
     option{ "debug", required_argument, nullptr, Options::DEBUG },
+    option{ "dry-run", no_argument, nullptr, Options::DRY_RUN },
     option{ nullptr, 0, nullptr, 0 }, // Must be last
   };
 
@@ -535,6 +538,9 @@ Args parse_args(int argc, char* argv[])
                         "'kprobe_multi,uprobe_multi'.";
           exit(1);
         }
+        break;
+      case Options::DRY_RUN:
+        dry_run = true;
         break;
       case 'o':
         args.output_file = optarg;

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -19,11 +19,11 @@ static const char *libbpf_print_level_string(enum libbpf_print_level level)
 
 int libbpf_print(enum libbpf_print_level level, const char *msg, va_list ap)
 {
-  if (bt_debug == DebugLevel::kNone)
+  if (bt_debug.find(DebugStage::Libbpf) == bt_debug.end())
     return 0;
 
-  fprintf(stderr, "[%s] ", libbpf_print_level_string(level));
-  return vfprintf(stderr, msg, ap);
+  printf("[%s] ", libbpf_print_level_string(level));
+  return vprintf(msg, ap);
 }
 
 int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)

--- a/tests/tools-parsing-test.sh
+++ b/tests/tools-parsing-test.sh
@@ -30,11 +30,11 @@ function set_tooldir() {
 
 function do_test() {
   local file="$1"
-  if $BPFTRACE_EXECUTABLE --unsafe -d "$file" 2>/dev/null >/dev/null; then
+  if $BPFTRACE_EXECUTABLE --unsafe -d all "$file" 2>/dev/null >/dev/null; then
     echo "$file    passed"
   else
     echo "$file    failed";
-    $BPFTRACE_EXECUTABLE --unsafe -d "$file";
+    $BPFTRACE_EXECUTABLE --unsafe -d all "$file";
     EXIT_STATUS=1;
   fi
 }

--- a/tests/tools-parsing-test.sh
+++ b/tests/tools-parsing-test.sh
@@ -30,11 +30,11 @@ function set_tooldir() {
 
 function do_test() {
   local file="$1"
-  if $BPFTRACE_EXECUTABLE --unsafe -d all "$file" 2>/dev/null >/dev/null; then
+  if $BPFTRACE_EXECUTABLE --unsafe -v --dry-run "$file" 2>/dev/null >/dev/null; then
     echo "$file    passed"
   else
     echo "$file    failed";
-    $BPFTRACE_EXECUTABLE --unsafe -d all "$file";
+    $BPFTRACE_EXECUTABLE --unsafe -v --dry-run "$file";
     EXIT_STATUS=1;
   fi
 }


### PR DESCRIPTION
Consolidate and cleanup information that is being printed in the verbose (`-v`) and debugging output (`-d`). The main idea is:
- the verbose output is intended for users to get more information on what bpftrace is doing and where it is (possibly) failing,
- the debug output is intended for developers to help them debugging bpftrace by providing very detailed outputs of individual stages of bpftrace runtime.

The main (user-facing) change this brings is that it introduces a mandatory argument to the `-d` option which allows to pick the stage whose output should be printed.

The currently supported stages are:
- `ast` - prints the AST after each pass,
- `codegen` - prints the LLVM IR code as emit by CodegenLLVM,
- `codegen-opt` - prints the LLVM IR code after it is optimized by LLVM (i.e. what is actually compiled to BPF bytecode),
- `libbpf` - captures and prints libbpf log for all libbpf operations that we use,
- `verifier` - captures and prints the BPF verifier log.

On top of that, `-d` can be used multiple times with different arguments and the argument `all` activates all of the above.

In addition, there are more user-facing changes:
- remove the `-dd` option,
- allow to use `-v` and `-d` simultaneously,
- add `--debug` as a long version of `-d`.

Also, some minor refactorings were done:
- make sure the verbosity output always goes to stderr while the debugging output always goes to stdout,
- improve some formatting of verbose outputs.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
