### PR TITLE
Tests: disable verbose logging after log tests

### DIFF
--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -31,6 +31,7 @@ TEST(LogStream, basic)
   LOG(V1) << content_1 << content_2;
   EXPECT_EQ(ss.str(), content_1 + content_2 + "\n");
   std::cerr.rdbuf(cerr_buf);
+  DISABLE_LOG(V1);
 }
 
 TEST(LogStream, with_location)


### PR DESCRIPTION
`LogStream.basic` test runs `ENABLE_LOG(V1)` to test the verbose logging output but forgets to run `DISABLE_LOG(V1)` afterwards. This causes all subsequent tests (e.g. when running all unit tests) to print verbose error messages which pollute the output.

Add the missing line.

Fixes #3310.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
