### PR TITLE
tools/runqlat: provide TASK_RUNNING as a define

### DIFF
--- a/tools/runqlat.bt
+++ b/tools/runqlat.bt
@@ -11,7 +11,17 @@
  * 17-Sep-2018	Brendan Gregg	Created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/sched.h>
+#else
+/*
+ * With BTF providing types, full headers are not needed.
+ * We only need to supply the preprocessor defines used in this script.
+ * TASK_RUNNING is not arch-dependant and has not changed in the linux
+ * git history (it is not part of the stable API though)
+ */
+#define TASK_RUNNING 0
+#endif
 
 BEGIN
 {


### PR DESCRIPTION
runqlat requires kernel headers to run even with BTF, just because of a define.
TASK_RUNNING isn't part of the stable API but it's never changed in all of the linux git history so let's pretend it's stable and just define it.

If we find a way to handle kheaders again in the future we might want to consider reverting this.

Fixes: #3255

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
^ once again no test for this as far as I know, but tested manually.