### PR TITLE
Disallow helpers accessing context in for-loops

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -199,6 +199,13 @@ public:
   std::string ident;
   int probe_id;
 
+  // Check if the builtin is 'arg0' - 'arg9'
+  bool is_argx() const
+  {
+    return !ident.compare(0, 3, "arg") && ident.size() == 4 &&
+           ident.at(3) >= '0' && ident.at(3) <= '9';
+  }
+
 private:
   Builtin(const Builtin &other) = default;
 };

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -405,10 +405,7 @@ void CodegenLLVM::visit(Builtin &builtin)
       Value *expr = expr_;
       expr_deleter_ = [this, expr]() { b_.CreateLifetimeEnd(expr); };
     }
-  } else if ((!builtin.ident.compare(0, 3, "arg") &&
-              builtin.ident.size() == 4 && builtin.ident.at(3) >= '0' &&
-              builtin.ident.at(3) <= '9') ||
-             builtin.ident == "retval") {
+  } else if (builtin.is_argx() || builtin.ident == "retval") {
     auto probe_type = probetype(current_attach_point_->provider);
 
     if (builtin.type.is_funcarg) {
@@ -429,8 +426,7 @@ void CodegenLLVM::visit(Builtin &builtin)
       return;
     }
 
-    if (!builtin.ident.compare(0, 3, "arg") &&
-        probe_type == ProbeType::rawtracepoint)
+    if (builtin.is_argx() && probe_type == ProbeType::rawtracepoint)
       expr_ = b_.CreateRawTracepointArg(ctx_, builtin.ident);
     else
       expr_ = b_.CreateRegisterRead(ctx_, builtin.ident);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -355,8 +355,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
                "using the 'probe' builtin instead.";
       }
     }
-  } else if (!builtin.ident.compare(0, 3, "arg") && builtin.ident.size() == 4 &&
-             builtin.ident.at(3) >= '0' && builtin.ident.at(3) <= '9') {
+  } else if (builtin.is_argx()) {
     auto probe = get_probe_from_scope(scope_, builtin.loc, builtin.ident);
     if (probe == nullptr)
       return;
@@ -2139,6 +2138,20 @@ void SemanticAnalyser::visit(For &f)
   loop_depth_++;
   accept_statements(f.stmts);
   loop_depth_--;
+
+  // Currently, we do not pass BPF context to the callback so disable builtins
+  // which require ctx access.
+  CollectNodes<Builtin> builtins;
+  for (auto *stmt : *f.stmts) {
+    builtins.run(*stmt);
+  }
+  for (const Builtin &builtin : builtins.nodes()) {
+    if (builtin.type.IsCtxAccess() || builtin.is_argx() ||
+        builtin.ident == "retval") {
+      LOG(ERROR, builtin.loc, err_)
+          << "'" << builtin.ident << "' builtin is not allowed in a for-loop";
+    }
+  }
 
   // Decl variable is not valid beyond this for-loop
   variable_val_[scope_].erase(decl_name);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3757,6 +3757,16 @@ BEGIN { @map[0] = 1; for ($kv : @map) { print($kv); } }
              false);
 }
 
+TEST(semantic_analyser, for_loop_no_ctx_access)
+{
+  test_error("kprobe:f { @map[0] = 1; for ($kv : @map) { arg0 } }",
+             R"(
+stdin:1:45-49: ERROR: 'arg0' builtin is not allowed in a for-loop
+kprobe:f { @map[0] = 1; for ($kv : @map) { arg0 } }
+                                            ~~~~
+)");
+}
+
 TEST_F(semantic_analyser_btf, args_builtin_mixed_probes)
 {
   test_error("kfunc:func_1,tracepoint:sched:sched_one { args }", R"(


### PR DESCRIPTION
Currently, we do not pass BPF context to the callback for the for-loop, so disable builtins which require ctx access. These are those with types marked as `IsCtxAccess` plus the `argX` and `retval` builtins.

This fixes the abort caused by #3182 and replaces it by a nicer error message.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
