### PR TITLE
Unify and improve ignoring of missing probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
   - [#3228](https://github.com/bpftrace/bpftrace/pull/3228)
   - [#3237](https://github.com/bpftrace/bpftrace/pull/3237)
   - [#3245](https://github.com/bpftrace/bpftrace/pull/3245)
+- Add config option for handling missing probes
+  - [#3246](https://github.com/bpftrace/bpftrace/pull/3246)
 #### Changed
 - Better error message for args in mixed probes
   - [#3047](https://github.com/bpftrace/bpftrace/pull/3047)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to
   - [#3220](https://github.com/bpftrace/bpftrace/pull/3220)
 - Fix type resolution for pointers with BTF_KIND_TYPE_TAG
   - [#3240](https://github.com/bpftrace/bpftrace/pull/3240)
+- Fix attachment of probes attaching to wildcarded and non-wildcarded kprobes
+  - [#3246](https://github.com/bpftrace/bpftrace/pull/3246)
 #### Security
 - Don't unpack kernel headers or look in tmp
   - [#3156](https://github.com/bpftrace/bpftrace/pull/3156)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ and this project adheres to
   - [#3156](https://github.com/bpftrace/bpftrace/pull/3156)
 #### Docs
 #### Tools
+- Ignore warnings for missing probes
+  - [#3246](https://github.com/bpftrace/bpftrace/pull/3246)
 
 ## [0.20.0] 2024-01-22
 

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2415,11 +2415,11 @@ i:s:10 {
 Count how often this function is called.
 
 Using `@=count()` is conceptually similar to `@++`.
-The difference is that the `count()` function uses a map type optimized for 
-writing (PER_CPU), increasing performance and correctness. However, sync reads 
-can be expensive as bpftrace needs to iterate over all the cpus to collect and 
+The difference is that the `count()` function uses a map type optimized for
+writing (PER_CPU), increasing performance and correctness. However, sync reads
+can be expensive as bpftrace needs to iterate over all the cpus to collect and
 sum these values.
-Note: In contrast to hash maps (e.g. `@++`), multiple writers to a shared 
+Note: In contrast to hash maps (e.g. `@++`), multiple writers to a shared
 global var might lose counts as bpftrace doesn't update them atomically.
 
 ----
@@ -2586,11 +2586,11 @@ kprobe:vfs_read {
 Calculate the sum of all `n` passed.
 
 Using `@=sum(5)` is conceptually similar to `@+=5`.
-The difference is that the `sum()` function uses a map type optimized for 
-writing (PER_CPU), increasing performance and correctness. However, sync reads 
-can be expensive as bpftrace needs to iterate over all the cpus to collect and 
+The difference is that the `sum()` function uses a map type optimized for
+writing (PER_CPU), increasing performance and correctness. However, sync reads
+can be expensive as bpftrace needs to iterate over all the cpus to collect and
 sum these values.
-Note: In contrast to hash maps (e.g. `@+=5`), multiple writers to a shared 
+Note: In contrast to hash maps (e.g. `@+=5`), multiple writers to a shared
 global var might lose updates as bpftrace doesn't update them atomically.
 
 ----

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3427,6 +3427,19 @@ Default: 0
 Maximum number of levels of nested field accesses for tracepoint args.
 0 is unlimited.
 
+=== missing_probes
+
+Default: `warn`
+
+Controls handling of probes with multiple kprobe or uprobe attach points which
+cannot be attached to some functions because they do not exist in the kernel or
+in the traced binary.
+
+The possible options are:
+- `error` - always fail on missing probes
+- `warn` - print a warning but continue execution
+- `ignore` - silently ignore missing probes
+
 === perf_rb_pages
 
 Default: 64

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -92,8 +92,9 @@ void ConfigAnalyser::set_user_symbol_cache_type_config(
     return;
   }
 
-  config_setter_.set_user_symbol_cache_type(
-      dynamic_cast<String *>(assignment.expr)->str);
+  auto val = dynamic_cast<String *>(assignment.expr)->str;
+  if (!config_setter_.set_user_symbol_cache_type(val))
+    LOG(ERROR, assignment.expr->loc, err_);
 }
 
 void ConfigAnalyser::visit(Integer &integer)

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -97,6 +97,20 @@ void ConfigAnalyser::set_user_symbol_cache_type_config(
     LOG(ERROR, assignment.expr->loc, err_);
 }
 
+void ConfigAnalyser::set_missing_probes_config(
+    AssignConfigVarStatement &assignment)
+{
+  auto &assignTy = assignment.expr->type;
+  if (!assignTy.IsStringTy()) {
+    log_type_error(assignTy, Type::string, assignment);
+    return;
+  }
+
+  auto val = dynamic_cast<String *>(assignment.expr)->str;
+  if (!config_setter_.set_missing_probes_config(val))
+    LOG(ERROR, assignment.expr->loc, err_);
+}
+
 void ConfigAnalyser::visit(Integer &integer)
 {
   integer.type = CreateInt64();
@@ -151,6 +165,9 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
           [&, this](ConfigKeyStackMode) { set_stack_mode_config(assignment); },
           [&, this](ConfigKeyUserSymbolCacheType) {
             set_user_symbol_cache_type_config(assignment);
+          },
+          [&, this](ConfigKeyMissingProbes) {
+            set_missing_probes_config(assignment);
           } },
       configKey);
 }

--- a/src/ast/passes/config_analyser.h
+++ b/src/ast/passes/config_analyser.h
@@ -47,6 +47,7 @@ private:
                          ConfigKeyString key);
   void set_stack_mode_config(AssignConfigVarStatement &assignment);
   void set_user_symbol_cache_type_config(AssignConfigVarStatement &assignment);
+  void set_missing_probes_config(AssignConfigVarStatement &assignment);
 
   void log_type_error(SizedType &type,
                       Type expected_type,

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2607,7 +2607,9 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       LOG(ERROR, ap.loc, err_) << "kprobes should be attached to a function";
     if (is_final_pass()) {
       // Warn if user tries to attach to a non-traceable function
-      if (!has_wildcard(ap.func) && !bpftrace_.is_traceable_func(ap.func)) {
+      if (bpftrace_.config_.get(ConfigKeyMissingProbes::default_) !=
+              ConfigMissingProbes::ignore &&
+          !has_wildcard(ap.func) && !bpftrace_.is_traceable_func(ap.func)) {
         LOG(WARNING, ap.loc, out_)
             << ap.func
             << " is not traceable (either non-existing, inlined, or marked as "

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -600,7 +600,7 @@ void AttachedProbe::resolve_offset_kprobe(bool safe_mode)
 
 std::map<std::string, int> AttachedProbe::cached_prog_fds_;
 
-bool AttachedProbe::use_cached_progfd(void)
+bool AttachedProbe::use_cached_progfd(BPFfeature &feature)
 {
   // Enabled for so far only for kprobes/kretprobes
   if (probe_.type != ProbeType::kprobe && probe_.type != ProbeType::kretprobe)
@@ -609,6 +609,9 @@ bool AttachedProbe::use_cached_progfd(void)
   // Only for a wildcard probe which does not need expansion,
   // because we can have multiple programs attached to a single probe
   if (!has_wildcard(probe_.orig_name) || probe_.need_expansion)
+    return false;
+
+  if (feature.has_kprobe_multi())
     return false;
 
   // Keep map of loaded programs based on their 'orig_name',
@@ -683,7 +686,7 @@ void maybe_throw_helper_verifier_error(std::string_view log,
 
 void AttachedProbe::load_prog(BPFfeature &feature)
 {
-  if (use_cached_progfd())
+  if (use_cached_progfd(feature))
     return;
 
   auto &insns = prog_.getCode();

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -78,7 +78,7 @@ private:
   int detach_raw_tracepoint(void);
 
   static std::map<std::string, int> cached_prog_fds_;
-  bool use_cached_progfd(void);
+  bool use_cached_progfd(BPFfeature &feature);
   void cache_progfd(void);
 
   Probe &probe_;

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -43,7 +43,7 @@ private:
   std::string eventprefix() const;
   std::string eventname() const;
   void resolve_offset_kprobe(bool safe_mode);
-  bool resolve_offset_uprobe(bool safe_mode);
+  bool resolve_offset_uprobe(bool safe_mode, bool error_on_missing_symbol);
   void load_prog(BPFfeature &feature);
   void attach_multi_kprobe(void);
   void attach_multi_uprobe(int pid);

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -8,6 +8,7 @@
 #include "bpffeature.h"
 #include "bpfprogram.h"
 #include "btf.h"
+#include "config.h"
 #include "types.h"
 
 #include <bcc/libbpf.h>
@@ -23,13 +24,11 @@ public:
   AttachedProbe(Probe &probe,
                 BpfProgram &&prog,
                 bool safe_mode,
-                BPFfeature &feature,
-                BTF &btf);
+                BPFtrace &bpftrace);
   AttachedProbe(Probe &probe,
                 BpfProgram &&prog,
                 int pid,
-                BPFfeature &feature,
-                BTF &btf,
+                BPFtrace &bpftrace,
                 bool safe_mode = true);
   ~AttachedProbe();
   AttachedProbe(const AttachedProbe &) = delete;
@@ -43,7 +42,7 @@ private:
   std::string eventprefix() const;
   std::string eventname() const;
   void resolve_offset_kprobe(bool safe_mode);
-  bool resolve_offset_uprobe(bool safe_mode, bool error_on_missing_symbol);
+  bool resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps);
   void load_prog(BPFfeature &feature);
   void attach_multi_kprobe(void);
   void attach_multi_uprobe(int pid);
@@ -91,7 +90,7 @@ private:
   std::function<void()> usdt_destructor_;
   USDTHelper usdt_helper;
 
-  BTF &btf_;
+  BPFtrace &bpftrace_;
 };
 
 class HelperVerifierError : public std::runtime_error {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -155,7 +155,7 @@ int BPFtrace::add_probe(const ast::AttachPoint &ap,
         resources.probes.push_back(std::move(pair.second));
       }
     } else {
-      probe.funcs.assign(matches.begin(), matches.end());
+      probe.funcs = std::vector<std::string>(matches.begin(), matches.end());
       resources.probes.push_back(std::move(probe));
     }
   } else if (probetype(ap.provider) == ProbeType::uprobe) {
@@ -677,8 +677,8 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_usdt_probe(
 
   if (feature_->has_uprobe_refcnt() ||
       !(file_activation && probe.path.size())) {
-    ret.emplace_back(std::make_unique<AttachedProbe>(
-        probe, std::move(program), pid, *feature_, *btf_));
+    ret.emplace_back(
+        std::make_unique<AttachedProbe>(probe, std::move(program), pid, *this));
     return ret;
   }
 
@@ -732,7 +732,7 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_usdt_probe(
       }
 
       ret.emplace_back(std::make_unique<AttachedProbe>(
-          probe, std::move(program), pid_parsed, *feature_, *btf_));
+          probe, std::move(program), pid_parsed, *this));
       break;
     }
   }
@@ -801,16 +801,16 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_probe(
     } else if (probe.type == ProbeType::uprobe ||
                probe.type == ProbeType::uretprobe) {
       ret.emplace_back(std::make_unique<AttachedProbe>(
-          probe, std::move(*program), pid, *feature_, *btf_, safe_mode_));
+          probe, std::move(*program), pid, *this, safe_mode_));
       return ret;
     } else if (probe.type == ProbeType::watchpoint ||
                probe.type == ProbeType::asyncwatchpoint) {
       ret.emplace_back(std::make_unique<AttachedProbe>(
-          probe, std::move(*program), pid, *feature_, *btf_));
+          probe, std::move(*program), pid, *this));
       return ret;
     } else {
       ret.emplace_back(std::make_unique<AttachedProbe>(
-          probe, std::move(*program), safe_mode_, *feature_, *btf_));
+          probe, std::move(*program), safe_mode_, *this));
       return ret;
     }
   } catch (const EnospcException &e) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -24,6 +24,8 @@ Config::Config(bool has_cmd, bool bt_verbose) : bt_verbose_(bt_verbose)
     { ConfigKeyInt::perf_rb_pages, { .value = (uint64_t)64 } },
     { ConfigKeyStackMode::default_, { .value = StackMode::bpftrace } },
     { ConfigKeyString::str_trunc_trailer, { .value = std::string("..") } },
+    { ConfigKeyMissingProbes::default_,
+      { .value = ConfigMissingProbes::warn } },
     // by default, cache user symbols per program if ASLR is disabled on system
     // or `-c` option is given
     { ConfigKeyUserSymbolCacheType::default_,
@@ -141,6 +143,23 @@ bool ConfigSetter::set_user_symbol_cache_type(const std::string &s)
     return false;
   }
   return config_.set(ConfigKeyUserSymbolCacheType::default_, usct, source_);
+}
+
+bool ConfigSetter::set_missing_probes_config(const std::string &s)
+{
+  ConfigMissingProbes mp;
+  if (s == "ignore") {
+    mp = ConfigMissingProbes::ignore;
+  } else if (s == "warn") {
+    mp = ConfigMissingProbes::warn;
+  } else if (s == "error") {
+    mp = ConfigMissingProbes::error;
+  } else {
+    LOG(ERROR) << "Invalid value for missing_probes: valid values are "
+                  "\"ignore\", \"warn\", and \"error\".";
+    return false;
+  }
+  return config_.set(ConfigKeyMissingProbes::default_, mp, source_);
 }
 
 } // namespace bpftrace

--- a/src/config.h
+++ b/src/config.h
@@ -51,11 +51,22 @@ enum class ConfigKeyUserSymbolCacheType {
   default_,
 };
 
+enum class ConfigMissingProbes {
+  ignore,
+  warn,
+  error,
+};
+
+enum class ConfigKeyMissingProbes {
+  default_,
+};
+
 typedef std::variant<ConfigKeyBool,
                      ConfigKeyInt,
                      ConfigKeyString,
                      ConfigKeyStackMode,
-                     ConfigKeyUserSymbolCacheType>
+                     ConfigKeyUserSymbolCacheType,
+                     ConfigKeyMissingProbes>
     ConfigKey;
 
 // The strings in CONFIG_KEY_MAP AND ENV_ONLY match the env variables (minus the
@@ -75,6 +86,7 @@ const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
   { "probe_inline", ConfigKeyBool::probe_inline },
   { "stack_mode", ConfigKeyStackMode::default_ },
   { "str_trunc_trailer", ConfigKeyString::str_trunc_trailer },
+  { "missing_probes", ConfigKeyMissingProbes::default_ },
 };
 
 // These are not tracked by the config class
@@ -85,7 +97,12 @@ const std::set<std::string> ENV_ONLY = {
 
 struct ConfigValue {
   ConfigSource source = ConfigSource::default_;
-  std::variant<bool, uint64_t, std::string, StackMode, UserSymbolCacheType>
+  std::variant<bool,
+               uint64_t,
+               std::string,
+               StackMode,
+               UserSymbolCacheType,
+               ConfigMissingProbes>
       value;
 };
 
@@ -116,6 +133,11 @@ public:
   UserSymbolCacheType get(ConfigKeyUserSymbolCacheType key) const
   {
     return get<UserSymbolCacheType>(key);
+  }
+
+  ConfigMissingProbes get(ConfigKeyMissingProbes key) const
+  {
+    return get<ConfigMissingProbes>(key);
   }
 
   static std::optional<StackMode> get_stack_mode(const std::string &s);
@@ -194,8 +216,14 @@ public:
     return config_.set(ConfigKeyUserSymbolCacheType::default_, val, source_);
   }
 
+  bool set(ConfigMissingProbes val)
+  {
+    return config_.set(ConfigKeyMissingProbes::default_, val, source_);
+  }
+
   bool set_stack_mode(const std::string &s);
   bool set_user_symbol_cache_type(const std::string &s);
+  bool set_missing_probes_config(const std::string &s);
 
   Config &config_;
 

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -52,6 +52,10 @@ TEST(Config, get_and_set)
   EXPECT_TRUE(config_setter.set(UserSymbolCacheType::per_program));
   EXPECT_EQ(config.get(ConfigKeyUserSymbolCacheType::default_),
             UserSymbolCacheType::per_program);
+
+  EXPECT_TRUE(config_setter.set(ConfigMissingProbes::ignore));
+  EXPECT_EQ(config.get(ConfigKeyMissingProbes::default_),
+            ConfigMissingProbes::ignore);
 }
 
 TEST(Config, get_config_key)
@@ -91,6 +95,19 @@ TEST(ConfigSetter, set_user_symbol_cache_type)
   EXPECT_TRUE(config_setter.set_user_symbol_cache_type("NONE"));
   EXPECT_EQ(config.get(ConfigKeyUserSymbolCacheType::default_),
             UserSymbolCacheType::none);
+}
+
+TEST(ConfigSetter, set_missing_probes)
+{
+  auto config = Config();
+  auto config_setter = ConfigSetter(config, ConfigSource::script);
+
+  EXPECT_EQ(config.get(ConfigKeyMissingProbes::default_),
+            ConfigMissingProbes::warn);
+  EXPECT_FALSE(config_setter.set_missing_probes_config("invalid"));
+  EXPECT_TRUE(config_setter.set_missing_probes_config("error"));
+  EXPECT_EQ(config.get(ConfigKeyMissingProbes::default_),
+            ConfigMissingProbes::error);
 }
 
 TEST(ConfigSetter, source_precedence)

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -336,6 +336,12 @@ EXPECT_REGEX arg0: [0-9]*
 TIMEOUT 5
 AFTER ./testprogs/uprobe_test
 
+NAME uprobe_warn_missing_probes
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
+EXPECT WARNING: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3, skipping probe.
+TIMEOUT 5
+AFTER ./testprogs/uprobe_test
+
 NAME uretprobe
 PROG uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}
 EXPECT_REGEX readline: [0-9]*

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -234,6 +234,22 @@ TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 WILL_FAIL
 
+NAME kprobe_warn_missing_probes
+PROG kprobe:vfs_read,kprobe:nonsense { exit(); }
+EXPECT WARNING: could not attach probe kprobe:nonsense, skipping.
+TIMEOUT 5
+
+NAME kprobe_ignore_missing_probes
+PROG config = { missing_probes = "ignore" } kprobe:vfs_read,kprobe:nonsense { exit(); }
+EXPECT_NONE WARNING: could not attach probe kprobe:nonsense, skipping.
+TIMEOUT 5
+
+NAME kprobe_error_missing_probes
+PROG config = { missing_probes = "error" } kprobe:vfs_read,kprobe:nonsense { exit(); }
+EXPECT ERROR: Error attaching probe: kprobe:nonsense
+TIMEOUT 5
+WILL_FAIL
+
 NAME kretprobe
 PROG kretprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
@@ -341,6 +357,19 @@ PROG uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_te
 EXPECT WARNING: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3, skipping probe.
 TIMEOUT 5
 AFTER ./testprogs/uprobe_test
+
+NAME uprobe_ignore_missing_probes
+PROG config = { missing_probes = "ignore" } uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
+EXPECT_NONE WARNING: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3, skipping probe.
+TIMEOUT 5
+AFTER ./testprogs/uprobe_test
+
+NAME uprobe_error_missing_probes
+PROG config = { missing_probes = "error" } uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
+EXPECT ERROR: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3, cannot attach probe.
+TIMEOUT 5
+AFTER ./testprogs/uprobe_test
+WILL_FAIL
 
 NAME uretprobe
 PROG uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}

--- a/tools/biolatency-kp.bt
+++ b/tools/biolatency-kp.bt
@@ -11,6 +11,8 @@
  * 13-Sep-2018	Brendan Gregg	Created this.
  */
 
+config = { missing_probes = "ignore" }
+
 BEGIN
 {
 	printf("Tracing block device I/O... Hit Ctrl-C to end.\n");

--- a/tools/biostacks.bt
+++ b/tools/biostacks.bt
@@ -13,6 +13,8 @@
  * 19-Mar-2019  Brendan Gregg   Created this.
  */
 
+config = { missing_probes = "ignore" }
+
 BEGIN
 {
 	printf("Tracing block I/O with init stacks. Hit Ctrl-C to end.\n");

--- a/tools/gethostlatency.bt
+++ b/tools/gethostlatency.bt
@@ -19,6 +19,8 @@
  * 08-Sep-2018	Brendan Gregg	Created this.
  */
 
+config = { missing_probes = "ignore" }
+
 BEGIN
 {
 	printf("Tracing getaddr/gethost calls... Hit Ctrl-C to end.\n");

--- a/tools/ssllatency.bt
+++ b/tools/ssllatency.bt
@@ -11,6 +11,8 @@
  * 17-Dec-2021	Tao Xu	created this.
  */
 
+config = { missing_probes = "ignore" }
+
 BEGIN
 {
 	printf("Tracing SSL/TLS handshake... Hit Ctrl-C to end.\n");

--- a/tools/sslsnoop.bt
+++ b/tools/sslsnoop.bt
@@ -12,6 +12,8 @@
  * 15-Dec-2021	Tao Xu	created this.
  */
 
+config = { missing_probes = "ignore" }
+
 BEGIN
 {
 	printf("Tracing SSL/TLS handshake... Hit Ctrl-C to end.\n");

--- a/tools/swapin.bt
+++ b/tools/swapin.bt
@@ -14,10 +14,12 @@
  * 31-May-2024  Rong Tao        Add folio support.
  */
 
+config = { missing_probes = "ignore" }
+
 /**
  * kernel commit c9bdf768dd93("mm: convert swap_readpage() to swap_read_folio()")
- * convert swap_readpage() to swap_read_folio(), try attaching two kprobes, one
- * will trigger a warning and the other will be attached successfully.
+ * convert swap_readpage() to swap_read_folio(), try attaching two kprobes,
+ * only one will succeed and the other will be silently ignored.
  */
 kprobe:swap_readpage,
 kprobe:swap_read_folio

--- a/tools/threadsnoop.bt
+++ b/tools/threadsnoop.bt
@@ -13,6 +13,8 @@
  * 15-Feb-2019  Brendan Gregg   Created this.
  */
 
+config = { missing_probes = "ignore" }
+
 BEGIN
 {
 	printf("%-15s %7s %-16s %s\n", "TIME", "PID", "COMM", "FUNC");

--- a/tools/xfsdist.bt
+++ b/tools/xfsdist.bt
@@ -16,6 +16,8 @@
  * 08-Sep-2018	Brendan Gregg	Created this.
  */
 
+config = { missing_probes = "ignore" }
+
 BEGIN
 {
 	printf("Tracing XFS operation latency... Hit Ctrl-C to end.\n");


### PR DESCRIPTION
For kprobes and uprobes, when a probe is attaching to multiple functions, we do not fail when some functions do not exist. The reason is that k(u)probes are dynamic events which regularly change between versions of kernel/binaries and we want to allow the tools to attach to all potential events while expecting some attachments to fail.

The problem is that we're not doing the ignoring consistently. For kprobes, we always show a warning if an attachment fails. For uprobes, bpftrace currently fails due to #3235 but even without the bug, we would just silently ignore the missing functions.

This PR unifies the approaches by always showing the warning. In addition, it adds a new config option `warn_missing_probes`, by default set to true, which allows to turn the warnings off. This is done for all the shipped tools.

Fixes #3235.

The first commit also fixes another attachment issue caused by a combination of kprobe_multi and progfd caching. See the commit message for details.

Note: one potential problem with ignoring missing probe warnings is that when all attach points of a probe are missing, the probe will not be attached at all without any warning. Normally, this is IMHO fine as the user must have requested to ignore warnings so he must be prepared that this may happen. The only problem is the shipped `xfsdist.bt` tool which behaves like this when the XFS module is not loaded but I wouldn't expect people to try to trace XFS calls without XFS being present on their system.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
