### PR TITLE
Add big memset() support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,9 @@ and this project adheres to
 - Enable count, sum, min, and max map reads in kernel space (implicit casting)
   - [#3189](https://github.com/bpftrace/bpftrace/pull/3189)
   - [#3226](https://github.com/bpftrace/bpftrace/pull/3226)
-- Allow BPFTRACE_MAX_STRLEN to go above 200 (up to 1024)
+- Remove limit on BPFTRACE_MAX_STRLEN
   - [#3228](https://github.com/bpftrace/bpftrace/pull/3228)
+  - [#3237](https://github.com/bpftrace/bpftrace/pull/3237)
 #### Changed
 - Better error message for args in mixed probes
   - [#3047](https://github.com/bpftrace/bpftrace/pull/3047)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -293,6 +293,13 @@ Value *IRBuilderBPF::GetMapVar(const std::string &map_name)
   return module_.getGlobalVariable(bpf_map_name(map_name));
 }
 
+Value *IRBuilderBPF::GetNull()
+{
+  return ConstantExpr::getCast(Instruction::IntToPtr,
+                               getInt64(0),
+                               GET_PTR_TY());
+}
+
 CallInst *IRBuilderBPF::CreateMapLookup(Map &map,
                                         Value *key,
                                         const std::string &name)
@@ -410,10 +417,9 @@ CallInst *IRBuilderBPF::createGetScratchMap(const std::string &map_name,
       module_.getContext(), "lookup_" + name + "_failure", parent);
   BasicBlock *lookup_merge_block = BasicBlock::Create(
       module_.getContext(), "lookup_" + name + "_merge", parent);
-  Value *condition = CreateICmpNE(
-      CreateIntCast(call, GET_PTR_TY(), true),
-      ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), GET_PTR_TY()),
-      "lookup_" + name + "_cond");
+  Value *condition = CreateICmpNE(CreateIntCast(call, GET_PTR_TY(), true),
+                                  GetNull(),
+                                  "lookup_" + name + "_cond");
   CreateCondBr(condition, lookup_merge_block, lookup_failure_block);
 
   SetInsertPoint(lookup_failure_block);
@@ -457,10 +463,9 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
                                                       parent);
 
   AllocaInst *value = CreateAllocaBPF(type, "lookup_elem_val");
-  Value *condition = CreateICmpNE(
-      CreateIntCast(call, GET_PTR_TY(), true),
-      ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), GET_PTR_TY()),
-      "map_lookup_cond");
+  Value *condition = CreateICmpNE(CreateIntCast(call, GET_PTR_TY(), true),
+                                  GetNull(),
+                                  "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
   SetInsertPoint(lookup_success_block);
@@ -564,10 +569,9 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
   BasicBlock *lookup_failure_block = BasicBlock::Create(module_.getContext(),
                                                         "lookup_failure",
                                                         lookup_parent);
-  Value *condition = CreateICmpNE(
-      CreateIntCast(call, GET_PTR_TY(), true),
-      ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), GET_PTR_TY()),
-      "map_lookup_cond");
+  Value *condition = CreateICmpNE(CreateIntCast(call, GET_PTR_TY(), true),
+                                  GetNull(),
+                                  "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
   SetInsertPoint(lookup_success_block);
@@ -1696,10 +1700,9 @@ void IRBuilderBPF::CreateAtomicIncCounter(const std::string &map_name,
                                                       "lookup_merge",
                                                       parent);
 
-  Value *condition = CreateICmpNE(
-      CreateIntCast(call, GET_PTR_TY(), true),
-      ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), GET_PTR_TY()),
-      "map_lookup_cond");
+  Value *condition = CreateICmpNE(CreateIntCast(call, GET_PTR_TY(), true),
+                                  GetNull(),
+                                  "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
   SetInsertPoint(lookup_success_block);
@@ -1753,10 +1756,9 @@ void IRBuilderBPF::CreateMapElemAdd(Value *ctx,
                                                       parent);
 
   AllocaInst *value = CreateAllocaBPF(type, "lookup_elem_val");
-  Value *condition = CreateICmpNE(
-      CreateIntCast(call, GET_PTR_TY(), true),
-      ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), GET_PTR_TY()),
-      "map_lookup_cond");
+  Value *condition = CreateICmpNE(CreateIntCast(call, GET_PTR_TY(), true),
+                                  GetNull(),
+                                  "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
   SetInsertPoint(lookup_success_block);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -77,6 +77,7 @@ public:
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Type *ty);
   Value *GetMapVar(const std::string &map_name);
+  Value *GetNull();
   CallInst *CreateMapLookup(Map &map,
                             Value *key,
                             const std::string &name = "lookup_elem");

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -73,6 +73,7 @@ public:
                               llvm::Value *arraysize,
                               const std::string &name = "");
   AllocaInst *CreateAllocaBPF(int bytes, const std::string &name = "");
+  void CreateMemsetBPF(Value *ptr, Value *val, uint32_t size);
   llvm::Type *GetType(const SizedType &stype);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Type *ty);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -30,14 +30,6 @@
 #error Unsupported LLVM version
 #endif
 
-#if LLVM_VERSION_MAJOR >= 10
-#define CREATE_MEMSET(ptr, val, size, align)                                   \
-  CreateMemSet((ptr), (val), (size), MaybeAlign((align)))
-#else
-#define CREATE_MEMSET(ptr, val, size, align)                                   \
-  CreateMemSet((ptr), (val), (size), (align))
-#endif
-
 #if LLVM_VERSION_MAJOR >= 13
 #define CREATE_ATOMIC_RMW(op, ptr, val, align, order)                          \
   CreateAtomicRMW((op), (ptr), (val), MaybeAlign((align)), (order))

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -533,9 +533,7 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *value = b_.CreateAllocaBPF(type, "lookup_elem_val");
     Value *condition = b_.CreateICmpNE(
         b_.CreateIntCast(lookup, b_.GET_PTR_TY(), true),
-        ConstantExpr::getCast(Instruction::IntToPtr,
-                              b_.getInt64(0),
-                              b_.GET_PTR_TY()),
+        b_.GetNull(),
         "map_lookup_cond");
     b_.CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
@@ -590,9 +588,7 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *value = b_.CreateAllocaBPF(type, "lookup_elem_val");
     Value *condition = b_.CreateICmpNE(
         b_.CreateIntCast(lookup, b_.GET_PTR_TY(), true),
-        ConstantExpr::getCast(Instruction::IntToPtr,
-                              b_.getInt64(0),
-                              b_.GET_PTR_TY()),
+        b_.GetNull(),
         "map_lookup_cond");
     b_.CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -269,17 +269,6 @@ static void parse_env(BPFtrace& bpftrace)
     config_setter.set(ConfigKeyInt::max_strlen, x);
   });
 
-  // The current 1024B limit comes from LLVM builtin memset(). Once
-  // we have a custom memset(), we can go above 1024B.
-  uint64_t max_strlen = bpftrace.config_.get(ConfigKeyInt::max_strlen);
-  if (max_strlen > 1024) {
-    LOG(ERROR) << "'BPFTRACE_MAX_STRLEN' " << max_strlen
-               << " exceeds the current maximum of 1024 bytes.\n"
-               << "Larger support is tracked in: "
-                  "https://github.com/bpftrace/bpftrace/issues/3229";
-    exit(1);
-  }
-
   if (const char* env_p = std::getenv("BPFTRACE_STR_TRUNC_TRAILER"))
     config_setter.set(ConfigKeyString::str_trunc_trailer, std::string(env_p));
 

--- a/tests/codegen/llvm/builtin_kstack.ll
+++ b/tests/codegen/llvm/builtin_kstack.ll
@@ -57,21 +57,20 @@ lookup_stack_scratch_failure:                     ; preds = %entry
   br label %stack_scratch_failure
 
 lookup_stack_scratch_merge:                       ; preds = %entry
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([127 x i64]*, i32, i8*)*)([127 x i64]* %lookup_stack_scratch_map, i32 1016, i8* null)
   %9 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 1016, i1 false)
-  %10 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %10, i32 1016, i64 0)
-  %11 = icmp sge i32 %get_stack, 0
-  br i1 %11, label %get_stack_success, label %get_stack_fail
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %9, i32 1016, i64 0)
+  %10 = icmp sge i32 %get_stack, 0
+  br i1 %10, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %12 = udiv i32 %get_stack, 8
-  %13 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
-  store i32 %12, i32* %13, align 4
-  %14 = trunc i32 %12 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %10, i8 %14, i64 1)
-  %15 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, i64* %15, align 8
+  %11 = udiv i32 %get_stack, 8
+  %12 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 %11, i32* %12, align 4
+  %13 = trunc i32 %11 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %9, i8 %13, i64 1)
+  %14 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, i64* %14, align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.0"* @stack_bpftrace_127, %stack_key* %stack_key, [127 x i64]* %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -169,13 +168,9 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #2
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #2
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
-
 attributes #0 = { nounwind }
 attributes #1 = { alwaysinline }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
-attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
 !llvm.dbg.cu = !{!82}
 !llvm.module.flags = !{!85}

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -77,21 +77,20 @@ lookup_stack_scratch_failure:                     ; preds = %entry
   br label %stack_scratch_failure
 
 lookup_stack_scratch_merge:                       ; preds = %entry
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([127 x i64]*, i32, i8*)*)([127 x i64]* %lookup_stack_scratch_map, i32 1016, i8* null)
   %20 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %20, i8 0, i64 1016, i1 false)
-  %21 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %21, i32 1016, i64 256)
-  %22 = icmp sge i32 %get_stack, 0
-  br i1 %22, label %get_stack_success, label %get_stack_fail
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %20, i32 1016, i64 256)
+  %21 = icmp sge i32 %get_stack, 0
+  br i1 %21, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %23 = udiv i32 %get_stack, 8
-  %24 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
-  store i32 %23, i32* %24, align 4
-  %25 = trunc i32 %23 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %21, i8 %25, i64 1)
-  %26 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, i64* %26, align 8
+  %22 = udiv i32 %get_stack, 8
+  %23 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 %22, i32* %23, align 4
+  %24 = trunc i32 %22 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %20, i8 %24, i64 1)
+  %25 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, i64* %25, align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.0"* @stack_bpftrace_127, %stack_key* %stack_key, [127 x i64]* %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -189,13 +188,9 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #2
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #2
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
-
 attributes #0 = { nounwind }
 attributes #1 = { alwaysinline }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn }
-attributes #3 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
 !llvm.dbg.cu = !{!86}
 !llvm.module.flags = !{!89}

--- a/tests/codegen/llvm/call_kstack.ll
+++ b/tests/codegen/llvm/call_kstack.ll
@@ -85,21 +85,20 @@ lookup_stack_scratch_failure:                     ; preds = %entry
   br label %stack_scratch_failure
 
 lookup_stack_scratch_merge:                       ; preds = %entry
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([127 x i64]*, i32, i8*)*)([127 x i64]* %lookup_stack_scratch_map, i32 1016, i8* null)
   %15 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %15, i8 0, i64 1016, i1 false)
-  %16 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %16, i32 1016, i64 0)
-  %17 = icmp sge i32 %get_stack, 0
-  br i1 %17, label %get_stack_success, label %get_stack_fail
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %15, i32 1016, i64 0)
+  %16 = icmp sge i32 %get_stack, 0
+  br i1 %16, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %18 = udiv i32 %get_stack, 8
-  %19 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
-  store i32 %18, i32* %19, align 4
-  %20 = trunc i32 %18 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %16, i8 %20, i64 1)
-  %21 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, i64* %21, align 8
+  %17 = udiv i32 %get_stack, 8
+  %18 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 %17, i32* %18, align 4
+  %19 = trunc i32 %17 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %15, i8 %19, i64 1)
+  %20 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, i64* %20, align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.4"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.4"* @stack_bpftrace_127, %stack_key* %stack_key, [127 x i64]* %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -110,47 +109,47 @@ stack_scratch_failure3:                           ; preds = %lookup_stack_scratc
   br label %merge_block4
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
-  %22 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %21 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
   store i64 0, i64* %"@y_key", align 8
   %update_elem15 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, %stack_key*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", %stack_key* %stack_key2, i64 0)
-  %23 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = bitcast %stack_key* %stack_key16 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
-  %25 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 0
-  store i64 0, i64* %25, align 8
-  %26 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 1
-  store i32 0, i32* %26, align 4
-  %27 = bitcast i32* %lookup_stack_scratch_key19 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
+  %22 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast %stack_key* %stack_key16 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %24 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 0
+  store i64 0, i64* %24, align 8
+  %25 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 1
+  store i32 0, i32* %25, align 4
+  %26 = bitcast i32* %lookup_stack_scratch_key19 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
   store i32 0, i32* %lookup_stack_scratch_key19, align 4
   %lookup_stack_scratch_map20 = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key19)
-  %28 = bitcast i32* %lookup_stack_scratch_key19 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %28)
-  %29 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
-  %lookup_stack_scratch_cond23 = icmp ne i8* %29, null
+  %27 = bitcast i32* %lookup_stack_scratch_key19 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
+  %28 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
+  %lookup_stack_scratch_cond23 = icmp ne i8* %28, null
   br i1 %lookup_stack_scratch_cond23, label %lookup_stack_scratch_merge22, label %lookup_stack_scratch_failure21
 
 lookup_stack_scratch_failure7:                    ; preds = %merge_block
   br label %stack_scratch_failure3
 
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
+  %29 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 48, i1 false)
   %30 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %30, i8 0, i64 48, i1 false)
-  %31 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
-  %get_stack12 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %31, i32 48, i64 0)
-  %32 = icmp sge i32 %get_stack12, 0
-  br i1 %32, label %get_stack_success10, label %get_stack_fail11
+  %get_stack12 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %30, i32 48, i64 0)
+  %31 = icmp sge i32 %get_stack12, 0
+  br i1 %31, label %get_stack_success10, label %get_stack_fail11
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
-  %33 = udiv i32 %get_stack12, 8
-  %34 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
-  store i32 %33, i32* %34, align 4
-  %35 = trunc i32 %33 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(i8* %31, i8 %35, i64 1)
-  %36 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_213, i64* %36, align 8
+  %32 = udiv i32 %get_stack12, 8
+  %33 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
+  store i32 %32, i32* %33, align 4
+  %34 = trunc i32 %32 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(i8* %30, i8 %34, i64 1)
+  %35 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, i64* %35, align 8
   %update_elem14 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.3"*, %stack_key*, [6 x i64]*, i64)*)(%"struct map_t.3"* @stack_bpftrace_6, %stack_key* %stack_key2, [6 x i64]* %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
@@ -160,38 +159,37 @@ get_stack_fail11:                                 ; preds = %lookup_stack_scratc
 stack_scratch_failure17:                          ; preds = %lookup_stack_scratch_failure21
   br label %merge_block18
 
-merge_block18:                                    ; preds = %stack_scratch_failure17, %get_stack_success24, %get_stack_fail25
-  %37 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
+merge_block18:                                    ; preds = %stack_scratch_failure17, %get_stack_success25, %get_stack_fail26
+  %36 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %36)
   store i64 0, i64* %"@z_key", align 8
-  %update_elem29 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, %stack_key*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", %stack_key* %stack_key16, i64 0)
-  %38 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %38)
+  %update_elem30 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, %stack_key*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", %stack_key* %stack_key16, i64 0)
+  %37 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
   ret i64 0
 
 lookup_stack_scratch_failure21:                   ; preds = %merge_block4
   br label %stack_scratch_failure17
 
 lookup_stack_scratch_merge22:                     ; preds = %merge_block4
-  %39 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %39, i8 0, i64 1016, i1 false)
-  %40 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
-  %get_stack26 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %40, i32 1016, i64 0)
-  %41 = icmp sge i32 %get_stack26, 0
-  br i1 %41, label %get_stack_success24, label %get_stack_fail25
+  %probe_read_kernel24 = call i64 inttoptr (i64 113 to i64 ([127 x i64]*, i32, i8*)*)([127 x i64]* %lookup_stack_scratch_map20, i32 1016, i8* null)
+  %38 = bitcast [127 x i64]* %lookup_stack_scratch_map20 to i8*
+  %get_stack27 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %38, i32 1016, i64 0)
+  %39 = icmp sge i32 %get_stack27, 0
+  br i1 %39, label %get_stack_success25, label %get_stack_fail26
 
-get_stack_success24:                              ; preds = %lookup_stack_scratch_merge22
-  %42 = udiv i32 %get_stack26, 8
-  %43 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 1
-  store i32 %42, i32* %43, align 4
-  %44 = trunc i32 %42 to i8
-  %murmur_hash_227 = call i64 @murmur_hash_2(i8* %40, i8 %44, i64 1)
-  %45 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 0
-  store i64 %murmur_hash_227, i64* %45, align 8
-  %update_elem28 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.2"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.2"* @stack_perf_127, %stack_key* %stack_key16, [127 x i64]* %lookup_stack_scratch_map20, i64 0)
+get_stack_success25:                              ; preds = %lookup_stack_scratch_merge22
+  %40 = udiv i32 %get_stack27, 8
+  %41 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 1
+  store i32 %40, i32* %41, align 4
+  %42 = trunc i32 %40 to i8
+  %murmur_hash_228 = call i64 @murmur_hash_2(i8* %38, i8 %42, i64 1)
+  %43 = getelementptr %stack_key, %stack_key* %stack_key16, i64 0, i32 0
+  store i64 %murmur_hash_228, i64* %43, align 8
+  %update_elem29 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.2"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.2"* @stack_perf_127, %stack_key* %stack_key16, [127 x i64]* %lookup_stack_scratch_map20, i64 0)
   br label %merge_block18
 
-get_stack_fail25:                                 ; preds = %lookup_stack_scratch_merge22
+get_stack_fail26:                                 ; preds = %lookup_stack_scratch_merge22
   br label %merge_block18
 }
 

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -32,7 +32,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !103 {
 entry:
   %"@z_key" = alloca i64, align 8
-  %stack_args31 = alloca %stack_t, align 8
+  %stack_args32 = alloca %stack_t, align 8
   %lookup_stack_scratch_key21 = alloca i32, align 4
   %stack_key18 = alloca %stack_key, align 8
   %"@y_key" = alloca i64, align 8
@@ -107,21 +107,20 @@ lookup_stack_scratch_failure:                     ; preds = %entry
   br label %stack_scratch_failure
 
 lookup_stack_scratch_merge:                       ; preds = %entry
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([127 x i64]*, i32, i8*)*)([127 x i64]* %lookup_stack_scratch_map, i32 1016, i8* null)
   %26 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %26, i8 0, i64 1016, i1 false)
-  %27 = bitcast [127 x i64]* %lookup_stack_scratch_map to i8*
-  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %27, i32 1016, i64 256)
-  %28 = icmp sge i32 %get_stack, 0
-  br i1 %28, label %get_stack_success, label %get_stack_fail
+  %get_stack = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %26, i32 1016, i64 256)
+  %27 = icmp sge i32 %get_stack, 0
+  br i1 %27, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %29 = udiv i32 %get_stack, 8
-  %30 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
-  store i32 %29, i32* %30, align 4
-  %31 = trunc i32 %29 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %27, i8 %31, i64 1)
-  %32 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, i64* %32, align 8
+  %28 = udiv i32 %get_stack, 8
+  %29 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 1
+  store i32 %28, i32* %29, align 4
+  %30 = trunc i32 %28 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(i8* %26, i8 %30, i64 1)
+  %31 = getelementptr %stack_key, %stack_key* %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, i64* %31, align 8
   %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t.4"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.4"* @stack_bpftrace_127, %stack_key* %stack_key, [127 x i64]* %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -132,65 +131,65 @@ stack_scratch_failure3:                           ; preds = %lookup_stack_scratc
   br label %merge_block4
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
-  %33 = bitcast %stack_t* %stack_args15 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
-  %34 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
-  %35 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 0
-  %36 = load i64, i64* %34, align 8
-  store i64 %36, i64* %35, align 8
-  %37 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
-  %38 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 1
-  %39 = load i32, i32* %37, align 4
-  store i32 %39, i32* %38, align 4
-  %40 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 2
+  %32 = bitcast %stack_t* %stack_args15 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %32)
+  %33 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
+  %34 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 0
+  %35 = load i64, i64* %33, align 8
+  store i64 %35, i64* %34, align 8
+  %36 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
+  %37 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 1
+  %38 = load i32, i32* %36, align 4
+  store i32 %38, i32* %37, align 4
+  %39 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 2
   %get_pid_tgid16 = call i64 inttoptr (i64 14 to i64 ()*)()
-  %41 = trunc i64 %get_pid_tgid16 to i32
-  store i32 %41, i32* %40, align 4
-  %42 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 3
-  store i32 0, i32* %42, align 4
-  %43 = bitcast %stack_key* %stack_key2 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
-  %44 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %44)
+  %40 = trunc i64 %get_pid_tgid16 to i32
+  store i32 %40, i32* %39, align 4
+  %41 = getelementptr %stack_t, %stack_t* %stack_args15, i64 0, i32 3
+  store i32 0, i32* %41, align 4
+  %42 = bitcast %stack_key* %stack_key2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
+  %43 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %43)
   store i64 0, i64* %"@y_key", align 8
   %update_elem17 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, %stack_t*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", %stack_t* %stack_args15, i64 0)
-  %45 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %45)
-  %46 = bitcast %stack_key* %stack_key18 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %46)
-  %47 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 0
-  store i64 0, i64* %47, align 8
-  %48 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 1
-  store i32 0, i32* %48, align 4
-  %49 = bitcast i32* %lookup_stack_scratch_key21 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %49)
+  %44 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  %45 = bitcast %stack_key* %stack_key18 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %45)
+  %46 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 0
+  store i64 0, i64* %46, align 8
+  %47 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 1
+  store i32 0, i32* %47, align 4
+  %48 = bitcast i32* %lookup_stack_scratch_key21 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %48)
   store i32 0, i32* %lookup_stack_scratch_key21, align 4
   %lookup_stack_scratch_map22 = call [127 x i64]* inttoptr (i64 1 to [127 x i64]* (%"struct map_t.5"*, i32*)*)(%"struct map_t.5"* @stack_scratch, i32* %lookup_stack_scratch_key21)
-  %50 = bitcast i32* %lookup_stack_scratch_key21 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %50)
-  %51 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
-  %lookup_stack_scratch_cond25 = icmp ne i8* %51, null
+  %49 = bitcast i32* %lookup_stack_scratch_key21 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
+  %50 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
+  %lookup_stack_scratch_cond25 = icmp ne i8* %50, null
   br i1 %lookup_stack_scratch_cond25, label %lookup_stack_scratch_merge24, label %lookup_stack_scratch_failure23
 
 lookup_stack_scratch_failure7:                    ; preds = %merge_block
   br label %stack_scratch_failure3
 
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
+  %51 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %51, i8 0, i64 48, i1 false)
   %52 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %52, i8 0, i64 48, i1 false)
-  %53 = bitcast [6 x i64]* %lookup_stack_scratch_map6 to i8*
-  %get_stack12 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %53, i32 48, i64 256)
-  %54 = icmp sge i32 %get_stack12, 0
-  br i1 %54, label %get_stack_success10, label %get_stack_fail11
+  %get_stack12 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %52, i32 48, i64 256)
+  %53 = icmp sge i32 %get_stack12, 0
+  br i1 %53, label %get_stack_success10, label %get_stack_fail11
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
-  %55 = udiv i32 %get_stack12, 8
-  %56 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
-  store i32 %55, i32* %56, align 4
-  %57 = trunc i32 %55 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(i8* %53, i8 %57, i64 1)
-  %58 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_213, i64* %58, align 8
+  %54 = udiv i32 %get_stack12, 8
+  %55 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 1
+  store i32 %54, i32* %55, align 4
+  %56 = trunc i32 %54 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(i8* %52, i8 %56, i64 1)
+  %57 = getelementptr %stack_key, %stack_key* %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, i64* %57, align 8
   %update_elem14 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.3"*, %stack_key*, [6 x i64]*, i64)*)(%"struct map_t.3"* @stack_bpftrace_6, %stack_key* %stack_key2, [6 x i64]* %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
@@ -200,56 +199,55 @@ get_stack_fail11:                                 ; preds = %lookup_stack_scratc
 stack_scratch_failure19:                          ; preds = %lookup_stack_scratch_failure23
   br label %merge_block20
 
-merge_block20:                                    ; preds = %stack_scratch_failure19, %get_stack_success26, %get_stack_fail27
-  %59 = bitcast %stack_t* %stack_args31 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %59)
-  %60 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 0
-  %61 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 0
-  %62 = load i64, i64* %60, align 8
-  store i64 %62, i64* %61, align 8
-  %63 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 1
-  %64 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 1
-  %65 = load i32, i32* %63, align 4
-  store i32 %65, i32* %64, align 4
-  %66 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 2
-  %get_pid_tgid32 = call i64 inttoptr (i64 14 to i64 ()*)()
-  %67 = trunc i64 %get_pid_tgid32 to i32
-  store i32 %67, i32* %66, align 4
-  %68 = getelementptr %stack_t, %stack_t* %stack_args31, i64 0, i32 3
-  store i32 0, i32* %68, align 4
-  %69 = bitcast %stack_key* %stack_key18 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %69)
-  %70 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %70)
+merge_block20:                                    ; preds = %stack_scratch_failure19, %get_stack_success27, %get_stack_fail28
+  %58 = bitcast %stack_t* %stack_args32 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %58)
+  %59 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 0
+  %60 = getelementptr %stack_t, %stack_t* %stack_args32, i64 0, i32 0
+  %61 = load i64, i64* %59, align 8
+  store i64 %61, i64* %60, align 8
+  %62 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 1
+  %63 = getelementptr %stack_t, %stack_t* %stack_args32, i64 0, i32 1
+  %64 = load i32, i32* %62, align 4
+  store i32 %64, i32* %63, align 4
+  %65 = getelementptr %stack_t, %stack_t* %stack_args32, i64 0, i32 2
+  %get_pid_tgid33 = call i64 inttoptr (i64 14 to i64 ()*)()
+  %66 = trunc i64 %get_pid_tgid33 to i32
+  store i32 %66, i32* %65, align 4
+  %67 = getelementptr %stack_t, %stack_t* %stack_args32, i64 0, i32 3
+  store i32 0, i32* %67, align 4
+  %68 = bitcast %stack_key* %stack_key18 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %68)
+  %69 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %69)
   store i64 0, i64* %"@z_key", align 8
-  %update_elem33 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, %stack_t*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", %stack_t* %stack_args31, i64 0)
-  %71 = bitcast i64* %"@z_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %71)
+  %update_elem34 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.1"*, i64*, %stack_t*, i64)*)(%"struct map_t.1"* @AT_z, i64* %"@z_key", %stack_t* %stack_args32, i64 0)
+  %70 = bitcast i64* %"@z_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %70)
   ret i64 0
 
 lookup_stack_scratch_failure23:                   ; preds = %merge_block4
   br label %stack_scratch_failure19
 
 lookup_stack_scratch_merge24:                     ; preds = %merge_block4
-  %72 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %72, i8 0, i64 1016, i1 false)
-  %73 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
-  %get_stack28 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %73, i32 1016, i64 256)
-  %74 = icmp sge i32 %get_stack28, 0
-  br i1 %74, label %get_stack_success26, label %get_stack_fail27
+  %probe_read_kernel26 = call i64 inttoptr (i64 113 to i64 ([127 x i64]*, i32, i8*)*)([127 x i64]* %lookup_stack_scratch_map22, i32 1016, i8* null)
+  %71 = bitcast [127 x i64]* %lookup_stack_scratch_map22 to i8*
+  %get_stack29 = call i32 inttoptr (i64 67 to i32 (i8*, i8*, i32, i64)*)(i8* %0, i8* %71, i32 1016, i64 256)
+  %72 = icmp sge i32 %get_stack29, 0
+  br i1 %72, label %get_stack_success27, label %get_stack_fail28
 
-get_stack_success26:                              ; preds = %lookup_stack_scratch_merge24
-  %75 = udiv i32 %get_stack28, 8
-  %76 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 1
-  store i32 %75, i32* %76, align 4
-  %77 = trunc i32 %75 to i8
-  %murmur_hash_229 = call i64 @murmur_hash_2(i8* %73, i8 %77, i64 1)
-  %78 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 0
-  store i64 %murmur_hash_229, i64* %78, align 8
-  %update_elem30 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.2"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.2"* @stack_perf_127, %stack_key* %stack_key18, [127 x i64]* %lookup_stack_scratch_map22, i64 0)
+get_stack_success27:                              ; preds = %lookup_stack_scratch_merge24
+  %73 = udiv i32 %get_stack29, 8
+  %74 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 1
+  store i32 %73, i32* %74, align 4
+  %75 = trunc i32 %73 to i8
+  %murmur_hash_230 = call i64 @murmur_hash_2(i8* %71, i8 %75, i64 1)
+  %76 = getelementptr %stack_key, %stack_key* %stack_key18, i64 0, i32 0
+  store i64 %murmur_hash_230, i64* %76, align 8
+  %update_elem31 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.2"*, %stack_key*, [127 x i64]*, i64)*)(%"struct map_t.2"* @stack_perf_127, %stack_key* %stack_key18, [127 x i64]* %lookup_stack_scratch_map22, i64 0)
   br label %merge_block20
 
-get_stack_fail27:                                 ; preds = %lookup_stack_scratch_merge24
+get_stack_fail28:                                 ; preds = %lookup_stack_scratch_merge24
   br label %merge_block20
 }
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -78,6 +78,23 @@ AFTER ./testprogs/syscall execve /bin/ls &>/dev/null
 EXPECT_REGEX P: /..._xxx
 TIMEOUT 5
 
+NAME str_big
+PROG t:syscalls:sys_enter_execve { @[str(args.filename)] = count() }
+ENV BPFTRACE_MAX_STRLEN=9999
+EXPECT_REGEX @\[/X{5555}\]: 1
+AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
+REQUIRES_FEATURE probe_read_kernel
+# We rely on the timeout to terminate the script
+TIMEOUT 1
+
+NAME str_big_strncmp
+PROG t:syscalls:sys_enter_execve { if (strncmp(str(args.filename), "/XXX", 4)) { print("matched"); exit(); } }
+ENV BPFTRACE_MAX_STRLEN=9999
+EXPECT matched
+AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
+REQUIRES_FEATURE probe_read_kernel
+TIMEOUT 5
+
 NAME buf
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \x09\x08\x07\x06-\x05\x04\x03\x02-\x01\x02\x03\x04-\x05\x00\x00\x00\x06\x00\x00\x00\x07\x00\x00\x00\x08\x00\x00\x00-\x09\x00\x0a\x00\x0b\x00\x0c\x00-\x0d\x00\x00\x00\x00\x00\x00\x00\x0e\x00\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00


### PR DESCRIPTION
This PR unlocks full support for big strings. Users can now have strings of
unlimited (until you run out of kernel memory) size. There's still the issue
of path(), buf(), etc. helpers trying to allocate BPFTRACE_MAX_STRLEN bytes
on the stack. We'll fix that next, but even if that doesn't go in, users now have
the option.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
