### PR TITLE
Fix: json formatting for strftime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to
   - #[3339](https://github.com/bpftrace/bpftrace/pull/3339)
 - Fix parsing large unsigned int strings as positional params
   - [#3336](https://github.com/bpftrace/bpftrace/pull/3336)
+- Fix json formatting for `strftime` function
+  - [#3381](https://github.com/bpftrace/bpftrace/pull/3381)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -27,6 +27,7 @@ bool is_quoted_type(const SizedType &ty)
     case Type::probe:
     case Type::strerror:
     case Type::string:
+    case Type::timestamp:
     case Type::username:
     case Type::ustack:
     case Type::usym:
@@ -46,7 +47,6 @@ bool is_quoted_type(const SizedType &ty)
     case Type::stack_mode:
     case Type::stats:
     case Type::sum:
-    case Type::timestamp:
     case Type::timestamp_mode:
     case Type::tuple:
     case Type::voidtype:

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -183,3 +183,8 @@ NAME cgroup_path
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print(cgroup_path(cgroup)); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin))'
 EXPECT_REGEX ^{'type': 'value', 'data': '.*'}$
 TIMEOUT 5
+
+NAME strftime
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { $t = (1, strftime("%m/%d/%y", nsecs)); print($t); exit() }' | python3 -c 'import sys,json; print(json.load(sys.stdin))'
+EXPECT_REGEX ^{'type': 'value', 'data': \[1, '[0-9]{2}\/[0-9]{2}\/[0-9]{2}'\]}$
+TIMEOUT 1


### PR DESCRIPTION
This should be output as a string when json formatting is selected.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
