### PR TITLE
Support big strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
 - Enable count, sum, min, and max map reads in kernel space (implicit casting)
   - [#3189](https://github.com/bpftrace/bpftrace/pull/3189)
   - [#3226](https://github.com/bpftrace/bpftrace/pull/3226)
+- Allow BPFTRACE_MAX_STRLEN to go above 200 (up to 1024)
+  - [#3228](https://github.com/bpftrace/bpftrace/pull/3228)
 #### Changed
 - Better error message for args in mixed probes
   - [#3047](https://github.com/bpftrace/bpftrace/pull/3047)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -375,6 +375,18 @@ CallInst *IRBuilderBPF::CreateGetStackScratchMap(StackType stack_type,
                              failure_callback);
 }
 
+CallInst *IRBuilderBPF::CreateGetStrScratchMap(int idx,
+                                               BasicBlock *failure_callback,
+                                               const location &loc)
+{
+  return createGetScratchMap(to_string(MapType::StrBuffer),
+                             "str",
+                             GET_PTR_TY(),
+                             loc,
+                             failure_callback,
+                             idx);
+}
+
 // createGetScratchMap will jump to failure_callback if it cannot find the map
 // value
 CallInst *IRBuilderBPF::createGetScratchMap(const std::string &map_name,

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -978,9 +978,7 @@ std::optional<std::string> ValToString(Value *val)
 }
 
 Value *IRBuilderBPF::CreateStrncmp(Value *str1,
-                                   uint64_t str1_size,
                                    Value *str2,
-                                   uint64_t str2_size,
                                    uint64_t n,
                                    bool inverse)
 {
@@ -1035,9 +1033,10 @@ Value *IRBuilderBPF::CreateStrncmp(Value *str1,
     if (literal1)
       l = getInt8(literal1->c_str()[i]);
     else {
-      auto *ptr_l = CreateGEP(ArrayType::get(getInt8Ty(), str1_size),
-                              str1,
-                              { getInt32(0), getInt32(i) });
+      auto *ptr_l = CreateGEP(getInt8Ty(),
+                              CreatePointerCast(str1,
+                                                getInt8Ty()->getPointerTo()),
+                              { getInt32(i) });
       l = CreateLoad(getInt8Ty(), ptr_l);
     }
 
@@ -1045,9 +1044,10 @@ Value *IRBuilderBPF::CreateStrncmp(Value *str1,
     if (literal2)
       r = getInt8(literal2->c_str()[i]);
     else {
-      auto *ptr_r = CreateGEP(ArrayType::get(getInt8Ty(), str2_size),
-                              str2,
-                              { getInt32(0), getInt32(i) });
+      auto *ptr_r = CreateGEP(getInt8Ty(),
+                              CreatePointerCast(str2,
+                                                getInt8Ty()->getPointerTo()),
+                              { getInt32(i) });
       r = CreateLoad(getInt8Ty(), ptr_r);
     }
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -156,12 +156,7 @@ public:
                                 pid_t pid,
                                 AddrSpace as,
                                 const location &loc);
-  Value *CreateStrncmp(Value *str1,
-                       uint64_t str1_size,
-                       Value *str2,
-                       uint64_t str2_size,
-                       uint64_t n,
-                       bool inverse);
+  Value *CreateStrncmp(Value *str1, Value *str2, uint64_t n, bool inverse);
   Value *CreateStrcontains(Value *val1,
                            uint64_t str1_size,
                            Value *val2,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -196,6 +196,9 @@ public:
   CallInst *CreateGetStackScratchMap(StackType stack_type,
                                      BasicBlock *failure_callback,
                                      const location &loc);
+  CallInst *CreateGetStrScratchMap(int idx,
+                                   BasicBlock *failure_callback,
+                                   const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
                              FunctionType *helper_type,
                              ArrayRef<Value *> args,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -4256,6 +4256,8 @@ std::function<void()> CodegenLLVM::create_reset_ids()
           starting_join_id = this->join_id_,
           starting_strftime_id = this->strftime_id_,
           starting_non_map_print_id = this->non_map_print_id_,
+          starting_watchpoint_id = this->watchpoint_id_,
+          starting_cgroup_path_id = this->cgroup_path_id_,
           starting_skb_output_id = this->skb_output_id_] {
     this->b_.helper_error_id_ = starting_helper_error_id;
     this->printf_id_ = starting_printf_id;
@@ -4266,6 +4268,8 @@ std::function<void()> CodegenLLVM::create_reset_ids()
     this->join_id_ = starting_join_id;
     this->system_id_ = starting_system_id;
     this->non_map_print_id_ = starting_non_map_print_id;
+    this->watchpoint_id_ = starting_watchpoint_id;
+    this->cgroup_path_id_ = starting_cgroup_path_id;
     this->skb_output_id_ = starting_skb_output_id;
   };
 }

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1281,12 +1281,8 @@ void CodegenLLVM::visit(Call &call)
     auto left_string = getString(left_arg);
     auto right_string = getString(right_arg);
 
-    expr_ = b_.CreateStrncmp(left_string.first,
-                             left_string.second,
-                             right_string.first,
-                             right_string.second,
-                             size,
-                             false);
+    expr_ = b_.CreateStrncmp(
+        left_string.first, right_string.first, size, false);
   } else if (call.func == "strcontains") {
     const auto &left_arg = call.vargs->at(0);
     const auto &right_arg = call.vargs->at(1);
@@ -1478,12 +1474,7 @@ void CodegenLLVM::binop_string(Binop &binop)
   auto right_string = getString(binop.right);
 
   size_t len = std::min(left_string.second, right_string.second);
-  expr_ = b_.CreateStrncmp(left_string.first,
-                           left_string.second,
-                           right_string.first,
-                           right_string.second,
-                           len,
-                           inverse);
+  expr_ = b_.CreateStrncmp(left_string.first, right_string.first, len, inverse);
 }
 
 void CodegenLLVM::binop_integer_array(Binop &binop)
@@ -1545,12 +1536,7 @@ void CodegenLLVM::binop_buf(Binop &binop)
 
   size_t len = std::min(binop.left->type.GetSize(),
                         binop.right->type.GetSize());
-  expr_ = b_.CreateStrncmp(left_string,
-                           binop.left->type.GetSize(),
-                           right_string,
-                           binop.right->type.GetSize(),
-                           len,
-                           inverse);
+  expr_ = b_.CreateStrncmp(left_string, right_string, len, inverse);
 }
 
 void CodegenLLVM::binop_int(Binop &binop)

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -4247,25 +4247,25 @@ Function *CodegenLLVM::createForEachMapCallback(
 std::function<void()> CodegenLLVM::create_reset_ids()
 {
   return [this,
+          starting_helper_error_id = this->b_.helper_error_id_,
           starting_printf_id = this->printf_id_,
+          starting_mapped_printf_id = this->mapped_printf_id_,
+          starting_time_id = this->time_id_,
           starting_cat_id = this->cat_id_,
           starting_system_id = this->system_id_,
-          starting_time_id = this->time_id_,
-          starting_strftime_id = this->strftime_id_,
           starting_join_id = this->join_id_,
-          starting_helper_error_id = this->b_.helper_error_id_,
+          starting_strftime_id = this->strftime_id_,
           starting_non_map_print_id = this->non_map_print_id_,
-          starting_mapped_printf_id = this->mapped_printf_id_,
           starting_skb_output_id = this->skb_output_id_] {
+    this->b_.helper_error_id_ = starting_helper_error_id;
     this->printf_id_ = starting_printf_id;
-    this->cat_id_ = starting_cat_id;
-    this->system_id_ = starting_system_id;
+    this->mapped_printf_id_ = starting_mapped_printf_id;
     this->time_id_ = starting_time_id;
+    this->cat_id_ = starting_cat_id;
     this->strftime_id_ = starting_strftime_id;
     this->join_id_ = starting_join_id;
-    this->b_.helper_error_id_ = starting_helper_error_id;
+    this->system_id_ = starting_system_id;
     this->non_map_print_id_ = starting_non_map_print_id;
-    this->mapped_printf_id_ = starting_mapped_printf_id;
     this->skb_output_id_ = starting_skb_output_id;
   };
 }

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -277,6 +277,8 @@ private:
   bool inside_subprog_ = false;
 
   std::map<std::string, AllocaInst *> variables_;
+
+  // NB: ensure all IDs are saved/restored in create_reset_ids()
   int printf_id_ = 0;
   int mapped_printf_id_ = 0;
   int time_id_ = 0;

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -290,6 +290,7 @@ private:
   uint64_t watchpoint_id_ = 0;
   int cgroup_path_id_ = 0;
   int skb_output_id_ = 0;
+  int str_id_ = 0;
 
   std::unordered_map<std::string, libbpf::bpf_map_type> map_types_;
 

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -155,6 +155,8 @@ void ResourceAnalyser::visit(Call &call)
       resources_.time_args.push_back(get_literal_string(*call.vargs->at(0)));
     else
       resources_.time_args.push_back("%H:%M:%S\n");
+  } else if (call.func == "str") {
+    resources_.str_buffers++;
   } else if (call.func == "strftime") {
     resources_.strftime_args.push_back(get_literal_string(*call.vargs->at(0)));
   } else if (call.func == "print") {

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -69,6 +69,8 @@ std::string to_string(MapType t)
       return "ringbuf";
     case MapType::RingbufLossCounter:
       return "ringbuf_loss_counter";
+    case MapType::StrBuffer:
+      return "str_buffer";
   }
   return {}; // unreached
 }

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -72,6 +72,7 @@ enum class MapType {
   MappedPrintfData,
   Ringbuf,
   RingbufLossCounter,
+  StrBuffer,
 };
 
 std::string to_string(MapType t);

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -117,6 +117,7 @@ public:
   bool needs_elapsed_map = false;
   bool needs_data_map = false;
   bool needs_perf_event_map = false;
+  uint32_t str_buffers = 0;
 
   // Probe metadata
   //

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -19,32 +19,22 @@ define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
-  %strlen = alloca i64, align 8
-  %1 = bitcast i64* %strlen to i8*
+  %1 = bitcast [64 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  store i64 64, i64* %strlen, align 8
-  %3 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 64, i1 false)
-  %5 = bitcast i8* %0 to i64*
-  %6 = getelementptr i64, i64* %5, i64 14
-  %arg0 = load volatile i64, i64* %6, align 8
-  %7 = load i64, i64* %strlen, align 8
-  %8 = trunc i64 %7 to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %8, i64 %arg0)
-  %9 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %2 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 64, i1 false)
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 64, i64 %arg0)
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 0, i64* %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [64 x i8]*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", [64 x i8]* %str, i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -19,38 +19,29 @@ define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
-  %strlen = alloca i64, align 8
-  %1 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  %3 = bitcast i8* %0 to i64*
-  %4 = getelementptr i64, i64* %3, i64 13
-  %arg1 = load volatile i64, i64* %4, align 8
-  %5 = add i64 %arg1, 1
-  %str.min.cmp = icmp ule i64 %5, 64
-  %str.min.select = select i1 %str.min.cmp, i64 %5, i64 64
-  store i64 %str.min.select, i64* %strlen, align 8
-  %6 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 64, i1 false)
-  %8 = bitcast i8* %0 to i64*
-  %9 = getelementptr i64, i64* %8, i64 14
-  %arg0 = load volatile i64, i64* %9, align 8
-  %10 = load i64, i64* %strlen, align 8
-  %11 = trunc i64 %10 to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %11, i64 %arg0)
-  %12 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 13
+  %arg1 = load volatile i64, i64* %2, align 8
+  %3 = add i64 %arg1, 1
+  %str.min.cmp = icmp ule i64 %3, 64
+  %str.min.select = select i1 %str.min.cmp, i64 %3, i64 64
+  %4 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %5 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 64, i1 false)
+  %6 = bitcast i8* %0 to i64*
+  %7 = getelementptr i64, i64* %6, i64 14
+  %arg0 = load volatile i64, i64* %7, align 8
+  %8 = trunc i64 %str.min.select to i32
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %8, i64 %arg0)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [64 x i8]*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", [64 x i8]* %str, i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -6,60 +6,76 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
 @ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@str_buffer = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !53
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !66 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %str = alloca [64 x i8], align 1
+  %lookup_str_key = alloca i32, align 4
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 13
   %arg1 = load volatile i64, i64* %2, align 8
   %3 = add i64 %arg1, 1
   %str.min.cmp = icmp ule i64 %3, 64
   %str.min.select = select i1 %str.min.cmp, i64 %3, i64 64
-  %4 = bitcast [64 x i8]* %str to i8*
+  %4 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 64, i1 false)
-  %6 = bitcast i8* %0 to i64*
-  %7 = getelementptr i64, i64* %6, i64 14
-  %arg0 = load volatile i64, i64* %7, align 8
-  %8 = trunc i64 %str.min.select to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %8, i64 %arg0)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [64 x i8]*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", [64 x i8]* %str, i64 0)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  store i32 0, i32* %lookup_str_key, align 4
+  %lookup_str_map = call i8* inttoptr (i64 1 to i8* (%"struct map_t.2"*, i32*)*)(%"struct map_t.2"* @str_buffer, i32* %lookup_str_key)
+  %5 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %lookup_str_cond = icmp ne i8* %lookup_str_map, null
+  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
+
+scratch_lookup_failure:                           ; preds = %lookup_str_failure
   ret i64 0
+
+scratch_lookup_merge:                             ; preds = %lookup_str_merge
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@x_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i8* %lookup_str_map, i64 0)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  ret i64 0
+
+lookup_str_failure:                               ; preds = %entry
+  br label %scratch_lookup_failure
+
+lookup_str_merge:                                 ; preds = %entry
+  call void @llvm.memset.p0i8.i64(i8* align 1 %lookup_str_map, i8 0, i64 64, i1 false)
+  %8 = bitcast i8* %0 to i64*
+  %9 = getelementptr i64, i64* %8, i64 14
+  %arg0 = load volatile i64, i64* %9, align 8
+  %10 = trunc i64 %str.min.select to i32
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 %10, i64 %arg0)
+  br label %scratch_lookup_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!56}
+!llvm.dbg.cu = !{!62}
+!llvm.module.flags = !{!65}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -114,13 +130,22 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
 !51 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
-!54 = !{}
-!55 = !{!0, !25, !39}
-!56 = !{i32 2, !"Debug Info Version", i32 3}
-!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!58 = !DISubroutineType(types: !59)
-!59 = !{!18, !60}
-!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !56)
+!56 = !{!57, !48, !49, !19}
+!57 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !58, size: 64)
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !60)
+!60 = !{!61}
+!61 = !DISubrange(count: 6, lowerBound: 0)
+!62 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !63, globals: !64)
+!63 = !{}
+!64 = !{!0, !25, !39, !53}
+!65 = !{i32 2, !"Debug Info Version", i32 3}
+!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !62, retainedNodes: !70)
+!67 = !DISubroutineType(types: !68)
+!68 = !{!18, !69}
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -19,32 +19,22 @@ define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
-  %strlen = alloca i64, align 8
-  %1 = bitcast i64* %strlen to i8*
+  %1 = bitcast [64 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  store i64 7, i64* %strlen, align 8
-  %3 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 64, i1 false)
-  %5 = bitcast i8* %0 to i64*
-  %6 = getelementptr i64, i64* %5, i64 14
-  %arg0 = load volatile i64, i64* %6, align 8
-  %7 = load i64, i64* %strlen, align 8
-  %8 = trunc i64 %7 to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %8, i64 %arg0)
-  %9 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %2 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 64, i1 false)
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 7, i64 %arg0)
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 0, i64* %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [64 x i8]*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", [64 x i8]* %str, i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -6,53 +6,69 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
 @ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@str_buffer = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !53
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !66 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %str = alloca [64 x i8], align 1
-  %1 = bitcast [64 x i8]* %str to i8*
+  %lookup_str_key = alloca i32, align 4
+  %1 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 64, i1 false)
-  %3 = bitcast i8* %0 to i64*
-  %4 = getelementptr i64, i64* %3, i64 14
-  %arg0 = load volatile i64, i64* %4, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 7, i64 %arg0)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 0, i64* %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [64 x i8]*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", [64 x i8]* %str, i64 0)
-  %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %lookup_str_key, align 4
+  %lookup_str_map = call i8* inttoptr (i64 1 to i8* (%"struct map_t.2"*, i32*)*)(%"struct map_t.2"* @str_buffer, i32* %lookup_str_key)
+  %2 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %lookup_str_cond = icmp ne i8* %lookup_str_map, null
+  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
+
+scratch_lookup_failure:                           ; preds = %lookup_str_failure
   ret i64 0
+
+scratch_lookup_merge:                             ; preds = %lookup_str_merge
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 0, i64* %"@x_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i8* %lookup_str_map, i64 0)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  ret i64 0
+
+lookup_str_failure:                               ; preds = %entry
+  br label %scratch_lookup_failure
+
+lookup_str_merge:                                 ; preds = %entry
+  call void @llvm.memset.p0i8.i64(i8* align 1 %lookup_str_map, i8 0, i64 64, i1 false)
+  %5 = bitcast i8* %0 to i64*
+  %6 = getelementptr i64, i64* %5, i64 14
+  %arg0 = load volatile i64, i64* %6, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 7, i64 %arg0)
+  br label %scratch_lookup_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!56}
+!llvm.dbg.cu = !{!62}
+!llvm.module.flags = !{!65}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -107,13 +123,22 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
 !51 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
-!54 = !{}
-!55 = !{!0, !25, !39}
-!56 = !{i32 2, !"Debug Info Version", i32 3}
-!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!58 = !DISubroutineType(types: !59)
-!59 = !{!18, !60}
-!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !56)
+!56 = !{!57, !48, !49, !19}
+!57 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !58, size: 64)
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !60)
+!60 = !{!61}
+!61 = !DISubrange(count: 6, lowerBound: 0)
+!62 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !63, globals: !64)
+!63 = !{}
+!64 = !{!0, !25, !39, !53}
+!65 = !{i32 2, !"Debug Info Version", i32 3}
+!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !62, retainedNodes: !70)
+!67 = !DISubroutineType(types: !68)
+!68 = !{!18, !69}
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)

--- a/tests/codegen/llvm/literal_strncmp.ll
+++ b/tests/codegen/llvm/literal_strncmp.ll
@@ -30,34 +30,35 @@ entry:
   %3 = bitcast i1* %strcmp.result to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i1 true, i1* %strcmp.result, align 1
-  %4 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 0
-  %5 = load i8, i8* %4, align 1
-  %strcmp.cmp = icmp ne i8 %5, 115
+  %4 = bitcast [16 x i8]* %comm to i8*
+  %5 = getelementptr i8, i8* %4, i32 0
+  %6 = load i8, i8* %5, align 1
+  %strcmp.cmp = icmp ne i8 %6, 115
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 pred_false:                                       ; preds = %strcmp.false
   ret i64 0
 
 pred_true:                                        ; preds = %strcmp.false
-  %6 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [16 x i8]* %comm5 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %7 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = bitcast [16 x i8]* %comm5 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 16, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [16 x i8]* %comm5 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 16, i1 false)
   %get_comm6 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm5, i64 16)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, [16 x i8]*)*)(%"struct map_t"* @AT_, [16 x i8]* %comm5)
-  %9 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop, %entry
-  %10 = load i1, i1* %strcmp.result, align 1
-  %11 = bitcast i1* %strcmp.result to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = zext i1 %10 to i64
-  %predcond = icmp eq i64 %12, 0
+  %11 = load i1, i1* %strcmp.result, align 1
+  %12 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = zext i1 %11 to i64
+  %predcond = icmp eq i64 %13, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.done:                                      ; preds = %strcmp.loop1, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
@@ -65,41 +66,42 @@ strcmp.done:                                      ; preds = %strcmp.loop1, %strc
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %13 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
-  %14 = load i8, i8* %13, align 1
-  %strcmp.cmp3 = icmp ne i8 %14, 115
+  %14 = bitcast [16 x i8]* %comm to i8*
+  %15 = getelementptr i8, i8* %14, i32 1
+  %16 = load i8, i8* %15, align 1
+  %strcmp.cmp3 = icmp ne i8 %16, 115
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
-  %strcmp.cmp_null = icmp eq i8 %5, 0
+  %strcmp.cmp_null = icmp eq i8 %6, 0
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
   br label %strcmp.done
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %14, 0
+  %strcmp.cmp_null4 = icmp eq i8 %16, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 lookup_success:                                   ; preds = %pred_true
   %cast = bitcast i8* %lookup_elem to i64*
-  %15 = load i64, i64* %cast, align 8
-  %16 = add i64 %15, 1
-  store i64 %16, i64* %cast, align 8
+  %17 = load i64, i64* %cast, align 8
+  %18 = add i64 %17, 1
+  store i64 %18, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %pred_true
-  %17 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %19 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
   store i64 1, i64* %initial_value, align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, [16 x i8]*, i64*, i64)*)(%"struct map_t"* @AT_, [16 x i8]* %comm5, i64* %initial_value, i64 1)
-  %18 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %20 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %19 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %21 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -22,7 +22,6 @@ entry:
   %"@y_key" = alloca i64, align 8
   %str1 = alloca [1 x i8], align 1
   %str = alloca [64 x i8], align 1
-  %strlen = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
@@ -36,36 +35,27 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %strlen to i8*
+  %5 = bitcast [64 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 8, i1 false)
-  store i64 64, i64* %strlen, align 8
-  %7 = bitcast [64 x i8]* %str to i8*
+  %6 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 64, i1 false)
+  %7 = bitcast [1 x i8]* %str1 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %8 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 64, i1 false)
-  %9 = bitcast [1 x i8]* %str1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [1 x i8]* %str1 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %10, i8 0, i64 1, i1 false)
+  %8 = bitcast [1 x i8]* %str1 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 1, i1 false)
   store [1 x i8] zeroinitializer, [1 x i8]* %str1, align 1
-  %11 = ptrtoint [1 x i8]* %str1 to i64
-  %12 = load i64, i64* %strlen, align 8
-  %13 = trunc i64 %12 to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %13, i64 %11)
-  %14 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast [1 x i8]* %str1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %9 = ptrtoint [1 x i8]* %str1 to i64
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 64, i64 %9)
+  %10 = bitcast [1 x i8]* %str1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@y_key", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, [64 x i8]*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", [64 x i8]* %str, i64 0)
-  %17 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %12 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -30,34 +30,35 @@ entry:
   %3 = bitcast i1* %strcmp.result to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i1 false, i1* %strcmp.result, align 1
-  %4 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 0
-  %5 = load i8, i8* %4, align 1
-  %strcmp.cmp = icmp ne i8 %5, 115
+  %4 = bitcast [16 x i8]* %comm to i8*
+  %5 = getelementptr i8, i8* %4, i32 0
+  %6 = load i8, i8* %5, align 1
+  %strcmp.cmp = icmp ne i8 %6, 115
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 pred_false:                                       ; preds = %strcmp.false
   ret i64 0
 
 pred_true:                                        ; preds = %strcmp.false
-  %6 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [16 x i8]* %comm17 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %7 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = bitcast [16 x i8]* %comm17 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 16, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [16 x i8]* %comm17 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 16, i1 false)
   %get_comm18 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm17, i64 16)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, [16 x i8]*)*)(%"struct map_t"* @AT_, [16 x i8]* %comm17)
-  %9 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
-  %10 = load i1, i1* %strcmp.result, align 1
-  %11 = bitcast i1* %strcmp.result to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = zext i1 %10 to i64
-  %predcond = icmp eq i64 %12, 0
+  %11 = load i1, i1* %strcmp.result, align 1
+  %12 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = zext i1 %11 to i64
+  %predcond = icmp eq i64 %13, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.done:                                      ; preds = %strcmp.loop13, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
@@ -65,71 +66,75 @@ strcmp.done:                                      ; preds = %strcmp.loop13, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %13 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
-  %14 = load i8, i8* %13, align 1
-  %strcmp.cmp3 = icmp ne i8 %14, 115
+  %14 = bitcast [16 x i8]* %comm to i8*
+  %15 = getelementptr i8, i8* %14, i32 1
+  %16 = load i8, i8* %15, align 1
+  %strcmp.cmp3 = icmp ne i8 %16, 115
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
-  %strcmp.cmp_null = icmp eq i8 %5, 0
+  %strcmp.cmp_null = icmp eq i8 %6, 0
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %15 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
-  %16 = load i8, i8* %15, align 1
-  %strcmp.cmp7 = icmp ne i8 %16, 104
+  %17 = bitcast [16 x i8]* %comm to i8*
+  %18 = getelementptr i8, i8* %17, i32 2
+  %19 = load i8, i8* %18, align 1
+  %strcmp.cmp7 = icmp ne i8 %19, 104
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %14, 0
+  %strcmp.cmp_null4 = icmp eq i8 %16, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %17 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
-  %18 = load i8, i8* %17, align 1
-  %strcmp.cmp11 = icmp ne i8 %18, 100
+  %20 = bitcast [16 x i8]* %comm to i8*
+  %21 = getelementptr i8, i8* %20, i32 3
+  %22 = load i8, i8* %21, align 1
+  %strcmp.cmp11 = icmp ne i8 %22, 100
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %16, 0
+  %strcmp.cmp_null8 = icmp eq i8 %19, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %19 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
-  %20 = load i8, i8* %19, align 1
-  %strcmp.cmp15 = icmp ne i8 %20, 0
+  %23 = bitcast [16 x i8]* %comm to i8*
+  %24 = getelementptr i8, i8* %23, i32 4
+  %25 = load i8, i8* %24, align 1
+  %strcmp.cmp15 = icmp ne i8 %25, 0
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %18, 0
+  %strcmp.cmp_null12 = icmp eq i8 %22, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
   br label %strcmp.done
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %20, 0
+  %strcmp.cmp_null16 = icmp eq i8 %25, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 lookup_success:                                   ; preds = %pred_true
   %cast = bitcast i8* %lookup_elem to i64*
-  %21 = load i64, i64* %cast, align 8
-  %22 = add i64 %21, 1
-  store i64 %22, i64* %cast, align 8
+  %26 = load i64, i64* %cast, align 8
+  %27 = add i64 %26, 1
+  store i64 %27, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %pred_true
-  %23 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %28 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
   store i64 1, i64* %initial_value, align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, [16 x i8]*, i64*, i64)*)(%"struct map_t"* @AT_, [16 x i8]* %comm17, i64* %initial_value, i64 1)
-  %24 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %29 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %25 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
+  %30 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -30,34 +30,35 @@ entry:
   %3 = bitcast i1* %strcmp.result to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i1 true, i1* %strcmp.result, align 1
-  %4 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 0
-  %5 = load i8, i8* %4, align 1
-  %strcmp.cmp = icmp ne i8 %5, 115
+  %4 = bitcast [16 x i8]* %comm to i8*
+  %5 = getelementptr i8, i8* %4, i32 0
+  %6 = load i8, i8* %5, align 1
+  %strcmp.cmp = icmp ne i8 %6, 115
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 pred_false:                                       ; preds = %strcmp.false
   ret i64 0
 
 pred_true:                                        ; preds = %strcmp.false
-  %6 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [16 x i8]* %comm17 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %7 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = bitcast [16 x i8]* %comm17 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 16, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [16 x i8]* %comm17 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 16, i1 false)
   %get_comm18 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm17, i64 16)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, [16 x i8]*)*)(%"struct map_t"* @AT_, [16 x i8]* %comm17)
-  %9 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
-  %10 = load i1, i1* %strcmp.result, align 1
-  %11 = bitcast i1* %strcmp.result to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = zext i1 %10 to i64
-  %predcond = icmp eq i64 %12, 0
+  %11 = load i1, i1* %strcmp.result, align 1
+  %12 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = zext i1 %11 to i64
+  %predcond = icmp eq i64 %13, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.done:                                      ; preds = %strcmp.loop13, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
@@ -65,71 +66,75 @@ strcmp.done:                                      ; preds = %strcmp.loop13, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %13 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
-  %14 = load i8, i8* %13, align 1
-  %strcmp.cmp3 = icmp ne i8 %14, 115
+  %14 = bitcast [16 x i8]* %comm to i8*
+  %15 = getelementptr i8, i8* %14, i32 1
+  %16 = load i8, i8* %15, align 1
+  %strcmp.cmp3 = icmp ne i8 %16, 115
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
-  %strcmp.cmp_null = icmp eq i8 %5, 0
+  %strcmp.cmp_null = icmp eq i8 %6, 0
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %15 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
-  %16 = load i8, i8* %15, align 1
-  %strcmp.cmp7 = icmp ne i8 %16, 104
+  %17 = bitcast [16 x i8]* %comm to i8*
+  %18 = getelementptr i8, i8* %17, i32 2
+  %19 = load i8, i8* %18, align 1
+  %strcmp.cmp7 = icmp ne i8 %19, 104
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %14, 0
+  %strcmp.cmp_null4 = icmp eq i8 %16, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %17 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
-  %18 = load i8, i8* %17, align 1
-  %strcmp.cmp11 = icmp ne i8 %18, 100
+  %20 = bitcast [16 x i8]* %comm to i8*
+  %21 = getelementptr i8, i8* %20, i32 3
+  %22 = load i8, i8* %21, align 1
+  %strcmp.cmp11 = icmp ne i8 %22, 100
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %16, 0
+  %strcmp.cmp_null8 = icmp eq i8 %19, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %19 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
-  %20 = load i8, i8* %19, align 1
-  %strcmp.cmp15 = icmp ne i8 %20, 0
+  %23 = bitcast [16 x i8]* %comm to i8*
+  %24 = getelementptr i8, i8* %23, i32 4
+  %25 = load i8, i8* %24, align 1
+  %strcmp.cmp15 = icmp ne i8 %25, 0
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %18, 0
+  %strcmp.cmp_null12 = icmp eq i8 %22, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
   br label %strcmp.done
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %20, 0
+  %strcmp.cmp_null16 = icmp eq i8 %25, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 lookup_success:                                   ; preds = %pred_true
   %cast = bitcast i8* %lookup_elem to i64*
-  %21 = load i64, i64* %cast, align 8
-  %22 = add i64 %21, 1
-  store i64 %22, i64* %cast, align 8
+  %26 = load i64, i64* %cast, align 8
+  %27 = add i64 %26, 1
+  store i64 %27, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %pred_true
-  %23 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %28 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
   store i64 1, i64* %initial_value, align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, [16 x i8]*, i64*, i64)*)(%"struct map_t"* @AT_, [16 x i8]* %comm17, i64* %initial_value, i64 1)
-  %24 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %29 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %25 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
+  %30 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -6,41 +6,65 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@str_buffer = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !47
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @tracepoint_file_filename_1(i8* %0) section "s_tracepoint_file_filename_1" !dbg !51 {
+define i64 @tracepoint_file_filename_1(i8* %0) section "s_tracepoint_file_filename_1" !dbg !66 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %strcmp.result = alloca i1, align 1
   %comm = alloca [16 x i8], align 1
-  %str = alloca [64 x i8], align 1
-  %1 = bitcast [64 x i8]* %str to i8*
+  %lookup_str_key = alloca i32, align 4
+  %1 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 64, i1 false)
-  %3 = ptrtoint i8* %0 to i64
-  %4 = add i64 %3, 8
-  %5 = inttoptr i64 %4 to i64*
-  %6 = load volatile i64, i64* %5, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 64, i64 %6)
-  %7 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %lookup_str_key, align 4
+  %lookup_str_map = call i8* inttoptr (i64 1 to i8* (%"struct map_t.2"*, i32*)*)(%"struct map_t.2"* @str_buffer, i32* %lookup_str_key)
+  %2 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %lookup_str_cond = icmp ne i8* %lookup_str_map, null
+  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
+
+pred_false:                                       ; preds = %strcmp.false
+  ret i64 1
+
+pred_true:                                        ; preds = %strcmp.false
+  %3 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@_key", align 8
+  %5 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 1, i64* %"@_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_, i64* %"@_key", i64* %"@_val", i64 0)
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  ret i64 1
+
+scratch_lookup_failure:                           ; preds = %lookup_str_failure
+  ret i64 1
+
+scratch_lookup_merge:                             ; preds = %lookup_str_merge
   %8 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 16, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm, i64 16)
-  %9 = bitcast i1* %strcmp.result to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i1 false, i1* %strcmp.result, align 1
-  %10 = bitcast [64 x i8]* %str to i8*
-  %11 = getelementptr i8, i8* %10, i32 0
+  %11 = getelementptr i8, i8* %lookup_str_map, i32 0
   %12 = load i8, i8* %11, align 1
   %13 = bitcast [16 x i8]* %comm to i8*
   %14 = getelementptr i8, i8* %13, i32 0
@@ -48,31 +72,24 @@ entry:
   %strcmp.cmp = icmp ne i8 %12, %15
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
-pred_false:                                       ; preds = %strcmp.false
-  ret i64 1
+lookup_str_failure:                               ; preds = %entry
+  br label %scratch_lookup_failure
 
-pred_true:                                        ; preds = %strcmp.false
-  %16 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  store i64 0, i64* %"@_key", align 8
-  %18 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
-  store i64 1, i64* %"@_val", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_, i64* %"@_key", i64* %"@_val", i64 0)
-  %19 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
-  %20 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  ret i64 1
+lookup_str_merge:                                 ; preds = %entry
+  call void @llvm.memset.p0i8.i64(i8* align 1 %lookup_str_map, i8 0, i64 64, i1 false)
+  %16 = ptrtoint i8* %0 to i64
+  %17 = add i64 %16, 8
+  %18 = inttoptr i64 %17 to i64*
+  %19 = load volatile i64, i64* %18, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 64, i64 %19)
+  br label %scratch_lookup_merge
 
-strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
-  %21 = load i1, i1* %strcmp.result, align 1
-  %22 = bitcast i1* %strcmp.result to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = zext i1 %21 to i64
-  %predcond = icmp eq i64 %23, 0
+strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %scratch_lookup_merge
+  %20 = load i1, i1* %strcmp.result, align 1
+  %21 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = zext i1 %20 to i64
+  %predcond = icmp eq i64 %22, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.done:                                      ; preds = %strcmp.loop57, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp54, %strcmp.loop_null_cmp50, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp42, %strcmp.loop_null_cmp38, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp30, %strcmp.loop_null_cmp26, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp18, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
@@ -80,238 +97,223 @@ strcmp.done:                                      ; preds = %strcmp.loop57, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %24 = bitcast [64 x i8]* %str to i8*
-  %25 = getelementptr i8, i8* %24, i32 1
-  %26 = load i8, i8* %25, align 1
-  %27 = bitcast [16 x i8]* %comm to i8*
-  %28 = getelementptr i8, i8* %27, i32 1
-  %29 = load i8, i8* %28, align 1
-  %strcmp.cmp3 = icmp ne i8 %26, %29
+  %23 = getelementptr i8, i8* %lookup_str_map, i32 1
+  %24 = load i8, i8* %23, align 1
+  %25 = bitcast [16 x i8]* %comm to i8*
+  %26 = getelementptr i8, i8* %25, i32 1
+  %27 = load i8, i8* %26, align 1
+  %strcmp.cmp3 = icmp ne i8 %24, %27
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
-strcmp.loop_null_cmp:                             ; preds = %entry
+strcmp.loop_null_cmp:                             ; preds = %scratch_lookup_merge
   %strcmp.cmp_null = icmp eq i8 %12, 0
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %30 = bitcast [64 x i8]* %str to i8*
+  %28 = getelementptr i8, i8* %lookup_str_map, i32 2
+  %29 = load i8, i8* %28, align 1
+  %30 = bitcast [16 x i8]* %comm to i8*
   %31 = getelementptr i8, i8* %30, i32 2
   %32 = load i8, i8* %31, align 1
-  %33 = bitcast [16 x i8]* %comm to i8*
-  %34 = getelementptr i8, i8* %33, i32 2
-  %35 = load i8, i8* %34, align 1
-  %strcmp.cmp7 = icmp ne i8 %32, %35
+  %strcmp.cmp7 = icmp ne i8 %29, %32
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %26, 0
+  %strcmp.cmp_null4 = icmp eq i8 %24, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %36 = bitcast [64 x i8]* %str to i8*
-  %37 = getelementptr i8, i8* %36, i32 3
-  %38 = load i8, i8* %37, align 1
-  %39 = bitcast [16 x i8]* %comm to i8*
-  %40 = getelementptr i8, i8* %39, i32 3
-  %41 = load i8, i8* %40, align 1
-  %strcmp.cmp11 = icmp ne i8 %38, %41
+  %33 = getelementptr i8, i8* %lookup_str_map, i32 3
+  %34 = load i8, i8* %33, align 1
+  %35 = bitcast [16 x i8]* %comm to i8*
+  %36 = getelementptr i8, i8* %35, i32 3
+  %37 = load i8, i8* %36, align 1
+  %strcmp.cmp11 = icmp ne i8 %34, %37
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %32, 0
+  %strcmp.cmp_null8 = icmp eq i8 %29, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %42 = bitcast [64 x i8]* %str to i8*
-  %43 = getelementptr i8, i8* %42, i32 4
-  %44 = load i8, i8* %43, align 1
-  %45 = bitcast [16 x i8]* %comm to i8*
-  %46 = getelementptr i8, i8* %45, i32 4
-  %47 = load i8, i8* %46, align 1
-  %strcmp.cmp15 = icmp ne i8 %44, %47
+  %38 = getelementptr i8, i8* %lookup_str_map, i32 4
+  %39 = load i8, i8* %38, align 1
+  %40 = bitcast [16 x i8]* %comm to i8*
+  %41 = getelementptr i8, i8* %40, i32 4
+  %42 = load i8, i8* %41, align 1
+  %strcmp.cmp15 = icmp ne i8 %39, %42
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %38, 0
+  %strcmp.cmp_null12 = icmp eq i8 %34, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
-  %48 = bitcast [64 x i8]* %str to i8*
-  %49 = getelementptr i8, i8* %48, i32 5
-  %50 = load i8, i8* %49, align 1
-  %51 = bitcast [16 x i8]* %comm to i8*
-  %52 = getelementptr i8, i8* %51, i32 5
-  %53 = load i8, i8* %52, align 1
-  %strcmp.cmp19 = icmp ne i8 %50, %53
+  %43 = getelementptr i8, i8* %lookup_str_map, i32 5
+  %44 = load i8, i8* %43, align 1
+  %45 = bitcast [16 x i8]* %comm to i8*
+  %46 = getelementptr i8, i8* %45, i32 5
+  %47 = load i8, i8* %46, align 1
+  %strcmp.cmp19 = icmp ne i8 %44, %47
   br i1 %strcmp.cmp19, label %strcmp.false, label %strcmp.loop_null_cmp18
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %44, 0
+  %strcmp.cmp_null16 = icmp eq i8 %39, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 strcmp.loop17:                                    ; preds = %strcmp.loop_null_cmp18
-  %54 = bitcast [64 x i8]* %str to i8*
-  %55 = getelementptr i8, i8* %54, i32 6
-  %56 = load i8, i8* %55, align 1
-  %57 = bitcast [16 x i8]* %comm to i8*
-  %58 = getelementptr i8, i8* %57, i32 6
-  %59 = load i8, i8* %58, align 1
-  %strcmp.cmp23 = icmp ne i8 %56, %59
+  %48 = getelementptr i8, i8* %lookup_str_map, i32 6
+  %49 = load i8, i8* %48, align 1
+  %50 = bitcast [16 x i8]* %comm to i8*
+  %51 = getelementptr i8, i8* %50, i32 6
+  %52 = load i8, i8* %51, align 1
+  %strcmp.cmp23 = icmp ne i8 %49, %52
   br i1 %strcmp.cmp23, label %strcmp.false, label %strcmp.loop_null_cmp22
 
 strcmp.loop_null_cmp18:                           ; preds = %strcmp.loop13
-  %strcmp.cmp_null20 = icmp eq i8 %50, 0
+  %strcmp.cmp_null20 = icmp eq i8 %44, 0
   br i1 %strcmp.cmp_null20, label %strcmp.done, label %strcmp.loop17
 
 strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
-  %60 = bitcast [64 x i8]* %str to i8*
-  %61 = getelementptr i8, i8* %60, i32 7
-  %62 = load i8, i8* %61, align 1
-  %63 = bitcast [16 x i8]* %comm to i8*
-  %64 = getelementptr i8, i8* %63, i32 7
-  %65 = load i8, i8* %64, align 1
-  %strcmp.cmp27 = icmp ne i8 %62, %65
+  %53 = getelementptr i8, i8* %lookup_str_map, i32 7
+  %54 = load i8, i8* %53, align 1
+  %55 = bitcast [16 x i8]* %comm to i8*
+  %56 = getelementptr i8, i8* %55, i32 7
+  %57 = load i8, i8* %56, align 1
+  %strcmp.cmp27 = icmp ne i8 %54, %57
   br i1 %strcmp.cmp27, label %strcmp.false, label %strcmp.loop_null_cmp26
 
 strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop17
-  %strcmp.cmp_null24 = icmp eq i8 %56, 0
+  %strcmp.cmp_null24 = icmp eq i8 %49, 0
   br i1 %strcmp.cmp_null24, label %strcmp.done, label %strcmp.loop21
 
 strcmp.loop25:                                    ; preds = %strcmp.loop_null_cmp26
-  %66 = bitcast [64 x i8]* %str to i8*
-  %67 = getelementptr i8, i8* %66, i32 8
-  %68 = load i8, i8* %67, align 1
-  %69 = bitcast [16 x i8]* %comm to i8*
-  %70 = getelementptr i8, i8* %69, i32 8
-  %71 = load i8, i8* %70, align 1
-  %strcmp.cmp31 = icmp ne i8 %68, %71
+  %58 = getelementptr i8, i8* %lookup_str_map, i32 8
+  %59 = load i8, i8* %58, align 1
+  %60 = bitcast [16 x i8]* %comm to i8*
+  %61 = getelementptr i8, i8* %60, i32 8
+  %62 = load i8, i8* %61, align 1
+  %strcmp.cmp31 = icmp ne i8 %59, %62
   br i1 %strcmp.cmp31, label %strcmp.false, label %strcmp.loop_null_cmp30
 
 strcmp.loop_null_cmp26:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null28 = icmp eq i8 %62, 0
+  %strcmp.cmp_null28 = icmp eq i8 %54, 0
   br i1 %strcmp.cmp_null28, label %strcmp.done, label %strcmp.loop25
 
 strcmp.loop29:                                    ; preds = %strcmp.loop_null_cmp30
-  %72 = bitcast [64 x i8]* %str to i8*
-  %73 = getelementptr i8, i8* %72, i32 9
-  %74 = load i8, i8* %73, align 1
-  %75 = bitcast [16 x i8]* %comm to i8*
-  %76 = getelementptr i8, i8* %75, i32 9
-  %77 = load i8, i8* %76, align 1
-  %strcmp.cmp35 = icmp ne i8 %74, %77
+  %63 = getelementptr i8, i8* %lookup_str_map, i32 9
+  %64 = load i8, i8* %63, align 1
+  %65 = bitcast [16 x i8]* %comm to i8*
+  %66 = getelementptr i8, i8* %65, i32 9
+  %67 = load i8, i8* %66, align 1
+  %strcmp.cmp35 = icmp ne i8 %64, %67
   br i1 %strcmp.cmp35, label %strcmp.false, label %strcmp.loop_null_cmp34
 
 strcmp.loop_null_cmp30:                           ; preds = %strcmp.loop25
-  %strcmp.cmp_null32 = icmp eq i8 %68, 0
+  %strcmp.cmp_null32 = icmp eq i8 %59, 0
   br i1 %strcmp.cmp_null32, label %strcmp.done, label %strcmp.loop29
 
 strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
-  %78 = bitcast [64 x i8]* %str to i8*
-  %79 = getelementptr i8, i8* %78, i32 10
-  %80 = load i8, i8* %79, align 1
-  %81 = bitcast [16 x i8]* %comm to i8*
-  %82 = getelementptr i8, i8* %81, i32 10
-  %83 = load i8, i8* %82, align 1
-  %strcmp.cmp39 = icmp ne i8 %80, %83
+  %68 = getelementptr i8, i8* %lookup_str_map, i32 10
+  %69 = load i8, i8* %68, align 1
+  %70 = bitcast [16 x i8]* %comm to i8*
+  %71 = getelementptr i8, i8* %70, i32 10
+  %72 = load i8, i8* %71, align 1
+  %strcmp.cmp39 = icmp ne i8 %69, %72
   br i1 %strcmp.cmp39, label %strcmp.false, label %strcmp.loop_null_cmp38
 
 strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop29
-  %strcmp.cmp_null36 = icmp eq i8 %74, 0
+  %strcmp.cmp_null36 = icmp eq i8 %64, 0
   br i1 %strcmp.cmp_null36, label %strcmp.done, label %strcmp.loop33
 
 strcmp.loop37:                                    ; preds = %strcmp.loop_null_cmp38
-  %84 = bitcast [64 x i8]* %str to i8*
-  %85 = getelementptr i8, i8* %84, i32 11
-  %86 = load i8, i8* %85, align 1
-  %87 = bitcast [16 x i8]* %comm to i8*
-  %88 = getelementptr i8, i8* %87, i32 11
-  %89 = load i8, i8* %88, align 1
-  %strcmp.cmp43 = icmp ne i8 %86, %89
+  %73 = getelementptr i8, i8* %lookup_str_map, i32 11
+  %74 = load i8, i8* %73, align 1
+  %75 = bitcast [16 x i8]* %comm to i8*
+  %76 = getelementptr i8, i8* %75, i32 11
+  %77 = load i8, i8* %76, align 1
+  %strcmp.cmp43 = icmp ne i8 %74, %77
   br i1 %strcmp.cmp43, label %strcmp.false, label %strcmp.loop_null_cmp42
 
 strcmp.loop_null_cmp38:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null40 = icmp eq i8 %80, 0
+  %strcmp.cmp_null40 = icmp eq i8 %69, 0
   br i1 %strcmp.cmp_null40, label %strcmp.done, label %strcmp.loop37
 
 strcmp.loop41:                                    ; preds = %strcmp.loop_null_cmp42
-  %90 = bitcast [64 x i8]* %str to i8*
-  %91 = getelementptr i8, i8* %90, i32 12
-  %92 = load i8, i8* %91, align 1
-  %93 = bitcast [16 x i8]* %comm to i8*
-  %94 = getelementptr i8, i8* %93, i32 12
-  %95 = load i8, i8* %94, align 1
-  %strcmp.cmp47 = icmp ne i8 %92, %95
+  %78 = getelementptr i8, i8* %lookup_str_map, i32 12
+  %79 = load i8, i8* %78, align 1
+  %80 = bitcast [16 x i8]* %comm to i8*
+  %81 = getelementptr i8, i8* %80, i32 12
+  %82 = load i8, i8* %81, align 1
+  %strcmp.cmp47 = icmp ne i8 %79, %82
   br i1 %strcmp.cmp47, label %strcmp.false, label %strcmp.loop_null_cmp46
 
 strcmp.loop_null_cmp42:                           ; preds = %strcmp.loop37
-  %strcmp.cmp_null44 = icmp eq i8 %86, 0
+  %strcmp.cmp_null44 = icmp eq i8 %74, 0
   br i1 %strcmp.cmp_null44, label %strcmp.done, label %strcmp.loop41
 
 strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
-  %96 = bitcast [64 x i8]* %str to i8*
-  %97 = getelementptr i8, i8* %96, i32 13
-  %98 = load i8, i8* %97, align 1
-  %99 = bitcast [16 x i8]* %comm to i8*
-  %100 = getelementptr i8, i8* %99, i32 13
-  %101 = load i8, i8* %100, align 1
-  %strcmp.cmp51 = icmp ne i8 %98, %101
+  %83 = getelementptr i8, i8* %lookup_str_map, i32 13
+  %84 = load i8, i8* %83, align 1
+  %85 = bitcast [16 x i8]* %comm to i8*
+  %86 = getelementptr i8, i8* %85, i32 13
+  %87 = load i8, i8* %86, align 1
+  %strcmp.cmp51 = icmp ne i8 %84, %87
   br i1 %strcmp.cmp51, label %strcmp.false, label %strcmp.loop_null_cmp50
 
 strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop41
-  %strcmp.cmp_null48 = icmp eq i8 %92, 0
+  %strcmp.cmp_null48 = icmp eq i8 %79, 0
   br i1 %strcmp.cmp_null48, label %strcmp.done, label %strcmp.loop45
 
 strcmp.loop49:                                    ; preds = %strcmp.loop_null_cmp50
-  %102 = bitcast [64 x i8]* %str to i8*
-  %103 = getelementptr i8, i8* %102, i32 14
-  %104 = load i8, i8* %103, align 1
-  %105 = bitcast [16 x i8]* %comm to i8*
-  %106 = getelementptr i8, i8* %105, i32 14
-  %107 = load i8, i8* %106, align 1
-  %strcmp.cmp55 = icmp ne i8 %104, %107
+  %88 = getelementptr i8, i8* %lookup_str_map, i32 14
+  %89 = load i8, i8* %88, align 1
+  %90 = bitcast [16 x i8]* %comm to i8*
+  %91 = getelementptr i8, i8* %90, i32 14
+  %92 = load i8, i8* %91, align 1
+  %strcmp.cmp55 = icmp ne i8 %89, %92
   br i1 %strcmp.cmp55, label %strcmp.false, label %strcmp.loop_null_cmp54
 
 strcmp.loop_null_cmp50:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null52 = icmp eq i8 %98, 0
+  %strcmp.cmp_null52 = icmp eq i8 %84, 0
   br i1 %strcmp.cmp_null52, label %strcmp.done, label %strcmp.loop49
 
 strcmp.loop53:                                    ; preds = %strcmp.loop_null_cmp54
-  %108 = bitcast [64 x i8]* %str to i8*
-  %109 = getelementptr i8, i8* %108, i32 15
-  %110 = load i8, i8* %109, align 1
-  %111 = bitcast [16 x i8]* %comm to i8*
-  %112 = getelementptr i8, i8* %111, i32 15
-  %113 = load i8, i8* %112, align 1
-  %strcmp.cmp59 = icmp ne i8 %110, %113
+  %93 = getelementptr i8, i8* %lookup_str_map, i32 15
+  %94 = load i8, i8* %93, align 1
+  %95 = bitcast [16 x i8]* %comm to i8*
+  %96 = getelementptr i8, i8* %95, i32 15
+  %97 = load i8, i8* %96, align 1
+  %strcmp.cmp59 = icmp ne i8 %94, %97
   br i1 %strcmp.cmp59, label %strcmp.false, label %strcmp.loop_null_cmp58
 
 strcmp.loop_null_cmp54:                           ; preds = %strcmp.loop49
-  %strcmp.cmp_null56 = icmp eq i8 %104, 0
+  %strcmp.cmp_null56 = icmp eq i8 %89, 0
   br i1 %strcmp.cmp_null56, label %strcmp.done, label %strcmp.loop53
 
 strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
   br label %strcmp.done
 
 strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop53
-  %strcmp.cmp_null60 = icmp eq i8 %110, 0
+  %strcmp.cmp_null60 = icmp eq i8 %94, 0
   br i1 %strcmp.cmp_null60, label %strcmp.done, label %strcmp.loop57
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!47}
-!llvm.module.flags = !{!50}
+!llvm.dbg.cu = !{!62}
+!llvm.module.flags = !{!65}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -360,14 +362,28 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !44 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !45, size: 64, offset: 128)
 !45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
 !46 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !48, globals: !49)
-!48 = !{}
-!49 = !{!0, !20, !34}
-!50 = !{i32 2, !"Debug Info Version", i32 3}
-!51 = distinct !DISubprogram(name: "tracepoint_file_filename_1", linkageName: "tracepoint_file_filename_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !56)
-!52 = !DISubroutineType(types: !53)
-!53 = !{!18, !54}
-!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
-!55 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!56 = !{!57}
-!57 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)
+!47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
+!48 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !49, isLocal: false, isDefinition: true)
+!49 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !50)
+!50 = !{!51, !43, !44, !56}
+!51 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !52, size: 64)
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !54)
+!54 = !{!55}
+!55 = !DISubrange(count: 6, lowerBound: 0)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !57, size: 64, offset: 192)
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
+!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 512, elements: !60)
+!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!60 = !{!61}
+!61 = !DISubrange(count: 64, lowerBound: 0)
+!62 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !63, globals: !64)
+!63 = !{}
+!64 = !{!0, !20, !34, !47}
+!65 = !{i32 2, !"Debug Info Version", i32 3}
+!66 = distinct !DISubprogram(name: "tracepoint_file_filename_1", linkageName: "tracepoint_file_filename_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !62, retainedNodes: !70)
+!67 = !DISubroutineType(types: !68)
+!68 = !{!18, !69}
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -22,65 +22,55 @@ entry:
   %strcmp.result = alloca i1, align 1
   %comm = alloca [16 x i8], align 1
   %str = alloca [64 x i8], align 1
-  %strlen = alloca i64, align 8
-  %1 = bitcast i64* %strlen to i8*
+  %1 = bitcast [64 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  store i64 64, i64* %strlen, align 8
-  %3 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 64, i1 false)
-  %5 = ptrtoint i8* %0 to i64
-  %6 = add i64 %5, 8
-  %7 = inttoptr i64 %6 to i64*
-  %8 = load volatile i64, i64* %7, align 8
-  %9 = load i64, i64* %strlen, align 8
-  %10 = trunc i64 %9 to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %10, i64 %8)
-  %11 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  %13 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 16, i1 false)
+  %2 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 64, i1 false)
+  %3 = ptrtoint i8* %0 to i64
+  %4 = add i64 %3, 8
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load volatile i64, i64* %5, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 64, i64 %6)
+  %7 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm, i64 16)
-  %14 = bitcast i1* %strcmp.result to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %9 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i1 false, i1* %strcmp.result, align 1
-  %15 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 0
-  %16 = load i8, i8* %15, align 1
-  %17 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 0
-  %18 = load i8, i8* %17, align 1
-  %strcmp.cmp = icmp ne i8 %16, %18
+  %10 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 0
+  %11 = load i8, i8* %10, align 1
+  %12 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 0
+  %13 = load i8, i8* %12, align 1
+  %strcmp.cmp = icmp ne i8 %11, %13
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 pred_false:                                       ; preds = %strcmp.false
   ret i64 1
 
 pred_true:                                        ; preds = %strcmp.false
-  %19 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
-  %20 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  %14 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   store i64 0, i64* %"@_key", align 8
-  %21 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  %16 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   store i64 1, i64* %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_, i64* %"@_key", i64* %"@_val", i64 0)
-  %22 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  %17 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 1
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
-  %24 = load i1, i1* %strcmp.result, align 1
-  %25 = bitcast i1* %strcmp.result to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
-  %26 = zext i1 %24 to i64
-  %predcond = icmp eq i64 %26, 0
+  %19 = load i1, i1* %strcmp.result, align 1
+  %20 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = zext i1 %19 to i64
+  %predcond = icmp eq i64 %21, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.done:                                      ; preds = %strcmp.loop57, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp54, %strcmp.loop_null_cmp50, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp42, %strcmp.loop_null_cmp38, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp30, %strcmp.loop_null_cmp26, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp18, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
@@ -88,190 +78,190 @@ strcmp.done:                                      ; preds = %strcmp.loop57, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %27 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 1
-  %28 = load i8, i8* %27, align 1
-  %29 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
-  %30 = load i8, i8* %29, align 1
-  %strcmp.cmp3 = icmp ne i8 %28, %30
+  %22 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 1
+  %23 = load i8, i8* %22, align 1
+  %24 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
+  %25 = load i8, i8* %24, align 1
+  %strcmp.cmp3 = icmp ne i8 %23, %25
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
-  %strcmp.cmp_null = icmp eq i8 %16, 0
+  %strcmp.cmp_null = icmp eq i8 %11, 0
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %31 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 2
-  %32 = load i8, i8* %31, align 1
-  %33 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
-  %34 = load i8, i8* %33, align 1
-  %strcmp.cmp7 = icmp ne i8 %32, %34
+  %26 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 2
+  %27 = load i8, i8* %26, align 1
+  %28 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
+  %29 = load i8, i8* %28, align 1
+  %strcmp.cmp7 = icmp ne i8 %27, %29
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %28, 0
+  %strcmp.cmp_null4 = icmp eq i8 %23, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %35 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 3
-  %36 = load i8, i8* %35, align 1
-  %37 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
-  %38 = load i8, i8* %37, align 1
-  %strcmp.cmp11 = icmp ne i8 %36, %38
+  %30 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 3
+  %31 = load i8, i8* %30, align 1
+  %32 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
+  %33 = load i8, i8* %32, align 1
+  %strcmp.cmp11 = icmp ne i8 %31, %33
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %32, 0
+  %strcmp.cmp_null8 = icmp eq i8 %27, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %39 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 4
-  %40 = load i8, i8* %39, align 1
-  %41 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
-  %42 = load i8, i8* %41, align 1
-  %strcmp.cmp15 = icmp ne i8 %40, %42
+  %34 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 4
+  %35 = load i8, i8* %34, align 1
+  %36 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
+  %37 = load i8, i8* %36, align 1
+  %strcmp.cmp15 = icmp ne i8 %35, %37
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %36, 0
+  %strcmp.cmp_null12 = icmp eq i8 %31, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
-  %43 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 5
-  %44 = load i8, i8* %43, align 1
-  %45 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 5
-  %46 = load i8, i8* %45, align 1
-  %strcmp.cmp19 = icmp ne i8 %44, %46
+  %38 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 5
+  %39 = load i8, i8* %38, align 1
+  %40 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 5
+  %41 = load i8, i8* %40, align 1
+  %strcmp.cmp19 = icmp ne i8 %39, %41
   br i1 %strcmp.cmp19, label %strcmp.false, label %strcmp.loop_null_cmp18
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %40, 0
+  %strcmp.cmp_null16 = icmp eq i8 %35, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 strcmp.loop17:                                    ; preds = %strcmp.loop_null_cmp18
-  %47 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 6
-  %48 = load i8, i8* %47, align 1
-  %49 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 6
-  %50 = load i8, i8* %49, align 1
-  %strcmp.cmp23 = icmp ne i8 %48, %50
+  %42 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 6
+  %43 = load i8, i8* %42, align 1
+  %44 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 6
+  %45 = load i8, i8* %44, align 1
+  %strcmp.cmp23 = icmp ne i8 %43, %45
   br i1 %strcmp.cmp23, label %strcmp.false, label %strcmp.loop_null_cmp22
 
 strcmp.loop_null_cmp18:                           ; preds = %strcmp.loop13
-  %strcmp.cmp_null20 = icmp eq i8 %44, 0
+  %strcmp.cmp_null20 = icmp eq i8 %39, 0
   br i1 %strcmp.cmp_null20, label %strcmp.done, label %strcmp.loop17
 
 strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
-  %51 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 7
-  %52 = load i8, i8* %51, align 1
-  %53 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 7
-  %54 = load i8, i8* %53, align 1
-  %strcmp.cmp27 = icmp ne i8 %52, %54
+  %46 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 7
+  %47 = load i8, i8* %46, align 1
+  %48 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 7
+  %49 = load i8, i8* %48, align 1
+  %strcmp.cmp27 = icmp ne i8 %47, %49
   br i1 %strcmp.cmp27, label %strcmp.false, label %strcmp.loop_null_cmp26
 
 strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop17
-  %strcmp.cmp_null24 = icmp eq i8 %48, 0
+  %strcmp.cmp_null24 = icmp eq i8 %43, 0
   br i1 %strcmp.cmp_null24, label %strcmp.done, label %strcmp.loop21
 
 strcmp.loop25:                                    ; preds = %strcmp.loop_null_cmp26
-  %55 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 8
-  %56 = load i8, i8* %55, align 1
-  %57 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 8
-  %58 = load i8, i8* %57, align 1
-  %strcmp.cmp31 = icmp ne i8 %56, %58
+  %50 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 8
+  %51 = load i8, i8* %50, align 1
+  %52 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 8
+  %53 = load i8, i8* %52, align 1
+  %strcmp.cmp31 = icmp ne i8 %51, %53
   br i1 %strcmp.cmp31, label %strcmp.false, label %strcmp.loop_null_cmp30
 
 strcmp.loop_null_cmp26:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null28 = icmp eq i8 %52, 0
+  %strcmp.cmp_null28 = icmp eq i8 %47, 0
   br i1 %strcmp.cmp_null28, label %strcmp.done, label %strcmp.loop25
 
 strcmp.loop29:                                    ; preds = %strcmp.loop_null_cmp30
-  %59 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 9
-  %60 = load i8, i8* %59, align 1
-  %61 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 9
-  %62 = load i8, i8* %61, align 1
-  %strcmp.cmp35 = icmp ne i8 %60, %62
+  %54 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 9
+  %55 = load i8, i8* %54, align 1
+  %56 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 9
+  %57 = load i8, i8* %56, align 1
+  %strcmp.cmp35 = icmp ne i8 %55, %57
   br i1 %strcmp.cmp35, label %strcmp.false, label %strcmp.loop_null_cmp34
 
 strcmp.loop_null_cmp30:                           ; preds = %strcmp.loop25
-  %strcmp.cmp_null32 = icmp eq i8 %56, 0
+  %strcmp.cmp_null32 = icmp eq i8 %51, 0
   br i1 %strcmp.cmp_null32, label %strcmp.done, label %strcmp.loop29
 
 strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
-  %63 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 10
-  %64 = load i8, i8* %63, align 1
-  %65 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 10
-  %66 = load i8, i8* %65, align 1
-  %strcmp.cmp39 = icmp ne i8 %64, %66
+  %58 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 10
+  %59 = load i8, i8* %58, align 1
+  %60 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 10
+  %61 = load i8, i8* %60, align 1
+  %strcmp.cmp39 = icmp ne i8 %59, %61
   br i1 %strcmp.cmp39, label %strcmp.false, label %strcmp.loop_null_cmp38
 
 strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop29
-  %strcmp.cmp_null36 = icmp eq i8 %60, 0
+  %strcmp.cmp_null36 = icmp eq i8 %55, 0
   br i1 %strcmp.cmp_null36, label %strcmp.done, label %strcmp.loop33
 
 strcmp.loop37:                                    ; preds = %strcmp.loop_null_cmp38
-  %67 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 11
-  %68 = load i8, i8* %67, align 1
-  %69 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 11
-  %70 = load i8, i8* %69, align 1
-  %strcmp.cmp43 = icmp ne i8 %68, %70
+  %62 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 11
+  %63 = load i8, i8* %62, align 1
+  %64 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 11
+  %65 = load i8, i8* %64, align 1
+  %strcmp.cmp43 = icmp ne i8 %63, %65
   br i1 %strcmp.cmp43, label %strcmp.false, label %strcmp.loop_null_cmp42
 
 strcmp.loop_null_cmp38:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null40 = icmp eq i8 %64, 0
+  %strcmp.cmp_null40 = icmp eq i8 %59, 0
   br i1 %strcmp.cmp_null40, label %strcmp.done, label %strcmp.loop37
 
 strcmp.loop41:                                    ; preds = %strcmp.loop_null_cmp42
-  %71 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 12
-  %72 = load i8, i8* %71, align 1
-  %73 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 12
-  %74 = load i8, i8* %73, align 1
-  %strcmp.cmp47 = icmp ne i8 %72, %74
+  %66 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 12
+  %67 = load i8, i8* %66, align 1
+  %68 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 12
+  %69 = load i8, i8* %68, align 1
+  %strcmp.cmp47 = icmp ne i8 %67, %69
   br i1 %strcmp.cmp47, label %strcmp.false, label %strcmp.loop_null_cmp46
 
 strcmp.loop_null_cmp42:                           ; preds = %strcmp.loop37
-  %strcmp.cmp_null44 = icmp eq i8 %68, 0
+  %strcmp.cmp_null44 = icmp eq i8 %63, 0
   br i1 %strcmp.cmp_null44, label %strcmp.done, label %strcmp.loop41
 
 strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
-  %75 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 13
-  %76 = load i8, i8* %75, align 1
-  %77 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 13
-  %78 = load i8, i8* %77, align 1
-  %strcmp.cmp51 = icmp ne i8 %76, %78
+  %70 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 13
+  %71 = load i8, i8* %70, align 1
+  %72 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 13
+  %73 = load i8, i8* %72, align 1
+  %strcmp.cmp51 = icmp ne i8 %71, %73
   br i1 %strcmp.cmp51, label %strcmp.false, label %strcmp.loop_null_cmp50
 
 strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop41
-  %strcmp.cmp_null48 = icmp eq i8 %72, 0
+  %strcmp.cmp_null48 = icmp eq i8 %67, 0
   br i1 %strcmp.cmp_null48, label %strcmp.done, label %strcmp.loop45
 
 strcmp.loop49:                                    ; preds = %strcmp.loop_null_cmp50
-  %79 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 14
-  %80 = load i8, i8* %79, align 1
-  %81 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 14
-  %82 = load i8, i8* %81, align 1
-  %strcmp.cmp55 = icmp ne i8 %80, %82
+  %74 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 14
+  %75 = load i8, i8* %74, align 1
+  %76 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 14
+  %77 = load i8, i8* %76, align 1
+  %strcmp.cmp55 = icmp ne i8 %75, %77
   br i1 %strcmp.cmp55, label %strcmp.false, label %strcmp.loop_null_cmp54
 
 strcmp.loop_null_cmp50:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null52 = icmp eq i8 %76, 0
+  %strcmp.cmp_null52 = icmp eq i8 %71, 0
   br i1 %strcmp.cmp_null52, label %strcmp.done, label %strcmp.loop49
 
 strcmp.loop53:                                    ; preds = %strcmp.loop_null_cmp54
-  %83 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 15
-  %84 = load i8, i8* %83, align 1
-  %85 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 15
-  %86 = load i8, i8* %85, align 1
-  %strcmp.cmp59 = icmp ne i8 %84, %86
+  %78 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 15
+  %79 = load i8, i8* %78, align 1
+  %80 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 15
+  %81 = load i8, i8* %80, align 1
+  %strcmp.cmp59 = icmp ne i8 %79, %81
   br i1 %strcmp.cmp59, label %strcmp.false, label %strcmp.loop_null_cmp58
 
 strcmp.loop_null_cmp54:                           ; preds = %strcmp.loop49
-  %strcmp.cmp_null56 = icmp eq i8 %80, 0
+  %strcmp.cmp_null56 = icmp eq i8 %75, 0
   br i1 %strcmp.cmp_null56, label %strcmp.done, label %strcmp.loop53
 
 strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
   br label %strcmp.done
 
 strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop53
-  %strcmp.cmp_null60 = icmp eq i8 %84, 0
+  %strcmp.cmp_null60 = icmp eq i8 %79, 0
   br i1 %strcmp.cmp_null60, label %strcmp.done, label %strcmp.loop57
 }
 

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -39,38 +39,40 @@ entry:
   %9 = bitcast i1* %strcmp.result to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i1 false, i1* %strcmp.result, align 1
-  %10 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 0
-  %11 = load i8, i8* %10, align 1
-  %12 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 0
-  %13 = load i8, i8* %12, align 1
-  %strcmp.cmp = icmp ne i8 %11, %13
+  %10 = bitcast [64 x i8]* %str to i8*
+  %11 = getelementptr i8, i8* %10, i32 0
+  %12 = load i8, i8* %11, align 1
+  %13 = bitcast [16 x i8]* %comm to i8*
+  %14 = getelementptr i8, i8* %13, i32 0
+  %15 = load i8, i8* %14, align 1
+  %strcmp.cmp = icmp ne i8 %12, %15
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 pred_false:                                       ; preds = %strcmp.false
   ret i64 1
 
 pred_true:                                        ; preds = %strcmp.false
-  %14 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %16 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
   store i64 0, i64* %"@_key", align 8
-  %16 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %18 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
   store i64 1, i64* %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_, i64* %"@_key", i64* %"@_val", i64 0)
-  %17 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   ret i64 1
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
-  %19 = load i1, i1* %strcmp.result, align 1
-  %20 = bitcast i1* %strcmp.result to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = zext i1 %19 to i64
-  %predcond = icmp eq i64 %21, 0
+  %21 = load i1, i1* %strcmp.result, align 1
+  %22 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = zext i1 %21 to i64
+  %predcond = icmp eq i64 %23, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.done:                                      ; preds = %strcmp.loop57, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp54, %strcmp.loop_null_cmp50, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp42, %strcmp.loop_null_cmp38, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp30, %strcmp.loop_null_cmp26, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp18, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
@@ -78,190 +80,220 @@ strcmp.done:                                      ; preds = %strcmp.loop57, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %22 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 1
-  %23 = load i8, i8* %22, align 1
-  %24 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
-  %25 = load i8, i8* %24, align 1
-  %strcmp.cmp3 = icmp ne i8 %23, %25
+  %24 = bitcast [64 x i8]* %str to i8*
+  %25 = getelementptr i8, i8* %24, i32 1
+  %26 = load i8, i8* %25, align 1
+  %27 = bitcast [16 x i8]* %comm to i8*
+  %28 = getelementptr i8, i8* %27, i32 1
+  %29 = load i8, i8* %28, align 1
+  %strcmp.cmp3 = icmp ne i8 %26, %29
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
-  %strcmp.cmp_null = icmp eq i8 %11, 0
+  %strcmp.cmp_null = icmp eq i8 %12, 0
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %26 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 2
-  %27 = load i8, i8* %26, align 1
-  %28 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
-  %29 = load i8, i8* %28, align 1
-  %strcmp.cmp7 = icmp ne i8 %27, %29
+  %30 = bitcast [64 x i8]* %str to i8*
+  %31 = getelementptr i8, i8* %30, i32 2
+  %32 = load i8, i8* %31, align 1
+  %33 = bitcast [16 x i8]* %comm to i8*
+  %34 = getelementptr i8, i8* %33, i32 2
+  %35 = load i8, i8* %34, align 1
+  %strcmp.cmp7 = icmp ne i8 %32, %35
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %23, 0
+  %strcmp.cmp_null4 = icmp eq i8 %26, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %30 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 3
-  %31 = load i8, i8* %30, align 1
-  %32 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
-  %33 = load i8, i8* %32, align 1
-  %strcmp.cmp11 = icmp ne i8 %31, %33
+  %36 = bitcast [64 x i8]* %str to i8*
+  %37 = getelementptr i8, i8* %36, i32 3
+  %38 = load i8, i8* %37, align 1
+  %39 = bitcast [16 x i8]* %comm to i8*
+  %40 = getelementptr i8, i8* %39, i32 3
+  %41 = load i8, i8* %40, align 1
+  %strcmp.cmp11 = icmp ne i8 %38, %41
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %27, 0
+  %strcmp.cmp_null8 = icmp eq i8 %32, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %34 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 4
-  %35 = load i8, i8* %34, align 1
-  %36 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
-  %37 = load i8, i8* %36, align 1
-  %strcmp.cmp15 = icmp ne i8 %35, %37
+  %42 = bitcast [64 x i8]* %str to i8*
+  %43 = getelementptr i8, i8* %42, i32 4
+  %44 = load i8, i8* %43, align 1
+  %45 = bitcast [16 x i8]* %comm to i8*
+  %46 = getelementptr i8, i8* %45, i32 4
+  %47 = load i8, i8* %46, align 1
+  %strcmp.cmp15 = icmp ne i8 %44, %47
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %31, 0
+  %strcmp.cmp_null12 = icmp eq i8 %38, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
-  %38 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 5
-  %39 = load i8, i8* %38, align 1
-  %40 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 5
-  %41 = load i8, i8* %40, align 1
-  %strcmp.cmp19 = icmp ne i8 %39, %41
+  %48 = bitcast [64 x i8]* %str to i8*
+  %49 = getelementptr i8, i8* %48, i32 5
+  %50 = load i8, i8* %49, align 1
+  %51 = bitcast [16 x i8]* %comm to i8*
+  %52 = getelementptr i8, i8* %51, i32 5
+  %53 = load i8, i8* %52, align 1
+  %strcmp.cmp19 = icmp ne i8 %50, %53
   br i1 %strcmp.cmp19, label %strcmp.false, label %strcmp.loop_null_cmp18
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %35, 0
+  %strcmp.cmp_null16 = icmp eq i8 %44, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 strcmp.loop17:                                    ; preds = %strcmp.loop_null_cmp18
-  %42 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 6
-  %43 = load i8, i8* %42, align 1
-  %44 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 6
-  %45 = load i8, i8* %44, align 1
-  %strcmp.cmp23 = icmp ne i8 %43, %45
+  %54 = bitcast [64 x i8]* %str to i8*
+  %55 = getelementptr i8, i8* %54, i32 6
+  %56 = load i8, i8* %55, align 1
+  %57 = bitcast [16 x i8]* %comm to i8*
+  %58 = getelementptr i8, i8* %57, i32 6
+  %59 = load i8, i8* %58, align 1
+  %strcmp.cmp23 = icmp ne i8 %56, %59
   br i1 %strcmp.cmp23, label %strcmp.false, label %strcmp.loop_null_cmp22
 
 strcmp.loop_null_cmp18:                           ; preds = %strcmp.loop13
-  %strcmp.cmp_null20 = icmp eq i8 %39, 0
+  %strcmp.cmp_null20 = icmp eq i8 %50, 0
   br i1 %strcmp.cmp_null20, label %strcmp.done, label %strcmp.loop17
 
 strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
-  %46 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 7
-  %47 = load i8, i8* %46, align 1
-  %48 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 7
-  %49 = load i8, i8* %48, align 1
-  %strcmp.cmp27 = icmp ne i8 %47, %49
+  %60 = bitcast [64 x i8]* %str to i8*
+  %61 = getelementptr i8, i8* %60, i32 7
+  %62 = load i8, i8* %61, align 1
+  %63 = bitcast [16 x i8]* %comm to i8*
+  %64 = getelementptr i8, i8* %63, i32 7
+  %65 = load i8, i8* %64, align 1
+  %strcmp.cmp27 = icmp ne i8 %62, %65
   br i1 %strcmp.cmp27, label %strcmp.false, label %strcmp.loop_null_cmp26
 
 strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop17
-  %strcmp.cmp_null24 = icmp eq i8 %43, 0
+  %strcmp.cmp_null24 = icmp eq i8 %56, 0
   br i1 %strcmp.cmp_null24, label %strcmp.done, label %strcmp.loop21
 
 strcmp.loop25:                                    ; preds = %strcmp.loop_null_cmp26
-  %50 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 8
-  %51 = load i8, i8* %50, align 1
-  %52 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 8
-  %53 = load i8, i8* %52, align 1
-  %strcmp.cmp31 = icmp ne i8 %51, %53
+  %66 = bitcast [64 x i8]* %str to i8*
+  %67 = getelementptr i8, i8* %66, i32 8
+  %68 = load i8, i8* %67, align 1
+  %69 = bitcast [16 x i8]* %comm to i8*
+  %70 = getelementptr i8, i8* %69, i32 8
+  %71 = load i8, i8* %70, align 1
+  %strcmp.cmp31 = icmp ne i8 %68, %71
   br i1 %strcmp.cmp31, label %strcmp.false, label %strcmp.loop_null_cmp30
 
 strcmp.loop_null_cmp26:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null28 = icmp eq i8 %47, 0
+  %strcmp.cmp_null28 = icmp eq i8 %62, 0
   br i1 %strcmp.cmp_null28, label %strcmp.done, label %strcmp.loop25
 
 strcmp.loop29:                                    ; preds = %strcmp.loop_null_cmp30
-  %54 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 9
-  %55 = load i8, i8* %54, align 1
-  %56 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 9
-  %57 = load i8, i8* %56, align 1
-  %strcmp.cmp35 = icmp ne i8 %55, %57
+  %72 = bitcast [64 x i8]* %str to i8*
+  %73 = getelementptr i8, i8* %72, i32 9
+  %74 = load i8, i8* %73, align 1
+  %75 = bitcast [16 x i8]* %comm to i8*
+  %76 = getelementptr i8, i8* %75, i32 9
+  %77 = load i8, i8* %76, align 1
+  %strcmp.cmp35 = icmp ne i8 %74, %77
   br i1 %strcmp.cmp35, label %strcmp.false, label %strcmp.loop_null_cmp34
 
 strcmp.loop_null_cmp30:                           ; preds = %strcmp.loop25
-  %strcmp.cmp_null32 = icmp eq i8 %51, 0
+  %strcmp.cmp_null32 = icmp eq i8 %68, 0
   br i1 %strcmp.cmp_null32, label %strcmp.done, label %strcmp.loop29
 
 strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
-  %58 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 10
-  %59 = load i8, i8* %58, align 1
-  %60 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 10
-  %61 = load i8, i8* %60, align 1
-  %strcmp.cmp39 = icmp ne i8 %59, %61
+  %78 = bitcast [64 x i8]* %str to i8*
+  %79 = getelementptr i8, i8* %78, i32 10
+  %80 = load i8, i8* %79, align 1
+  %81 = bitcast [16 x i8]* %comm to i8*
+  %82 = getelementptr i8, i8* %81, i32 10
+  %83 = load i8, i8* %82, align 1
+  %strcmp.cmp39 = icmp ne i8 %80, %83
   br i1 %strcmp.cmp39, label %strcmp.false, label %strcmp.loop_null_cmp38
 
 strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop29
-  %strcmp.cmp_null36 = icmp eq i8 %55, 0
+  %strcmp.cmp_null36 = icmp eq i8 %74, 0
   br i1 %strcmp.cmp_null36, label %strcmp.done, label %strcmp.loop33
 
 strcmp.loop37:                                    ; preds = %strcmp.loop_null_cmp38
-  %62 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 11
-  %63 = load i8, i8* %62, align 1
-  %64 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 11
-  %65 = load i8, i8* %64, align 1
-  %strcmp.cmp43 = icmp ne i8 %63, %65
+  %84 = bitcast [64 x i8]* %str to i8*
+  %85 = getelementptr i8, i8* %84, i32 11
+  %86 = load i8, i8* %85, align 1
+  %87 = bitcast [16 x i8]* %comm to i8*
+  %88 = getelementptr i8, i8* %87, i32 11
+  %89 = load i8, i8* %88, align 1
+  %strcmp.cmp43 = icmp ne i8 %86, %89
   br i1 %strcmp.cmp43, label %strcmp.false, label %strcmp.loop_null_cmp42
 
 strcmp.loop_null_cmp38:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null40 = icmp eq i8 %59, 0
+  %strcmp.cmp_null40 = icmp eq i8 %80, 0
   br i1 %strcmp.cmp_null40, label %strcmp.done, label %strcmp.loop37
 
 strcmp.loop41:                                    ; preds = %strcmp.loop_null_cmp42
-  %66 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 12
-  %67 = load i8, i8* %66, align 1
-  %68 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 12
-  %69 = load i8, i8* %68, align 1
-  %strcmp.cmp47 = icmp ne i8 %67, %69
+  %90 = bitcast [64 x i8]* %str to i8*
+  %91 = getelementptr i8, i8* %90, i32 12
+  %92 = load i8, i8* %91, align 1
+  %93 = bitcast [16 x i8]* %comm to i8*
+  %94 = getelementptr i8, i8* %93, i32 12
+  %95 = load i8, i8* %94, align 1
+  %strcmp.cmp47 = icmp ne i8 %92, %95
   br i1 %strcmp.cmp47, label %strcmp.false, label %strcmp.loop_null_cmp46
 
 strcmp.loop_null_cmp42:                           ; preds = %strcmp.loop37
-  %strcmp.cmp_null44 = icmp eq i8 %63, 0
+  %strcmp.cmp_null44 = icmp eq i8 %86, 0
   br i1 %strcmp.cmp_null44, label %strcmp.done, label %strcmp.loop41
 
 strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
-  %70 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 13
-  %71 = load i8, i8* %70, align 1
-  %72 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 13
-  %73 = load i8, i8* %72, align 1
-  %strcmp.cmp51 = icmp ne i8 %71, %73
+  %96 = bitcast [64 x i8]* %str to i8*
+  %97 = getelementptr i8, i8* %96, i32 13
+  %98 = load i8, i8* %97, align 1
+  %99 = bitcast [16 x i8]* %comm to i8*
+  %100 = getelementptr i8, i8* %99, i32 13
+  %101 = load i8, i8* %100, align 1
+  %strcmp.cmp51 = icmp ne i8 %98, %101
   br i1 %strcmp.cmp51, label %strcmp.false, label %strcmp.loop_null_cmp50
 
 strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop41
-  %strcmp.cmp_null48 = icmp eq i8 %67, 0
+  %strcmp.cmp_null48 = icmp eq i8 %92, 0
   br i1 %strcmp.cmp_null48, label %strcmp.done, label %strcmp.loop45
 
 strcmp.loop49:                                    ; preds = %strcmp.loop_null_cmp50
-  %74 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 14
-  %75 = load i8, i8* %74, align 1
-  %76 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 14
-  %77 = load i8, i8* %76, align 1
-  %strcmp.cmp55 = icmp ne i8 %75, %77
+  %102 = bitcast [64 x i8]* %str to i8*
+  %103 = getelementptr i8, i8* %102, i32 14
+  %104 = load i8, i8* %103, align 1
+  %105 = bitcast [16 x i8]* %comm to i8*
+  %106 = getelementptr i8, i8* %105, i32 14
+  %107 = load i8, i8* %106, align 1
+  %strcmp.cmp55 = icmp ne i8 %104, %107
   br i1 %strcmp.cmp55, label %strcmp.false, label %strcmp.loop_null_cmp54
 
 strcmp.loop_null_cmp50:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null52 = icmp eq i8 %71, 0
+  %strcmp.cmp_null52 = icmp eq i8 %98, 0
   br i1 %strcmp.cmp_null52, label %strcmp.done, label %strcmp.loop49
 
 strcmp.loop53:                                    ; preds = %strcmp.loop_null_cmp54
-  %78 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 15
-  %79 = load i8, i8* %78, align 1
-  %80 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 15
-  %81 = load i8, i8* %80, align 1
-  %strcmp.cmp59 = icmp ne i8 %79, %81
+  %108 = bitcast [64 x i8]* %str to i8*
+  %109 = getelementptr i8, i8* %108, i32 15
+  %110 = load i8, i8* %109, align 1
+  %111 = bitcast [16 x i8]* %comm to i8*
+  %112 = getelementptr i8, i8* %111, i32 15
+  %113 = load i8, i8* %112, align 1
+  %strcmp.cmp59 = icmp ne i8 %110, %113
   br i1 %strcmp.cmp59, label %strcmp.false, label %strcmp.loop_null_cmp58
 
 strcmp.loop_null_cmp54:                           ; preds = %strcmp.loop49
-  %strcmp.cmp_null56 = icmp eq i8 %75, 0
+  %strcmp.cmp_null56 = icmp eq i8 %104, 0
   br i1 %strcmp.cmp_null56, label %strcmp.done, label %strcmp.loop53
 
 strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
   br label %strcmp.done
 
 strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop53
-  %strcmp.cmp_null60 = icmp eq i8 %79, 0
+  %strcmp.cmp_null60 = icmp eq i8 %110, 0
   br i1 %strcmp.cmp_null60, label %strcmp.done, label %strcmp.loop57
 }
 

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -20,7 +20,6 @@ entry:
   %"@mystr_key" = alloca i64, align 8
   %"struct Foo.str" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
-  %strlen = alloca i64, align 8
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -29,36 +28,27 @@ entry:
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3, align 8
   store i64 %arg0, i64* %"$foo", align 8
-  %4 = bitcast i64* %strlen to i8*
+  %4 = bitcast [64 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 8, i1 false)
-  store i64 64, i64* %strlen, align 8
-  %6 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 64, i1 false)
-  %8 = load i64, i64* %"$foo", align 8
-  %9 = add i64 %8, 0
+  %5 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 64, i1 false)
+  %6 = load i64, i64* %"$foo", align 8
+  %7 = add i64 %6, 0
+  %8 = bitcast i64* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %7)
+  %9 = load i64, i64* %"struct Foo.str", align 8
   %10 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %9)
-  %11 = load i64, i64* %"struct Foo.str", align 8
-  %12 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = load i64, i64* %strlen, align 8
-  %14 = trunc i64 %13 to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %14, i64 %11)
-  %15 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 64, i64 %9)
+  %11 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@mystr_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [64 x i8]*, i64)*)(%"struct map_t"* @AT_mystr, i64* %"@mystr_key", [64 x i8]* %str, i64 0)
-  %17 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %12 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -6,20 +6,22 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_mystr = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
 @ringbuf_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@str_buffer = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !53
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !66 {
 entry:
   %"@mystr_key" = alloca i64, align 8
   %"struct Foo.str" = alloca i64, align 8
-  %str = alloca [64 x i8], align 1
+  %lookup_str_key = alloca i32, align 4
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -28,45 +30,59 @@ entry:
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3, align 8
   store i64 %arg0, i64* %"$foo", align 8
-  %4 = bitcast [64 x i8]* %str to i8*
+  %4 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 64, i1 false)
-  %6 = load i64, i64* %"$foo", align 8
-  %7 = add i64 %6, 0
-  %8 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %7)
-  %9 = load i64, i64* %"struct Foo.str", align 8
-  %10 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 64, i64 %9)
-  %11 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 0, i64* %"@mystr_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, [64 x i8]*, i64)*)(%"struct map_t"* @AT_mystr, i64* %"@mystr_key", [64 x i8]* %str, i64 0)
-  %12 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  store i32 0, i32* %lookup_str_key, align 4
+  %lookup_str_map = call i8* inttoptr (i64 1 to i8* (%"struct map_t.2"*, i32*)*)(%"struct map_t.2"* @str_buffer, i32* %lookup_str_key)
+  %5 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %lookup_str_cond = icmp ne i8* %lookup_str_map, null
+  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
+
+scratch_lookup_failure:                           ; preds = %lookup_str_failure
   ret i64 0
+
+scratch_lookup_merge:                             ; preds = %lookup_str_merge
+  %6 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@mystr_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_mystr, i64* %"@mystr_key", i8* %lookup_str_map, i64 0)
+  %7 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  ret i64 0
+
+lookup_str_failure:                               ; preds = %entry
+  br label %scratch_lookup_failure
+
+lookup_str_merge:                                 ; preds = %entry
+  call void @llvm.memset.p0i8.i64(i8* align 1 %lookup_str_map, i8 0, i64 64, i1 false)
+  %8 = load i64, i64* %"$foo", align 8
+  %9 = add i64 %8, 0
+  %10 = bitcast i64* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %9)
+  %11 = load i64, i64* %"struct Foo.str", align 8
+  %12 = bitcast i64* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 64, i64 %11)
+  br label %scratch_lookup_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!56}
+!llvm.dbg.cu = !{!62}
+!llvm.module.flags = !{!65}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_mystr", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -121,13 +137,22 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
 !51 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
-!54 = !{}
-!55 = !{!0, !25, !39}
-!56 = !{i32 2, !"Debug Info Version", i32 3}
-!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!58 = !DISubroutineType(types: !59)
-!59 = !{!18, !60}
-!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !56)
+!56 = !{!57, !48, !49, !19}
+!57 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !58, size: 64)
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !60)
+!60 = !{!61}
+!61 = !DISubrange(count: 6, lowerBound: 0)
+!62 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !63, globals: !64)
+!63 = !{}
+!64 = !{!0, !25, !39, !53}
+!65 = !{i32 2, !"Debug Info Version", i32 3}
+!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !62, retainedNodes: !70)
+!67 = !DISubroutineType(types: !68)
+!68 = !{!18, !69}
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)


### PR DESCRIPTION
Previously, all strings needed to be stored on the stack. Given that BPF
has a 512B stack limit, this put serious limits on strings. In practice,
it was limited to about 200B.

This PR raises the limit much higher to around 1024. The new limit
we hit is from the LLVM memset() builtin. It only supports up to 1K. To
go above this, we need to create our own memset() routine in BPF. This
is quite easy to do and will be attempted in a later commit.

The way big strings work is by assigning each str() call in the script a
unique ID. Then we create a percpu array map such that for each CPU,
there is a percpu entry that can accomodate each str() callsite. This
makes it so scripts can keep as many strings "on the stack" as they'd
like, with the tradeoff being the amount of memory we need to
preallocate.

As long as the kernel never allows BPF programs to nest (eg execute prog
A while prog A is already on the call stack), this approach is robust to
self-corruption.

This closes https://github.com/bpftrace/bpftrace/issues/305.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
