### PR TITLE
CHANGELOG: Move `buf` entry to the correct version (i.e. unreleased)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to
 ## Unreleased
 
 #### Added
-- Add --dry-run CLI option
+- Add `--dry-run` CLI option
   - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)
 - Enable avg map reads in kernel space (implicit casting)
   - [#3268](https://github.com/bpftrace/bpftrace/pull/3268)
@@ -18,17 +18,17 @@ and this project adheres to
   - [#3264](https://github.com/bpftrace/bpftrace/pull/3264)
 - Only print kernel headers not found message if parsing fails
   - [#3265](https://github.com/bpftrace/bpftrace/pull/3265)
-- Add mandatory "stage" argument to the -d CLI option
+- Add mandatory "stage" argument to the `-d` CLI option
   - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)
-- Allow simultaneous use of -v and -d
+- Allow simultaneous use of `-v` and `-d`
   - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)
+- Remove length limitations for the `buf` builtin function
+  - [#3249](https://github.com/bpftrace/bpftrace/pull/3249)
 #### Deprecated
 #### Removed
-- Remove the -dd CLI option
+- Remove the `-dd` CLI option
   - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)
 #### Fixed
-- Fix incorrect buf() size calculation which could lead to verifier errors
-  - [#3281](https://github.com/bpftrace/bpftrace/pull/3281)
 #### Security
 #### Docs
 #### Tools
@@ -80,7 +80,6 @@ and this project adheres to
   - [#3228](https://github.com/bpftrace/bpftrace/pull/3228)
   - [#3237](https://github.com/bpftrace/bpftrace/pull/3237)
   - [#3245](https://github.com/bpftrace/bpftrace/pull/3245)
-  - [#3249](https://github.com/bpftrace/bpftrace/pull/3249)
 #### Deprecated
 - Deprecate `sarg` builtin
   - [#3095](https://github.com/bpftrace/bpftrace/pull/3095)


### PR DESCRIPTION
- Remove entry for #3281, as it's a fix for a bug that hasn't made it to a release
- Quote a bunch of things with backticks to make the markdown render more nicely