### PR TITLE
Release/0.21.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to
 #### Docs
 #### Tools
 
+## [0.21.2] 2024-07-17
+
+- Fix min/max map functions
+  - [#3298](https://github.com/bpftrace/bpftrace/pull/3298)
+- Fix segfault for multi-tracepoint probes
+  - [#3274](https://github.com/bpftrace/bpftrace/pull/3274)
+
 ## [0.21.1] 2024-06-24
 
 - Fix include path on loongarch, mips, riscv, and s390

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0057 NEW)
 # bpftrace version number components.
 set(bpftrace_VERSION_MAJOR 0)
 set(bpftrace_VERSION_MINOR 21)
-set(bpftrace_VERSION_PATCH 1)
+set(bpftrace_VERSION_PATCH 2)
 
 include(GNUInstallDirs)
 

--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -34,6 +34,7 @@ public:
 
   DIType *GetType(const SizedType &stype);
   DIType *CreateTupleType(const SizedType &stype);
+  DIType *CreateMinMaxType(const SizedType &stype);
   DIType *createPointerMemberType(const std::string &name,
                                   uint64_t offset,
                                   DIType *type);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -311,6 +311,21 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
   return ty;
 }
 
+llvm::Type *IRBuilderBPF::GetMapValueType(const SizedType &stype)
+{
+  llvm::Type *ty;
+  if (stype.IsMinTy() || stype.IsMaxTy()) {
+    // The first field is the value
+    // The second field is the "value is set" flag
+    std::vector<llvm::Type *> llvm_elems = { getInt64Ty(), getInt64Ty() };
+    ty = GetStructType("min_max_val", llvm_elems, false);
+  } else {
+    ty = GetType(stype);
+  }
+
+  return ty;
+}
+
 CallInst *IRBuilderBPF::CreateHelperCall(libbpf::bpf_func_id func_id,
                                          FunctionType *helper_type,
                                          ArrayRef<Value *> args,
@@ -587,7 +602,7 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
    *        debug("No cpu found for cpu id: %lu", i) // Mostly for AOT
    *     break;
    *   }
-   *   // Get the sum, min, or max value
+   *   // update ret for sum, count, avg, min, max
    *   i++;
    * }
    * return ret;
@@ -597,8 +612,10 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
 
   const std::string &map_name = map.ident;
 
-  AllocaInst *ret = CreateAllocaBPF(getInt64Ty(), "ret");
   AllocaInst *i = CreateAllocaBPF(getInt32Ty(), "i");
+  AllocaInst *ret = CreateAllocaBPF(getInt64Ty(), "ret");
+  // used only for min/max
+  AllocaInst *is_ret_set = CreateAllocaBPF(getInt64Ty(), "is_ret_set");
 
   // Set a large upper bound if we don't know the number of cpus
   // when generating the instructions
@@ -606,6 +623,7 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
 
   CreateStore(getInt32(0), i);
   CreateStore(getInt64(0), ret);
+  CreateStore(getInt64(0), is_ret_set);
 
   Function *parent = GetInsertBlock()->getParent();
   BasicBlock *while_cond = BasicBlock::Create(module_.getContext(),
@@ -646,15 +664,11 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
   SetInsertPoint(lookup_success_block);
-  // createMapLookup  returns an u8*
-  auto *cast = CreatePointerCast(call, getInt64Ty()->getPointerTo(), "cast");
 
-  if (type.IsSumTy() || type.IsCountTy()) {
-    createPerCpuSum(ret, cast);
-  } else if (type.IsMaxTy()) {
-    createPerCpuMinMax(ret, cast, true);
-  } else if (type.IsMinTy()) {
-    createPerCpuMinMax(ret, cast, false);
+  if (type.IsMinTy() || type.IsMaxTy()) {
+    createPerCpuMinMax(ret, is_ret_set, call, type);
+  } else if (type.IsSumTy() || type.IsCountTy()) {
+    createPerCpuSum(ret, call, type);
   } else {
     LOG(BUG) << "Unsupported map aggregation type: " << type;
   }
@@ -697,46 +711,110 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
   SetInsertPoint(while_end);
 
   CreateLifetimeEnd(i);
+  CreateLifetimeEnd(is_ret_set);
+
   Value *ret_reg = CreateLoad(getInt64Ty(), ret);
+
   CreateLifetimeEnd(ret);
   return ret_reg;
 }
 
-void IRBuilderBPF::createPerCpuSum(AllocaInst *ret, Value *cpu_value)
+void IRBuilderBPF::createPerCpuSum(AllocaInst *ret,
+                                   CallInst *call,
+                                   const SizedType &type)
 {
-  CreateStore(CreateAdd(CreateLoad(getInt64Ty(), cpu_value),
+  auto *cast = CreatePointerCast(call, GetType(type)->getPointerTo(), "cast");
+  CreateStore(CreateAdd(CreateLoad(GetType(type), cast),
                         CreateLoad(getInt64Ty(), ret)),
               ret);
 }
 
 void IRBuilderBPF::createPerCpuMinMax(AllocaInst *ret,
-                                      Value *cpu_value,
-                                      bool is_max)
+                                      AllocaInst *is_ret_set,
+                                      CallInst *call,
+                                      const SizedType &type)
 {
+  auto *value_type = GetMapValueType(type);
+  auto *cast = CreatePointerCast(call, value_type->getPointerTo(), "cast");
+  bool is_max = type.IsMaxTy();
+
+  Value *mm_val = CreateLoad(
+      getInt64Ty(), CreateGEP(value_type, cast, { getInt64(0), getInt32(0) }));
+
+  Value *is_val_set = CreateLoad(
+      getInt64Ty(), CreateGEP(value_type, cast, { getInt64(0), getInt32(1) }));
+
+  /*
+   * (ret, is_ret_set, min_max_val, is_val_set) {
+   * // if the min_max_val is 0, which is the initial map value,
+   * // we need to know if it was explicitly set by user
+   * if (!is_val_set == 1) {
+   *   return;
+   * }
+   * if (!is_ret_set == 1) {
+   *   ret = min_max_val;
+   *   is_ret_set = 1;
+   * } else if (min_max_val > ret) { // or min_max_val < ret if min operation
+   *   ret = min_max_val;
+   *   is_ret_set = 1;
+   * }
+   */
+
   Function *parent = GetInsertBlock()->getParent();
-  BasicBlock *success_block = BasicBlock::Create(module_.getContext(),
-                                                 "min_max_success",
-                                                 parent);
+  BasicBlock *val_set_success = BasicBlock::Create(module_.getContext(),
+                                                   "val_set_success",
+                                                   parent);
+  BasicBlock *min_max_success = BasicBlock::Create(module_.getContext(),
+                                                   "min_max_success",
+                                                   parent);
+  BasicBlock *ret_set_success = BasicBlock::Create(module_.getContext(),
+                                                   "ret_set_success",
+                                                   parent);
   BasicBlock *merge_block = BasicBlock::Create(module_.getContext(),
                                                "min_max_merge",
                                                parent);
-  Value *condition;
+
+  Value *val_set_condition = CreateICmpEQ(is_val_set,
+                                          getInt64(1),
+                                          "val_set_cond");
+
+  Value *ret_set_condition = CreateICmpEQ(CreateLoad(getInt64Ty(), is_ret_set),
+                                          getInt64(1),
+                                          "ret_set_cond");
+
+  Value *min_max_condition;
 
   if (is_max) {
-    condition = CreateICmpSGT(CreateLoad(getInt64Ty(), cpu_value),
-                              CreateLoad(getInt64Ty(), ret),
-                              "max_cond");
+    min_max_condition =
+        type.IsSigned()
+            ? CreateICmpSGT(mm_val, CreateLoad(getInt64Ty(), ret), "max_cond")
+            : CreateICmpUGT(mm_val, CreateLoad(getInt64Ty(), ret), "max_cond");
   } else {
-    condition = CreateICmpSLT(CreateLoad(getInt64Ty(), cpu_value),
-                              CreateLoad(getInt64Ty(), ret),
-                              "min_cond");
+    min_max_condition =
+        type.IsSigned()
+            ? CreateICmpSLT(mm_val, CreateLoad(getInt64Ty(), ret), "min_cond")
+            : CreateICmpULT(mm_val, CreateLoad(getInt64Ty(), ret), "max_cond");
   }
-  CreateCondBr(condition, success_block, merge_block);
 
-  SetInsertPoint(success_block);
+  // if (is_val_set == 1)
+  CreateCondBr(val_set_condition, val_set_success, merge_block);
+
+  SetInsertPoint(val_set_success);
+
+  // if (is_ret_set == 1)
+  CreateCondBr(ret_set_condition, ret_set_success, min_max_success);
+
+  SetInsertPoint(ret_set_success);
+
+  // if (min_max_val > ret) or if (min_max_val < ret)
+  CreateCondBr(min_max_condition, min_max_success, merge_block);
+
+  SetInsertPoint(min_max_success);
 
   // ret = cpu_value;
-  CreateStore(CreateLoad(getInt64Ty(), cpu_value), ret);
+  CreateStore(mm_val, ret);
+  // is_ret_set = 1;
+  CreateStore(getInt64(1), is_ret_set);
 
   CreateBr(merge_block);
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -67,6 +67,7 @@ public:
   AllocaInst *CreateAllocaBPF(int bytes, const std::string &name = "");
   void CreateMemsetBPF(Value *ptr, Value *val, uint32_t size);
   llvm::Type *GetType(const SizedType &stype);
+  llvm::Type *GetMapValueType(const SizedType &stype);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Type *ty);
   Value *GetMapVar(const std::string &map_name);
@@ -329,8 +330,11 @@ private:
                              size_t size,
                              const location *loc = nullptr);
 
-  void createPerCpuSum(AllocaInst *ret, Value *cpu_value);
-  void createPerCpuMinMax(AllocaInst *ret, Value *cpu_value, bool is_max);
+  void createPerCpuSum(AllocaInst *ret, CallInst *call, const SizedType &type);
+  void createPerCpuMinMax(AllocaInst *ret,
+                          AllocaInst *is_ret_set,
+                          CallInst *call,
+                          const SizedType &type);
 
   std::map<std::string, StructType *> structs_;
 };

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2699,6 +2699,7 @@ void CodegenLLVM::visit(Probe &probe)
   // We begin by saving state that gets changed by the codegen pass, so we
   // can restore it for the next pass (printf_id_, time_id_).
   auto reset_ids = create_reset_ids();
+  bool generated = false;
   for (auto *attach_point : *probe.attach_points) {
     reset_ids();
     current_attach_point_ = attach_point;
@@ -2728,15 +2729,17 @@ void CodegenLLVM::visit(Probe &probe)
 
         auto match_ap = attach_point->create_expansion_copy(match);
         add_probe(match_ap, probe, match, func_type);
-      }
-      if (matches.empty()) {
-        generateProbe(probe, "dummy", "dummy", func_type, std::nullopt, true);
+        generated = true;
       }
     } else {
       if (probe.index() == 0)
         probe.set_index(getNextIndexForProbe());
       add_probe(*attach_point, probe, attach_point->name(), func_type);
+      generated = true;
     }
+  }
+  if (!generated) {
+    generateProbe(probe, "dummy", "dummy", func_type, std::nullopt, true);
   }
 
   current_attach_point_ = nullptr;

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -690,7 +690,7 @@ void maybe_throw_helper_verifier_error(std::string_view log,
                     exception_msg_suffix;
   throw HelperVerifierError(msg, static_cast<libbpf::bpf_func_id>(func_id));
 }
-}
+} // namespace
 
 void AttachedProbe::load_prog(BPFfeature &feature)
 {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1436,16 +1436,17 @@ int BPFtrace::print_map(const BpfMap &map, uint32_t top, uint32_t div)
                 return reduce_value<uint64_t>(a.second, nvalues) <
                        reduce_value<uint64_t>(b.second, nvalues);
               });
-  } else if (value_type.IsMinTy()) {
-    std::sort(
-        values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b) {
-          return min_value(a.second, nvalues) < min_value(b.second, nvalues);
-        });
-  } else if (value_type.IsMaxTy()) {
-    std::sort(
-        values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b) {
-          return max_value(a.second, nvalues) < max_value(b.second, nvalues);
-        });
+  } else if (value_type.IsMinTy() || value_type.IsMaxTy()) {
+    std::sort(values_by_key.begin(),
+              values_by_key.end(),
+              [&](auto &a, auto &b) {
+                return min_max_value<uint64_t>(a.second,
+                                               nvalues,
+                                               value_type.IsMaxTy()) <
+                       min_max_value<uint64_t>(b.second,
+                                               nvalues,
+                                               value_type.IsMaxTy());
+              });
   } else {
     sort_by_key(map_info.key.args_, values_by_key);
   };

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -340,11 +340,20 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
       return std::to_string(reduce_value<int64_t>(value, nvalues) / div);
 
     return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
-  } else if (type.IsMinTy())
-    return std::to_string(min_value(value, nvalues) / div);
-  else if (type.IsMaxTy())
-    return std::to_string(max_value(value, nvalues) / div);
-  else if (type.IsProbeTy())
+  } else if (type.IsMinTy() || type.IsMaxTy()) {
+    if (is_per_cpu) {
+      if (type.IsSigned()) {
+        return std::to_string(
+            min_max_value<int64_t>(value, nvalues, type.IsMaxTy()) / div);
+      }
+      return std::to_string(
+          min_max_value<uint64_t>(value, nvalues, type.IsMaxTy()) / div);
+    }
+    if (type.IsSigned()) {
+      return std::to_string(read_data<int64_t>(value.data()) / div);
+    }
+    return std::to_string(read_data<uint64_t>(value.data()) / div);
+  } else if (type.IsProbeTy())
     return bpftrace.resolve_probe(read_data<uint64_t>(value.data()));
   else if (type.IsTimestampTy())
     return bpftrace.resolve_timestamp(

--- a/src/types.h
+++ b/src/types.h
@@ -154,7 +154,7 @@ private:
                                        // StructManager
   AddrSpace as_ = AddrSpace::none;
   bool is_signed_ = false;
-  bool ctx_ = false; // Is bpf program context
+  bool ctx_ = false;                                   // Is bpf program context
   std::unordered_set<std::string> btf_type_tags_ = {}; // Only populated for
                                                        // Type::pointer
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1296,29 +1296,6 @@ std::optional<std::string> abs_path(const std::string &rel_path)
   }
 }
 
-int64_t min_value(const std::vector<uint8_t> &value, int nvalues)
-{
-  int64_t val, max = 0;
-  for (int i = 0; i < nvalues; i++) {
-    val = read_data<int64_t>(value.data() + i * sizeof(int64_t));
-    if (val > max)
-      max = val;
-  }
-
-  return max;
-}
-
-uint64_t max_value(const std::vector<uint8_t> &value, int nvalues)
-{
-  uint64_t val, max = 0;
-  for (int i = 0; i < nvalues; i++) {
-    val = read_data<uint64_t>(value.data() + i * sizeof(uint64_t));
-    if (val > max)
-      max = val;
-  }
-  return max;
-}
-
 bool symbol_has_module(const std::string &symbol)
 {
   return !symbol.empty() && symbol[symbol.size() - 1] == ']';

--- a/src/utils.h
+++ b/src/utils.h
@@ -326,8 +326,30 @@ T reduce_value(const std::vector<uint8_t> &value, int nvalues)
   }
   return sum;
 }
-int64_t min_value(const std::vector<uint8_t> &value, int nvalues);
-uint64_t max_value(const std::vector<uint8_t> &value, int nvalues);
+
+template <typename T>
+T min_max_value(const std::vector<uint8_t> &value, int nvalues, bool is_max)
+{
+  T mm_val = 0;
+  bool mm_set = false;
+  for (int i = 0; i < nvalues; i++) {
+    T val = read_data<T>(value.data() + i * (sizeof(T) * 2));
+    uint32_t is_set = read_data<uint32_t>(value.data() + sizeof(T) +
+                                          i * (sizeof(T) * 2));
+    if (!is_set) {
+      continue;
+    }
+    if (!mm_set) {
+      mm_val = val;
+      mm_set = true;
+    } else if (is_max && val > mm_val) {
+      mm_val = val;
+    } else if (!is_max && val < mm_val) {
+      mm_val = val;
+    }
+  }
+  return mm_val;
+}
 
 // Combination of 2 hashes
 // The algorithm is taken from boost::hash_combine

--- a/tests/codegen/llvm/avg_cast.ll
+++ b/tests/codegen/llvm/avg_cast.ll
@@ -1,0 +1,353 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { i8*, i8*, i8*, i8* }
+%"struct map_t.0" = type { i8*, i8* }
+%"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !57 {
+entry:
+  %key = alloca i32, align 4
+  %print_integer_8_t = alloca %print_integer_8_t, align 8
+  %is_ret_set20 = alloca i64, align 8
+  %ret19 = alloca i64, align 8
+  %i18 = alloca i32, align 4
+  %"@x_key17" = alloca i64, align 8
+  %is_ret_set = alloca i64, align 8
+  %ret = alloca i64, align 8
+  %i = alloca i32, align 4
+  %"@x_key12" = alloca i64, align 8
+  %"@x_key11" = alloca i64, align 8
+  %initial_value9 = alloca i64, align 8
+  %lookup_elem_val6 = alloca i64, align 8
+  %"@x_key1" = alloca i64, align 8
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@x_key", align 8
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
+  %2 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %3 = load i64, i64* %cast, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, i64* %cast, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  %5 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 1, i64* %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 1, i64* %"@x_key1", align 8
+  %lookup_elem2 = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key1")
+  %10 = bitcast i64* %lookup_elem_val6 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %map_lookup_cond7 = icmp ne i8* %lookup_elem2, null
+  br i1 %map_lookup_cond7, label %lookup_success3, label %lookup_failure4
+
+lookup_success3:                                  ; preds = %lookup_merge
+  %cast8 = bitcast i8* %lookup_elem2 to i64*
+  %11 = load i64, i64* %cast8, align 8
+  %12 = add i64 %11, 2
+  store i64 %12, i64* %cast8, align 8
+  br label %lookup_merge5
+
+lookup_failure4:                                  ; preds = %lookup_merge
+  %13 = bitcast i64* %initial_value9 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 2, i64* %initial_value9, align 8
+  %update_elem10 = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i64* %initial_value9, i64 1)
+  %14 = bitcast i64* %initial_value9 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  br label %lookup_merge5
+
+lookup_merge5:                                    ; preds = %lookup_failure4, %lookup_success3
+  %15 = bitcast i64* %lookup_elem_val6 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_key11" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  store i64 0, i64* %"@x_key11", align 8
+  %18 = bitcast i64* %"@x_key12" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i64 0, i64* %"@x_key12", align 8
+  %19 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
+  %20 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  %21 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  store i32 0, i32* %i, align 4
+  store i64 0, i64* %ret, align 8
+  store i64 0, i64* %is_ret_set, align 8
+  br label %while_cond
+
+if_body:                                          ; preds = %while_end23
+  %22 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %23 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
+  store i64 30007, i64* %23, align 8
+  %24 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
+  store i64 0, i64* %24, align 8
+  %25 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
+  %26 = bitcast [8 x i8]* %25 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %26, i8 0, i64 8, i1 false)
+  %27 = bitcast [8 x i8]* %25 to i64*
+  store i64 6, i64* %27, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_integer_8_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_integer_8_t* %print_integer_8_t, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+if_end:                                           ; preds = %counter_merge, %while_end23
+  ret i64 0
+
+while_cond:                                       ; preds = %lookup_success13, %lookup_merge5
+  %28 = load i32, i64* @num_cpus, align 4
+  %29 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %29, %28
+  br i1 %num_cpu.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %30 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key12", i32 %30)
+  %map_lookup_cond15 = icmp ne i8* %lookup_percpu_elem, null
+  br i1 %map_lookup_cond15, label %lookup_success13, label %lookup_failure14
+
+while_end:                                        ; preds = %error_failure, %error_success, %while_cond
+  %31 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
+  %32 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  %33 = load i64, i64* %ret, align 8
+  %34 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  %35 = bitcast i64* %"@x_key12" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %35)
+  %36 = bitcast i64* %"@x_key17" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %36)
+  store i64 1, i64* %"@x_key17", align 8
+  %37 = bitcast i32* %i18 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
+  %38 = bitcast i64* %ret19 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %38)
+  %39 = bitcast i64* %is_ret_set20 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  store i32 0, i32* %i18, align 4
+  store i64 0, i64* %ret19, align 8
+  store i64 0, i64* %is_ret_set20, align 8
+  br label %while_cond21
+
+lookup_success13:                                 ; preds = %while_body
+  %cast16 = bitcast i8* %lookup_percpu_elem to i64*
+  %40 = load i64, i64* %ret, align 8
+  %41 = load i64, i64* %cast16, align 8
+  %42 = add i64 %41, %40
+  store i64 %42, i64* %ret, align 8
+  %43 = load i32, i32* %i, align 4
+  %44 = add i32 %43, 1
+  store i32 %44, i32* %i, align 4
+  br label %while_cond
+
+lookup_failure14:                                 ; preds = %while_body
+  %45 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %45, 0
+  br i1 %error_lookup_cond, label %error_success, label %error_failure
+
+error_success:                                    ; preds = %lookup_failure14
+  br label %while_end
+
+error_failure:                                    ; preds = %lookup_failure14
+  %46 = load i32, i32* %i, align 4
+  br label %while_end
+
+while_cond21:                                     ; preds = %lookup_success26, %while_end
+  %47 = load i32, i64* @num_cpus, align 4
+  %48 = load i32, i32* %i18, align 4
+  %num_cpu.cmp24 = icmp ult i32 %48, %47
+  br i1 %num_cpu.cmp24, label %while_body22, label %while_end23
+
+while_body22:                                     ; preds = %while_cond21
+  %49 = load i32, i32* %i18, align 4
+  %lookup_percpu_elem25 = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key17", i32 %49)
+  %map_lookup_cond28 = icmp ne i8* %lookup_percpu_elem25, null
+  br i1 %map_lookup_cond28, label %lookup_success26, label %lookup_failure27
+
+while_end23:                                      ; preds = %error_failure31, %error_success30, %while_cond21
+  %50 = bitcast i32* %i18 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %50)
+  %51 = bitcast i64* %is_ret_set20 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %51)
+  %52 = load i64, i64* %ret19, align 8
+  %53 = bitcast i64* %ret19 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %53)
+  %54 = bitcast i64* %"@x_key17" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %54)
+  %55 = udiv i64 %52, %33
+  %56 = bitcast i64* %"@x_key11" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %56)
+  %57 = icmp eq i64 %55, 2
+  %58 = zext i1 %57 to i64
+  %true_cond = icmp ne i64 %58, 0
+  br i1 %true_cond, label %if_body, label %if_end
+
+lookup_success26:                                 ; preds = %while_body22
+  %cast29 = bitcast i8* %lookup_percpu_elem25 to i64*
+  %59 = load i64, i64* %ret19, align 8
+  %60 = load i64, i64* %cast29, align 8
+  %61 = add i64 %60, %59
+  store i64 %61, i64* %ret19, align 8
+  %62 = load i32, i32* %i18, align 4
+  %63 = add i32 %62, 1
+  store i32 %63, i32* %i18, align 4
+  br label %while_cond21
+
+lookup_failure27:                                 ; preds = %while_body22
+  %64 = load i32, i32* %i18, align 4
+  %error_lookup_cond32 = icmp eq i32 %64, 0
+  br i1 %error_lookup_cond32, label %error_success30, label %error_failure31
+
+error_success30:                                  ; preds = %lookup_failure27
+  br label %while_end23
+
+error_failure31:                                  ; preds = %lookup_failure27
+  %65 = load i32, i32* %i18, align 4
+  br label %while_end23
+
+event_loss_counter:                               ; preds = %if_body
+  %66 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %66)
+  store i32 0, i32* %key, align 4
+  %lookup_elem33 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
+  %map_lookup_cond37 = icmp ne i8* %lookup_elem33, null
+  br i1 %map_lookup_cond37, label %lookup_success34, label %lookup_failure35
+
+counter_merge:                                    ; preds = %lookup_merge36, %if_body
+  %67 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %67)
+  br label %if_end
+
+lookup_success34:                                 ; preds = %event_loss_counter
+  %68 = bitcast i8* %lookup_elem33 to i64*
+  %69 = atomicrmw add i64* %68, i64 1 seq_cst
+  br label %lookup_merge36
+
+lookup_failure35:                                 ; preds = %event_loss_counter
+  br label %lookup_merge36
+
+lookup_merge36:                                   ; preds = %lookup_failure35, %lookup_success34
+  %70 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %70)
+  br label %counter_merge
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
+
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!56}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 160, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 5, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
+!23 = !{!24, !29}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
+!27 = !{!28}
+!28 = !DISubrange(count: 27, lowerBound: 0)
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 262144, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
+!37 = !{!38, !43, !48, !19}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 2, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 1, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !54, globals: !55)
+!54 = !{}
+!55 = !{!0, !20, !34, !51}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -6,19 +6,19 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%min_max_val = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !61 {
 entry:
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -26,35 +26,44 @@ entry:
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %2 = lshr i64 %get_pid_tgid, 32
-  %3 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %map_lookup_cond = icmp ne i8* %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %cast = bitcast i8* %lookup_elem to i64*
-  %4 = load i64, i64* %cast, align 8
-  %5 = icmp sge i64 %2, %4
-  br i1 %5, label %max.ge, label %lookup_merge
+  %cast = bitcast i8* %lookup_elem to %min_max_val*
+  %3 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  %4 = load i64, i64* %3, align 8
+  %5 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  %6 = load i64, i64* %5, align 8
+  %is_set_cond = icmp eq i64 %6, 1
+  br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
-  %6 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store i64 %2, i64* %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
-  %7 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %7 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 0
+  store i64 %2, i64* %8, align 8
+  %9 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 1
+  store i64 1, i64* %9, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %min_max_val*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %min_max_val* %mm_struct, i64 0)
+  %10 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure, %max.ge, %lookup_success
-  %8 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+lookup_merge:                                     ; preds = %lookup_failure, %min_max, %is_set
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 
-max.ge:                                           ; preds = %lookup_success
-  store i64 %2, i64* %cast, align 8
+is_set:                                           ; preds = %lookup_success
+  %12 = icmp uge i64 %2, %4
+  br i1 %12, label %min_max, label %lookup_merge
+
+min_max:                                          ; preds = %is_set, %lookup_success
+  %13 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  store i64 %2, i64* %13, align 8
+  %14 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  store i64 1, i64* %14, align 8
   br label %lookup_merge
 }
 
@@ -67,8 +76,8 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!60}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -89,46 +98,52 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !58, globals: !59)
+!58 = !{}
+!59 = !{!0, !26, !40}
+!60 = !{i32 2, !"Debug Info Version", i32 3}
+!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !66)
+!62 = !DISubroutineType(types: !63)
+!63 = !{!18, !64}
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!66 = !{!67}
+!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -6,19 +6,19 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%min_max_val = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !61 {
 entry:
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -26,35 +26,44 @@ entry:
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %2 = lshr i64 %get_pid_tgid, 32
-  %3 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %map_lookup_cond = icmp ne i8* %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %cast = bitcast i8* %lookup_elem to i64*
-  %4 = load i64, i64* %cast, align 8
-  %5 = icmp sge i64 %4, %2
-  br i1 %5, label %min.ge, label %lookup_merge
+  %cast = bitcast i8* %lookup_elem to %min_max_val*
+  %3 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  %4 = load i64, i64* %3, align 8
+  %5 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  %6 = load i64, i64* %5, align 8
+  %is_set_cond = icmp eq i64 %6, 1
+  br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
-  %6 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store i64 %2, i64* %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
-  %7 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %7 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 0
+  store i64 %2, i64* %8, align 8
+  %9 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 1
+  store i64 1, i64* %9, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %min_max_val*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %min_max_val* %mm_struct, i64 0)
+  %10 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure, %min.ge, %lookup_success
-  %8 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+lookup_merge:                                     ; preds = %lookup_failure, %min_max, %is_set
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 
-min.ge:                                           ; preds = %lookup_success
-  store i64 %2, i64* %cast, align 8
+is_set:                                           ; preds = %lookup_success
+  %12 = icmp uge i64 %4, %2
+  br i1 %12, label %min_max, label %lookup_merge
+
+min_max:                                          ; preds = %is_set, %lookup_success
+  %13 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  store i64 %2, i64* %13, align 8
+  %14 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  store i64 1, i64* %14, align 8
   br label %lookup_merge
 }
 
@@ -67,8 +76,8 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!60}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -89,46 +98,52 @@ attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !58, globals: !59)
+!58 = !{}
+!59 = !{!0, !26, !40}
+!60 = !{i32 2, !"Debug Info Version", i32 3}
+!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !66)
+!62 = !DISubroutineType(types: !63)
+!63 = !{!18, !64}
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!66 = !{!67}
+!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)

--- a/tests/codegen/llvm/count_cast.ll
+++ b/tests/codegen/llvm/count_cast.ll
@@ -20,8 +20,9 @@ define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %i = alloca i32, align 4
+  %is_ret_set = alloca i64, align 8
   %ret = alloca i64, align 8
+  %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -59,26 +60,29 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %9 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key1", align 8
-  %10 = bitcast i64* %ret to i8*
+  %10 = bitcast i32* %i to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i32* %i to i8*
+  %11 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i32 0, i32* %i, align 4
   store i64 0, i64* %ret, align 8
+  store i64 0, i64* %is_ret_set, align 8
   br label %while_cond
 
 if_body:                                          ; preds = %while_end
-  %12 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  %13 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
-  store i64 30007, i64* %13, align 8
-  %14 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
-  store i64 0, i64* %14, align 8
-  %15 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
-  %16 = bitcast [8 x i8]* %15 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 8, i1 false)
-  %17 = bitcast [8 x i8]* %15 to i64*
-  store i64 6, i64* %17, align 8
+  %13 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
+  store i64 30007, i64* %14, align 8
+  %15 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
+  store i64 0, i64* %15, align 8
+  %16 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
+  %17 = bitcast [8 x i8]* %16 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %17, i8 0, i64 8, i1 false)
+  %18 = bitcast [8 x i8]* %16 to i64*
+  store i64 6, i64* %18, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_integer_8_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_integer_8_t* %print_integer_8_t, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -87,76 +91,78 @@ if_end:                                           ; preds = %counter_merge, %whi
   ret i64 0
 
 while_cond:                                       ; preds = %lookup_success2, %lookup_merge
-  %18 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %18, 20
+  %19 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %19, 20
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %19 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %19)
+  %20 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %20)
   %map_lookup_cond4 = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %20 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = load i64, i64* %ret, align 8
-  %22 = bitcast i64* %ret to i8*
+  %21 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %is_ret_set to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = icmp sgt i64 %21, 5
-  %25 = zext i1 %24 to i64
-  %true_cond = icmp ne i64 %25, 0
+  %23 = load i64, i64* %ret, align 8
+  %24 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
+  %26 = icmp sgt i64 %23, 5
+  %27 = zext i1 %26 to i64
+  %true_cond = icmp ne i64 %27, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
   %cast5 = bitcast i8* %lookup_percpu_elem to i64*
-  %26 = load i64, i64* %ret, align 8
-  %27 = load i64, i64* %cast5, align 8
-  %28 = add i64 %27, %26
-  store i64 %28, i64* %ret, align 8
-  %29 = load i32, i32* %i, align 4
-  %30 = add i32 %29, 1
-  store i32 %30, i32* %i, align 4
+  %28 = load i64, i64* %ret, align 8
+  %29 = load i64, i64* %cast5, align 8
+  %30 = add i64 %29, %28
+  store i64 %30, i64* %ret, align 8
+  %31 = load i32, i32* %i, align 4
+  %32 = add i32 %31, 1
+  store i32 %32, i32* %i, align 4
   br label %while_cond
 
 lookup_failure3:                                  ; preds = %while_body
-  %31 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %31, 0
+  %33 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %33, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %32 = load i32, i32* %i, align 4
+  %34 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %if_body
-  %33 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %35 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
   store i32 0, i32* %key, align 4
   %lookup_elem6 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
   %map_lookup_cond10 = icmp ne i8* %lookup_elem6, null
   br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
 
 counter_merge:                                    ; preds = %lookup_merge9, %if_body
-  %34 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  %36 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
   br label %if_end
 
 lookup_success7:                                  ; preds = %event_loss_counter
-  %35 = bitcast i8* %lookup_elem6 to i64*
-  %36 = atomicrmw add i64* %35, i64 1 seq_cst
+  %37 = bitcast i8* %lookup_elem6 to i64*
+  %38 = atomicrmw add i64* %37, i64 1 seq_cst
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter
   br label %lookup_merge9
 
 lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
-  %37 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+  %39 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %39)
   br label %counter_merge
 }
 

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -67,123 +67,129 @@ define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".t
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_count__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_count__tuple_t", align 8
-  %i = alloca i32, align 4
+  %is_ret_set = alloca i64, align 8
   %ret = alloca i64, align 8
+  %i = alloca i32, align 4
   %lookup_key = alloca i64, align 8
   %key = load i64, i8* %1, align 8
   %5 = bitcast i64* %lookup_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 %key, i64* %lookup_key, align 8
-  %6 = bitcast i64* %ret to i8*
+  %6 = bitcast i32* %i to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i32* %i to i8*
+  %7 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i32 0, i32* %i, align 4
   store i64 0, i64* %ret, align 8
+  store i64 0, i64* %is_ret_set, align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %lookup_success, %4
-  %8 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %8, 20
+  %9 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %9, 20
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %9 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %9)
+  %10 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %10)
   %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %10 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = load i64, i64* %ret, align 8
-  %12 = bitcast i64* %ret to i8*
+  %11 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %is_ret_set to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %"unsigned int64_count__tuple_t"* %"$kv" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  %14 = bitcast %"unsigned int64_count__tuple_t"* %"$kv" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 0
-  store i64 %key, i64* %15, align 8
-  %16 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 1
-  store i64 %11, i64* %16, align 8
+  %13 = load i64, i64* %ret, align 8
+  %14 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast %"unsigned int64_count__tuple_t"* %"$kv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %16 = bitcast %"unsigned int64_count__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 16, i1 false)
   %17 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 0
-  %18 = load i64, i64* %17, align 8
-  %19 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %key, i64* %17, align 8
+  %18 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %13, i64* %18, align 8
+  %19 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 0
   %20 = load i64, i64* %19, align 8
-  %21 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
-  %22 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
-  %23 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %tuple, i32 0, i32 0
-  store i64 %18, i64* %23, align 8
-  %24 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %tuple, i32 0, i32 1
-  store i64 %20, i64* %24, align 8
-  %25 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, i64* %26, align 8
-  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
-  store i64 0, i64* %27, align 8
-  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
-  %29 = bitcast [16 x i8]* %28 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 16, i1 false)
-  %30 = bitcast [16 x i8]* %28 to i8*
-  %31 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %30, i8* align 1 %31, i64 16, i1 false)
+  %21 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %"$kv", i32 0, i32 1
+  %22 = load i64, i64* %21, align 8
+  %23 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %24 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %24, i8 0, i64 16, i1 false)
+  %25 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %tuple, i32 0, i32 0
+  store i64 %20, i64* %25, align 8
+  %26 = getelementptr %"unsigned int64_count__tuple_t", %"unsigned int64_count__tuple_t"* %tuple, i32 0, i32 1
+  store i64 %22, i64* %26, align 8
+  %27 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
+  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, i64* %28, align 8
+  %29 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
+  store i64 0, i64* %29, align 8
+  %30 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %31 = bitcast [16 x i8]* %30 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %31, i8 0, i64 16, i1 false)
+  %32 = bitcast [16 x i8]* %30 to i8*
+  %33 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %32, i8* align 1 %33, i64 16, i1 false)
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_tuple_16_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
   %cast = bitcast i8* %lookup_percpu_elem to i64*
-  %32 = load i64, i64* %ret, align 8
-  %33 = load i64, i64* %cast, align 8
-  %34 = add i64 %33, %32
-  store i64 %34, i64* %ret, align 8
-  %35 = load i32, i32* %i, align 4
-  %36 = add i32 %35, 1
-  store i32 %36, i32* %i, align 4
+  %34 = load i64, i64* %ret, align 8
+  %35 = load i64, i64* %cast, align 8
+  %36 = add i64 %35, %34
+  store i64 %36, i64* %ret, align 8
+  %37 = load i32, i32* %i, align 4
+  %38 = add i32 %37, 1
+  store i32 %38, i32* %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %37 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %37, 0
+  %39 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %39, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %38 = load i32, i32* %i, align 4
+  %40 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  %39 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  %41 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %41)
   store i32 0, i32* %key1, align 4
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key1)
   %map_lookup_cond4 = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  %40 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %41 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %42 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
+  %43 = bitcast %"unsigned int64_count__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %42 = bitcast i8* %lookup_elem to i64*
-  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  %44 = bitcast i8* %lookup_elem to i64*
+  %45 = atomicrmw add i64* %44, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  %44 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  %46 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %46)
   br label %counter_merge
 }
 

--- a/tests/codegen/llvm/max_cast.ll
+++ b/tests/codegen/llvm/max_cast.ll
@@ -7,81 +7,94 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%min_max_val = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !61 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %i = alloca i32, align 4
+  %is_ret_set = alloca i64, align 8
   %ret = alloca i64, align 8
+  %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
-  %2 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %map_lookup_cond = icmp ne i8* %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %cast = bitcast i8* %lookup_elem to i64*
-  %3 = load i64, i64* %cast, align 8
-  %4 = icmp sge i64 2, %3
-  br i1 %4, label %max.ge, label %lookup_merge
+  %cast = bitcast i8* %lookup_elem to %min_max_val*
+  %2 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  %3 = load i64, i64* %2, align 8
+  %4 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  %5 = load i64, i64* %4, align 8
+  %is_set_cond = icmp eq i64 %5, 1
+  br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
-  %5 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 2, i64* %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
-  %6 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %6 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 0
+  store i64 2, i64* %7, align 8
+  %8 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 1
+  store i64 1, i64* %8, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %min_max_val*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %min_max_val* %mm_struct, i64 0)
+  %9 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure, %max.ge, %lookup_success
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key1" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key1", align 8
-  %10 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i32* %i to i8*
+lookup_merge:                                     ; preds = %lookup_failure, %min_max, %is_set
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@x_key1", align 8
+  %12 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i32 0, i32* %i, align 4
   store i64 0, i64* %ret, align 8
+  store i64 0, i64* %is_ret_set, align 8
   br label %while_cond
 
-max.ge:                                           ; preds = %lookup_success
-  store i64 2, i64* %cast, align 8
+is_set:                                           ; preds = %lookup_success
+  %15 = icmp sge i64 2, %3
+  br i1 %15, label %min_max, label %lookup_merge
+
+min_max:                                          ; preds = %is_set, %lookup_success
+  %16 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  store i64 2, i64* %16, align 8
+  %17 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  store i64 1, i64* %17, align 8
   br label %lookup_merge
 
 if_body:                                          ; preds = %while_end
-  %12 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  %13 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
-  store i64 30007, i64* %13, align 8
-  %14 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
-  store i64 0, i64* %14, align 8
-  %15 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
-  %16 = bitcast [8 x i8]* %15 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 8, i1 false)
-  %17 = bitcast [8 x i8]* %15 to i64*
-  store i64 6, i64* %17, align 8
+  %18 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  %19 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
+  store i64 30007, i64* %19, align 8
+  %20 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
+  store i64 0, i64* %20, align 8
+  %21 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
+  %22 = bitcast [8 x i8]* %21 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 8, i1 false)
+  %23 = bitcast [8 x i8]* %21 to i64*
+  store i64 6, i64* %23, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_integer_8_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_integer_8_t* %print_integer_8_t, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -90,83 +103,97 @@ if_end:                                           ; preds = %counter_merge, %whi
   ret i64 0
 
 while_cond:                                       ; preds = %min_max_merge, %lookup_merge
-  %18 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %18, 20
+  %24 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %24, 20
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %19 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %19)
-  %map_lookup_cond4 = icmp ne i8* %lookup_percpu_elem, null
-  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+  %25 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %25)
+  %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
+  br i1 %map_lookup_cond, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %20 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = load i64, i64* %ret, align 8
-  %22 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = icmp sgt i64 %21, 5
-  %25 = zext i1 %24 to i64
-  %true_cond = icmp ne i64 %25, 0
+  %26 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
+  %27 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
+  %28 = load i64, i64* %ret, align 8
+  %29 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
+  %30 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
+  %31 = icmp sgt i64 %28, 5
+  %32 = zext i1 %31 to i64
+  %true_cond = icmp ne i64 %32, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %cast5 = bitcast i8* %lookup_percpu_elem to i64*
-  %26 = load i64, i64* %ret, align 8
-  %27 = load i64, i64* %cast5, align 8
-  %max_cond = icmp sgt i64 %27, %26
-  br i1 %max_cond, label %min_max_success, label %min_max_merge
+  %cast4 = bitcast i8* %lookup_percpu_elem to %min_max_val*
+  %33 = getelementptr %min_max_val, %min_max_val* %cast4, i64 0, i32 0
+  %34 = load i64, i64* %33, align 8
+  %35 = getelementptr %min_max_val, %min_max_val* %cast4, i64 0, i32 1
+  %36 = load i64, i64* %35, align 8
+  %val_set_cond = icmp eq i64 %36, 1
+  %37 = load i64, i64* %is_ret_set, align 8
+  %ret_set_cond = icmp eq i64 %37, 1
+  %38 = load i64, i64* %ret, align 8
+  %max_cond = icmp sgt i64 %34, %38
+  br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure3:                                  ; preds = %while_body
-  %28 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %28, 0
+  %39 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %39, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
-min_max_success:                                  ; preds = %lookup_success2
-  %29 = load i64, i64* %cast5, align 8
-  store i64 %29, i64* %ret, align 8
+val_set_success:                                  ; preds = %lookup_success2
+  br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
+
+min_max_success:                                  ; preds = %ret_set_success, %val_set_success
+  store i64 %34, i64* %ret, align 8
+  store i64 1, i64* %is_ret_set, align 8
   br label %min_max_merge
 
-min_max_merge:                                    ; preds = %min_max_success, %lookup_success2
-  %30 = load i32, i32* %i, align 4
-  %31 = add i32 %30, 1
-  store i32 %31, i32* %i, align 4
+ret_set_success:                                  ; preds = %val_set_success
+  br i1 %max_cond, label %min_max_success, label %min_max_merge
+
+min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success2
+  %40 = load i32, i32* %i, align 4
+  %41 = add i32 %40, 1
+  store i32 %41, i32* %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %32 = load i32, i32* %i, align 4
+  %42 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %if_body
-  %33 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %43 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %43)
   store i32 0, i32* %key, align 4
-  %lookup_elem6 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
-  %map_lookup_cond10 = icmp ne i8* %lookup_elem6, null
-  br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
+  %lookup_elem5 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
+  %map_lookup_cond9 = icmp ne i8* %lookup_elem5, null
+  br i1 %map_lookup_cond9, label %lookup_success6, label %lookup_failure7
 
-counter_merge:                                    ; preds = %lookup_merge9, %if_body
-  %34 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+counter_merge:                                    ; preds = %lookup_merge8, %if_body
+  %44 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
   br label %if_end
 
-lookup_success7:                                  ; preds = %event_loss_counter
-  %35 = bitcast i8* %lookup_elem6 to i64*
-  %36 = atomicrmw add i64* %35, i64 1 seq_cst
-  br label %lookup_merge9
+lookup_success6:                                  ; preds = %event_loss_counter
+  %45 = bitcast i8* %lookup_elem5 to i64*
+  %46 = atomicrmw add i64* %45, i64 1 seq_cst
+  br label %lookup_merge8
 
-lookup_failure8:                                  ; preds = %event_loss_counter
-  br label %lookup_merge9
+lookup_failure7:                                  ; preds = %event_loss_counter
+  br label %lookup_merge8
 
-lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
-  %37 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+lookup_merge8:                                    ; preds = %lookup_failure7, %lookup_success6
+  %47 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %47)
   br label %counter_merge
 }
 
@@ -183,8 +210,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!60}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -205,46 +232,52 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !58, globals: !59)
+!58 = !{}
+!59 = !{!0, !26, !40}
+!60 = !{i32 2, !"Debug Info Version", i32 3}
+!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !66)
+!62 = !DISubroutineType(types: !63)
+!63 = !{!18, !64}
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!66 = !{!67}
+!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -6,56 +6,65 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%min_max_val = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 %"unsigned int64_max__tuple_t" = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !61 {
 entry:
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 1, i64* %"@x_key", align 8
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
-  %2 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %map_lookup_cond = icmp ne i8* %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %cast = bitcast i8* %lookup_elem to i64*
-  %3 = load i64, i64* %cast, align 8
-  %4 = icmp sge i64 2, %3
-  br i1 %4, label %max.ge, label %lookup_merge
+  %cast = bitcast i8* %lookup_elem to %min_max_val*
+  %2 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  %3 = load i64, i64* %2, align 8
+  %4 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  %5 = load i64, i64* %4, align 8
+  %is_set_cond = icmp eq i64 %5, 1
+  br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
-  %5 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 2, i64* %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
-  %6 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %6 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 0
+  store i64 2, i64* %7, align 8
+  %8 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 1
+  store i64 1, i64* %8, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %min_max_val*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %min_max_val* %mm_struct, i64 0)
+  %9 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure, %max.ge, %lookup_success
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+lookup_merge:                                     ; preds = %lookup_failure, %min_max, %is_set
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %for_each_map_elem = call i64 inttoptr (i64 164 to i64 (%"struct map_t"*, i64 (i8*, i8*, i8*, i8*)*, i8*, i64)*)(%"struct map_t"* @AT_x, i64 (i8*, i8*, i8*, i8*)* @map_for_each_cb, i8* null, i64 0)
   ret i64 0
 
-max.ge:                                           ; preds = %lookup_success
-  store i64 2, i64* %cast, align 8
+is_set:                                           ; preds = %lookup_success
+  %11 = icmp sge i64 2, %3
+  br i1 %11, label %min_max, label %lookup_merge
+
+min_max:                                          ; preds = %is_set, %lookup_success
+  %12 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  store i64 2, i64* %12, align 8
+  %13 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  store i64 1, i64* %13, align 8
   br label %lookup_merge
 }
 
@@ -65,135 +74,153 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !62 {
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !68 {
   %key1 = alloca i32, align 4
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_max__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_max__tuple_t", align 8
-  %i = alloca i32, align 4
+  %is_ret_set = alloca i64, align 8
   %ret = alloca i64, align 8
+  %i = alloca i32, align 4
   %lookup_key = alloca i64, align 8
   %key = load i64, i8* %1, align 8
   %5 = bitcast i64* %lookup_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 %key, i64* %lookup_key, align 8
-  %6 = bitcast i64* %ret to i8*
+  %6 = bitcast i32* %i to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i32* %i to i8*
+  %7 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i32 0, i32* %i, align 4
   store i64 0, i64* %ret, align 8
+  store i64 0, i64* %is_ret_set, align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %min_max_merge, %4
-  %8 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %8, 20
+  %9 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %9, 20
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %9 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %9)
+  %10 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %10)
   %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %10 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = load i64, i64* %ret, align 8
-  %12 = bitcast i64* %ret to i8*
+  %11 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %is_ret_set to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %"unsigned int64_max__tuple_t"* %"$kv" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  %14 = bitcast %"unsigned int64_max__tuple_t"* %"$kv" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 0
-  store i64 %key, i64* %15, align 8
-  %16 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 1
-  store i64 %11, i64* %16, align 8
+  %13 = load i64, i64* %ret, align 8
+  %14 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast %"unsigned int64_max__tuple_t"* %"$kv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %16 = bitcast %"unsigned int64_max__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 16, i1 false)
   %17 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 0
-  %18 = load i64, i64* %17, align 8
-  %19 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %key, i64* %17, align 8
+  %18 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %13, i64* %18, align 8
+  %19 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 0
   %20 = load i64, i64* %19, align 8
-  %21 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
-  %22 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
-  %23 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %tuple, i32 0, i32 0
-  store i64 %18, i64* %23, align 8
-  %24 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %tuple, i32 0, i32 1
-  store i64 %20, i64* %24, align 8
-  %25 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, i64* %26, align 8
-  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
-  store i64 0, i64* %27, align 8
-  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
-  %29 = bitcast [16 x i8]* %28 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 16, i1 false)
-  %30 = bitcast [16 x i8]* %28 to i8*
-  %31 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %30, i8* align 1 %31, i64 16, i1 false)
+  %21 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %"$kv", i32 0, i32 1
+  %22 = load i64, i64* %21, align 8
+  %23 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %24 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %24, i8 0, i64 16, i1 false)
+  %25 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %tuple, i32 0, i32 0
+  store i64 %20, i64* %25, align 8
+  %26 = getelementptr %"unsigned int64_max__tuple_t", %"unsigned int64_max__tuple_t"* %tuple, i32 0, i32 1
+  store i64 %22, i64* %26, align 8
+  %27 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
+  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, i64* %28, align 8
+  %29 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
+  store i64 0, i64* %29, align 8
+  %30 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %31 = bitcast [16 x i8]* %30 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %31, i8 0, i64 16, i1 false)
+  %32 = bitcast [16 x i8]* %30 to i8*
+  %33 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %32, i8* align 1 %33, i64 16, i1 false)
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_tuple_16_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %cast = bitcast i8* %lookup_percpu_elem to i64*
-  %32 = load i64, i64* %ret, align 8
-  %33 = load i64, i64* %cast, align 8
-  %max_cond = icmp sgt i64 %33, %32
-  br i1 %max_cond, label %min_max_success, label %min_max_merge
+  %cast = bitcast i8* %lookup_percpu_elem to %min_max_val*
+  %34 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  %35 = load i64, i64* %34, align 8
+  %36 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  %37 = load i64, i64* %36, align 8
+  %val_set_cond = icmp eq i64 %37, 1
+  %38 = load i64, i64* %is_ret_set, align 8
+  %ret_set_cond = icmp eq i64 %38, 1
+  %39 = load i64, i64* %ret, align 8
+  %max_cond = icmp sgt i64 %35, %39
+  br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %34 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %34, 0
+  %40 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %40, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
-min_max_success:                                  ; preds = %lookup_success
-  %35 = load i64, i64* %cast, align 8
+val_set_success:                                  ; preds = %lookup_success
+  br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
+
+min_max_success:                                  ; preds = %ret_set_success, %val_set_success
   store i64 %35, i64* %ret, align 8
+  store i64 1, i64* %is_ret_set, align 8
   br label %min_max_merge
 
-min_max_merge:                                    ; preds = %min_max_success, %lookup_success
-  %36 = load i32, i32* %i, align 4
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %i, align 4
+ret_set_success:                                  ; preds = %val_set_success
+  br i1 %max_cond, label %min_max_success, label %min_max_merge
+
+min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
+  %41 = load i32, i32* %i, align 4
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %38 = load i32, i32* %i, align 4
+  %43 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  %39 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  %44 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %44)
   store i32 0, i32* %key1, align 4
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key1)
   %map_lookup_cond4 = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  %40 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %41 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %45 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %45)
+  %46 = bitcast %"unsigned int64_max__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %46)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %42 = bitcast i8* %lookup_elem to i64*
-  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  %47 = bitcast i8* %lookup_elem to i64*
+  %48 = atomicrmw add i64* %47, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  %44 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  %49 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
   br label %counter_merge
 }
 
@@ -207,8 +234,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!60}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -229,49 +256,55 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
-!62 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !63)
-!63 = !{!64}
-!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !58)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !58, globals: !59)
+!58 = !{}
+!59 = !{!0, !26, !40}
+!60 = !{i32 2, !"Debug Info Version", i32 3}
+!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !66)
+!62 = !DISubroutineType(types: !63)
+!63 = !{!18, !64}
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!66 = !{!67}
+!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)
+!68 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !57, retainedNodes: !69)
+!69 = !{!70}
+!70 = !DILocalVariable(name: "ctx", arg: 1, scope: !68, file: !2, type: !64)

--- a/tests/codegen/llvm/min_cast.ll
+++ b/tests/codegen/llvm/min_cast.ll
@@ -7,81 +7,94 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%min_max_val = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !61 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %i = alloca i32, align 4
+  %is_ret_set = alloca i64, align 8
   %ret = alloca i64, align 8
+  %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
-  %2 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %map_lookup_cond = icmp ne i8* %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %cast = bitcast i8* %lookup_elem to i64*
-  %3 = load i64, i64* %cast, align 8
-  %4 = icmp sge i64 %3, 2
-  br i1 %4, label %min.ge, label %lookup_merge
+  %cast = bitcast i8* %lookup_elem to %min_max_val*
+  %2 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  %3 = load i64, i64* %2, align 8
+  %4 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  %5 = load i64, i64* %4, align 8
+  %is_set_cond = icmp eq i64 %5, 1
+  br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
-  %5 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 2, i64* %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
-  %6 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %6 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 0
+  store i64 2, i64* %7, align 8
+  %8 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 1
+  store i64 1, i64* %8, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %min_max_val*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %min_max_val* %mm_struct, i64 0)
+  %9 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure, %min.ge, %lookup_success
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key1" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key1", align 8
-  %10 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i32* %i to i8*
+lookup_merge:                                     ; preds = %lookup_failure, %min_max, %is_set
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@x_key1", align 8
+  %12 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i32 0, i32* %i, align 4
   store i64 0, i64* %ret, align 8
+  store i64 0, i64* %is_ret_set, align 8
   br label %while_cond
 
-min.ge:                                           ; preds = %lookup_success
-  store i64 2, i64* %cast, align 8
+is_set:                                           ; preds = %lookup_success
+  %15 = icmp sge i64 %3, 2
+  br i1 %15, label %min_max, label %lookup_merge
+
+min_max:                                          ; preds = %is_set, %lookup_success
+  %16 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  store i64 2, i64* %16, align 8
+  %17 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  store i64 1, i64* %17, align 8
   br label %lookup_merge
 
 if_body:                                          ; preds = %while_end
-  %12 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  %13 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
-  store i64 30007, i64* %13, align 8
-  %14 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
-  store i64 0, i64* %14, align 8
-  %15 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
-  %16 = bitcast [8 x i8]* %15 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 8, i1 false)
-  %17 = bitcast [8 x i8]* %15 to i64*
-  store i64 6, i64* %17, align 8
+  %18 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  %19 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
+  store i64 30007, i64* %19, align 8
+  %20 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
+  store i64 0, i64* %20, align 8
+  %21 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
+  %22 = bitcast [8 x i8]* %21 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 8, i1 false)
+  %23 = bitcast [8 x i8]* %21 to i64*
+  store i64 6, i64* %23, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_integer_8_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_integer_8_t* %print_integer_8_t, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -90,83 +103,97 @@ if_end:                                           ; preds = %counter_merge, %whi
   ret i64 0
 
 while_cond:                                       ; preds = %min_max_merge, %lookup_merge
-  %18 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %18, 20
+  %24 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %24, 20
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %19 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %19)
-  %map_lookup_cond4 = icmp ne i8* %lookup_percpu_elem, null
-  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+  %25 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %25)
+  %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
+  br i1 %map_lookup_cond, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %20 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = load i64, i64* %ret, align 8
-  %22 = bitcast i64* %ret to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = icmp sgt i64 %21, 5
-  %25 = zext i1 %24 to i64
-  %true_cond = icmp ne i64 %25, 0
+  %26 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
+  %27 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
+  %28 = load i64, i64* %ret, align 8
+  %29 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
+  %30 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
+  %31 = icmp sgt i64 %28, 5
+  %32 = zext i1 %31 to i64
+  %true_cond = icmp ne i64 %32, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %cast5 = bitcast i8* %lookup_percpu_elem to i64*
-  %26 = load i64, i64* %ret, align 8
-  %27 = load i64, i64* %cast5, align 8
-  %min_cond = icmp slt i64 %27, %26
-  br i1 %min_cond, label %min_max_success, label %min_max_merge
+  %cast4 = bitcast i8* %lookup_percpu_elem to %min_max_val*
+  %33 = getelementptr %min_max_val, %min_max_val* %cast4, i64 0, i32 0
+  %34 = load i64, i64* %33, align 8
+  %35 = getelementptr %min_max_val, %min_max_val* %cast4, i64 0, i32 1
+  %36 = load i64, i64* %35, align 8
+  %val_set_cond = icmp eq i64 %36, 1
+  %37 = load i64, i64* %is_ret_set, align 8
+  %ret_set_cond = icmp eq i64 %37, 1
+  %38 = load i64, i64* %ret, align 8
+  %min_cond = icmp slt i64 %34, %38
+  br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure3:                                  ; preds = %while_body
-  %28 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %28, 0
+  %39 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %39, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
-min_max_success:                                  ; preds = %lookup_success2
-  %29 = load i64, i64* %cast5, align 8
-  store i64 %29, i64* %ret, align 8
+val_set_success:                                  ; preds = %lookup_success2
+  br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
+
+min_max_success:                                  ; preds = %ret_set_success, %val_set_success
+  store i64 %34, i64* %ret, align 8
+  store i64 1, i64* %is_ret_set, align 8
   br label %min_max_merge
 
-min_max_merge:                                    ; preds = %min_max_success, %lookup_success2
-  %30 = load i32, i32* %i, align 4
-  %31 = add i32 %30, 1
-  store i32 %31, i32* %i, align 4
+ret_set_success:                                  ; preds = %val_set_success
+  br i1 %min_cond, label %min_max_success, label %min_max_merge
+
+min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success2
+  %40 = load i32, i32* %i, align 4
+  %41 = add i32 %40, 1
+  store i32 %41, i32* %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %32 = load i32, i32* %i, align 4
+  %42 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %if_body
-  %33 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %43 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %43)
   store i32 0, i32* %key, align 4
-  %lookup_elem6 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
-  %map_lookup_cond10 = icmp ne i8* %lookup_elem6, null
-  br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
+  %lookup_elem5 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
+  %map_lookup_cond9 = icmp ne i8* %lookup_elem5, null
+  br i1 %map_lookup_cond9, label %lookup_success6, label %lookup_failure7
 
-counter_merge:                                    ; preds = %lookup_merge9, %if_body
-  %34 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+counter_merge:                                    ; preds = %lookup_merge8, %if_body
+  %44 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
   br label %if_end
 
-lookup_success7:                                  ; preds = %event_loss_counter
-  %35 = bitcast i8* %lookup_elem6 to i64*
-  %36 = atomicrmw add i64* %35, i64 1 seq_cst
-  br label %lookup_merge9
+lookup_success6:                                  ; preds = %event_loss_counter
+  %45 = bitcast i8* %lookup_elem5 to i64*
+  %46 = atomicrmw add i64* %45, i64 1 seq_cst
+  br label %lookup_merge8
 
-lookup_failure8:                                  ; preds = %event_loss_counter
-  br label %lookup_merge9
+lookup_failure7:                                  ; preds = %event_loss_counter
+  br label %lookup_merge8
 
-lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
-  %37 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+lookup_merge8:                                    ; preds = %lookup_failure7, %lookup_success6
+  %47 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %47)
   br label %counter_merge
 }
 
@@ -183,8 +210,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!60}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -205,46 +232,52 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !58, globals: !59)
+!58 = !{}
+!59 = !{!0, !26, !40}
+!60 = !{i32 2, !"Debug Info Version", i32 3}
+!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !66)
+!62 = !DISubroutineType(types: !63)
+!63 = !{!18, !64}
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!66 = !{!67}
+!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -6,56 +6,65 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { i8*, i8*, i8*, i8* }
 %"struct map_t.0" = type { i8*, i8* }
 %"struct map_t.1" = type { i8*, i8*, i8*, i8* }
+%min_max_val = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 %"unsigned int64_min__tuple_t" = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !61 {
 entry:
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 1, i64* %"@x_key", align 8
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t"*, i64*)*)(%"struct map_t"* @AT_x, i64* %"@x_key")
-  %2 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %map_lookup_cond = icmp ne i8* %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %cast = bitcast i8* %lookup_elem to i64*
-  %3 = load i64, i64* %cast, align 8
-  %4 = icmp sge i64 %3, 2
-  br i1 %4, label %min.ge, label %lookup_merge
+  %cast = bitcast i8* %lookup_elem to %min_max_val*
+  %2 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  %3 = load i64, i64* %2, align 8
+  %4 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  %5 = load i64, i64* %4, align 8
+  %is_set_cond = icmp eq i64 %5, 1
+  br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
-  %5 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 2, i64* %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, i64*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", i64* %initial_value, i64 1)
-  %6 = bitcast i64* %initial_value to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %6 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 0
+  store i64 2, i64* %7, align 8
+  %8 = getelementptr %min_max_val, %min_max_val* %mm_struct, i64 0, i32 1
+  store i64 1, i64* %8, align 8
+  %update_elem = call i64 inttoptr (i64 2 to i64 (%"struct map_t"*, i64*, %min_max_val*, i64)*)(%"struct map_t"* @AT_x, i64* %"@x_key", %min_max_val* %mm_struct, i64 0)
+  %9 = bitcast %min_max_val* %mm_struct to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure, %min.ge, %lookup_success
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+lookup_merge:                                     ; preds = %lookup_failure, %min_max, %is_set
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %for_each_map_elem = call i64 inttoptr (i64 164 to i64 (%"struct map_t"*, i64 (i8*, i8*, i8*, i8*)*, i8*, i64)*)(%"struct map_t"* @AT_x, i64 (i8*, i8*, i8*, i8*)* @map_for_each_cb, i8* null, i64 0)
   ret i64 0
 
-min.ge:                                           ; preds = %lookup_success
-  store i64 2, i64* %cast, align 8
+is_set:                                           ; preds = %lookup_success
+  %11 = icmp sge i64 %3, 2
+  br i1 %11, label %min_max, label %lookup_merge
+
+min_max:                                          ; preds = %is_set, %lookup_success
+  %12 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  store i64 2, i64* %12, align 8
+  %13 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  store i64 1, i64* %13, align 8
   br label %lookup_merge
 }
 
@@ -65,135 +74,153 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !62 {
+define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".text" !dbg !68 {
   %key1 = alloca i32, align 4
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_min__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_min__tuple_t", align 8
-  %i = alloca i32, align 4
+  %is_ret_set = alloca i64, align 8
   %ret = alloca i64, align 8
+  %i = alloca i32, align 4
   %lookup_key = alloca i64, align 8
   %key = load i64, i8* %1, align 8
   %5 = bitcast i64* %lookup_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 %key, i64* %lookup_key, align 8
-  %6 = bitcast i64* %ret to i8*
+  %6 = bitcast i32* %i to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i32* %i to i8*
+  %7 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i32 0, i32* %i, align 4
   store i64 0, i64* %ret, align 8
+  store i64 0, i64* %is_ret_set, align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %min_max_merge, %4
-  %8 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %8, 20
+  %9 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %9, 20
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %9 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %9)
+  %10 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %10)
   %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %10 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = load i64, i64* %ret, align 8
-  %12 = bitcast i64* %ret to i8*
+  %11 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %is_ret_set to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %"unsigned int64_min__tuple_t"* %"$kv" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  %14 = bitcast %"unsigned int64_min__tuple_t"* %"$kv" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 0
-  store i64 %key, i64* %15, align 8
-  %16 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 1
-  store i64 %11, i64* %16, align 8
+  %13 = load i64, i64* %ret, align 8
+  %14 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast %"unsigned int64_min__tuple_t"* %"$kv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %16 = bitcast %"unsigned int64_min__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 16, i1 false)
   %17 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 0
-  %18 = load i64, i64* %17, align 8
-  %19 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %key, i64* %17, align 8
+  %18 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %13, i64* %18, align 8
+  %19 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 0
   %20 = load i64, i64* %19, align 8
-  %21 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
-  %22 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
-  %23 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %tuple, i32 0, i32 0
-  store i64 %18, i64* %23, align 8
-  %24 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %tuple, i32 0, i32 1
-  store i64 %20, i64* %24, align 8
-  %25 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, i64* %26, align 8
-  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
-  store i64 0, i64* %27, align 8
-  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
-  %29 = bitcast [16 x i8]* %28 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 16, i1 false)
-  %30 = bitcast [16 x i8]* %28 to i8*
-  %31 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %30, i8* align 1 %31, i64 16, i1 false)
+  %21 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %"$kv", i32 0, i32 1
+  %22 = load i64, i64* %21, align 8
+  %23 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %24 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %24, i8 0, i64 16, i1 false)
+  %25 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %tuple, i32 0, i32 0
+  store i64 %20, i64* %25, align 8
+  %26 = getelementptr %"unsigned int64_min__tuple_t", %"unsigned int64_min__tuple_t"* %tuple, i32 0, i32 1
+  store i64 %22, i64* %26, align 8
+  %27 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
+  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, i64* %28, align 8
+  %29 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
+  store i64 0, i64* %29, align 8
+  %30 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %31 = bitcast [16 x i8]* %30 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %31, i8 0, i64 16, i1 false)
+  %32 = bitcast [16 x i8]* %30 to i8*
+  %33 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %32, i8* align 1 %33, i64 16, i1 false)
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_tuple_16_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %cast = bitcast i8* %lookup_percpu_elem to i64*
-  %32 = load i64, i64* %ret, align 8
-  %33 = load i64, i64* %cast, align 8
-  %min_cond = icmp slt i64 %33, %32
-  br i1 %min_cond, label %min_max_success, label %min_max_merge
+  %cast = bitcast i8* %lookup_percpu_elem to %min_max_val*
+  %34 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 0
+  %35 = load i64, i64* %34, align 8
+  %36 = getelementptr %min_max_val, %min_max_val* %cast, i64 0, i32 1
+  %37 = load i64, i64* %36, align 8
+  %val_set_cond = icmp eq i64 %37, 1
+  %38 = load i64, i64* %is_ret_set, align 8
+  %ret_set_cond = icmp eq i64 %38, 1
+  %39 = load i64, i64* %ret, align 8
+  %min_cond = icmp slt i64 %35, %39
+  br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %34 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %34, 0
+  %40 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %40, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
-min_max_success:                                  ; preds = %lookup_success
-  %35 = load i64, i64* %cast, align 8
+val_set_success:                                  ; preds = %lookup_success
+  br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
+
+min_max_success:                                  ; preds = %ret_set_success, %val_set_success
   store i64 %35, i64* %ret, align 8
+  store i64 1, i64* %is_ret_set, align 8
   br label %min_max_merge
 
-min_max_merge:                                    ; preds = %min_max_success, %lookup_success
-  %36 = load i32, i32* %i, align 4
-  %37 = add i32 %36, 1
-  store i32 %37, i32* %i, align 4
+ret_set_success:                                  ; preds = %val_set_success
+  br i1 %min_cond, label %min_max_success, label %min_max_merge
+
+min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
+  %41 = load i32, i32* %i, align 4
+  %42 = add i32 %41, 1
+  store i32 %42, i32* %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %38 = load i32, i32* %i, align 4
+  %43 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  %39 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  %44 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %44)
   store i32 0, i32* %key1, align 4
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key1)
   %map_lookup_cond4 = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  %40 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %41 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %45 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %45)
+  %46 = bitcast %"unsigned int64_min__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %46)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %42 = bitcast i8* %lookup_elem to i64*
-  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  %47 = bitcast i8* %lookup_elem to i64*
+  %48 = atomicrmw add i64* %47, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  %44 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  %49 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
   br label %counter_merge
 }
 
@@ -207,8 +234,8 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
 attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!60}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -229,49 +256,55 @@ attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !52, globals: !53)
-!52 = !{}
-!53 = !{!0, !20, !34}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !60)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!18, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
-!62 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !63)
-!63 = !{!64}
-!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !58)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, enums: !58, globals: !59)
+!58 = !{}
+!59 = !{!0, !26, !40}
+!60 = !{i32 2, !"Debug Info Version", i32 3}
+!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !66)
+!62 = !DISubroutineType(types: !63)
+!63 = !{!18, !64}
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!66 = !{!67}
+!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)
+!68 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !57, retainedNodes: !69)
+!69 = !{!70}
+!70 = !DILocalVariable(name: "ctx", arg: 1, scope: !68, file: !2, type: !64)

--- a/tests/codegen/llvm/sum_cast.ll
+++ b/tests/codegen/llvm/sum_cast.ll
@@ -20,8 +20,9 @@ define i64 @kprobe_f_1(i8* %0) section "s_kprobe_f_1" !dbg !55 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %i = alloca i32, align 4
+  %is_ret_set = alloca i64, align 8
   %ret = alloca i64, align 8
+  %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -59,26 +60,29 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %9 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key1", align 8
-  %10 = bitcast i64* %ret to i8*
+  %10 = bitcast i32* %i to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i32* %i to i8*
+  %11 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i32 0, i32* %i, align 4
   store i64 0, i64* %ret, align 8
+  store i64 0, i64* %is_ret_set, align 8
   br label %while_cond
 
 if_body:                                          ; preds = %while_end
-  %12 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  %13 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
-  store i64 30007, i64* %13, align 8
-  %14 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
-  store i64 0, i64* %14, align 8
-  %15 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
-  %16 = bitcast [8 x i8]* %15 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 8, i1 false)
-  %17 = bitcast [8 x i8]* %15 to i64*
-  store i64 6, i64* %17, align 8
+  %13 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
+  store i64 30007, i64* %14, align 8
+  %15 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
+  store i64 0, i64* %15, align 8
+  %16 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i32 0, i32 2
+  %17 = bitcast [8 x i8]* %16 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %17, i8 0, i64 8, i1 false)
+  %18 = bitcast [8 x i8]* %16 to i64*
+  store i64 6, i64* %18, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_integer_8_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_integer_8_t* %print_integer_8_t, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -87,76 +91,78 @@ if_end:                                           ; preds = %counter_merge, %whi
   ret i64 0
 
 while_cond:                                       ; preds = %lookup_success2, %lookup_merge
-  %18 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %18, 20
+  %19 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %19, 20
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %19 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %19)
+  %20 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %"@x_key1", i32 %20)
   %map_lookup_cond4 = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %20 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = load i64, i64* %ret, align 8
-  %22 = bitcast i64* %ret to i8*
+  %21 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %is_ret_set to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = icmp sgt i64 %21, 5
-  %25 = zext i1 %24 to i64
-  %true_cond = icmp ne i64 %25, 0
+  %23 = load i64, i64* %ret, align 8
+  %24 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
+  %26 = icmp sgt i64 %23, 5
+  %27 = zext i1 %26 to i64
+  %true_cond = icmp ne i64 %27, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
   %cast5 = bitcast i8* %lookup_percpu_elem to i64*
-  %26 = load i64, i64* %ret, align 8
-  %27 = load i64, i64* %cast5, align 8
-  %28 = add i64 %27, %26
-  store i64 %28, i64* %ret, align 8
-  %29 = load i32, i32* %i, align 4
-  %30 = add i32 %29, 1
-  store i32 %30, i32* %i, align 4
+  %28 = load i64, i64* %ret, align 8
+  %29 = load i64, i64* %cast5, align 8
+  %30 = add i64 %29, %28
+  store i64 %30, i64* %ret, align 8
+  %31 = load i32, i32* %i, align 4
+  %32 = add i32 %31, 1
+  store i32 %32, i32* %i, align 4
   br label %while_cond
 
 lookup_failure3:                                  ; preds = %while_body
-  %31 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %31, 0
+  %33 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %33, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %32 = load i32, i32* %i, align 4
+  %34 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %if_body
-  %33 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %35 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
   store i32 0, i32* %key, align 4
   %lookup_elem6 = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key)
   %map_lookup_cond10 = icmp ne i8* %lookup_elem6, null
   br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
 
 counter_merge:                                    ; preds = %lookup_merge9, %if_body
-  %34 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  %36 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
   br label %if_end
 
 lookup_success7:                                  ; preds = %event_loss_counter
-  %35 = bitcast i8* %lookup_elem6 to i64*
-  %36 = atomicrmw add i64* %35, i64 1 seq_cst
+  %37 = bitcast i8* %lookup_elem6 to i64*
+  %38 = atomicrmw add i64* %37, i64 1 seq_cst
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter
   br label %lookup_merge9
 
 lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
-  %37 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+  %39 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %39)
   br label %counter_merge
 }
 

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -67,123 +67,129 @@ define internal i64 @map_for_each_cb(i8* %0, i8* %1, i8* %2, i8* %3) section ".t
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_sum__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_sum__tuple_t", align 8
-  %i = alloca i32, align 4
+  %is_ret_set = alloca i64, align 8
   %ret = alloca i64, align 8
+  %i = alloca i32, align 4
   %lookup_key = alloca i64, align 8
   %key = load i64, i8* %1, align 8
   %5 = bitcast i64* %lookup_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 %key, i64* %lookup_key, align 8
-  %6 = bitcast i64* %ret to i8*
+  %6 = bitcast i32* %i to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i32* %i to i8*
+  %7 = bitcast i64* %ret to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %is_ret_set to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i32 0, i32* %i, align 4
   store i64 0, i64* %ret, align 8
+  store i64 0, i64* %is_ret_set, align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %lookup_success, %4
-  %8 = load i32, i32* %i, align 4
-  %num_cpu.cmp = icmp ult i32 %8, 20
+  %9 = load i32, i32* %i, align 4
+  %num_cpu.cmp = icmp ult i32 %9, 20
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %9 = load i32, i32* %i, align 4
-  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %9)
+  %10 = load i32, i32* %i, align 4
+  %lookup_percpu_elem = call i8* inttoptr (i64 195 to i8* (%"struct map_t"*, i64*, i32)*)(%"struct map_t"* @AT_x, i64* %lookup_key, i32 %10)
   %map_lookup_cond = icmp ne i8* %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
-  %10 = bitcast i32* %i to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = load i64, i64* %ret, align 8
-  %12 = bitcast i64* %ret to i8*
+  %11 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %is_ret_set to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %"unsigned int64_sum__tuple_t"* %"$kv" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  %14 = bitcast %"unsigned int64_sum__tuple_t"* %"$kv" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 0
-  store i64 %key, i64* %15, align 8
-  %16 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 1
-  store i64 %11, i64* %16, align 8
+  %13 = load i64, i64* %ret, align 8
+  %14 = bitcast i64* %ret to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast %"unsigned int64_sum__tuple_t"* %"$kv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %16 = bitcast %"unsigned int64_sum__tuple_t"* %"$kv" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 16, i1 false)
   %17 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 0
-  %18 = load i64, i64* %17, align 8
-  %19 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %key, i64* %17, align 8
+  %18 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 1
+  store i64 %13, i64* %18, align 8
+  %19 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 0
   %20 = load i64, i64* %19, align 8
-  %21 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
-  %22 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
-  %23 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %tuple, i32 0, i32 0
-  store i64 %18, i64* %23, align 8
-  %24 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %tuple, i32 0, i32 1
-  store i64 %20, i64* %24, align 8
-  %25 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, i64* %26, align 8
-  %27 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
-  store i64 0, i64* %27, align 8
-  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
-  %29 = bitcast [16 x i8]* %28 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %29, i8 0, i64 16, i1 false)
-  %30 = bitcast [16 x i8]* %28 to i8*
-  %31 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %30, i8* align 1 %31, i64 16, i1 false)
+  %21 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %"$kv", i32 0, i32 1
+  %22 = load i64, i64* %21, align 8
+  %23 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %24 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %24, i8 0, i64 16, i1 false)
+  %25 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %tuple, i32 0, i32 0
+  store i64 %20, i64* %25, align 8
+  %26 = getelementptr %"unsigned int64_sum__tuple_t", %"unsigned int64_sum__tuple_t"* %tuple, i32 0, i32 1
+  store i64 %22, i64* %26, align 8
+  %27 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
+  %28 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, i64* %28, align 8
+  %29 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
+  store i64 0, i64* %29, align 8
+  %30 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %31 = bitcast [16 x i8]* %30 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %31, i8 0, i64 16, i1 false)
+  %32 = bitcast [16 x i8]* %30 to i8*
+  %33 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %32, i8* align 1 %33, i64 16, i1 false)
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (%"struct map_t.0"*, %print_tuple_16_t*, i64, i64)*)(%"struct map_t.0"* @ringbuf, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
   %cast = bitcast i8* %lookup_percpu_elem to i64*
-  %32 = load i64, i64* %ret, align 8
-  %33 = load i64, i64* %cast, align 8
-  %34 = add i64 %33, %32
-  store i64 %34, i64* %ret, align 8
-  %35 = load i32, i32* %i, align 4
-  %36 = add i32 %35, 1
-  store i32 %36, i32* %i, align 4
+  %34 = load i64, i64* %ret, align 8
+  %35 = load i64, i64* %cast, align 8
+  %36 = add i64 %35, %34
+  store i64 %36, i64* %ret, align 8
+  %37 = load i32, i32* %i, align 4
+  %38 = add i32 %37, 1
+  store i32 %38, i32* %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %37 = load i32, i32* %i, align 4
-  %error_lookup_cond = icmp eq i32 %37, 0
+  %39 = load i32, i32* %i, align 4
+  %error_lookup_cond = icmp eq i32 %39, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %38 = load i32, i32* %i, align 4
+  %40 = load i32, i32* %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  %39 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  %41 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %41)
   store i32 0, i32* %key1, align 4
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (%"struct map_t.1"*, i32*)*)(%"struct map_t.1"* @event_loss_counter, i32* %key1)
   %map_lookup_cond4 = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  %40 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %41 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %42 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
+  %43 = bitcast %"unsigned int64_sum__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %42 = bitcast i8* %lookup_elem to i64*
-  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  %44 = bitcast i8* %lookup_elem to i64*
+  %45 = atomicrmw add i64* %44, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  %44 = bitcast i32* %key1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  %46 = bitcast i32* %key1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %46)
   br label %counter_merge
 }
 

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -295,3 +295,8 @@ NAME map strings are memset
 PROG BEGIN { @x = "xxxxx"; @x = "a"; @[@x] = 1; @y = "yyyyy"; @y = "a"; @[@y] = 1; printf("len: %d\n", len(@)); exit(); }
 EXPECT len: 1
 TIMEOUT 1
+
+NAME print_per_cpu_map_vals
+PROG BEGIN { @c = count(); @s = sum(5); @mn = min(1); @mx = max(-1); print((@c, @s, @mn, @mx)); exit(); }
+EXPECT (1, 5, 1, -1)
+TIMEOUT 3


### PR DESCRIPTION
v0.21.2 release which has:
- fix min/max map functions
- fix segfault for multi-tracepoint probes

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
