### PR TITLE
Fix: BTF type tag resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ and this project adheres to
   - [#3195](https://github.com/bpftrace/bpftrace/pull/3195)
 - Fix crash when assigning a record type to a map
   - [#3220](https://github.com/bpftrace/bpftrace/pull/3220)
+- Fix type resolution for pointers with BTF_KIND_TYPE_TAG
+  - [#3240](https://github.com/bpftrace/bpftrace/pull/3240)
 #### Security
 - Don't unpack kernel headers or look in tmp
   - [#3156](https://github.com/bpftrace/bpftrace/pull/3156)

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -348,6 +348,21 @@ const struct btf_type *BTF::btf_type_skip_modifiers(const struct btf_type *t,
   return t;
 }
 
+__u32 BTF::get_type_tags(std::unordered_set<std::string> &tags,
+                         const BTFId &btf_id) const
+{
+  __u32 id = btf_id.id;
+  const struct btf_type *t = btf__type_by_id(btf_id.btf, btf_id.id);
+
+  while (t && btf_is_type_tag(t)) {
+    tags.insert(btf_str(btf_id.btf, t->name_off));
+    id = t->type;
+    t = btf__type_by_id(btf_id.btf, t->type);
+  }
+
+  return id;
+}
+
 SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
 {
   const struct btf_type *t = btf__type_by_id(btf_id.btf, btf_id.id);
@@ -375,9 +390,12 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
     if (resolve_structs)
       resolve_fields(stype);
   } else if (btf_is_ptr(t)) {
-    // t->type is the pointee type
+    const BTFId pointee_btf_id = { .btf = btf_id.btf, .id = t->type };
+    std::unordered_set<std::string> tags;
+    auto id = get_type_tags(tags, pointee_btf_id);
     stype = CreatePointer(
-        get_stype(BTFId{ .btf = btf_id.btf, .id = t->type }, false));
+        get_stype(BTFId{ .btf = btf_id.btf, .id = id }, false));
+    stype.SetBtfTypeTags(std::move(tags));
   } else if (btf_is_array(t)) {
     auto *array = btf_array(t);
     const auto &elem_type = get_stype(

--- a/src/btf.h
+++ b/src/btf.h
@@ -103,6 +103,13 @@ private:
   std::set<std::string> get_all_structs_from_btf(const struct btf* btf) const;
   std::unordered_set<std::string> get_all_iters_from_btf(
       const struct btf* btf) const;
+  /*
+   * Similar to btf_type_skip_modifiers this returns the id of the first
+   * type that is not a BTF_KIND_TYPE_TAG while also populating the tags set
+   * with the tag/attribute names from the BTF_KIND_TYPE_TAG types it finds.
+   */
+  __u32 get_type_tags(std::unordered_set<std::string>& tags,
+                      const BTFId& btf_id) const;
 
   __s32 start_id(const struct btf* btf) const;
 

--- a/src/types.h
+++ b/src/types.h
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <map>
 #include <memory>
+#include <optional>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -154,6 +155,8 @@ private:
   AddrSpace as_ = AddrSpace::none;
   bool is_signed_ = false;
   bool ctx_ = false; // Is bpf program context
+  std::unordered_set<std::string> btf_type_tags_ = {}; // Only populated for
+                                                       // Type::pointer
 
   friend class cereal::access;
   template <typename Archive>
@@ -204,6 +207,18 @@ public:
   void SetAS(AddrSpace as)
   {
     as_ = as;
+  }
+
+  void SetBtfTypeTags(std::unordered_set<std::string> &&tags)
+  {
+    assert(IsPtrTy());
+    btf_type_tags_ = std::move(tags);
+  }
+
+  const std::unordered_set<std::string> &GetBtfTypeTags() const
+  {
+    assert(IsPtrTy());
+    return btf_type_tags_;
   }
 
   bool IsCtxAccess() const

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -97,3 +97,11 @@ PROG kprobe:kvm:x86_emulate_insn { $ctxt = (struct x86_emulate_ctxt *) arg0; pri
 EXPECT Attaching 1 probe...
 TIMEOUT 2
 REQUIRES lsmod | grep '^kvm'
+
+# This test only matters on Clang-built kernels, which support btf_type_tag
+# and require special handling in bpftrace
+NAME btf_type_tag_access
+PROG BEGIN { printf("SUCCESS %d\n", curtask->parent->pid); exit() }
+EXPECT_REGEX SUCCESS [0-9][0-9]*
+TIMEOUT 5
+REQUIRES_FEATURE btf

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3457,6 +3457,16 @@ fexit:func_1 { reg("ip") }
   test("fentry:func_1 { $x = args->a; }");
 }
 
+TEST(semantic_analyser, btf_type_tags)
+{
+  test("t:btf:tag { args.parent }");
+  test_error("t:btf:tag { args.real_parent }", R"(
+stdin:1:13-18: ERROR: Attempting to access pointer field 'real_parent' with unsupported tag attribute: percpu
+t:btf:tag { args.real_parent }
+            ~~~~~
+)");
+}
+
 TEST(semantic_analyser, for_loop_map_one_key)
 {
   test("BEGIN { @map[0] = 1; for ($kv : @map) { print($kv); } }", R"(


### PR DESCRIPTION
This adds support for 'BTF_KIND_TYPE_TAG' in that we ignore it and follow the pointer to the base type.

This fixes issue: https://github.com/bpftrace/bpftrace/issues/3221

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
