### PR TITLE
Filter out kernel functions that can cause systemic instability

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -141,6 +141,24 @@ EXPECT ERROR: Error attaching probe: kprobe:nonsense:vfs_read: specified module 
 TIMEOUT 5
 WILL_FAIL
 
+NAME kprobe_wildcard_all_leading_underscore
+PROG kprobe:_* { } interval:s:1{ printf("SUCCESS"); exit(); }
+EXPECT_REGEX SUCCESS
+ENV BPFTRACE_MAX_PROBES=20000
+TIMEOUT 5
+REQUIRES_FEATURE kprobe_multi
+
+NAME kprobe_disallow_rcu_functions
+PROG kprobe:rcu_* { printf("SUCCESS %d\n", pid); exit(); }
+EXPECT No probes to attach
+TIMEOUT 5
+WILL_FAIL
+
+NAME kprobe_hide_ftrace_invalid_address
+RUN {{BPFTRACE}} -l | grep -c __ftrace_invalid_address__ || true
+EXPECT 0
+TIMEOUT 5
+
 NAME kprobe_func_missing
 PROG kprobe:vmlinux:nonsense { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT ERROR: Error attaching probe: kprobe:vmlinux:nonsense


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

When using globbing with kprobes it easy extremely easy to hang the system and this is because certain kernel functions react badly to being instrumented. For example, on a 5.19 based kernel, the following invocation will hang the system:

```
sudo bpftrace -e 'kprobe:*' -e 'interval:s:5{exit();}'
```

The bpf kernel selftests specify some functions that must be explicitly filtered and also some patterns that are used to match groups of functions that must be filtered. This change uses these patterns to exclude functions when the available function list is being built.
##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
