### PR TITLE
Remove unused member variables

### DIFF
--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -276,7 +276,6 @@ private:
   // Used if there are duplicate USDT entries
   int current_usdt_location_index_{ 0 };
   bool inside_subprog_ = false;
-  bool need_recursion_check_ = false;
 
   std::map<std::string, AllocaInst *> variables_;
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -8,7 +8,7 @@
 
 namespace bpftrace {
 
-Config::Config(bool has_cmd, bool bt_verbose) : bt_verbose_(bt_verbose)
+Config::Config(bool has_cmd)
 {
   config_map_ = {
     { ConfigKeyBool::cpp_demangle, { .value = true } },

--- a/src/config.h
+++ b/src/config.h
@@ -108,7 +108,7 @@ struct ConfigValue {
 
 class Config {
 public:
-  explicit Config(bool has_cmd = false, bool bt_verbose = false);
+  explicit Config(bool has_cmd = false);
 
   bool get(ConfigKeyBool key) const
   {
@@ -181,7 +181,6 @@ private:
 private:
   bool can_set(ConfigSource prevSource, ConfigSource);
   bool is_aslr_enabled();
-  bool bt_verbose_ = false;
 
   std::map<ConfigKey, ConfigValue> config_map_;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -724,7 +724,7 @@ int main(int argc, char* argv[])
 
   libbpf_set_print(libbpf_print);
 
-  Config config = Config(!args.cmd_str.empty(), bt_verbose);
+  Config config = Config(!args.cmd_str.empty());
   BPFtrace bpftrace(std::move(output), args.no_feature, config);
 
   if (!args.cmd_str.empty())


### PR DESCRIPTION
Nix build is reporting two warnings about unused variables. They are indeed unused, so remove.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
