### PR TITLE
AST: Switch to non-owning pointers in nodes

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -121,7 +121,6 @@ public:
   explicit PositionalParameter(PositionalParameterType ptype,
                                long n,
                                location loc);
-  ~PositionalParameter() = default;
 
   PositionalParameterType ptype;
   long n;
@@ -136,7 +135,6 @@ public:
   DEFINE_ACCEPT
 
   explicit String(const std::string &str, location loc);
-  ~String() = default;
 
   std::string str;
 
@@ -149,7 +147,6 @@ public:
   DEFINE_ACCEPT
 
   explicit StackMode(const std::string &mode, location loc);
-  ~StackMode() = default;
 
   std::string mode;
 
@@ -162,7 +159,6 @@ public:
   DEFINE_ACCEPT
 
   explicit Identifier(const std::string &ident, location loc);
-  ~Identifier() = default;
 
   std::string ident;
 
@@ -175,7 +171,6 @@ public:
   DEFINE_ACCEPT
 
   explicit Builtin(const std::string &ident, location loc);
-  ~Builtin() = default;
 
   std::string ident;
   int probe_id;
@@ -196,14 +191,14 @@ public:
   DEFINE_ACCEPT
 
   explicit Call(const std::string &func, location loc);
-  Call(const std::string &func, ExpressionList *vargs, location loc);
-  ~Call();
+  Call(const std::string &func, ExpressionList &&vargs, location loc);
 
   std::string func;
-  ExpressionList *vargs = nullptr;
+  ExpressionList *vargs = &vargs_;
 
 private:
   Call(const Call &other) = default;
+  ExpressionList vargs_;
 };
 
 class Sizeof : public Expression {
@@ -212,7 +207,6 @@ public:
 
   Sizeof(SizedType type, location loc);
   Sizeof(Expression *expr, location loc);
-  ~Sizeof();
 
   Expression *expr;
   SizedType argtype;
@@ -227,7 +221,6 @@ public:
 
   Offsetof(SizedType record, std::string &field, location loc);
   Offsetof(Expression *expr, std::string &field, location loc);
-  ~Offsetof();
 
   SizedType record;
   Expression *expr;
@@ -242,16 +235,16 @@ public:
   DEFINE_ACCEPT
 
   explicit Map(const std::string &ident, location loc);
-  Map(const std::string &ident, ExpressionList *vargs, location loc);
-  ~Map();
+  Map(const std::string &ident, ExpressionList &&vargs, location loc);
 
   std::string ident;
   MapKey key_type;
-  ExpressionList *vargs = nullptr;
+  ExpressionList *vargs = &vargs_;
   bool skip_key_validation = false;
 
 private:
   Map(const Map &other) = default;
+  ExpressionList vargs_;
 };
 
 class Variable : public Expression {
@@ -259,7 +252,6 @@ public:
   DEFINE_ACCEPT
 
   explicit Variable(const std::string &ident, location loc);
-  ~Variable() = default;
 
   std::string ident;
 
@@ -272,8 +264,6 @@ public:
   DEFINE_ACCEPT
 
   Binop(Expression *left, Operator op, Expression *right, location loc);
-
-  ~Binop();
 
   Expression *left = nullptr;
   Expression *right = nullptr;
@@ -293,8 +283,6 @@ public:
        bool is_post_op = false,
        location loc = location());
 
-  ~Unop();
-
   Expression *expr = nullptr;
   Operator op;
   bool is_post_op;
@@ -310,7 +298,6 @@ public:
   FieldAccess(Expression *expr, const std::string &field);
   FieldAccess(Expression *expr, const std::string &field, location loc);
   FieldAccess(Expression *expr, ssize_t index, location loc);
-  ~FieldAccess();
 
   Expression *expr = nullptr;
   std::string field;
@@ -326,7 +313,6 @@ public:
 
   ArrayAccess(Expression *expr, Expression *indexpr);
   ArrayAccess(Expression *expr, Expression *indexpr, location loc);
-  ~ArrayAccess();
 
   Expression *expr = nullptr;
   Expression *indexpr = nullptr;
@@ -340,7 +326,6 @@ public:
   DEFINE_ACCEPT
 
   Cast(SizedType type, Expression *expr, location loc);
-  ~Cast();
 
   Expression *expr = nullptr;
 
@@ -352,13 +337,13 @@ class Tuple : public Expression {
 public:
   DEFINE_ACCEPT
 
-  Tuple(ExpressionList *elems, location loc);
-  ~Tuple();
+  Tuple(ExpressionList &&elems, location loc);
 
-  ExpressionList *elems = nullptr;
+  ExpressionList *elems = &elems_;
 
 private:
   Tuple(const Tuple &other) = default;
+  ExpressionList elems_;
 };
 
 class Statement : public Node {
@@ -380,7 +365,6 @@ public:
   DEFINE_ACCEPT
 
   explicit ExprStatement(Expression *expr, location loc);
-  ~ExprStatement();
 
   Expression *expr = nullptr;
 
@@ -392,15 +376,10 @@ class AssignMapStatement : public Statement {
 public:
   DEFINE_ACCEPT
 
-  AssignMapStatement(Map *map,
-                     Expression *expr,
-                     bool compound = false,
-                     location loc = location());
-  ~AssignMapStatement();
+  AssignMapStatement(Map *map, Expression *expr, location loc = location());
 
   Map *map = nullptr;
   Expression *expr = nullptr;
-  bool compound;
 
 private:
   AssignMapStatement(const AssignMapStatement &other) = default;
@@ -412,13 +391,10 @@ public:
 
   AssignVarStatement(Variable *var,
                      Expression *expr,
-                     bool compound = false,
                      location loc = location());
-  ~AssignVarStatement();
 
   Variable *var = nullptr;
   Expression *expr = nullptr;
-  bool compound;
 
 private:
   AssignVarStatement(const AssignVarStatement &other) = default;
@@ -431,7 +407,6 @@ public:
   AssignConfigVarStatement(const std::string &config_var,
                            Expression *expr,
                            location loc = location());
-  ~AssignConfigVarStatement();
 
   std::string config_var;
   Expression *expr = nullptr;
@@ -444,31 +419,32 @@ class If : public Statement {
 public:
   DEFINE_ACCEPT
 
-  If(Expression *cond, StatementList *stmts);
-  If(Expression *cond, StatementList *stmts, StatementList *else_stmts);
-  ~If();
+  If(Expression *cond, StatementList &&stmts);
+  If(Expression *cond, StatementList &&stmts, StatementList &&else_stmts);
 
   Expression *cond = nullptr;
-  StatementList *stmts = nullptr;
-  StatementList *else_stmts = nullptr;
+  StatementList *stmts = &stmts_;
+  StatementList *else_stmts = &else_stmts_;
 
 private:
   If(const If &other) = default;
+  StatementList stmts_;
+  StatementList else_stmts_;
 };
 
 class Unroll : public Statement {
 public:
   DEFINE_ACCEPT
 
-  Unroll(Expression *expr, StatementList *stmts, location loc);
-  ~Unroll();
+  Unroll(Expression *expr, StatementList &&stmts, location loc);
 
   long int var = 0;
   Expression *expr = nullptr;
-  StatementList *stmts = nullptr;
+  StatementList *stmts = &stmts_;
 
 private:
   Unroll(const Unroll &other) = default;
+  StatementList stmts_;
 };
 
 class Jump : public Statement {
@@ -483,7 +459,6 @@ public:
       : Statement(loc), ident(ident), return_value(nullptr)
   {
   }
-  ~Jump();
 
   JumpType ident = JumpType::INVALID;
   Expression *return_value;
@@ -497,7 +472,6 @@ public:
   DEFINE_ACCEPT
 
   explicit Predicate(Expression *expr, location loc);
-  ~Predicate();
 
   Expression *expr = nullptr;
 
@@ -510,7 +484,6 @@ public:
   DEFINE_ACCEPT
 
   Ternary(Expression *cond, Expression *left, Expression *right, location loc);
-  ~Ternary();
 
   Expression *cond = nullptr;
   Expression *left = nullptr;
@@ -521,60 +494,63 @@ class While : public Statement {
 public:
   DEFINE_ACCEPT
 
-  While(Expression *cond, StatementList *stmts, location loc)
-      : Statement(loc), cond(cond), stmts(stmts)
+  While(Expression *cond, StatementList &&stmts, location loc)
+      : Statement(loc), cond(cond), stmts_(std::move(stmts))
   {
   }
-  ~While();
 
   Expression *cond = nullptr;
-  StatementList *stmts = nullptr;
+  StatementList *stmts = &stmts_;
 
 private:
   While(const While &other) = default;
+  StatementList stmts_;
 };
 
 class For : public Statement {
 public:
   DEFINE_ACCEPT
 
-  For(Variable *decl, Expression *expr, StatementList *stmts, location loc)
-      : Statement(loc), decl(decl), expr(expr), stmts(stmts)
+  For(Variable *decl, Expression *expr, StatementList &&stmts, location loc)
+      : Statement(loc), decl(decl), expr(expr), stmts_(std::move(stmts))
   {
   }
-  ~For();
 
   Variable *decl = nullptr;
   Expression *expr = nullptr;
-  StatementList *stmts = nullptr;
+  StatementList *stmts = &stmts_;
 
   SizedType ctx_type;
 
 private:
   For(const For &other) = default;
+  StatementList stmts_;
 };
 
 class Config : public Statement {
 public:
   DEFINE_ACCEPT
 
-  Config(StatementList *stmts) : stmts(stmts)
+  Config(StatementList &&stmts) : stmts_(std::move(stmts))
   {
   }
-  ~Config();
 
-  StatementList *stmts = nullptr;
+  StatementList *stmts = &stmts_;
 
 private:
   Config(const Config &other) = default;
+  StatementList stmts_;
 };
 
 class Scope : public Node {
 public:
-  Scope(StatementList *stmts);
-  virtual ~Scope() = 0;
+  Scope(StatementList &&stmts);
+  virtual ~Scope() = default;
 
-  StatementList *stmts;
+  StatementList *stmts = &stmts_;
+
+private:
+  StatementList stmts_;
 };
 
 class AttachPoint : public Node {
@@ -586,13 +562,6 @@ public:
       : AttachPoint(raw_input)
   {
     this->ignore_invalid = ignore_invalid;
-  }
-
-  // TODO delete this function when migrating away from manual memory management
-  // It has been left to keep tests working during a refactoring
-  AttachPoint *leafcopy()
-  {
-    return new AttachPoint(*this);
   }
 
   // Raw, unparsed input from user, eg. kprobe:vfs_read
@@ -635,10 +604,11 @@ class Probe : public Scope {
 public:
   DEFINE_ACCEPT
 
-  Probe(AttachPointList *attach_points, Predicate *pred, StatementList *stmts);
-  ~Probe();
+  Probe(AttachPointList &&attach_points,
+        Predicate *pred,
+        StatementList &&stmts);
 
-  AttachPointList *attach_points = nullptr;
+  AttachPointList *attach_points = &attach_points_;
   Predicate *pred = nullptr;
 
   std::string name() const;
@@ -655,6 +625,7 @@ public:
 private:
   Probe(const Probe &other) = default;
   int index_ = 0;
+  AttachPointList attach_points_;
 };
 using ProbeList = std::vector<Probe *>;
 
@@ -679,11 +650,10 @@ public:
 
   Subprog(std::string name,
           SizedType return_type,
-          SubprogArgList *args,
-          StatementList *stmts);
-  ~Subprog();
+          SubprogArgList &&args,
+          StatementList &&stmts);
 
-  SubprogArgList *args = nullptr;
+  SubprogArgList *args = &args_;
   SizedType return_type;
 
   std::string name() const;
@@ -691,6 +661,7 @@ public:
 private:
   Subprog(const Subprog &other) = default;
   std::string name_;
+  SubprogArgList args_;
 };
 using SubprogList = std::vector<Subprog *>;
 
@@ -700,17 +671,18 @@ public:
 
   Program(const std::string &c_definitions,
           Config *config,
-          SubprogList *functions,
-          ProbeList *probes);
-  ~Program();
+          SubprogList &&functions,
+          ProbeList &&probes);
 
   std::string c_definitions;
   Config *config = nullptr;
-  SubprogList *functions = nullptr;
-  ProbeList *probes = nullptr;
+  SubprogList *functions = &functions_;
+  ProbeList *probes = &probes_;
 
 private:
   Program(const Program &other) = default;
+  SubprogList functions_;
+  ProbeList probes_;
 };
 
 std::string opstr(const Binop &binop);
@@ -718,6 +690,35 @@ std::string opstr(const Unop &unop);
 std::string opstr(const Jump &jump);
 
 SizedType ident_to_record(const std::string &ident, int pointer_level = 0);
+
+template <typename T>
+concept NodeType = std::derived_from<T, Node>;
+
+/*
+ * Manages the lifetime of AST nodes.
+ *
+ * Nodes allocated by an ASTContext will be kept alive for the duration of the
+ * owning ASTContext object.
+ */
+class ASTContext {
+public:
+  Program *root = nullptr;
+
+  /*
+   * Creates and returns a pointer to an AST node.
+   */
+  template <NodeType T, typename... Args>
+  T *make_node(Args &&...args)
+  {
+    auto uniq_ptr = std::make_unique<T>(std::forward<Args>(args)...);
+    auto *raw_ptr = uniq_ptr.get();
+    nodes_.push_back(std::move(uniq_ptr));
+    return raw_ptr;
+  }
+
+private:
+  std::vector<std::unique_ptr<Node>> nodes_;
+};
 
 #undef DEFINE_ACCEPT
 

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -13,7 +13,7 @@ namespace ast {
 
 class AttachPointParser {
 public:
-  AttachPointParser(Program *root,
+  AttachPointParser(ASTContext &ctx,
                     BPFtrace &bpftrace,
                     std::ostream &sink,
                     bool listing);
@@ -59,7 +59,7 @@ private:
   std::optional<uint64_t> stoull(const std::string &str);
   std::optional<int64_t> stoll(const std::string &str);
 
-  Program *root_{ nullptr }; // Non-owning pointer
+  ASTContext &ctx_;
   BPFtrace &bpftrace_;
   std::ostream &sink_;
   AttachPoint *ap_{ nullptr }; // Non-owning pointer

--- a/src/ast/pass_manager.cpp
+++ b/src/ast/pass_manager.cpp
@@ -24,9 +24,8 @@ void PassManager::AddPass(Pass p)
   passes_.push_back(std::move(p));
 }
 
-PassResult PassManager::Run(std::unique_ptr<Node> node, PassContext &ctx)
+PassResult PassManager::Run(Node *root, PassContext &ctx)
 {
-  Node *root = node.release();
   if (bt_debug.find(DebugStage::Ast) != bt_debug.end())
     print(root, "parser", std::cout);
   for (auto &pass : passes_) {
@@ -35,7 +34,6 @@ PassResult PassManager::Run(std::unique_ptr<Node> node, PassContext &ctx)
       return result;
 
     if (result.Root()) {
-      delete root;
       root = result.Root();
     }
 

--- a/src/ast/pass_manager.h
+++ b/src/ast/pass_manager.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <functional>
-#include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -13,6 +12,7 @@ class BPFtrace;
 
 namespace ast {
 
+class ASTContext;
 class Node;
 class SemanticAnalyser;
 class Pass;
@@ -95,8 +95,9 @@ private:
 
 struct PassContext {
 public:
-  PassContext(BPFtrace &b) : b(b){};
+  PassContext(BPFtrace &b, ASTContext &ast_ctx) : b(b), ast_ctx(ast_ctx){};
   BPFtrace &b;
+  ASTContext &ast_ctx;
 };
 
 using PassFPtr = std::function<PassResult(Node &, PassContext &)>;
@@ -128,7 +129,7 @@ public:
   PassManager() = default;
 
   void AddPass(Pass p);
-  [[nodiscard]] PassResult Run(std::unique_ptr<Node> n, PassContext &ctx);
+  [[nodiscard]] PassResult Run(Node *n, PassContext &ctx);
 
 private:
   std::vector<Pass> passes_;

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -16,12 +16,12 @@ namespace ast {
 
 class SemanticAnalyser : public Visitor {
 public:
-  explicit SemanticAnalyser(Node *root,
+  explicit SemanticAnalyser(ASTContext &ctx,
                             BPFtrace &bpftrace,
                             std::ostream &out = std::cerr,
                             bool has_child = true,
                             bool listing = false)
-      : root_(root),
+      : ctx_(ctx),
         bpftrace_(bpftrace),
         out_(out),
         listing_(listing),
@@ -29,16 +29,16 @@ public:
   {
   }
 
-  explicit SemanticAnalyser(Node *root, BPFtrace &bpftrace, bool has_child)
-      : SemanticAnalyser(root, bpftrace, std::cerr, has_child)
+  explicit SemanticAnalyser(ASTContext &ctx, BPFtrace &bpftrace, bool has_child)
+      : SemanticAnalyser(ctx, bpftrace, std::cerr, has_child)
   {
   }
 
-  explicit SemanticAnalyser(Node *root,
+  explicit SemanticAnalyser(ASTContext &ctx,
                             BPFtrace &bpftrace,
                             bool has_child,
                             bool listing)
-      : SemanticAnalyser(root, bpftrace, std::cerr, has_child, listing)
+      : SemanticAnalyser(ctx, bpftrace, std::cerr, has_child, listing)
   {
   }
 
@@ -79,7 +79,7 @@ public:
   int analyse();
 
 private:
-  Node *root_ = nullptr;
+  ASTContext &ctx_;
   BPFtrace &bpftrace_;
   std::ostream &out_;
   std::ostringstream err_;

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -32,7 +32,7 @@ int Driver::parse_str(std::string_view script)
 int Driver::parse()
 {
   // Reset previous state if we parse more than once
-  root.reset();
+  ctx = {};
 
   // Reset source location info on every pass
   loc.initialize();
@@ -48,13 +48,13 @@ int Driver::parse()
   yylex_destroy(scanner);
 
   if (!failed_) {
-    ast::AttachPointParser ap_parser(root.get(), bpftrace_, out_, listing_);
+    ast::AttachPointParser ap_parser(ctx, bpftrace_, out_, listing_);
     if (ap_parser.parse())
       failed_ = true;
   }
 
   if (failed_) {
-    root.reset();
+    ctx = {};
   }
 
   // Keep track of errors thrown ourselves, since the result of
@@ -81,7 +81,7 @@ void Driver::error(const std::string &m)
 std::set<std::string> Driver::list_modules() const
 {
   std::set<std::string> modules;
-  for (auto &probe : *root->probes) {
+  for (auto &probe : *ctx.root->probes) {
     for (auto &ap : *probe->attach_points) {
       auto probe_type = probetype(ap->provider);
       if (probe_type == ProbeType::kfunc || probe_type == ProbeType::kretfunc ||

--- a/src/driver.h
+++ b/src/driver.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <fstream>
-#include <memory>
 #include <string_view>
 
 #include "ast/ast.h"
@@ -21,7 +20,7 @@ public:
   void error(std::ostream &, const location &, const std::string &);
   void error(const location &l, const std::string &m);
   void error(const std::string &m);
-  std::unique_ptr<ast::Program> root;
+  ast::ASTContext ctx;
 
   void debug()
   {

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -10,152 +10,129 @@ using bpftrace::ast::AttachPoint;
 using bpftrace::ast::AttachPointList;
 using bpftrace::ast::Probe;
 
-static AttachPointList *APL(std::vector<AttachPoint *> list)
-{
-  auto apl = new AttachPointList();
-  for (auto l : list)
-    apl->push_back(l->leafcopy());
-  return apl;
-}
-
 TEST(ast, probe_name_special)
 {
-  auto ap1 = new AttachPoint("");
-  ap1->provider = "BEGIN";
-  auto attach_points1 = APL({ ap1 });
-  Probe begin(attach_points1, nullptr, nullptr);
+  AttachPoint ap1{ "" };
+  ap1.provider = "BEGIN";
+  Probe begin({ &ap1 }, nullptr, {});
   EXPECT_EQ(begin.name(), "BEGIN");
 
-  auto ap2 = new AttachPoint("");
-  ap2->provider = "END";
-  auto attach_points2 = APL({ ap2 });
-  Probe end(attach_points2, nullptr, nullptr);
+  AttachPoint ap2{ "" };
+  ap2.provider = "END";
+  Probe end({ &ap2 }, nullptr, {});
   EXPECT_EQ(end.name(), "END");
 }
 
 TEST(ast, probe_name_kprobe)
 {
-  auto ap1 = new AttachPoint("");
-  ap1->provider = "kprobe";
-  ap1->func = "sys_read";
+  AttachPoint ap1{ "" };
+  ap1.provider = "kprobe";
+  ap1.func = "sys_read";
 
-  auto ap2 = new AttachPoint("");
-  ap2->provider = "kprobe";
-  ap2->func = "sys_write";
+  AttachPoint ap2{ "" };
+  ap2.provider = "kprobe";
+  ap2.func = "sys_write";
 
-  auto ap3 = new AttachPoint("");
-  ap3->provider = "kprobe";
-  ap3->func = "sys_read";
-  ap3->func_offset = 10;
+  AttachPoint ap3{ "" };
+  ap3.provider = "kprobe";
+  ap3.func = "sys_read";
+  ap3.func_offset = 10;
 
-  auto attach_points1 = APL({ ap1 });
-  Probe kprobe1(attach_points1, nullptr, nullptr);
+  Probe kprobe1({ &ap1 }, nullptr, {});
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  auto attach_points2 = APL({ ap1, ap2 });
-  Probe kprobe2(attach_points2, nullptr, nullptr);
+  Probe kprobe2({ &ap1, &ap2 }, nullptr, {});
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
 
-  auto attach_points3 = APL({ ap1, ap2, ap3 });
-  Probe kprobe3(attach_points3, nullptr, nullptr);
+  Probe kprobe3({ &ap1, &ap2, &ap3 }, nullptr, {});
   EXPECT_EQ(kprobe3.name(),
             "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");
 }
 
 TEST(ast, probe_name_uprobe)
 {
-  auto ap1 = new AttachPoint("");
-  ap1->provider = "uprobe";
-  ap1->target = "/bin/sh";
-  ap1->func = "readline";
-  auto attach_points1 = APL({ ap1 });
-  Probe uprobe1(attach_points1, nullptr, nullptr);
+  AttachPoint ap1{ "" };
+  ap1.provider = "uprobe";
+  ap1.target = "/bin/sh";
+  ap1.func = "readline";
+  Probe uprobe1({ &ap1 }, nullptr, {});
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
-  auto ap2 = new AttachPoint("");
-  ap2->provider = "uprobe";
-  ap2->target = "/bin/sh";
-  ap2->func = "somefunc";
-  auto attach_points2 = APL({ ap1, ap2 });
-  Probe uprobe2(attach_points2, nullptr, nullptr);
+  AttachPoint ap2{ "" };
+  ap2.provider = "uprobe";
+  ap2.target = "/bin/sh";
+  ap2.func = "somefunc";
+  Probe uprobe2({ &ap1, &ap2 }, nullptr, {});
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
 
-  auto ap3 = new AttachPoint("");
-  ap3->provider = "uprobe";
-  ap3->target = "/bin/sh";
-  ap3->address = 1000;
-  auto attach_points3 = APL({ ap1, ap2, ap3 });
-  Probe uprobe3(attach_points3, nullptr, nullptr);
+  AttachPoint ap3{ "" };
+  ap3.provider = "uprobe";
+  ap3.target = "/bin/sh";
+  ap3.address = 1000;
+  Probe uprobe3({ &ap1, &ap2, &ap3 }, nullptr, {});
   EXPECT_EQ(
       uprobe3.name(),
       "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
 
-  auto ap4 = new AttachPoint("");
-  ap4->provider = "uprobe";
-  ap4->target = "/bin/sh";
-  ap4->func = "somefunc";
-  ap4->func_offset = 10;
-  auto attach_points4 = APL({ ap1, ap2, ap3, ap4 });
-  Probe uprobe4(attach_points4, nullptr, nullptr);
+  AttachPoint ap4{ "" };
+  ap4.provider = "uprobe";
+  ap4.target = "/bin/sh";
+  ap4.func = "somefunc";
+  ap4.func_offset = 10;
+  Probe uprobe4({ &ap1, &ap2, &ap3, &ap4 }, nullptr, {});
   EXPECT_EQ(uprobe4.name(),
             "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/"
             "sh:1000,uprobe:/bin/sh:somefunc+10");
 
-  auto ap5 = new AttachPoint("");
-  ap5->provider = "uprobe";
-  ap5->target = "/bin/sh";
-  ap5->address = 10;
-  auto attach_points5 = APL({ ap5 });
-  Probe uprobe5(attach_points5, nullptr, nullptr);
+  AttachPoint ap5{ "" };
+  ap5.provider = "uprobe";
+  ap5.target = "/bin/sh";
+  ap5.address = 10;
+  Probe uprobe5({ &ap5 }, nullptr, {});
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
 
-  auto ap6 = new AttachPoint("");
-  ap6->provider = "uretprobe";
-  ap6->target = "/bin/sh";
-  ap6->address = 10;
-  auto attach_points6 = APL({ ap6 });
-  Probe uprobe6(attach_points6, nullptr, nullptr);
+  AttachPoint ap6{ "" };
+  ap6.provider = "uretprobe";
+  ap6.target = "/bin/sh";
+  ap6.address = 10;
+  Probe uprobe6({ &ap6 }, nullptr, {});
   EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
 }
 
 TEST(ast, probe_name_usdt)
 {
-  auto ap1 = new AttachPoint("");
-  ap1->provider = "usdt";
-  ap1->target = "/bin/sh";
-  ap1->func = "probe1";
-  auto attach_points1 = APL({ ap1 });
-  Probe usdt1(attach_points1, nullptr, nullptr);
+  AttachPoint ap1{ "" };
+  ap1.provider = "usdt";
+  ap1.target = "/bin/sh";
+  ap1.func = "probe1";
+  Probe usdt1({ &ap1 }, nullptr, {});
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
-  auto ap2 = new AttachPoint("");
-  ap2->provider = "usdt";
-  ap2->target = "/bin/sh";
-  ap2->func = "probe2";
-  auto attach_points2 = APL({ ap1, ap2 });
-  Probe usdt2(attach_points2, nullptr, nullptr);
+  AttachPoint ap2{ "" };
+  ap2.provider = "usdt";
+  ap2.target = "/bin/sh";
+  ap2.func = "probe2";
+  Probe usdt2({ &ap1, &ap2 }, nullptr, {});
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
 }
 
 TEST(ast, attach_point_name)
 {
-  auto ap1 = new AttachPoint("");
-  ap1->provider = "kprobe";
-  ap1->func = "sys_read";
-  auto ap2 = new AttachPoint("");
-  ap2->provider = "kprobe";
-  ap2->func = "sys_thisone";
-  auto ap3 = new AttachPoint("");
-  ap3->provider = "uprobe";
-  ap3->target = "/bin/sh";
-  ap3->func = "readline";
-  auto attach_points = APL({ ap1, ap2, ap3 });
-  Probe kprobe(attach_points, nullptr, nullptr);
-  EXPECT_EQ(ap2->name(), "kprobe:sys_thisone");
+  AttachPoint ap1{ "" };
+  ap1.provider = "kprobe";
+  ap1.func = "sys_read";
+  AttachPoint ap2{ "" };
+  ap2.provider = "kprobe";
+  ap2.func = "sys_thisone";
+  AttachPoint ap3{ "" };
+  ap3.provider = "uprobe";
+  ap3.target = "/bin/sh";
+  ap3.func = "readline";
+  Probe kprobe({ &ap1, &ap2, &ap3 }, nullptr, {});
+  EXPECT_EQ(ap2.name(), "kprobe:sys_thisone");
 
-  attach_points = APL({ ap1, ap2, ap3 });
-  Probe uprobe(attach_points, nullptr, nullptr);
-  EXPECT_EQ(ap3->name(), "uprobe:/bin/sh:readline");
+  Probe uprobe({ &ap1, &ap2, &ap3 }, nullptr, {});
+  EXPECT_EQ(ap3.name(), "uprobe:/bin/sh:readline");
 }
 
 } // namespace ast

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -17,10 +17,10 @@ BpfBytecode codegen(std::string_view input)
   Driver driver(*bpftrace);
   EXPECT_EQ(driver.parse_str(input), 0);
 
-  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   EXPECT_EQ(semantics.analyse(), 0);
 
-  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
   return codegen.compile();
 }
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -40,18 +40,18 @@ static auto parse_probe(const std::string &str,
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(str), 0);
 
-  ast::FieldAnalyser fields(driver.root.get(), bpftrace);
+  ast::FieldAnalyser fields(driver.ctx.root, bpftrace);
   ASSERT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
-  clang.parse(driver.root.get(), bpftrace);
+  clang.parse(driver.ctx.root, bpftrace);
 
-  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
   auto usdt_helper = get_mock_usdt_helper(usdt_num_locations);
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.root.get(), bpftrace, std::move(usdt_helper));
+  ast::CodegenLLVM codegen(driver.ctx.root, bpftrace, std::move(usdt_helper));
   codegen.generate_ir();
 }
 

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -22,11 +22,11 @@ static void parse(const std::string &input,
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(extended_input), 0);
 
-  ast::FieldAnalyser fields(driver.root.get(), bpftrace);
+  ast::FieldAnalyser fields(driver.ctx.root, bpftrace);
   EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
-  ASSERT_EQ(clang.parse(driver.root.get(), bpftrace), result);
+  ASSERT_EQ(clang.parse(driver.ctx.root, bpftrace), result);
 }
 
 TEST(clang_parser, integers)

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -23,19 +23,19 @@ TEST(codegen, call_kstack_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root.get(), *bpftrace);
+  clang.parse(driver.ctx.root, *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 8);
@@ -59,19 +59,19 @@ TEST(codegen, call_kstack_modes_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root.get(), *bpftrace);
+  clang.parse(driver.ctx.root, *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 10);

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -23,19 +23,19 @@ TEST(codegen, call_ustack_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root.get(), *bpftrace);
+  clang.parse(driver.ctx.root, *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 8);
@@ -59,19 +59,19 @@ TEST(codegen, call_ustack_modes_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root.get(), *bpftrace);
+  clang.parse(driver.ctx.root, *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 10);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -49,24 +49,24 @@ static void test(BPFtrace &bpftrace,
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root.get(), bpftrace);
+  ast::FieldAnalyser fields(driver.ctx.root, bpftrace);
   ASSERT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
-  clang.parse(driver.root.get(), bpftrace);
+  clang.parse(driver.ctx.root, bpftrace);
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get(), bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx.root, bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace.resources = resources_optional.value();
 
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.root.get(), bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx.root, bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
   // Test that generated code compiles cleanly

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -61,19 +61,19 @@ TEST(codegen, printf_offsets)
                 "}"),
             0);
   ClangParser clang;
-  clang.parse(driver.root.get(), *bpftrace);
+  clang.parse(driver.ctx.root, *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
   codegen.generate_ir();
 
   EXPECT_EQ(bpftrace->resources.printf_args.size(), 1U);
@@ -113,9 +113,9 @@ TEST(codegen, probe_count)
   ASSERT_EQ(driver.parse_str("kprobe:f { 1; } kprobe:d { 1; }"), 0);
   // Override to mockbpffeature.
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ast::CodegenLLVM codegen(driver.root.get(), bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx.root, bpftrace);
   codegen.generate_ir();
 }
 } // namespace codegen

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -16,15 +16,15 @@ TEST(codegen, regression_957)
 
   ASSERT_EQ(driver.parse_str("t:sched:sched_one* { cat(\"%s\", probe); }"), 0);
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
   codegen.compile();
 }
 

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -26,14 +26,14 @@ void test(BPFtrace &bpftrace,
   ASSERT_EQ(driver.parse_str(input), 0);
 
   ClangParser clang;
-  ASSERT_TRUE(clang.parse(driver.root.get(), bpftrace));
+  ASSERT_TRUE(clang.parse(driver.ctx.root, bpftrace));
 
   ASSERT_EQ(driver.parse_str(input), 0);
   out.str("");
-  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, out, false);
+  ast::SemanticAnalyser semantics(driver.ctx, bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::ConfigAnalyser config_analyser(driver.root.get(), bpftrace, out);
+  ast::ConfigAnalyser config_analyser(driver.ctx.root, bpftrace, out);
   EXPECT_EQ(config_analyser.analyse(), expected_result)
       << msg.str() << out.str();
   if (expected_error.data()) {

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -20,7 +20,7 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
   Driver driver(bpftrace);
   EXPECT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root.get(), bpftrace, out);
+  ast::FieldAnalyser fields(driver.ctx.root, bpftrace, out);
   EXPECT_EQ(fields.analyse(), expected_result) << msg.str() + out.str();
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -42,7 +42,7 @@ void test(BPFtrace &bpftrace, std::string_view input, std::string_view expected)
 
   std::ostringstream out;
   Printer printer(out);
-  printer.print(driver.root.get());
+  printer.print(driver.ctx.root);
   EXPECT_EQ(expected, out.str());
 }
 

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -24,18 +24,18 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root.get(), bpftrace, out);
+  ast::FieldAnalyser fields(driver.ctx.root, bpftrace, out);
   ASSERT_EQ(fields.analyse(), 0) << msg.str() << out.str();
 
   ClangParser clang;
-  ASSERT_TRUE(clang.parse(driver.root.get(), bpftrace));
+  ASSERT_TRUE(clang.parse(driver.ctx.root, bpftrace));
 
   ASSERT_EQ(driver.parse_str(input), 0);
   out.str("");
-  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, out, false);
+  ast::SemanticAnalyser semantics(driver.ctx, bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::PortabilityAnalyser portability(driver.root.get(), out);
+  ast::PortabilityAnalyser portability(driver.ctx.root, out);
   EXPECT_EQ(portability.analyse(), expected_result) << msg.str() << out.str();
 }
 

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -28,23 +28,23 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root.get(), *bpftrace);
+  ast::FieldAnalyser fields(driver.ctx.root, *bpftrace);
   EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
-  clang.parse(driver.root.get(), *bpftrace);
+  clang.parse(driver.ctx.root, *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get(), *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
 }

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -25,18 +25,18 @@ void test(BPFtrace &bpftrace,
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root.get(), bpftrace, out);
+  ast::FieldAnalyser fields(driver.ctx.root, bpftrace, out);
   ASSERT_EQ(fields.analyse(), 0) << msg.str() << out.str();
 
   ClangParser clang;
-  ASSERT_TRUE(clang.parse(driver.root.get(), bpftrace));
+  ASSERT_TRUE(clang.parse(driver.ctx.root, bpftrace));
 
   ASSERT_EQ(driver.parse_str(input), 0);
   out.str("");
-  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, out, false);
+  ast::SemanticAnalyser semantics(driver.ctx, bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::ResourceAnalyser resource_analyser(driver.root.get(), bpftrace, out);
+  ast::ResourceAnalyser resource_analyser(driver.ctx.root, bpftrace, out);
   auto resources_optional = resource_analyser.analyse();
   EXPECT_EQ(resources_optional.has_value(), expected_result)
       << msg.str() << out.str();

--- a/tests/return_path_analyser.cpp
+++ b/tests/return_path_analyser.cpp
@@ -23,18 +23,18 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root.get(), bpftrace, out);
+  ast::FieldAnalyser fields(driver.ctx.root, bpftrace, out);
   ASSERT_EQ(fields.analyse(), 0) << msg.str() << out.str();
 
   ClangParser clang;
-  ASSERT_TRUE(clang.parse(driver.root.get(), bpftrace));
+  ASSERT_TRUE(clang.parse(driver.ctx.root, bpftrace));
 
   ASSERT_EQ(driver.parse_str(input), 0);
   out.str("");
-  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, out, false);
+  ast::SemanticAnalyser semantics(driver.ctx, bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::ReturnPathAnalyser return_path(driver.root.get(), out);
+  ast::ReturnPathAnalyser return_path(driver.ctx.root, out);
   EXPECT_EQ(return_path.analyse(), expected_result) << msg.str() << out.str();
 }
 

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -266,23 +266,23 @@ TEST(tracepoint_format_parser, args_field_access)
   ast::TracepointArgsVisitor visitor;
 
   EXPECT_EQ(driver.parse_str("BEGIN { args.f1->f2->f3 }"), 0);
-  visitor.visit(*driver.root->probes->at(0));
-  EXPECT_EQ(driver.root->probes->at(0)->tp_args_structs_level, 3);
+  visitor.visit(*driver.ctx.root->probes->at(0));
+  EXPECT_EQ(driver.ctx.root->probes->at(0)->tp_args_structs_level, 3);
 
   // Should work via intermediary variable, too
   EXPECT_EQ(driver.parse_str("BEGIN { $x = args.f1; $x->f2->f3 }"), 0);
-  visitor.visit(*driver.root->probes->at(0));
-  EXPECT_EQ(driver.root->probes->at(0)->tp_args_structs_level, 3);
+  visitor.visit(*driver.ctx.root->probes->at(0));
+  EXPECT_EQ(driver.ctx.root->probes->at(0)->tp_args_structs_level, 3);
 
   // "args" used without field access => level should be 0
   EXPECT_EQ(driver.parse_str("BEGIN { args }"), 0);
-  visitor.visit(*driver.root->probes->at(0));
-  EXPECT_EQ(driver.root->probes->at(0)->tp_args_structs_level, 0);
+  visitor.visit(*driver.ctx.root->probes->at(0));
+  EXPECT_EQ(driver.ctx.root->probes->at(0)->tp_args_structs_level, 0);
 
   // "args" not used => level should be -1
   EXPECT_EQ(driver.parse_str("BEGIN { x->f1->f2->f3 }"), 0);
-  visitor.visit(*driver.root->probes->at(0));
-  EXPECT_EQ(driver.root->probes->at(0)->tp_args_structs_level, -1);
+  visitor.visit(*driver.ctx.root->probes->at(0));
+  EXPECT_EQ(driver.ctx.root->probes->at(0)->tp_args_structs_level, -1);
 }
 
 } // namespace tracepoint_format_parser


### PR DESCRIPTION
Nodes are now owned by the ASTContext class.

This lets us get rid of the custom node destructors and eliminates a source of memory leaks (not all destructors were complete).

AST lists are embedded directly in the nodes that own them, but the pointers-to-lists are maintained in this commit for API compatibility. The pointers will be removed entirely in a separate, API-breaking, commit. Changing them adds a lot of churn (especially in semantic_analyser.cpp) so I've left them out of this PR for clarity.