### PR TITLE
tests: lldb: Fix ifdef in codegen tests

### DIFF
--- a/tests/codegen/map_args.cpp
+++ b/tests/codegen/map_args.cpp
@@ -1,4 +1,4 @@
-#if HAVE_LIBLLDB
+#ifdef HAVE_LIBLLDB
 
 #include "../dwarf_common.h"
 #include "common.h"


### PR DESCRIPTION
It should've been an ifdef. When it's not defined, #if is a compile error.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
