### PR TITLE
ci: Backstop AOT tests

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -1,0 +1,78 @@
+aot.basic.print_per_cpu_map_vals
+aot.btf.kernel_module_type_fwd
+aot.builtin.args in kfunc as a map key
+aot.builtin.args in kfunc store in map
+aot.builtin.args in uprobe as a map key
+aot.builtin.args in uprobe print
+aot.builtin.args in uprobe store in map
+aot.builtin.args in uprobe store in map and access field
+aot.builtin.cat limited output
+aot.builtin.comm
+aot.builtin.func_uprobe_elf_symtable
+aot.builtin.print args in kfunc
+aot.call.cgroup_path
+aot.call.cgroup_path printf
+aot.call.hist_10g
+aot.call.iter:task
+aot.call.iter:task_file
+aot.call.iter:task_vma
+aot.call.path_in_unsupported_kfunc
+aot.call.print_map_item_tuple
+aot.call.print_non_map_builtin
+aot.call.print_non_map_struct_kfunc
+aot.call.print_non_map_tuple
+aot.call.str_truncated
+aot.call.str_truncated_custom
+aot.call.strftime
+aot.call.strftime_as_map_key
+aot.call.strftime_as_map_value
+aot.call.ustack_elf_symtable
+aot.dwarf.uprobe inlined function
+aot.for.map multiple loops
+aot.for.map multiple probes
+aot.for.map nested vals
+aot.for.map one key
+aot.for.map strings
+aot.for.map two keys
+aot.for.variable context multiple
+aot.json-output.complex
+aot.json-output.histogram
+aot.json-output.histogram zero
+aot.json-output.histogram-finegrain
+aot.json-output.linear histogram
+aot.json-output.linear histogram zero
+aot.json-output.map
+aot.json-output.multiple histograms
+aot.json-output.multiple linear histograms
+aot.json-output.multiple maps
+aot.json-output.multiple stats
+aot.json-output.scalar
+aot.json-output.scalar_str
+aot.json-output.stats
+aot.other.if_compare_and_print_string
+aot.other.per_cpu_map_arithmetic
+aot.other.per_cpu_map_avg_if
+aot.probe.fentry
+aot.probe.fexit
+aot.probe.kfunc
+aot.probe.kfunc args
+aot.probe.kfunc args as a pointer
+aot.probe.kfunc func builtin
+aot.probe.kfunc_module
+aot.probe.kfunc_module_wildcard
+aot.probe.kfunc_multiple_attach_point_multiple_functions
+aot.probe.kfunc_wildcard
+aot.probe.kprobe_error_missing_probes
+aot.probe.kprobe_ignore_missing_probes
+aot.probe.kretfunc
+aot.probe.uprobe_error_missing_probes
+aot.probe.uprobe_ignore_missing_probes
+aot.regression.kfunc double pointer array access
+aot.regression.kfunc double pointer dereference
+aot.tuples.basic tuple map
+aot.tuples.tuple print
+aot.tuples.tuple strftime type is packed
+aot.variable.tuple string resize
+aot.dwarf.uprobe inlined function - func
+aot.dwarf.uprobe inlined function - probe
+aot.dwarf.uprobe inlined function - ustack

--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -38,6 +38,7 @@ NIX_TARGET = os.environ.get("NIX_TARGET", "")
 CMAKE_BUILD_TYPE = os.environ.get("CMAKE_BUILD_TYPE", "Release")
 RUN_TESTS = os.environ.get("RUN_TESTS", "1")
 RUN_MEMLEAK_TEST = os.environ.get("RUN_MEMLEAK_TEST", "0")
+RUN_AOT_TESTS = os.environ.get("RUN_AOT_TESTS", "0")
 CC = os.environ.get("CC", "cc")
 CXX = os.environ.get("CXX", "c++")
 GTEST_COLOR = os.environ.get("GTEST_COLOR", "auto")
@@ -45,6 +46,7 @@ CI = os.environ.get("CI", "false")
 RUNTIME_TEST_COLOR = os.environ.get("RUNTIME_TEST_COLOR", "auto")
 TOOLS_TEST_OLDVERSION = os.environ.get("TOOLS_TEST_OLDVERSION", "")
 TOOLS_TEST_DISABLE = os.environ.get("TOOLS_TEST_DISABLE", "")
+AOT_SKIPLIST_FILE = os.environ.get("AOT_SKIPLIST_FILE", "")
 
 
 class TestStatus(Enum):
@@ -270,6 +272,34 @@ def test():
                 env={
                     "TOOLS_TEST_OLDVERSION": TOOLS_TEST_OLDVERSION,
                     "TOOLS_TEST_DISABLE": TOOLS_TEST_DISABLE,
+                },
+            ),
+        )
+    )
+    results.append(
+        test_one(
+            "runtime-tests.sh (AOT)",
+            lambda: truthy(RUN_AOT_TESTS),
+            lambda: shell(
+                (
+                    [
+                        "./tests/runtime-tests.sh",
+                        "--run-aot-tests",
+                        "--filter",
+                        "aot.*",
+                    ]
+                    + [
+                        "--skiplist_file",
+                        f"{root()}/{AOT_SKIPLIST_FILE}",
+                    ]
+                    if AOT_SKIPLIST_FILE
+                    else []
+                ),
+                as_root=True,
+                cwd=Path(BUILD_DIR),
+                env={
+                    "CI": CI,
+                    "RUNTIME_TEST_COLOR": RUNTIME_TEST_COLOR,
                 },
             ),
         )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,12 @@ jobs:
           CC: clang
           CXX: clang++
           TOOLS_TEST_DISABLE: biosnoop.bt
+        - NAME: AOT (LLVM 18 Debug)
+          CMAKE_BUILD_TYPE: Debug
+          NIX_TARGET: .#bpftrace-llvm18
+          RUN_TESTS: 0
+          RUN_AOT_TESTS: 1
+          AOT_SKIPLIST_FILE: .github/include/aot_skip.txt
         - NAME: Memleak test (LLVM 18 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm18

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -463,17 +463,15 @@ class Runner(object):
         def print_befores_and_after_output():
             if len(befores_output) > 0:
                 for out in befores_output:
-                    out = out.encode("unicode_escape").decode("utf-8")
-                    print(f"\tBefore cmd output: {out}")
+                    print(f"\tBefore cmd output: {to_utf8(out)}")
             if after_output is not None:
-                out = after_output.encode("unicode_escape").decode("utf-8")
-                print(f"\tAfter cmd output: {out}")
+                print(f"\tAfter cmd output: {to_utf8(after_output)}")
 
         if p and p.returncode != 0 and not test.will_fail and not timeout:
             print(fail("[  FAILED  ] ") + "%s.%s" % (test.suite, test.name))
             print('\tCommand: ' + bpf_call)
             print('\tUnclean exit code: ' + str(p.returncode))
-            print('\tOutput: ' + output.encode("unicode_escape").decode("utf-8"))
+            print('\tOutput: ' + to_utf8(output))
             print_befores_and_after_output()
             return Runner.FAIL
 

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -57,6 +57,7 @@ class Runner(object):
     SKIP_FEATURE_REQUIREMENT_UNSATISFIED = 6
     SKIP_AOT_NOT_SUPPORTED = 7
     SKIP_KERNEL_VERSION_MAX = 8
+    SKIP_IN_SKIPLIST = 9
 
     @staticmethod
     def failed(status):
@@ -75,6 +76,7 @@ class Runner(object):
             Runner.SKIP_ENVIRONMENT_DISABLED,
             Runner.SKIP_FEATURE_REQUIREMENT_UNSATISFIED,
             Runner.SKIP_AOT_NOT_SUPPORTED,
+            Runner.SKIP_IN_SKIPLIST,
         ]
 
     @staticmethod
@@ -93,6 +95,8 @@ class Runner(object):
             return "disabled by environment variable"
         elif status == Runner.SKIP_AOT_NOT_SUPPORTED:
             return "aot does not yet support this"
+        elif status == Runner.SKIP_IN_SKIPLIST:
+            return "disabled by entry in skiplist file"
         else:
             raise ValueError("Invalid skip reason: %d" % status)
 

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -467,6 +467,10 @@ class Runner(object):
             if after_output is not None:
                 print(f"\tAfter cmd output: {to_utf8(after_output)}")
 
+        if '__BPFTRACE_NOTIFY_AOT_PORTABILITY_DISABLED' in to_utf8(output):
+            print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
+            return Runner.SKIP_AOT_NOT_SUPPORTED
+
         if p and p.returncode != 0 and not test.will_fail and not timeout:
             print(fail("[  FAILED  ] ") + "%s.%s" % (test.suite, test.name))
             print('\tCommand: ' + bpf_call)
@@ -478,9 +482,6 @@ class Runner(object):
         if result:
             print(ok("[       OK ] ") + "%s.%s" % (test.suite, test.name))
             return Runner.PASS
-        elif '__BPFTRACE_NOTIFY_AOT_PORTABILITY_DISABLED' in output:
-            print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
-            return Runner.SKIP_AOT_NOT_SUPPORTED
         else:
             print(fail("[  FAILED  ] ") + "%s.%s" % (test.suite, test.name))
             print('\tCommand: ' + bpf_call)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

This PR backstops AOT tests in CI. Not all the AOT test pass or get
skipped yet. Rather than wait for it to happen and then add in CI,
let's just add a subset in CI now to prevent any more backsliding.

We've already had quite a few regressions due to the codepaths
not being exercised in CI.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
