### PR TITLE
kprobe inlined function

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -115,3 +115,4 @@ aot.variable.map key tuple with casted ints
 aot.dwarf.uprobe inlined function - func
 aot.dwarf.uprobe inlined function - probe
 aot.dwarf.uprobe inlined function - ustack
+aot.dwarf.kprobe inlined function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
   - [#3390](https://github.com/bpftrace/bpftrace/pull/3390/)
 - Add `has_key` function for maps
   - [#3358](https://github.com/bpftrace/bpftrace/pull/3358)
+- Add ability to attach kprobes to inlined functions
+  - [#3301](https://github.com/bpftrace/bpftrace/pull/3095)
 #### Changed
 - Merge output into `stdout` when `-lv`
   - [#3383](https://github.com/bpftrace/bpftrace/pull/3383)

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -617,6 +617,8 @@ void AttachedProbe::attach_kprobe()
   if (!is_symbol_kprobe)
     funcname += probe_.attach_point;
 
+  LOG(V1) << "bpf_attach_kprobe(" << progfd_ << ", " << probe_.type << ", "
+          << eventname() << ", " << funcname << ", " << offset_ << ", 0)";
   int perf_event_fd = bpf_attach_kprobe(progfd_,
                                         attachtype(probe_.type),
                                         eventname().c_str(),

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -102,6 +102,7 @@ public:
   bool has_prog_kfunc();
   bool has_module_btf();
   bool has_iter(std::string name);
+  bool has_kernel_dwarf();
 
   std::string report(void);
 
@@ -143,6 +144,7 @@ protected:
   std::optional<bool> has_prog_kfunc_;
   std::optional<bool> has_module_btf_;
   std::optional<bool> has_btf_func_global_;
+  std::optional<bool> has_kernel_dwarf_;
 
 private:
   bool detect_map(libbpf::bpf_map_type map_type);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -38,13 +38,6 @@ namespace bpftrace {
 
 const int timeout_ms = 100;
 
-struct symbol {
-  std::string name;
-  uint64_t start;
-  uint64_t size;
-  uint64_t address;
-};
-
 struct stack_key {
   int64_t stackid;
   uint32_t nr_stack_frames;

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -18,10 +18,10 @@ class BPFtrace;
 
 class Dwarf {
 public:
-  virtual ~Dwarf();
-
   static std::unique_ptr<Dwarf> GetFromBinary(BPFtrace *bpftrace,
                                               std::string file_path);
+
+  bool has_debug_info();
 
   std::vector<uint64_t> get_function_locations(const std::string &function,
                                                bool include_inlined);
@@ -32,8 +32,6 @@ public:
   void resolve_fields(const SizedType &type);
 
 private:
-  static std::atomic<size_t> instance_count;
-
   Dwarf(BPFtrace *bpftrace, std::string file_path);
 
   lldb::SBValueList function_params(const std::string &function);
@@ -43,6 +41,17 @@ private:
   void resolve_fields(std::shared_ptr<Struct> str, lldb::SBType type);
   std::optional<Bitfield> resolve_bitfield(lldb::SBTypeMember field);
 
+  // Initialize/Terminate liblldb globally with RAII
+  class InstanceCounter final {
+  private:
+    static std::atomic<size_t> count;
+
+  public:
+    InstanceCounter();
+    ~InstanceCounter();
+  };
+
+  InstanceCounter counter_;
   BPFtrace *bpftrace_;
   std::string file_path_;
 
@@ -67,6 +76,11 @@ public:
                                               __attribute__((unused)))
   {
     return nullptr;
+  }
+
+  bool has_debug_info()
+  {
+    return false;
   }
 
   std::vector<uint64_t> get_function_locations(const std::string &function

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -109,6 +109,72 @@ const struct vmlinux_location vmlinux_locs[] = {
   { nullptr, false },
 };
 
+std::optional<std::string> find_vmlinux(struct vmlinux_location const *locs,
+                                        struct symbol *sym)
+{
+  struct utsname uts;
+  if (uname(&uts) != 0)
+    return std::nullopt;
+
+  for (size_t i = 0; locs[i].path; ++i) {
+    auto &loc = locs[i];
+    if (loc.raw)
+      continue; // This file is for BTF. skip
+
+    // Format the loc.path with the current release.
+    char path[PATH_MAX] = {};
+    int bytes_written = std::snprintf(
+        path, sizeof(path), loc.path, uts.release);
+    if (bytes_written < 0) {
+      LOG(ERROR) << "Failed to format vmlinux path '" << loc.path << "' using "
+                 << uts.release;
+      continue;
+    } else if (static_cast<size_t>(bytes_written) > sizeof(path)) {
+      LOG(WARNING) << "Truncated format for vmlinux path '" << loc.path
+                   << "' using " << uts.release;
+      continue;
+    }
+
+    if (access(path, R_OK))
+      continue;
+
+    if (sym == nullptr) {
+      return path;
+    } else {
+      bcc_elf_symcb callback = !sym->name.empty() ? sym_name_cb
+                                                  : sym_address_cb;
+      struct bcc_symbol_option options = {
+        .use_debug_file = 0,
+        .check_debug_file_crc = 0,
+        .lazy_symbolize = 0,
+        .use_symbol_type = BCC_SYM_ALL_TYPES ^ (1 << STT_NOTYPE),
+      };
+      if (bcc_elf_foreach_sym(path, callback, &options, sym) == -1) {
+        LOG(ERROR) << "Failed to iterate over symbols in " << path;
+        continue;
+      }
+
+      if (sym->start) {
+        LOG(V1) << "vmlinux: using " << path;
+        return path;
+      }
+    }
+  }
+
+  return std::nullopt;
+}
+
+// find vmlinux file.
+// if sym is not null, check vmlinux contains the given symbol information
+std::optional<std::string> find_vmlinux(struct symbol *sym)
+{
+  struct vmlinux_location locs_env[] = {
+    { std::getenv("BPFTRACE_VMLINUX"), false },
+    { nullptr, false },
+  };
+  return find_vmlinux(locs_env[0].path ? locs_env : vmlinux_locs, sym);
+}
+
 static bool pid_in_different_mountns(int pid);
 static std::vector<std::string> resolve_binary_path(const std::string &cmd,
                                                     const char *env_paths,

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -206,8 +206,14 @@ EXPECT foo1->b = 123
 REQUIRES_FEATURE dwarf
 BEFORE ./testprogs/uprobe_test
 
+# The function `str_has_prefix` is marked to be always inlined, so we'll get
+# more than one occurrence for it.
+# We first check that bpftrace attaches to more probes than the two defined in the script.
+# We also check that the offsets bpftrace attaches to are different from 0,
+# since they should be inline instances part of another function/symbol.
 NAME kprobe inlined function
-PROG config = { probe_inline = 1 } BEGIN { exit() }
-     kprobe:str_has_prefix { }
-EXPECT_NONE Attaching 2 probe...
+RUN {{BPFTRACE}} -ve \ 'config = { probe_inline = 1 } BEGIN { exit() } kprobe:str_has_prefix { }'
+EXPECT_NONE Attaching 1 probe...
+EXPECT_NONE Attaching 2 probes...
+EXPECT_REGEX_NONE ^bpf_attach_kprobe\(.*, 0, 0\)$
 REQUIRES_FEATURE dwarf kernel_dwarf

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -205,3 +205,9 @@ PROG struct Foo { int b; } uprobe:./testprogs/uprobe_test:uprobeFunction2 { prin
 EXPECT foo1->b = 123
 REQUIRES_FEATURE dwarf
 BEFORE ./testprogs/uprobe_test
+
+NAME kprobe inlined function
+PROG config = { probe_inline = 1 } BEGIN { exit() }
+     kprobe:str_has_prefix { }
+EXPECT_NONE Attaching 2 probe...
+REQUIRES_FEATURE dwarf kernel_dwarf

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -199,6 +199,7 @@ class TestParser(object):
                     "iter",
                     "libpath_resolv",
                     "dwarf",
+                    "kernel_dwarf",
                     "aot",
                     "kprobe_multi",
                     "uprobe_multi",

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -144,6 +144,7 @@ class Runner(object):
         bpffeature["iter"] = output.find("iter: yes") != -1
         bpffeature["libpath_resolv"] = output.find("bcc library path resolution: yes") != -1
         bpffeature["dwarf"] = output.find("liblldb (DWARF support): yes") != -1
+        bpffeature["kernel_dwarf"] = output.find("Kernel DWARF: yes") != -1
         bpffeature["kprobe_multi"] = output.find("kprobe_multi: yes") != -1
         bpffeature["uprobe_multi"] = output.find("uprobe_multi: yes") != -1
         bpffeature["aot"] = cmake_vars.LIBBCC_BPF_CONTAINS_RUNTIME


### PR DESCRIPTION
Extend the `probe_inline` config to also apply to `kprobe`.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
