### PR TITLE
Restrict looping over some map types

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2080,6 +2080,12 @@ void SemanticAnalyser::visit(For &f)
   }
   Map &map = static_cast<Map &>(*f.expr);
 
+  if (!map.type.IsMapIterableTy()) {
+    LOG(ERROR, f.expr->loc, err_)
+        << "Loop expression does not support type: " << map.type;
+    return;
+  }
+
   // Validate body
   CollectNodes<Variable> vars_referenced;
   for (auto *stmt : *f.stmts) {

--- a/src/types.h
+++ b/src/types.h
@@ -417,6 +417,11 @@ public:
     return type_ == Type::count || type_ == Type::sum || type_ == Type::max ||
            type_ == Type::min;
   }
+  bool IsMapIterableTy() const
+  {
+    return !(type_ == Type::avg || type_ == Type::hist ||
+             type_ == Type::lhist || type_ == Type::stats);
+  }
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);
   friend std::ostream &operator<<(std::ostream &, Type);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3542,6 +3542,31 @@ BEGIN { @map[0] = 1; for ($kv : @undef) { @map[$kv.0]; } }
 )");
 }
 
+TEST(semantic_analyser, for_loop_map_restricted_types)
+{
+  test_error("BEGIN { @map[0] = avg(1); for ($kv : @map) { } }", R"(
+stdin:1:38-43: ERROR: Loop expression does not support type: avg
+BEGIN { @map[0] = avg(1); for ($kv : @map) { } }
+                                     ~~~~~
+)");
+  test_error("BEGIN { @map[0] = hist(10); for ($kv : @map) { } }", R"(
+stdin:1:40-45: ERROR: Loop expression does not support type: hist
+BEGIN { @map[0] = hist(10); for ($kv : @map) { } }
+                                       ~~~~~
+)");
+  test_error("BEGIN { @map[0] = lhist(10, 0, 10, 1); for ($kv : @map) { } }",
+             R"(
+stdin:1:51-56: ERROR: Loop expression does not support type: lhist
+BEGIN { @map[0] = lhist(10, 0, 10, 1); for ($kv : @map) { } }
+                                                  ~~~~~
+)");
+  test_error("BEGIN { @map[0] = stats(10); for ($kv : @map) { } }", R"(
+stdin:1:41-46: ERROR: Loop expression does not support type: stats
+BEGIN { @map[0] = stats(10); for ($kv : @map) { } }
+                                        ~~~~~
+)");
+}
+
 TEST(semantic_analyser, for_loop_shadowed_decl)
 {
   test_error(R"(


### PR DESCRIPTION
It doesn't make sense to loop over these types:
- avg
- stats
- hist
- lhist

This is because these maps have complex values and keys, which don't work for iteration. Example:
```
$ sudo ./src/bpftrace -e 'BEGIN { @x[1] = avg(5); for ($kv : @x) { print(($kv.0, $kv.1)); } exit(); }'
Attaching 1 probe...
(1, )
(1, )

@x[1]: 5
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
