### PR TITLE
tests: codegen: Make codegen-tests.sh build less

### DIFF
--- a/tests/codegen-tests.sh
+++ b/tests/codegen-tests.sh
@@ -48,5 +48,5 @@ done
 cd "$(git rev-parse --show-toplevel)"
 
 run cmake -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Debug
-run make -C "$BUILD_DIR" -j $(nproc)
+run make -C "$BUILD_DIR" -j $(nproc) bpftrace_test
 BPFTRACE_UPDATE_TESTS=${UPDATE_TESTS} run ./"$BUILD_DIR"/tests/bpftrace_test --gtest_filter="codegen*"


### PR DESCRIPTION
We only need to build the bpftrace_test binary. Not everything.

This change should save a bit of time for anyone using this script.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
