### PR TITLE
AttachedProbe: Remove references to load_prog()

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -95,9 +95,6 @@ std::string progtypeName(libbpf::bpf_prog_type t)
 
 void AttachedProbe::attach_kfunc(void)
 {
-  if (progfd_ < 0)
-    // Errors for kfunc are handled in load_prog, ignore here
-    return;
   tracing_fd_ = bpf_raw_tracepoint_open(nullptr, progfd_);
   if (tracing_fd_ < 0) {
     throw FatalUserException("Error attaching probe: " + probe_.name);
@@ -130,9 +127,6 @@ int AttachedProbe::detach_iter(void)
 
 void AttachedProbe::attach_raw_tracepoint(void)
 {
-  if (progfd_ < 0)
-    // Errors for raw_tracepoint are handled in load_prog, ignore here
-    return;
   tracing_fd_ = bpf_raw_tracepoint_open(probe_.attach_point.c_str(), progfd_);
   if (tracing_fd_ < 0) {
     if (tracing_fd_ == -ENOENT)

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -44,7 +44,6 @@ private:
   std::string eventname() const;
   void resolve_offset_kprobe(bool safe_mode);
   bool resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps);
-  void load_prog(BPFfeature &feature);
   void attach_multi_kprobe(void);
   void attach_multi_uprobe(int pid);
   void attach_kprobe(bool safe_mode);


### PR DESCRIPTION
The load_prog() function was deleted in 0c3a9492ab8d2b2e0dc9d16802a97e88dd8f1b13.

I don't really understand the purpose of the code I'm deleting here so this might not be the right "fix". It was introduced in 5a84f46212aeffa4223a721eee3c2b6988163ab8 to improve error messages. If it's still needed, should we be checking `progfd_ < 0` for all probe types?

@viktormalik probably has the most context.