### PR TITLE
Merge `-lv` output into `stdout`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
 - For-loops: Allow sharing variables between the main probe and the loop's body
   - [#3014](https://github.com/bpftrace/bpftrace/pull/3014)
 #### Changed
+- Merge output into `stdout` when `-lv`
+  - [#3383](https://github.com/bpftrace/bpftrace/pull/3383)
 - Stream output when printing maps
   - [#3264](https://github.com/bpftrace/bpftrace/pull/3264)
 - Only print kernel headers not found message if parsing fails

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -480,7 +480,7 @@ void ProbeMatcher::list_probes(ast::Program* prog)
         std::cout << probe_type << ":" << match_print << std::endl;
         if (bt_verbose) {
           for (auto& param : param_lists[match])
-            LOG(V1) << "    " << param;
+            std::cout << "    " << param << std::endl;
         }
       }
     }


### PR DESCRIPTION
To fix https://github.com/bpftrace/bpftrace/issues/3379



##### Checklist

- [*] Language changes are updated in `man/adoc/bpftrace.adoc`
- [*] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [*] The new behaviour is covered by tests
