### PR TITLE
Add 'has_key' builtin for maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#3285](https://github.com/bpftrace/bpftrace/pull/3285)
 - For-loops: Allow sharing variables between the main probe and the loop's body
   - [#3014](https://github.com/bpftrace/bpftrace/pull/3014)
+- Add `has_key` builtin for maps
+  - [#1111](https://github.com/bpftrace/bpftrace/pull/1111)
 #### Changed
 - Stream output when printing maps
   - [#3264](https://github.com/bpftrace/bpftrace/pull/3264)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2347,6 +2347,10 @@ Functions that are marked *async* are asynchronous which can lead to unexpected 
 | Delete a single key from a map. For a single value map this deletes the only element. For an associative-array the key to delete has to be specified. Multiple arguments can be passed to delete many keys at once.
 | Sync
 
+| <<map-functions-has_key, `has_key(mapkey k)`>>
+| Return true if the key exists in this map. Otherwise return false. For a single value map this returns true. For an associative-array the key has to be specified.
+| Sync
+
 | <<map-functions-hist, `hist(int64 n[, int k])`>>
 | Create a log2 histogram of n using buckets per power of 2, 0 <= k <= 5, defaults to 0.
 | Sync
@@ -2478,6 +2482,32 @@ kprobe:dummy {
   delete(@scalar, @associative[1,2]);
 
   delete(@associative); // error
+}
+```
+
+[#map-functions-has_key]
+=== has_key
+
+.variants
+* `has_key(mapkey k)`
+
+Return true if the key exists in this map.
+Otherwise return false.
+For a single value map this returns true.
+For an associative-array the key has to be specified.
+
+```
+kprobe:dummy {
+  @scalar = 1;
+  @associative[1,2] = 1;
+  
+  if (has_key(@scalar)) {
+    print(("hello"));
+  }
+  
+  if (!has_key(@associative[1,3])) {
+    print(("bye"));
+  }
 }
 ```
 

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -678,6 +678,16 @@ void SemanticAnalyser::visit(Call &call)
       }
     }
     call.type = CreateNone();
+  } else if (call.func == "has_key") {
+    check_assignment(call, false, false, false);
+    if (check_varargs(call, 1, 1)) {
+      for (const auto &arg : *call.vargs) {
+        if (!arg->is_map)
+          LOG(ERROR, arg->loc, err_)
+              << "has_key() only expects maps to be provided";
+      }
+    }
+    call.type = CreateBool();
   } else if (call.func == "str") {
     if (check_varargs(call, 1, 2)) {
       auto *arg = call.vargs->at(0);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#+\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|len|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|len|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf|has_key
 
 int_type        bool|(u)?int(8|16|32|64)
 builtin_type    void|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp_t|macaddr_t|cgroup_path_t|strerror_t

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -243,6 +243,21 @@ PROG BEGIN { @ = count(); @a[1] = count(); delete(@); delete(@a[1]); exit(); }
 EXPECT @: 0
 TIMEOUT 1
 
+NAME has_key exists
+PROG BEGIN { @a[1] = 1; if (has_key(@a[1])) { printf("ok\n"); exit(); } }
+EXPECT ok
+TIMEOUT 1
+
+NAME has_key no_exists
+PROG BEGIN { @a[1] = 1; if (has_key(@a[2])) { printf("ok\n"); exit(); } }
+EXPECT_NONE ok
+TIMEOUT 1
+
+NAME has_key count-map
+PROG BEGIN { @a = count(); if (has_key(@a)) { printf("ok\n"); exit(); } }
+EXPECT ok
+TIMEOUT 1
+
 NAME increment/decrement map
 PROG BEGIN { @x = 10; printf("%d", @x++); printf(" %d", ++@x); printf(" %d", @x--); printf(" %d\n", --@x); delete(@x); exit(); }
 EXPECT 10 12 12 10

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -327,6 +327,7 @@ TEST(semantic_analyser, builtin_functions)
   test("kprobe:f { @x = 1; print(@x) }");
   test("kprobe:f { @x = 1; clear(@x) }");
   test("kprobe:f { @x = 1; zero(@x) }");
+  test("kprobe:f { @x = 1; if (has_key(@x)) {} }");
   test("kprobe:f { @x = 1; @s = len(@x) }");
   test("kprobe:f { time() }");
   test("kprobe:f { exit() }");
@@ -975,6 +976,17 @@ TEST(semantic_analyser, call_len)
   test("kprobe:f { @x[0] = 0; len(@x, 1); }", 1);
   test("kprobe:f { @x[0] = 0; len(@x[2]); }", 1);
   test("kprobe:f { $x = 0; len($x); }", 1);
+}
+
+TEST(semantic_analyser, call_has_key)
+{
+  test(
+      "kprobe:f { @x[0] = 0; if (has_key(@x[0])) { } if (has_key(@x[1])) {} }");
+  test("kprobe:f { @x = 0; has_key(@x); }");
+  test("kprobe:f { @x = 0; has_key(@x) ? 1 : 0; }");
+  test("kprobe:f { @x[0] = 0; has_key(@x); }", 10);
+  test("kprobe:f { @x[0] = 0; has_key(@x, @x[0]); }", 1);
+  test("kprobe:f { @x[0] = 0; has_key(@x, 1); }", 1);
 }
 
 TEST(semantic_analyser, call_time)


### PR DESCRIPTION
This is so we can check if a map has a key
instead of relying on the wrong way by seeing
if the value is 0.

```
kprobe:dummy {
  @scalar = 1;
  @associative[1,2] = 1;

  if (has_key(@scalar)) {
    print(("hello"));
  }

  if (!has_key(@associative[1,3])) {
    print(("bye"));
  }
}
```

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
