### PR TITLE
nix: Re-enable LLDB support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716755743,
-        "narHash": "sha256-IwLq4CTHXkEeBUQeVWhmKsX0pZ8snSQi0uPo6JGeQkA=",
+        "lastModified": 1718290262,
+        "narHash": "sha256-C1OvC8At5IvvYHKf278Zq+wfnUXhO8vd2yNgbzZzArc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "baf5166949ef8cb8e85e3f940eec53b9c916db64",
+        "rev": "aeb13d0815848e88980ee5164f949f7238e728ee",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -88,11 +88,7 @@
                     libopcodes
                     libpcap
                     libsystemtap
-                    # Temporarily disable LLDB support in CI. We're waiting on upstream
-                    # nixpkgs fixes:
-                    #     https://github.com/NixOS/nixpkgs/issues/315214
-                    #     https://github.com/NixOS/nixpkgs/pull/316045
-                    #lldb
+                    lldb
                     llvm
                     pahole
                     xxd


### PR DESCRIPTION
Upstream nixpkgs fixes have been merged. So update to latest in 24.05 channel and re-enable LLDB.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
