### PR TITLE
Replace usage of bcc_elf_is_*() functions

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -194,7 +194,7 @@ int BPFtrace::add_probe(const ast::AttachPoint &ap,
   // Preload symbol tables if necessary
   if (resources.probes_using_usym.find(&p) !=
           resources.probes_using_usym.end() &&
-      bcc_elf_is_exe(ap.target.c_str())) {
+      is_exe(ap.target)) {
     auto user_symbol_cache_type = config_.get(
         ConfigKeyUserSymbolCacheType::default_);
     // preload symbol table for executable to make it available even if the

--- a/src/utils.h
+++ b/src/utils.h
@@ -214,6 +214,7 @@ bool is_compile_time_func(const std::string &func_name);
 bool is_supported_lang(const std::string &lang);
 bool is_type_name(std::string_view str);
 std::string exec_system(const char *cmd);
+bool is_exe(const std::string &path);
 std::vector<std::string> resolve_binary_path(const std::string &cmd);
 std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid);
 std::string path_for_pid_mountns(int pid, const std::string &path);


### PR DESCRIPTION
In the long term, the project wants to get rid of the `bcc` dependency. As another step towards achieving this goal, replace the usage of `bcc_elf_is_*()` functions with implementations based directly on `libelf`. The `bcc` layer basically doesn't add any value here.

In `resolve_binary_path()`, we benefit additionally from not unnecessarily opening the file in question and reading its ELF header twice, if it does not reference an executable.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
  - N/A
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
  - not user visible
- [x] The new behaviour is covered by tests
  - semantic preserving refactoring
