### PR TITLE
Codegen: fix printf of multiple values in iter

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1028,8 +1028,7 @@ void CodegenLLVM::visit(Call &call)
         // and store it to data area
         Value *offset = b_.CreateGEP(b_.GetType(data_type),
                                      data,
-                                     { b_.getInt64(0),
-                                       b_.getInt64((i - 1) * ptr_size) });
+                                     { b_.getInt64(0), b_.getInt32(i - 1) });
         b_.CreateStore(
             expr_, b_.CreateBitCast(offset, expr_->getType()->getPointerTo()));
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -515,6 +515,12 @@ EXPECT comm: bpftrace
 REQUIRES_FEATURE iter
 TIMEOUT 5
 
+NAME iter printf multiple values
+PROG iter:task { printf("%s: %d\n", "hello", 0); exit(); }
+EXPECT hello: 0
+REQUIRES_FEATURE iter
+TIMEOUT 5
+
 NAME cgroup_path
 PROG BEGIN { print(cgroup_path(cgroup & ((1 << 32) - 1))); exit(); }
 EXPECT_REGEX ([a-z]*:\/.*;)*[a-z]*:\/.*


### PR DESCRIPTION
Since commit 4e4f7ac2 ("codegen: iter: Allocate an array rather than a buffer"), we use array of int64 to store arguments of printf in iter probes but the commit forgot to update GEP indices for accessing the elements of the array (the GEPs still assumed buffer of int8).

This causes accesses to any element except for the one to index 0 to be incorrect, effectively failing in the verifier. Fix the issue by correctly accessing the array elements.

Fixes #3315.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
