### PR TITLE
Use struct for Avg/Stats map value types

### DIFF
--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -34,7 +34,7 @@ public:
 
   DIType *GetType(const SizedType &stype);
   DIType *CreateTupleType(const SizedType &stype);
-  DIType *CreateMinMaxType(const SizedType &stype);
+  DIType *CreateMapStructType(const SizedType &stype);
   DIType *createPointerMemberType(const std::string &name,
                                   uint64_t offset,
                                   DIType *type);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -316,6 +316,11 @@ llvm::Type *IRBuilderBPF::GetMapValueType(const SizedType &stype)
     // The second field is the "value is set" flag
     std::vector<llvm::Type *> llvm_elems = { getInt64Ty(), getInt64Ty() };
     ty = GetStructType("min_max_val", llvm_elems, false);
+  } else if (stype.IsAvgTy() || stype.IsStatsTy()) {
+    // The first field is the total value
+    // The second is the count value
+    std::vector<llvm::Type *> llvm_elems = { getInt64Ty(), getInt64Ty() };
+    ty = GetStructType("avg_stas_val", llvm_elems, false);
   } else {
     ty = GetType(stype);
   }
@@ -605,13 +610,13 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
   const std::string &map_name = map.ident;
 
   AllocaInst *i = CreateAllocaBPF(getInt32Ty(), "i");
-  AllocaInst *ret = CreateAllocaBPF(getInt64Ty(), "ret");
-  // used only for min/max
-  AllocaInst *is_ret_set = CreateAllocaBPF(getInt64Ty(), "is_ret_set");
+  AllocaInst *val_1 = CreateAllocaBPF(getInt64Ty(), "val_1");
+  // used for min/max/avg
+  AllocaInst *val_2 = CreateAllocaBPF(getInt64Ty(), "val_2");
 
   CreateStore(getInt32(0), i);
-  CreateStore(getInt64(0), ret);
-  CreateStore(getInt64(0), is_ret_set);
+  CreateStore(getInt64(0), val_1);
+  CreateStore(getInt64(0), val_2);
 
   Function *parent = GetInsertBlock()->getParent();
   BasicBlock *while_cond = BasicBlock::Create(module_.getContext(),
@@ -655,9 +660,11 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
   SetInsertPoint(lookup_success_block);
 
   if (type.IsMinTy() || type.IsMaxTy()) {
-    createPerCpuMinMax(ret, is_ret_set, call, type);
-  } else if (type.IsSumTy() || type.IsCountTy() || type.IsAvgTy()) {
-    createPerCpuSum(ret, call, type);
+    createPerCpuMinMax(val_1, val_2, call, type);
+  } else if (type.IsAvgTy()) {
+    createPerCpuAvg(val_1, val_2, call, type);
+  } else if (type.IsSumTy() || type.IsCountTy()) {
+    createPerCpuSum(val_1, call, type);
   } else {
     LOG(BUG) << "Unsupported map aggregation type: " << type;
   }
@@ -700,11 +707,60 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
   SetInsertPoint(while_end);
 
   CreateLifetimeEnd(i);
-  CreateLifetimeEnd(is_ret_set);
 
-  Value *ret_reg = CreateLoad(getInt64Ty(), ret);
+  Value *ret_reg;
 
-  CreateLifetimeEnd(ret);
+  if (type.IsAvgTy()) {
+    AllocaInst *ret = CreateAllocaBPF(getInt64Ty(), "ret");
+    // BPF doesn't yet support a signed division so we have to check if
+    // the value is negative, flip it, do an unsigned division, and then
+    // flip it back
+    if (type.IsSigned()) {
+      Function *avg_parent = GetInsertBlock()->getParent();
+      BasicBlock *is_negative_block = BasicBlock::Create(module_.getContext(),
+                                                         "is_negative",
+                                                         avg_parent);
+      BasicBlock *is_positive_block = BasicBlock::Create(module_.getContext(),
+                                                         "is_positive",
+                                                         avg_parent);
+      BasicBlock *merge_block = BasicBlock::Create(module_.getContext(),
+                                                   "is_negative_merge_block",
+                                                   avg_parent);
+
+      Value *is_negative_condition = CreateICmpSLT(
+          CreateLoad(getInt64Ty(), val_1), getInt64(0), "is_negative_cond");
+      CreateCondBr(is_negative_condition, is_negative_block, is_positive_block);
+
+      SetInsertPoint(is_negative_block);
+
+      Value *pos_total = CreateAdd(CreateNot(CreateLoad(getInt64Ty(), val_1)),
+                                   getInt64(1));
+      Value *pos_avg = CreateUDiv(pos_total, CreateLoad(getInt64Ty(), val_2));
+      CreateStore(CreateNeg(pos_avg), ret);
+
+      CreateBr(merge_block);
+
+      SetInsertPoint(is_positive_block);
+
+      CreateStore(CreateUDiv(CreateLoad(getInt64Ty(), val_1),
+                             CreateLoad(getInt64Ty(), val_2)),
+                  ret);
+
+      CreateBr(merge_block);
+
+      SetInsertPoint(merge_block);
+      ret_reg = CreateLoad(getInt64Ty(), ret);
+      CreateLifetimeEnd(ret);
+    } else {
+      ret_reg = CreateUDiv(CreateLoad(getInt64Ty(), val_1),
+                           CreateLoad(getInt64Ty(), val_2));
+    }
+  } else {
+    ret_reg = CreateLoad(getInt64Ty(), val_1);
+  }
+
+  CreateLifetimeEnd(val_1);
+  CreateLifetimeEnd(val_2);
   return ret_reg;
 }
 
@@ -808,6 +864,24 @@ void IRBuilderBPF::createPerCpuMinMax(AllocaInst *ret,
   CreateBr(merge_block);
 
   SetInsertPoint(merge_block);
+}
+
+void IRBuilderBPF::createPerCpuAvg(AllocaInst *total,
+                                   AllocaInst *count,
+                                   CallInst *call,
+                                   const SizedType &type)
+{
+  auto *value_type = GetMapValueType(type);
+  auto *cast = CreatePointerCast(call, value_type->getPointerTo(), "cast");
+
+  Value *total_val = CreateLoad(
+      getInt64Ty(), CreateGEP(value_type, cast, { getInt64(0), getInt32(0) }));
+
+  Value *count_val = CreateLoad(
+      getInt64Ty(), CreateGEP(value_type, cast, { getInt64(0), getInt32(1) }));
+
+  CreateStore(CreateAdd(total_val, CreateLoad(getInt64Ty(), total)), total);
+  CreateStore(CreateAdd(count_val, CreateLoad(getInt64Ty(), count)), count);
 }
 
 void IRBuilderBPF::CreateMapUpdateElem(Value *ctx,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -319,6 +319,10 @@ private:
                           AllocaInst *is_ret_set,
                           CallInst *call,
                           const SizedType &type);
+  void createPerCpuAvg(AllocaInst *total,
+                       AllocaInst *count,
+                       CallInst *call,
+                       const SizedType &type);
 
   std::map<std::string, StructType *> structs_;
 };

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -247,7 +247,6 @@ private:
   int poll_perf_events();
   void handle_event_loss();
   int print_map_hist(const BpfMap &map, uint32_t top, uint32_t div);
-  int print_map_stats(const BpfMap &map, uint32_t top, uint32_t div);
   static uint64_t read_address_from_output(std::string output);
   std::optional<std::vector<uint8_t>> find_empty_key(const BpfMap &map) const;
   struct bcc_symbol_option &get_symbol_opts();

--- a/src/output.h
+++ b/src/output.h
@@ -76,9 +76,8 @@ public:
       const BpfMap &map,
       uint32_t top,
       uint32_t div,
-      const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
-      const std::vector<std::pair<std::vector<uint8_t>, int64_t>>
-          &total_counts_by_key) const = 0;
+      const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+          &values_by_key) const = 0;
   // Write non-map value to output
   // Ideally, the implementation should use value_to_str to convert a value into
   // a string, format it properly, and print it to out_.
@@ -152,9 +151,8 @@ protected:
       const BpfMap &map,
       uint32_t top,
       uint32_t div,
-      const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
-      const std::vector<std::pair<std::vector<uint8_t>, int64_t>>
-          &total_counts_by_key) const;
+      const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+          &values_by_key) const;
   // Convert map key to string
   virtual std::string map_key_to_str(BPFtrace &bpftrace,
                                      const BpfMap &map,
@@ -189,11 +187,9 @@ protected:
   virtual std::string tuple_to_str(
       const std::vector<std::string> &elems) const = 0;
   // Convert a vector of (key, value) pairs into string
-  // keys are strings
-  // values are 64-bit integers
   // Used for properly formatting map statistics
   virtual std::string key_value_pairs_to_str(
-      std::vector<std::pair<std::string, int64_t>> &keyvals) const = 0;
+      std::vector<std::pair<std::string, std::string>> &keyvals) const = 0;
 };
 
 class TextOutput : public Output {
@@ -224,9 +220,8 @@ public:
       const BpfMap &map,
       uint32_t top,
       uint32_t div,
-      const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
-      const std::vector<std::pair<std::vector<uint8_t>, int64_t>>
-          &total_counts_by_key) const override;
+      const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+          &values_by_key) const override;
   virtual void value(BPFtrace &bpftrace,
                      const SizedType &ty,
                      std::vector<uint8_t> &value) const override;
@@ -263,7 +258,7 @@ protected:
   std::string tuple_to_str(
       const std::vector<std::string> &elems) const override;
   std::string key_value_pairs_to_str(
-      std::vector<std::pair<std::string, int64_t>> &keyvals) const override;
+      std::vector<std::pair<std::string, std::string>> &keyvals) const override;
 };
 
 class JsonOutput : public Output {
@@ -294,9 +289,8 @@ public:
       const BpfMap &map,
       uint32_t top,
       uint32_t div,
-      const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
-      const std::vector<std::pair<std::vector<uint8_t>, int64_t>>
-          &total_counts_by_key) const override;
+      const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+          &values_by_key) const override;
   virtual void value(BPFtrace &bpftrace,
                      const SizedType &ty,
                      std::vector<uint8_t> &value) const override;
@@ -342,7 +336,7 @@ protected:
   std::string tuple_to_str(
       const std::vector<std::string> &elems) const override;
   std::string key_value_pairs_to_str(
-      std::vector<std::pair<std::string, int64_t>> &keyvals) const override;
+      std::vector<std::pair<std::string, std::string>> &keyvals) const override;
 };
 
 } // namespace bpftrace

--- a/src/types.h
+++ b/src/types.h
@@ -449,8 +449,8 @@ public:
   }
   bool IsMapIterableTy() const
   {
-    return !(type_ == Type::avg || type_ == Type::hist ||
-             type_ == Type::lhist || type_ == Type::stats);
+    return !(type_ == Type::hist || type_ == Type::lhist ||
+             type_ == Type::stats);
   }
 
   bool NeedsPercpuMap() const;

--- a/src/utils.h
+++ b/src/utils.h
@@ -353,6 +353,33 @@ T min_max_value(const std::vector<uint8_t> &value, int nvalues, bool is_max)
   return mm_val;
 }
 
+template <typename T>
+struct stats {
+  T total;
+  T count;
+  T avg;
+};
+
+template <typename T>
+stats<T> stats_value(const std::vector<uint8_t> &value, int nvalues)
+{
+  stats<T> ret = { 0, 0, 0 };
+  for (int i = 0; i < nvalues; i++) {
+    T val = read_data<T>(value.data() + i * (sizeof(T) * 2));
+    T cpu_count = read_data<T>(value.data() + sizeof(T) + i * (sizeof(T) * 2));
+    ret.count += cpu_count;
+    ret.total += val;
+  }
+  ret.avg = (T)(ret.total / ret.count);
+  return ret;
+}
+
+template <typename T>
+T avg_value(const std::vector<uint8_t> &value, int nvalues)
+{
+  return stats_value<T>(value, nvalues).avg;
+}
+
 // Combination of 2 hashes
 // The algorithm is taken from boost::hash_combine
 template <class T>

--- a/tests/codegen/llvm/avg_cast.ll
+++ b/tests/codegen/llvm/avg_cast.ll
@@ -7,225 +7,179 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%avg_stas_val = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %is_ret_set18 = alloca i64, align 8
-  %ret17 = alloca i64, align 8
-  %i16 = alloca i32, align 4
-  %"@x_key15" = alloca i64, align 8
-  %is_ret_set = alloca i64, align 8
   %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %"@x_key11" = alloca i64, align 8
-  %"@x_key10" = alloca i64, align 8
-  %initial_value8 = alloca i64, align 8
-  %lookup_elem_val6 = alloca i64, align 8
   %"@x_key1" = alloca i64, align 8
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %avg_struct = alloca %avg_stas_val, align 8
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
-  %map_lookup_cond = icmp ne ptr %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  %2 = add i64 %1, 1
-  store i64 %2, ptr %lookup_elem, align 8
+  %1 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %2 = load i64, ptr %1, align 8
+  %3 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %4 = load i64, ptr %3, align 8
+  %5 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %6 = add i64 %2, 2
+  store i64 %6, ptr %5, align 8
+  %7 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %8 = add i64 1, %4
+  store i64 %8, ptr %7, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
-  store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
+  %9 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
+  store i64 2, ptr %9, align 8
+  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %10, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 1, ptr %"@x_key1", align 8
-  %lookup_elem2 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val6)
-  %map_lookup_cond7 = icmp ne ptr %lookup_elem2, null
-  br i1 %map_lookup_cond7, label %lookup_success3, label %lookup_failure4
-
-lookup_success3:                                  ; preds = %lookup_merge
-  %3 = load i64, ptr %lookup_elem2, align 8
-  %4 = add i64 %3, 2
-  store i64 %4, ptr %lookup_elem2, align 8
-  br label %lookup_merge5
-
-lookup_failure4:                                  ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value8)
-  store i64 2, ptr %initial_value8, align 8
-  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key1", ptr %initial_value8, i64 1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value8)
-  br label %lookup_merge5
-
-lookup_merge5:                                    ; preds = %lookup_failure4, %lookup_success3
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val6)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key10")
-  store i64 0, ptr %"@x_key10", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key11")
-  store i64 0, ptr %"@x_key11", align 8
+  store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
-if_body:                                          ; preds = %while_end21
+if_body:                                          ; preds = %is_negative_merge_block
   call void @llvm.lifetime.start.p0(i64 -1, ptr %print_integer_8_t)
-  %5 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
-  store i64 30007, ptr %5, align 8
-  %6 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
-  store i64 0, ptr %6, align 8
-  %7 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 8, i1 false)
-  store i64 6, ptr %7, align 8
+  %11 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 0
+  store i64 30007, ptr %11, align 8
+  %12 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i64 0, i32 1
+  store i64 0, ptr %12, align 8
+  %13 = getelementptr %print_integer_8_t, ptr %print_integer_8_t, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %13, i8 0, i64 8, i1 false)
+  store i64 6, ptr %13, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_integer_8_t, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-if_end:                                           ; preds = %counter_merge, %while_end21
+if_end:                                           ; preds = %counter_merge, %is_negative_merge_block
   ret i64 0
 
-while_cond:                                       ; preds = %lookup_success12, %lookup_merge5
-  %8 = load i32, ptr @num_cpus, align 4
-  %9 = load i32, ptr %i, align 4
-  %num_cpu.cmp = icmp ult i32 %9, %8
+while_cond:                                       ; preds = %lookup_success2, %lookup_merge
+  %14 = load i32, ptr @num_cpus, align 4
+  %15 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %15, %14
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %10 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key11", i32 %10)
-  %map_lookup_cond14 = icmp ne ptr %lookup_percpu_elem, null
-  br i1 %map_lookup_cond14, label %lookup_success12, label %lookup_failure13
+  %16 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %16)
+  %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
+  br i1 %map_lookup_cond, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %11 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key11")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key15")
-  store i64 1, ptr %"@x_key15", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %i16)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret17)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set18)
-  store i32 0, ptr %i16, align 4
-  store i64 0, ptr %ret17, align 8
-  store i64 0, ptr %is_ret_set18, align 8
-  br label %while_cond19
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
+  %17 = load i64, ptr %val_1, align 8
+  %is_negative_cond = icmp slt i64 %17, 0
+  br i1 %is_negative_cond, label %is_negative, label %is_positive
 
-lookup_success12:                                 ; preds = %while_body
-  %12 = load i64, ptr %ret, align 8
-  %13 = load i64, ptr %lookup_percpu_elem, align 8
-  %14 = add i64 %13, %12
-  store i64 %14, ptr %ret, align 8
-  %15 = load i32, ptr %i, align 4
-  %16 = add i32 %15, 1
-  store i32 %16, ptr %i, align 4
+lookup_success2:                                  ; preds = %while_body
+  %18 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %19 = load i64, ptr %18, align 8
+  %20 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %21 = load i64, ptr %20, align 8
+  %22 = load i64, ptr %val_1, align 8
+  %23 = add i64 %19, %22
+  store i64 %23, ptr %val_1, align 8
+  %24 = load i64, ptr %val_2, align 8
+  %25 = add i64 %21, %24
+  store i64 %25, ptr %val_2, align 8
+  %26 = load i32, ptr %i, align 4
+  %27 = add i32 %26, 1
+  store i32 %27, ptr %i, align 4
   br label %while_cond
 
-lookup_failure13:                                 ; preds = %while_body
-  %17 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %17, 0
+lookup_failure3:                                  ; preds = %while_body
+  %28 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %28, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
-error_success:                                    ; preds = %lookup_failure13
+error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
-error_failure:                                    ; preds = %lookup_failure13
-  %18 = load i32, ptr %i, align 4
+error_failure:                                    ; preds = %lookup_failure3
+  %29 = load i32, ptr %i, align 4
   br label %while_end
 
-while_cond19:                                     ; preds = %lookup_success24, %while_end
-  %19 = load i32, ptr @num_cpus, align 4
-  %20 = load i32, ptr %i16, align 4
-  %num_cpu.cmp22 = icmp ult i32 %20, %19
-  br i1 %num_cpu.cmp22, label %while_body20, label %while_end21
+is_negative:                                      ; preds = %while_end
+  %30 = load i64, ptr %val_1, align 8
+  %31 = xor i64 %30, -1
+  %32 = add i64 %31, 1
+  %33 = load i64, ptr %val_2, align 8
+  %34 = udiv i64 %32, %33
+  %35 = sub i64 0, %34
+  store i64 %35, ptr %ret, align 8
+  br label %is_negative_merge_block
 
-while_body20:                                     ; preds = %while_cond19
-  %21 = load i32, ptr %i16, align 4
-  %lookup_percpu_elem23 = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key15", i32 %21)
-  %map_lookup_cond26 = icmp ne ptr %lookup_percpu_elem23, null
-  br i1 %map_lookup_cond26, label %lookup_success24, label %lookup_failure25
+is_positive:                                      ; preds = %while_end
+  %36 = load i64, ptr %val_2, align 8
+  %37 = load i64, ptr %val_1, align 8
+  %38 = udiv i64 %37, %36
+  store i64 %38, ptr %ret, align 8
+  br label %is_negative_merge_block
 
-while_end21:                                      ; preds = %error_failure28, %error_success27, %while_cond19
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %i16)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set18)
-  %22 = load i64, ptr %ret17, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret17)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key15")
-  %23 = udiv i64 %22, %11
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key10")
-  %24 = icmp eq i64 %23, 2
-  %25 = zext i1 %24 to i64
-  %true_cond = icmp ne i64 %25, 0
+is_negative_merge_block:                          ; preds = %is_positive, %is_negative
+  %39 = load i64, ptr %ret, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
+  %40 = icmp eq i64 %39, 2
+  %41 = zext i1 %40 to i64
+  %true_cond = icmp ne i64 %41, 0
   br i1 %true_cond, label %if_body, label %if_end
-
-lookup_success24:                                 ; preds = %while_body20
-  %26 = load i64, ptr %ret17, align 8
-  %27 = load i64, ptr %lookup_percpu_elem23, align 8
-  %28 = add i64 %27, %26
-  store i64 %28, ptr %ret17, align 8
-  %29 = load i32, ptr %i16, align 4
-  %30 = add i32 %29, 1
-  store i32 %30, ptr %i16, align 4
-  br label %while_cond19
-
-lookup_failure25:                                 ; preds = %while_body20
-  %31 = load i32, ptr %i16, align 4
-  %error_lookup_cond29 = icmp eq i32 %31, 0
-  br i1 %error_lookup_cond29, label %error_success27, label %error_failure28
-
-error_success27:                                  ; preds = %lookup_failure25
-  br label %while_end21
-
-error_failure28:                                  ; preds = %lookup_failure25
-  %32 = load i32, ptr %i16, align 4
-  br label %while_end21
 
 event_loss_counter:                               ; preds = %if_body
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
-  %lookup_elem30 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
-  %map_lookup_cond34 = icmp ne ptr %lookup_elem30, null
-  br i1 %map_lookup_cond34, label %lookup_success31, label %lookup_failure32
+  %lookup_elem4 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
+  %map_lookup_cond8 = icmp ne ptr %lookup_elem4, null
+  br i1 %map_lookup_cond8, label %lookup_success5, label %lookup_failure6
 
-counter_merge:                                    ; preds = %lookup_merge33, %if_body
+counter_merge:                                    ; preds = %lookup_merge7, %if_body
   call void @llvm.lifetime.end.p0(i64 -1, ptr %print_integer_8_t)
   br label %if_end
 
-lookup_success31:                                 ; preds = %event_loss_counter
-  %33 = atomicrmw add ptr %lookup_elem30, i64 1 seq_cst, align 8
-  br label %lookup_merge33
+lookup_success5:                                  ; preds = %event_loss_counter
+  %42 = atomicrmw add ptr %lookup_elem4, i64 1 seq_cst, align 8
+  br label %lookup_merge7
 
-lookup_failure32:                                 ; preds = %event_loss_counter
-  br label %lookup_merge33
+lookup_failure6:                                  ; preds = %event_loss_counter
+  br label %lookup_merge7
 
-lookup_merge33:                                   ; preds = %lookup_failure32, %lookup_success31
+lookup_merge7:                                    ; preds = %lookup_failure6, %lookup_success5
   call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
   br label %counter_merge
 }
@@ -243,8 +197,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!55}
+!llvm.dbg.cu = !{!59}
+!llvm.module.flags = !{!61}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -265,47 +219,53 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
-!54 = !{!0, !20, !34, !51}
-!55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!18, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
-!60 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
+!60 = !{!0, !26, !40, !57}
+!61 = !{i32 2, !"Debug Info Version", i32 3}
+!62 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !67)
+!63 = !DISubroutineType(types: !64)
+!64 = !{!18, !65}
+!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
+!66 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!67 = !{!68}
+!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !65)

--- a/tests/codegen/llvm/avg_cast_loop.ll
+++ b/tests/codegen/llvm/avg_cast_loop.ll
@@ -6,9 +6,9 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%min_max_val = type { i64, i64 }
+%avg_stas_val = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
-%"unsigned int64_max__tuple_t" = type { i64, i64 }
+%"unsigned int64_avg__tuple_t" = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -21,7 +21,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
-  %mm_struct = alloca %min_max_val, align 8
+  %avg_struct = alloca %avg_stas_val, align 8
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 1, ptr %"@x_key", align 8
@@ -30,38 +30,32 @@ entry:
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  %1 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
   %2 = load i64, ptr %1, align 8
-  %3 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  %3 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
   %4 = load i64, ptr %3, align 8
-  %is_set_cond = icmp eq i64 %4, 1
-  br i1 %is_set_cond, label %is_set, label %min_max
-
-lookup_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %mm_struct)
-  %5 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
-  store i64 2, ptr %5, align 8
-  %6 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
-  store i64 1, ptr %6, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %mm_struct, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %mm_struct)
+  %5 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %6 = add i64 %2, 2
+  store i64 %6, ptr %5, align 8
+  %7 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %8 = add i64 1, %4
+  store i64 %8, ptr %7, align 8
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure, %min_max, %is_set
+lookup_failure:                                   ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
+  %9 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
+  store i64 2, ptr %9, align 8
+  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %10, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_x, ptr @map_for_each_cb, ptr null, i64 0)
   ret i64 0
-
-is_set:                                           ; preds = %lookup_success
-  %7 = icmp sge i64 2, %2
-  br i1 %7, label %min_max, label %lookup_merge
-
-min_max:                                          ; preds = %is_set, %lookup_success
-  %8 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  store i64 2, ptr %8, align 8
-  %9 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  store i64 1, ptr %9, align 8
-  br label %lookup_merge
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -73,8 +67,9 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !69 {
   %key1 = alloca i32, align 4
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
-  %tuple = alloca %"unsigned int64_max__tuple_t", align 8
-  %"$kv" = alloca %"unsigned int64_max__tuple_t", align 8
+  %tuple = alloca %"unsigned int64_avg__tuple_t", align 8
+  %"$kv" = alloca %"unsigned int64_avg__tuple_t", align 8
+  %ret = alloca i64, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -90,7 +85,7 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   store i64 0, ptr %val_2, align 8
   br label %while_cond
 
-while_cond:                                       ; preds = %min_max_merge, %4
+while_cond:                                       ; preds = %lookup_success, %4
   %5 = load i32, ptr @num_cpus, align 4
   %6 = load i32, ptr %i, align 4
   %num_cpu.cmp = icmp ult i32 %6, %5
@@ -104,92 +99,103 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
   %8 = load i64, ptr %val_1, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %9 = getelementptr %"unsigned int64_max__tuple_t", ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %"unsigned int64_max__tuple_t", ptr %"$kv", i32 0, i32 1
-  store i64 %8, ptr %10, align 8
-  %11 = getelementptr %"unsigned int64_max__tuple_t", ptr %"$kv", i32 0, i32 0
-  %12 = load i64, ptr %11, align 8
-  %13 = getelementptr %"unsigned int64_max__tuple_t", ptr %"$kv", i32 0, i32 1
-  %14 = load i64, ptr %13, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_max__tuple_t", ptr %tuple, i32 0, i32 0
-  store i64 %12, ptr %15, align 8
-  %16 = getelementptr %"unsigned int64_max__tuple_t", ptr %tuple, i32 0, i32 1
-  store i64 %14, ptr %16, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_tuple_16_t)
-  %17 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, ptr %17, align 8
-  %18 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 1
-  store i64 0, ptr %18, align 8
-  %19 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %19, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %19, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_tuple_16_t, i64 32, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  %is_negative_cond = icmp slt i64 %8, 0
+  br i1 %is_negative_cond, label %is_negative, label %is_positive
 
 lookup_success:                                   ; preds = %while_body
-  %20 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %21 = load i64, ptr %20, align 8
-  %22 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %23 = load i64, ptr %22, align 8
-  %val_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %24, 1
-  %25 = load i64, ptr %val_1, align 8
-  %max_cond = icmp sgt i64 %21, %25
-  br i1 %val_set_cond, label %val_set_success, label %min_max_merge
+  %9 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %10 = load i64, ptr %9, align 8
+  %11 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %12 = load i64, ptr %11, align 8
+  %13 = load i64, ptr %val_1, align 8
+  %14 = add i64 %10, %13
+  store i64 %14, ptr %val_1, align 8
+  %15 = load i64, ptr %val_2, align 8
+  %16 = add i64 %12, %15
+  store i64 %16, ptr %val_2, align 8
+  %17 = load i32, ptr %i, align 4
+  %18 = add i32 %17, 1
+  store i32 %18, ptr %i, align 4
+  br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %26 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %26, 0
+  %19 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %19, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
-
-val_set_success:                                  ; preds = %lookup_success
-  br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
-
-min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %21, ptr %val_1, align 8
-  store i64 1, ptr %val_2, align 8
-  br label %min_max_merge
-
-ret_set_success:                                  ; preds = %val_set_success
-  br i1 %max_cond, label %min_max_success, label %min_max_merge
-
-min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
-  %27 = load i32, ptr %i, align 4
-  %28 = add i32 %27, 1
-  store i32 %28, ptr %i, align 4
-  br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %29 = load i32, ptr %i, align 4
+  %20 = load i32, ptr %i, align 4
   br label %while_end
 
-event_loss_counter:                               ; preds = %while_end
+is_negative:                                      ; preds = %while_end
+  %21 = load i64, ptr %val_1, align 8
+  %22 = xor i64 %21, -1
+  %23 = add i64 %22, 1
+  %24 = load i64, ptr %val_2, align 8
+  %25 = udiv i64 %23, %24
+  %26 = sub i64 0, %25
+  store i64 %26, ptr %ret, align 8
+  br label %is_negative_merge_block
+
+is_positive:                                      ; preds = %while_end
+  %27 = load i64, ptr %val_2, align 8
+  %28 = load i64, ptr %val_1, align 8
+  %29 = udiv i64 %28, %27
+  store i64 %29, ptr %ret, align 8
+  br label %is_negative_merge_block
+
+is_negative_merge_block:                          ; preds = %is_positive, %is_negative
+  %30 = load i64, ptr %ret, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
+  %31 = getelementptr %"unsigned int64_avg__tuple_t", ptr %"$kv", i32 0, i32 0
+  store i64 %key, ptr %31, align 8
+  %32 = getelementptr %"unsigned int64_avg__tuple_t", ptr %"$kv", i32 0, i32 1
+  store i64 %30, ptr %32, align 8
+  %33 = getelementptr %"unsigned int64_avg__tuple_t", ptr %"$kv", i32 0, i32 0
+  %34 = load i64, ptr %33, align 8
+  %35 = getelementptr %"unsigned int64_avg__tuple_t", ptr %"$kv", i32 0, i32 1
+  %36 = load i64, ptr %35, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
+  %37 = getelementptr %"unsigned int64_avg__tuple_t", ptr %tuple, i32 0, i32 0
+  store i64 %34, ptr %37, align 8
+  %38 = getelementptr %"unsigned int64_avg__tuple_t", ptr %tuple, i32 0, i32 1
+  store i64 %36, ptr %38, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_tuple_16_t)
+  %39 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 0
+  store i64 30007, ptr %39, align 8
+  %40 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 1
+  store i64 0, ptr %40, align 8
+  %41 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %41, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %41, ptr align 1 %tuple, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_tuple_16_t, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %is_negative_merge_block
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
   store i32 0, ptr %key1, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
   %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
-counter_merge:                                    ; preds = %lookup_merge, %while_end
+counter_merge:                                    ; preds = %lookup_merge, %is_negative_merge_block
   call void @llvm.lifetime.end.p0(i64 -1, ptr %print_tuple_16_t)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %30 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %42 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter

--- a/tests/codegen/llvm/call_avg.ll
+++ b/tests/codegen/llvm/call_avg.ll
@@ -6,72 +6,54 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%avg_stas_val = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
+@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
-  %initial_value8 = alloca i64, align 8
-  %lookup_elem_val6 = alloca i64, align 8
-  %"@x_key1" = alloca i64, align 8
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %avg_struct = alloca %avg_stas_val, align 8
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
-  %map_lookup_cond = icmp ne ptr %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %1 = lshr i64 %get_pid_tgid, 32
+  %lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  %2 = add i64 %1, 1
-  store i64 %2, ptr %lookup_elem, align 8
+  %2 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %3 = load i64, ptr %2, align 8
+  %4 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %5 = load i64, ptr %4, align 8
+  %6 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %7 = add i64 %3, %1
+  store i64 %7, ptr %6, align 8
+  %8 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %9 = add i64 1, %5
+  store i64 %9, ptr %8, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
-  store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
+  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
+  store i64 %1, ptr %10, align 8
+  %11 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %11, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 1, ptr %"@x_key1", align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %3 = lshr i64 %get_pid_tgid, 32
-  %lookup_elem2 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val6)
-  %map_lookup_cond7 = icmp ne ptr %lookup_elem2, null
-  br i1 %map_lookup_cond7, label %lookup_success3, label %lookup_failure4
-
-lookup_success3:                                  ; preds = %lookup_merge
-  %4 = load i64, ptr %lookup_elem2, align 8
-  %5 = add i64 %4, %3
-  store i64 %5, ptr %lookup_elem2, align 8
-  br label %lookup_merge5
-
-lookup_failure4:                                  ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value8)
-  store i64 %3, ptr %initial_value8, align 8
-  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key1", ptr %initial_value8, i64 1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value8)
-  br label %lookup_merge5
-
-lookup_merge5:                                    ; preds = %lookup_failure4, %lookup_success3
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val6)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   ret i64 0
 }
 
@@ -84,8 +66,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!55}
+!llvm.dbg.cu = !{!59}
+!llvm.module.flags = !{!61}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -106,47 +88,53 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
-!54 = !{!0, !20, !34, !51}
-!55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!18, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
-!60 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
+!60 = !{!0, !26, !40, !57}
+!61 = !{i32 2, !"Debug Info Version", i32 3}
+!62 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !67)
+!63 = !DISubroutineType(types: !64)
+!64 = !{!18, !65}
+!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
+!66 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!67 = !{!68}
+!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !65)

--- a/tests/codegen/llvm/call_stats.ll
+++ b/tests/codegen/llvm/call_stats.ll
@@ -6,71 +6,53 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%avg_stas_val = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !60 {
 entry:
-  %initial_value8 = alloca i64, align 8
-  %lookup_elem_val6 = alloca i64, align 8
-  %"@x_key1" = alloca i64, align 8
-  %initial_value = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %avg_struct = alloca %avg_stas_val, align 8
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
-  %map_lookup_cond = icmp ne ptr %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %1 = lshr i64 %get_pid_tgid, 32
+  %lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  %2 = add i64 %1, 1
-  store i64 %2, ptr %lookup_elem, align 8
+  %2 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %3 = load i64, ptr %2, align 8
+  %4 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %5 = load i64, ptr %4, align 8
+  %6 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %7 = add i64 %3, %1
+  store i64 %7, ptr %6, align 8
+  %8 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %9 = add i64 1, %5
+  store i64 %9, ptr %8, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
-  store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
+  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
+  store i64 %1, ptr %10, align 8
+  %11 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %11, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 1, ptr %"@x_key1", align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %3 = lshr i64 %get_pid_tgid, 32
-  %lookup_elem2 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val6)
-  %map_lookup_cond7 = icmp ne ptr %lookup_elem2, null
-  br i1 %map_lookup_cond7, label %lookup_success3, label %lookup_failure4
-
-lookup_success3:                                  ; preds = %lookup_merge
-  %4 = load i64, ptr %lookup_elem2, align 8
-  %5 = add i64 %4, %3
-  store i64 %5, ptr %lookup_elem2, align 8
-  br label %lookup_merge5
-
-lookup_failure4:                                  ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value8)
-  store i64 %3, ptr %initial_value8, align 8
-  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key1", ptr %initial_value8, i64 1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value8)
-  br label %lookup_merge5
-
-lookup_merge5:                                    ; preds = %lookup_failure4, %lookup_success3
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val6)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   ret i64 0
 }
 
@@ -83,8 +65,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!59}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -105,45 +87,51 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
 !18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
-!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
-!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
-!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
-!23 = !{!24, !29}
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
-!27 = !{!28}
-!28 = !DISubrange(count: 27, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
-!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
-!32 = !{!33}
-!33 = !DISubrange(count: 262144, lowerBound: 0)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
-!37 = !{!38, !43, !48, !19}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 2, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !20, !34}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !59)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!18, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
-!58 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!59 = !{!60}
-!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !54, !56}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !52)
+!52 = !{!53}
+!53 = !DISubrange(count: 1, lowerBound: 0)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
+!58 = !{!0, !26, !40}
+!59 = !{i32 2, !"Debug Info Version", i32 3}
+!60 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !65)
+!61 = !DISubroutineType(types: !62)
+!62 = !{!18, !63}
+!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
+!64 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!65 = !{!66}
+!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !63)

--- a/tests/codegen/llvm/count_cast.ll
+++ b/tests/codegen/llvm/count_cast.ll
@@ -21,8 +21,8 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !50 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
   %initial_value = alloca i64, align 8
@@ -54,11 +54,11 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 if_body:                                          ; preds = %while_end
@@ -91,9 +91,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %9 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %9 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   %10 = icmp sgt i64 %9, 5
   %11 = zext i1 %10 to i64
@@ -101,10 +101,10 @@ while_end:                                        ; preds = %error_failure, %err
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %12 = load i64, ptr %ret, align 8
+  %12 = load i64, ptr %val_1, align 8
   %13 = load i64, ptr %lookup_percpu_elem, align 8
   %14 = add i64 %13, %12
-  store i64 %14, ptr %ret, align 8
+  store i64 %14, ptr %val_1, align 8
   %15 = load i32, ptr %i, align 4
   %16 = add i32 %15, 1
   store i32 %16, ptr %i, align 4

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -61,19 +61,19 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_count__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_count__tuple_t", align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
   store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %lookup_success, %4
@@ -90,9 +90,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %8 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %8 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
   %9 = getelementptr %"unsigned int64_count__tuple_t", ptr %"$kv", i32 0, i32 0
@@ -122,10 +122,10 @@ while_end:                                        ; preds = %error_failure, %err
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %20 = load i64, ptr %ret, align 8
+  %20 = load i64, ptr %val_1, align 8
   %21 = load i64, ptr %lookup_percpu_elem, align 8
   %22 = add i64 %21, %20
-  store i64 %22, ptr %ret, align 8
+  store i64 %22, ptr %val_1, align 8
   %23 = load i32, ptr %i, align 4
   %24 = add i32 %23, 1
   store i32 %24, ptr %i, align 4

--- a/tests/codegen/llvm/max_cast.ll
+++ b/tests/codegen/llvm/max_cast.ll
@@ -22,8 +22,8 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
   %mm_struct = alloca %min_max_val, align 8
@@ -57,11 +57,11 @@ lookup_merge:                                     ; preds = %lookup_failure, %mi
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 is_set:                                           ; preds = %lookup_success
@@ -105,9 +105,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %16 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %16 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   %17 = icmp sgt i64 %16, 5
   %18 = zext i1 %17 to i64
@@ -120,9 +120,9 @@ lookup_success2:                                  ; preds = %while_body
   %21 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
   %22 = load i64, ptr %21, align 8
   %val_set_cond = icmp eq i64 %22, 1
-  %23 = load i64, ptr %is_ret_set, align 8
+  %23 = load i64, ptr %val_2, align 8
   %ret_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %ret, align 8
+  %24 = load i64, ptr %val_1, align 8
   %max_cond = icmp sgt i64 %20, %24
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
@@ -135,8 +135,8 @@ val_set_success:                                  ; preds = %lookup_success2
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %20, ptr %ret, align 8
-  store i64 1, ptr %is_ret_set, align 8
+  store i64 %20, ptr %val_1, align 8
+  store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
 ret_set_success:                                  ; preds = %val_set_success

--- a/tests/codegen/llvm/min_cast.ll
+++ b/tests/codegen/llvm/min_cast.ll
@@ -22,8 +22,8 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
   %mm_struct = alloca %min_max_val, align 8
@@ -57,11 +57,11 @@ lookup_merge:                                     ; preds = %lookup_failure, %mi
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 is_set:                                           ; preds = %lookup_success
@@ -105,9 +105,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %16 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %16 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   %17 = icmp sgt i64 %16, 5
   %18 = zext i1 %17 to i64
@@ -120,9 +120,9 @@ lookup_success2:                                  ; preds = %while_body
   %21 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
   %22 = load i64, ptr %21, align 8
   %val_set_cond = icmp eq i64 %22, 1
-  %23 = load i64, ptr %is_ret_set, align 8
+  %23 = load i64, ptr %val_2, align 8
   %ret_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %ret, align 8
+  %24 = load i64, ptr %val_1, align 8
   %min_cond = icmp slt i64 %20, %24
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
@@ -135,8 +135,8 @@ val_set_success:                                  ; preds = %lookup_success2
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %20, ptr %ret, align 8
-  store i64 1, ptr %is_ret_set, align 8
+  store i64 %20, ptr %val_1, align 8
+  store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
 ret_set_success:                                  ; preds = %val_set_success

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -75,19 +75,19 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_min__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_min__tuple_t", align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
   store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %min_max_merge, %4
@@ -104,9 +104,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %8 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %8 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
   %9 = getelementptr %"unsigned int64_min__tuple_t", ptr %"$kv", i32 0, i32 0
@@ -141,9 +141,9 @@ lookup_success:                                   ; preds = %while_body
   %22 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
   %23 = load i64, ptr %22, align 8
   %val_set_cond = icmp eq i64 %23, 1
-  %24 = load i64, ptr %is_ret_set, align 8
+  %24 = load i64, ptr %val_2, align 8
   %ret_set_cond = icmp eq i64 %24, 1
-  %25 = load i64, ptr %ret, align 8
+  %25 = load i64, ptr %val_1, align 8
   %min_cond = icmp slt i64 %21, %25
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
@@ -156,8 +156,8 @@ val_set_success:                                  ; preds = %lookup_success
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %21, ptr %ret, align 8
-  store i64 1, ptr %is_ret_set, align 8
+  store i64 %21, ptr %val_1, align 8
+  store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
 ret_set_success:                                  ; preds = %val_set_success

--- a/tests/codegen/llvm/sum_cast.ll
+++ b/tests/codegen/llvm/sum_cast.ll
@@ -21,8 +21,8 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
 entry:
   %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %"@x_key1" = alloca i64, align 8
   %initial_value = alloca i64, align 8
@@ -54,11 +54,11 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 if_body:                                          ; preds = %while_end
@@ -91,9 +91,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %9 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %9 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   %10 = icmp sgt i64 %9, 5
   %11 = zext i1 %10 to i64
@@ -101,10 +101,10 @@ while_end:                                        ; preds = %error_failure, %err
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %12 = load i64, ptr %ret, align 8
+  %12 = load i64, ptr %val_1, align 8
   %13 = load i64, ptr %lookup_percpu_elem, align 8
   %14 = add i64 %13, %12
-  store i64 %14, ptr %ret, align 8
+  store i64 %14, ptr %val_1, align 8
   %15 = load i32, ptr %i, align 4
   %16 = add i32 %15, 1
   store i32 %16, ptr %i, align 4

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -61,19 +61,19 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"unsigned int64_sum__tuple_t", align 8
   %"$kv" = alloca %"unsigned int64_sum__tuple_t", align 8
-  %is_ret_set = alloca i64, align 8
-  %ret = alloca i64, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
   store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %is_ret_set)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
   store i32 0, ptr %i, align 4
-  store i64 0, ptr %ret, align 8
-  store i64 0, ptr %is_ret_set, align 8
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %lookup_success, %4
@@ -90,9 +90,9 @@ while_body:                                       ; preds = %while_cond
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %is_ret_set)
-  %8 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
+  %8 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
   %9 = getelementptr %"unsigned int64_sum__tuple_t", ptr %"$kv", i32 0, i32 0
@@ -122,10 +122,10 @@ while_end:                                        ; preds = %error_failure, %err
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %20 = load i64, ptr %ret, align 8
+  %20 = load i64, ptr %val_1, align 8
   %21 = load i64, ptr %lookup_percpu_elem, align 8
   %22 = add i64 %21, %20
-  store i64 %22, ptr %ret, align 8
+  store i64 %22, ptr %val_1, align 8
   %23 = load i32, ptr %i, align 4
   %24 = add i32 %23, 1
   store i32 %24, ptr %i, align 4

--- a/tests/codegen/per_cpu_map_cast.cpp
+++ b/tests/codegen/per_cpu_map_cast.cpp
@@ -54,6 +54,12 @@ TEST(codegen, max_cast_loop)
        NAME);
 }
 
+TEST(codegen, avg_cast_loop)
+{
+  test("kprobe:f { @x[1] = avg(2); for ($kv : @x) { print(($kv.0, $kv.1)); } }",
+       NAME);
+}
+
 TEST(codegen, count_no_cast_for_print)
 {
   test("BEGIN { @ = count(); print(@) }", NAME);

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -8,6 +8,11 @@ PROG BEGIN { @=avg(-30); @=avg(-10); exit(); }
 EXPECT @: -20
 TIMEOUT 5
 
+NAME avg cast negative values
+PROG BEGIN { @ = avg(-1); @ = avg(-1); @ = avg(-10); if (@ == -4) { printf("done\n"); exit(); }}
+EXPECT done
+TIMEOUT 5
+
 NAME negative map value
 PROG BEGIN { @ = -11; exit(); }
 EXPECT @: -11

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3565,11 +3565,6 @@ BEGIN { @map[0] = 1; for ($kv : @undef) { @map[$kv.0]; } }
 
 TEST(semantic_analyser, for_loop_map_restricted_types)
 {
-  test_error("BEGIN { @map[0] = avg(1); for ($kv : @map) { } }", R"(
-stdin:1:38-43: ERROR: Loop expression does not support type: avg
-BEGIN { @map[0] = avg(1); for ($kv : @map) { } }
-                                     ~~~~~
-)");
   test_error("BEGIN { @map[0] = hist(10); for ($kv : @map) { } }", R"(
 stdin:1:40-45: ERROR: Loop expression does not support type: hist
 BEGIN { @map[0] = hist(10); for ($kv : @map) { } }


### PR DESCRIPTION
Similar to how min/max works, instead of storing
two keys (one for total and one for count) for
each user key store a struct with the total and
count. This skips an additional map lookup and
allows users to loop over avg type maps.

This also fixes implicit casting of avg in
kernel space when the avg is a negative number.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
