### PR TITLE
cmake: libbpf: Require at least v1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to
   - [#3095](https://github.com/bpftrace/bpftrace/pull/3095)
 - Move error printing from debug to verbose mode
   - [#3202](https://github.com/bpftrace/bpftrace/pull/3202)
+- Better error message when libbpf is too old
+  - [#3212](https://github.com/bpftrace/bpftrace/pull/3212)
 #### Deprecated
 - Deprecate `sarg` builtin
   - [#3095](https://github.com/bpftrace/bpftrace/pull/3095)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,9 @@ include_directories(SYSTEM ${LIBBCC_INCLUDE_DIRS})
 
 find_package(LibBpf REQUIRED)
 include_directories(SYSTEM ${LIBBPF_INCLUDE_DIRS})
+if(LIBBPF_VERSION_MAJOR VERSION_LESS 1)
+  message(SEND_ERROR "bpftrace requires libbpf 1.0 or greater")
+endif()
 
 find_package(LibElf REQUIRED)
 include_directories(SYSTEM ${LIBELF_INCLUDE_DIRS})

--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -5,6 +5,8 @@
 #  LIBBPF_INCLUDE_DIRS - the libbpf include directory
 #  LIBBPF_LIBRARIES - Link these to use libbpf
 #  LIBBPF_DEFINITIONS - Compiler switches required for using libbpf
+#  LIBBPF_VERSION_MAJOR - Libbpf major version
+#  LIBBPF_VERSION_MINOR - Libbpf minor version
 
 #if (LIBBPF_LIBRARIES AND LIBBPF_INCLUDE_DIRS)
 #  set (LibBpf_FIND_QUIETLY TRUE)
@@ -33,7 +35,20 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibBpf ${LIBBPF_ERROR_MESSAGE}
   LIBBPF_LIBRARIES
   LIBBPF_INCLUDE_DIRS)
 
-mark_as_advanced(LIBBPF_INCLUDE_DIRS LIBBPF_LIBRARIES)
+# Parse version information out of libbpf_version.h
+if(EXISTS "${LIBBPF_INCLUDE_DIRS}/bpf/libbpf_version.h")
+  file(READ "${LIBBPF_INCLUDE_DIRS}/bpf/libbpf_version.h" version_header)
+  string(REGEX MATCH "LIBBPF_MAJOR_VERSION[ \t]+([0-9]+)" major_match "${version_header}")
+  string(REGEX MATCH "LIBBPF_MINOR_VERSION[ \t]+([0-9]+)" minor_match "${version_header}")
+  string(REGEX REPLACE "LIBBPF_MAJOR_VERSION[ \t]+" "" LIBBPF_VERSION_MAJOR "${major_match}")
+  string(REGEX REPLACE "LIBBPF_MINOR_VERSION[ \t]+" "" LIBBPF_VERSION_MINOR "${minor_match}")
+else()
+  set(LIBBPF_VERSION_MAJOR 0)
+  set(LIBBPF_VERSION_MINOR 0)
+  message(SEND_ERROR "Libbpf version is too old and does not have libbpf_version.h, which was introduced in v0.6")
+endif()
+
+mark_as_advanced(LIBBPF_INCLUDE_DIRS LIBBPF_LIBRARIES LIBBPF_VERSION_MAJOR LIBBPF_VERSION_MINOR)
 
 INCLUDE(CheckCXXSourceCompiles)
 SET(CMAKE_REQUIRED_INCLUDES ${LIBBPF_INCLUDE_DIRS})


### PR DESCRIPTION
bpftrace relies on libbpf 1.0 b/c the 1.0 release contained major API breaks. Going forward from 1.0, we can feature detect and expect backwards compat.

This commit makes it so the error is more apparent on older systems. Otherwise you just get confusing build failures. Now you get:

```
0.763 -- Found LibBpf: /usr/lib/x86_64-linux-gnu/libbpf.so
0.763 CMake Error at cmake/FindLibBpf.cmake:48 (message):
0.763   Libbpf version too old to have libbpf_version.h
0.763 Call Stack (most recent call first):
0.763   CMakeLists.txt:84 (find_package)
0.763
0.763
0.763 -- Performing Test HAVE_LIBBPF_UPROBE_MULTI
0.791 -- Performing Test HAVE_LIBBPF_UPROBE_MULTI - Failed
0.791 CMake Error at CMakeLists.txt:87 (message):
0.791   bpftrace requires libbpf 1.0 or greater
```

This closes #3210.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
