### PR TITLE
tests: runtime: Exit unclean for timeouted tests

### DIFF
--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -121,7 +121,8 @@ void ResourceAnalyser::visit(Call &call)
     resources_.needs_join_map = true;
   } else if (call.func == "count" || call.func == "sum" || call.func == "min" ||
              call.func == "max" || call.func == "avg") {
-    resources_.needed_global_vars.insert(bpftrace::globalvars::NUM_CPUS);
+    resources_.needed_global_vars.insert(
+        std::string(bpftrace::globalvars::NUM_CPUS));
   } else if (call.func == "hist") {
     auto &map_info = resources_.maps_info[call.map->ident];
     int bits = static_cast<Integer *>(call.vargs.at(1))->n;

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -40,7 +40,7 @@ void update_global_vars(const struct bpf_object *bpf_object,
   // First locate the offsets of each global variable in the section with btf
   std::map<std::string_view, int> vars_and_offsets;
 
-  for (auto name : GLOBAL_VAR_NAMES) {
+  for (const auto &name : GLOBAL_VAR_NAMES) {
     if (bpftrace.resources.needed_global_vars.find(name) ==
         bpftrace.resources.needed_global_vars.end()) {
       continue;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -16,8 +16,8 @@ static constexpr std::string_view SECTION_NAME = ".rodata";
 
 static constexpr std::string_view NUM_CPUS = "num_cpus";
 
-const std::unordered_set<std::string_view> GLOBAL_VAR_NAMES = {
-  NUM_CPUS,
+const std::unordered_set<std::string> GLOBAL_VAR_NAMES = {
+  std::string(NUM_CPUS),
 };
 
 void update_global_vars(const struct bpf_object *obj,

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -110,7 +110,7 @@ public:
   // Map metadata
   std::map<std::string, MapInfo> maps_info;
   std::unordered_set<StackType> stackid_maps;
-  std::unordered_set<std::string_view> needed_global_vars;
+  std::unordered_set<std::string> needed_global_vars;
   bool needs_join_map = false;
   bool needs_elapsed_map = false;
   bool needs_perf_event_map = false;
@@ -145,6 +145,7 @@ private:
             probe_ids,
             maps_info,
             stackid_maps,
+            needed_global_vars,
             needs_join_map,
             needs_elapsed_map,
             needs_perf_event_map,

--- a/tests/runtime/engine/main.py
+++ b/tests/runtime/engine/main.py
@@ -82,7 +82,7 @@ def main(test_filter, skiplist_file, run_aot_tests):
         for timeouted_test in timeouted_tests:
             print(fail("[  TIMEOUT ]") + " %s" % timeouted_test)
 
-    if failed_tests:
+    if failed_tests or timeouted_tests:
         exit(1)
 
 


### PR DESCRIPTION
There's a latent bug where the runtime test suite "passes" if only timed out tests fail. Obviously wrong and bad.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
