### PR TITLE
Fix include path on loongarch, mips, riscv, and s390

### DIFF
--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -17,3 +17,5 @@ elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "loongarch64")
 else()
   message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
+
+target_include_directories(arch PUBLIC ${CMAKE_SOURCE_DIR}/src)


### PR DESCRIPTION
The build appears to be broken on a few architectures in 0.21.0 ([source](https://gitlab.alpinelinux.org/acj/aports/-/pipelines/242714)):

```
bpftrace-0.21.0/src/arch/riscv64.cpp:2:10: fatal error: utils.h: No such file or directory
    2 | #include "utils.h"
      |          ^~~~~~~~~
compilation terminated.
```

Patching the includes to `../utils.h` [seems to work](https://gitlab.alpinelinux.org/acj/aports/-/pipelines/242948). I don't have access to hardware for testing loongarch or mips, though.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
