### PR TITLE
Semantic analyser: fix checking record map types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to
   - [#3024](https://github.com/bpftrace/bpftrace/pull/3024)
 - Fix variable corruption when used as map key
   - [#3195](https://github.com/bpftrace/bpftrace/pull/3195)
+- Semantic analyser: fix checking record map types
+  - [#3220](https://github.com/bpftrace/bpftrace/pull/3220)
 #### Docs
 #### Tools
 

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2392,7 +2392,7 @@ void SemanticAnalyser::visit(AssignMapStatement &assignment)
   const std::string &map_ident = assignment.map->ident;
   auto type = assignment.expr->type;
 
-  if (type.IsRecordTy()) {
+  if (type.IsRecordTy() && map_val_[map_ident].IsRecordTy()) {
     std::string ty = assignment.expr->type.GetName();
     std::string stored_ty = map_val_[map_ident].GetName();
     if (!stored_ty.empty() && stored_ty != ty) {

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -379,6 +379,11 @@ stdin:1:20-22: ERROR: Type mismatch for @x: trying to assign value of type 'stri
 kprobe:f { @x = 0; @x = "a"; }
                    ~~
 )");
+  test_error("kprobe:f { @x = 0; @x = *curtask; }", R"(
+stdin:1:20-22: ERROR: Type mismatch for @x: trying to assign value of type 'struct task_struct' when map already contains a value of type 'int64'
+kprobe:f { @x = 0; @x = *curtask; }
+                   ~~
+)");
 }
 
 TEST(semantic_analyser, consistent_map_keys)


### PR DESCRIPTION
When assigning a struct type to a map already containing a type, semantic analyser checks if the types have the same name. However, if the map contains a non-struct type, this will cause a crash:

    # bpftrace -e 'BEGIN { @x = 0; @x = *curtask }'
    bpftrace: [...]/src/types.h:266: const std::string bpftrace::SizedType::GetName() const: Assertion `IsRecordTy()' failed.

The reason is that we detect the type mismatch but only log an error and continue with follow-up checks.

Fix the crash by only doing the names check if both the existing and the newly assigned types are records.

Fixes #3218.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
