### PR TITLE
Support big buf()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to
   - [#3228](https://github.com/bpftrace/bpftrace/pull/3228)
   - [#3237](https://github.com/bpftrace/bpftrace/pull/3237)
   - [#3245](https://github.com/bpftrace/bpftrace/pull/3245)
+  - [#3249](https://github.com/bpftrace/bpftrace/pull/3249)
 #### Deprecated
 - Deprecate `sarg` builtin
   - [#3095](https://github.com/bpftrace/bpftrace/pull/3095)

--- a/src/ast/async_event_types.cpp
+++ b/src/ast/async_event_types.cpp
@@ -53,10 +53,10 @@ std::vector<llvm::Type*> Strftime::asLLVMType(ast::IRBuilderBPF& b)
   };
 }
 
-std::vector<llvm::Type*> Buf::asLLVMType(ast::IRBuilderBPF& b, size_t length)
+std::vector<llvm::Type*> Buf::asLLVMType(ast::IRBuilderBPF& b, uint32_t length)
 {
   return {
-    b.getInt8Ty(),                               // buffer length
+    b.getInt32Ty(),                              // buffer length
     llvm::ArrayType::get(b.getInt8Ty(), length), // buffer content
   };
 }

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -68,14 +68,14 @@ struct Strftime {
 } __attribute__((packed));
 
 struct Buf {
-  uint8_t length;
+  uint32_t length;
   // Seems like GCC 7.4.x can't handle `char content[]`. Work around by using
   // 0 sized array (a GCC extension that clang also accepts:
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70932). It also looks like
   // the issue doesn't exist in GCC 7.5.x.
   char content[0];
 
-  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t length);
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, uint32_t length);
 } __attribute__((packed));
 
 struct HelperError {

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -155,7 +155,7 @@ void ResourceAnalyser::visit(Call &call)
       resources_.time_args.push_back(get_literal_string(*call.vargs->at(0)));
     else
       resources_.time_args.push_back("%H:%M:%S\n");
-  } else if (call.func == "str" || call.func == "path") {
+  } else if (call.func == "str" || call.func == "buf" || call.func == "path") {
     resources_.str_buffers++;
   } else if (call.func == "strftime") {
     resources_.strftime_args.push_back(get_literal_string(*call.vargs->at(0)));

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -760,7 +760,6 @@ void SemanticAnalyser::visit(Call &call)
       buffer_size = max_buffer_size;
     }
 
-    buffer_size++; // extra byte is used to embed the length of the buffer
     call.type = CreateBuffer(buffer_size);
     // Consider case : $a = buf("hi", 2); $b = buf("bye", 3);  $a == $b
     // The result of buf is copied to bpf stack. Hence kernel probe read

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -553,12 +553,14 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
             config_.get(ConfigKeyString::str_trunc_trailer).c_str()));
         break;
       }
-      case Type::buffer:
+      case Type::buffer: {
+        auto length =
+            reinterpret_cast<AsyncEvent::Buf *>(arg_data + arg.offset)->length;
         arg_values.push_back(std::make_unique<PrintableBuffer>(
             reinterpret_cast<AsyncEvent::Buf *>(arg_data + arg.offset)->content,
-            reinterpret_cast<AsyncEvent::Buf *>(arg_data + arg.offset)
-                ->length));
+            length));
         break;
+      }
       case Type::ksym:
         arg_values.push_back(std::make_unique<PrintableString>(resolve_ksym(
             *reinterpret_cast<uint64_t *>(arg_data + arg.offset))));

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -115,8 +115,9 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       return std::string(p, strnlen(p, arg.GetSize()));
     }
     case Type::buffer: {
-      auto p = static_cast<const char *>(data) + 1;
-      return hex_format_buffer(p, arg.GetSize() - 1);
+      auto p = reinterpret_cast<const AsyncEvent::Buf *>(data)->content;
+      auto len = reinterpret_cast<const AsyncEvent::Buf *>(data)->length;
+      return hex_format_buffer(p, len);
     }
     case Type::pointer: {
       // use case: show me these pointer values

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -267,10 +267,12 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
                                  (uint8_t *)(value.data() + 8));
   else if (type.IsUsernameTy())
     return bpftrace.resolve_uid(read_data<uint64_t>(value.data()));
-  else if (type.IsBufferTy())
-    return bpftrace.resolve_buf(reinterpret_cast<char *>(value.data() + 1),
-                                *reinterpret_cast<uint8_t *>(value.data()));
-  else if (type.IsStringTy()) {
+  else if (type.IsBufferTy()) {
+    return bpftrace.resolve_buf(
+        reinterpret_cast<AsyncEvent::Buf *>(value.data())->content,
+        reinterpret_cast<AsyncEvent::Buf *>(value.data())->length);
+
+  } else if (type.IsStringTy()) {
     auto p = reinterpret_cast<const char *>(value.data());
     return std::string(p, strnlen(p, type.GetSize()));
   } else if (type.IsArrayTy()) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include <iostream>
 
+#include "ast/async_event_types.h"
 #include "bpftrace.h"
 #include "log.h"
 #include "struct.h"
@@ -434,7 +435,8 @@ SizedType CreateKSym()
 
 SizedType CreateBuffer(size_t size)
 {
-  return SizedType(Type::buffer, size);
+  auto metadata_headroom_bits = sizeof(AsyncEvent::Buf) * 8;
+  return SizedType(Type::buffer, size + metadata_headroom_bits);
 }
 
 SizedType CreateTimestamp()

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -6,61 +6,73 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
-%buffer_16_t = type { i8, [16 x i8] }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
+%buffer_16_t = type <{ i32, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !71 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %buffer = alloca %buffer_16_t, align 8
+  %lookup_str_key = alloca i32, align 4
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo", align 8
   store i64 0, i64* %"$foo", align 8
-  %2 = bitcast %buffer_16_t* %buffer to i8*
+  %2 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %3 = getelementptr %buffer_16_t, %buffer_16_t* %buffer, i32 0, i32 0
-  store i8 16, i8* %3, align 1
-  %4 = getelementptr %buffer_16_t, %buffer_16_t* %buffer, i32 0, i32 1
-  %5 = bitcast [16 x i8]* %4 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 16, i1 false)
-  %6 = load i64, i64* %"$foo", align 8
-  %7 = add i64 %6, 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %4, i32 16, i64 %7)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i32 0, i32* %lookup_str_key, align 4
+  %lookup_str_map = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @str_buffer, i32* %lookup_str_key)
+  %3 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %lookup_str_cond = icmp ne i8* %lookup_str_map, null
+  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
+
+lookup_str_failure:                               ; preds = %entry
+  ret i64 0
+
+lookup_str_merge:                                 ; preds = %entry
+  %4 = bitcast i8* %lookup_str_map to %buffer_16_t*
+  %5 = getelementptr %buffer_16_t, %buffer_16_t* %4, i32 0, i32 0
+  store i32 16, i32* %5, align 4
+  %6 = getelementptr %buffer_16_t, %buffer_16_t* %4, i32 0, i32 1
+  %7 = bitcast [16 x i8]* %6 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 16, i1 false)
+  %8 = load i64, i64* %"$foo", align 8
+  %9 = add i64 %8, 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %6, i32 16, i64 %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %buffer_16_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %buffer_16_t* %buffer, i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast %buffer_16_t* %buffer to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %buffer_16_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %buffer_16_t* %4, i64 0)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!56}
+!llvm.dbg.cu = !{!67}
+!llvm.module.flags = !{!70}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -83,10 +95,10 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 136, elements: !23)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 384, elements: !23)
 !22 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !23 = !{!24}
-!24 = !DISubrange(count: 17, lowerBound: 0)
+!24 = !DISubrange(count: 48, lowerBound: 0)
 !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
 !26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
 !27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
@@ -102,26 +114,40 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !37 = !{!38}
 !38 = !DISubrange(count: 262144, lowerBound: 0)
 !39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!40 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
 !41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
 !42 = !{!43, !48, !49, !52}
 !43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !46)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
 !46 = !{!47}
-!47 = !DISubrange(count: 2, lowerBound: 0)
+!47 = !DISubrange(count: 6, lowerBound: 0)
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
 !49 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !50, size: 64, offset: 128)
 !50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
 !51 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
-!54 = !{}
-!55 = !{!0, !25, !39}
-!56 = !{i32 2, !"Debug Info Version", i32 3}
-!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!58 = !DISubroutineType(types: !59)
-!59 = !{!18, !60}
-!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)
+!52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !53, size: 64, offset: 192)
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !55)
+!55 = !{!56}
+!56 = !DISubrange(count: 64, lowerBound: 0)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
+!60 = !{!61, !48, !49, !66}
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
+!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !64)
+!64 = !{!65}
+!65 = !DISubrange(count: 2, lowerBound: 0)
+!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!67 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !68, globals: !69)
+!68 = !{}
+!69 = !{!0, !25, !39, !57}
+!70 = !{i32 2, !"Debug Info Version", i32 3}
+!71 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !67, retainedNodes: !75)
+!72 = !DISubroutineType(types: !73)
+!73 = !{!18, !74}
+!74 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!75 = !{!76}
+!76 = !DILocalVariable(name: "ctx", arg: 1, scope: !71, file: !2, type: !74)

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -6,57 +6,69 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
-%buffer_1_t = type { i8, [1 x i8] }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
+%buffer_1_t = type <{ i32, [1 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !71 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %buffer = alloca %buffer_1_t, align 8
-  %1 = bitcast %buffer_1_t* %buffer to i8*
+  %lookup_str_key = alloca i32, align 4
+  %1 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = getelementptr %buffer_1_t, %buffer_1_t* %buffer, i32 0, i32 0
-  store i8 1, i8* %2, align 1
-  %3 = getelementptr %buffer_1_t, %buffer_1_t* %buffer, i32 0, i32 1
-  %4 = bitcast [1 x i8]* %3 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 1, i1 false)
-  %5 = bitcast i8* %0 to i64*
-  %6 = getelementptr i64, i64* %5, i64 14
-  %arg0 = load volatile i64, i64* %6, align 8
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([1 x i8]*, i32, i64)*)([1 x i8]* %3, i32 1, i64 %arg0)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %lookup_str_key, align 4
+  %lookup_str_map = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @str_buffer, i32* %lookup_str_key)
+  %2 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %lookup_str_cond = icmp ne i8* %lookup_str_map, null
+  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
+
+lookup_str_failure:                               ; preds = %entry
+  ret i64 0
+
+lookup_str_merge:                                 ; preds = %entry
+  %3 = bitcast i8* %lookup_str_map to %buffer_1_t*
+  %4 = getelementptr %buffer_1_t, %buffer_1_t* %3, i32 0, i32 0
+  store i32 1, i32* %4, align 4
+  %5 = getelementptr %buffer_1_t, %buffer_1_t* %3, i32 0, i32 1
+  %6 = bitcast [1 x i8]* %5 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 1, i1 false)
+  %7 = bitcast i8* %0 to i64*
+  %8 = getelementptr i64, i64* %7, i64 14
+  %arg0 = load volatile i64, i64* %8, align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([1 x i8]*, i32, i64)*)([1 x i8]* %5, i32 1, i64 %arg0)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %buffer_1_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %buffer_1_t* %buffer, i64 0)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %buffer_1_t* %buffer to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %buffer_1_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %buffer_1_t* %3, i64 0)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!67}
+!llvm.module.flags = !{!70}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -79,10 +91,10 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 16, elements: !23)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 264, elements: !23)
 !22 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !23 = !{!24}
-!24 = !DISubrange(count: 2, lowerBound: 0)
+!24 = !DISubrange(count: 33, lowerBound: 0)
 !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
 !26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
 !27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
@@ -98,24 +110,40 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !37 = !{!38}
 !38 = !DISubrange(count: 262144, lowerBound: 0)
 !39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!40 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
 !41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !46, !47, !50}
+!42 = !{!43, !48, !49, !52}
 !43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
-!46 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
-!47 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !48, size: 64, offset: 128)
-!48 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !49, size: 64)
-!49 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!50 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !25, !39}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !59)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!59 = !{!60}
-!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 6, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !50, size: 64, offset: 128)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !53, size: 64, offset: 192)
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !55)
+!55 = !{!56}
+!56 = !DISubrange(count: 64, lowerBound: 0)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
+!60 = !{!61, !48, !49, !66}
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
+!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !64)
+!64 = !{!65}
+!65 = !DISubrange(count: 2, lowerBound: 0)
+!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!67 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !68, globals: !69)
+!68 = !{}
+!69 = !{!0, !25, !39, !57}
+!70 = !{i32 2, !"Debug Info Version", i32 3}
+!71 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !67, retainedNodes: !75)
+!72 = !DISubroutineType(types: !73)
+!73 = !{!18, !74}
+!74 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!75 = !{!76}
+!76 = !DILocalVariable(name: "ctx", arg: 1, scope: !71, file: !2, type: !74)

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -6,45 +6,56 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
-%buffer_64_t = type { i8, [64 x i8] }
+%"struct map_t.2" = type { i8*, i8*, i8*, i8* }
+%buffer_60_t = type <{ i32, [60 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !71 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %buffer = alloca %buffer_64_t, align 8
+  %lookup_str_key = alloca i32, align 4
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 13
   %arg1 = load volatile i64, i64* %2, align 8
-  %length.cmp = icmp ule i64 %arg1, 64
-  %length.select = select i1 %length.cmp, i64 %arg1, i64 64
-  %3 = bitcast %buffer_64_t* %buffer to i8*
+  %length.cmp = icmp ule i64 %arg1, 60
+  %length.select = select i1 %length.cmp, i64 %arg1, i64 60
+  %3 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = getelementptr %buffer_64_t, %buffer_64_t* %buffer, i32 0, i32 0
-  %5 = trunc i64 %length.select to i8
-  store i8 %5, i8* %4, align 1
-  %6 = getelementptr %buffer_64_t, %buffer_64_t* %buffer, i32 0, i32 1
-  %7 = bitcast [64 x i8]* %6 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 64, i1 false)
-  %8 = bitcast i8* %0 to i64*
-  %9 = getelementptr i64, i64* %8, i64 14
-  %arg0 = load volatile i64, i64* %9, align 8
-  %10 = zext i8 %5 to i32
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %6, i32 %10, i64 %arg0)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 0, i64* %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %buffer_64_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %buffer_64_t* %buffer, i64 0)
+  store i32 0, i32* %lookup_str_key, align 4
+  %lookup_str_map = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @str_buffer, i32* %lookup_str_key)
+  %4 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %lookup_str_cond = icmp ne i8* %lookup_str_map, null
+  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
+
+lookup_str_failure:                               ; preds = %entry
+  ret i64 0
+
+lookup_str_merge:                                 ; preds = %entry
+  %5 = bitcast i8* %lookup_str_map to %buffer_60_t*
+  %6 = getelementptr %buffer_60_t, %buffer_60_t* %5, i32 0, i32 0
+  %7 = trunc i64 %length.select to i32
+  store i32 %7, i32* %6, align 4
+  %8 = getelementptr %buffer_60_t, %buffer_60_t* %5, i32 0, i32 1
+  %9 = bitcast [60 x i8]* %8 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 60, i1 false)
+  %10 = bitcast i8* %0 to i64*
+  %11 = getelementptr i64, i64* %10, i64 14
+  %arg0 = load volatile i64, i64* %11, align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([60 x i8]*, i32, i64)*)([60 x i8]* %8, i32 %7, i64 %arg0)
   %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %buffer_64_t* %buffer to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 0, i64* %"@x_key", align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %buffer_60_t*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %buffer_60_t* %5, i64 0)
+  %13 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
@@ -52,18 +63,18 @@ entry:
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!56}
+!llvm.dbg.cu = !{!67}
+!llvm.module.flags = !{!70}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -86,10 +97,10 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 520, elements: !23)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 736, elements: !23)
 !22 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !23 = !{!24}
-!24 = !DISubrange(count: 65, lowerBound: 0)
+!24 = !DISubrange(count: 92, lowerBound: 0)
 !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
 !26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
 !27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
@@ -105,26 +116,40 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !37 = !{!38}
 !38 = !DISubrange(count: 262144, lowerBound: 0)
 !39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!40 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
 !41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
 !42 = !{!43, !48, !49, !52}
 !43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !46)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
 !46 = !{!47}
-!47 = !DISubrange(count: 2, lowerBound: 0)
+!47 = !DISubrange(count: 6, lowerBound: 0)
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
 !49 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !50, size: 64, offset: 128)
 !50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
 !51 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
-!54 = !{}
-!55 = !{!0, !25, !39}
-!56 = !{i32 2, !"Debug Info Version", i32 3}
-!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!58 = !DISubroutineType(types: !59)
-!59 = !{!18, !60}
-!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)
+!52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !53, size: 64, offset: 192)
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !55)
+!55 = !{!56}
+!56 = !DISubrange(count: 64, lowerBound: 0)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
+!60 = !{!61, !48, !49, !66}
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
+!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !64)
+!64 = !{!65}
+!65 = !DISubrange(count: 2, lowerBound: 0)
+!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!67 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !68, globals: !69)
+!68 = !{}
+!69 = !{!0, !25, !39, !57}
+!70 = !{i32 2, !"Debug Info Version", i32 3}
+!71 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !67, retainedNodes: !75)
+!72 = !DISubroutineType(types: !73)
+!73 = !{!18, !74}
+!74 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!75 = !{!76}
+!76 = !DILocalVariable(name: "ctx", arg: 1, scope: !71, file: !2, type: !74)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3790,6 +3790,25 @@ kfunc:func_1,tracepoint:sched:sched_one { args }
 )");
 }
 
+TEST(semantic_analyser, buf_strlen_too_large)
+{
+  auto bpftrace = get_mock_bpftrace();
+  ConfigSetter configs{ bpftrace->config_, ConfigSource::script };
+  configs.set(ConfigKeyInt::max_strlen, 9999999999);
+
+  test_error(*bpftrace, "uprobe:/bin/sh:f { buf(arg0, 4) }", R"(
+stdin:1:20-32: ERROR: BPFTRACE_MAX_STRLEN too large to use on buffer (9999999999 > 4294967295)
+uprobe:/bin/sh:f { buf(arg0, 4) }
+                   ~~~~~~~~~~~~
+)");
+
+  test_error(*bpftrace, "uprobe:/bin/sh:f { buf(arg0) }", R"(
+stdin:1:20-29: ERROR: BPFTRACE_MAX_STRLEN too large to use on buffer (9999999999 > 4294967295)
+uprobe:/bin/sh:f { buf(arg0) }
+                   ~~~~~~~~~
+)");
+}
+
 } // namespace semantic_analyser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
Similar to big str() and big path(), this PR moves buf() over to new
scratch space infra. Users can now create arbitrary sized buf()s.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
