### PR TITLE
nix: Temporarily disable LLDB support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,11 @@
                     libopcodes
                     libpcap
                     libsystemtap
-                    lldb
+                    # Temporarily disable LLDB support in CI. We're waiting on upstream
+                    # nixpkgs fixes:
+                    #     https://github.com/NixOS/nixpkgs/issues/315214
+                    #     https://github.com/NixOS/nixpkgs/pull/316045
+                    #lldb
                     llvm
                     pahole
                     xxd

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -278,6 +278,8 @@ ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM
 PROG uprobe:./testprogs/uprobe_symres_exited_process:test { print(ustack); exit(); }
 EXPECT_REGEX ^\s+test\+[0-9]+\s+test2\+[0-9]+\s+main\+[0-9]+
 AFTER ./testprogs/disable_aslr ./testprogs/uprobe_symres_exited_process
+# Required to skip function prologue
+REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME cat

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -214,6 +214,8 @@ NAME positional ustack
 RUN {{BPFTRACE}} -e 'u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack($1)); exit(); }' 1
 EXPECT_REGEX .*uprobeFunction1\+[0-9]+\n\s+spin\+[0-9]+\n\s+main\+[0-9]+\n.*\n\n\n\s+uprobeFunction1\+[0-9]+
 TIMEOUT 5
+# Required to skip function prologue
+REQUIRES_FEATURE dwarf
 AFTER ./testprogs/uprobe_loop
 
 NAME lhist can be cleared

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -262,6 +262,7 @@ kprobe:f { fake }
   test(feature, "k:f { jiffies }", 1);
 }
 
+#ifdef HAVE_LIBLLDB
 TEST(semantic_analyser, builtin_variables_inline)
 {
   auto bpftrace = get_mock_bpftrace();
@@ -288,6 +289,7 @@ uprobe:/bin/sh:f { args }
                    ~~~~
 )");
 }
+#endif // HAVE_LIBLLDB
 
 TEST(semantic_analyser, builtin_cpid)
 {


### PR DESCRIPTION
LLDB package is broken in upstream nix. Appimages and local builds are broken. We're still waiting for the proper fix to land, so disable for now.

cc @ttreyer 
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
