### PR TITLE
Fix LIBBPF_OPTS noise

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ set (CMAKE_CXX_EXTENSIONS OFF)
 
 add_compile_options("-Wall")
 add_compile_options("-Wextra")
+add_compile_options("-Werror=missing-field-initializers")
 add_compile_options("-Werror=undef")
 add_compile_options("-Wpointer-arith")
 add_compile_options("-Wcast-align")

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -752,7 +752,7 @@ void AttachedProbe::load_prog(BPFfeature &feature)
       prog_type = progtype(ProbeType::uprobe);
 
     {
-      LIBBPF_OPTS(bpf_prog_load_opts, opts);
+      BPFTRACE_LIBBPF_OPTS(bpf_prog_load_opts, opts);
       opts.log_buf = log_buf.get();
       opts.log_size = log_buf_size;
       opts.log_level = log_level;
@@ -824,11 +824,11 @@ void AttachedProbe::load_prog(BPFfeature &feature)
 
         int btf_fd = -1;
         if (load_config.btf) {
-          LIBBPF_OPTS(bpf_btf_load_opts,
-                      btf_opts,
-                      .log_buf = log_buf.get(),
-                      .log_level = static_cast<__u32>(log_level),
-                      .log_size = static_cast<__u32>(log_buf_size), );
+          BPFTRACE_LIBBPF_OPTS(bpf_btf_load_opts,
+                               btf_opts,
+                               .log_buf = log_buf.get(),
+                               .log_level = static_cast<__u32>(log_level),
+                               .log_size = static_cast<__u32>(log_buf_size), );
 
           auto &btf = prog_.getBTF();
           btf_fd = bpf_btf_load(btf.data(), btf.size(), &btf_opts);
@@ -927,7 +927,7 @@ void AttachedProbe::load_prog(BPFfeature &feature)
 
 void AttachedProbe::attach_multi_kprobe(void)
 {
-  DECLARE_LIBBPF_OPTS(bpf_link_create_opts, opts);
+  BPFTRACE_LIBBPF_OPTS(bpf_link_create_opts, opts);
   std::vector<const char *> syms;
   unsigned int i = 0;
 
@@ -1133,7 +1133,7 @@ void AttachedProbe::attach_multi_uprobe(int pid)
       probe_.path, probe_.name, probe_.funcs, syms, offsets);
 
   // Attach uprobe through uprobe_multi link
-  DECLARE_LIBBPF_OPTS(bpf_link_create_opts, opts);
+  BPFTRACE_LIBBPF_OPTS(bpf_link_create_opts, opts);
 
   opts.uprobe_multi.path = probe_.path.c_str();
   opts.uprobe_multi.offsets = offsets.data();

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -48,7 +48,7 @@ bool BpfBytecode::create_maps()
 {
   int failed_maps = 0;
   for (auto &map : maps_) {
-    LIBBPF_OPTS(bpf_map_create_opts, opts);
+    BPFTRACE_LIBBPF_OPTS(bpf_map_create_opts, opts);
     map.second.fd = bpf_map_create(static_cast<::bpf_map_type>(
                                        map.second.type()),
                                    map.second.bpf_name().c_str(),

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -59,7 +59,7 @@ static bool try_load_(const char* name,
       continue;
     }
 
-    LIBBPF_OPTS(bpf_prog_load_opts, opts);
+    BPFTRACE_LIBBPF_OPTS(bpf_prog_load_opts, opts);
     opts.log_buf = logbuf;
     opts.log_size = logbuf_size;
     opts.log_level = loglevel;
@@ -131,11 +131,11 @@ bool BPFfeature::try_load_btf(const void* btf_data, size_t btf_size)
 {
   constexpr int log_size = 4096;
   char log_buf[log_size] = {};
-  LIBBPF_OPTS(bpf_btf_load_opts,
-              btf_opts,
-              .log_buf = log_buf,
-              .log_level = 0,
-              .log_size = log_size, );
+  BPFTRACE_LIBBPF_OPTS(bpf_btf_load_opts,
+                       btf_opts,
+                       .log_buf = log_buf,
+                       .log_level = 0,
+                       .log_size = log_size, );
 
   int fd = bpf_btf_load(btf_data, btf_size, &btf_opts);
   if (fd >= 0) {
@@ -220,7 +220,7 @@ bool BPFfeature::detect_map(enum libbpf::bpf_map_type map_type)
       break;
   }
 
-  LIBBPF_OPTS(bpf_map_create_opts, opts);
+  BPFTRACE_LIBBPF_OPTS(bpf_map_create_opts, opts);
   opts.map_flags = flags;
   map_fd = bpf_map_create(static_cast<enum ::bpf_map_type>(map_type),
                           nullptr,
@@ -341,7 +341,7 @@ bool BPFfeature::has_map_batch()
   if (has_map_batch_.has_value())
     return *has_map_batch_;
 
-  LIBBPF_OPTS(bpf_map_create_opts, opts);
+  BPFTRACE_LIBBPF_OPTS(bpf_map_create_opts, opts);
   opts.map_flags = flags;
   map_fd = bpf_map_create(static_cast<enum ::bpf_map_type>(
                               libbpf::BPF_MAP_TYPE_HASH),
@@ -413,7 +413,7 @@ bool BPFfeature::has_kprobe_multi()
   }
 
   const char* sym = "ksys_read";
-  DECLARE_LIBBPF_OPTS(bpf_link_create_opts, link_opts);
+  BPFTRACE_LIBBPF_OPTS(bpf_link_create_opts, link_opts);
   int progfd, linkfd = -1;
 
   struct bpf_insn insns[] = {
@@ -424,7 +424,7 @@ bool BPFfeature::has_kprobe_multi()
   link_opts.kprobe_multi.syms = &sym;
   link_opts.kprobe_multi.cnt = 1;
 
-  LIBBPF_OPTS(bpf_prog_load_opts, load_opts);
+  BPFTRACE_LIBBPF_OPTS(bpf_prog_load_opts, load_opts);
   load_opts.expected_attach_type = static_cast<enum ::bpf_attach_type>(
       libbpf::BPF_TRACE_KPROBE_MULTI);
 
@@ -466,10 +466,11 @@ bool BPFfeature::has_uprobe_multi()
     return *has_uprobe_multi_;
   }
 
-  LIBBPF_OPTS(bpf_prog_load_opts,
-              load_opts,
-              .expected_attach_type = static_cast<enum ::bpf_attach_type>(
-                  libbpf::BPF_TRACE_UPROBE_MULTI), );
+  BPFTRACE_LIBBPF_OPTS(
+      bpf_prog_load_opts,
+      load_opts,
+      .expected_attach_type = static_cast<enum ::bpf_attach_type>(
+          libbpf::BPF_TRACE_UPROBE_MULTI), );
 
   int err = 0, progfd, linkfd = -1;
 
@@ -487,7 +488,7 @@ bool BPFfeature::has_uprobe_multi()
                          &load_opts);
 
   if (progfd >= 0) {
-    LIBBPF_OPTS(bpf_link_create_opts, link_opts);
+    BPFTRACE_LIBBPF_OPTS(bpf_link_create_opts, link_opts);
     const unsigned long offset = 0;
 
     link_opts.uprobe_multi.path = "/";
@@ -526,7 +527,7 @@ bool BPFfeature::has_skb_output(void)
 
   int map_fd = 0;
 
-  LIBBPF_OPTS(bpf_map_create_opts, opts);
+  BPFTRACE_LIBBPF_OPTS(bpf_map_create_opts, opts);
   opts.map_flags = 0;
   map_fd = bpf_map_create(static_cast<enum ::bpf_map_type>(
                               libbpf::BPF_MAP_TYPE_PERF_EVENT_ARRAY),

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -567,16 +567,11 @@ std::map<std::string, std::vector<std::string>> BTF::get_params_from_btf(
     if (!t)
       continue;
 
-    _Pragma("GCC diagnostic push")
-        _Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")
+    BPFTRACE_LIBBPF_OPTS(btf_dump_emit_type_decl_opts,
+                         decl_opts,
+                         .field_name = "");
 
-            DECLARE_LIBBPF_OPTS(btf_dump_emit_type_decl_opts,
-                                decl_opts,
-                                .field_name = "");
-
-    _Pragma("GCC diagnostic pop")
-
-        const struct btf_param *p;
+    const struct btf_param *p;
     int j;
 
     for (j = 0, p = btf_params(t); j < btf_vlen(t); j++, p++) {

--- a/src/libbpf/bpf.h
+++ b/src/libbpf/bpf.h
@@ -365,4 +365,9 @@ enum bpf_func_id {
 	__BPF_FUNC_MAX_ID,
 };
 #undef __BPF_ENUM_FN
+
+#define BPFTRACE_LIBBPF_OPTS(TYPE, NAME, ...)                                  \
+  _Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")           \
+      LIBBPF_OPTS(TYPE, NAME, __VA_ARGS__)
+
 // clang-format on


### PR DESCRIPTION
- add `-Werror=missing-field-initializers` to the CI build config so that accidental use of the wrong macro fails the build
- wrap LIBBPF_OPTS into a pragma-guarded macro to silence `-Wmissing-field-initializers`

Fixes: #3276 

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
