### PR TITLE
Add global vars which can be set from userspace

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(runtime
   disasm.cpp
   dwarf_parser.cpp
   format_string.cpp
+  globalvars.cpp
   log.cpp
   mapkey.cpp
   output.cpp

--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -341,7 +341,7 @@ int load(BPFtrace &bpftrace, const std::string &in)
 
   bpftrace.bytecode_ = BpfBytecode(btaot_section + hdr->elf_off,
                                    hdr->elf_len,
-                                   bpftrace.config_);
+                                   bpftrace);
   if (err)
     goto out;
 

--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -117,15 +117,6 @@ int main(int argc, char* argv[])
 
   BPFtrace bpftrace(std::move(output));
 
-  // TODO: remove this once we move to libbpf or move to open-coded iterators
-  auto num_cpus = bpftrace.get_num_possible_cpus();
-  if (num_cpus > 1024) {
-    LOG(WARNING) << "Detected " << num_cpus
-                 << " cpus. For ahead-of-time compilation there is a max of "
-                    "1024 cpus so there may be incorrect data for 'count' "
-                    "and 'sum' aggregations.";
-  }
-
   int err = aot::load(bpftrace, argv[0]);
   if (err) {
     LOG(ERROR) << "Failed to load AOT script";

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -240,5 +240,12 @@ DIGlobalVariableExpression *DIBuilderBPF::createMapEntry(
       file, name, "global", file, 0, map_entry_type, false);
 }
 
+DIGlobalVariableExpression *DIBuilderBPF::createGlobalInt64(
+    std::string_view name)
+{
+  return createGlobalVariableExpression(
+      file, name, "global", file, 0, getInt64Ty(), false);
+}
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -44,6 +44,7 @@ public:
                                              uint64_t max_entries,
                                              const MapKey &key,
                                              const SizedType &value_type);
+  DIGlobalVariableExpression *createGlobalInt64(std::string_view name);
 
   DIFile *file = nullptr;
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -91,8 +91,7 @@ public:
                                  Map &map,
                                  Value *key,
                                  const SizedType &type,
-                                 const location &loc,
-                                 bool is_aot);
+                                 const location &loc);
   void CreateMapUpdateElem(Value *ctx,
                            const std::string &map_ident,
                            Value *key,

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -29,10 +29,9 @@ using CallArgs = std::vector<std::tuple<FormatString, std::vector<Field>>>;
 
 class CodegenLLVM : public Visitor {
 public:
-  explicit CodegenLLVM(Node *root, BPFtrace &bpftrace, bool is_aot = false);
+  explicit CodegenLLVM(Node *root, BPFtrace &bpftrace);
   explicit CodegenLLVM(Node *root,
                        BPFtrace &bpftrace,
-                       bool is_aot,
                        std::unique_ptr<USDTHelper> usdt_helper);
 
   void visit(Integer &integer) override;
@@ -99,6 +98,7 @@ public:
   libbpf::bpf_map_type get_map_type(const SizedType &val_type,
                                     const MapKey &key);
   void generate_maps(const RequiredResources &resources);
+  void generate_global_vars(const RequiredResources &resources);
   void optimize(void);
   bool verify(void);
   BpfBytecode emit(void);
@@ -252,7 +252,6 @@ private:
   IRBuilderBPF b_;
 
   DIBuilderBPF debug_;
-  bool is_aot_;
 
   const DataLayout &datalayout() const
   {

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -1,6 +1,7 @@
 #include "resource_analyser.h"
 
 #include "bpftrace.h"
+#include "globalvars.h"
 #include "log.h"
 #include "struct.h"
 
@@ -115,6 +116,9 @@ void ResourceAnalyser::visit(Call &call)
                                         : " ";
     resources_.join_args.push_back(delim);
     resources_.needs_join_map = true;
+  } else if (call.func == "count" || call.func == "sum" || call.func == "min" ||
+             call.func == "max" || call.func == "avg") {
+    resources_.needed_global_vars.insert(bpftrace::globalvars::NUM_CPUS);
   } else if (call.func == "hist") {
     auto &map_info = resources_.maps_info[call.map->ident];
     int bits = static_cast<Integer *>(call.vargs->at(1))->n;

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -23,7 +23,7 @@ public:
   BpfBytecode()
   {
   }
-  BpfBytecode(const void *elf, size_t elf_size, const Config &config);
+  BpfBytecode(const void *elf, size_t elf_size, BPFtrace &bpftrace);
 
   BpfBytecode(const BpfBytecode &) = delete;
   BpfBytecode &operator=(const BpfBytecode &) = delete;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2180,11 +2180,6 @@ struct bcc_symbol_option &BPFtrace::get_symbol_opts()
   return symopts;
 }
 
-int BPFtrace::get_num_possible_cpus() const
-{
-  return libbpf_num_possible_cpus();
-}
-
 /*
  * This prevents an ABBA deadlock when attaching to spin lock internal
  * functions e.g. "kfunc:queued_spin_lock_slowpath".

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -140,7 +140,6 @@ public:
   std::optional<int64_t> get_int_literal(const ast::Expression *expr) const;
   std::optional<std::string> get_watchpoint_binary_path() const;
   virtual bool is_traceable_func(const std::string &func_name) const;
-  virtual int get_num_possible_cpus() const;
   virtual std::unordered_set<std::string> get_func_modules(
       const std::string &func_name) const;
   int create_pcaps(void);

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -1,0 +1,95 @@
+#include "globalvars.h"
+
+#include "bpftrace.h"
+#include "log.h"
+#include "utils.h"
+
+#include <bpf/bpf.h>
+#include <bpf/btf.h>
+#include <elf.h>
+#include <map>
+#include <stdexcept>
+#include <sys/mman.h>
+
+namespace bpftrace {
+namespace globalvars {
+
+void update_global_vars(const struct bpf_object *bpf_object,
+                        struct bpf_map *global_vars_map,
+                        BPFtrace &bpftrace)
+{
+  struct btf *self_btf = bpf_object__btf(bpf_object);
+
+  if (!self_btf) {
+    LOG(BUG) << "Failed to get BTF from BPF object";
+  }
+
+  __s32 section_id = btf__find_by_name(self_btf,
+                                       std::string(SECTION_NAME).c_str());
+  if (section_id < 0) {
+    LOG(BUG) << "Failed to find section " << SECTION_NAME
+             << " to update global vars";
+  }
+
+  const struct btf_type *section_type = btf__type_by_id(self_btf,
+                                                        (__u32)section_id);
+  if (!section_type) {
+    LOG(BUG) << "Failed to get BTF type for section " << SECTION_NAME;
+  }
+
+  // First locate the offsets of each global variable in the section with btf
+  std::map<std::string_view, int> vars_and_offsets;
+
+  for (auto name : GLOBAL_VAR_NAMES) {
+    if (bpftrace.resources.needed_global_vars.find(name) ==
+        bpftrace.resources.needed_global_vars.end()) {
+      continue;
+    }
+    vars_and_offsets[name] = -1;
+  }
+
+  int i;
+  struct btf_var_secinfo *member;
+
+  for (i = 0, member = btf_var_secinfos(section_type);
+       i < btf_vlen(section_type);
+       ++i, ++member) {
+    const struct btf_type *type_id = btf__type_by_id(self_btf, member->type);
+    if (!type_id) {
+      continue;
+    }
+
+    std::string_view name = btf__name_by_offset(self_btf, type_id->name_off);
+
+    if (vars_and_offsets.find(name) != vars_and_offsets.end()) {
+      vars_and_offsets[name] = member->offset;
+    } else {
+      LOG(BUG) << "Unknown global variable " << name;
+    }
+  }
+
+  size_t v_size;
+  char *global_vars_buf = (char *)bpf_map__initial_value(global_vars_map,
+                                                         &v_size);
+
+  if (!global_vars_buf) {
+    LOG(BUG) << "Failed to get array buf for global variable map";
+  }
+
+  // Update the values for the global vars (using the above offsets)
+  for (auto [name, offset] : vars_and_offsets) {
+    if (offset < 0) {
+      LOG(BUG) << "Global variable has not been added to the BPF code "
+                  "(codegen_llvm)";
+    }
+
+    int64_t *var = (int64_t *)(global_vars_buf + offset);
+
+    if (name == NUM_CPUS) {
+      *var = bpftrace.ncpus_;
+    }
+  }
+}
+
+} // namespace globalvars
+} // namespace bpftrace

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <set>
+#include <string>
+
+#include "bpftrace.h"
+#include "required_resources.h"
+
+#include <bpf/bpf.h>
+#include <bpf/btf.h>
+
+namespace bpftrace {
+namespace globalvars {
+
+static constexpr std::string_view SECTION_NAME = ".rodata";
+
+static constexpr std::string_view NUM_CPUS = "num_cpus";
+
+const std::unordered_set<std::string_view> GLOBAL_VAR_NAMES = {
+  NUM_CPUS,
+};
+
+void update_global_vars(const struct bpf_object *obj,
+                        struct bpf_map *global_vars_map,
+                        BPFtrace &bpftrace);
+
+} // namespace globalvars
+} // namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -916,9 +916,7 @@ int main(int argc, char* argv[])
     return err;
   }
 
-  ast::CodegenLLVM llvm(&*ast_root,
-                        bpftrace,
-                        args.build_mode == BuildMode::AHEAD_OF_TIME);
+  ast::CodegenLLVM llvm(&*ast_root, bpftrace);
   BpfBytecode bytecode;
   try {
     llvm.generate_ir();

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -110,6 +110,7 @@ public:
   // Map metadata
   std::map<std::string, MapInfo> maps_info;
   std::unordered_set<StackType> stackid_maps;
+  std::unordered_set<std::string_view> needed_global_vars;
   bool needs_join_map = false;
   bool needs_elapsed_map = false;
   bool needs_perf_event_map = false;

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -51,8 +51,7 @@ static auto parse_probe(const std::string &str,
 
   auto usdt_helper = get_mock_usdt_helper(usdt_num_locations);
   std::stringstream out;
-  ast::CodegenLLVM codegen(
-      driver.root.get(), bpftrace, false, std::move(usdt_helper));
+  ast::CodegenLLVM codegen(driver.root.get(), bpftrace, std::move(usdt_helper));
   codegen.generate_ir();
 }
 

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -45,11 +45,6 @@ public:
   {
     return feature_->has_loop();
   }
-
-  int get_num_possible_cpus() const override
-  {
-    return 20;
-  }
 };
 
 TEST(codegen, printf_offsets)

--- a/tests/codegen/llvm/avg_cast.ll
+++ b/tests/codegen/llvm/avg_cast.ll
@@ -12,11 +12,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
@@ -127,132 +128,134 @@ if_end:                                           ; preds = %counter_merge, %whi
   ret i64 0
 
 while_cond:                                       ; preds = %lookup_success13, %lookup_merge5
-  %27 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %27, 20
+  %27 = load i32, i64* @num_cpus, align 4
+  %28 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %28, %27
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %28 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key12", i32 %28)
+  %29 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key12", i32 %29)
   %map_lookup_cond15 = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond15, label %lookup_success13, label %lookup_failure14
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %29 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
-  %30 = load i64, i64* %ret, align 8
-  %31 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
-  %32 = bitcast i64* %"@x_key12" to i8*
+  %30 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
+  %31 = load i64, i64* %ret, align 8
+  %32 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
-  %33 = bitcast i64* %"@x_key17" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
-  store i64 1, i64* %"@x_key17", align 8
-  %34 = bitcast i64* %ret18 to i8*
+  %33 = bitcast i64* %"@x_key12" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %34 = bitcast i64* %"@x_key17" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
-  %35 = bitcast i32* %i19 to i8*
+  store i64 1, i64* %"@x_key17", align 8
+  %35 = bitcast i64* %ret18 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
+  %36 = bitcast i32* %i19 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %36)
   store i32 0, i32* %i19, align 4
   store i64 0, i64* %ret18, align 8
   br label %while_cond20
 
 lookup_success13:                                 ; preds = %while_body
   %cast16 = bitcast i8* %lookup_percpu_elem to i64*
-  %36 = load i64, i64* %ret, align 8
-  %37 = load i64, i64* %cast16, align 8
-  %38 = add i64 %37, %36
-  store i64 %38, i64* %ret, align 8
-  %39 = load i32, i32* %i, align 4
-  %40 = add i32 %39, 1
-  store i32 %40, i32* %i, align 4
+  %37 = load i64, i64* %ret, align 8
+  %38 = load i64, i64* %cast16, align 8
+  %39 = add i64 %38, %37
+  store i64 %39, i64* %ret, align 8
+  %40 = load i32, i32* %i, align 4
+  %41 = add i32 %40, 1
+  store i32 %41, i32* %i, align 4
   br label %while_cond
 
 lookup_failure14:                                 ; preds = %while_body
-  %41 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %41, 0
+  %42 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %42, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure14
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure14
-  %42 = load i32, i32* %i, align 4
+  %43 = load i32, i32* %i, align 4
   br label %while_end
 
 while_cond20:                                     ; preds = %lookup_success25, %while_end
-  %43 = load i32, i32* %i19, align 4
-  %num_cpu.cmp23 = icmp ult i32 %43, 20
+  %44 = load i32, i64* @num_cpus, align 4
+  %45 = load i32, i32* %i19, align 4
+  %num_cpu.cmp23 = icmp ult i32 %45, %44
   br i1 %num_cpu.cmp23, label %while_body21, label %while_end22
 
 while_body21:                                     ; preds = %while_cond20
-  %44 = load i32, i32* %i19, align 4
-  %lookup_percpu_elem24 = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key17", i32 %44)
+  %46 = load i32, i32* %i19, align 4
+  %lookup_percpu_elem24 = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key17", i32 %46)
   %map_lookup_cond27 = icmp ne i8* %lookup_percpu_elem24, null
   br i1 %map_lookup_cond27, label %lookup_success25, label %lookup_failure26
 
 while_end22:                                      ; preds = %error_failure30, %error_success29, %while_cond20
-  %45 = bitcast i32* %i19 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %45)
-  %46 = load i64, i64* %ret18, align 8
-  %47 = bitcast i64* %ret18 to i8*
+  %47 = bitcast i32* %i19 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %47)
-  %48 = bitcast i64* %"@x_key17" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %48)
-  %49 = udiv i64 %46, %30
-  %50 = bitcast i64* %"@x_key11" to i8*
+  %48 = load i64, i64* %ret18, align 8
+  %49 = bitcast i64* %ret18 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
+  %50 = bitcast i64* %"@x_key17" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %50)
-  %51 = icmp eq i64 %49, 2
-  %52 = zext i1 %51 to i64
-  %true_cond = icmp ne i64 %52, 0
+  %51 = udiv i64 %48, %31
+  %52 = bitcast i64* %"@x_key11" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %52)
+  %53 = icmp eq i64 %51, 2
+  %54 = zext i1 %53 to i64
+  %true_cond = icmp ne i64 %54, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success25:                                 ; preds = %while_body21
   %cast28 = bitcast i8* %lookup_percpu_elem24 to i64*
-  %53 = load i64, i64* %ret18, align 8
-  %54 = load i64, i64* %cast28, align 8
-  %55 = add i64 %54, %53
-  store i64 %55, i64* %ret18, align 8
-  %56 = load i32, i32* %i19, align 4
-  %57 = add i32 %56, 1
-  store i32 %57, i32* %i19, align 4
+  %55 = load i64, i64* %ret18, align 8
+  %56 = load i64, i64* %cast28, align 8
+  %57 = add i64 %56, %55
+  store i64 %57, i64* %ret18, align 8
+  %58 = load i32, i32* %i19, align 4
+  %59 = add i32 %58, 1
+  store i32 %59, i32* %i19, align 4
   br label %while_cond20
 
 lookup_failure26:                                 ; preds = %while_body21
-  %58 = load i32, i32* %i19, align 4
-  %error_lookup_cond31 = icmp eq i32 %58, 0
+  %60 = load i32, i32* %i19, align 4
+  %error_lookup_cond31 = icmp eq i32 %60, 0
   br i1 %error_lookup_cond31, label %error_success29, label %error_failure30
 
 error_success29:                                  ; preds = %lookup_failure26
   br label %while_end22
 
 error_failure30:                                  ; preds = %lookup_failure26
-  %59 = load i32, i32* %i19, align 4
+  %61 = load i32, i32* %i19, align 4
   br label %while_end22
 
 event_loss_counter:                               ; preds = %if_body
-  %60 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %60)
+  %62 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %62)
   store i32 0, i32* %key, align 4
   %lookup_elem32 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
   %map_lookup_cond36 = icmp ne i8* %lookup_elem32, null
   br i1 %map_lookup_cond36, label %lookup_success33, label %lookup_failure34
 
 counter_merge:                                    ; preds = %lookup_merge35, %if_body
-  %61 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %61)
+  %63 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %63)
   br label %if_end
 
 lookup_success33:                                 ; preds = %event_loss_counter
-  %62 = bitcast i8* %lookup_elem32 to i64*
-  %63 = atomicrmw add i64* %62, i64 1 seq_cst
+  %64 = bitcast i8* %lookup_elem32 to i64*
+  %65 = atomicrmw add i64* %64, i64 1 seq_cst
   br label %lookup_merge35
 
 lookup_failure34:                                 ; preds = %event_loss_counter
   br label %lookup_merge35
 
 lookup_merge35:                                   ; preds = %lookup_failure34, %lookup_success33
-  %64 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %64)
+  %66 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %66)
   br label %counter_merge
 }
 
@@ -269,8 +272,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -323,14 +326,16 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/call_avg.ll
+++ b/tests/codegen/llvm/call_avg.ll
@@ -11,11 +11,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %initial_value9 = alloca i64, align 8
   %lookup_elem_val6 = alloca i64, align 8
@@ -97,8 +98,8 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -151,14 +152,16 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/call_count.ll
+++ b/tests/codegen/llvm/call_count.ll
@@ -11,11 +11,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !49 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !51 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -62,8 +63,8 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 
-!llvm.dbg.cu = !{!45}
-!llvm.module.flags = !{!48}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -110,14 +111,16 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !43)
 !43 = !{!44}
 !44 = !DISubrange(count: 2, lowerBound: 0)
-!45 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !46, globals: !47)
-!46 = !{}
-!47 = !{!0, !22, !36}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !45, retainedNodes: !54)
-!50 = !DISubroutineType(types: !51)
-!51 = !{!21, !52}
-!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
-!53 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !48, globals: !49)
+!48 = !{}
+!49 = !{!0, !22, !36, !45}
+!50 = !{i32 2, !"Debug Info Version", i32 3}
+!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !56)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!21, !54}
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
+!55 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!56 = !{!57}
+!57 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -11,11 +11,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -67,8 +68,8 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -121,14 +122,16 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -11,11 +11,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -67,8 +68,8 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -121,14 +122,16 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -11,11 +11,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -64,8 +65,8 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -118,14 +119,16 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/count_cast.ll
+++ b/tests/codegen/llvm/count_cast.ll
@@ -12,11 +12,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !49 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !51 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
@@ -87,76 +88,77 @@ if_end:                                           ; preds = %counter_merge, %whi
   ret i64 0
 
 while_cond:                                       ; preds = %lookup_success2, %lookup_merge
-  %18 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %18, 20
+  %18 = load i32, i64* @num_cpus, align 4
+  %19 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %19, %18
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %19 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %19)
+  %20 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %20)
   %map_lookup_cond4 = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %20 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = load i64, i64* %ret, align 8
-  %22 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@x_key1" to i8*
+  %21 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = load i64, i64* %ret, align 8
+  %23 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = icmp sgt i64 %21, 5
-  %25 = zext i1 %24 to i64
-  %true_cond = icmp ne i64 %25, 0
+  %24 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = icmp sgt i64 %22, 5
+  %26 = zext i1 %25 to i64
+  %true_cond = icmp ne i64 %26, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
   %cast5 = bitcast i8* %lookup_percpu_elem to i64*
-  %26 = load i64, i64* %ret, align 8
-  %27 = load i64, i64* %cast5, align 8
-  %28 = add i64 %27, %26
-  store i64 %28, i64* %ret, align 8
-  %29 = load i32, i32* %i, align 4
-  %30 = add i32 %29, 1
-  store i32 %30, i32* %i, align 4
+  %27 = load i64, i64* %ret, align 8
+  %28 = load i64, i64* %cast5, align 8
+  %29 = add i64 %28, %27
+  store i64 %29, i64* %ret, align 8
+  %30 = load i32, i32* %i, align 4
+  %31 = add i32 %30, 1
+  store i32 %31, i32* %i, align 4
   br label %while_cond
 
 lookup_failure3:                                  ; preds = %while_body
-  %31 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %31, 0
+  %32 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %32, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %32 = load i32, i32* %i, align 4
+  %33 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %if_body
-  %33 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %34 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
   store i32 0, i32* %key, align 4
   %lookup_elem6 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
   %map_lookup_cond10 = icmp ne i8* %lookup_elem6, null
   br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
 
 counter_merge:                                    ; preds = %lookup_merge9, %if_body
-  %34 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  %35 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %35)
   br label %if_end
 
 lookup_success7:                                  ; preds = %event_loss_counter
-  %35 = bitcast i8* %lookup_elem6 to i64*
-  %36 = atomicrmw add i64* %35, i64 1 seq_cst
+  %36 = bitcast i8* %lookup_elem6 to i64*
+  %37 = atomicrmw add i64* %36, i64 1 seq_cst
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter
   br label %lookup_merge9
 
 lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
-  %37 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+  %38 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %38)
   br label %counter_merge
 }
 
@@ -173,8 +175,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!45}
-!llvm.module.flags = !{!48}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -221,14 +223,16 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !43)
 !43 = !{!44}
 !44 = !DISubrange(count: 2, lowerBound: 0)
-!45 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !46, globals: !47)
-!46 = !{}
-!47 = !{!0, !22, !36}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !45, retainedNodes: !54)
-!50 = !DISubroutineType(types: !51)
-!51 = !{!21, !52}
-!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
-!53 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !48, globals: !49)
+!48 = !{}
+!49 = !{!0, !22, !36, !45}
+!50 = !{i32 2, !"Debug Info Version", i32 3}
+!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !56)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!21, !54}
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
+!55 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!56 = !{!57}
+!57 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -13,11 +13,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -62,7 +63,7 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !62 {
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !64 {
   %key1 = alloca i32, align 4
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_count__tuple_t", align 8
@@ -83,107 +84,108 @@ define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".t
   br label %while_cond
 
 while_cond:                                       ; preds = %lookup_success, %4
-  %8 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %8, 20
+  %8 = load i32, i64* @num_cpus, align 4
+  %9 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %9, %8
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %9 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %9)
+  %10 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %10)
   %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %10 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = load i64, i64* %ret, align 8
-  %12 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %"unsigned int64_count__tuple_t"* %"$kv" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %11 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = load i64, i64* %ret, align 8
+  %13 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast %"unsigned int64_count__tuple_t"* %"$kv" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 0
-  store i64 %key, i64* %15, align 8
-  %16 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 1
-  store i64 %11, i64* %16, align 8
-  %17 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 0
-  %18 = load i64, i64* %17, align 8
-  %19 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 1
-  %20 = load i64, i64* %19, align 8
-  %21 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %15 = bitcast %"unsigned int64_count__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %15, i8 0, i64 16, i1 false)
+  %16 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 0
+  store i64 %key, i64* %16, align 8
+  %17 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %12, i64* %17, align 8
+  %18 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 0
+  %19 = load i64, i64* %18, align 8
+  %20 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 1
+  %21 = load i64, i64* %20, align 8
   %22 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
-  %23 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %tuple, i32 0, i32 0
-  store i64 %18, i64* %23, align 8
-  %24 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %tuple, i32 0, i32 1
-  store i64 %20, i64* %24, align 8
-  %25 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, i64* %26, align 8
-  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
-  store i64 0, i64* %27, align 8
-  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
-  %29 = bitcast [16 x i8]* %28 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 16, i1 false)
-  %30 = bitcast [16 x i8]* %28 to i8*
-  %31 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %30, i8* align 1 %31, i64 16, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %23 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %23, i8 0, i64 16, i1 false)
+  %24 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %tuple, i32 0, i32 0
+  store i64 %19, i64* %24, align 8
+  %25 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %tuple, i32 0, i32 1
+  store i64 %21, i64* %25, align 8
+  %26 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, i64* %27, align 8
+  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
+  store i64 0, i64* %28, align 8
+  %29 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %30 = bitcast [16 x i8]* %29 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %30, i8 0, i64 16, i1 false)
+  %31 = bitcast [16 x i8]* %29 to i8*
+  %32 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %31, i8* align 1 %32, i64 16, i1 false)
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_tuple_16_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
   %cast = bitcast i8* %lookup_percpu_elem to i64*
-  %32 = load i64, i64* %ret, align 8
-  %33 = load i64, i64* %cast, align 8
-  %34 = add i64 %33, %32
-  store i64 %34, i64* %ret, align 8
-  %35 = load i32, i32* %i, align 4
-  %36 = add i32 %35, 1
-  store i32 %36, i32* %i, align 4
+  %33 = load i64, i64* %ret, align 8
+  %34 = load i64, i64* %cast, align 8
+  %35 = add i64 %34, %33
+  store i64 %35, i64* %ret, align 8
+  %36 = load i32, i32* %i, align 4
+  %37 = add i32 %36, 1
+  store i32 %37, i32* %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %37 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %37, 0
+  %38 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %38, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %38 = load i32, i32* %i, align 4
+  %39 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  %39 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  %40 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %40)
   store i32 0, i32* %key1, align 4
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key1)
   %map_lookup_cond4 = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  %40 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %41 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  %41 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %42 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %42 = bitcast i8* %lookup_elem to i64*
-  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  %43 = bitcast i8* %lookup_elem to i64*
+  %44 = atomicrmw add i64* %43, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  %44 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  %45 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %45)
   br label %counter_merge
 }
 
@@ -197,8 +199,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -251,17 +253,19 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
-!62 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !63)
-!63 = !{!64}
-!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)
+!64 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !53, retainedNodes: !65)
+!65 = !{!66}
+!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !64, file: !2, type: !60)

--- a/tests/codegen/llvm/count_no_cast_for_print.ll
+++ b/tests/codegen/llvm/count_no_cast_for_print.ll
@@ -12,11 +12,12 @@ target triple = "bpf-pc-linux"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(i8* %0) section "s_BEGIN_1" !dbg !49 {
+define i64 @BEGIN_1(i8* %0) section "s_BEGIN_1" !dbg !51 {
 entry:
   %key = alloca i32, align 4
   %"print_@" = alloca %print_t, align 8
@@ -103,8 +104,8 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 
-!llvm.dbg.cu = !{!45}
-!llvm.module.flags = !{!48}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -151,14 +152,16 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !43)
 !43 = !{!44}
 !44 = !DISubrange(count: 2, lowerBound: 0)
-!45 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !46, globals: !47)
-!46 = !{}
-!47 = !{!0, !22, !36}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !45, retainedNodes: !54)
-!50 = !DISubroutineType(types: !51)
-!51 = !{!21, !52}
-!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
-!53 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !48, globals: !49)
+!48 = !{}
+!49 = !{!0, !22, !36, !45}
+!50 = !{i32 2, !"Debug Info Version", i32 3}
+!51 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !56)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!21, !54}
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
+!55 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!56 = !{!57}
+!57 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -11,11 +11,12 @@ target triple = "bpf-pc-linux"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kretprobe_f_1(i8* %0) section "s_kretprobe_f_1" !dbg !55 {
+define i64 @kretprobe_f_1(i8* %0) section "s_kretprobe_f_1" !dbg !57 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -67,8 +68,8 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -121,14 +122,16 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kretprobe_f_1", linkageName: "kretprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kretprobe_f_1", linkageName: "kretprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -11,11 +11,12 @@ target triple = "bpf-pc-linux"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kretprobe_f_1(i8* %0) section "s_kretprobe_f_1" !dbg !55 {
+define i64 @kretprobe_f_1(i8* %0) section "s_kretprobe_f_1" !dbg !57 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -72,8 +73,8 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -126,14 +127,16 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kretprobe_f_1", linkageName: "kretprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kretprobe_f_1", linkageName: "kretprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/max_cast.ll
+++ b/tests/codegen/llvm/max_cast.ll
@@ -12,11 +12,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
@@ -90,83 +91,84 @@ if_end:                                           ; preds = %counter_merge, %whi
   ret i64 0
 
 while_cond:                                       ; preds = %min_max_merge, %lookup_merge
-  %18 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %18, 20
+  %18 = load i32, i64* @num_cpus, align 4
+  %19 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %19, %18
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %19 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %19)
+  %20 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %20)
   %map_lookup_cond4 = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %20 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = load i64, i64* %ret, align 8
-  %22 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@x_key1" to i8*
+  %21 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = load i64, i64* %ret, align 8
+  %23 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = icmp sgt i64 %21, 5
-  %25 = zext i1 %24 to i64
-  %true_cond = icmp ne i64 %25, 0
+  %24 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = icmp sgt i64 %22, 5
+  %26 = zext i1 %25 to i64
+  %true_cond = icmp ne i64 %26, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
   %cast5 = bitcast i8* %lookup_percpu_elem to i64*
-  %26 = load i64, i64* %ret, align 8
-  %27 = load i64, i64* %cast5, align 8
-  %max_cond = icmp sgt i64 %27, %26
+  %27 = load i64, i64* %ret, align 8
+  %28 = load i64, i64* %cast5, align 8
+  %max_cond = icmp sgt i64 %28, %27
   br i1 %max_cond, label %min_max_success, label %min_max_merge
 
 lookup_failure3:                                  ; preds = %while_body
-  %28 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %28, 0
+  %29 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %29, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 min_max_success:                                  ; preds = %lookup_success2
-  %29 = load i64, i64* %cast5, align 8
-  store i64 %29, i64* %ret, align 8
+  %30 = load i64, i64* %cast5, align 8
+  store i64 %30, i64* %ret, align 8
   br label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %lookup_success2
-  %30 = load i32, i32* %i, align 4
-  %31 = add i32 %30, 1
-  store i32 %31, i32* %i, align 4
+  %31 = load i32, i32* %i, align 4
+  %32 = add i32 %31, 1
+  store i32 %32, i32* %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %32 = load i32, i32* %i, align 4
+  %33 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %if_body
-  %33 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %34 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
   store i32 0, i32* %key, align 4
   %lookup_elem6 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
   %map_lookup_cond10 = icmp ne i8* %lookup_elem6, null
   br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
 
 counter_merge:                                    ; preds = %lookup_merge9, %if_body
-  %34 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  %35 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %35)
   br label %if_end
 
 lookup_success7:                                  ; preds = %event_loss_counter
-  %35 = bitcast i8* %lookup_elem6 to i64*
-  %36 = atomicrmw add i64* %35, i64 1 seq_cst
+  %36 = bitcast i8* %lookup_elem6 to i64*
+  %37 = atomicrmw add i64* %36, i64 1 seq_cst
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter
   br label %lookup_merge9
 
 lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
-  %37 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+  %38 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %38)
   br label %counter_merge
 }
 
@@ -183,8 +185,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -237,14 +239,16 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -13,11 +13,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -65,7 +66,7 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !62 {
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !64 {
   %key1 = alloca i32, align 4
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_max__tuple_t", align 8
@@ -86,114 +87,115 @@ define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".t
   br label %while_cond
 
 while_cond:                                       ; preds = %min_max_merge, %4
-  %8 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %8, 20
+  %8 = load i32, i64* @num_cpus, align 4
+  %9 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %9, %8
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %9 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %9)
+  %10 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %10)
   %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %10 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = load i64, i64* %ret, align 8
-  %12 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %"unsigned int64_max__tuple_t"* %"$kv" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %11 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = load i64, i64* %ret, align 8
+  %13 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast %"unsigned int64_max__tuple_t"* %"$kv" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 0
-  store i64 %key, i64* %15, align 8
-  %16 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 1
-  store i64 %11, i64* %16, align 8
-  %17 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 0
-  %18 = load i64, i64* %17, align 8
-  %19 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 1
-  %20 = load i64, i64* %19, align 8
-  %21 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %15 = bitcast %"unsigned int64_max__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %15, i8 0, i64 16, i1 false)
+  %16 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 0
+  store i64 %key, i64* %16, align 8
+  %17 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %12, i64* %17, align 8
+  %18 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 0
+  %19 = load i64, i64* %18, align 8
+  %20 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 1
+  %21 = load i64, i64* %20, align 8
   %22 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
-  %23 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %tuple, i32 0, i32 0
-  store i64 %18, i64* %23, align 8
-  %24 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %tuple, i32 0, i32 1
-  store i64 %20, i64* %24, align 8
-  %25 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, i64* %26, align 8
-  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
-  store i64 0, i64* %27, align 8
-  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
-  %29 = bitcast [16 x i8]* %28 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 16, i1 false)
-  %30 = bitcast [16 x i8]* %28 to i8*
-  %31 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %30, i8* align 1 %31, i64 16, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %23 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %23, i8 0, i64 16, i1 false)
+  %24 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %tuple, i32 0, i32 0
+  store i64 %19, i64* %24, align 8
+  %25 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %tuple, i32 0, i32 1
+  store i64 %21, i64* %25, align 8
+  %26 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, i64* %27, align 8
+  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
+  store i64 0, i64* %28, align 8
+  %29 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %30 = bitcast [16 x i8]* %29 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %30, i8 0, i64 16, i1 false)
+  %31 = bitcast [16 x i8]* %29 to i8*
+  %32 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %31, i8* align 1 %32, i64 16, i1 false)
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_tuple_16_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
   %cast = bitcast i8* %lookup_percpu_elem to i64*
-  %32 = load i64, i64* %ret, align 8
-  %33 = load i64, i64* %cast, align 8
-  %max_cond = icmp sgt i64 %33, %32
+  %33 = load i64, i64* %ret, align 8
+  %34 = load i64, i64* %cast, align 8
+  %max_cond = icmp sgt i64 %34, %33
   br i1 %max_cond, label %min_max_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %34 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %34, 0
+  %35 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %35, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 min_max_success:                                  ; preds = %lookup_success
-  %35 = load i64, i64* %cast, align 8
-  store i64 %35, i64* %ret, align 8
+  %36 = load i64, i64* %cast, align 8
+  store i64 %36, i64* %ret, align 8
   br label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %lookup_success
-  %36 = load i32, i32* %i, align 4
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %i, align 4
+  %37 = load i32, i32* %i, align 4
+  %38 = add i32 %37, 1
+  store i32 %38, i32* %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %38 = load i32, i32* %i, align 4
+  %39 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  %39 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  %40 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %40)
   store i32 0, i32* %key1, align 4
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key1)
   %map_lookup_cond4 = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  %40 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %41 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
+  %41 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %42 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %42 = bitcast i8* %lookup_elem to i64*
-  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  %43 = bitcast i8* %lookup_elem to i64*
+  %44 = atomicrmw add i64* %43, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  %44 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  %45 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %45)
   br label %counter_merge
 }
 
@@ -207,8 +209,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -261,17 +263,19 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
-!62 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !63)
-!63 = !{!64}
-!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)
+!64 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !53, retainedNodes: !65)
+!65 = !{!66}
+!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !64, file: !2, type: !60)

--- a/tests/codegen/llvm/min_cast.ll
+++ b/tests/codegen/llvm/min_cast.ll
@@ -12,11 +12,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
@@ -90,83 +91,84 @@ if_end:                                           ; preds = %counter_merge, %whi
   ret i64 0
 
 while_cond:                                       ; preds = %min_max_merge, %lookup_merge
-  %18 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %18, 20
+  %18 = load i32, i64* @num_cpus, align 4
+  %19 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %19, %18
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %19 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %19)
+  %20 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %20)
   %map_lookup_cond4 = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %20 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = load i64, i64* %ret, align 8
-  %22 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@x_key1" to i8*
+  %21 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = load i64, i64* %ret, align 8
+  %23 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = icmp sgt i64 %21, 5
-  %25 = zext i1 %24 to i64
-  %true_cond = icmp ne i64 %25, 0
+  %24 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = icmp sgt i64 %22, 5
+  %26 = zext i1 %25 to i64
+  %true_cond = icmp ne i64 %26, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
   %cast5 = bitcast i8* %lookup_percpu_elem to i64*
-  %26 = load i64, i64* %ret, align 8
-  %27 = load i64, i64* %cast5, align 8
-  %min_cond = icmp slt i64 %27, %26
+  %27 = load i64, i64* %ret, align 8
+  %28 = load i64, i64* %cast5, align 8
+  %min_cond = icmp slt i64 %28, %27
   br i1 %min_cond, label %min_max_success, label %min_max_merge
 
 lookup_failure3:                                  ; preds = %while_body
-  %28 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %28, 0
+  %29 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %29, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 min_max_success:                                  ; preds = %lookup_success2
-  %29 = load i64, i64* %cast5, align 8
-  store i64 %29, i64* %ret, align 8
+  %30 = load i64, i64* %cast5, align 8
+  store i64 %30, i64* %ret, align 8
   br label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %lookup_success2
-  %30 = load i32, i32* %i, align 4
-  %31 = add i32 %30, 1
-  store i32 %31, i32* %i, align 4
+  %31 = load i32, i32* %i, align 4
+  %32 = add i32 %31, 1
+  store i32 %32, i32* %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %32 = load i32, i32* %i, align 4
+  %33 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %if_body
-  %33 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %34 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
   store i32 0, i32* %key, align 4
   %lookup_elem6 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
   %map_lookup_cond10 = icmp ne i8* %lookup_elem6, null
   br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
 
 counter_merge:                                    ; preds = %lookup_merge9, %if_body
-  %34 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  %35 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %35)
   br label %if_end
 
 lookup_success7:                                  ; preds = %event_loss_counter
-  %35 = bitcast i8* %lookup_elem6 to i64*
-  %36 = atomicrmw add i64* %35, i64 1 seq_cst
+  %36 = bitcast i8* %lookup_elem6 to i64*
+  %37 = atomicrmw add i64* %36, i64 1 seq_cst
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter
   br label %lookup_merge9
 
 lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
-  %37 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+  %38 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %38)
   br label %counter_merge
 }
 
@@ -183,8 +185,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -237,14 +239,16 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -13,11 +13,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -65,7 +66,7 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !62 {
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !64 {
   %key1 = alloca i32, align 4
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_min__tuple_t", align 8
@@ -86,114 +87,115 @@ define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".t
   br label %while_cond
 
 while_cond:                                       ; preds = %min_max_merge, %4
-  %8 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %8, 20
+  %8 = load i32, i64* @num_cpus, align 4
+  %9 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %9, %8
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %9 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %9)
+  %10 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %10)
   %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %10 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = load i64, i64* %ret, align 8
-  %12 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %"unsigned int64_min__tuple_t"* %"$kv" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %11 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = load i64, i64* %ret, align 8
+  %13 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast %"unsigned int64_min__tuple_t"* %"$kv" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 0
-  store i64 %key, i64* %15, align 8
-  %16 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 1
-  store i64 %11, i64* %16, align 8
-  %17 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 0
-  %18 = load i64, i64* %17, align 8
-  %19 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 1
-  %20 = load i64, i64* %19, align 8
-  %21 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %15 = bitcast %"unsigned int64_min__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %15, i8 0, i64 16, i1 false)
+  %16 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 0
+  store i64 %key, i64* %16, align 8
+  %17 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %12, i64* %17, align 8
+  %18 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 0
+  %19 = load i64, i64* %18, align 8
+  %20 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 1
+  %21 = load i64, i64* %20, align 8
   %22 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
-  %23 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %tuple, i32 0, i32 0
-  store i64 %18, i64* %23, align 8
-  %24 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %tuple, i32 0, i32 1
-  store i64 %20, i64* %24, align 8
-  %25 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, i64* %26, align 8
-  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
-  store i64 0, i64* %27, align 8
-  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
-  %29 = bitcast [16 x i8]* %28 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 16, i1 false)
-  %30 = bitcast [16 x i8]* %28 to i8*
-  %31 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %30, i8* align 1 %31, i64 16, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %23 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %23, i8 0, i64 16, i1 false)
+  %24 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %tuple, i32 0, i32 0
+  store i64 %19, i64* %24, align 8
+  %25 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %tuple, i32 0, i32 1
+  store i64 %21, i64* %25, align 8
+  %26 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, i64* %27, align 8
+  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
+  store i64 0, i64* %28, align 8
+  %29 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %30 = bitcast [16 x i8]* %29 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %30, i8 0, i64 16, i1 false)
+  %31 = bitcast [16 x i8]* %29 to i8*
+  %32 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %31, i8* align 1 %32, i64 16, i1 false)
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_tuple_16_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
   %cast = bitcast i8* %lookup_percpu_elem to i64*
-  %32 = load i64, i64* %ret, align 8
-  %33 = load i64, i64* %cast, align 8
-  %min_cond = icmp slt i64 %33, %32
+  %33 = load i64, i64* %ret, align 8
+  %34 = load i64, i64* %cast, align 8
+  %min_cond = icmp slt i64 %34, %33
   br i1 %min_cond, label %min_max_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %34 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %34, 0
+  %35 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %35, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 min_max_success:                                  ; preds = %lookup_success
-  %35 = load i64, i64* %cast, align 8
-  store i64 %35, i64* %ret, align 8
+  %36 = load i64, i64* %cast, align 8
+  store i64 %36, i64* %ret, align 8
   br label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %lookup_success
-  %36 = load i32, i32* %i, align 4
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %i, align 4
+  %37 = load i32, i32* %i, align 4
+  %38 = add i32 %37, 1
+  store i32 %38, i32* %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %38 = load i32, i32* %i, align 4
+  %39 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  %39 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  %40 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %40)
   store i32 0, i32* %key1, align 4
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key1)
   %map_lookup_cond4 = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  %40 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %41 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
+  %41 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %42 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %42 = bitcast i8* %lookup_elem to i64*
-  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  %43 = bitcast i8* %lookup_elem to i64*
+  %44 = atomicrmw add i64* %43, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  %44 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  %45 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %45)
   br label %counter_merge
 }
 
@@ -207,8 +209,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -261,17 +263,19 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
-!62 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !63)
-!63 = !{!64}
-!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)
+!64 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !53, retainedNodes: !65)
+!65 = !{!66}
+!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !64, file: !2, type: !60)

--- a/tests/codegen/llvm/sum_cast.ll
+++ b/tests/codegen/llvm/sum_cast.ll
@@ -12,11 +12,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
@@ -87,76 +88,77 @@ if_end:                                           ; preds = %counter_merge, %whi
   ret i64 0
 
 while_cond:                                       ; preds = %lookup_success2, %lookup_merge
-  %18 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %18, 20
+  %18 = load i32, i64* @num_cpus, align 4
+  %19 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %19, %18
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %19 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %19)
+  %20 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %20)
   %map_lookup_cond4 = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %20 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = load i64, i64* %ret, align 8
-  %22 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@x_key1" to i8*
+  %21 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = load i64, i64* %ret, align 8
+  %23 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = icmp sgt i64 %21, 5
-  %25 = zext i1 %24 to i64
-  %true_cond = icmp ne i64 %25, 0
+  %24 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = icmp sgt i64 %22, 5
+  %26 = zext i1 %25 to i64
+  %true_cond = icmp ne i64 %26, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
   %cast5 = bitcast i8* %lookup_percpu_elem to i64*
-  %26 = load i64, i64* %ret, align 8
-  %27 = load i64, i64* %cast5, align 8
-  %28 = add i64 %27, %26
-  store i64 %28, i64* %ret, align 8
-  %29 = load i32, i32* %i, align 4
-  %30 = add i32 %29, 1
-  store i32 %30, i32* %i, align 4
+  %27 = load i64, i64* %ret, align 8
+  %28 = load i64, i64* %cast5, align 8
+  %29 = add i64 %28, %27
+  store i64 %29, i64* %ret, align 8
+  %30 = load i32, i32* %i, align 4
+  %31 = add i32 %30, 1
+  store i32 %31, i32* %i, align 4
   br label %while_cond
 
 lookup_failure3:                                  ; preds = %while_body
-  %31 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %31, 0
+  %32 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %32, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %32 = load i32, i32* %i, align 4
+  %33 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %if_body
-  %33 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %34 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
   store i32 0, i32* %key, align 4
   %lookup_elem6 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
   %map_lookup_cond10 = icmp ne i8* %lookup_elem6, null
   br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
 
 counter_merge:                                    ; preds = %lookup_merge9, %if_body
-  %34 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  %35 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %35)
   br label %if_end
 
 lookup_success7:                                  ; preds = %event_loss_counter
-  %35 = bitcast i8* %lookup_elem6 to i64*
-  %36 = atomicrmw add i64* %35, i64 1 seq_cst
+  %36 = bitcast i8* %lookup_elem6 to i64*
+  %37 = atomicrmw add i64* %36, i64 1 seq_cst
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter
   br label %lookup_merge9
 
 lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
-  %37 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+  %38 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %38)
   br label %counter_merge
 }
 
@@ -173,8 +175,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -227,14 +229,16 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -13,11 +13,12 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -62,7 +63,7 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !62 {
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !64 {
   %key1 = alloca i32, align 4
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_sum__tuple_t", align 8
@@ -83,107 +84,108 @@ define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".t
   br label %while_cond
 
 while_cond:                                       ; preds = %lookup_success, %4
-  %8 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %8, 20
+  %8 = load i32, i64* @num_cpus, align 4
+  %9 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %9, %8
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %9 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %9)
+  %10 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %10)
   %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %10 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = load i64, i64* %ret, align 8
-  %12 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %"unsigned int64_sum__tuple_t"* %"$kv" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %11 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = load i64, i64* %ret, align 8
+  %13 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast %"unsigned int64_sum__tuple_t"* %"$kv" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 0
-  store i64 %key, i64* %15, align 8
-  %16 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 1
-  store i64 %11, i64* %16, align 8
-  %17 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 0
-  %18 = load i64, i64* %17, align 8
-  %19 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 1
-  %20 = load i64, i64* %19, align 8
-  %21 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %15 = bitcast %"unsigned int64_sum__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %15, i8 0, i64 16, i1 false)
+  %16 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 0
+  store i64 %key, i64* %16, align 8
+  %17 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %12, i64* %17, align 8
+  %18 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 0
+  %19 = load i64, i64* %18, align 8
+  %20 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 1
+  %21 = load i64, i64* %20, align 8
   %22 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
-  %23 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %tuple, i32 0, i32 0
-  store i64 %18, i64* %23, align 8
-  %24 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %tuple, i32 0, i32 1
-  store i64 %20, i64* %24, align 8
-  %25 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, i64* %26, align 8
-  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
-  store i64 0, i64* %27, align 8
-  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
-  %29 = bitcast [16 x i8]* %28 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 16, i1 false)
-  %30 = bitcast [16 x i8]* %28 to i8*
-  %31 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %30, i8* align 1 %31, i64 16, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %23 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %23, i8 0, i64 16, i1 false)
+  %24 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %tuple, i32 0, i32 0
+  store i64 %19, i64* %24, align 8
+  %25 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %tuple, i32 0, i32 1
+  store i64 %21, i64* %25, align 8
+  %26 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, i64* %27, align 8
+  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
+  store i64 0, i64* %28, align 8
+  %29 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %30 = bitcast [16 x i8]* %29 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %30, i8 0, i64 16, i1 false)
+  %31 = bitcast [16 x i8]* %29 to i8*
+  %32 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %31, i8* align 1 %32, i64 16, i1 false)
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_tuple_16_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
   %cast = bitcast i8* %lookup_percpu_elem to i64*
-  %32 = load i64, i64* %ret, align 8
-  %33 = load i64, i64* %cast, align 8
-  %34 = add i64 %33, %32
-  store i64 %34, i64* %ret, align 8
-  %35 = load i32, i32* %i, align 4
-  %36 = add i32 %35, 1
-  store i32 %36, i32* %i, align 4
+  %33 = load i64, i64* %ret, align 8
+  %34 = load i64, i64* %cast, align 8
+  %35 = add i64 %34, %33
+  store i64 %35, i64* %ret, align 8
+  %36 = load i32, i32* %i, align 4
+  %37 = add i32 %36, 1
+  store i32 %37, i32* %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %37 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %37, 0
+  %38 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %38, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %38 = load i32, i32* %i, align 4
+  %39 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  %39 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  %40 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %40)
   store i32 0, i32* %key1, align 4
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key1)
   %map_lookup_cond4 = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  %40 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %41 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  %41 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %42 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %42 = bitcast i8* %lookup_elem to i64*
-  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  %43 = bitcast i8* %lookup_elem to i64*
+  %44 = atomicrmw add i64* %43, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  %44 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  %45 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %45)
   br label %counter_merge
 }
 
@@ -197,8 +199,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -251,17 +253,19 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
-!62 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !63)
-!63 = !{!64}
-!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !58)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)
+!64 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !53, retainedNodes: !65)
+!65 = !{!66}
+!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !64, file: !2, type: !60)

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -81,11 +81,6 @@ public:
     mock_probe_matcher = dynamic_cast<MockProbeMatcher *>(probe_matcher_.get());
   }
 
-  int get_num_possible_cpus() const override
-  {
-    return 20;
-  }
-
   MockProbeMatcher *mock_probe_matcher;
 };
 


### PR DESCRIPTION
This adds the ability to create const volatile global variables in bpf and allow them to be updated in userspace after program opening but before program loading.

This is useful for things like AOT, where we don't know know the number of CPUs on the machine where the bpftrace program will run at the time of codegen.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
