### PR TITLE
Fix variable lexical scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to
 - Remove multi-map `delete` functionality
   - [#3506](https://github.com/bpftrace/bpftrace/pull/3506)
   - [Migration guide](docs/migration_guide.md#multi-key-delete-removed)
+- Add lexical/block scoping for variables
+  - [#3367](https://github.com/bpftrace/bpftrace/pull/3367)
+  - [Migration guide](docs/migration_guide.md#added-block-scoping-for-scratch-variables)
 #### Added
 - Add `--dry-run` CLI option
   - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -941,13 +941,27 @@ fentry:tcp_connect {
 
 bpftrace knows two types of variables, 'scratch' and 'map'.
 
-'scratch' variables are kept on the BPF stack and only exists during the execution of the action block and cannot be accessed outside of the program.
-Scratch variable names always start with a `$`, e.g. `$myvar`.
+'scratch' variables are kept on the BPF stack and their names always start
+with a `$`, e.g. `$myvar`.
+'scratch' variables cannot be accessed outside of their lexical block e.g.
+```
+$a = 1;
+if ($a == 1) {
+  $b = "hello"
+  $a = 2;
+}
+// $b is not accessible here
+```
 
 'scratch' variables can also declared before or during initialization with `let` e.g.
 ```
-let $x;
-let $y = 11;
+let $a = 1;
+let $b;
+if ($a == 1) {
+  $b = "hello"
+  $a = 2;
+}
+// $b IS accessible here and would be an empty string if the condition wasn't true
 ```
 
 If no assignment is specified variables will initialize to 0.

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -43,6 +43,7 @@ MAKE_ACCEPT(Unroll)
 MAKE_ACCEPT(While)
 MAKE_ACCEPT(For)
 MAKE_ACCEPT(Config)
+MAKE_ACCEPT(Block)
 MAKE_ACCEPT(Jump)
 MAKE_ACCEPT(Probe)
 MAKE_ACCEPT(SubprogArg)
@@ -242,31 +243,33 @@ AttachPoint::AttachPoint(const std::string &raw_input, location loc)
 {
 }
 
+Block::Block(StatementList &&stmts) : stmts(std::move(stmts))
+{
+}
+
 If::If(Expression *cond, StatementList &&stmts)
-    : cond(cond), stmts(std::move(stmts))
+    : cond(cond), if_block(Block(std::move(stmts))), else_block(Block({}))
 {
 }
 
 If::If(Expression *cond, StatementList &&stmts, StatementList &&else_stmts)
-    : cond(cond), stmts(std::move(stmts)), else_stmts(std::move(else_stmts))
+    : cond(cond),
+      if_block(Block(std::move(stmts))),
+      else_block(Block(std::move(else_stmts)))
 {
 }
 
 Unroll::Unroll(Expression *expr, StatementList &&stmts, location loc)
-    : Statement(loc), expr(expr), stmts(std::move(stmts))
-{
-}
-
-Scope::Scope(StatementList &&stmts) : stmts(std::move(stmts))
+    : Statement(loc), expr(expr), block(std::move(stmts))
 {
 }
 
 Probe::Probe(AttachPointList &&attach_points,
              Predicate *pred,
              StatementList &&stmts)
-    : Scope(std::move(stmts)),
-      attach_points(std::move(attach_points)),
-      pred(pred)
+    : attach_points(std::move(attach_points)),
+      pred(pred),
+      block(std::move(stmts))
 {
 }
 
@@ -284,9 +287,9 @@ Subprog::Subprog(std::string name,
                  SizedType return_type,
                  SubprogArgList &&args,
                  StatementList &&stmts)
-    : Scope(std::move(stmts)),
-      args(std::move(args)),
+    : args(std::move(args)),
       return_type(std::move(return_type)),
+      stmts(std::move(stmts)),
       name_(std::move(name))
 {
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -430,6 +430,18 @@ private:
   AssignConfigVarStatement(const AssignConfigVarStatement &other) = default;
 };
 
+class Block : public Statement {
+public:
+  DEFINE_ACCEPT
+
+  Block(StatementList &&stmts);
+
+  StatementList stmts;
+
+private:
+  Block(const Block &other) = default;
+};
+
 class If : public Statement {
 public:
   DEFINE_ACCEPT
@@ -438,8 +450,8 @@ public:
   If(Expression *cond, StatementList &&stmts, StatementList &&else_stmts);
 
   Expression *cond = nullptr;
-  StatementList stmts;
-  StatementList else_stmts;
+  Block if_block;
+  Block else_block;
 
 private:
   If(const If &other) = default;
@@ -453,7 +465,7 @@ public:
 
   long int var = 0;
   Expression *expr = nullptr;
-  StatementList stmts;
+  Block block;
 
 private:
   Unroll(const Unroll &other) = default;
@@ -507,12 +519,12 @@ public:
   DEFINE_ACCEPT
 
   While(Expression *cond, StatementList &&stmts, location loc)
-      : Statement(loc), cond(cond), stmts(std::move(stmts))
+      : Statement(loc), cond(cond), block(std::move(stmts))
   {
   }
 
   Expression *cond = nullptr;
-  StatementList stmts;
+  Block block;
 
 private:
   While(const While &other) = default;
@@ -530,7 +542,6 @@ public:
   Variable *decl = nullptr;
   Expression *expr = nullptr;
   StatementList stmts;
-
   SizedType ctx_type;
 
 private:
@@ -549,14 +560,6 @@ public:
 
 private:
   Config(const Config &other) = default;
-};
-
-class Scope : public Node {
-public:
-  Scope(StatementList &&stmts);
-  virtual ~Scope() = default;
-
-  StatementList stmts;
 };
 
 class AttachPoint : public Node {
@@ -606,7 +609,7 @@ private:
 };
 using AttachPointList = std::vector<AttachPoint *>;
 
-class Probe : public Scope {
+class Probe : public Node {
 public:
   DEFINE_ACCEPT
 
@@ -616,6 +619,7 @@ public:
 
   AttachPointList attach_points;
   Predicate *pred = nullptr;
+  Block block;
 
   std::string name() const;
   std::string args_typename() const;
@@ -649,7 +653,7 @@ private:
 };
 using SubprogArgList = std::vector<SubprogArg *>;
 
-class Subprog : public Scope {
+class Subprog : public Node {
 public:
   DEFINE_ACCEPT
 
@@ -660,6 +664,7 @@ public:
 
   SubprogArgList args;
   SizedType return_type;
+  StatementList stmts;
 
   std::string name() const;
 

--- a/src/ast/passes/callback_visitor.h
+++ b/src/ast/passes/callback_visitor.h
@@ -35,7 +35,7 @@ public:
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
   void visit(AssignConfigVarStatement &assignment) override;
-  void visit(If &if_block) override;
+  void visit(If &if_node) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
   void visit(Jump &jump) override;
@@ -43,6 +43,7 @@ public:
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
   void visit(Config &config) override;
+  void visit(Block &block) override;
   void visit(Program &program) override;
 
 private:

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -58,7 +58,7 @@ public:
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
   void visit(VarDeclStatement &decl) override;
-  void visit(If &if_block) override;
+  void visit(If &if_node) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
   void visit(For &f) override;
@@ -68,6 +68,7 @@ public:
   void visit(Probe &probe) override;
   void visit(Subprog &subprog) override;
   void visit(Program &program) override;
+  void visit(Block &block) override;
 
   AllocaInst *getHistMapKey(Map &map, Value *log2);
   int getNextIndexForProbe();

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -315,9 +315,7 @@ void FieldAnalyser::visit(Probe &probe)
   if (probe.pred) {
     Visit(*probe.pred);
   }
-  for (Statement *stmt : probe.stmts) {
-    Visit(*stmt);
-  }
+  Visit(probe.block);
 }
 
 void FieldAnalyser::visit(Subprog &subprog)

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -299,27 +299,23 @@ void Printer::visit(VarDeclStatement &decl)
   --depth_;
 }
 
-void Printer::visit(If &if_block)
+void Printer::visit(If &if_node)
 {
   std::string indent(depth_, ' ');
 
   out_ << indent << "if" << std::endl;
 
   ++depth_;
-  if_block.cond->accept(*this);
+  if_node.cond->accept(*this);
 
   ++depth_;
   out_ << indent << " then" << std::endl;
 
-  for (Statement *stmt : if_block.stmts) {
-    stmt->accept(*this);
-  }
+  if_node.if_block.accept(*this);
 
-  if (!if_block.else_stmts.empty()) {
+  if (!if_node.else_block.stmts.empty()) {
     out_ << indent << " else" << std::endl;
-    for (Statement *stmt : if_block.else_stmts) {
-      stmt->accept(*this);
-    }
+    if_node.else_block.accept(*this);
   }
   depth_ -= 2;
 }
@@ -334,9 +330,7 @@ void Printer::visit(Unroll &unroll)
   out_ << indent << " block" << std::endl;
 
   ++depth_;
-  for (Statement *stmt : unroll.stmts) {
-    stmt->accept(*this);
-  }
+  unroll.block.accept(*this);
   depth_ -= 2;
 }
 
@@ -352,9 +346,7 @@ void Printer::visit(While &while_block)
   ++depth_;
   out_ << indent << " )" << std::endl;
 
-  for (Statement *stmt : while_block.stmts) {
-    stmt->accept(*this);
-  }
+  while_block.block.accept(*this);
 }
 
 void Printer::visit(For &for_loop)
@@ -424,6 +416,13 @@ void Printer::visit(AttachPoint &ap)
   out_ << indent << ap.name() << std::endl;
 }
 
+void Printer::visit(Block &block)
+{
+  for (Statement *stmt : block.stmts) {
+    stmt->accept(*this);
+  }
+}
+
 void Printer::visit(Probe &probe)
 {
   for (AttachPoint *ap : probe.attach_points) {
@@ -434,9 +433,7 @@ void Printer::visit(Probe &probe)
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  for (Statement *stmt : probe.stmts) {
-    stmt->accept(*this);
-  }
+  probe.block.accept(*this);
   --depth_;
 }
 

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -38,11 +38,12 @@ public:
   void visit(AssignVarStatement &assignment) override;
   void visit(AssignConfigVarStatement &assignment) override;
   void visit(VarDeclStatement &decl) override;
-  void visit(If &if_block) override;
+  void visit(If &if_node) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
   void visit(For &for_loop) override;
   void visit(Config &config) override;
+  void visit(Block &block) override;
   void visit(Jump &jump) override;
   void visit(Predicate &pred) override;
   void visit(AttachPoint &ap) override;

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -35,10 +35,10 @@ bool ReturnPathAnalyser::visit(Jump &jump)
   return jump.ident == JumpType::RETURN;
 }
 
-bool ReturnPathAnalyser::visit(If &if_stmt)
+bool ReturnPathAnalyser::visit(If &if_node)
 {
   bool result = false;
-  for (Statement *stmt : if_stmt.stmts) {
+  for (Statement *stmt : if_node.if_block.stmts) {
     if (Visit(*stmt))
       result = true;
   }
@@ -47,7 +47,7 @@ bool ReturnPathAnalyser::visit(If &if_stmt)
     return false;
   }
 
-  for (Statement *stmt : if_stmt.else_stmts) {
+  for (Statement *stmt : if_node.else_block.stmts) {
     if (Visit(*stmt)) {
       // both blocks have a return
       return true;

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -124,34 +124,23 @@ void Visitor::visit(VarDeclStatement &decl)
   Visit(*decl.var);
 }
 
-void Visitor::visit(If &if_block)
+void Visitor::visit(If &if_node)
 {
-  Visit(*if_block.cond);
-
-  for (Statement *stmt : if_block.stmts) {
-    Visit(*stmt);
-  }
-
-  for (Statement *stmt : if_block.else_stmts) {
-    Visit(*stmt);
-  }
+  Visit(*if_node.cond);
+  Visit(if_node.if_block);
+  Visit(if_node.else_block);
 }
 
 void Visitor::visit(Unroll &unroll)
 {
   Visit(*unroll.expr);
-  for (Statement *stmt : unroll.stmts) {
-    Visit(*stmt);
-  }
+  Visit(unroll.block);
 }
 
 void Visitor::visit(While &while_block)
 {
   Visit(*while_block.cond);
-
-  for (Statement *stmt : while_block.stmts) {
-    Visit(*stmt);
-  }
+  Visit(while_block.block);
 }
 
 void Visitor::visit(For &for_loop)
@@ -188,9 +177,7 @@ void Visitor::visit(Probe &probe)
   if (probe.pred) {
     Visit(*probe.pred);
   }
-  for (Statement *stmt : probe.stmts) {
-    Visit(*stmt);
-  }
+  Visit(probe.block);
 }
 
 void Visitor::visit(Config &config)
@@ -222,6 +209,13 @@ void Visitor::visit(Program &program)
     Visit(*probe);
   if (program.config)
     Visit(*program.config);
+}
+
+void Visitor::visit(Block &block)
+{
+  for (Statement *stmt : block.stmts) {
+    Visit(*stmt);
+  }
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -37,7 +37,7 @@ public:
   virtual void visit(AssignVarStatement &assignment) = 0;
   virtual void visit(AssignConfigVarStatement &assignment) = 0;
   virtual void visit(VarDeclStatement &decl) = 0;
-  virtual void visit(If &if_block) = 0;
+  virtual void visit(If &if_node) = 0;
   virtual void visit(Jump &jump) = 0;
   virtual void visit(Unroll &unroll) = 0;
   virtual void visit(While &while_block) = 0;
@@ -46,6 +46,7 @@ public:
   virtual void visit(AttachPoint &ap) = 0;
   virtual void visit(Probe &probe) = 0;
   virtual void visit(Config &config) = 0;
+  virtual void visit(Block &block) = 0;
   virtual void visit(SubprogArg &subprog_arg) = 0;
   virtual void visit(Subprog &subprog) = 0;
   virtual void visit(Program &program) = 0;
@@ -118,6 +119,7 @@ public:
   void visit(SubprogArg &subprog_arg) override;
   void visit(Subprog &subprog) override;
   void visit(Program &program) override;
+  void visit(Block &block) override;
 };
 
 /**
@@ -182,6 +184,7 @@ public:
   virtual R visit(Predicate &node) DEFAULT_FN;
   virtual R visit(AttachPoint &node) DEFAULT_FN;
   virtual R visit(Probe &node) DEFAULT_FN;
+  virtual R visit(Block &node) DEFAULT_FN;
   virtual R visit(Config &node) DEFAULT_FN;
   virtual R visit(SubprogArg &node) DEFAULT_FN;
   virtual R visit(Subprog &node) DEFAULT_FN;
@@ -238,6 +241,7 @@ private:
     DEFINE_DISPATCH(Subprog);
     DEFINE_DISPATCH(Probe);
     DEFINE_DISPATCH(Config);
+    DEFINE_DISPATCH(Block);
     DEFINE_DISPATCH(Program);
 
     return table;

--- a/tests/codegen/if_variable.cpp
+++ b/tests/codegen/if_variable.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, if_variable)
 {
-  test("kprobe:f { if (1) { $x = 10 } $y = $x; }",
+  test("kprobe:f { let $x; if (1) { $x = 10 } $y = $x; }",
 
        NAME);
 }

--- a/tools/tcpconnect.bt
+++ b/tools/tcpconnect.bt
@@ -40,6 +40,8 @@ BEGIN
 
 kprobe:tcp_connect
 {
+  let $daddr;
+  let $saddr;
   $sk = ((struct sock *) arg0);
   $inet_family = $sk->__sk_common.skc_family;
 

--- a/tools/tcpdrop.bt
+++ b/tools/tcpdrop.bt
@@ -55,6 +55,8 @@ BEGIN
 
 tracepoint:skb:kfree_skb
 {
+  let $daddr;
+  let $saddr;
   $reason = args.reason;
   $skb = (struct sk_buff *)args.skbaddr;
   $sk = ((struct sock *) $skb->sk);


### PR DESCRIPTION
This implements a `scope` stack to prevent blocks
from accessing variables outside of their lexical scope.

Example, which is no longer valid:
```
BEGIN { if (0) { $var = 1; } print($var) }
```

We need to do this for:
- While
- For
- If (both the if and else blocks)
- Unroll
- Probe
- Subprog

Issue: https://github.com/bpftrace/bpftrace/issues/3017

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
