### PR TITLE
Fix unaligned map key access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to
 #### Fixed
 - Fix segfault for multi-tracepoint probes
   - [#3274](https://github.com/bpftrace/bpftrace/pull/3274)
+- Fix verifier error from misaligned stack access when using strings as map keys
+  - [#3294](https://github.com/bpftrace/bpftrace/issues/3294)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2855,13 +2855,13 @@ AllocaInst *CodegenLLVM::getMultiMapKey(Map &map,
       if (expr->type.IsStringTy() && expr->type.GetSize() < map_key_size)
         b_.CreateMemsetBPF(offset_val, b_.getInt8(0), map_key_size);
       b_.CREATE_MEMCPY(offset_val, expr_, expr->type.GetSize(), 1);
-      if ((expr->type.GetSize() % 8) != 0)
+      if ((map_key_size % 8) != 0)
         aligned = false;
     } else {
       if (expr->type.IsArrayTy() || expr->type.IsRecordTy()) {
         // Read the array/struct into the key
         b_.CreateProbeRead(ctx_, offset_val, expr->type, expr_, expr->loc);
-        if ((expr->type.GetSize() % 8) != 0)
+        if ((map_key_size % 8) != 0)
           aligned = false;
       } else {
         // promote map key to 64-bit:

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -97,3 +97,8 @@ PROG kfunc:__module_get { print(args.module->trace_events[1]->flags); exit(); }
 AFTER lsmod
 EXPECT Attaching 1 probe...
 TIMEOUT 1
+
+NAME unaligned key with aligned value
+PROG BEGIN { @mapA["aaaabbb", 0] = 1; @mapA["ccccdddd", 0] = 1; }
+EXPECT Attaching 1 probe...
+TIMEOUT 1


### PR DESCRIPTION
Fixes #3294

If we have a map with key type `[string[9], int64]`, then the `int64` should be treated as an unaligned access.

Previously the alignment calculations worked off the length of the string value, not the maximum size allocated for the string key.

Example:
```
  @mapA["ccccdddd", 0] = 1;
  @mapA["aaaabbb", 0] = 1;
```

The string key's size is taken from the maximum string length, which is 9 bytes. Fields after this key should be considered unaligned.

The second line contains a string of 8 bytes. Padding was not taken into account and the following key(s) were incorrectly treated as aligned.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- ~[ ]~ Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
