### PR TITLE
docs: remove mention to unsupported character literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
   - [#3281](https://github.com/bpftrace/bpftrace/pull/3281)
 #### Security
 #### Docs
+- Remove mention of unsupported character literals
+  - [#3283](https://github.com/bpftrace/bpftrace/pull/3283)
 #### Tools
 
 ## [0.21.0] 2024-06-21

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -501,7 +501,7 @@ Identifiers must match the following regular expression: `[_a-zA-Z][_a-zA-Z0-9]*
 
 === Literals
 
-Integer, char, and string literals are supported.
+Integer and string literals are supported.
 
 Integer literals can be defined in the following formats:
 
@@ -520,11 +520,17 @@ To improve the readability of big literals an underscore `_` can be used as fiel
 Integer suffixes as found in the C language are parsed by bpftrace to ensure compatibility with C headers/definitions but they're not used as size specifiers.
 `123UL`, `123U` and `123LL` all result in the same integer type with a value of `123`.
 
-Character literals can be defined by enclosing the character in single quotes e.g. `$c = 'c';`.
+Character literals are not supported at this time, and the corresponding ASCII code must be used instead:
+
+----
+BEGIN {
+  printf("Echo A: %c\n", 65);
+}
+----
 
 String literals can be defined by enclosing the character string in double quotes e.g. `$str = "Hello world";`.
 
-Characters and strings support the following escape sequences:
+Strings support the following escape sequences:
 
 [cols="~,~"]
 |===


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Character literals appear to not be supported at this time. Hence, let's clarify this aspect in the documentation.

Fixes: fd0461dc ("docs: entries for new int syntax")
Fixes: #3278

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
