### PR TITLE
testprogs: Fix cc: error: unrecognized command-line option '-mno-omit-leaf-frame-pointer'

### DIFF
--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -1,4 +1,24 @@
-set(testprog_cflags "-g -O0 -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer")
+set_property(GLOBAL APPEND_STRING PROPERTY testprog_cflags "-g -O0")
+
+# Check and add CFLAG to testprog_cflags
+function(test_and_add_testprog_cflag flag)
+  execute_process(
+    COMMAND echo "int main(void) { return 0; }"
+    COMMAND ${CMAKE_C_COMPILER} -x c -Wall - ${flag} -o -
+    OUTPUT_VARIABLE /dev/null
+    ERROR_VARIABLE /dev/null
+    RESULT_VARIABLE NO_THIS_FLAG)
+  if(NOT ${NO_THIS_FLAG})
+    set_property(GLOBAL APPEND_STRING PROPERTY testprog_cflags " ${flag}")
+  else()
+    message(STATUS "${CMAKE_C_COMPILER} does not support ${flag}")
+  endif()
+endfunction()
+
+test_and_add_testprog_cflag("-fno-omit-frame-pointer")
+test_and_add_testprog_cflag("-mno-omit-leaf-frame-pointer")
+get_property(testprog_cflags GLOBAL PROPERTY testprog_cflags)
+
 if(LLVM_VERSION_MAJOR VERSION_LESS 13)
   # CI's GCC compile the testprogs using DWARF version 5
   # LLDB doesn't support DWARF5 before version 13, so we force DWARF4


### PR DESCRIPTION
Compile error on debian12, riscv64:

    $ make
    ...
    [ 59%] Built target runtime_test_files
    [ 59%] Building C object tests/testprogs/CMakeFiles/array_access.dir/array_access.c.o
    cc: error: unrecognized command-line option '-mno-omit-leaf-frame-pointer'; did you mean '-fno-omit-frame-pointer'?
    make[2]: *** [tests/testprogs/CMakeFiles/array_access.dir/build.make:76: tests/testprogs/CMakeFiles/array_access.dir/array_access.c.o] Error 1
    make[1]: *** [CMakeFiles/Makefile2:1925: tests/testprogs/CMakeFiles/array_access.dir/all] Error 2
    make: *** [Makefile:146: all] Error 2

gcc [1] commit 39663298b593 ("RISCV: Add -m(no)-omit-leaf-frame-pointer support.")

    $ git describe 39663298b5934831a0125e12f113ebd83248c3be
    basepoints/gcc-14-2940-g39663298b593

Link: git://gcc.gnu.org/git/gcc.git [1]
