### PR TITLE
Add new runtime test suite for aggregations

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -708,9 +708,11 @@ void TextOutput::map_key_val(const SizedType &map_type,
                              const std::string &key,
                              const std::string &val) const
 {
-  out_ << key + ": ";
+  out_ << key << ":";
   if (map_type.IsHistTy() || map_type.IsLhistTy())
     out_ << "\n";
+  else
+    out_ << " ";
   out_ << val;
 }
 

--- a/tests/runtime/aggregations
+++ b/tests/runtime/aggregations
@@ -1,0 +1,72 @@
+NAME count
+PROG uprobe:testprogs/multithreaded_data:accept_positive { @cnt = count() }
+     uretprobe:testprogs/multithreaded_data:main { exit() }
+AFTER ./testprogs/multithreaded_data
+EXPECT @cnt: 100
+
+NAME hist
+PROG uprobe:testprogs/multithreaded_data:accept_positive { @hist = hist(arg0) }
+     uretprobe:testprogs/multithreaded_data:main { exit() }
+AFTER ./testprogs/multithreaded_data
+EXPECT @hist:
+       [1]                    1 |@                                                   |
+       [2, 4)                 2 |@@                                                  |
+       [4, 8)                 4 |@@@@@                                               |
+       [8, 16)                8 |@@@@@@@@@@@                                         |
+       [16, 32)              16 |@@@@@@@@@@@@@@@@@@@@@@                              |
+       [32, 64)              32 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@        |
+       [64, 128)             37 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+
+NAME lhist
+PROG uprobe:testprogs/multithreaded_data:accept_positive { @lhist = lhist(arg0, 0, 100, 20) }
+     uretprobe:testprogs/multithreaded_data:main { exit() }
+AFTER ./testprogs/multithreaded_data
+EXPECT @lhist:
+       [0, 20)               19 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@   |
+       [20, 40)              20 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+       [40, 60)              20 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+       [60, 80)              20 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+       [80, 100)             20 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+       [100, ...)             1 |@@                                                  |
+
+NAME min
+PROG uprobe:testprogs/multithreaded_data:accept_positive { @min = min(arg0) }
+     uretprobe:testprogs/multithreaded_data:main { exit() }
+AFTER ./testprogs/multithreaded_data
+EXPECT @min: 1
+
+NAME min_negative
+PROG uprobe:testprogs/multithreaded_data:accept_positive { @min = min(-arg0) }
+     uretprobe:testprogs/multithreaded_data:main { exit() }
+AFTER ./testprogs/multithreaded_data
+EXPECT @min: -100
+
+NAME max
+PROG uprobe:testprogs/multithreaded_data:accept_positive { @max = max(arg0) }
+     uretprobe:testprogs/multithreaded_data:main { exit() }
+AFTER ./testprogs/multithreaded_data
+EXPECT @max: 100
+
+NAME max_negative
+PROG uprobe:testprogs/multithreaded_data:accept_positive { @max = max(-arg0) }
+     uretprobe:testprogs/multithreaded_data:main { exit() }
+AFTER ./testprogs/multithreaded_data
+EXPECT @max: -1
+
+NAME sum
+PROG uprobe:testprogs/multithreaded_data:accept_positive { @sum = sum(arg0) }
+     uretprobe:testprogs/multithreaded_data:main { exit() }
+AFTER ./testprogs/multithreaded_data
+EXPECT @sum: 5050
+
+NAME avg
+PROG uprobe:testprogs/multithreaded_data:accept_positive { @avg = avg(arg0) }
+     uretprobe:testprogs/multithreaded_data:main { exit() }
+AFTER ./testprogs/multithreaded_data
+EXPECT @avg: 50
+
+NAME stats
+PROG uprobe:testprogs/multithreaded_data:accept_positive { @stats = stats(arg0) }
+     uretprobe:testprogs/multithreaded_data:main { exit() }
+AFTER ./testprogs/multithreaded_data
+EXPECT @stats: count 100, average 50, total 5050

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 import os
 import platform
 
+DEFAULT_TIMEOUT = 5
 
 class RequiredFieldError(Exception):
     pass
@@ -236,7 +237,7 @@ class TestParser(object):
         elif len(expects) > 1 and has_exact_expect:
             raise InvalidFieldError('EXPECT_JSON or EXPECT_FILE can not be used with other EXPECTs. Suite: ' + test_suite)
         elif timeout == '':
-            raise RequiredFieldError('Test TIMEOUT is required. Suite: ' + test_suite)
+            timeout = DEFAULT_TIMEOUT
 
         return TestStruct(
             name,

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -15,7 +15,6 @@ import cmake_vars
 BPFTRACE_BIN = os.environ["BPFTRACE_RUNTIME_TEST_EXECUTABLE"]
 COLOR_SETTING = os.environ.get("RUNTIME_TEST_COLOR", "auto")
 ATTACH_TIMEOUT = 10
-DEFAULT_TIMEOUT = 5
 
 
 OK_COLOR = '\033[92m'
@@ -388,7 +387,7 @@ class Runner(object):
                     attached = True
                     if test.has_exact_expect:
                         output = ""  # ignore earlier ouput
-                    signal.alarm(test.timeout or DEFAULT_TIMEOUT)
+                    signal.alarm(test.timeout)
                     if test.after:
                         after_cmd = get_pid_ns_cmd(test.after) if test.new_pidns else test.after
                         after = subprocess.Popen(after_cmd, shell=True,

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -457,6 +457,7 @@ class Runner(object):
                 return Runner.FAIL
 
         def to_utf8(s):
+            return s
             return s.encode("unicode_escape").decode("utf-8")
 
         def print_befores_and_after_output():

--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -24,7 +24,7 @@ if(LLVM_VERSION_MAJOR VERSION_LESS 13)
   set(testprog_cflags "${testprog_cflags} -gdwarf-4")
 endif()
 
-file(GLOB testprog_sources CONFIGURE_DEPENDS *.c)
+file(GLOB testprog_sources CONFIGURE_DEPENDS *.c *.cpp)
 set(testprogtargets "")
 foreach(testprog_source ${testprog_sources})
   get_filename_component(testprog_name ${testprog_source} NAME_WE)

--- a/tests/testprogs/multithreaded_data.cpp
+++ b/tests/testprogs/multithreaded_data.cpp
@@ -1,0 +1,28 @@
+#include <thread>
+#include <vector>
+
+
+extern "C" {
+void accept_positive(int x) {
+}
+
+void accept_mixed(int x) {
+}
+}
+
+int main() {
+  // TODO use jthread
+  constexpr int num_threads = 100;
+  std::vector<std::thread> threads;
+  threads.reserve(num_threads);
+
+  for (int i=0; i<num_threads; i++) {
+    threads.emplace_back(accept_positive, i+1);
+  }
+
+  for (auto &thread : threads) {
+    thread.join();
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Run aggregations against a multi-threaded target program and validate that the results are correct.

Work in progress.
- I haven't worked out how to use signed integers for min/max aggregations
- I'm seeing flakey results for `hist` and `stats`. Don't understand why, as they're using per-cpu (hash) maps.