### PR TITLE
Remove unused #includes

### DIFF
--- a/src/bfd-disasm.cpp
+++ b/src/bfd-disasm.cpp
@@ -8,8 +8,6 @@
 #define PACKAGE "bpftrace"
 #include "bfd-disasm.h"
 #include "utils.h"
-#include <bcc/bcc_elf.h>
-#include <bcc/bcc_syms.h>
 #include <bfd.h>
 #include <dis-asm.h>
 

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -1,6 +1,5 @@
 #include "bpffeature.h"
 
-#include <bcc/bcc_syms.h>
 #include <bcc/libbpf.h>
 #include <bpf/bpf.h>
 #include <bpf/btf.h>


### PR DESCRIPTION
Remove a bunch of #include statements for files whose contents aren't actually used in the source code.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
