### PR TITLE
ci: Make most of the CI jobs build in debug mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,24 +28,24 @@ jobs:
     strategy:
       matrix:
         env:
-        - NAME: LLVM 13 Release
-          CMAKE_BUILD_TYPE: Release
+        - NAME: LLVM 13
+          CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm13
           TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: LLVM 14 Release
-          CMAKE_BUILD_TYPE: Release
+        - NAME: LLVM 14
+          CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm14
           TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: LLVM 15 Release
-          CMAKE_BUILD_TYPE: Release
+        - NAME: LLVM 15
+          CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm15
           TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: LLVM 16 Release
-          CMAKE_BUILD_TYPE: Release
+        - NAME: LLVM 16
+          CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm16
           TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: LLVM 17 Release
-          CMAKE_BUILD_TYPE: Release
+        - NAME: LLVM 17
+          CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm17
           TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 18 Release


### PR DESCRIPTION
Debug mode leaves assertions in. We want this for CI.

Note we still build the latest LLVM release in both debug and release so we exercise all the compiler optimizations that users will use.

This closes #3231.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
