### PR TITLE
codegen: NFC: Rename onStack() and shouldBeOnStackAlready()

### DIFF
--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -10,7 +10,12 @@ inline bool needMemcpy(const SizedType &stype)
   return stype.IsAggregate() || stype.IsTimestampTy() || stype.IsCgroupPathTy();
 }
 
-inline bool shouldBeOnStackAlready(const SizedType &type)
+// BPF memory is memory that the program can access with a regular
+// dereference. This could mean the value is on the stack, a map, or
+// maybe something else (like BPF arenas) in the future.
+//
+// This means that a bpf_probe_read_*() is _NOT_ required.
+inline bool shouldBeInBpfMemoryAlready(const SizedType &type)
 {
   return type.IsStringTy() || type.IsBufferTy() || type.IsInetTy() ||
          type.IsUsymTy() || type.IsKstackTy() || type.IsUstackTy() ||
@@ -18,14 +23,14 @@ inline bool shouldBeOnStackAlready(const SizedType &type)
          type.IsCgroupPathTy();
 }
 
-inline bool onStack(const SizedType &type)
+inline bool inBpfMemory(const SizedType &type)
 {
-  return type.is_internal || shouldBeOnStackAlready(type);
+  return type.is_internal || shouldBeInBpfMemoryAlready(type);
 }
 
 inline AddrSpace find_addrspace_stack(const SizedType &ty)
 {
-  return (shouldBeOnStackAlready(ty)) ? AddrSpace::kernel : ty.GetAS();
+  return (shouldBeInBpfMemoryAlready(ty)) ? AddrSpace::kernel : ty.GetAS();
 }
 
 } // namespace ast

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1650,7 +1650,7 @@ Value *IRBuilderBPF::CreateIntegerArrayCmpUnrolled(Value *ctx,
     auto *ptr_val1_elem_i = CreateGEP(GetType(val1_type),
                                       ptr_val1,
                                       { getInt32(0), getInt32(i) });
-    if (onStack(val1_type)) {
+    if (inBpfMemory(val1_type)) {
       val1_elem_i = CreateLoad(GetType(elem_type), ptr_val1_elem_i);
     } else {
       CreateProbeRead(ctx,
@@ -1665,7 +1665,7 @@ Value *IRBuilderBPF::CreateIntegerArrayCmpUnrolled(Value *ctx,
     auto *ptr_val2_elem_i = CreateGEP(GetType(val2_type),
                                       ptr_val2,
                                       { getInt32(0), getInt32(i) });
-    if (onStack(val2_type)) {
+    if (inBpfMemory(val2_type)) {
       val2_elem_i = CreateLoad(GetType(elem_type), ptr_val2_elem_i);
     } else {
       CreateProbeRead(ctx,
@@ -1766,7 +1766,7 @@ Value *IRBuilderBPF::CreateIntegerArrayCmp(Value *ctx,
                                     ptr_val1,
                                     { getInt32(0),
                                       CreateLoad(getInt32Ty(), i) });
-  if (onStack(val1_type)) {
+  if (inBpfMemory(val1_type)) {
     val1_elem_i = CreateLoad(GetType(elem_type), ptr_val1_elem_i);
   } else {
     CreateProbeRead(ctx,
@@ -1782,7 +1782,7 @@ Value *IRBuilderBPF::CreateIntegerArrayCmp(Value *ctx,
                                     ptr_val2,
                                     { getInt32(0),
                                       CreateLoad(getInt32Ty(), i) });
-  if (onStack(val2_type)) {
+  if (inBpfMemory(val2_type)) {
     val2_elem_i = CreateLoad(GetType(elem_type), ptr_val2_elem_i);
   } else {
     CreateProbeRead(ctx,


### PR DESCRIPTION
The two functions are misnamed. The intent is to check for types that are directly accessible from the program. Meaning no probe reads. Now that we are making heavier use of perpcu scratch maps, we should rename the helper so the code is more clear.


<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
