### PR TITLE
Remove test binary created to test CFLAGs

### DIFF
--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -13,6 +13,7 @@ function(test_and_add_testprog_cflag flag)
   else()
     message(STATUS "${CMAKE_C_COMPILER} does not support ${flag}")
   endif()
+  execute_process(COMMAND rm -rf -)
 endfunction()
 
 test_and_add_testprog_cflag("-fno-omit-frame-pointer")


### PR DESCRIPTION
Caused by this commit:
https://github.com/bpftrace/bpftrace/commit/1021b5f6275ef1cec57ce5c3c2a04580d6020088

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
