### PR TITLE
codegen: Only initialize BPF target

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -65,9 +65,10 @@ CodegenLLVM::CodegenLLVM(Node *root,
       b_(*context_, *module_, bpftrace, async_ids_),
       debug_(*module_)
 {
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmPrinters();
+  LLVMInitializeBPFTargetInfo();
+  LLVMInitializeBPFTarget();
+  LLVMInitializeBPFTargetMC();
+  LLVMInitializeBPFAsmPrinter();
   std::string error_str;
   auto target = llvm::TargetRegistry::lookupTarget(LLVMTargetTriple, error_str);
   if (!target)


### PR DESCRIPTION
Previously, we were initializing all targets. We only codegen BPF code so we should be good to scope it down. In some basic tests, I don't see any performance wins. But nonetheless good to do this.

This also fixes the ubuntu distro build. Looks like there's some packaging issue where ubuntu configures with VE target but doesn't ship it in the shared library or something. This was the error:

```
/usr/bin/ld: ast/libast.a(codegen_llvm.cpp.o): undefined reference to symbol 'LLVMInitializeVETargetInfo@@LLVM_18.1'
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
