### PR TITLE
Support printing large arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ and this project adheres to
   - [#3226](https://github.com/bpftrace/bpftrace/pull/3226)
 - Add config option for handling missing probes
   - [#3246](https://github.com/bpftrace/bpftrace/pull/3246)
+- Support large arguments for printf() and print()
+  - [#3252](https://github.com/bpftrace/bpftrace/pull/3252)
 #### Changed
 - Better error message for args in mixed probes
   - [#3047](https://github.com/bpftrace/bpftrace/pull/3047)
@@ -102,6 +104,8 @@ and this project adheres to
   - [#3228](https://github.com/bpftrace/bpftrace/pull/3228)
   - [#3237](https://github.com/bpftrace/bpftrace/pull/3237)
   - [#3245](https://github.com/bpftrace/bpftrace/pull/3245)
+- Increase default size of strings from 64 to 1024
+  - [#3252](https://github.com/bpftrace/bpftrace/pull/3252)
 #### Deprecated
 - Deprecate `sarg` builtin
   - [#3095](https://github.com/bpftrace/bpftrace/pull/3095)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -483,6 +483,17 @@ CallInst *IRBuilderBPF::CreateGetStrScratchMap(int idx,
                              idx);
 }
 
+CallInst *IRBuilderBPF::CreateGetFmtStringArgsScratchMap(
+    BasicBlock *failure_callback,
+    const location &loc)
+{
+  return createGetScratchMap(to_string(MapType::FmtStringArgs),
+                             "fmtstr",
+                             GET_PTR_TY(),
+                             loc,
+                             failure_callback);
+}
+
 /*
  * Failure to lookup a scratch map will result in a jump to the
  * failure_callback, if non-null.

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -174,6 +174,8 @@ public:
   CallInst *CreateGetStrScratchMap(int idx,
                                    BasicBlock *failure_callback,
                                    const location &loc);
+  CallInst *CreateGetFmtStringArgsScratchMap(BasicBlock *failure_callback,
+                                             const location &loc);
   void CreateCheckSetRecursion(const location &loc, int early_exit_ret);
   void CreateUnSetRecursion(const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -12,11 +12,6 @@
 #include "bpftrace.h"
 #include "types.h"
 
-#define CREATE_MEMCPY(dst, src, size, algn)                                    \
-  CreateMemCpy((dst), MaybeAlign(algn), (src), MaybeAlign(algn), (size))
-#define CREATE_MEMCPY_VOLATILE(dst, src, size, algn)                           \
-  CreateMemCpy((dst), MaybeAlign(algn), (src), MaybeAlign(algn), (size), true)
-
 #define CREATE_ATOMIC_RMW(op, ptr, val, align, order)                          \
   CreateAtomicRMW((op), (ptr), (val), MaybeAlign((align)), (order))
 
@@ -51,6 +46,7 @@ public:
                               const std::string &name = "");
   AllocaInst *CreateAllocaBPF(int bytes, const std::string &name = "");
   void CreateMemsetBPF(Value *ptr, Value *val, uint32_t size);
+  void CreateMemcpyBPF(Value *dst, Value *src, uint32_t size);
   llvm::Type *GetType(const SizedType &stype);
   llvm::Type *GetMapValueType(const SizedType &stype);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -78,7 +78,7 @@ public:
   void DumpIR(const std::string filename);
   void createFormatStringCall(Call &call,
                               int id,
-                              CallArgs &call_args,
+                              const CallArgs &call_args,
                               const std::string &call_name,
                               AsyncAction async_action);
 

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -1,5 +1,8 @@
 #include "resource_analyser.h"
 
+#include <algorithm>
+
+#include "ast/async_event_types.h"
 #include "bpftrace.h"
 #include "globalvars.h"
 #include "log.h"
@@ -83,7 +86,12 @@ void ResourceAnalyser::visit(Call &call)
 
   if (call.func == "printf" || call.func == "system" || call.func == "cat" ||
       call.func == "debugf") {
-    std::vector<Field> args;
+    // Implicit first field is the 64bit printf ID.
+    //
+    // Put it in initially so that offset and alignment calculation is
+    // accurate. We'll take it out before saving into resources.
+    std::vector<SizedType> args = { CreateInt64() };
+
     // NOTE: the same logic can be found in the semantic_analyser pass
     for (auto it = call.vargs.begin() + 1; it != call.vargs.end(); it++) {
       // Promote to 64-bit if it's not an aggregate type
@@ -91,13 +99,28 @@ void ResourceAnalyser::visit(Call &call)
       if (!ty.IsAggregate() && !ty.IsTimestampTy())
         ty.SetSize(8);
 
-      args.push_back(Field{
-          .name = "",
-          .type = ty,
-          .offset = 0,
-          .bitfield = std::nullopt,
-      });
+      args.push_back(ty);
     }
+
+    // It may seem odd that we're creating a tuple as part of format
+    // string analysis, but it kinda makes sense. When we transmit
+    // the format string from kernelspace to userspace, we are basically
+    // creating a tuple. Namely: a bunch of values without names, back to
+    // back, and with struct alignment rules.
+    //
+    // Thus, we are good to reuse the padding logic present in tuple
+    // creation to generate offsets for each argument in the args "tuple".
+    auto tuple = Struct::CreateTuple(args);
+
+    // Remove implicit printf ID field. Downstream consumers do not
+    // expect it nor do they care about it.
+    tuple->fields.erase(tuple->fields.begin());
+
+    // Keep track of max "tuple" size needed for fmt string args. Codegen
+    // will use this information to create a percpu array map of large
+    // enough size for all fmt string calls to use.
+    resources_.max_fmtstring_args_size = std::max(
+        resources_.max_fmtstring_args_size, static_cast<uint64_t>(tuple->size));
 
     auto fmtstr = get_literal_string(*call.vargs.at(0));
     if (call.func == "printf") {
@@ -105,14 +128,14 @@ void ResourceAnalyser::visit(Call &call)
           single_provider_type_postsema(probe_) == ProbeType::iter) {
         resources_.bpf_print_fmts.push_back(fmtstr);
       } else {
-        resources_.printf_args.emplace_back(fmtstr, args);
+        resources_.printf_args.emplace_back(fmtstr, tuple->fields);
       }
     } else if (call.func == "debugf") {
       resources_.bpf_print_fmts.push_back(fmtstr);
     } else if (call.func == "system") {
-      resources_.system_args.emplace_back(fmtstr, args);
+      resources_.system_args.emplace_back(fmtstr, tuple->fields);
     } else {
-      resources_.cat_args.emplace_back(fmtstr, args);
+      resources_.cat_args.emplace_back(fmtstr, tuple->fields);
     }
   } else if (call.func == "join") {
     auto delim = call.vargs.size() > 1 ? get_literal_string(*call.vargs.at(1))
@@ -164,13 +187,21 @@ void ResourceAnalyser::visit(Call &call)
   } else if (call.func == "strftime") {
     resources_.strftime_args.push_back(get_literal_string(*call.vargs.at(0)));
   } else if (call.func == "print") {
+    constexpr auto nonmap_headroom = sizeof(AsyncEvent::PrintNonMap);
     auto &arg = *call.vargs.at(0);
-    if (!arg.is_map)
+    if (!arg.is_map) {
       resources_.non_map_print_args.push_back(arg.type);
-    else {
+      resources_.max_fmtstring_args_size = std::max(
+          resources_.max_fmtstring_args_size,
+          nonmap_headroom + arg.type.GetSize());
+    } else {
       auto &map = static_cast<Map &>(arg);
-      if (map.vargs.size() > 0)
+      if (map.vargs.size() > 0) {
         resources_.non_map_print_args.push_back(map.type);
+        resources_.max_fmtstring_args_size = std::max(
+            resources_.max_fmtstring_args_size,
+            nonmap_headroom + map.type.GetSize());
+      }
     }
   } else if (call.func == "kstack" || call.func == "ustack") {
     resources_.stackid_maps.insert(call.type.stack_type);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2636,6 +2636,14 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
           << "String size mismatch: " << var_size << " != " << expr_size
           << ". The value may be truncated.";
     }
+    // Scratch variables are on stack. Big strings do not fit on the BPF stack.
+    if (is_final_pass() && expr_size > 200) {
+      LOG(ERROR, assignment.loc, err_)
+          << "Trying to store a big string "
+          << "(" << var_size << "B) on stack. "
+          << "It will not fit. Try storing in a map or only using str() in "
+          << "argument position for print()/printf() calls.";
+    }
   } else if (assignTy.IsBufferTy()) {
     auto var_size = storedTy.GetSize();
     auto expr_size = assignTy.GetSize();

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -64,6 +64,8 @@ std::string to_string(MapType t)
   switch (t) {
     case MapType::PerfEvent:
       return "perf_event";
+    case MapType::FmtStringArgs:
+      return "fmt_string_args";
     case MapType::Join:
       return "join";
     case MapType::Elapsed:

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -68,6 +68,7 @@ private:
 enum class MapType {
   // Also update to_string
   PerfEvent,
+  FmtStringArgs,
   Join,
   Elapsed,
   Ringbuf,

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -19,7 +19,7 @@ Config::Config(bool has_cmd)
     { ConfigKeyInt::max_cat_bytes, { .value = (uint64_t)10240 } },
     { ConfigKeyInt::max_map_keys, { .value = (uint64_t)4096 } },
     { ConfigKeyInt::max_probes, { .value = (uint64_t)512 } },
-    { ConfigKeyInt::max_strlen, { .value = (uint64_t)64 } },
+    { ConfigKeyInt::max_strlen, { .value = (uint64_t)1024 } },
     { ConfigKeyInt::max_type_res_iterations, { .value = (uint64_t)0 } },
     { ConfigKeyInt::perf_rb_pages, { .value = (uint64_t)64 } },
     { ConfigKeyStackMode::default_, { .value = StackMode::bpftrace } },

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,7 +134,7 @@ void usage()
   std::cerr << "    BPFTRACE_MAX_CAT_BYTES            [default: 10k] maximum bytes read by cat builtin" << std::endl;
   std::cerr << "    BPFTRACE_MAX_MAP_KEYS             [default: 4096] max keys in a map" << std::endl;
   std::cerr << "    BPFTRACE_MAX_PROBES               [default: 512] max number of probes" << std::endl;
-  std::cerr << "    BPFTRACE_MAX_STRLEN               [default: 64] bytes on BPF stack per str()" << std::endl;
+  std::cerr << "    BPFTRACE_MAX_STRLEN               [default: 1024] bytes on BPF stack per str()" << std::endl;
   std::cerr << "    BPFTRACE_MAX_TYPE_RES_ITERATIONS  [default: 0] number of levels of nested field accesses for tracepoint args" << std::endl;
   std::cerr << "    BPFTRACE_PERF_RB_PAGES            [default: 64] pages per CPU to allocate for ring buffer" << std::endl;
   std::cerr << "    BPFTRACE_STACK_MODE               [default: bpftrace] Output format for ustack and kstack builtins" << std::endl;

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -86,14 +86,16 @@ public:
   void load_state(const uint8_t *ptr, size_t len);
 
   // Async argument metadata
+  uint64_t max_fmtstring_args_size = 0;
+  std::vector<std::tuple<FormatString, std::vector<Field>>> printf_args;
   std::vector<std::tuple<FormatString, std::vector<Field>>> system_args;
   // fmt strings for BPF helpers (bpf_seq_printf, bpf_trace_printk)
   std::vector<FormatString> bpf_print_fmts;
+  std::vector<std::tuple<FormatString, std::vector<Field>>> cat_args;
   std::vector<std::string> join_args;
   std::vector<std::string> time_args;
   std::vector<std::string> strftime_args;
   std::vector<std::string> cgroup_path_args;
-  std::vector<std::tuple<FormatString, std::vector<Field>>> cat_args;
   std::vector<SizedType> non_map_print_args;
   std::vector<std::tuple<std::string, long>> skboutput_args_;
 
@@ -102,9 +104,6 @@ public:
   //
   // Don't add more async arguments here!.
   std::unordered_map<int64_t, struct HelperErrorInfo> helper_error_info;
-  // `printf_args` is created here but the field offsets are fixed up
-  // by codegen -- only codegen knows data layout to compute offsets
-  std::vector<std::tuple<FormatString, std::vector<Field>>> printf_args;
   std::vector<std::string> probe_ids;
 
   // Map metadata
@@ -141,6 +140,7 @@ private:
             non_map_print_args,
             // Hard to annotate flex types, so skip
             // helper_error_info,
+            max_fmtstring_args_size,
             printf_args,
             probe_ids,
             maps_info,

--- a/tests/codegen/llvm/call_cat.ll
+++ b/tests/codegen/llvm/call_cat.ll
@@ -5,36 +5,47 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %cat_t = type { i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
-  %cat_args = alloca %cat_t, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %cat_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %cat_args, i8 0, i64 8, i1 false)
-  %1 = getelementptr %cat_t, ptr %cat_args, i32 0, i32 0
+  %lookup_fmtstr_key = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 8, i1 false)
+  %1 = getelementptr %cat_t, ptr %lookup_fmtstr_map, i32 0, i32 0
   store i64 20000, ptr %1, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %cat_args, i64 8, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %cat_args)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -52,18 +63,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -101,13 +112,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 64, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 8, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/call_cgroup_path.ll
+++ b/tests/codegen/llvm/call_cgroup_path.ll
@@ -5,20 +5,22 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%print_cgroup_path_16_t = type <{ i64, i64, [16 x i8] }>
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %cgroup_path_t = type <{ i64, i64 }>
+%print_cgroup_path_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
-  %print_cgroup_path_16_t = alloca %print_cgroup_path_16_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %cgroup_path_args = alloca %cgroup_path_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %cgroup_path_args)
   %1 = getelementptr %cgroup_path_t, ptr %cgroup_path_args, i64 0, i32 0
@@ -26,27 +28,36 @@ entry:
   %get_cgroup_id = call i64 inttoptr (i64 80 to ptr)()
   %2 = getelementptr %cgroup_path_t, ptr %cgroup_path_args, i64 0, i32 1
   store i64 %get_cgroup_id, ptr %2, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_cgroup_path_16_t)
-  %3 = getelementptr %print_cgroup_path_16_t, ptr %print_cgroup_path_16_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  %3 = getelementptr %print_cgroup_path_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
   store i64 30007, ptr %3, align 8
-  %4 = getelementptr %print_cgroup_path_16_t, ptr %print_cgroup_path_16_t, i64 0, i32 1
+  %4 = getelementptr %print_cgroup_path_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
   store i64 0, ptr %4, align 8
-  %5 = getelementptr %print_cgroup_path_16_t, ptr %print_cgroup_path_16_t, i32 0, i32 2
+  %5 = getelementptr %print_cgroup_path_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %cgroup_path_args, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_cgroup_path_16_t, i64 32, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_cgroup_path_16_t)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -64,22 +75,22 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -117,13 +128,27 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 256, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 32, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -5,20 +5,22 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"int64_string[4]__tuple_t" = type { i64, [4 x i8] }
+%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
-  %print_tuple_16_t = alloca %print_tuple_16_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %tuple = alloca %"int64_string[4]__tuple_t", align 8
   %str = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
@@ -30,27 +32,36 @@ entry:
   %2 = getelementptr %"int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 4, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_tuple_16_t)
-  %3 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  %3 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
   store i64 30007, ptr %3, align 8
-  %4 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 1
+  %4 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
   store i64 0, ptr %4, align 8
-  %5 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i32 0, i32 2
+  %5 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_tuple_16_t, i64 32, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_tuple_16_t)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
@@ -83,8 +94,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -122,13 +133,27 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 256, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 32, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -5,40 +5,51 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
-  %print_integer_8_t = alloca %print_integer_8_t, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_integer_8_t)
-  %1 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
+  %lookup_fmtstr_key = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  %1 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
   store i64 30007, ptr %1, align 8
-  %2 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
+  %2 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
   store i64 0, ptr %2, align 8
-  %3 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
+  %3 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %3, i8 0, i64 8, i1 false)
   store i64 3, ptr %3, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_integer_8_t, i64 24, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_integer_8_t)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -56,18 +67,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -105,13 +116,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 192, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 24, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -5,30 +5,42 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
   %"struct Foo.l" = alloca i64, align 8
   %"struct Foo.c" = alloca i8, align 1
-  %printf_args = alloca %printf_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = getelementptr i64, ptr %0, i64 14
   %arg0 = load volatile i64, ptr %1, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 24, i1 false)
-  %2 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 24, i1 false)
+  %2 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
   store i64 0, ptr %2, align 8
   %3 = load i64, ptr %"$foo", align 8
   %4 = add i64 %3, 0
@@ -36,7 +48,7 @@ entry:
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.c", i32 1, i64 %4)
   %5 = load i8, ptr %"struct Foo.c", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.c")
-  %6 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
+  %6 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
   %7 = sext i8 %5 to i64
   store i64 %7, ptr %6, align 8
   %8 = load i64, ptr %"$foo", align 8
@@ -45,21 +57,20 @@ entry:
   %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, i64 %9)
   %10 = load i64, ptr %"struct Foo.l", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.l")
-  %11 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 2
+  %11 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 2
   store i64 %10, ptr %11, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 24, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -77,18 +88,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -126,13 +137,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 192, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 24, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -5,24 +5,36 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %strftime_t = type <{ i32, i32, i64 }>
 %printf_t = type { i64, [16 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
   %strftime_args = alloca %strftime_t, align 8
-  %printf_args = alloca %printf_t, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 24, i1 false)
-  %1 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  %lookup_fmtstr_key = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 24, i1 false)
+  %1 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
   store i64 0, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %strftime_args)
   %2 = getelementptr %strftime_t, ptr %strftime_args, i64 0, i32 0
@@ -32,21 +44,20 @@ entry:
   %get_ns = call i64 inttoptr (i64 125 to ptr)()
   %4 = getelementptr %strftime_t, ptr %strftime_args, i64 0, i32 2
   store i64 %get_ns, ptr %4, align 8
-  %5 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
+  %5 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %strftime_args, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 24, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -64,22 +75,22 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -117,13 +128,27 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 192, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 24, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/call_system.ll
+++ b/tests/codegen/llvm/call_system.ll
@@ -5,38 +5,49 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %system_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
-  %system_args = alloca %system_t, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %system_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %system_args, i8 0, i64 16, i1 false)
-  %1 = getelementptr %system_t, ptr %system_args, i32 0, i32 0
+  %lookup_fmtstr_key = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
+  %1 = getelementptr %system_t, ptr %lookup_fmtstr_map, i32 0, i32 0
   store i64 10000, ptr %1, align 8
-  %2 = getelementptr %system_t, ptr %system_args, i32 0, i32 1
+  %2 = getelementptr %system_t, ptr %lookup_fmtstr_map, i32 0, i32 1
   store i64 100, ptr %2, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %system_args, i64 16, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %system_args)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -54,18 +65,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -103,13 +114,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 16, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -5,19 +5,21 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
-  %printf_args = alloca %printf_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$s" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
@@ -33,30 +35,39 @@ if_body:                                          ; preds = %entry
   br label %if_end
 
 if_end:                                           ; preds = %else_body, %if_body
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 16, i1 false)
-  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %5 = load i64, ptr %"$s", align 8
-  %6 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
-  store i64 %5, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 16, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 else_body:                                        ; preds = %entry
   store i64 20, ptr %"$s", align 8
   br label %if_end
 
-event_loss_counter:                               ; preds = %if_end
+lookup_fmtstr_failure:                            ; preds = %if_end
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %if_end
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
+  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, ptr %4, align 8
+  %5 = load i64, ptr %"$s", align 8
+  %6 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %5, ptr %6, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %if_end
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -74,18 +85,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -123,13 +134,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 16, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -5,19 +5,21 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
-  %printf_args = alloca %printf_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ugt i64 %1, 10000
@@ -38,26 +40,35 @@ if_end:                                           ; preds = %if_end2, %entry
   ret i64 0
 
 if_body1:                                         ; preds = %if_body
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 8, i1 false)
-  %8 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
-  store i64 0, ptr %8, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 8, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 if_end2:                                          ; preds = %counter_merge, %if_body
   br label %if_end
 
-event_loss_counter:                               ; preds = %if_body1
+lookup_fmtstr_failure:                            ; preds = %if_body1
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %if_body1
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 8, i1 false)
+  %8 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, ptr %8, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %if_body1
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   br label %if_end2
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -75,18 +86,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -124,13 +135,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 64, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 8, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -5,19 +5,21 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
-  %printf_args = alloca %printf_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ugt i64 %1, 10000
@@ -26,30 +28,39 @@ entry:
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 16, i1 false)
-  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %5 = lshr i64 %get_pid_tgid1, 32
-  %6 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
-  store i64 %5, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 16, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 if_end:                                           ; preds = %counter_merge, %entry
   ret i64 0
 
-event_loss_counter:                               ; preds = %if_body
+lookup_fmtstr_failure:                            ; preds = %if_body
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %if_body
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
+  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, ptr %4, align 8
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %5 = lshr i64 %get_pid_tgid1, 32
+  %6 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %5, ptr %6, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %if_body
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -67,18 +78,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -116,13 +127,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 16, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -5,19 +5,21 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
-  %printf_args = alloca %printf_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$s" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
@@ -33,26 +35,35 @@ if_body:                                          ; preds = %entry
   br label %if_end
 
 if_end:                                           ; preds = %if_body, %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 16, i1 false)
-  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %if_end
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %if_end
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
+  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
   store i64 0, ptr %4, align 8
   %5 = load i64, ptr %"$s", align 8
-  %6 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
+  %6 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
   store i64 %5, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 16, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %if_end
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %if_end
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -70,18 +81,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -119,13 +130,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 16, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/kfunc_recursion_check.ll
+++ b/tests/codegen/llvm/kfunc_recursion_check.ll
@@ -6,21 +6,23 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @recursion_prevention = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kfunc_queued_spin_lock_slowpath_1(ptr %0) section "s_kfunc_queued_spin_lock_slowpath_1" !dbg !48 {
+define i64 @kfunc_queued_spin_lock_slowpath_1(ptr %0) section "s_kfunc_queued_spin_lock_slowpath_1" !dbg !58 {
 entry:
   %lookup_key12 = alloca i32, align 4
   %key6 = alloca i32, align 4
-  %print_integer_8_t = alloca %print_integer_8_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %key = alloca i32, align 4
   %lookup_key = alloca i32, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
@@ -40,17 +42,12 @@ lookup_failure:                                   ; preds = %entry
   ret i64 0
 
 lookup_merge:                                     ; preds = %lookup_success
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_integer_8_t)
-  %2 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
-  store i64 30007, ptr %2, align 8
-  %3 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
-  store i64 0, ptr %3, align 8
-  %4 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 8, i1 false)
-  store i64 2, ptr %4, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_integer_8_t, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 value_is_set:                                     ; preds = %lookup_success
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
@@ -60,7 +57,7 @@ value_is_set:                                     ; preds = %lookup_success
   br i1 %map_lookup_cond5, label %lookup_success2, label %lookup_failure3
 
 lookup_success2:                                  ; preds = %value_is_set
-  %5 = atomicrmw add ptr %lookup_elem1, i64 1 seq_cst, align 8
+  %2 = atomicrmw add ptr %lookup_elem1, i64 1 seq_cst, align 8
   br label %lookup_merge4
 
 lookup_failure3:                                  ; preds = %value_is_set
@@ -70,15 +67,29 @@ lookup_merge4:                                    ; preds = %lookup_failure3, %l
   call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
   ret i64 0
 
-event_loss_counter:                               ; preds = %lookup_merge
+lookup_fmtstr_failure:                            ; preds = %lookup_merge
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %lookup_merge
+  %3 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
+  store i64 30007, ptr %3, align 8
+  %4 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
+  store i64 0, ptr %4, align 8
+  %5 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
+  store i64 2, ptr %5, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key6)
   store i32 0, ptr %key6, align 4
   %lookup_elem7 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key6)
   %map_lookup_cond11 = icmp ne ptr %lookup_elem7, null
   br i1 %map_lookup_cond11, label %lookup_success8, label %lookup_failure9
 
-counter_merge:                                    ; preds = %lookup_merge10, %lookup_merge
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_integer_8_t)
+counter_merge:                                    ; preds = %lookup_merge10, %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key12)
   store i32 0, ptr %lookup_key12, align 4
   %lookup_elem13 = call ptr inttoptr (i64 1 to ptr)(ptr @recursion_prevention, ptr %lookup_key12)
@@ -118,11 +129,11 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
-define i64 @tracepoint_exceptions_page_fault_user_2(ptr %0) section "s_tracepoint_exceptions_page_fault_user_2" !dbg !55 {
+define i64 @tracepoint_exceptions_page_fault_user_2(ptr %0) section "s_tracepoint_exceptions_page_fault_user_2" !dbg !64 {
 entry:
   %lookup_key12 = alloca i32, align 4
   %key6 = alloca i32, align 4
-  %print_integer_8_t = alloca %print_integer_8_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %key = alloca i32, align 4
   %lookup_key = alloca i32, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
@@ -142,17 +153,12 @@ lookup_failure:                                   ; preds = %entry
   ret i64 0
 
 lookup_merge:                                     ; preds = %lookup_success
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_integer_8_t)
-  %2 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
-  store i64 30007, ptr %2, align 8
-  %3 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
-  store i64 1, ptr %3, align 8
-  %4 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 8, i1 false)
-  store i64 1, ptr %4, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_integer_8_t, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 value_is_set:                                     ; preds = %lookup_success
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
@@ -162,7 +168,7 @@ value_is_set:                                     ; preds = %lookup_success
   br i1 %map_lookup_cond5, label %lookup_success2, label %lookup_failure3
 
 lookup_success2:                                  ; preds = %value_is_set
-  %5 = atomicrmw add ptr %lookup_elem1, i64 1 seq_cst, align 8
+  %2 = atomicrmw add ptr %lookup_elem1, i64 1 seq_cst, align 8
   br label %lookup_merge4
 
 lookup_failure3:                                  ; preds = %value_is_set
@@ -172,15 +178,29 @@ lookup_merge4:                                    ; preds = %lookup_failure3, %l
   call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
   ret i64 1
 
-event_loss_counter:                               ; preds = %lookup_merge
+lookup_fmtstr_failure:                            ; preds = %lookup_merge
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %lookup_merge
+  %3 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
+  store i64 30007, ptr %3, align 8
+  %4 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
+  store i64 1, ptr %4, align 8
+  %5 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
+  store i64 1, ptr %5, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key6)
   store i32 0, ptr %key6, align 4
   %lookup_elem7 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key6)
   %map_lookup_cond11 = icmp ne ptr %lookup_elem7, null
   br i1 %map_lookup_cond11, label %lookup_success8, label %lookup_failure9
 
-counter_merge:                                    ; preds = %lookup_merge10, %lookup_merge
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_integer_8_t)
+counter_merge:                                    ; preds = %lookup_merge10, %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key12)
   store i32 0, ptr %lookup_key12, align 4
   %lookup_elem13 = call ptr inttoptr (i64 1 to ptr)(ptr @recursion_prevention, ptr %lookup_key12)
@@ -215,8 +235,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!45}
-!llvm.module.flags = !{!47}
+!llvm.dbg.cu = !{!55}
+!llvm.module.flags = !{!57}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "recursion_prevention", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -263,16 +283,25 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !43)
 !43 = !{!44}
 !44 = !DISubrange(count: 2, lowerBound: 0)
-!45 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !46)
-!46 = !{!0, !22, !36}
-!47 = !{i32 2, !"Debug Info Version", i32 3}
-!48 = distinct !DISubprogram(name: "kfunc_queued_spin_lock_slowpath_1", linkageName: "kfunc_queued_spin_lock_slowpath_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !45, retainedNodes: !53)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!21, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
+!47 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !48)
+!48 = !{!5, !11, !16, !49}
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !50, size: 64, offset: 192)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !52, size: 192, elements: !53)
 !52 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !53 = !{!54}
-!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
-!55 = distinct !DISubprogram(name: "tracepoint_exceptions_page_fault_user_2", linkageName: "tracepoint_exceptions_page_fault_user_2", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !45, retainedNodes: !56)
-!56 = !{!57}
-!57 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !51)
+!54 = !DISubrange(count: 24, lowerBound: 0)
+!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
+!56 = !{!0, !22, !36, !45}
+!57 = !{i32 2, !"Debug Info Version", i32 3}
+!58 = distinct !DISubprogram(name: "kfunc_queued_spin_lock_slowpath_1", linkageName: "kfunc_queued_spin_lock_slowpath_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
+!59 = !DISubroutineType(types: !60)
+!60 = !{!21, !61}
+!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)
+!64 = distinct !DISubprogram(name: "tracepoint_exceptions_page_fault_user_2", linkageName: "tracepoint_exceptions_page_fault_user_2", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !65)
+!65 = !{!66}
+!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !64, file: !2, type: !61)

--- a/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
@@ -6,21 +6,23 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @recursion_prevention = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kfunc_queued_spin_lock_slowpath_1(ptr %0) section "s_kfunc_queued_spin_lock_slowpath_1" !dbg !48 {
+define i64 @kfunc_queued_spin_lock_slowpath_1(ptr %0) section "s_kfunc_queued_spin_lock_slowpath_1" !dbg !58 {
 entry:
   %lookup_key19 = alloca i32, align 4
   %key13 = alloca i32, align 4
-  %print_integer_8_t = alloca %print_integer_8_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %lookup_key6 = alloca i32, align 4
   %key = alloca i32, align 4
   %lookup_key = alloca i32, align 4
@@ -74,17 +76,12 @@ pred_false:                                       ; preds = %lookup_merge
   br i1 %map_lookup_cond11, label %lookup_success8, label %lookup_failure9
 
 pred_true:                                        ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_integer_8_t)
-  %6 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
-  store i64 30007, ptr %6, align 8
-  %7 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
-  store i64 0, ptr %7, align 8
-  %8 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 8, i1 false)
-  store i64 2, ptr %8, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_integer_8_t, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 lookup_success8:                                  ; preds = %pred_false
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key6)
@@ -98,15 +95,29 @@ lookup_failure9:                                  ; preds = %pred_false
 lookup_merge10:                                   ; preds = %lookup_failure9, %lookup_success8
   ret i64 0
 
-event_loss_counter:                               ; preds = %pred_true
+lookup_fmtstr_failure:                            ; preds = %pred_true
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %pred_true
+  %6 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
+  store i64 30007, ptr %6, align 8
+  %7 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
+  store i64 0, ptr %7, align 8
+  %8 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 8, i1 false)
+  store i64 2, ptr %8, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key13)
   store i32 0, ptr %key13, align 4
   %lookup_elem14 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key13)
   %map_lookup_cond18 = icmp ne ptr %lookup_elem14, null
   br i1 %map_lookup_cond18, label %lookup_success15, label %lookup_failure16
 
-counter_merge:                                    ; preds = %lookup_merge17, %pred_true
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_integer_8_t)
+counter_merge:                                    ; preds = %lookup_merge17, %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key19)
   store i32 0, ptr %lookup_key19, align 4
   %lookup_elem20 = call ptr inttoptr (i64 1 to ptr)(ptr @recursion_prevention, ptr %lookup_key19)
@@ -150,8 +161,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!45}
-!llvm.module.flags = !{!47}
+!llvm.dbg.cu = !{!55}
+!llvm.module.flags = !{!57}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "recursion_prevention", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -198,13 +209,22 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !43)
 !43 = !{!44}
 !44 = !DISubrange(count: 2, lowerBound: 0)
-!45 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !46)
-!46 = !{!0, !22, !36}
-!47 = !{i32 2, !"Debug Info Version", i32 3}
-!48 = distinct !DISubprogram(name: "kfunc_queued_spin_lock_slowpath_1", linkageName: "kfunc_queued_spin_lock_slowpath_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !45, retainedNodes: !53)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!21, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
+!47 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !48)
+!48 = !{!5, !11, !16, !49}
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !50, size: 64, offset: 192)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !52, size: 192, elements: !53)
 !52 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !53 = !{!54}
-!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!54 = !DISubrange(count: 24, lowerBound: 0)
+!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
+!56 = !{!0, !22, !36, !45}
+!57 = !{i32 2, !"Debug Info Version", i32 3}
+!58 = distinct !DISubprogram(name: "kfunc_queued_spin_lock_slowpath_1", linkageName: "kfunc_queued_spin_lock_slowpath_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
+!59 = !DISubroutineType(types: !60)
+!60 = !{!21, !61}
+!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -5,16 +5,18 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64, i64, i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !39 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
   %"struct Foo.m16" = alloca i32, align 4
@@ -25,14 +27,24 @@ entry:
   %"&&_result5" = alloca i64, align 8
   %"struct Foo.m" = alloca i32, align 4
   %"&&_result" = alloca i64, align 8
-  %printf_args = alloca %printf_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   store i64 0, ptr %"$foo", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 40, i1 false)
-  %1 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 40, i1 false)
+  %1 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
   store i64 0, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
   %2 = load i64, ptr %"$foo", align 8
@@ -44,20 +56,20 @@ entry:
   %lhs_true_cond = icmp ne i32 %4, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
-"&&_lhs_true":                                    ; preds = %entry
+"&&_lhs_true":                                    ; preds = %lookup_fmtstr_merge
   br i1 false, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
   store i64 1, ptr %"&&_result", align 8
   br label %"&&_merge"
 
-"&&_false":                                       ; preds = %"&&_lhs_true", %entry
+"&&_false":                                       ; preds = %"&&_lhs_true", %lookup_fmtstr_merge
   store i64 0, ptr %"&&_result", align 8
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
   %5 = load i64, ptr %"&&_result", align 8
-  %6 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
+  %6 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
   store i64 %5, ptr %6, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result5")
   br i1 true, label %"&&_lhs_true1", label %"&&_false3"
@@ -82,7 +94,7 @@ entry:
 
 "&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
   %10 = load i64, ptr %"&&_result5", align 8
-  %11 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 2
+  %11 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 2
   store i64 %10, ptr %11, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
   %12 = load i64, ptr %"$foo", align 8
@@ -107,7 +119,7 @@ entry:
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
   %15 = load i64, ptr %"||_result", align 8
-  %16 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 3
+  %16 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 3
   store i64 %15, ptr %16, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result15")
   br i1 false, label %"||_true13", label %"||_lhs_false11"
@@ -132,9 +144,9 @@ entry:
 
 "||_merge14":                                     ; preds = %"||_true13", %"||_false12"
   %20 = load i64, ptr %"||_result15", align 8
-  %21 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 4
+  %21 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 4
   store i64 %20, ptr %21, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 40, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 40, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -146,7 +158,6 @@ event_loss_counter:                               ; preds = %"||_merge14"
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 counter_merge:                                    ; preds = %lookup_merge, %"||_merge14"
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -164,18 +175,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -213,13 +224,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 320, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 40, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/max_cast.ll
+++ b/tests/codegen/llvm/max_cast.ll
@@ -6,22 +6,24 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
+%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
+@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !72
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !77 {
 entry:
   %key = alloca i32, align 4
-  %print_integer_8_t = alloca %print_integer_8_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -76,66 +78,61 @@ min_max:                                          ; preds = %is_set, %lookup_suc
   br label %lookup_merge
 
 if_body:                                          ; preds = %while_end
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_integer_8_t)
-  %10 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
-  store i64 30007, ptr %10, align 8
-  %11 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
-  store i64 0, ptr %11, align 8
-  %12 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %12, i8 0, i64 8, i1 false)
-  store i64 6, ptr %12, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_integer_8_t, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 if_end:                                           ; preds = %counter_merge, %while_end
   ret i64 0
 
 while_cond:                                       ; preds = %min_max_merge, %lookup_merge
-  %13 = load i32, ptr @num_cpus, align 4
-  %14 = load i32, ptr %i, align 4
-  %num_cpu.cmp = icmp ult i32 %14, %13
+  %10 = load i32, ptr @num_cpus, align 4
+  %11 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %11, %10
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %15 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %15)
+  %12 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %12)
   %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  %16 = load i64, ptr %val_1, align 8
+  %13 = load i64, ptr %val_1, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  %17 = icmp sgt i64 %16, 5
-  %18 = zext i1 %17 to i64
-  %true_cond = icmp ne i64 %18, 0
+  %14 = icmp sgt i64 %13, 5
+  %15 = zext i1 %14 to i64
+  %true_cond = icmp ne i64 %15, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %19 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %20 = load i64, ptr %19, align 8
-  %21 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %22 = load i64, ptr %21, align 8
-  %val_set_cond = icmp eq i64 %22, 1
-  %23 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %val_1, align 8
-  %max_cond = icmp sgt i64 %20, %24
+  %16 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %17 = load i64, ptr %16, align 8
+  %18 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %19 = load i64, ptr %18, align 8
+  %val_set_cond = icmp eq i64 %19, 1
+  %20 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %20, 1
+  %21 = load i64, ptr %val_1, align 8
+  %max_cond = icmp sgt i64 %17, %21
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure3:                                  ; preds = %while_body
-  %25 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %25, 0
+  %22 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %22, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success2
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %20, ptr %val_1, align 8
+  store i64 %17, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -143,27 +140,41 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %max_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success2
-  %26 = load i32, ptr %i, align 4
-  %27 = add i32 %26, 1
-  store i32 %27, ptr %i, align 4
+  %23 = load i32, ptr %i, align 4
+  %24 = add i32 %23, 1
+  store i32 %24, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %28 = load i32, ptr %i, align 4
+  %25 = load i32, ptr %i, align 4
   br label %while_end
 
-event_loss_counter:                               ; preds = %if_body
+lookup_fmtstr_failure:                            ; preds = %if_body
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %if_body
+  %26 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
+  store i64 30007, ptr %26, align 8
+  %27 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
+  store i64 0, ptr %27, align 8
+  %28 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %28, i8 0, i64 8, i1 false)
+  store i64 6, ptr %28, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem4 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond8 = icmp ne ptr %lookup_elem4, null
   br i1 %map_lookup_cond8, label %lookup_success5, label %lookup_failure6
 
-counter_merge:                                    ; preds = %lookup_merge7, %if_body
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_integer_8_t)
+counter_merge:                                    ; preds = %lookup_merge7, %lookup_fmtstr_merge
   br label %if_end
 
 lookup_success5:                                  ; preds = %event_loss_counter
@@ -191,8 +202,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!59}
-!llvm.module.flags = !{!61}
+!llvm.dbg.cu = !{!74}
+!llvm.module.flags = !{!76}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -252,14 +263,28 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
-!60 = !{!0, !26, !40, !57}
-!61 = !{i32 2, !"Debug Info Version", i32 3}
-!62 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !67)
-!63 = !DISubroutineType(types: !64)
-!64 = !{!18, !65}
-!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
-!66 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!67 = !{!68}
-!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !65)
+!58 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
+!60 = !{!61, !49, !54, !66}
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
+!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !64)
+!64 = !{!65}
+!65 = !DISubrange(count: 6, lowerBound: 0)
+!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !67, size: 64, offset: 192)
+!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
+!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 192, elements: !70)
+!69 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!70 = !{!71}
+!71 = !DISubrange(count: 24, lowerBound: 0)
+!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
+!73 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!74 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !75)
+!75 = !{!0, !26, !40, !57, !72}
+!76 = !{i32 2, !"Debug Info Version", i32 3}
+!77 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !74, retainedNodes: !81)
+!78 = !DISubroutineType(types: !79)
+!79 = !{!18, !80}
+!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
+!81 = !{!82}
+!82 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !80)

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -6,20 +6,22 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
-%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 %"unsigned int64_max__tuple_t" = type { i64, i64 }
+%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
+@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !72
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !77 {
 entry:
   %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
@@ -70,9 +72,9 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !69 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !83 {
   %key1 = alloca i32, align 4
-  %print_tuple_16_t = alloca %print_tuple_16_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %tuple = alloca %"unsigned int64_max__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_max__tuple_t", align 8
   %val_2 = alloca i64, align 8
@@ -123,40 +125,35 @@ while_end:                                        ; preds = %error_failure, %err
   store i64 %12, ptr %15, align 8
   %16 = getelementptr %"unsigned int64_max__tuple_t", ptr %tuple, i32 0, i32 1
   store i64 %14, ptr %16, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_tuple_16_t)
-  %17 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, ptr %17, align 8
-  %18 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 1
-  store i64 0, ptr %18, align 8
-  %19 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %19, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %19, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_tuple_16_t, i64 32, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 lookup_success:                                   ; preds = %while_body
-  %20 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %21 = load i64, ptr %20, align 8
-  %22 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %23 = load i64, ptr %22, align 8
-  %val_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %24, 1
-  %25 = load i64, ptr %val_1, align 8
-  %max_cond = icmp sgt i64 %21, %25
+  %17 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %18 = load i64, ptr %17, align 8
+  %19 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %20 = load i64, ptr %19, align 8
+  %val_set_cond = icmp eq i64 %20, 1
+  %21 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %21, 1
+  %22 = load i64, ptr %val_1, align 8
+  %max_cond = icmp sgt i64 %18, %22
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %26 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %26, 0
+  %23 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %23, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %21, ptr %val_1, align 8
+  store i64 %18, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -164,27 +161,41 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %max_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
-  %27 = load i32, ptr %i, align 4
-  %28 = add i32 %27, 1
-  store i32 %28, ptr %i, align 4
+  %24 = load i32, ptr %i, align 4
+  %25 = add i32 %24, 1
+  store i32 %25, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %29 = load i32, ptr %i, align 4
+  %26 = load i32, ptr %i, align 4
   br label %while_end
 
-event_loss_counter:                               ; preds = %while_end
+lookup_fmtstr_failure:                            ; preds = %while_end
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %while_end
+  %27 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
+  store i64 30007, ptr %27, align 8
+  %28 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
+  store i64 0, ptr %28, align 8
+  %29 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %29, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %29, ptr align 1 %tuple, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
   store i32 0, ptr %key1, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
   %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
-counter_merge:                                    ; preds = %lookup_merge, %while_end
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_tuple_16_t)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
@@ -211,8 +222,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!59}
-!llvm.module.flags = !{!61}
+!llvm.dbg.cu = !{!74}
+!llvm.module.flags = !{!76}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -272,17 +283,31 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
-!60 = !{!0, !26, !40, !57}
-!61 = !{i32 2, !"Debug Info Version", i32 3}
-!62 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !67)
-!63 = !DISubroutineType(types: !64)
-!64 = !{!18, !65}
-!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
-!66 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!67 = !{!68}
-!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !65)
-!69 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !59, retainedNodes: !70)
+!58 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
+!60 = !{!61, !49, !54, !66}
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
+!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !64)
+!64 = !{!65}
+!65 = !DISubrange(count: 6, lowerBound: 0)
+!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !67, size: 64, offset: 192)
+!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
+!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 256, elements: !70)
+!69 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !70 = !{!71}
-!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !69, file: !2, type: !65)
+!71 = !DISubrange(count: 32, lowerBound: 0)
+!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
+!73 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!74 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !75)
+!75 = !{!0, !26, !40, !57, !72}
+!76 = !{i32 2, !"Debug Info Version", i32 3}
+!77 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !74, retainedNodes: !81)
+!78 = !DISubroutineType(types: !79)
+!79 = !{!18, !80}
+!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
+!81 = !{!82}
+!82 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !80)
+!83 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !74, retainedNodes: !84)
+!84 = !{!85}
+!85 = !DILocalVariable(name: "ctx", arg: 1, scope: !83, file: !2, type: !80)

--- a/tests/codegen/llvm/min_cast.ll
+++ b/tests/codegen/llvm/min_cast.ll
@@ -6,22 +6,24 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
+%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
+@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !72
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !77 {
 entry:
   %key = alloca i32, align 4
-  %print_integer_8_t = alloca %print_integer_8_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -76,66 +78,61 @@ min_max:                                          ; preds = %is_set, %lookup_suc
   br label %lookup_merge
 
 if_body:                                          ; preds = %while_end
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_integer_8_t)
-  %10 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
-  store i64 30007, ptr %10, align 8
-  %11 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
-  store i64 0, ptr %11, align 8
-  %12 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %12, i8 0, i64 8, i1 false)
-  store i64 6, ptr %12, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_integer_8_t, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 if_end:                                           ; preds = %counter_merge, %while_end
   ret i64 0
 
 while_cond:                                       ; preds = %min_max_merge, %lookup_merge
-  %13 = load i32, ptr @num_cpus, align 4
-  %14 = load i32, ptr %i, align 4
-  %num_cpu.cmp = icmp ult i32 %14, %13
+  %10 = load i32, ptr @num_cpus, align 4
+  %11 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %11, %10
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %15 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %15)
+  %12 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %12)
   %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  %16 = load i64, ptr %val_1, align 8
+  %13 = load i64, ptr %val_1, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  %17 = icmp sgt i64 %16, 5
-  %18 = zext i1 %17 to i64
-  %true_cond = icmp ne i64 %18, 0
+  %14 = icmp sgt i64 %13, 5
+  %15 = zext i1 %14 to i64
+  %true_cond = icmp ne i64 %15, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %19 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %20 = load i64, ptr %19, align 8
-  %21 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %22 = load i64, ptr %21, align 8
-  %val_set_cond = icmp eq i64 %22, 1
-  %23 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %val_1, align 8
-  %min_cond = icmp slt i64 %20, %24
+  %16 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %17 = load i64, ptr %16, align 8
+  %18 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %19 = load i64, ptr %18, align 8
+  %val_set_cond = icmp eq i64 %19, 1
+  %20 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %20, 1
+  %21 = load i64, ptr %val_1, align 8
+  %min_cond = icmp slt i64 %17, %21
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure3:                                  ; preds = %while_body
-  %25 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %25, 0
+  %22 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %22, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success2
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %20, ptr %val_1, align 8
+  store i64 %17, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -143,27 +140,41 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %min_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success2
-  %26 = load i32, ptr %i, align 4
-  %27 = add i32 %26, 1
-  store i32 %27, ptr %i, align 4
+  %23 = load i32, ptr %i, align 4
+  %24 = add i32 %23, 1
+  store i32 %24, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %28 = load i32, ptr %i, align 4
+  %25 = load i32, ptr %i, align 4
   br label %while_end
 
-event_loss_counter:                               ; preds = %if_body
+lookup_fmtstr_failure:                            ; preds = %if_body
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %if_body
+  %26 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
+  store i64 30007, ptr %26, align 8
+  %27 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
+  store i64 0, ptr %27, align 8
+  %28 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %28, i8 0, i64 8, i1 false)
+  store i64 6, ptr %28, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem4 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond8 = icmp ne ptr %lookup_elem4, null
   br i1 %map_lookup_cond8, label %lookup_success5, label %lookup_failure6
 
-counter_merge:                                    ; preds = %lookup_merge7, %if_body
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_integer_8_t)
+counter_merge:                                    ; preds = %lookup_merge7, %lookup_fmtstr_merge
   br label %if_end
 
 lookup_success5:                                  ; preds = %event_loss_counter
@@ -191,8 +202,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!59}
-!llvm.module.flags = !{!61}
+!llvm.dbg.cu = !{!74}
+!llvm.module.flags = !{!76}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -252,14 +263,28 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
-!60 = !{!0, !26, !40, !57}
-!61 = !{i32 2, !"Debug Info Version", i32 3}
-!62 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !67)
-!63 = !DISubroutineType(types: !64)
-!64 = !{!18, !65}
-!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
-!66 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!67 = !{!68}
-!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !65)
+!58 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
+!60 = !{!61, !49, !54, !66}
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
+!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !64)
+!64 = !{!65}
+!65 = !DISubrange(count: 6, lowerBound: 0)
+!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !67, size: 64, offset: 192)
+!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
+!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 192, elements: !70)
+!69 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!70 = !{!71}
+!71 = !DISubrange(count: 24, lowerBound: 0)
+!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
+!73 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!74 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !75)
+!75 = !{!0, !26, !40, !57, !72}
+!76 = !{i32 2, !"Debug Info Version", i32 3}
+!77 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !74, retainedNodes: !81)
+!78 = !DISubroutineType(types: !79)
+!79 = !{!18, !80}
+!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
+!81 = !{!82}
+!82 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !80)

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -6,20 +6,22 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
-%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 %"unsigned int64_min__tuple_t" = type { i64, i64 }
+%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
+@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !72
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !77 {
 entry:
   %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
@@ -70,9 +72,9 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !69 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !83 {
   %key1 = alloca i32, align 4
-  %print_tuple_16_t = alloca %print_tuple_16_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %tuple = alloca %"unsigned int64_min__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_min__tuple_t", align 8
   %val_2 = alloca i64, align 8
@@ -123,40 +125,35 @@ while_end:                                        ; preds = %error_failure, %err
   store i64 %12, ptr %15, align 8
   %16 = getelementptr %"unsigned int64_min__tuple_t", ptr %tuple, i32 0, i32 1
   store i64 %14, ptr %16, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_tuple_16_t)
-  %17 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, ptr %17, align 8
-  %18 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 1
-  store i64 0, ptr %18, align 8
-  %19 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %19, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %19, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_tuple_16_t, i64 32, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 lookup_success:                                   ; preds = %while_body
-  %20 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %21 = load i64, ptr %20, align 8
-  %22 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %23 = load i64, ptr %22, align 8
-  %val_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %24, 1
-  %25 = load i64, ptr %val_1, align 8
-  %min_cond = icmp slt i64 %21, %25
+  %17 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %18 = load i64, ptr %17, align 8
+  %19 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %20 = load i64, ptr %19, align 8
+  %val_set_cond = icmp eq i64 %20, 1
+  %21 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %21, 1
+  %22 = load i64, ptr %val_1, align 8
+  %min_cond = icmp slt i64 %18, %22
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %26 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %26, 0
+  %23 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %23, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %21, ptr %val_1, align 8
+  store i64 %18, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -164,27 +161,41 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %min_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
-  %27 = load i32, ptr %i, align 4
-  %28 = add i32 %27, 1
-  store i32 %28, ptr %i, align 4
+  %24 = load i32, ptr %i, align 4
+  %25 = add i32 %24, 1
+  store i32 %25, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %29 = load i32, ptr %i, align 4
+  %26 = load i32, ptr %i, align 4
   br label %while_end
 
-event_loss_counter:                               ; preds = %while_end
+lookup_fmtstr_failure:                            ; preds = %while_end
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %while_end
+  %27 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
+  store i64 30007, ptr %27, align 8
+  %28 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
+  store i64 0, ptr %28, align 8
+  %29 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %29, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %29, ptr align 1 %tuple, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
   store i32 0, ptr %key1, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
   %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
-counter_merge:                                    ; preds = %lookup_merge, %while_end
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_tuple_16_t)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
@@ -211,8 +222,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!59}
-!llvm.module.flags = !{!61}
+!llvm.dbg.cu = !{!74}
+!llvm.module.flags = !{!76}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -272,17 +283,31 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
-!60 = !{!0, !26, !40, !57}
-!61 = !{i32 2, !"Debug Info Version", i32 3}
-!62 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !67)
-!63 = !DISubroutineType(types: !64)
-!64 = !{!18, !65}
-!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
-!66 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!67 = !{!68}
-!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !65)
-!69 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !59, retainedNodes: !70)
+!58 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
+!60 = !{!61, !49, !54, !66}
+!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
+!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !64)
+!64 = !{!65}
+!65 = !DISubrange(count: 6, lowerBound: 0)
+!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !67, size: 64, offset: 192)
+!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
+!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 256, elements: !70)
+!69 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !70 = !{!71}
-!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !69, file: !2, type: !65)
+!71 = !DISubrange(count: 32, lowerBound: 0)
+!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
+!73 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!74 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !75)
+!75 = !{!0, !26, !40, !57, !72}
+!76 = !{i32 2, !"Debug Info Version", i32 3}
+!77 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !74, retainedNodes: !81)
+!78 = !DISubroutineType(types: !79)
+!79 = !{!18, !80}
+!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
+!81 = !{!82}
+!82 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !80)
+!83 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !74, retainedNodes: !84)
+!84 = !{!85}
+!85 = !DILocalVariable(name: "ctx", arg: 1, scope: !83, file: !2, type: !80)

--- a/tests/codegen/llvm/ptr_to_ptr.ll
+++ b/tests/codegen/llvm/ptr_to_ptr.ll
@@ -5,28 +5,40 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key = alloca i32, align 4
   %deref1 = alloca i32, align 4
   %deref = alloca i64, align 8
-  %printf_args = alloca %printf_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$pp" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$pp")
   store i64 0, ptr %"$pp", align 8
   store i64 0, ptr %"$pp", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 16, i1 false)
-  %1 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
+  %1 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
   store i64 0, ptr %1, align 8
   %2 = load i64, ptr %"$pp", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
@@ -37,22 +49,21 @@ entry:
   %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %deref1, i32 4, i64 %3)
   %4 = load i32, ptr %deref1, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref1)
-  %5 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
+  %5 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
   %6 = sext i32 %4 to i64
   store i64 %6, ptr %5, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 16, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -70,18 +81,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -119,13 +130,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 16, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/sum_cast.ll
+++ b/tests/codegen/llvm/sum_cast.ll
@@ -6,21 +6,23 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
+@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !51
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !66
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !71 {
 entry:
   %key = alloca i32, align 4
-  %print_integer_8_t = alloca %print_integer_8_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -62,75 +64,84 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br label %while_cond
 
 if_body:                                          ; preds = %while_end
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_integer_8_t)
-  %3 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
-  store i64 30007, ptr %3, align 8
-  %4 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
-  store i64 0, ptr %4, align 8
-  %5 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
-  store i64 6, ptr %5, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_integer_8_t, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 if_end:                                           ; preds = %counter_merge, %while_end
   ret i64 0
 
 while_cond:                                       ; preds = %lookup_success2, %lookup_merge
-  %6 = load i32, ptr @num_cpus, align 4
-  %7 = load i32, ptr %i, align 4
-  %num_cpu.cmp = icmp ult i32 %7, %6
+  %3 = load i32, ptr @num_cpus, align 4
+  %4 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %4, %3
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %8 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %8)
+  %5 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %5)
   %map_lookup_cond4 = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  %9 = load i64, ptr %val_1, align 8
+  %6 = load i64, ptr %val_1, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  %10 = icmp sgt i64 %9, 5
-  %11 = zext i1 %10 to i64
-  %true_cond = icmp ne i64 %11, 0
+  %7 = icmp sgt i64 %6, 5
+  %8 = zext i1 %7 to i64
+  %true_cond = icmp ne i64 %8, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %12 = load i64, ptr %val_1, align 8
-  %13 = load i64, ptr %lookup_percpu_elem, align 8
-  %14 = add i64 %13, %12
-  store i64 %14, ptr %val_1, align 8
-  %15 = load i32, ptr %i, align 4
-  %16 = add i32 %15, 1
-  store i32 %16, ptr %i, align 4
+  %9 = load i64, ptr %val_1, align 8
+  %10 = load i64, ptr %lookup_percpu_elem, align 8
+  %11 = add i64 %10, %9
+  store i64 %11, ptr %val_1, align 8
+  %12 = load i32, ptr %i, align 4
+  %13 = add i32 %12, 1
+  store i32 %13, ptr %i, align 4
   br label %while_cond
 
 lookup_failure3:                                  ; preds = %while_body
-  %17 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %17, 0
+  %14 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %14, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %18 = load i32, ptr %i, align 4
+  %15 = load i32, ptr %i, align 4
   br label %while_end
 
-event_loss_counter:                               ; preds = %if_body
+lookup_fmtstr_failure:                            ; preds = %if_body
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %if_body
+  %16 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
+  store i64 30007, ptr %16, align 8
+  %17 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
+  store i64 0, ptr %17, align 8
+  %18 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 8, i1 false)
+  store i64 6, ptr %18, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem5 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond9 = icmp ne ptr %lookup_elem5, null
   br i1 %map_lookup_cond9, label %lookup_success6, label %lookup_failure7
 
-counter_merge:                                    ; preds = %lookup_merge8, %if_body
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_integer_8_t)
+counter_merge:                                    ; preds = %lookup_merge8, %lookup_fmtstr_merge
   br label %if_end
 
 lookup_success6:                                  ; preds = %event_loss_counter
@@ -158,8 +169,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!55}
+!llvm.dbg.cu = !{!68}
+!llvm.module.flags = !{!70}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -213,14 +224,28 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
-!54 = !{!0, !20, !34, !51}
-!55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!18, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
-!60 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!52 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
+!53 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !54)
+!54 = !{!55, !43, !48, !60}
+!55 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !56, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !57, size: 64)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !58)
+!58 = !{!59}
+!59 = !DISubrange(count: 6, lowerBound: 0)
+!60 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !61, size: 64, offset: 192)
+!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 192, elements: !64)
+!63 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!64 = !{!65}
+!65 = !DISubrange(count: 24, lowerBound: 0)
+!66 = !DIGlobalVariableExpression(var: !67, expr: !DIExpression())
+!67 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!68 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !69)
+!69 = !{!0, !20, !34, !51, !66}
+!70 = !{i32 2, !"Debug Info Version", i32 3}
+!71 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !68, retainedNodes: !75)
+!72 = !DISubroutineType(types: !73)
+!73 = !{!18, !74}
+!74 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!75 = !{!76}
+!76 = !DILocalVariable(name: "ctx", arg: 1, scope: !71, file: !2, type: !74)

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -6,19 +6,21 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %"unsigned int64_sum__tuple_t" = type { i64, i64 }
+%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
+@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !51
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !66
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !71 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -56,9 +58,9 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !63 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !77 {
   %key1 = alloca i32, align 4
-  %print_tuple_16_t = alloca %print_tuple_16_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %tuple = alloca %"unsigned int64_sum__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_sum__tuple_t", align 8
   %val_2 = alloca i64, align 8
@@ -109,49 +111,58 @@ while_end:                                        ; preds = %error_failure, %err
   store i64 %12, ptr %15, align 8
   %16 = getelementptr %"unsigned int64_sum__tuple_t", ptr %tuple, i32 0, i32 1
   store i64 %14, ptr %16, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_tuple_16_t)
-  %17 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, ptr %17, align 8
-  %18 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 1
-  store i64 0, ptr %18, align 8
-  %19 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %19, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %19, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_tuple_16_t, i64 32, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 lookup_success:                                   ; preds = %while_body
-  %20 = load i64, ptr %val_1, align 8
-  %21 = load i64, ptr %lookup_percpu_elem, align 8
-  %22 = add i64 %21, %20
-  store i64 %22, ptr %val_1, align 8
-  %23 = load i32, ptr %i, align 4
-  %24 = add i32 %23, 1
-  store i32 %24, ptr %i, align 4
+  %17 = load i64, ptr %val_1, align 8
+  %18 = load i64, ptr %lookup_percpu_elem, align 8
+  %19 = add i64 %18, %17
+  store i64 %19, ptr %val_1, align 8
+  %20 = load i32, ptr %i, align 4
+  %21 = add i32 %20, 1
+  store i32 %21, ptr %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %25 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %25, 0
+  %22 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %22, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %26 = load i32, ptr %i, align 4
+  %23 = load i32, ptr %i, align 4
   br label %while_end
 
-event_loss_counter:                               ; preds = %while_end
+lookup_fmtstr_failure:                            ; preds = %while_end
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %while_end
+  %24 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
+  store i64 30007, ptr %24, align 8
+  %25 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
+  store i64 0, ptr %25, align 8
+  %26 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %26, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %26, ptr align 1 %tuple, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
   store i32 0, ptr %key1, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
   %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
-counter_merge:                                    ; preds = %lookup_merge, %while_end
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_tuple_16_t)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
@@ -178,8 +189,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!55}
+!llvm.dbg.cu = !{!68}
+!llvm.module.flags = !{!70}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -233,17 +244,31 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
-!54 = !{!0, !20, !34, !51}
-!55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!18, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
-!60 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
-!63 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !53, retainedNodes: !64)
+!52 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
+!53 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !54)
+!54 = !{!55, !43, !48, !60}
+!55 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !56, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !57, size: 64)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !58)
+!58 = !{!59}
+!59 = !DISubrange(count: 6, lowerBound: 0)
+!60 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !61, size: 64, offset: 192)
+!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 256, elements: !64)
+!63 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !64 = !{!65}
-!65 = !DILocalVariable(name: "ctx", arg: 1, scope: !63, file: !2, type: !59)
+!65 = !DISubrange(count: 32, lowerBound: 0)
+!66 = !DIGlobalVariableExpression(var: !67, expr: !DIExpression())
+!67 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!68 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !69)
+!69 = !{!0, !20, !34, !51, !66}
+!70 = !{i32 2, !"Debug Info Version", i32 3}
+!71 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !68, retainedNodes: !75)
+!72 = !DISubroutineType(types: !73)
+!73 = !{!18, !74}
+!74 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
+!75 = !{!76}
+!76 = !DILocalVariable(name: "ctx", arg: 1, scope: !71, file: !2, type: !74)
+!77 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !68, retainedNodes: !78)
+!78 = !{!79}
+!79 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !74)

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -5,21 +5,23 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %key5 = alloca i32, align 4
   %perfdata = alloca i64, align 8
   %key = alloca i32, align 4
-  %printf_args = alloca %printf_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ult i64 %1, 10000
@@ -28,13 +30,12 @@ entry:
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 8, i1 false)
-  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 8, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
 
 right:                                            ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %perfdata)
@@ -46,15 +47,25 @@ right:                                            ; preds = %entry
 done:                                             ; preds = %deadcode, %counter_merge
   ret i64 0
 
-event_loss_counter:                               ; preds = %left
+lookup_fmtstr_failure:                            ; preds = %left
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %left
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 8, i1 false)
+  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, ptr %4, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %left
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
   br label %done
 
 lookup_success:                                   ; preds = %event_loss_counter
@@ -97,18 +108,18 @@ deadcode:                                         ; No predecessors!
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -146,13 +157,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 64, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 8, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/unroll_async_id.ll
+++ b/tests/codegen/llvm/unroll_async_id.ll
@@ -6,32 +6,34 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%printf_t.5 = type { i64 }
-%printf_t.4 = type { i64 }
-%printf_t.3 = type { i64 }
-%printf_t.2 = type { i64 }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64 }
+%printf_t.3 = type { i64 }
+%printf_t.4 = type { i64 }
+%printf_t.5 = type { i64 }
+%printf_t.6 = type { i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_i = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !41 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !56 {
 entry:
-  %key39 = alloca i32, align 4
-  %printf_args34 = alloca %printf_t.5, align 8
-  %key28 = alloca i32, align 4
-  %printf_args23 = alloca %printf_t.4, align 8
-  %key17 = alloca i32, align 4
-  %printf_args12 = alloca %printf_t.3, align 8
-  %key6 = alloca i32, align 4
-  %printf_args1 = alloca %printf_t.2, align 8
+  %key55 = alloca i32, align 4
+  %lookup_fmtstr_key46 = alloca i32, align 4
+  %key40 = alloca i32, align 4
+  %lookup_fmtstr_key31 = alloca i32, align 4
+  %key25 = alloca i32, align 4
+  %lookup_fmtstr_key16 = alloca i32, align 4
+  %key10 = alloca i32, align 4
+  %lookup_fmtstr_key1 = alloca i32, align 4
   %key = alloca i32, align 4
-  %printf_args = alloca %printf_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"@i_val" = alloca i64, align 8
   %"@i_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@i_key")
@@ -41,33 +43,41 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_i, ptr %"@i_key", ptr %"@i_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@i_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@i_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 8, i1 false)
-  %1 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 8, i1 false)
+  %1 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
   store i64 0, ptr %1, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 8, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args1)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args1, i8 0, i64 8, i1 false)
-  %2 = getelementptr %printf_t.2, ptr %printf_args1, i32 0, i32 0
-  store i64 0, ptr %2, align 8
-  %ringbuf_output2 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args1, i64 8, i64 0)
-  %ringbuf_loss5 = icmp slt i64 %ringbuf_output2, 0
-  br i1 %ringbuf_loss5, label %event_loss_counter3, label %counter_merge4
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key1)
+  store i32 0, ptr %lookup_fmtstr_key1, align 4
+  %lookup_fmtstr_map2 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key1)
+  %lookup_fmtstr_cond5 = icmp ne ptr %lookup_fmtstr_map2, null
+  br i1 %lookup_fmtstr_cond5, label %lookup_fmtstr_merge4, label %lookup_fmtstr_failure3
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %3 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %2 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -77,111 +87,148 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
   br label %counter_merge
 
-event_loss_counter3:                              ; preds = %counter_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key6)
-  store i32 0, ptr %key6, align 4
-  %lookup_elem7 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key6)
-  %map_lookup_cond11 = icmp ne ptr %lookup_elem7, null
-  br i1 %map_lookup_cond11, label %lookup_success8, label %lookup_failure9
-
-counter_merge4:                                   ; preds = %lookup_merge10, %counter_merge
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args1)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args12)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args12, i8 0, i64 8, i1 false)
-  %4 = getelementptr %printf_t.3, ptr %printf_args12, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %ringbuf_output13 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args12, i64 8, i64 0)
-  %ringbuf_loss16 = icmp slt i64 %ringbuf_output13, 0
-  br i1 %ringbuf_loss16, label %event_loss_counter14, label %counter_merge15
-
-lookup_success8:                                  ; preds = %event_loss_counter3
-  %5 = atomicrmw add ptr %lookup_elem7, i64 1 seq_cst, align 8
-  br label %lookup_merge10
-
-lookup_failure9:                                  ; preds = %event_loss_counter3
-  br label %lookup_merge10
-
-lookup_merge10:                                   ; preds = %lookup_failure9, %lookup_success8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key6)
-  br label %counter_merge4
-
-event_loss_counter14:                             ; preds = %counter_merge4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key17)
-  store i32 0, ptr %key17, align 4
-  %lookup_elem18 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key17)
-  %map_lookup_cond22 = icmp ne ptr %lookup_elem18, null
-  br i1 %map_lookup_cond22, label %lookup_success19, label %lookup_failure20
-
-counter_merge15:                                  ; preds = %lookup_merge21, %counter_merge4
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args12)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args23)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args23, i8 0, i64 8, i1 false)
-  %6 = getelementptr %printf_t.4, ptr %printf_args23, i32 0, i32 0
-  store i64 0, ptr %6, align 8
-  %ringbuf_output24 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args23, i64 8, i64 0)
-  %ringbuf_loss27 = icmp slt i64 %ringbuf_output24, 0
-  br i1 %ringbuf_loss27, label %event_loss_counter25, label %counter_merge26
-
-lookup_success19:                                 ; preds = %event_loss_counter14
-  %7 = atomicrmw add ptr %lookup_elem18, i64 1 seq_cst, align 8
-  br label %lookup_merge21
-
-lookup_failure20:                                 ; preds = %event_loss_counter14
-  br label %lookup_merge21
-
-lookup_merge21:                                   ; preds = %lookup_failure20, %lookup_success19
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key17)
-  br label %counter_merge15
-
-event_loss_counter25:                             ; preds = %counter_merge15
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key28)
-  store i32 0, ptr %key28, align 4
-  %lookup_elem29 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key28)
-  %map_lookup_cond33 = icmp ne ptr %lookup_elem29, null
-  br i1 %map_lookup_cond33, label %lookup_success30, label %lookup_failure31
-
-counter_merge26:                                  ; preds = %lookup_merge32, %counter_merge15
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args23)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args34)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args34, i8 0, i64 8, i1 false)
-  %8 = getelementptr %printf_t.5, ptr %printf_args34, i32 0, i32 0
-  store i64 0, ptr %8, align 8
-  %ringbuf_output35 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args34, i64 8, i64 0)
-  %ringbuf_loss38 = icmp slt i64 %ringbuf_output35, 0
-  br i1 %ringbuf_loss38, label %event_loss_counter36, label %counter_merge37
-
-lookup_success30:                                 ; preds = %event_loss_counter25
-  %9 = atomicrmw add ptr %lookup_elem29, i64 1 seq_cst, align 8
-  br label %lookup_merge32
-
-lookup_failure31:                                 ; preds = %event_loss_counter25
-  br label %lookup_merge32
-
-lookup_merge32:                                   ; preds = %lookup_failure31, %lookup_success30
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key28)
-  br label %counter_merge26
-
-event_loss_counter36:                             ; preds = %counter_merge26
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key39)
-  store i32 0, ptr %key39, align 4
-  %lookup_elem40 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key39)
-  %map_lookup_cond44 = icmp ne ptr %lookup_elem40, null
-  br i1 %map_lookup_cond44, label %lookup_success41, label %lookup_failure42
-
-counter_merge37:                                  ; preds = %lookup_merge43, %counter_merge26
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args34)
+lookup_fmtstr_failure3:                           ; preds = %counter_merge
   ret i64 0
 
-lookup_success41:                                 ; preds = %event_loss_counter36
-  %10 = atomicrmw add ptr %lookup_elem40, i64 1 seq_cst, align 8
-  br label %lookup_merge43
+lookup_fmtstr_merge4:                             ; preds = %counter_merge
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map2, i8 0, i64 8, i1 false)
+  %3 = getelementptr %printf_t.3, ptr %lookup_fmtstr_map2, i32 0, i32 0
+  store i64 0, ptr %3, align 8
+  %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map2, i64 8, i64 0)
+  %ringbuf_loss9 = icmp slt i64 %ringbuf_output6, 0
+  br i1 %ringbuf_loss9, label %event_loss_counter7, label %counter_merge8
 
-lookup_failure42:                                 ; preds = %event_loss_counter36
-  br label %lookup_merge43
+event_loss_counter7:                              ; preds = %lookup_fmtstr_merge4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key10)
+  store i32 0, ptr %key10, align 4
+  %lookup_elem11 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key10)
+  %map_lookup_cond15 = icmp ne ptr %lookup_elem11, null
+  br i1 %map_lookup_cond15, label %lookup_success12, label %lookup_failure13
 
-lookup_merge43:                                   ; preds = %lookup_failure42, %lookup_success41
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key39)
-  br label %counter_merge37
+counter_merge8:                                   ; preds = %lookup_merge14, %lookup_fmtstr_merge4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key16)
+  store i32 0, ptr %lookup_fmtstr_key16, align 4
+  %lookup_fmtstr_map17 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key16)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key16)
+  %lookup_fmtstr_cond20 = icmp ne ptr %lookup_fmtstr_map17, null
+  br i1 %lookup_fmtstr_cond20, label %lookup_fmtstr_merge19, label %lookup_fmtstr_failure18
+
+lookup_success12:                                 ; preds = %event_loss_counter7
+  %4 = atomicrmw add ptr %lookup_elem11, i64 1 seq_cst, align 8
+  br label %lookup_merge14
+
+lookup_failure13:                                 ; preds = %event_loss_counter7
+  br label %lookup_merge14
+
+lookup_merge14:                                   ; preds = %lookup_failure13, %lookup_success12
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key10)
+  br label %counter_merge8
+
+lookup_fmtstr_failure18:                          ; preds = %counter_merge8
+  ret i64 0
+
+lookup_fmtstr_merge19:                            ; preds = %counter_merge8
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map17, i8 0, i64 8, i1 false)
+  %5 = getelementptr %printf_t.4, ptr %lookup_fmtstr_map17, i32 0, i32 0
+  store i64 0, ptr %5, align 8
+  %ringbuf_output21 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map17, i64 8, i64 0)
+  %ringbuf_loss24 = icmp slt i64 %ringbuf_output21, 0
+  br i1 %ringbuf_loss24, label %event_loss_counter22, label %counter_merge23
+
+event_loss_counter22:                             ; preds = %lookup_fmtstr_merge19
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key25)
+  store i32 0, ptr %key25, align 4
+  %lookup_elem26 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key25)
+  %map_lookup_cond30 = icmp ne ptr %lookup_elem26, null
+  br i1 %map_lookup_cond30, label %lookup_success27, label %lookup_failure28
+
+counter_merge23:                                  ; preds = %lookup_merge29, %lookup_fmtstr_merge19
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key31)
+  store i32 0, ptr %lookup_fmtstr_key31, align 4
+  %lookup_fmtstr_map32 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key31)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key31)
+  %lookup_fmtstr_cond35 = icmp ne ptr %lookup_fmtstr_map32, null
+  br i1 %lookup_fmtstr_cond35, label %lookup_fmtstr_merge34, label %lookup_fmtstr_failure33
+
+lookup_success27:                                 ; preds = %event_loss_counter22
+  %6 = atomicrmw add ptr %lookup_elem26, i64 1 seq_cst, align 8
+  br label %lookup_merge29
+
+lookup_failure28:                                 ; preds = %event_loss_counter22
+  br label %lookup_merge29
+
+lookup_merge29:                                   ; preds = %lookup_failure28, %lookup_success27
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key25)
+  br label %counter_merge23
+
+lookup_fmtstr_failure33:                          ; preds = %counter_merge23
+  ret i64 0
+
+lookup_fmtstr_merge34:                            ; preds = %counter_merge23
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map32, i8 0, i64 8, i1 false)
+  %7 = getelementptr %printf_t.5, ptr %lookup_fmtstr_map32, i32 0, i32 0
+  store i64 0, ptr %7, align 8
+  %ringbuf_output36 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map32, i64 8, i64 0)
+  %ringbuf_loss39 = icmp slt i64 %ringbuf_output36, 0
+  br i1 %ringbuf_loss39, label %event_loss_counter37, label %counter_merge38
+
+event_loss_counter37:                             ; preds = %lookup_fmtstr_merge34
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key40)
+  store i32 0, ptr %key40, align 4
+  %lookup_elem41 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key40)
+  %map_lookup_cond45 = icmp ne ptr %lookup_elem41, null
+  br i1 %map_lookup_cond45, label %lookup_success42, label %lookup_failure43
+
+counter_merge38:                                  ; preds = %lookup_merge44, %lookup_fmtstr_merge34
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key46)
+  store i32 0, ptr %lookup_fmtstr_key46, align 4
+  %lookup_fmtstr_map47 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key46)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key46)
+  %lookup_fmtstr_cond50 = icmp ne ptr %lookup_fmtstr_map47, null
+  br i1 %lookup_fmtstr_cond50, label %lookup_fmtstr_merge49, label %lookup_fmtstr_failure48
+
+lookup_success42:                                 ; preds = %event_loss_counter37
+  %8 = atomicrmw add ptr %lookup_elem41, i64 1 seq_cst, align 8
+  br label %lookup_merge44
+
+lookup_failure43:                                 ; preds = %event_loss_counter37
+  br label %lookup_merge44
+
+lookup_merge44:                                   ; preds = %lookup_failure43, %lookup_success42
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key40)
+  br label %counter_merge38
+
+lookup_fmtstr_failure48:                          ; preds = %counter_merge38
+  ret i64 0
+
+lookup_fmtstr_merge49:                            ; preds = %counter_merge38
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map47, i8 0, i64 8, i1 false)
+  %9 = getelementptr %printf_t.6, ptr %lookup_fmtstr_map47, i32 0, i32 0
+  store i64 0, ptr %9, align 8
+  %ringbuf_output51 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map47, i64 8, i64 0)
+  %ringbuf_loss54 = icmp slt i64 %ringbuf_output51, 0
+  br i1 %ringbuf_loss54, label %event_loss_counter52, label %counter_merge53
+
+event_loss_counter52:                             ; preds = %lookup_fmtstr_merge49
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key55)
+  store i32 0, ptr %key55, align 4
+  %lookup_elem56 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key55)
+  %map_lookup_cond60 = icmp ne ptr %lookup_elem56, null
+  br i1 %map_lookup_cond60, label %lookup_success57, label %lookup_failure58
+
+counter_merge53:                                  ; preds = %lookup_merge59, %lookup_fmtstr_merge49
+  ret i64 0
+
+lookup_success57:                                 ; preds = %event_loss_counter52
+  %10 = atomicrmw add ptr %lookup_elem56, i64 1 seq_cst, align 8
+  br label %lookup_merge59
+
+lookup_failure58:                                 ; preds = %event_loss_counter52
+  br label %lookup_merge59
+
+lookup_merge59:                                   ; preds = %lookup_failure58, %lookup_success57
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key55)
+  br label %counter_merge53
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -197,8 +244,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!38}
-!llvm.module.flags = !{!40}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!55}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_i", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -238,13 +285,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !35 = !DISubrange(count: 262144, lowerBound: 0)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
 !37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
-!38 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !39)
-!39 = !{!0, !22, !36}
-!40 = !{i32 2, !"Debug Info Version", i32 3}
-!41 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !42, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !38, retainedNodes: !46)
-!42 = !DISubroutineType(types: !43)
-!43 = !{!21, !44}
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!46 = !{!47}
-!47 = !DILocalVariable(name: "ctx", arg: 1, scope: !41, file: !2, type: !44)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !41)
+!41 = !{!42, !11, !16, !47}
+!42 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !43, size: 64)
+!43 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !44, size: 64)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !45)
+!45 = !{!46}
+!46 = !DISubrange(count: 6, lowerBound: 0)
+!47 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !48, size: 64, offset: 192)
+!48 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !49, size: 64)
+!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !50, size: 64, elements: !51)
+!50 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!51 = !{!52}
+!52 = !DISubrange(count: 8, lowerBound: 0)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
+!54 = !{!0, !22, !36, !38}
+!55 = !{i32 2, !"Debug Info Version", i32 3}
+!56 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
+!57 = !DISubroutineType(types: !58)
+!58 = !{!21, !59}
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!60 = !{!61}
+!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)

--- a/tests/codegen/llvm/variable_increment_decrement.ll
+++ b/tests/codegen/llvm/variable_increment_decrement.ll
@@ -5,69 +5,74 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%printf_t.3 = type { i64, i64 }
-%printf_t.2 = type { i64, i64 }
-%printf_t.1 = type { i64, i64 }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64 }
+%printf_t.2 = type { i64, i64 }
+%printf_t.3 = type { i64, i64 }
+%printf_t.4 = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !39 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !54 {
 entry:
-  %key28 = alloca i32, align 4
-  %printf_args23 = alloca %printf_t.3, align 8
-  %key17 = alloca i32, align 4
-  %printf_args12 = alloca %printf_t.2, align 8
-  %key6 = alloca i32, align 4
-  %printf_args1 = alloca %printf_t.1, align 8
+  %key40 = alloca i32, align 4
+  %lookup_fmtstr_key31 = alloca i32, align 4
+  %key25 = alloca i32, align 4
+  %lookup_fmtstr_key16 = alloca i32, align 4
+  %key10 = alloca i32, align 4
+  %lookup_fmtstr_key1 = alloca i32, align 4
   %key = alloca i32, align 4
-  %printf_args = alloca %printf_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$x" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
   store i64 0, ptr %"$x", align 8
   store i64 10, ptr %"$x", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 16, i1 false)
-  %1 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
+  store i32 0, ptr %lookup_fmtstr_key, align 4
+  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
+  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
+  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+
+lookup_fmtstr_failure:                            ; preds = %entry
+  ret i64 0
+
+lookup_fmtstr_merge:                              ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
+  %1 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
   store i64 0, ptr %1, align 8
   %2 = load i64, ptr %"$x", align 8
   %3 = add i64 %2, 1
   store i64 %3, ptr %"$x", align 8
-  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
+  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
   store i64 %2, ptr %4, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 16, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %entry
+event_loss_counter:                               ; preds = %lookup_fmtstr_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args1)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args1, i8 0, i64 16, i1 false)
-  %5 = getelementptr %printf_t.1, ptr %printf_args1, i32 0, i32 0
-  store i64 1, ptr %5, align 8
-  %6 = load i64, ptr %"$x", align 8
-  %7 = add i64 %6, 1
-  store i64 %7, ptr %"$x", align 8
-  %8 = getelementptr %printf_t.1, ptr %printf_args1, i32 0, i32 1
-  store i64 %7, ptr %8, align 8
-  %ringbuf_output2 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args1, i64 16, i64 0)
-  %ringbuf_loss5 = icmp slt i64 %ringbuf_output2, 0
-  br i1 %ringbuf_loss5, label %event_loss_counter3, label %counter_merge4
+counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key1)
+  store i32 0, ptr %lookup_fmtstr_key1, align 4
+  %lookup_fmtstr_map2 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key1)
+  %lookup_fmtstr_cond5 = icmp ne ptr %lookup_fmtstr_map2, null
+  br i1 %lookup_fmtstr_cond5, label %lookup_fmtstr_merge4, label %lookup_fmtstr_failure3
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %5 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -77,110 +82,143 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
   br label %counter_merge
 
-event_loss_counter3:                              ; preds = %counter_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key6)
-  store i32 0, ptr %key6, align 4
-  %lookup_elem7 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key6)
-  %map_lookup_cond11 = icmp ne ptr %lookup_elem7, null
-  br i1 %map_lookup_cond11, label %lookup_success8, label %lookup_failure9
-
-counter_merge4:                                   ; preds = %lookup_merge10, %counter_merge
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args1)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args12)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args12, i8 0, i64 16, i1 false)
-  %10 = getelementptr %printf_t.2, ptr %printf_args12, i32 0, i32 0
-  store i64 2, ptr %10, align 8
-  %11 = load i64, ptr %"$x", align 8
-  %12 = sub i64 %11, 1
-  store i64 %12, ptr %"$x", align 8
-  %13 = getelementptr %printf_t.2, ptr %printf_args12, i32 0, i32 1
-  store i64 %11, ptr %13, align 8
-  %ringbuf_output13 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args12, i64 16, i64 0)
-  %ringbuf_loss16 = icmp slt i64 %ringbuf_output13, 0
-  br i1 %ringbuf_loss16, label %event_loss_counter14, label %counter_merge15
-
-lookup_success8:                                  ; preds = %event_loss_counter3
-  %14 = atomicrmw add ptr %lookup_elem7, i64 1 seq_cst, align 8
-  br label %lookup_merge10
-
-lookup_failure9:                                  ; preds = %event_loss_counter3
-  br label %lookup_merge10
-
-lookup_merge10:                                   ; preds = %lookup_failure9, %lookup_success8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key6)
-  br label %counter_merge4
-
-event_loss_counter14:                             ; preds = %counter_merge4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key17)
-  store i32 0, ptr %key17, align 4
-  %lookup_elem18 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key17)
-  %map_lookup_cond22 = icmp ne ptr %lookup_elem18, null
-  br i1 %map_lookup_cond22, label %lookup_success19, label %lookup_failure20
-
-counter_merge15:                                  ; preds = %lookup_merge21, %counter_merge4
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args12)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args23)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args23, i8 0, i64 16, i1 false)
-  %15 = getelementptr %printf_t.3, ptr %printf_args23, i32 0, i32 0
-  store i64 3, ptr %15, align 8
-  %16 = load i64, ptr %"$x", align 8
-  %17 = sub i64 %16, 1
-  store i64 %17, ptr %"$x", align 8
-  %18 = getelementptr %printf_t.3, ptr %printf_args23, i32 0, i32 1
-  store i64 %17, ptr %18, align 8
-  %ringbuf_output24 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args23, i64 16, i64 0)
-  %ringbuf_loss27 = icmp slt i64 %ringbuf_output24, 0
-  br i1 %ringbuf_loss27, label %event_loss_counter25, label %counter_merge26
-
-lookup_success19:                                 ; preds = %event_loss_counter14
-  %19 = atomicrmw add ptr %lookup_elem18, i64 1 seq_cst, align 8
-  br label %lookup_merge21
-
-lookup_failure20:                                 ; preds = %event_loss_counter14
-  br label %lookup_merge21
-
-lookup_merge21:                                   ; preds = %lookup_failure20, %lookup_success19
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key17)
-  br label %counter_merge15
-
-event_loss_counter25:                             ; preds = %counter_merge15
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key28)
-  store i32 0, ptr %key28, align 4
-  %lookup_elem29 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key28)
-  %map_lookup_cond33 = icmp ne ptr %lookup_elem29, null
-  br i1 %map_lookup_cond33, label %lookup_success30, label %lookup_failure31
-
-counter_merge26:                                  ; preds = %lookup_merge32, %counter_merge15
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args23)
+lookup_fmtstr_failure3:                           ; preds = %counter_merge
   ret i64 0
 
-lookup_success30:                                 ; preds = %event_loss_counter25
-  %20 = atomicrmw add ptr %lookup_elem29, i64 1 seq_cst, align 8
-  br label %lookup_merge32
+lookup_fmtstr_merge4:                             ; preds = %counter_merge
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map2, i8 0, i64 16, i1 false)
+  %6 = getelementptr %printf_t.2, ptr %lookup_fmtstr_map2, i32 0, i32 0
+  store i64 1, ptr %6, align 8
+  %7 = load i64, ptr %"$x", align 8
+  %8 = add i64 %7, 1
+  store i64 %8, ptr %"$x", align 8
+  %9 = getelementptr %printf_t.2, ptr %lookup_fmtstr_map2, i32 0, i32 1
+  store i64 %8, ptr %9, align 8
+  %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map2, i64 16, i64 0)
+  %ringbuf_loss9 = icmp slt i64 %ringbuf_output6, 0
+  br i1 %ringbuf_loss9, label %event_loss_counter7, label %counter_merge8
 
-lookup_failure31:                                 ; preds = %event_loss_counter25
-  br label %lookup_merge32
+event_loss_counter7:                              ; preds = %lookup_fmtstr_merge4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key10)
+  store i32 0, ptr %key10, align 4
+  %lookup_elem11 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key10)
+  %map_lookup_cond15 = icmp ne ptr %lookup_elem11, null
+  br i1 %map_lookup_cond15, label %lookup_success12, label %lookup_failure13
 
-lookup_merge32:                                   ; preds = %lookup_failure31, %lookup_success30
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key28)
-  br label %counter_merge26
+counter_merge8:                                   ; preds = %lookup_merge14, %lookup_fmtstr_merge4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key16)
+  store i32 0, ptr %lookup_fmtstr_key16, align 4
+  %lookup_fmtstr_map17 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key16)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key16)
+  %lookup_fmtstr_cond20 = icmp ne ptr %lookup_fmtstr_map17, null
+  br i1 %lookup_fmtstr_cond20, label %lookup_fmtstr_merge19, label %lookup_fmtstr_failure18
+
+lookup_success12:                                 ; preds = %event_loss_counter7
+  %10 = atomicrmw add ptr %lookup_elem11, i64 1 seq_cst, align 8
+  br label %lookup_merge14
+
+lookup_failure13:                                 ; preds = %event_loss_counter7
+  br label %lookup_merge14
+
+lookup_merge14:                                   ; preds = %lookup_failure13, %lookup_success12
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key10)
+  br label %counter_merge8
+
+lookup_fmtstr_failure18:                          ; preds = %counter_merge8
+  ret i64 0
+
+lookup_fmtstr_merge19:                            ; preds = %counter_merge8
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map17, i8 0, i64 16, i1 false)
+  %11 = getelementptr %printf_t.3, ptr %lookup_fmtstr_map17, i32 0, i32 0
+  store i64 2, ptr %11, align 8
+  %12 = load i64, ptr %"$x", align 8
+  %13 = sub i64 %12, 1
+  store i64 %13, ptr %"$x", align 8
+  %14 = getelementptr %printf_t.3, ptr %lookup_fmtstr_map17, i32 0, i32 1
+  store i64 %12, ptr %14, align 8
+  %ringbuf_output21 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map17, i64 16, i64 0)
+  %ringbuf_loss24 = icmp slt i64 %ringbuf_output21, 0
+  br i1 %ringbuf_loss24, label %event_loss_counter22, label %counter_merge23
+
+event_loss_counter22:                             ; preds = %lookup_fmtstr_merge19
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key25)
+  store i32 0, ptr %key25, align 4
+  %lookup_elem26 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key25)
+  %map_lookup_cond30 = icmp ne ptr %lookup_elem26, null
+  br i1 %map_lookup_cond30, label %lookup_success27, label %lookup_failure28
+
+counter_merge23:                                  ; preds = %lookup_merge29, %lookup_fmtstr_merge19
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key31)
+  store i32 0, ptr %lookup_fmtstr_key31, align 4
+  %lookup_fmtstr_map32 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key31)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key31)
+  %lookup_fmtstr_cond35 = icmp ne ptr %lookup_fmtstr_map32, null
+  br i1 %lookup_fmtstr_cond35, label %lookup_fmtstr_merge34, label %lookup_fmtstr_failure33
+
+lookup_success27:                                 ; preds = %event_loss_counter22
+  %15 = atomicrmw add ptr %lookup_elem26, i64 1 seq_cst, align 8
+  br label %lookup_merge29
+
+lookup_failure28:                                 ; preds = %event_loss_counter22
+  br label %lookup_merge29
+
+lookup_merge29:                                   ; preds = %lookup_failure28, %lookup_success27
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key25)
+  br label %counter_merge23
+
+lookup_fmtstr_failure33:                          ; preds = %counter_merge23
+  ret i64 0
+
+lookup_fmtstr_merge34:                            ; preds = %counter_merge23
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map32, i8 0, i64 16, i1 false)
+  %16 = getelementptr %printf_t.4, ptr %lookup_fmtstr_map32, i32 0, i32 0
+  store i64 3, ptr %16, align 8
+  %17 = load i64, ptr %"$x", align 8
+  %18 = sub i64 %17, 1
+  store i64 %18, ptr %"$x", align 8
+  %19 = getelementptr %printf_t.4, ptr %lookup_fmtstr_map32, i32 0, i32 1
+  store i64 %18, ptr %19, align 8
+  %ringbuf_output36 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map32, i64 16, i64 0)
+  %ringbuf_loss39 = icmp slt i64 %ringbuf_output36, 0
+  br i1 %ringbuf_loss39, label %event_loss_counter37, label %counter_merge38
+
+event_loss_counter37:                             ; preds = %lookup_fmtstr_merge34
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key40)
+  store i32 0, ptr %key40, align 4
+  %lookup_elem41 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key40)
+  %map_lookup_cond45 = icmp ne ptr %lookup_elem41, null
+  br i1 %map_lookup_cond45, label %lookup_success42, label %lookup_failure43
+
+counter_merge38:                                  ; preds = %lookup_merge44, %lookup_fmtstr_merge34
+  ret i64 0
+
+lookup_success42:                                 ; preds = %event_loss_counter37
+  %20 = atomicrmw add ptr %lookup_elem41, i64 1 seq_cst, align 8
+  br label %lookup_merge44
+
+lookup_failure43:                                 ; preds = %event_loss_counter37
+  br label %lookup_merge44
+
+lookup_merge44:                                   ; preds = %lookup_failure43, %lookup_success42
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key40)
+  br label %counter_merge38
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -218,13 +256,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !25, !30, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
+!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!49 = !{!50}
+!50 = !DISubrange(count: 16, lowerBound: 0)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !36}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!35, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -16,7 +16,8 @@ using ::testing::_;
 
 void test(BPFtrace &bpftrace,
           const std::string &input,
-          bool expected_result = true)
+          bool expected_result = true,
+          RequiredResources *out_p = nullptr)
 {
   Driver driver(bpftrace);
   std::stringstream out;
@@ -40,13 +41,18 @@ void test(BPFtrace &bpftrace,
   auto resources_optional = resource_analyser.analyse();
   EXPECT_EQ(resources_optional.has_value(), expected_result)
       << msg.str() << out.str();
+
+  if (out_p)
+    *out_p = *resources_optional;
 }
 
-void test(const std::string &input, bool expected_result = true)
+void test(const std::string &input,
+          bool expected_result = true,
+          RequiredResources *out = nullptr)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  test(*bpftrace, input, expected_result);
+  return test(*bpftrace, input, expected_result, out);
 }
 
 TEST(resource_analyser, multiple_hist_bits_in_single_map)
@@ -64,6 +70,50 @@ TEST(resource_analyser, multiple_lhist_bounds_in_single_map)
 TEST(resource_analyser, printf_in_subprog)
 {
   test("fn greet(): void { printf(\"Hello, world\\n\"); }", true);
+}
+
+TEST(resource_analyser, fmt_string_args_size_ints)
+{
+  RequiredResources resources;
+  test(R"(BEGIN { printf("%d %d", 3, 4) })", true, &resources);
+  EXPECT_EQ(resources.max_fmtstring_args_size, 24);
+}
+
+TEST(resource_analyser, fmt_string_args_size_arrays)
+{
+  RequiredResources resources;
+  test(
+      R"(struct Foo { int a; char b[10]; } BEGIN { $foo = (struct Foo *)0; $foo2 = (struct Foo *)1; printf("%d %s %d %s\n", $foo->a, $foo->b, $foo2->a, $foo2->b) })",
+      true,
+      &resources);
+  EXPECT_EQ(resources.max_fmtstring_args_size, 56);
+}
+
+TEST(resource_analyser, fmt_string_args_size_strings)
+{
+  RequiredResources resources;
+  test(
+      R"(BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd") })",
+      true,
+      &resources);
+  EXPECT_EQ(resources.max_fmtstring_args_size, 72);
+}
+
+TEST(resource_analyser, fmt_string_args_non_map_print_int)
+{
+  RequiredResources resources;
+  test(R"(BEGIN { print(5) })", true, &resources);
+  EXPECT_EQ(resources.max_fmtstring_args_size, 24);
+}
+
+TEST(resource_analyser, fmt_string_args_non_map_print_arr)
+{
+  RequiredResources resources;
+  test(
+      R"(struct Foo { char a[24]; } BEGIN { print(5); $foo = (struct Foo *)0; print($foo->a) })",
+      true,
+      &resources);
+  EXPECT_EQ(resources.max_fmtstring_args_size, 40);
 }
 
 } // namespace resource_analyser

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -95,6 +95,22 @@ AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
 REQUIRES_FEATURE probe_read_kernel
 TIMEOUT 5
 
+NAME str_big_printf
+PROG t:syscalls:sys_enter_execve { printf("%s\n", str(args.filename)) }
+ENV BPFTRACE_MAX_STRLEN=9999
+EXPECT_REGEX /X{5555}
+AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
+REQUIRES_FEATURE probe_read_kernel
+TIMEOUT 5
+
+NAME str_big_print
+PROG t:syscalls:sys_enter_execve { print(str(args.filename)) }
+ENV BPFTRACE_MAX_STRLEN=9999
+EXPECT_REGEX /X{5555}
+AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
+REQUIRES_FEATURE probe_read_kernel
+TIMEOUT 5
+
 NAME buf
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \x09\x08\x07\x06-\x05\x04\x03\x02-\x01\x02\x03\x04-\x05\x00\x00\x00\x06\x00\x00\x00\x07\x00\x00\x00\x08\x00\x00\x00-\x09\x00\x0a\x00\x0b\x00\x0c\x00-\x0d\x00\x00\x00\x00\x00\x00\x00\x0e\x00\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -113,13 +113,13 @@ EXPECT @[ok_key]: 1
 TIMEOUT 5
 
 NAME buf_map_multikey
-PROG BEGIN { @[buf("ok_key", 8), 1] = hist(1); exit(); }
-EXPECT @[ok_key\x00\x00, 1]:
+PROG BEGIN { @[buf("ok_key", 7), 1] = hist(1); exit(); }
+EXPECT @[ok_key\x00, 1]:
 TIMEOUT 5
 
 NAME buf_hist_map_key
-PROG BEGIN { @[buf("ok_key", 8)] = hist(1); exit(); }
-EXPECT @[ok_key\x00\x00]:
+PROG BEGIN { @[buf("ok_key", 7)] = hist(1); exit(); }
+EXPECT @[ok_key\x00]:
 TIMEOUT 5
 
 NAME buf_map_value


### PR DESCRIPTION
This PR adds support for large arguments. Namely: you can now
`printf()` and `print()` big strings/buffers.

With this, we can raise the default on `BPFTRACE_MAX_STRLEN`
from 64 -> 1024 without large regressions. The operative word
is large, as anyone assigning a string to a scratch variable will
get new failures.

To assist with that, we add a new error for anyone trying to assign
a large string to a scratch variable along with a remediation.

**This is considered a regression.** But we have precedent in the past
where we have introduced intentional regressions if it provides a
better overall outcome **and** there is a trivial migration path.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
