### PR TITLE
dwarf: Do not excessively warn on missing lldb

### DIFF
--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -65,10 +65,6 @@ public:
                                               std::string file_path_
                                               __attribute__((unused)))
   {
-    static bool warned = false;
-    if (!warned)
-      LOG(WARNING) << "Cannot parse DWARF: liblldb not available";
-    warned = true;
     return nullptr;
   }
 


### PR DESCRIPTION
When building without LLDB, any uprobe will trigger a missing LLDB warning. Given that all downstream users of Dwarf class will already emit a warning if necessary, we can drop this warning and make bpftrace less noisy.

Fixes #3222.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
