### PR TITLE
Fix memleak in tuple creation

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -475,6 +475,8 @@ primary_expr:
                   auto args = new ast::ExpressionList;
                   args->emplace_back($2);
                   args->insert(args->end(), $4->begin(), $4->end());
+                  delete $4;
+                  $4 = nullptr;
                   $$ = new ast::Tuple(args, @$);
                 }
                 ;

--- a/tests/memleak-tests.sh
+++ b/tests/memleak-tests.sh
@@ -51,6 +51,7 @@ run_tests () {
 program_tests=(
     '"BEGIN { exit(); }"'
     $'"#include <linux/skbuff.h>\n BEGIN { \$x = ((struct sk_buff *)curtask)->data_len; exit(); }"'
+    '"BEGIN { print((1, 2)); exit(); }"'
 )
 
 listing_tests=(


### PR DESCRIPTION
The new ExpressionList created by vargs needs to get deleted after we move it's elements into the Tuple's ExpressionList.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
