### PR TITLE
Support big path()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to
 - Remove limit on BPFTRACE_MAX_STRLEN
   - [#3228](https://github.com/bpftrace/bpftrace/pull/3228)
   - [#3237](https://github.com/bpftrace/bpftrace/pull/3237)
+  - [#3245](https://github.com/bpftrace/bpftrace/pull/3245)
 #### Changed
 - Better error message for args in mixed probes
   - [#3047](https://github.com/bpftrace/bpftrace/pull/3047)
@@ -49,7 +50,7 @@ and this project adheres to
 - Allow trailing semicolons and empty blocks in config syntax
   - [#3077](https://github.com/bpftrace/bpftrace/pull/3077)
 - Allow attaching to 'spin_lock' functions with mitigations to prevent deadlocks
-  - [#3206](https://github.com/bpftrace/bpftrace/pull/3206) 
+  - [#3206](https://github.com/bpftrace/bpftrace/pull/3206)
 #### Deprecated
 - Deprecate `sarg` builtin
   - [#3095](https://github.com/bpftrace/bpftrace/pull/3095)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -2306,7 +2306,7 @@ void IRBuilderBPF::CreateHelperErrorCond(Value *ctx,
 }
 
 void IRBuilderBPF::CreatePath(Value *ctx,
-                              AllocaInst *buf,
+                              Value *buf,
                               Value *path,
                               const location &loc)
 {

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -255,10 +255,7 @@ public:
                             Value *len,
                             AllocaInst *data,
                             size_t size);
-  void CreatePath(Value *ctx,
-                  AllocaInst *buf,
-                  Value *path,
-                  const location &loc);
+  void CreatePath(Value *ctx, Value *buf, Value *path, const location &loc);
   void CreateSeqPrintf(Value *ctx,
                        Value *fmt,
                        Value *fmt_size,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -812,8 +812,7 @@ void CodegenLLVM::visit(Call &call)
     expr_ = buf;
     expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
   } else if (call.func == "path") {
-    AllocaInst *buf = b_.CreateAllocaBPF(
-        bpftrace_.config_.get(ConfigKeyInt::max_strlen), "path");
+    Value *buf = b_.CreateGetStrScratchMap(str_id_, nullptr, call.loc);
     b_.CreateMemsetBPF(buf,
                        b_.getInt8(0),
                        bpftrace_.config_.get(ConfigKeyInt::max_strlen));
@@ -826,8 +825,8 @@ void CodegenLLVM::visit(Call &call)
                                 expr_,
                                 b_.GET_PTR_TY()),
                   call.loc);
+    str_id_++;
     expr_ = buf;
-    expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
   } else if (call.func == "kaddr") {
     uint64_t addr;
     auto name = bpftrace_.get_string_literal(call.vargs->at(0));

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -155,7 +155,7 @@ void ResourceAnalyser::visit(Call &call)
       resources_.time_args.push_back(get_literal_string(*call.vargs->at(0)));
     else
       resources_.time_args.push_back("%H:%M:%S\n");
-  } else if (call.func == "str") {
+  } else if (call.func == "str" || call.func == "path") {
     resources_.str_buffers++;
   } else if (call.func == "strftime") {
     resources_.strftime_args.push_back(get_literal_string(*call.vargs->at(0)));

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -30,28 +30,22 @@ entry:
   %lookup_str_cond = icmp ne i8* %lookup_str_map, null
   br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
 
-scratch_lookup_failure:                           ; preds = %lookup_str_failure
-  ret i64 0
-
-scratch_lookup_merge:                             ; preds = %lookup_str_merge
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i8* %lookup_str_map, i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  ret i64 0
-
 lookup_str_failure:                               ; preds = %entry
-  br label %scratch_lookup_failure
+  ret i64 0
 
 lookup_str_merge:                                 ; preds = %entry
   call void @llvm.memset.p0i8.i64(i8* align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %5 = bitcast i8* %0 to i64*
-  %6 = getelementptr i64, i64* %5, i64 14
-  %arg0 = load volatile i64, i64* %6, align 8
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 64, i64 %arg0)
-  br label %scratch_lookup_merge
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 0, i64* %"@x_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i8* %lookup_str_map, i64 0)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -36,29 +36,23 @@ entry:
   %lookup_str_cond = icmp ne i8* %lookup_str_map, null
   br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
 
-scratch_lookup_failure:                           ; preds = %lookup_str_failure
-  ret i64 0
-
-scratch_lookup_merge:                             ; preds = %lookup_str_merge
-  %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store i64 0, i64* %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i8* %lookup_str_map, i64 0)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  ret i64 0
-
 lookup_str_failure:                               ; preds = %entry
-  br label %scratch_lookup_failure
+  ret i64 0
 
 lookup_str_merge:                                 ; preds = %entry
   call void @llvm.memset.p0i8.i64(i8* align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %8 = bitcast i8* %0 to i64*
-  %9 = getelementptr i64, i64* %8, i64 14
-  %arg0 = load volatile i64, i64* %9, align 8
-  %10 = trunc i64 %str.min.select to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 %10, i64 %arg0)
-  br label %scratch_lookup_merge
+  %6 = bitcast i8* %0 to i64*
+  %7 = getelementptr i64, i64* %6, i64 14
+  %arg0 = load volatile i64, i64* %7, align 8
+  %8 = trunc i64 %str.min.select to i32
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 %8, i64 %arg0)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@x_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i8* %lookup_str_map, i64 0)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -30,28 +30,22 @@ entry:
   %lookup_str_cond = icmp ne i8* %lookup_str_map, null
   br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
 
-scratch_lookup_failure:                           ; preds = %lookup_str_failure
-  ret i64 0
-
-scratch_lookup_merge:                             ; preds = %lookup_str_merge
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i8* %lookup_str_map, i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  ret i64 0
-
 lookup_str_failure:                               ; preds = %entry
-  br label %scratch_lookup_failure
+  ret i64 0
 
 lookup_str_merge:                                 ; preds = %entry
   call void @llvm.memset.p0i8.i64(i8* align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %5 = bitcast i8* %0 to i64*
-  %6 = getelementptr i64, i64* %5, i64 14
-  %arg0 = load volatile i64, i64* %6, align 8
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 7, i64 %arg0)
-  br label %scratch_lookup_merge
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 0, i64* %"@x_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i8* %lookup_str_map, i64 0)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -46,33 +46,27 @@ entry:
   %lookup_str_cond = icmp ne i8* %lookup_str_map, null
   br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
 
-scratch_lookup_failure:                           ; preds = %lookup_str_failure
-  ret i64 0
-
-scratch_lookup_merge:                             ; preds = %lookup_str_merge
-  %7 = bitcast [1 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 0, i64* %"@y_key", align 8
-  %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, i8*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", i8* %lookup_str_map, i64 0)
-  %9 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  ret i64 0
-
 lookup_str_failure:                               ; preds = %entry
-  br label %scratch_lookup_failure
+  ret i64 0
 
 lookup_str_merge:                                 ; preds = %entry
   call void @llvm.memset.p0i8.i64(i8* align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %10 = bitcast [1 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = bitcast [1 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 1, i1 false)
+  %7 = bitcast [1 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = bitcast [1 x i8]* %str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 1, i1 false)
   store [1 x i8] zeroinitializer, [1 x i8]* %str, align 1
-  %12 = ptrtoint [1 x i8]* %str to i64
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 64, i64 %12)
-  br label %scratch_lookup_merge
+  %9 = ptrtoint [1 x i8]* %str to i64
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 64, i64 %9)
+  %10 = bitcast [1 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@y_key", align 8
+  %update_elem1 = call i64 inttoptr (i64 2 to i64 (%"struct map_t.0"*, i64*, i8*, i64)*)(%"struct map_t.0"* @AT_y, i64* %"@y_key", i8* %lookup_str_map, i64 0)
+  %12 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -52,39 +52,33 @@ pred_true:                                        ; preds = %strcmp.false
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 1
 
-scratch_lookup_failure:                           ; preds = %lookup_str_failure
-  ret i64 1
-
-scratch_lookup_merge:                             ; preds = %lookup_str_merge
-  %8 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 16, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm, i64 16)
-  %10 = bitcast i1* %strcmp.result to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i1 false, i1* %strcmp.result, align 1
-  %11 = getelementptr i8, i8* %lookup_str_map, i32 0
-  %12 = load i8, i8* %11, align 1
-  %13 = bitcast [16 x i8]* %comm to i8*
-  %14 = getelementptr i8, i8* %13, i32 0
-  %15 = load i8, i8* %14, align 1
-  %strcmp.cmp = icmp ne i8 %12, %15
-  br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
-
 lookup_str_failure:                               ; preds = %entry
-  br label %scratch_lookup_failure
+  ret i64 0
 
 lookup_str_merge:                                 ; preds = %entry
   call void @llvm.memset.p0i8.i64(i8* align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %16 = ptrtoint i8* %0 to i64
-  %17 = add i64 %16, 8
-  %18 = inttoptr i64 %17 to i64*
-  %19 = load volatile i64, i64* %18, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 64, i64 %19)
-  br label %scratch_lookup_merge
+  %8 = ptrtoint i8* %0 to i64
+  %9 = add i64 %8, 8
+  %10 = inttoptr i64 %9 to i64*
+  %11 = load volatile i64, i64* %10, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 64, i64 %11)
+  %12 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 16, i1 false)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm, i64 16)
+  %14 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i1 false, i1* %strcmp.result, align 1
+  %15 = getelementptr i8, i8* %lookup_str_map, i32 0
+  %16 = load i8, i8* %15, align 1
+  %17 = bitcast [16 x i8]* %comm to i8*
+  %18 = getelementptr i8, i8* %17, i32 0
+  %19 = load i8, i8* %18, align 1
+  %strcmp.cmp = icmp ne i8 %16, %19
+  br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
-strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %scratch_lookup_merge
+strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %lookup_str_merge
   %20 = load i1, i1* %strcmp.result, align 1
   %21 = bitcast i1* %strcmp.result to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
@@ -105,8 +99,8 @@ strcmp.loop:                                      ; preds = %strcmp.loop_null_cm
   %strcmp.cmp3 = icmp ne i8 %24, %27
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
-strcmp.loop_null_cmp:                             ; preds = %scratch_lookup_merge
-  %strcmp.cmp_null = icmp eq i8 %12, 0
+strcmp.loop_null_cmp:                             ; preds = %lookup_str_merge
+  %strcmp.cmp_null = icmp eq i8 %16, 0
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -39,33 +39,27 @@ entry:
   %lookup_str_cond = icmp ne i8* %lookup_str_map, null
   br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
 
-scratch_lookup_failure:                           ; preds = %lookup_str_failure
-  ret i64 0
-
-scratch_lookup_merge:                             ; preds = %lookup_str_merge
-  %6 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store i64 0, i64* %"@mystr_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_mystr, i64* %"@mystr_key", i8* %lookup_str_map, i64 0)
-  %7 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  ret i64 0
-
 lookup_str_failure:                               ; preds = %entry
-  br label %scratch_lookup_failure
+  ret i64 0
 
 lookup_str_merge:                                 ; preds = %entry
   call void @llvm.memset.p0i8.i64(i8* align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %8 = load i64, i64* %"$foo", align 8
-  %9 = add i64 %8, 0
+  %6 = load i64, i64* %"$foo", align 8
+  %7 = add i64 %6, 0
+  %8 = bitcast i64* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %7)
+  %9 = load i64, i64* %"struct Foo.str", align 8
   %10 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %9)
-  %11 = load i64, i64* %"struct Foo.str", align 8
-  %12 = bitcast i64* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 64, i64 %9)
+  %11 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@mystr_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i8*, i64)*)(%"struct map_t"* @AT_mystr, i64* %"@mystr_key", i8* %lookup_str_map, i64 0)
+  %12 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %lookup_str_map, i32 64, i64 %11)
-  br label %scratch_lookup_merge
+  ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn


### PR DESCRIPTION
This PR moves codegen for path() onto similar implementation as big strings.
That is to say: path() no longer has length limitations.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
