### PR TITLE
tests: utils: Use actually non-existing binary for test

### DIFF
--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -370,7 +370,7 @@ TEST(utils, get_pids_for_program)
   ASSERT_EQ(pids.size(), 1);
   ASSERT_EQ(pids[0], getpid());
 
-  pids = get_pids_for_program("/proc/12345/root/usr/bin/bash");
+  pids = get_pids_for_program("/doesnotexist");
   ASSERT_EQ(pids.size(), 0);
 }
 


### PR DESCRIPTION
12345 is a PID that could plausibly exist. I've seen test failures locally and in CI along the following:

```
/home/runner/work/bpftrace/bpftrace/tests/utils.cpp:374: Failure
Expected equality of these values:
  pids.size()
    Which is: 1
  0

[  FAILED  ] utils.get_pids_for_program (1 ms)
```

Make the test more reliable by using an actually non-existent exe.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
