### PR TITLE
Ignore LLVM IR files when detecting repo language

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.bt linguist-language=D
 *.bt linguist-vendored
+*.ll linguist-detectable=false


### PR DESCRIPTION
bpftrace uses `.ll` files in codegen tests (as expected results of codegen) but we now have so many tests that their amount is bigger than the amount of actual source files. This makes GitHub mark LLVM as the primary language of bpftrace.

Update `.gitattributes` file to tell GitHub to ignore `.ll` files during language detection.

Tested on my [fork](https://github.com/viktormalik/bpftrace), see the Languages section there for illustration.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
