### PR TITLE
AST: Use default copy constructors

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -699,88 +699,6 @@ void Probe::set_index(int index)
   index_ = index;
 }
 
-Expression::Expression(const Expression &other) : Node(other)
-{
-  type = other.type;
-  is_literal = other.is_literal;
-  is_variable = other.is_variable;
-  is_map = other.is_map;
-}
-
-Call::Call(const Call &other) : Expression(other)
-{
-  func = other.func;
-}
-
-Sizeof::Sizeof(const Sizeof &other) : Expression(other)
-{
-}
-
-Offsetof::Offsetof(const Offsetof &other) : Expression(other)
-{
-}
-
-Binop::Binop(const Binop &other) : Expression(other)
-{
-  op = other.op;
-}
-
-Unop::Unop(const Unop &other) : Expression(other)
-{
-  op = other.op;
-  is_post_op = other.is_post_op;
-}
-
-Map::Map(const Map &other) : Expression(other)
-{
-  ident = other.ident;
-  skip_key_validation = other.skip_key_validation;
-}
-
-FieldAccess::FieldAccess(const FieldAccess &other)
-    : Expression(other), expr(nullptr)
-{
-  field = other.field;
-  index = other.index;
-}
-
-Unroll::Unroll(const Unroll &other) : Statement(other)
-{
-  var = other.var;
-}
-
-Program::Program(const Program &other) : Node(other)
-{
-  c_definitions = other.c_definitions;
-  config = other.config;
-}
-
-Config::Config(const Config &other) : Statement(other)
-{
-}
-
-Cast::Cast(const Cast &other) : Expression(other)
-{
-}
-
-SubprogArg::SubprogArg(const SubprogArg &other) : Node(other)
-{
-  name_ = other.name_;
-  type = other.type;
-}
-
-Subprog::Subprog(const Subprog &other) : Scope(other)
-{
-  name_ = other.name_;
-}
-
-Probe::Probe(const Probe &other) : Scope(static_cast<const Scope &>(other))
-{
-  need_expansion = other.need_expansion;
-  tp_args_structs_level = other.tp_args_structs_level;
-  index_ = other.index_;
-}
-
 std::string Subprog::name() const
 {
   return name_;
@@ -796,38 +714,6 @@ bool Probe::has_ap_of_probetype(ProbeType probe_type)
   }
   return false;
 }
-
-While::While(const While &other) : Statement(other)
-{
-}
-
-For::For(const For &other) : Statement(other)
-{
-}
-
-Tuple::Tuple(const Tuple &other) : Expression(other)
-{
-}
-
-If::If(const If &other) : Statement(other)
-{
-}
-
-AssignVarStatement::AssignVarStatement(const AssignVarStatement &other)
-    : Statement(other)
-{
-  compound = other.compound;
-};
-
-AssignMapStatement::AssignMapStatement(const AssignMapStatement &other)
-    : Statement(other)
-{
-  compound = other.compound;
-};
-
-AssignConfigVarStatement::AssignConfigVarStatement(
-    const AssignConfigVarStatement &other)
-    : Statement(other){};
 
 SizedType ident_to_record(const std::string &ident, int pointer_level)
 {

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -52,12 +52,11 @@ TEST(ast, probe_name_kprobe)
   Probe kprobe1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  auto ap2_copy1 = ap2->leafcopy();
   auto attach_points2 = APL({ ap1, ap2 });
   Probe kprobe2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
 
-  auto attach_points3 = APL({ ap1, ap2_copy1, ap3 });
+  auto attach_points3 = APL({ ap1, ap2, ap3 });
   Probe kprobe3(attach_points3, nullptr, nullptr);
   EXPECT_EQ(kprobe3.name(),
             "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");


### PR DESCRIPTION
AST: Use default copy constructors

Manually defined copy-ctors were in use previously to avoid copying
pointers, as the AST currently operates on a manual memory management
scheme where (most) raw pointers are owning.

The AST will soon be migrated across to a safer memory management
scheme, rendering the custom copy-ctors pointless (harmful, even).

In the meantime, there is little risk in making this change as AST
nodes are only copied in one unit test. The leafcopy() function has
been deleted to ensure no new call sites can appear.
