### PR TITLE
tools/swapin: Support swap_read_folio()

### DIFF
--- a/tools/swapin.bt
+++ b/tools/swapin.bt
@@ -11,9 +11,16 @@
  * When copying or porting, include this comment.
  *
  * 26-Jan-2019  Brendan Gregg   Created this.
+ * 31-May-2024  Rong Tao        Add folio support.
  */
 
-kprobe:swap_readpage
+/**
+ * kernel commit c9bdf768dd93("mm: convert swap_readpage() to swap_read_folio()")
+ * convert swap_readpage() to swap_read_folio(), try attaching two kprobes, one
+ * will trigger a warning and the other will be attached successfully.
+ */
+kprobe:swap_readpage,
+kprobe:swap_read_folio
 {
         @[comm, pid] = count();
 }


### PR DESCRIPTION
kernel commit c9bdf768dd93("mm: convert swap_readpage() to swap_read_folio()") convert swap_readpage() to swap_read_folio(), try attaching two kprobes, one will trigger a warning and the other will be attached successfully.

kernel version:

    $ git describe c9bdf768dd93
    v6.7-rc4-290-gc9bdf768dd93

For example, on fedora 40:

    $ uname -r
    6.8.10-300.fc40.x86_64
    $ sudo ./swapin.bt
    ./swapin.bt:1-22: WARNING: swap_readpage is not traceable (either non-
    existing, inlined, or marked as "notrace"); attaching to it will likely fail
    Attaching 3 probes...
    cannot attach kprobe, probe entry may not exist
    WARNING: could not attach probe kprobe:swap_readpage, skipping.

As we could see above, swap_readpage() trigger a warning, and swap_read_folio kprobe be attached.


