### PR TITLE
Fix stack mode for stack builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to
   - [#3294](https://github.com/bpftrace/bpftrace/issues/3294)
 - Fix min/max map functions
   - [#3298](https://github.com/bpftrace/bpftrace/pull/3298)
+- Fix stack mode for stack builtin
+  - [#3322](https://github.com/bpftrace/bpftrace/pull/3322)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -21,7 +21,9 @@ namespace ast {
 // example the helper error metadata is still being collected during codegen.
 class ResourceAnalyser : public Visitor {
 public:
-  ResourceAnalyser(Node *root, std::ostream &out = std::cerr);
+  ResourceAnalyser(Node *root,
+                   BPFtrace &bpftrace,
+                   std::ostream &out = std::cerr);
 
   std::optional<RequiredResources> analyse();
 
@@ -38,6 +40,7 @@ private:
 
   RequiredResources resources_;
   Node *root_;
+  BPFtrace &bpftrace_;
   std::ostream &out_;
   std::ostringstream err_;
   // Current probe we're analysing

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -319,9 +319,13 @@ void SemanticAnalyser::visit(Builtin &builtin)
     // For uretprobe -> AddrSpace::user
     builtin.type.SetAS(find_addrspace(type));
   } else if (builtin.ident == "kstack") {
-    builtin.type = CreateStack(true, StackType());
+    builtin.type = CreateStack(true,
+                               StackType{ .mode = bpftrace_.config_.get(
+                                              ConfigKeyStackMode::default_) });
   } else if (builtin.ident == "ustack") {
-    builtin.type = CreateStack(false, StackType());
+    builtin.type = CreateStack(false,
+                               StackType{ .mode = bpftrace_.config_.get(
+                                              ConfigKeyStackMode::default_) });
   } else if (builtin.ident == "comm") {
     builtin.type = CreateString(COMM_SIZE);
     // comm allocated in the bpf stack. See codegen

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -30,7 +30,7 @@ TEST(codegen, call_kstack_mapids)
   ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
@@ -66,7 +66,7 @@ TEST(codegen, call_kstack_modes_mapids)
   ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -30,7 +30,7 @@ TEST(codegen, call_ustack_mapids)
   ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
@@ -66,7 +66,7 @@ TEST(codegen, call_ustack_modes_mapids)
   ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -60,7 +60,7 @@ static void test(BPFtrace &bpftrace,
   ast::SemanticAnalyser semantics(driver.root.get(), bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get(), bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace.resources = resources_optional.value();

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -68,7 +68,7 @@ TEST(codegen, printf_offsets)
   ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -19,7 +19,7 @@ TEST(codegen, regression_957)
   ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -39,7 +39,7 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
   ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -36,7 +36,7 @@ void test(BPFtrace &bpftrace,
   ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get(), out);
+  ast::ResourceAnalyser resource_analyser(driver.root.get(), bpftrace, out);
   auto resources_optional = resource_analyser.analyse();
   EXPECT_EQ(resources_optional.has_value(), expected_result)
       << msg.str() << out.str();

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -270,3 +270,15 @@ EXPECT_REGEX SUCCESS [0-9]+
 REQUIRES_FEATURE jiffies64
 TIMEOUT 5
 MIN_KERNEL 5.9
+
+NAME ustack builtin with stack_mode config
+RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { @c[ustack] = 1; exit(); }' -p {{BEFORE_PID}}
+EXPECT_REGEX ^@c\[\n[0-9a-f]+$
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME kstack builtin with stack_mode config
+RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } k:do_nanosleep { @c[kstack] = 1; exit(); }'
+EXPECT_REGEX ^@c\[\n[0-9a-f]+$
+TIMEOUT 5
+AFTER ./testprogs/syscall nanosleep  1e8


### PR DESCRIPTION
The stack mode for kstack and ustack builtin
variables (i.e. without ()) were not respecting
the stack mode value set by the config block.

Example:
```
bpftrace -e 'config = { stack_mode = raw } kprobe:vfs_read { @ = kstack; exit() }'
bpftrace -e 'config = { stack_mode = raw } kprobe:vfs_read { @[kstack] = 0; exit() }'
bpftrace -e 'config = { stack_mode = raw } kprobe:vfs_read { $s = kstack; print($s); exit() }'
```

All of these would have the default 'bpftrace'
stack mode instead of 'raw'.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
