### PR TITLE
AST: Finish the refactoring of Lists from pointers to inline members

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -194,11 +194,10 @@ public:
   Call(const std::string &func, ExpressionList &&vargs, location loc);
 
   std::string func;
-  ExpressionList *vargs = &vargs_;
+  ExpressionList vargs;
 
 private:
   Call(const Call &other) = default;
-  ExpressionList vargs_;
 };
 
 class Sizeof : public Expression {
@@ -208,7 +207,7 @@ public:
   Sizeof(SizedType type, location loc);
   Sizeof(Expression *expr, location loc);
 
-  Expression *expr;
+  Expression *expr = nullptr;
   SizedType argtype;
 
 private:
@@ -223,7 +222,7 @@ public:
   Offsetof(Expression *expr, std::string &field, location loc);
 
   SizedType record;
-  Expression *expr;
+  Expression *expr = nullptr;
   std::string field;
 
 private:
@@ -239,12 +238,11 @@ public:
 
   std::string ident;
   MapKey key_type;
-  ExpressionList *vargs = &vargs_;
+  ExpressionList vargs;
   bool skip_key_validation = false;
 
 private:
   Map(const Map &other) = default;
-  ExpressionList vargs_;
 };
 
 class Variable : public Expression {
@@ -339,11 +337,10 @@ public:
 
   Tuple(ExpressionList &&elems, location loc);
 
-  ExpressionList *elems = &elems_;
+  ExpressionList elems;
 
 private:
   Tuple(const Tuple &other) = default;
-  ExpressionList elems_;
 };
 
 class Statement : public Node {
@@ -423,13 +420,11 @@ public:
   If(Expression *cond, StatementList &&stmts, StatementList &&else_stmts);
 
   Expression *cond = nullptr;
-  StatementList *stmts = &stmts_;
-  StatementList *else_stmts = &else_stmts_;
+  StatementList stmts;
+  StatementList else_stmts;
 
 private:
   If(const If &other) = default;
-  StatementList stmts_;
-  StatementList else_stmts_;
 };
 
 class Unroll : public Statement {
@@ -440,11 +435,10 @@ public:
 
   long int var = 0;
   Expression *expr = nullptr;
-  StatementList *stmts = &stmts_;
+  StatementList stmts;
 
 private:
   Unroll(const Unroll &other) = default;
-  StatementList stmts_;
 };
 
 class Jump : public Statement {
@@ -495,16 +489,15 @@ public:
   DEFINE_ACCEPT
 
   While(Expression *cond, StatementList &&stmts, location loc)
-      : Statement(loc), cond(cond), stmts_(std::move(stmts))
+      : Statement(loc), cond(cond), stmts(std::move(stmts))
   {
   }
 
   Expression *cond = nullptr;
-  StatementList *stmts = &stmts_;
+  StatementList stmts;
 
 private:
   While(const While &other) = default;
-  StatementList stmts_;
 };
 
 class For : public Statement {
@@ -512,34 +505,32 @@ public:
   DEFINE_ACCEPT
 
   For(Variable *decl, Expression *expr, StatementList &&stmts, location loc)
-      : Statement(loc), decl(decl), expr(expr), stmts_(std::move(stmts))
+      : Statement(loc), decl(decl), expr(expr), stmts(std::move(stmts))
   {
   }
 
   Variable *decl = nullptr;
   Expression *expr = nullptr;
-  StatementList *stmts = &stmts_;
+  StatementList stmts;
 
   SizedType ctx_type;
 
 private:
   For(const For &other) = default;
-  StatementList stmts_;
 };
 
 class Config : public Statement {
 public:
   DEFINE_ACCEPT
 
-  Config(StatementList &&stmts) : stmts_(std::move(stmts))
+  Config(StatementList &&stmts) : stmts(std::move(stmts))
   {
   }
 
-  StatementList *stmts = &stmts_;
+  StatementList stmts;
 
 private:
   Config(const Config &other) = default;
-  StatementList stmts_;
 };
 
 class Scope : public Node {
@@ -547,10 +538,7 @@ public:
   Scope(StatementList &&stmts);
   virtual ~Scope() = default;
 
-  StatementList *stmts = &stmts_;
-
-private:
-  StatementList stmts_;
+  StatementList stmts;
 };
 
 class AttachPoint : public Node {
@@ -608,7 +596,7 @@ public:
         Predicate *pred,
         StatementList &&stmts);
 
-  AttachPointList *attach_points = &attach_points_;
+  AttachPointList attach_points;
   Predicate *pred = nullptr;
 
   std::string name() const;
@@ -625,7 +613,6 @@ public:
 private:
   Probe(const Probe &other) = default;
   int index_ = 0;
-  AttachPointList attach_points_;
 };
 using ProbeList = std::vector<Probe *>;
 
@@ -653,7 +640,7 @@ public:
           SubprogArgList &&args,
           StatementList &&stmts);
 
-  SubprogArgList *args = &args_;
+  SubprogArgList args;
   SizedType return_type;
 
   std::string name() const;
@@ -661,7 +648,6 @@ public:
 private:
   Subprog(const Subprog &other) = default;
   std::string name_;
-  SubprogArgList args_;
 };
 using SubprogList = std::vector<Subprog *>;
 
@@ -676,13 +662,11 @@ public:
 
   std::string c_definitions;
   Config *config = nullptr;
-  SubprogList *functions = &functions_;
-  ProbeList *probes = &probes_;
+  SubprogList functions;
+  ProbeList probes;
 
 private:
   Program(const Program &other) = default;
-  SubprogList functions_;
-  ProbeList probes_;
 };
 
 std::string opstr(const Binop &binop);

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -66,9 +66,9 @@ int AttachPointParser::parse()
     return 1;
 
   uint32_t failed = 0;
-  for (Probe *probe : *(ctx_.root->probes)) {
-    for (size_t i = 0; i < probe->attach_points->size(); ++i) {
-      auto ap_ptr = (*probe->attach_points)[i];
+  for (Probe *probe : ctx_.root->probes) {
+    for (size_t i = 0; i < probe->attach_points.size(); ++i) {
+      auto ap_ptr = probe->attach_points[i];
       auto &ap = *ap_ptr;
       new_attach_points.clear();
 
@@ -78,13 +78,13 @@ int AttachPointParser::parse()
         LOG(ERROR, ap.loc, sink_) << errs_.str();
       } else if (s == SKIP || s == NEW_APS) {
         // Remove the current attach point
-        probe->attach_points->erase(probe->attach_points->begin() + i);
+        probe->attach_points.erase(probe->attach_points.begin() + i);
         i--;
         if (s == NEW_APS) {
           // The removed attach point is replaced by new ones
-          probe->attach_points->insert(probe->attach_points->end(),
-                                       new_attach_points.begin(),
-                                       new_attach_points.end());
+          probe->attach_points.insert(probe->attach_points.end(),
+                                      new_attach_points.begin(),
+                                      new_attach_points.end());
         }
       }
 
@@ -93,14 +93,14 @@ int AttachPointParser::parse()
       errs_.str({});
     }
 
-    auto new_end = std::remove_if(probe->attach_points->begin(),
-                                  probe->attach_points->end(),
+    auto new_end = std::remove_if(probe->attach_points.begin(),
+                                  probe->attach_points.end(),
                                   [](const AttachPoint *ap) {
                                     return ap->provider.empty();
                                   });
-    probe->attach_points->erase(new_end, probe->attach_points->end());
+    probe->attach_points.erase(new_end, probe->attach_points.end());
 
-    if (probe->attach_points->empty()) {
+    if (probe->attach_points.empty()) {
       LOG(ERROR, probe->loc, sink_) << "No attach points for probe";
       failed++;
     }

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -63,10 +63,8 @@ void FieldAnalyser::visit(Builtin &builtin)
 void FieldAnalyser::visit(Map &map)
 {
   MapKey key;
-  if (map.vargs) {
-    for (Expression *expr : *map.vargs) {
-      Visit(*expr);
-    }
+  for (Expression *expr : map.vargs) {
+    Visit(*expr);
   }
 
   auto it = var_types_.find(map.ident);
@@ -169,7 +167,7 @@ void FieldAnalyser::resolve_args(Probe &probe)
 {
   // load probe arguments into a special record type "struct <probename>_args"
   Struct probe_args;
-  for (auto *ap : *probe.attach_points) {
+  for (auto *ap : probe.attach_points) {
     auto probe_type = probetype(ap->provider);
     if (probe_type != ProbeType::kfunc && probe_type != ProbeType::kretfunc &&
         probe_type != ProbeType::uprobe)
@@ -272,7 +270,7 @@ void FieldAnalyser::resolve_fields(SizedType &type)
     return;
 
   if (probe_) {
-    for (auto &ap : *probe_->attach_points)
+    for (auto &ap : probe_->attach_points)
       if (Dwarf *dwarf = bpftrace_.get_dwarf(*ap))
         dwarf->resolve_fields(type);
   }
@@ -293,7 +291,7 @@ void FieldAnalyser::resolve_type(SizedType &type)
   auto name = inner_type->GetName();
 
   if (probe_) {
-    for (auto &ap : *probe_->attach_points)
+    for (auto &ap : probe_->attach_points)
       if (Dwarf *dwarf = bpftrace_.get_dwarf(*ap))
         sized_type_ = dwarf->get_stype(name);
   }
@@ -310,7 +308,7 @@ void FieldAnalyser::visit(Probe &probe)
 {
   probe_ = &probe;
 
-  for (AttachPoint *ap : *probe.attach_points) {
+  for (AttachPoint *ap : probe.attach_points) {
     probe_type_ = probetype(ap->provider);
     prog_type_ = progtype(probe_type_);
     attach_func_ = ap->func;
@@ -318,7 +316,7 @@ void FieldAnalyser::visit(Probe &probe)
   if (probe.pred) {
     Visit(*probe.pred);
   }
-  for (Statement *stmt : *probe.stmts) {
+  for (Statement *stmt : probe.stmts) {
     Visit(*stmt);
   }
 }
@@ -327,7 +325,7 @@ void FieldAnalyser::visit(Subprog &subprog)
 {
   probe_ = nullptr;
 
-  for (Statement *stmt : *subprog.stmts) {
+  for (Statement *stmt : subprog.stmts) {
     Visit(*stmt);
   }
 }

--- a/src/ast/passes/portability_analyser.cpp
+++ b/src/ast/passes/portability_analyser.cpp
@@ -54,10 +54,8 @@ void PortabilityAnalyser::visit(Builtin &builtin)
 
 void PortabilityAnalyser::visit(Call &call)
 {
-  if (call.vargs) {
-    for (Expression *expr : *call.vargs)
-      Visit(*expr);
-  }
+  for (Expression *expr : call.vargs)
+    Visit(*expr);
 
   // kaddr() and uaddr() both resolve symbols -> address during codegen and
   // embeds the values into the bytecode. For AOT to support kaddr()/uaddr(),

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -110,10 +110,8 @@ void Printer::visit(Call &call)
   out_ << indent << "call: " << call.func << type(call.type) << std::endl;
 
   ++depth_;
-  if (call.vargs) {
-    for (Expression *expr : *call.vargs) {
-      expr->accept(*this);
-    }
+  for (Expression *expr : call.vargs) {
+    expr->accept(*this);
   }
   --depth_;
 }
@@ -154,10 +152,8 @@ void Printer::visit(Map &map)
   out_ << indent << "map: " << map.ident << type(map.type) << std::endl;
 
   ++depth_;
-  if (map.vargs) {
-    for (Expression *expr : *map.vargs) {
-      expr->accept(*this);
-    }
+  for (Expression *expr : map.vargs) {
+    expr->accept(*this);
   }
   --depth_;
 }
@@ -250,7 +246,7 @@ void Printer::visit(Tuple &tuple)
   out_ << indent << "tuple:" << std::endl;
 
   ++depth_;
-  for (Expression *expr : *tuple.elems)
+  for (Expression *expr : tuple.elems)
     expr->accept(*this);
   --depth_;
 }
@@ -306,13 +302,13 @@ void Printer::visit(If &if_block)
   ++depth_;
   out_ << indent << " then" << std::endl;
 
-  for (Statement *stmt : *if_block.stmts) {
+  for (Statement *stmt : if_block.stmts) {
     stmt->accept(*this);
   }
 
-  if (if_block.else_stmts) {
+  if (!if_block.else_stmts.empty()) {
     out_ << indent << " else" << std::endl;
-    for (Statement *stmt : *if_block.else_stmts) {
+    for (Statement *stmt : if_block.else_stmts) {
       stmt->accept(*this);
     }
   }
@@ -329,7 +325,7 @@ void Printer::visit(Unroll &unroll)
   out_ << indent << " block" << std::endl;
 
   ++depth_;
-  for (Statement *stmt : *unroll.stmts) {
+  for (Statement *stmt : unroll.stmts) {
     stmt->accept(*this);
   }
   depth_ -= 2;
@@ -347,7 +343,7 @@ void Printer::visit(While &while_block)
   ++depth_;
   out_ << indent << " )" << std::endl;
 
-  for (Statement *stmt : *while_block.stmts) {
+  for (Statement *stmt : while_block.stmts) {
     stmt->accept(*this);
   }
 }
@@ -373,7 +369,7 @@ void Printer::visit(For &for_loop)
   print(for_loop.expr);
 
   out_ << indent << " stmts\n";
-  for (Statement *stmt : *for_loop.stmts) {
+  for (Statement *stmt : for_loop.stmts) {
     print(stmt);
   }
   --depth_;
@@ -386,7 +382,7 @@ void Printer::visit(Config &config)
   out_ << indent << "config" << std::endl;
 
   ++depth_;
-  for (Statement *stmt : *config.stmts) {
+  for (Statement *stmt : config.stmts) {
     stmt->accept(*this);
   }
   --depth_;
@@ -421,7 +417,7 @@ void Printer::visit(AttachPoint &ap)
 
 void Printer::visit(Probe &probe)
 {
-  for (AttachPoint *ap : *probe.attach_points) {
+  for (AttachPoint *ap : probe.attach_points) {
     ap->accept(*this);
   }
 
@@ -429,7 +425,7 @@ void Printer::visit(Probe &probe)
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  for (Statement *stmt : *probe.stmts) {
+  for (Statement *stmt : probe.stmts) {
     stmt->accept(*this);
   }
   --depth_;
@@ -441,16 +437,16 @@ void Printer::visit(Subprog &subprog)
   out_ << indent << subprog.name() << ": " << subprog.return_type;
 
   out_ << "(";
-  for (size_t i = 0; i < subprog.args->size(); i++) {
-    auto &arg = subprog.args->at(i);
+  for (size_t i = 0; i < subprog.args.size(); i++) {
+    auto &arg = subprog.args.at(i);
     out_ << arg->name() << " : " << arg->type;
-    if (i < subprog.args->size() - 1)
+    if (i < subprog.args.size() - 1)
       out_ << ", ";
   }
   out_ << ")" << std::endl;
 
   ++depth_;
-  for (Statement *stmt : *subprog.stmts) {
+  for (Statement *stmt : subprog.stmts) {
     stmt->accept(*this);
   }
   --depth_;
@@ -471,9 +467,9 @@ void Printer::visit(Program &program)
   }
 
   ++depth_;
-  for (Subprog *subprog : *program.functions)
+  for (Subprog *subprog : program.functions)
     subprog->accept(*this);
-  for (Probe *probe : *program.probes)
+  for (Probe *probe : program.probes)
     probe->accept(*this);
   --depth_;
 }

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -11,7 +11,7 @@ ReturnPathAnalyser::ReturnPathAnalyser(Node *root, std::ostream &out)
 
 bool ReturnPathAnalyser::visit(Program &prog)
 {
-  for (Subprog *subprog : *prog.functions) {
+  for (Subprog *subprog : prog.functions) {
     if (!visit(*subprog))
       return false;
   }
@@ -23,7 +23,7 @@ bool ReturnPathAnalyser::visit(Subprog &subprog)
   if (subprog.return_type.IsVoidTy())
     return true;
 
-  for (Statement *stmt : *subprog.stmts) {
+  for (Statement *stmt : subprog.stmts) {
     if (Visit(*stmt))
       return true;
   }
@@ -39,7 +39,7 @@ bool ReturnPathAnalyser::visit(Jump &jump)
 bool ReturnPathAnalyser::visit(If &if_stmt)
 {
   bool result = false;
-  for (Statement *stmt : *if_stmt.stmts) {
+  for (Statement *stmt : if_stmt.stmts) {
     if (Visit(*stmt))
       result = true;
   }
@@ -48,19 +48,14 @@ bool ReturnPathAnalyser::visit(If &if_stmt)
     return false;
   }
 
-  if (if_stmt.else_stmts) {
-    for (Statement *stmt : *if_stmt.else_stmts) {
-      if (Visit(*stmt)) {
-        // both blocks have a return
-        return true;
-      }
+  for (Statement *stmt : if_stmt.else_stmts) {
+    if (Visit(*stmt)) {
+      // both blocks have a return
+      return true;
     }
-    // else block has no return
-    return false;
-  } else {
-    // if without else always requires another return in the code after it
-    return false;
   }
+  // else block has no return (or there is no else block)
+  return false;
 }
 
 bool ReturnPathAnalyser::default_visitor(__attribute__((unused)) Node &node)

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -131,7 +131,7 @@ private:
   {
     return loop_depth_ > 0;
   };
-  void accept_statements(StatementList *stmts);
+  void accept_statements(StatementList &stmts);
 
   Scope *scope_;
 

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -31,10 +31,8 @@ void Visitor::visit(Identifier &identifier __attribute__((__unused__)))
 
 void Visitor::visit(Call &call)
 {
-  if (call.vargs) {
-    for (Expression *expr : *call.vargs) {
-      Visit(*expr);
-    }
+  for (Expression *expr : call.vargs) {
+    Visit(*expr);
   }
 }
 
@@ -52,10 +50,8 @@ void Visitor::visit(Offsetof &ofof)
 
 void Visitor::visit(Map &map)
 {
-  if (map.vargs) {
-    for (Expression *expr : *map.vargs) {
-      Visit(*expr);
-    }
+  for (Expression *expr : map.vargs) {
+    Visit(*expr);
   }
 }
 
@@ -99,7 +95,7 @@ void Visitor::visit(Cast &cast)
 
 void Visitor::visit(Tuple &tuple)
 {
-  for (Expression *expr : *tuple.elems)
+  for (Expression *expr : tuple.elems)
     Visit(*expr);
 }
 
@@ -129,21 +125,19 @@ void Visitor::visit(If &if_block)
 {
   Visit(*if_block.cond);
 
-  for (Statement *stmt : *if_block.stmts) {
+  for (Statement *stmt : if_block.stmts) {
     Visit(*stmt);
   }
 
-  if (if_block.else_stmts) {
-    for (Statement *stmt : *if_block.else_stmts) {
-      Visit(*stmt);
-    }
+  for (Statement *stmt : if_block.else_stmts) {
+    Visit(*stmt);
   }
 }
 
 void Visitor::visit(Unroll &unroll)
 {
   Visit(*unroll.expr);
-  for (Statement *stmt : *unroll.stmts) {
+  for (Statement *stmt : unroll.stmts) {
     Visit(*stmt);
   }
 }
@@ -152,7 +146,7 @@ void Visitor::visit(While &while_block)
 {
   Visit(*while_block.cond);
 
-  for (Statement *stmt : *while_block.stmts) {
+  for (Statement *stmt : while_block.stmts) {
     Visit(*stmt);
   }
 }
@@ -162,7 +156,7 @@ void Visitor::visit(For &for_loop)
   Visit(*for_loop.decl);
   Visit(*for_loop.expr);
 
-  for (Statement *stmt : *for_loop.stmts) {
+  for (Statement *stmt : for_loop.stmts) {
     Visit(*stmt);
   }
 }
@@ -184,21 +178,21 @@ void Visitor::visit(AttachPoint &ap __attribute__((__unused__)))
 
 void Visitor::visit(Probe &probe)
 {
-  for (AttachPoint *ap : *probe.attach_points) {
+  for (AttachPoint *ap : probe.attach_points) {
     Visit(*ap);
   }
 
   if (probe.pred) {
     Visit(*probe.pred);
   }
-  for (Statement *stmt : *probe.stmts) {
+  for (Statement *stmt : probe.stmts) {
     Visit(*stmt);
   }
 }
 
 void Visitor::visit(Config &config)
 {
-  for (Statement *stmt : *config.stmts) {
+  for (Statement *stmt : config.stmts) {
     Visit(*stmt);
   }
 }
@@ -209,20 +203,19 @@ void Visitor::visit(SubprogArg &subprog_arg __attribute__((__unused__)))
 
 void Visitor::visit(Subprog &subprog)
 {
-  for (SubprogArg *arg : *subprog.args) {
+  for (SubprogArg *arg : subprog.args) {
     Visit(*arg);
   }
-  for (Statement *stmt : *subprog.stmts) {
+  for (Statement *stmt : subprog.stmts) {
     Visit(*stmt);
   }
 }
 
 void Visitor::visit(Program &program)
 {
-  if (program.functions)
-    for (Subprog *subprog : *program.functions)
-      Visit(*subprog);
-  for (Probe *probe : *program.probes)
+  for (Subprog *subprog : program.functions)
+    Visit(*subprog);
+  for (Probe *probe : program.probes)
     Visit(*probe);
   if (program.config)
     Visit(*program.config);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1983,7 +1983,7 @@ std::string BPFtrace::get_string_literal(const ast::Expression *expr) const
       // Positional parameters in the form str($1) can be used as literals
       if (str_call->func == "str") {
         if (auto *pos_param = dynamic_cast<const ast::PositionalParameter *>(
-                str_call->vargs->at(0)))
+                str_call->vargs.at(0)))
           return get_param(pos_param->n, true);
       }
     }
@@ -2154,8 +2154,8 @@ struct bcc_symbol_option &BPFtrace::get_symbol_opts()
  */
 void BPFtrace::kfunc_recursion_check(ast::Program *prog)
 {
-  for (auto *probe : *prog->probes) {
-    for (auto *ap : *probe->attach_points) {
+  for (auto *probe : prog->probes) {
+    for (auto *ap : probe->attach_points) {
       auto probe_type = probetype(ap->provider);
       if (probe_type == ProbeType::kfunc || probe_type == ProbeType::kretfunc) {
         auto matches = probe_matcher_->get_matches_for_ap(*ap);

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -495,14 +495,14 @@ std::unordered_set<std::string> ClangParser::get_incomplete_types()
 
 void ClangParser::resolve_incomplete_types_from_btf(
     BPFtrace &bpftrace,
-    const ast::ProbeList *probes)
+    const ast::ProbeList &probes)
 {
   // Resolution of incomplete types must run at least once, maximum should be
   // the number of levels of nested field accesses for tracepoint args.
   // The maximum number of iterations can be also controlled by the
   // BPFTRACE_MAX_TYPE_RES_ITERATIONS env variable (0 is unlimited).
   uint64_t field_lvl = 1;
-  for (auto &probe : *probes)
+  for (auto &probe : probes)
     if (probe->tp_args_structs_level > (int)field_lvl)
       field_lvl = probe->tp_args_structs_level;
 

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -38,7 +38,7 @@ private:
    * and update the input files with the definitions.
    */
   void resolve_incomplete_types_from_btf(BPFtrace &bpftrace,
-                                         const ast::ProbeList *probes);
+                                         const ast::ProbeList &probes);
 
   /*
    * Collect names of types defined by typedefs that are in non-included

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -81,8 +81,8 @@ void Driver::error(const std::string &m)
 std::set<std::string> Driver::list_modules() const
 {
   std::set<std::string> modules;
-  for (auto &probe : *ctx.root->probes) {
-    for (auto &ap : *probe->attach_points) {
+  for (auto &probe : ctx.root->probes) {
+    for (auto &ap : probe->attach_points) {
       auto probe_type = probetype(ap->provider);
       if (probe_type == ProbeType::kfunc || probe_type == ProbeType::kretfunc ||
           ((probe_type == ProbeType::kprobe ||

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -445,8 +445,8 @@ FuncParamLists ProbeMatcher::get_uprobe_params(
 
 void ProbeMatcher::list_probes(ast::Program* prog)
 {
-  for (auto* probe : *prog->probes) {
-    for (auto* ap : *probe->attach_points) {
+  for (auto* probe : prog->probes) {
+    for (auto* ap : probe->attach_points) {
       auto matches = get_matches_for_ap(*ap);
       auto probe_type = probetype(ap->provider);
       FuncParamLists param_lists;

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -17,7 +17,7 @@ std::set<std::string> TracepointFormatParser::struct_list;
 bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
 {
   std::vector<ast::Probe *> probes_with_tracepoint;
-  for (ast::Probe *probe : *program->probes) {
+  for (ast::Probe *probe : program->probes) {
     if (probe->has_ap_of_probetype(ProbeType::tracepoint))
       probes_with_tracepoint.push_back(probe);
   }
@@ -31,7 +31,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
   for (ast::Probe *probe : probes_with_tracepoint) {
     n.visit(*probe);
 
-    for (ast::AttachPoint *ap : *probe->attach_points) {
+    for (ast::AttachPoint *ap : probe->attach_points) {
       if (ap->provider == "tracepoint") {
         std::string &category = ap->target;
         std::string &event_name = ap->func;
@@ -96,7 +96,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
 
             // Do not fail if trying to attach to multiple tracepoints
             // (at least one of them could succeed)
-            bool fail = probe->attach_points->size() == 1;
+            bool fail = probe->attach_points.size() == 1;
             auto msg = "tracepoint not found: " + category + ":" + event_name;
             if (fail)
               LOG(ERROR, ap->loc, std::cerr) << msg;

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1190,7 +1190,7 @@ TEST(semantic_analyser, call_uaddr)
 
   for (size_t i = 0; i < sizes.size(); i++) {
     auto v = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes->at(0)->stmts->at(i));
+        driver.ctx.root->probes.at(0)->stmts.at(i));
     EXPECT_TRUE(v->var->type.IsPtrTy());
     EXPECT_TRUE(v->var->type.GetPointeeTy()->IsIntTy());
     EXPECT_EQ((unsigned long int)sizes.at(i),
@@ -1471,26 +1471,26 @@ TEST(semantic_analyser, array_access)
        "struct MyStruct { int y[4]; } kprobe:f { $s = (struct MyStruct *) "
        "arg0; @x = $s->y[0];}");
   auto assignment = static_cast<ast::AssignMapStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(1));
+      driver.ctx.root->probes.at(0)->stmts.at(1));
   EXPECT_EQ(CreateInt64(), assignment->map->type);
 
   test(driver,
        "struct MyStruct { int y[4]; } kprobe:f { $s = ((struct MyStruct *) "
        "arg0)->y; @x = $s[0];}");
   auto array_var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(0));
+      driver.ctx.root->probes.at(0)->stmts.at(0));
   EXPECT_EQ(CreateArray(4, CreateInt32()), array_var_assignment->var->type);
 
   test(driver,
        "struct MyStruct { int y[4]; } kprobe:f { @a[0] = ((struct MyStruct *) "
        "arg0)->y; @x = @a[0][0];}");
   auto array_map_assignment = static_cast<ast::AssignMapStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(0));
+      driver.ctx.root->probes.at(0)->stmts.at(0));
   EXPECT_EQ(CreateArray(4, CreateInt32()), array_map_assignment->map->type);
 
   test(driver, "kprobe:f { $s = (int32 *) arg0; $x = $s[0]; }");
   auto var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(1));
+      driver.ctx.root->probes.at(0)->stmts.at(1));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
 
   // Positional parameter as index
@@ -1595,7 +1595,7 @@ TEST(semantic_analyser, variable_type)
   test(driver, "kprobe:f { $x = 1 }");
   auto st = CreateInt64();
   auto assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(0));
+      driver.ctx.root->probes.at(0)->stmts.at(0));
   EXPECT_EQ(st, assignment->var->type);
 }
 
@@ -1627,9 +1627,9 @@ TEST(semantic_analyser, map_integer_sizes)
   test(driver, "kprobe:f { $x = (int32) -1; @x = $x; }");
 
   auto var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(0));
+      driver.ctx.root->probes.at(0)->stmts.at(0));
   auto map_assignment = static_cast<ast::AssignMapStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(1));
+      driver.ctx.root->probes.at(0)->stmts.at(1));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
   EXPECT_EQ(CreateInt64(), map_assignment->map->type);
 }
@@ -2212,17 +2212,17 @@ TEST(semantic_analyser, field_access_is_internal)
 
   {
     test(driver, structs + "kprobe:f { $x = (*(struct type1*)0).x }");
-    auto stmts = driver.ctx.root->probes->at(0)->stmts;
-    auto var_assignment1 = static_cast<ast::AssignVarStatement *>(stmts->at(0));
+    auto stmts = driver.ctx.root->probes.at(0)->stmts;
+    auto var_assignment1 = static_cast<ast::AssignVarStatement *>(stmts.at(0));
     EXPECT_FALSE(var_assignment1->var->type.is_internal);
   }
 
   {
     test(driver,
          structs + "kprobe:f { @type1 = *(struct type1*)0; $x = @type1.x }");
-    auto stmts = driver.ctx.root->probes->at(0)->stmts;
-    auto map_assignment = static_cast<ast::AssignMapStatement *>(stmts->at(0));
-    auto var_assignment2 = static_cast<ast::AssignVarStatement *>(stmts->at(1));
+    auto stmts = driver.ctx.root->probes.at(0)->stmts;
+    auto map_assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
+    auto var_assignment2 = static_cast<ast::AssignVarStatement *>(stmts.at(1));
     EXPECT_TRUE(map_assignment->map->type.is_internal);
     EXPECT_TRUE(var_assignment2->var->type.is_internal);
   }
@@ -2301,7 +2301,7 @@ TEST(semantic_analyser, positional_parameters)
   Driver driver(bpftrace);
   test(driver, "k:f { $1 }");
   auto stmt = static_cast<ast::ExprStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(0));
+      driver.ctx.root->probes.at(0)->stmts.at(0));
   auto pp = static_cast<ast::PositionalParameter *>(stmt->expr);
   EXPECT_EQ(CreateUInt64(), pp->type);
   EXPECT_TRUE(pp->is_literal);
@@ -2428,13 +2428,13 @@ TEST(semantic_analyser, cast_sign)
   test(driver, prog);
 
   auto s = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(1));
+      driver.ctx.root->probes.at(0)->stmts.at(1));
   auto us = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(2));
+      driver.ctx.root->probes.at(0)->stmts.at(2));
   auto l = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(3));
+      driver.ctx.root->probes.at(0)->stmts.at(3));
   auto ul = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes->at(0)->stmts->at(4));
+      driver.ctx.root->probes.at(0)->stmts.at(4));
   EXPECT_EQ(CreateInt32(), s->var->type);
   EXPECT_EQ(CreateUInt32(), us->var->type);
   EXPECT_EQ(CreateInt64(), l->var->type);
@@ -2465,13 +2465,13 @@ TEST(semantic_analyser, binop_sign)
 
     test(driver, prog);
     auto varA = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes->at(0)->stmts->at(1));
+        driver.ctx.root->probes.at(0)->stmts.at(1));
     EXPECT_EQ(CreateInt64(), varA->var->type);
     auto varB = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes->at(0)->stmts->at(2));
+        driver.ctx.root->probes.at(0)->stmts.at(2));
     EXPECT_EQ(CreateUInt64(), varB->var->type);
     auto varC = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes->at(0)->stmts->at(3));
+        driver.ctx.root->probes.at(0)->stmts.at(3));
     EXPECT_EQ(CreateUInt64(), varC->var->type);
   }
 }
@@ -2778,14 +2778,14 @@ TEST(semantic_analyser, type_ctx)
   test(driver,
        structs + "kprobe:f { $x = (struct x*)ctx; $a = $x->a; $b = $x->b[0]; "
                  "$c = $x->c.c; $d = $x->d->c;}");
-  auto &stmts = driver.ctx.root->probes->at(0)->stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->stmts;
 
   // $x = (struct x*)ctx;
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts->at(0));
+  auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   EXPECT_TRUE(assignment->var->type.IsPtrTy());
 
   // $a = $x->a;
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(1));
+  assignment = static_cast<ast::AssignVarStatement *>(stmts.at(1));
   EXPECT_EQ(CreateInt64(), assignment->var->type);
   auto fieldaccess = static_cast<ast::FieldAccess *>(assignment->expr);
   EXPECT_EQ(CreateInt64(), fieldaccess->type);
@@ -2795,7 +2795,7 @@ TEST(semantic_analyser, type_ctx)
   EXPECT_TRUE(var->type.IsPtrTy());
 
   // $b = $x->b[0];
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(2));
+  assignment = static_cast<ast::AssignVarStatement *>(stmts.at(2));
   EXPECT_EQ(CreateInt16(), assignment->var->type);
   auto arrayaccess = static_cast<ast::ArrayAccess *>(assignment->expr);
   EXPECT_EQ(CreateInt16(), arrayaccess->type);
@@ -2813,7 +2813,7 @@ TEST(semantic_analyser, type_ctx)
 #endif
 
   // $c = $x->c.c;
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(3));
+  assignment = static_cast<ast::AssignVarStatement *>(stmts.at(3));
   EXPECT_EQ(chartype, assignment->var->type);
   fieldaccess = static_cast<ast::FieldAccess *>(assignment->expr);
   EXPECT_EQ(chartype, fieldaccess->type);
@@ -2825,7 +2825,7 @@ TEST(semantic_analyser, type_ctx)
   EXPECT_TRUE(var->type.IsPtrTy());
 
   // $d = $x->d->c;
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(4));
+  assignment = static_cast<ast::AssignVarStatement *>(stmts.at(4));
   EXPECT_EQ(chartype, assignment->var->type);
   fieldaccess = static_cast<ast::FieldAccess *>(assignment->expr);
   EXPECT_EQ(chartype, fieldaccess->type);
@@ -2857,10 +2857,10 @@ TEST(semantic_analyser, double_pointer_int)
   BPFtrace bpftrace;
   Driver driver(bpftrace);
   test(driver, "kprobe:f { $pp = (int8 **)1; $p = *$pp; $val = *$p; }");
-  auto &stmts = driver.ctx.root->probes->at(0)->stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->stmts;
 
   // $pp = (int8 **)1;
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts->at(0));
+  auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   ASSERT_TRUE(assignment->var->type.IsPtrTy());
   ASSERT_TRUE(assignment->var->type.GetPointeeTy()->IsPtrTy());
   ASSERT_TRUE(assignment->var->type.GetPointeeTy()->GetPointeeTy()->IsIntTy());
@@ -2869,13 +2869,13 @@ TEST(semantic_analyser, double_pointer_int)
       8ULL);
 
   // $p = *$pp;
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(1));
+  assignment = static_cast<ast::AssignVarStatement *>(stmts.at(1));
   ASSERT_TRUE(assignment->var->type.IsPtrTy());
   ASSERT_TRUE(assignment->var->type.GetPointeeTy()->IsIntTy());
   EXPECT_EQ(assignment->var->type.GetPointeeTy()->GetIntBitWidth(), 8ULL);
 
   // $val = *$p;
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(2));
+  assignment = static_cast<ast::AssignVarStatement *>(stmts.at(2));
   ASSERT_TRUE(assignment->var->type.IsIntTy());
   EXPECT_EQ(assignment->var->type.GetIntBitWidth(), 8ULL);
 }
@@ -2887,10 +2887,10 @@ TEST(semantic_analyser, double_pointer_struct)
   test(driver,
        "struct Foo { char x; long y; }"
        "kprobe:f { $pp = (struct Foo **)1; $p = *$pp; $val = $p->x; }");
-  auto &stmts = driver.ctx.root->probes->at(0)->stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->stmts;
 
   // $pp = (struct Foo **)1;
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts->at(0));
+  auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   ASSERT_TRUE(assignment->var->type.IsPtrTy());
   ASSERT_TRUE(assignment->var->type.GetPointeeTy()->IsPtrTy());
   ASSERT_TRUE(
@@ -2899,13 +2899,13 @@ TEST(semantic_analyser, double_pointer_struct)
             "struct Foo");
 
   // $p = *$pp;
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(1));
+  assignment = static_cast<ast::AssignVarStatement *>(stmts.at(1));
   ASSERT_TRUE(assignment->var->type.IsPtrTy());
   ASSERT_TRUE(assignment->var->type.GetPointeeTy()->IsRecordTy());
   EXPECT_EQ(assignment->var->type.GetPointeeTy()->GetName(), "struct Foo");
 
   // $val = $p->x;
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(2));
+  assignment = static_cast<ast::AssignVarStatement *>(stmts.at(2));
   ASSERT_TRUE(assignment->var->type.IsIntTy());
   EXPECT_EQ(assignment->var->type.GetIntBitWidth(), 8ULL);
 }
@@ -3043,14 +3043,14 @@ TEST(semantic_analyser, tuple_assign_var)
        R"_(BEGIN { $t = (1, "str"); $t = (4, "other"); })_",
        0);
 
-  auto &stmts = driver.ctx.root->probes->at(0)->stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->stmts;
 
   // $t = (1, "str");
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts->at(0));
+  auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   EXPECT_EQ(ty, assignment->var->type);
 
   // $t = (4, "other");
-  assignment = static_cast<ast::AssignVarStatement *>(stmts->at(1));
+  assignment = static_cast<ast::AssignVarStatement *>(stmts.at(1));
   EXPECT_EQ(ty, assignment->var->type);
 }
 
@@ -3066,16 +3066,16 @@ TEST(semantic_analyser, tuple_assign_map)
        R"_(BEGIN { @ = (1, 3, 3, 7); @ = (0, 0, 0, 0); })_",
        0);
 
-  auto &stmts = driver.ctx.root->probes->at(0)->stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->stmts;
 
   // $t = (1, 3, 3, 7);
-  auto assignment = static_cast<ast::AssignMapStatement *>(stmts->at(0));
+  auto assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
   ty = CreateTuple(bpftrace.structs.AddTuple(
       { CreateInt64(), CreateInt64(), CreateInt64(), CreateInt64() }));
   EXPECT_EQ(ty, assignment->map->type);
 
   // $t = (0, 0, 0, 0);
-  assignment = static_cast<ast::AssignMapStatement *>(stmts->at(1));
+  assignment = static_cast<ast::AssignMapStatement *>(stmts.at(1));
   ty = CreateTuple(bpftrace.structs.AddTuple(
       { CreateInt64(), CreateInt64(), CreateInt64(), CreateInt64() }));
   EXPECT_EQ(ty, assignment->map->type);
@@ -3092,10 +3092,10 @@ TEST(semantic_analyser, tuple_nested)
       bpftrace.structs.AddTuple({ CreateInt64(), ty_inner }));
   test(bpftrace, true, driver, R"_(BEGIN { $t = (1,(1,2)); })_", 0);
 
-  auto &stmts = driver.ctx.root->probes->at(0)->stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->stmts;
 
   // $t = (1, "str");
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts->at(0));
+  auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   EXPECT_EQ(ty, assignment->var->type);
 }
 
@@ -3200,13 +3200,13 @@ TEST(semantic_analyser, string_size)
   BPFtrace bpftrace;
   Driver driver(bpftrace);
   test(bpftrace, true, driver, R"_(BEGIN { $x = "hi"; $x = "hello"; })_", 0);
-  auto stmt = driver.ctx.root->probes->at(0)->stmts->at(0);
+  auto stmt = driver.ctx.root->probes.at(0)->stmts.at(0);
   auto var_assign = dynamic_cast<ast::AssignVarStatement *>(stmt);
   ASSERT_TRUE(var_assign->var->type.IsStringTy());
   ASSERT_EQ(var_assign->var->type.GetSize(), 6UL);
 
   test(bpftrace, true, driver, R"_(k:f1 {@ = "hi";} k:f2 {@ = "hello";})_", 0);
-  stmt = driver.ctx.root->probes->at(0)->stmts->at(0);
+  stmt = driver.ctx.root->probes.at(0)->stmts.at(0);
   auto map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
   ASSERT_TRUE(map_assign->map->type.IsStringTy());
   ASSERT_EQ(map_assign->map->type.GetSize(), 6UL);
@@ -3216,7 +3216,7 @@ TEST(semantic_analyser, string_size)
        driver,
        R"_(k:f1 {@["hi"] = 0;} k:f2 {@["hello"] = 1;})_",
        0);
-  stmt = driver.ctx.root->probes->at(0)->stmts->at(0);
+  stmt = driver.ctx.root->probes.at(0)->stmts.at(0);
   map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
   ASSERT_TRUE(map_assign->map->key_type.args_.at(0).IsStringTy());
   ASSERT_EQ(map_assign->map->key_type.args_.at(0).GetSize(), 6UL);
@@ -3226,7 +3226,7 @@ TEST(semantic_analyser, string_size)
        driver,
        R"_(k:f1 {@["hi", 0] = 0;} k:f2 {@["hello", 1] = 1;})_",
        0);
-  stmt = driver.ctx.root->probes->at(0)->stmts->at(0);
+  stmt = driver.ctx.root->probes.at(0)->stmts.at(0);
   map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
   ASSERT_EQ(map_assign->map->key_type.size(), 14UL);
   ASSERT_TRUE(map_assign->map->key_type.args_.at(0).IsStringTy());
@@ -3237,7 +3237,7 @@ TEST(semantic_analyser, string_size)
        driver,
        R"_(k:f1 {$x = ("hello", 0);} k:f2 {$x = ("hi", 0); })_",
        0);
-  stmt = driver.ctx.root->probes->at(0)->stmts->at(0);
+  stmt = driver.ctx.root->probes.at(0)->stmts.at(0);
   var_assign = dynamic_cast<ast::AssignVarStatement *>(stmt);
   ASSERT_TRUE(var_assign->var->type.IsTupleTy());
   ASSERT_TRUE(var_assign->var->type.GetField(0).type.IsStringTy());

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -266,23 +266,23 @@ TEST(tracepoint_format_parser, args_field_access)
   ast::TracepointArgsVisitor visitor;
 
   EXPECT_EQ(driver.parse_str("BEGIN { args.f1->f2->f3 }"), 0);
-  visitor.visit(*driver.ctx.root->probes->at(0));
-  EXPECT_EQ(driver.ctx.root->probes->at(0)->tp_args_structs_level, 3);
+  visitor.visit(*driver.ctx.root->probes.at(0));
+  EXPECT_EQ(driver.ctx.root->probes.at(0)->tp_args_structs_level, 3);
 
   // Should work via intermediary variable, too
   EXPECT_EQ(driver.parse_str("BEGIN { $x = args.f1; $x->f2->f3 }"), 0);
-  visitor.visit(*driver.ctx.root->probes->at(0));
-  EXPECT_EQ(driver.ctx.root->probes->at(0)->tp_args_structs_level, 3);
+  visitor.visit(*driver.ctx.root->probes.at(0));
+  EXPECT_EQ(driver.ctx.root->probes.at(0)->tp_args_structs_level, 3);
 
   // "args" used without field access => level should be 0
   EXPECT_EQ(driver.parse_str("BEGIN { args }"), 0);
-  visitor.visit(*driver.ctx.root->probes->at(0));
-  EXPECT_EQ(driver.ctx.root->probes->at(0)->tp_args_structs_level, 0);
+  visitor.visit(*driver.ctx.root->probes.at(0));
+  EXPECT_EQ(driver.ctx.root->probes.at(0)->tp_args_structs_level, 0);
 
   // "args" not used => level should be -1
   EXPECT_EQ(driver.parse_str("BEGIN { x->f1->f2->f3 }"), 0);
-  visitor.visit(*driver.ctx.root->probes->at(0));
-  EXPECT_EQ(driver.ctx.root->probes->at(0)->tp_args_structs_level, -1);
+  visitor.visit(*driver.ctx.root->probes.at(0));
+  EXPECT_EQ(driver.ctx.root->probes.at(0)->tp_args_structs_level, -1);
 }
 
 } // namespace tracepoint_format_parser


### PR DESCRIPTION
Follow up to #3350

```
1. Remove the pointer-to-vector members
2. Rename the inline vector members to the pointers' old names
3. Update users of the AST to handle std::vector instead of pointers
  - This is mainly just replacing "->" with "."
  - The bigger changes come in places where we used to check for null
    pointers. Empty vectors are now used in place of null pointers, so
    these checks are not necessary before loops.
```