### PR TITLE
appimage: Strip header files out of appimage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,7 @@
               # Exclude the following groups to reduce appimage size:
               #
               # *.a: Static archives are not necessary at runtime
+              # *.h: Header files are not necessary at runtime (some ARM headers for clang are large)
               # *.pyc, *.py, *.whl: bpftrace does not use python at runtime
               # libLLVM-11.so: Appimage uses the latest llvm we support, so not llvm11
               #
@@ -172,6 +173,7 @@
               # ```
               exclude = [
                 "... *.a"
+                "... *.h"
                 "... *.pyc"
                 "... *.py"
                 "... *.whl"


### PR DESCRIPTION
Some header files libclang ships are quite huge (megabytes). Looks like they're for ARM. Regardless, we don't need any header files at runtime.

This saves us about 1M of disk space.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
