### PR TITLE
utils: fix kernel headers not found warning

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -741,13 +741,9 @@ std::tuple<std::string, std::string> get_kernel_dirs(
 
   // if one of source/ or build/ is not present - try to use the other one for
   // both.
-  if (!is_dir(ksrc)) {
-    ksrc = "";
-  }
-  if (!is_dir(kobj)) {
-    kobj = "";
-  }
-  if (ksrc.empty() && kobj.empty()) {
+  auto has_ksrc = is_dir(ksrc);
+  auto has_kobj = is_dir(kobj);
+  if (!has_ksrc && !has_kobj) {
     LOG(WARNING) << "Could not find kernel headers in " << ksrc << " or "
                  << kobj
                  << ". To specify a particular path to kernel headers, set the "
@@ -758,9 +754,9 @@ std::tuple<std::string, std::string> get_kernel_dirs(
                     "file at /sys/kernel/kheaders.tar.xz";
     return std::make_tuple("", "");
   }
-  if (ksrc.empty()) {
+  if (!has_ksrc) {
     ksrc = kobj;
-  } else if (kobj.empty()) {
+  } else if (!has_kobj) {
     kobj = ksrc;
   }
 


### PR DESCRIPTION
The code would make ksrc and kobj empty then try to print them, this would always print empty strings.
Store is_dir() checks as bool instead and use these, the strings cannot be empty if the check passed.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
^ doesn't really seem applicable here; tested manually on nixos where directory isn't found