### PR TITLE
Use struct for Avg map value type

### DIFF
--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -123,12 +123,13 @@ DIType *DIBuilderBPF::CreateTupleType(const SizedType &stype)
   return result;
 }
 
-DIType *DIBuilderBPF::CreateMinMaxType(const SizedType &stype)
+DIType *DIBuilderBPF::CreateMinMaxAvgType(const SizedType &stype)
 {
-  assert(stype.IsMinTy() || stype.IsMaxTy());
+  assert(stype.IsMinTy() || stype.IsMaxTy() || stype.IsAvgTy());
 
-  // The first field is the value
-  // The second field is the "value is set" flag
+  // For Min/Max, the first field is the value and the second field is the
+  // "value is set" flag. For Avg, the first field is the total and the second
+  // field is the count.
   SmallVector<Metadata *, 2> fields = { createMemberType(file,
                                                          "",
                                                          file,
@@ -179,8 +180,8 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype)
   if (stype.IsTupleTy())
     return CreateTupleType(stype);
 
-  if (stype.IsMinTy() || stype.IsMaxTy())
-    return CreateMinMaxType(stype);
+  if (stype.IsMinTy() || stype.IsMaxTy() || stype.IsAvgTy())
+    return CreateMinMaxAvgType(stype);
 
   if (stype.IsPtrTy())
     return getInt64Ty();
@@ -213,8 +214,7 @@ DIType *DIBuilderBPF::GetMapKeyType(const MapKey &key,
 
   // Some map types need an extra 8-byte key.
   uint64_t extra_arg_size = 0;
-  if (value_type.IsHistTy() || value_type.IsLhistTy() || value_type.IsAvgTy() ||
-      value_type.IsStatsTy())
+  if (value_type.IsHistTy() || value_type.IsLhistTy() || value_type.IsStatsTy())
     extra_arg_size = 8;
 
   // Single map key -> use the appropriate type.

--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -34,7 +34,7 @@ public:
 
   DIType *GetType(const SizedType &stype);
   DIType *CreateTupleType(const SizedType &stype);
-  DIType *CreateMinMaxType(const SizedType &stype);
+  DIType *CreateMinMaxAvgType(const SizedType &stype);
   DIType *createPointerMemberType(const std::string &name,
                                   uint64_t offset,
                                   DIType *type);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -319,6 +319,10 @@ private:
                           AllocaInst *is_ret_set,
                           CallInst *call,
                           const SizedType &type);
+  void createPerCpuAvg(AllocaInst *total,
+                       AllocaInst *count,
+                       CallInst *call,
+                       const SizedType &type);
 
   std::map<std::string, StructType *> structs_;
 };

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -613,7 +613,85 @@ void CodegenLLVM::visit(Call &call)
     b_.SetInsertPoint(lookup_merge_block);
 
     expr_ = nullptr;
-  } else if (call.func == "avg" || call.func == "stats") {
+  } else if (call.func == "avg") {
+    Map &map = *call.map;
+
+    auto [key, scoped_key_deleter] = getMapKey(map);
+
+    CallInst *lookup = b_.CreateMapLookup(map, key);
+
+    auto scoped_del = accept(call.vargs->front());
+    // promote int to 64-bit
+    expr_ = b_.CreateIntCast(expr_,
+                             b_.getInt64Ty(),
+                             call.vargs->front()->type.IsSigned());
+
+    llvm::Type *avg_struct_ty = b_.GetMapValueType(map.type);
+
+    Function *parent = b_.GetInsertBlock()->getParent();
+    BasicBlock *lookup_success_block = BasicBlock::Create(module_->getContext(),
+                                                          "lookup_success",
+                                                          parent);
+    BasicBlock *lookup_failure_block = BasicBlock::Create(module_->getContext(),
+                                                          "lookup_failure",
+                                                          parent);
+    BasicBlock *lookup_merge_block = BasicBlock::Create(module_->getContext(),
+                                                        "lookup_merge",
+                                                        parent);
+
+    Value *lookup_condition = b_.CreateICmpNE(
+        b_.CreateIntCast(lookup, b_.GET_PTR_TY(), true),
+        b_.GetNull(),
+        "lookup_cond");
+    b_.CreateCondBr(lookup_condition,
+                    lookup_success_block,
+                    lookup_failure_block);
+
+    b_.SetInsertPoint(lookup_success_block);
+
+    auto *cast = b_.CreatePointerCast(lookup,
+                                      avg_struct_ty->getPointerTo(),
+                                      "cast");
+
+    Value *total_val = b_.CreateLoad(
+        b_.getInt64Ty(),
+        b_.CreateGEP(avg_struct_ty, cast, { b_.getInt64(0), b_.getInt32(0) }));
+
+    Value *count_val = b_.CreateLoad(
+        b_.getInt64Ty(),
+        b_.CreateGEP(avg_struct_ty, cast, { b_.getInt64(0), b_.getInt32(1) }));
+
+    b_.CreateStore(
+        b_.CreateAdd(total_val, expr_),
+        b_.CreateGEP(avg_struct_ty, cast, { b_.getInt64(0), b_.getInt32(0) }));
+    b_.CreateStore(
+        b_.CreateAdd(b_.getInt64(1), count_val),
+        b_.CreateGEP(avg_struct_ty, cast, { b_.getInt64(0), b_.getInt32(1) }));
+
+    b_.CreateBr(lookup_merge_block);
+
+    b_.SetInsertPoint(lookup_failure_block);
+
+    AllocaInst *avg_struct = b_.CreateAllocaBPF(avg_struct_ty, "avg_struct");
+
+    b_.CreateStore(expr_,
+                   b_.CreateGEP(avg_struct_ty,
+                                avg_struct,
+                                { b_.getInt64(0), b_.getInt32(0) }));
+    b_.CreateStore(b_.getInt64(1),
+                   b_.CreateGEP(avg_struct_ty,
+                                avg_struct,
+                                { b_.getInt64(0), b_.getInt32(1) }));
+
+    b_.CreateMapUpdateElem(ctx_, map.ident, key, avg_struct, call.loc);
+
+    b_.CreateLifetimeEnd(avg_struct);
+
+    b_.CreateBr(lookup_merge_block);
+    b_.SetInsertPoint(lookup_merge_block);
+
+    expr_ = nullptr;
+  } else if (call.func == "stats") {
     // avg stores the count and total in a hist map using indexes 0 and 1
     // respectively, and the calculation is made when printing.
     Map &map = *call.map;
@@ -1394,20 +1472,7 @@ void CodegenLLVM::visit(Map &map)
   const auto &val_type = map_info->second.value_type;
   Value *value;
   if (canAggPerCpuMapElems(val_type, map_info->second.key)) {
-    if (val_type.IsAvgTy()) {
-      AllocaInst *count_key = getHistMapKey(map, b_.getInt64(0));
-      Value *count_val = b_.CreatePerCpuMapAggElems(
-          ctx_, map, count_key, val_type, map.loc);
-      b_.CreateLifetimeEnd(count_key);
-
-      AllocaInst *total_key = getHistMapKey(map, b_.getInt64(1));
-      Value *total_val = b_.CreatePerCpuMapAggElems(
-          ctx_, map, total_key, val_type, map.loc);
-      b_.CreateLifetimeEnd(total_key);
-      value = b_.CreateUDiv(total_val, count_val);
-    } else {
-      value = b_.CreatePerCpuMapAggElems(ctx_, map, key, val_type, map.loc);
-    }
+    value = b_.CreatePerCpuMapAggElems(ctx_, map, key, val_type, map.loc);
   } else {
     value = b_.CreateMapLookupElem(ctx_, map, key, map.loc);
   }

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1346,7 +1346,7 @@ int BPFtrace::print_map(const BpfMap &map, uint32_t top, uint32_t div)
   const auto &value_type = map_info.value_type;
   if (value_type.IsHistTy() || value_type.IsLhistTy())
     return print_map_hist(map, top, div);
-  else if (value_type.IsAvgTy() || value_type.IsStatsTy())
+  else if (value_type.IsStatsTy())
     return print_map_stats(map, top, div);
 
   uint64_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
@@ -1398,6 +1398,13 @@ int BPFtrace::print_map(const BpfMap &map, uint32_t top, uint32_t div)
                        min_max_value<uint64_t>(b.second,
                                                nvalues,
                                                value_type.IsMaxTy());
+              });
+  } else if (value_type.IsAvgTy()) {
+    std::sort(values_by_key.begin(),
+              values_by_key.end(),
+              [&](auto &a, auto &b) {
+                return avg_value<uint64_t>(a.second, nvalues) <
+                       avg_value<uint64_t>(b.second, nvalues);
               });
   } else {
     sort_by_key(map_info.key.args_, values_by_key);

--- a/src/types.h
+++ b/src/types.h
@@ -449,8 +449,8 @@ public:
   }
   bool IsMapIterableTy() const
   {
-    return !(type_ == Type::avg || type_ == Type::hist ||
-             type_ == Type::lhist || type_ == Type::stats);
+    return !(type_ == Type::hist || type_ == Type::lhist ||
+             type_ == Type::stats);
   }
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);

--- a/src/utils.h
+++ b/src/utils.h
@@ -353,6 +353,20 @@ T min_max_value(const std::vector<uint8_t> &value, int nvalues, bool is_max)
   return mm_val;
 }
 
+template <typename T>
+T avg_value(const std::vector<uint8_t> &value, int nvalues)
+{
+  T mm_val = 0;
+  T count = 0;
+  for (int i = 0; i < nvalues; i++) {
+    T val = read_data<T>(value.data() + i * (sizeof(T) * 2));
+    T cpu_count = read_data<T>(value.data() + sizeof(T) + i * (sizeof(T) * 2));
+    count += cpu_count;
+    mm_val += val;
+  }
+  return (T)(mm_val / count);
+}
+
 // Combination of 2 hashes
 // The algorithm is taken from boost::hash_combine
 template <class T>

--- a/tests/codegen/llvm/avg_cast.ll
+++ b/tests/codegen/llvm/avg_cast.ll
@@ -7,225 +7,179 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%avg_val = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %is_ret_set18 = alloca i64, align 8
-  %ret17 = alloca i64, align 8
-  %i16 = alloca i32, align 4
-  %"@x_key15" = alloca i64, align 8
-  %is_ret_set = alloca i64, align 8
   %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %"@x_key11" = alloca i64, align 8
-  %"@x_key10" = alloca i64, align 8
-  %initial_value8 = alloca i64, align 8
-  %lookup_elem_val6 = alloca i64, align 8
   %"@x_key1" = alloca i64, align 8
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %avg_struct = alloca %avg_val, align 8
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
-  %map_lookup_cond = icmp ne ptr %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  %2 = add i64 %1, 1
-  store i64 %2, ptr %lookup_elem, align 8
+  %1 = getelementptr %avg_val, ptr %lookup_elem, i64 0, i32 0
+  %2 = load i64, ptr %1, align 8
+  %3 = getelementptr %avg_val, ptr %lookup_elem, i64 0, i32 1
+  %4 = load i64, ptr %3, align 8
+  %5 = getelementptr %avg_val, ptr %lookup_elem, i64 0, i32 0
+  %6 = add i64 %2, 2
+  store i64 %6, ptr %5, align 8
+  %7 = getelementptr %avg_val, ptr %lookup_elem, i64 0, i32 1
+  %8 = add i64 1, %4
+  store i64 %8, ptr %7, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
-  store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
+  %9 = getelementptr %avg_val, ptr %avg_struct, i64 0, i32 0
+  store i64 2, ptr %9, align 8
+  %10 = getelementptr %avg_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %10, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 1, ptr %"@x_key1", align 8
-  %lookup_elem2 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val6)
-  %map_lookup_cond7 = icmp ne ptr %lookup_elem2, null
-  br i1 %map_lookup_cond7, label %lookup_success3, label %lookup_failure4
-
-lookup_success3:                                  ; preds = %lookup_merge
-  %3 = load i64, ptr %lookup_elem2, align 8
-  %4 = add i64 %3, 2
-  store i64 %4, ptr %lookup_elem2, align 8
-  br label %lookup_merge5
-
-lookup_failure4:                                  ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value8)
-  store i64 2, ptr %initial_value8, align 8
-  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key1", ptr %initial_value8, i64 1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value8)
-  br label %lookup_merge5
-
-lookup_merge5:                                    ; preds = %lookup_failure4, %lookup_success3
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val6)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key10")
-  store i64 0, ptr %"@x_key10", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key11")
-  store i64 0, ptr %"@x_key11", align 8
+  store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
-if_body:                                          ; preds = %while_end21
+if_body:                                          ; preds = %is_negative_merge_block
   call void @llvm.lifetime.start.p0(i64 -1, ptr %print_integer_8_t)
-  %5 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
-  store i64 30007, ptr %5, align 8
-  %6 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
-  store i64 0, ptr %6, align 8
-  %7 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 8, i1 false)
-  store i64 6, ptr %7, align 8
+  %11 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
+  store i64 30007, ptr %11, align 8
+  %12 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
+  store i64 0, ptr %12, align 8
+  %13 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %13, i8 0, i64 8, i1 false)
+  store i64 6, ptr %13, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_integer_8_t, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-if_end:                                           ; preds = %counter_merge, %while_end21
+if_end:                                           ; preds = %counter_merge, %is_negative_merge_block
   ret i64 0
 
-while_cond:                                       ; preds = %lookup_success12, %lookup_merge5
-  %8 = load i32, ptr @num_cpus, align 4
-  %9 = load i32, ptr %i, align 4
-  %num_cpu.cmp = icmp ult i32 %9, %8
+while_cond:                                       ; preds = %lookup_success2, %lookup_merge
+  %14 = load i32, ptr @num_cpus, align 4
+  %15 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %15, %14
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %10 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key11", i32 %10)
-  %map_lookup_cond14 = icmp ne ptr %lookup_percpu_elem, null
-  br i1 %map_lookup_cond14, label %lookup_success12, label %lookup_failure13
+  %16 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %16)
+  %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
+  br i1 %map_lookup_cond, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %11 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key11")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key15")
-  store i64 1, ptr %"@x_key15", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %i16)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret17)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set18)
-  store i32 0, ptr %i16, align 4
-  store i64 0, ptr %ret17, align 8
-  store i64 0, ptr %is_ret_set18, align 8
-  br label %while_cond19
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
+  %17 = load i64, ptr %val_1, align 8
+  %is_negative_cond = icmp slt i64 %17, 0
+  br i1 %is_negative_cond, label %is_negative, label %is_positive
 
-lookup_success12:                                 ; preds = %while_body
-  %12 = load i64, ptr %ret, align 8
-  %13 = load i64, ptr %lookup_percpu_elem, align 8
-  %14 = add i64 %13, %12
-  store i64 %14, ptr %ret, align 8
-  %15 = load i32, ptr %i, align 4
-  %16 = add i32 %15, 1
-  store i32 %16, ptr %i, align 4
+lookup_success2:                                  ; preds = %while_body
+  %18 = getelementptr %avg_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %19 = load i64, ptr %18, align 8
+  %20 = getelementptr %avg_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %21 = load i64, ptr %20, align 8
+  %22 = load i64, ptr %val_1, align 8
+  %23 = add i64 %19, %22
+  store i64 %23, ptr %val_1, align 8
+  %24 = load i64, ptr %val_2, align 8
+  %25 = add i64 %21, %24
+  store i64 %25, ptr %val_2, align 8
+  %26 = load i32, ptr %i, align 4
+  %27 = add i32 %26, 1
+  store i32 %27, ptr %i, align 4
   br label %while_cond
 
-lookup_failure13:                                 ; preds = %while_body
-  %17 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %17, 0
+lookup_failure3:                                  ; preds = %while_body
+  %28 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %28, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
-error_success:                                    ; preds = %lookup_failure13
+error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
-error_failure:                                    ; preds = %lookup_failure13
-  %18 = load i32, ptr %i, align 4
+error_failure:                                    ; preds = %lookup_failure3
+  %29 = load i32, ptr %i, align 4
   br label %while_end
 
-while_cond19:                                     ; preds = %lookup_success24, %while_end
-  %19 = load i32, ptr @num_cpus, align 4
-  %20 = load i32, ptr %i16, align 4
-  %num_cpu.cmp22 = icmp ult i32 %20, %19
-  br i1 %num_cpu.cmp22, label %while_body20, label %while_end21
+is_negative:                                      ; preds = %while_end
+  %30 = load i64, ptr %val_1, align 8
+  %31 = xor i64 %30, -1
+  %32 = add i64 %31, 1
+  %33 = load i64, ptr %val_2, align 8
+  %34 = udiv i64 %32, %33
+  %35 = sub i64 0, %34
+  store i64 %35, ptr %ret, align 8
+  br label %is_negative_merge_block
 
-while_body20:                                     ; preds = %while_cond19
-  %21 = load i32, ptr %i16, align 4
-  %lookup_percpu_elem23 = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key15", i32 %21)
-  %map_lookup_cond26 = icmp ne ptr %lookup_percpu_elem23, null
-  br i1 %map_lookup_cond26, label %lookup_success24, label %lookup_failure25
+is_positive:                                      ; preds = %while_end
+  %36 = load i64, ptr %val_2, align 8
+  %37 = load i64, ptr %val_1, align 8
+  %38 = udiv i64 %37, %36
+  store i64 %38, ptr %ret, align 8
+  br label %is_negative_merge_block
 
-while_end21:                                      ; preds = %error_failure28, %error_success27, %while_cond19
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %i16)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set18)
-  %22 = load i64, ptr %ret17, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret17)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key15")
-  %23 = udiv i64 %22, %11
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key10")
-  %24 = icmp eq i64 %23, 2
-  %25 = zext i1 %24 to i64
-  %true_cond = icmp ne i64 %25, 0
+is_negative_merge_block:                          ; preds = %is_positive, %is_negative
+  %39 = load i64, ptr %ret, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
+  %40 = icmp eq i64 %39, 2
+  %41 = zext i1 %40 to i64
+  %true_cond = icmp ne i64 %41, 0
   br i1 %true_cond, label %if_body, label %if_end
-
-lookup_success24:                                 ; preds = %while_body20
-  %26 = load i64, ptr %ret17, align 8
-  %27 = load i64, ptr %lookup_percpu_elem23, align 8
-  %28 = add i64 %27, %26
-  store i64 %28, ptr %ret17, align 8
-  %29 = load i32, ptr %i16, align 4
-  %30 = add i32 %29, 1
-  store i32 %30, ptr %i16, align 4
-  br label %while_cond19
-
-lookup_failure25:                                 ; preds = %while_body20
-  %31 = load i32, ptr %i16, align 4
-  %error_lookup_cond29 = icmp eq i32 %31, 0
-  br i1 %error_lookup_cond29, label %error_success27, label %error_failure28
-
-error_success27:                                  ; preds = %lookup_failure25
-  br label %while_end21
-
-error_failure28:                                  ; preds = %lookup_failure25
-  %32 = load i32, ptr %i16, align 4
-  br label %while_end21
 
 event_loss_counter:                               ; preds = %if_body
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
-  %lookup_elem30 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
-  %map_lookup_cond34 = icmp ne ptr %lookup_elem30, null
-  br i1 %map_lookup_cond34, label %lookup_success31, label %lookup_failure32
+  %lookup_elem4 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
+  %map_lookup_cond8 = icmp ne ptr %lookup_elem4, null
+  br i1 %map_lookup_cond8, label %lookup_success5, label %lookup_failure6
 
-counter_merge:                                    ; preds = %lookup_merge33, %if_body
+counter_merge:                                    ; preds = %lookup_merge7, %if_body
   call void @llvm.lifetime.end.p0(i64 -1, ptr %print_integer_8_t)
   br label %if_end
 
-lookup_success31:                                 ; preds = %event_loss_counter
-  %33 = atomicrmw add ptr %lookup_elem30, i64 1 seq_cst, align 8
-  br label %lookup_merge33
+lookup_success5:                                  ; preds = %event_loss_counter
+  %42 = atomicrmw add ptr %lookup_elem4, i64 1 seq_cst, align 8
+  br label %lookup_merge7
 
-lookup_failure32:                                 ; preds = %event_loss_counter
-  br label %lookup_merge33
+lookup_failure6:                                  ; preds = %event_loss_counter
+  br label %lookup_merge7
 
-lookup_merge33:                                   ; preds = %lookup_failure32, %lookup_success31
+lookup_merge7:                                    ; preds = %lookup_failure6, %lookup_success5
   call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
   br label %counter_merge
 }
@@ -243,8 +197,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!55}
+!llvm.dbg.cu = !{!59}
+!llvm.module.flags = !{!61}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -265,47 +219,53 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
-!54 = !{!0, !20, !34, !51}
-!55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!18, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
-!60 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
+!60 = !{!0, !26, !40, !57}
+!61 = !{i32 2, !"Debug Info Version", i32 3}
+!62 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !67)
+!63 = !DISubroutineType(types: !64)
+!64 = !{!18, !65}
+!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
+!66 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!67 = !{!68}
+!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !65)

--- a/tests/codegen/llvm/call_avg.ll
+++ b/tests/codegen/llvm/call_avg.ll
@@ -6,72 +6,54 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%avg_val = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
-  %initial_value8 = alloca i64, align 8
-  %lookup_elem_val6 = alloca i64, align 8
-  %"@x_key1" = alloca i64, align 8
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %avg_struct = alloca %avg_val, align 8
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
-  %map_lookup_cond = icmp ne ptr %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %1 = lshr i64 %get_pid_tgid, 32
+  %lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  %2 = add i64 %1, 1
-  store i64 %2, ptr %lookup_elem, align 8
+  %2 = getelementptr %avg_val, ptr %lookup_elem, i64 0, i32 0
+  %3 = load i64, ptr %2, align 8
+  %4 = getelementptr %avg_val, ptr %lookup_elem, i64 0, i32 1
+  %5 = load i64, ptr %4, align 8
+  %6 = getelementptr %avg_val, ptr %lookup_elem, i64 0, i32 0
+  %7 = add i64 %3, %1
+  store i64 %7, ptr %6, align 8
+  %8 = getelementptr %avg_val, ptr %lookup_elem, i64 0, i32 1
+  %9 = add i64 1, %5
+  store i64 %9, ptr %8, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
-  store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
+  %10 = getelementptr %avg_val, ptr %avg_struct, i64 0, i32 0
+  store i64 %1, ptr %10, align 8
+  %11 = getelementptr %avg_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %11, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 1, ptr %"@x_key1", align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %3 = lshr i64 %get_pid_tgid, 32
-  %lookup_elem2 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val6)
-  %map_lookup_cond7 = icmp ne ptr %lookup_elem2, null
-  br i1 %map_lookup_cond7, label %lookup_success3, label %lookup_failure4
-
-lookup_success3:                                  ; preds = %lookup_merge
-  %4 = load i64, ptr %lookup_elem2, align 8
-  %5 = add i64 %4, %3
-  store i64 %5, ptr %lookup_elem2, align 8
-  br label %lookup_merge5
-
-lookup_failure4:                                  ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value8)
-  store i64 %3, ptr %initial_value8, align 8
-  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key1", ptr %initial_value8, i64 1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value8)
-  br label %lookup_merge5
-
-lookup_merge5:                                    ; preds = %lookup_failure4, %lookup_success3
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val6)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   ret i64 0
 }
 
@@ -84,8 +66,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!55}
+!llvm.dbg.cu = !{!59}
+!llvm.module.flags = !{!61}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -106,47 +88,53 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
-!54 = !{!0, !20, !34, !51}
-!55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!18, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
-!60 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
+!60 = !{!0, !26, !40, !57}
+!61 = !{i32 2, !"Debug Info Version", i32 3}
+!62 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !67)
+!63 = !DISubroutineType(types: !64)
+!64 = !{!18, !65}
+!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
+!66 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!67 = !{!68}
+!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !65)

--- a/tests/codegen/llvm/count_cast.ll
+++ b/tests/codegen/llvm/count_cast.ll
@@ -21,8 +21,8 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !50 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
   %initial_value = alloca i64, align 8
@@ -54,11 +54,11 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 if_body:                                          ; preds = %while_end
@@ -91,9 +91,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %9 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %9 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   %10 = icmp sgt i64 %9, 5
   %11 = zext i1 %10 to i64
@@ -101,10 +101,10 @@ while_end:                                        ; preds = %error_failure, %err
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %12 = load i64, ptr %ret, align 8
+  %12 = load i64, ptr %val_1, align 8
   %13 = load i64, ptr %lookup_percpu_elem, align 8
   %14 = add i64 %13, %12
-  store i64 %14, ptr %ret, align 8
+  store i64 %14, ptr %val_1, align 8
   %15 = load i32, ptr %i, align 4
   %16 = add i32 %15, 1
   store i32 %16, ptr %i, align 4

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -61,19 +61,19 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_count__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_count__tuple_t", align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
   store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %lookup_success, %4
@@ -90,9 +90,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %8 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %8 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
   %9 = getelementptr %"unsigned int64_count__tuple_t", ptr %"$kv", i32 0, i32 0
@@ -122,10 +122,10 @@ while_end:                                        ; preds = %error_failure, %err
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %20 = load i64, ptr %ret, align 8
+  %20 = load i64, ptr %val_1, align 8
   %21 = load i64, ptr %lookup_percpu_elem, align 8
   %22 = add i64 %21, %20
-  store i64 %22, ptr %ret, align 8
+  store i64 %22, ptr %val_1, align 8
   %23 = load i32, ptr %i, align 4
   %24 = add i32 %23, 1
   store i32 %24, ptr %i, align 4

--- a/tests/codegen/llvm/max_cast.ll
+++ b/tests/codegen/llvm/max_cast.ll
@@ -22,8 +22,8 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
   %mm_struct = alloca %min_max_val, align 8
@@ -57,11 +57,11 @@ lookup_merge:                                     ; preds = %lookup_failure, %mi
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 is_set:                                           ; preds = %lookup_success
@@ -105,9 +105,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %16 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %16 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   %17 = icmp sgt i64 %16, 5
   %18 = zext i1 %17 to i64
@@ -120,9 +120,9 @@ lookup_success2:                                  ; preds = %while_body
   %21 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
   %22 = load i64, ptr %21, align 8
   %val_set_cond = icmp eq i64 %22, 1
-  %23 = load i64, ptr %is_ret_set, align 8
+  %23 = load i64, ptr %val_2, align 8
   %ret_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %ret, align 8
+  %24 = load i64, ptr %val_1, align 8
   %max_cond = icmp sgt i64 %20, %24
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
@@ -135,8 +135,8 @@ val_set_success:                                  ; preds = %lookup_success2
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %20, ptr %ret, align 8
-  store i64 1, ptr %is_ret_set, align 8
+  store i64 %20, ptr %val_1, align 8
+  store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
 ret_set_success:                                  ; preds = %val_set_success

--- a/tests/codegen/llvm/min_cast.ll
+++ b/tests/codegen/llvm/min_cast.ll
@@ -22,8 +22,8 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
   %mm_struct = alloca %min_max_val, align 8
@@ -57,11 +57,11 @@ lookup_merge:                                     ; preds = %lookup_failure, %mi
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 is_set:                                           ; preds = %lookup_success
@@ -105,9 +105,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %16 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %16 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   %17 = icmp sgt i64 %16, 5
   %18 = zext i1 %17 to i64
@@ -120,9 +120,9 @@ lookup_success2:                                  ; preds = %while_body
   %21 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
   %22 = load i64, ptr %21, align 8
   %val_set_cond = icmp eq i64 %22, 1
-  %23 = load i64, ptr %is_ret_set, align 8
+  %23 = load i64, ptr %val_2, align 8
   %ret_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %ret, align 8
+  %24 = load i64, ptr %val_1, align 8
   %min_cond = icmp slt i64 %20, %24
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
@@ -135,8 +135,8 @@ val_set_success:                                  ; preds = %lookup_success2
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %20, ptr %ret, align 8
-  store i64 1, ptr %is_ret_set, align 8
+  store i64 %20, ptr %val_1, align 8
+  store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
 ret_set_success:                                  ; preds = %val_set_success

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -75,19 +75,19 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_min__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_min__tuple_t", align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
   store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %min_max_merge, %4
@@ -104,9 +104,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %8 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %8 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
   %9 = getelementptr %"unsigned int64_min__tuple_t", ptr %"$kv", i32 0, i32 0
@@ -141,9 +141,9 @@ lookup_success:                                   ; preds = %while_body
   %22 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
   %23 = load i64, ptr %22, align 8
   %val_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %is_ret_set, align 8
+  %24 = load i64, ptr %val_2, align 8
   %ret_set_cond = icmp eq i64 %24, 1
-  %25 = load i64, ptr %ret, align 8
+  %25 = load i64, ptr %val_1, align 8
   %min_cond = icmp slt i64 %21, %25
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
@@ -156,8 +156,8 @@ val_set_success:                                  ; preds = %lookup_success
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %21, ptr %ret, align 8
-  store i64 1, ptr %is_ret_set, align 8
+  store i64 %21, ptr %val_1, align 8
+  store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
 ret_set_success:                                  ; preds = %val_set_success

--- a/tests/codegen/llvm/sum_cast.ll
+++ b/tests/codegen/llvm/sum_cast.ll
@@ -21,8 +21,8 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
   %initial_value = alloca i64, align 8
@@ -54,11 +54,11 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 if_body:                                          ; preds = %while_end
@@ -91,9 +91,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %9 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %9 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   %10 = icmp sgt i64 %9, 5
   %11 = zext i1 %10 to i64
@@ -101,10 +101,10 @@ while_end:                                        ; preds = %error_failure, %err
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %12 = load i64, ptr %ret, align 8
+  %12 = load i64, ptr %val_1, align 8
   %13 = load i64, ptr %lookup_percpu_elem, align 8
   %14 = add i64 %13, %12
-  store i64 %14, ptr %ret, align 8
+  store i64 %14, ptr %val_1, align 8
   %15 = load i32, ptr %i, align 4
   %16 = add i32 %15, 1
   store i32 %16, ptr %i, align 4

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -61,19 +61,19 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_sum__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_sum__tuple_t", align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
   store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %lookup_success, %4
@@ -90,9 +90,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %8 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %8 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
   %9 = getelementptr %"unsigned int64_sum__tuple_t", ptr %"$kv", i32 0, i32 0
@@ -122,10 +122,10 @@ while_end:                                        ; preds = %error_failure, %err
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %20 = load i64, ptr %ret, align 8
+  %20 = load i64, ptr %val_1, align 8
   %21 = load i64, ptr %lookup_percpu_elem, align 8
   %22 = add i64 %21, %20
-  store i64 %22, ptr %ret, align 8
+  store i64 %22, ptr %val_1, align 8
   %23 = load i32, ptr %i, align 4
   %24 = add i32 %23, 1
   store i32 %24, ptr %i, align 4

--- a/tests/codegen/per_cpu_map_cast.cpp
+++ b/tests/codegen/per_cpu_map_cast.cpp
@@ -54,6 +54,12 @@ TEST(codegen, max_cast_loop)
        NAME);
 }
 
+TEST(codegen, avg_cast_loop)
+{
+  test("kprobe:f { @x[1] = avg(2); for ($kv : @x) { print(($kv.0, $kv.1)); } }",
+       NAME);
+}
+
 TEST(codegen, count_no_cast_for_print)
 {
   test("BEGIN { @ = count(); print(@) }", NAME);

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -425,7 +425,6 @@ PROG BEGIN { print("BEGIN"); @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30
 EXPECT BEGIN
        @[c]: 3
        @[d]: 4
-       
        END
 TIMEOUT 1
 
@@ -436,7 +435,6 @@ EXPECT BEGIN
        @[b]: 2
        @[c]: 3
        @[d]: 4
-       
        END
 TIMEOUT 1
 

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -156,12 +156,12 @@ AFTER ./testprogs/simple_struct
 
 NAME print_avg_map_args
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@); exit(); }'
-EXPECT {"type": "stats", "data": {"@": {"c": 3, "d": 4}}}
+EXPECT {"type": "map", "data": {"@": {"c": 3, "d": 4}}}
 TIMEOUT 1
 
 NAME print_avg_map_with_large_top
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@); exit(); }'
-EXPECT {"type": "stats", "data": {"@": {"a": 1, "b": 2, "c": 3, "d": 4}}}
+EXPECT {"type": "map", "data": {"@": {"a": 1, "b": 2, "c": 3, "d": 4}}}
 TIMEOUT 1
 
 NAME print_hist_with_top_arg

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -8,6 +8,11 @@ PROG BEGIN { @=avg(-30); @=avg(-10); exit(); }
 EXPECT @: -20
 TIMEOUT 5
 
+NAME avg cast negative values
+PROG BEGIN { @ = avg(-1); @ = avg(-1); @ = avg(-10); if (@ == -4) { printf("done\n"); exit(); }}
+EXPECT done
+TIMEOUT 5
+
 NAME negative map value
 PROG BEGIN { @ = -11; exit(); }
 EXPECT @: -11

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3565,11 +3565,6 @@ BEGIN { @map[0] = 1; for ($kv : @undef) { @map[$kv.0]; } }
 
 TEST(semantic_analyser, for_loop_map_restricted_types)
 {
-  test_error("BEGIN { @map[0] = avg(1); for ($kv : @map) { } }", R"(
-stdin:1:38-43: ERROR: Loop expression does not support type: avg
-BEGIN { @map[0] = avg(1); for ($kv : @map) { } }
-                                     ~~~~~
-)");
   test_error("BEGIN { @map[0] = hist(10); for ($kv : @map) { } }", R"(
 stdin:1:40-45: ERROR: Loop expression does not support type: hist
 BEGIN { @map[0] = hist(10); for ($kv : @map) { } }


### PR DESCRIPTION
Similar to how min/max works, instead of storing
two keys (one for total and one for count) for
each user key store a struct with the total and
count. This skips an additional map lookup and
allows users to loop over avg type maps.

This also fixes implicit casting of avg in
kernel space when the avg is a negative number.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
