### PR TITLE
runtime: runner: Properly escape special sequences

### DIFF
--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -211,9 +211,9 @@ class Runner(object):
             try:
                 if expect.mode == "text":
                     # Raw text match on an entire line, ignoring leading/trailing whitespace
-                    return re.search(f"^\s*{re.escape(expect.expect)}\s*$", output, re.M)
+                    return re.search(f"^\\s*{re.escape(expect.expect)}\\s*$", output, re.M)
                 elif expect.mode == "text_none":
-                    return not re.search(f"^\s*{re.escape(expect.expect)}\s*$", output, re.M)
+                    return not re.search(f"^\\s*{re.escape(expect.expect)}\\s*$", output, re.M)
                 elif expect.mode == "regex":
                     return re.search(expect.expect, output, re.M)
                 elif expect.mode == "regex_none":


### PR DESCRIPTION
I was seeing the following warning when running runtime tests:

```
/home/dxu/dev/bpftrace2/build/tests/runtime/engine/runner.py:214: SyntaxWarning: invalid escape sequence '\s'
  return re.search(f"^\s*{re.escape(expect.expect)}\s*$", output, re.M)
/home/dxu/dev/bpftrace2/build/tests/runtime/engine/runner.py:214: SyntaxWarning: invalid escape sequence '\s'
  return re.search(f"^\s*{re.escape(expect.expect)}\s*$", output, re.M)
/home/dxu/dev/bpftrace2/build/tests/runtime/engine/runner.py:216: SyntaxWarning: invalid escape sequence '\s'
  return not re.search(f"^\s*{re.escape(expect.expect)}\s*$", output, re.M)
/home/dxu/dev/bpftrace2/build/tests/runtime/engine/runner.py:216: SyntaxWarning: invalid escape sequence '\s'
  return not re.search(f"^\s*{re.escape(expect.expect)}\s*$", output, re.M)
```

This seems legit. Fix by escaping the `\` in the special regex sequences.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
