### PR TITLE
Add user-friendly error for multiple for loops

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2065,6 +2065,13 @@ void SemanticAnalyser::visit(For &f)
    *     }
    */
 
+  if (scope_with_for_loop_.has_value() && *scope_with_for_loop_ != scope_) {
+    LOG(ERROR, f.loc, err_)
+        << "Currently, for-loops can be used only in a single probe.";
+  } else {
+    scope_with_for_loop_ = scope_;
+  }
+
   // Validate decl
   const auto &decl_name = f.decl->ident;
   if (variable_val_[scope_].find(decl_name) != variable_val_[scope_].end()) {

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -148,6 +148,7 @@ private:
   bool has_end_probe_ = false;
   bool has_child_ = false;
   bool has_pos_param_ = false;
+  std::optional<ast::Scope *> scope_with_for_loop_ = std::nullopt;
 };
 
 Pass CreateSemanticPass();

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3767,6 +3767,20 @@ kprobe:f { @map[0] = 1; for ($kv : @map) { arg0 } }
 )");
 }
 
+TEST(semantic_analyser, for_loop_multiple_probes)
+{
+  test_error(R"(
+      BEGIN { @map[0] = 1 }
+      k:f1 { for ($kv : @map) { print($kv); } }
+      k:f2 { for ($kv : @map) { print($kv); } }
+  )",
+             R"(
+stdin:3:14-17: ERROR: Currently, for-loops can be used only in a single probe.
+      k:f2 { for ($kv : @map) { print($kv); } }
+             ~~~
+)");
+}
+
 TEST_F(semantic_analyser_btf, args_builtin_mixed_probes)
 {
   test_error("kfunc:func_1,tracepoint:sched:sched_one { args }", R"(


### PR DESCRIPTION
Currently, we do not allow for-loops to be used from multiple probes at the same time (see #3021 for details). If that happens, detect it in the semantic analyser and print a nice error instead of a generic `Error loading program`.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
