### PR TITLE
Add root check to AOT binaries

### DIFF
--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -123,6 +123,8 @@ int main(int argc, char* argv[])
     return 1;
   }
 
+  check_is_root();
+
   libbpf_set_print(libbpf_print);
 
   auto output = prepare_output(output_file, output_format);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,14 +165,6 @@ static void enforce_infinite_rlimit()
                  << "\"ulimit -l 8192\" to fix the problem";
 }
 
-void check_is_root()
-{
-  if (geteuid() != 0) {
-    LOG(ERROR) << "bpftrace currently only supports running as the root user.";
-    exit(1);
-  }
-}
-
 static void info(BPFnofeature no_feature)
 {
   struct utsname utsname;

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -26,6 +26,14 @@ int libbpf_print(enum libbpf_print_level level, const char *msg, va_list ap)
   return vprintf(msg, ap);
 }
 
+void check_is_root()
+{
+  if (geteuid() != 0) {
+    LOG(ERROR) << "bpftrace currently only supports running as the root user.";
+    exit(1);
+  }
+}
+
 int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
 {
   int err;

--- a/src/run_bpftrace.h
+++ b/src/run_bpftrace.h
@@ -3,5 +3,6 @@
 #include "bpftrace.h"
 
 int libbpf_print(enum libbpf_print_level level, const char *msg, va_list ap);
+void check_is_root();
 
 int run_bpftrace(bpftrace::BPFtrace &bpftrace, bpftrace::BpfBytecode &bytecode);


### PR DESCRIPTION
Currently running the binary without root will result in a verifier error, which is not a good user experience.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
