### PR TITLE
AST: Replace non-optional pointers with reference types

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -99,7 +99,7 @@ Sizeof::Sizeof(SizedType type, location loc) : Expression(loc), argtype(type)
 {
 }
 
-Sizeof::Sizeof(Expression *expr, location loc) : Expression(loc), expr(expr)
+Sizeof::Sizeof(Expression &expr, location loc) : Expression(loc), expr(&expr)
 {
 }
 
@@ -108,8 +108,8 @@ Offsetof::Offsetof(SizedType record, std::string &field, location loc)
 {
 }
 
-Offsetof::Offsetof(Expression *expr, std::string &field, location loc)
-    : Expression(loc), expr(expr), field(field)
+Offsetof::Offsetof(Expression &expr, std::string &field, location loc)
+    : Expression(loc), expr(&expr), field(field)
 {
 }
 
@@ -122,8 +122,8 @@ Map::Map(const std::string &ident, ExpressionList &&vargs_, location loc)
     : Expression(loc), ident(ident), vargs(std::move(vargs_))
 {
   is_map = true;
-  for (auto *expr : vargs) {
-    expr->key_for_map = this;
+  for (Expression &expr : vargs) {
+    expr.key_for_map = this;
   }
 }
 
@@ -133,47 +133,47 @@ Variable::Variable(const std::string &ident, location loc)
   is_variable = true;
 }
 
-Binop::Binop(Expression *left, Operator op, Expression *right, location loc)
+Binop::Binop(Expression &left, Operator op, Expression &right, location loc)
     : Expression(loc), left(left), right(right), op(op)
 {
 }
 
-Unop::Unop(Operator op, Expression *expr, location loc)
+Unop::Unop(Operator op, Expression &expr, location loc)
     : Expression(loc), expr(expr), op(op), is_post_op(false)
 {
 }
 
-Unop::Unop(Operator op, Expression *expr, bool is_post_op, location loc)
+Unop::Unop(Operator op, Expression &expr, bool is_post_op, location loc)
     : Expression(loc), expr(expr), op(op), is_post_op(is_post_op)
 {
 }
 
-Ternary::Ternary(Expression *cond,
-                 Expression *left,
-                 Expression *right,
+Ternary::Ternary(Expression &cond,
+                 Expression &left,
+                 Expression &right,
                  location loc)
     : Expression(loc), cond(cond), left(left), right(right)
 {
 }
 
-FieldAccess::FieldAccess(Expression *expr,
+FieldAccess::FieldAccess(Expression &expr,
                          const std::string &field,
                          location loc)
     : Expression(loc), expr(expr), field(field)
 {
 }
 
-FieldAccess::FieldAccess(Expression *expr, ssize_t index, location loc)
+FieldAccess::FieldAccess(Expression &expr, ssize_t index, location loc)
     : Expression(loc), expr(expr), index(index)
 {
 }
 
-ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr, location loc)
+ArrayAccess::ArrayAccess(Expression &expr, Expression &indexpr, location loc)
     : Expression(loc), expr(expr), indexpr(indexpr)
 {
 }
 
-Cast::Cast(SizedType cast_type, Expression *expr, location loc)
+Cast::Cast(SizedType cast_type, Expression &expr, location loc)
     : Expression(loc), expr(expr)
 {
   type = cast_type;
@@ -184,34 +184,34 @@ Tuple::Tuple(ExpressionList &&elems, location loc)
 {
 }
 
-ExprStatement::ExprStatement(Expression *expr, location loc)
+ExprStatement::ExprStatement(Expression &expr, location loc)
     : Statement(loc), expr(expr)
 {
 }
 
-AssignMapStatement::AssignMapStatement(Map *map, Expression *expr, location loc)
+AssignMapStatement::AssignMapStatement(Map &map, Expression &expr, location loc)
     : Statement(loc), map(map), expr(expr)
 {
-  expr->map = map;
+  expr.map = &map;
 };
 
-AssignVarStatement::AssignVarStatement(Variable *var,
-                                       Expression *expr,
+AssignVarStatement::AssignVarStatement(Variable &var,
+                                       Expression &expr,
                                        location loc)
     : Statement(loc), var(var), expr(expr)
 {
-  expr->var = var;
+  expr.var = &var;
 }
 
 AssignConfigVarStatement::AssignConfigVarStatement(
     const std::string &config_var,
-    Expression *expr,
+    Expression &expr,
     location loc)
     : Statement(loc), config_var(config_var), expr(expr)
 {
 }
 
-Predicate::Predicate(Expression *expr, location loc) : Node(loc), expr(expr)
+Predicate::Predicate(Expression &expr, location loc) : Node(loc), expr(expr)
 {
 }
 
@@ -220,17 +220,17 @@ AttachPoint::AttachPoint(const std::string &raw_input, location loc)
 {
 }
 
-If::If(Expression *cond, StatementList &&stmts)
+If::If(Expression &cond, StatementList &&stmts)
     : cond(cond), stmts(std::move(stmts))
 {
 }
 
-If::If(Expression *cond, StatementList &&stmts, StatementList &&else_stmts)
+If::If(Expression &cond, StatementList &&stmts, StatementList &&else_stmts)
     : cond(cond), stmts(std::move(stmts)), else_stmts(std::move(else_stmts))
 {
 }
 
-Unroll::Unroll(Expression *expr, StatementList &&stmts, location loc)
+Unroll::Unroll(Expression &expr, StatementList &&stmts, location loc)
     : Statement(loc), expr(expr), stmts(std::move(stmts))
 {
 }
@@ -457,7 +457,7 @@ std::string Probe::name() const
   std::transform(attach_points.begin(),
                  attach_points.end(),
                  std::back_inserter(ap_names),
-                 [](const AttachPoint *ap) { return ap->name(); });
+                 [](const AttachPoint &ap) { return ap.name(); });
   return str_join(ap_names, ",");
 }
 
@@ -483,8 +483,8 @@ std::string Subprog::name() const
 
 bool Probe::has_ap_of_probetype(ProbeType probe_type)
 {
-  for (auto *ap : attach_points) {
-    if (probetype(ap->provider) == probe_type)
+  for (AttachPoint &ap : attach_points) {
+    if (probetype(ap.provider) == probe_type)
       return true;
   }
   return false;

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -66,10 +66,9 @@ int AttachPointParser::parse()
     return 1;
 
   uint32_t failed = 0;
-  for (Probe *probe : ctx_.root->probes) {
-    for (size_t i = 0; i < probe->attach_points.size(); ++i) {
-      auto ap_ptr = probe->attach_points[i];
-      auto &ap = *ap_ptr;
+  for (Probe &probe : ctx_.root->probes) {
+    for (size_t i = 0; i < probe.attach_points.size(); ++i) {
+      AttachPoint &ap = probe.attach_points[i];
       new_attach_points.clear();
 
       State s = parse_attachpoint(ap);
@@ -78,13 +77,13 @@ int AttachPointParser::parse()
         LOG(ERROR, ap.loc, sink_) << errs_.str();
       } else if (s == SKIP || s == NEW_APS) {
         // Remove the current attach point
-        probe->attach_points.erase(probe->attach_points.begin() + i);
+        probe.attach_points.erase(probe.attach_points.begin() + i);
         i--;
         if (s == NEW_APS) {
           // The removed attach point is replaced by new ones
-          probe->attach_points.insert(probe->attach_points.end(),
-                                      new_attach_points.begin(),
-                                      new_attach_points.end());
+          probe.attach_points.insert(probe.attach_points.end(),
+                                     new_attach_points.begin(),
+                                     new_attach_points.end());
         }
       }
 
@@ -93,15 +92,15 @@ int AttachPointParser::parse()
       errs_.str({});
     }
 
-    auto new_end = std::remove_if(probe->attach_points.begin(),
-                                  probe->attach_points.end(),
-                                  [](const AttachPoint *ap) {
-                                    return ap->provider.empty();
+    auto new_end = std::remove_if(probe.attach_points.begin(),
+                                  probe.attach_points.end(),
+                                  [](const AttachPoint &ap) {
+                                    return ap.provider.empty();
                                   });
-    probe->attach_points.erase(new_end, probe->attach_points.end());
+    probe.attach_points.erase(new_end, probe.attach_points.end());
 
-    if (probe->attach_points.empty()) {
-      LOG(ERROR, probe->loc, sink_) << "No attach points for probe";
+    if (probe.attach_points.empty()) {
+      LOG(ERROR, probe.loc, sink_) << "No attach points for probe";
       failed++;
     }
   }

--- a/src/ast/pass_manager.cpp
+++ b/src/ast/pass_manager.cpp
@@ -9,7 +9,7 @@ namespace bpftrace {
 namespace ast {
 
 namespace {
-void print(Node *root, const std::string &name, std::ostream &out)
+void print(Node &root, const std::string &name, std::ostream &out)
 {
   out << "\nAST after: " << name << std::endl;
   out << "-------------------\n";
@@ -27,7 +27,7 @@ void PassManager::AddPass(Pass p)
 PassResult PassManager::Run(Node *root, PassContext &ctx)
 {
   if (bt_debug.find(DebugStage::Ast) != bt_debug.end())
-    print(root, "parser", std::cout);
+    print(*root, "parser", std::cout);
   for (auto &pass : passes_) {
     auto result = pass.Run(*root, ctx);
     if (!result.Ok())
@@ -38,7 +38,7 @@ PassResult PassManager::Run(Node *root, PassContext &ctx)
     }
 
     if (bt_debug.find(DebugStage::Ast) != bt_debug.end())
-      print(root, pass.name, std::cout);
+      print(*root, pass.name, std::cout);
   }
   return PassResult::Success(root);
 }

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -166,7 +166,7 @@ private:
                  const std::string &name,
                  FunctionType *func_type);
 
-  [[nodiscard]] ScopedExprDeleter accept(Node *node);
+  [[nodiscard]] ScopedExprDeleter accept(Node &node);
   [[nodiscard]] std::tuple<Value *, ScopedExprDeleter> getMapKey(Map &map);
   AllocaInst *getMultiMapKey(Map &map, const std::vector<Value *> &extra_keys);
 
@@ -176,7 +176,7 @@ private:
   Function *createLinearFunction();
   MDNode *createLoopMetadata();
 
-  std::pair<Value *, uint64_t> getString(Expression *expr);
+  std::pair<Value *, uint64_t> getString(Expression &expr);
 
   void binop_string(Binop &binop);
   void binop_integer_array(Binop &binop);

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -31,25 +31,25 @@ void ConfigAnalyser::log_type_error(SizedType &type,
 void ConfigAnalyser::set_uint64_config(AssignConfigVarStatement &assignment,
                                        ConfigKeyInt key)
 {
-  auto &assignTy = assignment.expr->type;
+  auto &assignTy = assignment.expr().type;
   if (!assignTy.IsIntegerTy()) {
     log_type_error(assignTy, Type::integer, assignment);
     return;
   }
 
-  config_setter_.set(key, dynamic_cast<Integer *>(assignment.expr)->n);
+  config_setter_.set(key, dynamic_cast<Integer &>(assignment.expr()).n);
 }
 
 void ConfigAnalyser::set_bool_config(AssignConfigVarStatement &assignment,
                                      ConfigKeyBool key)
 {
-  auto &assignTy = assignment.expr->type;
+  auto &assignTy = assignment.expr().type;
   if (!assignTy.IsIntegerTy()) {
     log_type_error(assignTy, Type::integer, assignment);
     return;
   }
 
-  auto val = dynamic_cast<Integer *>(assignment.expr)->n;
+  auto val = dynamic_cast<Integer &>(assignment.expr()).n;
   if (val == 0) {
     config_setter_.set(key, false);
   } else if (val == 1) {
@@ -63,18 +63,18 @@ void ConfigAnalyser::set_bool_config(AssignConfigVarStatement &assignment,
 void ConfigAnalyser::set_string_config(AssignConfigVarStatement &assignment,
                                        ConfigKeyString key)
 {
-  auto &assignTy = assignment.expr->type;
+  auto &assignTy = assignment.expr().type;
   if (!assignTy.IsStringTy()) {
     log_type_error(assignTy, Type::string, assignment);
     return;
   }
 
-  config_setter_.set(key, dynamic_cast<String *>(assignment.expr)->str);
+  config_setter_.set(key, dynamic_cast<String &>(assignment.expr()).str);
 }
 
 void ConfigAnalyser::set_stack_mode_config(AssignConfigVarStatement &assignment)
 {
-  auto &assignTy = assignment.expr->type;
+  auto &assignTy = assignment.expr().type;
   if (!assignTy.IsStackModeTy()) {
     log_type_error(assignTy, Type::stack_mode, assignment);
     return;
@@ -86,29 +86,29 @@ void ConfigAnalyser::set_stack_mode_config(AssignConfigVarStatement &assignment)
 void ConfigAnalyser::set_user_symbol_cache_type_config(
     AssignConfigVarStatement &assignment)
 {
-  auto &assignTy = assignment.expr->type;
+  auto &assignTy = assignment.expr().type;
   if (!assignTy.IsStringTy()) {
     log_type_error(assignTy, Type::string, assignment);
     return;
   }
 
-  auto val = dynamic_cast<String *>(assignment.expr)->str;
+  auto val = dynamic_cast<String &>(assignment.expr()).str;
   if (!config_setter_.set_user_symbol_cache_type(val))
-    LOG(ERROR, assignment.expr->loc, err_);
+    LOG(ERROR, assignment.expr().loc, err_);
 }
 
 void ConfigAnalyser::set_missing_probes_config(
     AssignConfigVarStatement &assignment)
 {
-  auto &assignTy = assignment.expr->type;
+  auto &assignTy = assignment.expr().type;
   if (!assignTy.IsStringTy()) {
     log_type_error(assignTy, Type::string, assignment);
     return;
   }
 
-  auto val = dynamic_cast<String *>(assignment.expr)->str;
+  auto val = dynamic_cast<String &>(assignment.expr()).str;
   if (!config_setter_.set_missing_probes_config(val))
-    LOG(ERROR, assignment.expr->loc, err_);
+    LOG(ERROR, assignment.expr().loc, err_);
 }
 
 void ConfigAnalyser::visit(Integer &integer)
@@ -147,7 +147,7 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
     return;
   }
 
-  if (!assignment.expr->is_literal) {
+  if (!assignment.expr().is_literal) {
     LOG(ERROR, assignment.loc, err_)
         << "Assignemnt for " << assignment.config_var << " must be literal.";
     return;

--- a/src/ast/passes/portability_analyser.cpp
+++ b/src/ast/passes/portability_analyser.cpp
@@ -54,8 +54,8 @@ void PortabilityAnalyser::visit(Builtin &builtin)
 
 void PortabilityAnalyser::visit(Call &call)
 {
-  for (Expression *expr : call.vargs)
-    Visit(*expr);
+  for (Expression &expr : call.vargs)
+    Visit(expr);
 
   // kaddr() and uaddr() both resolve symbols -> address during codegen and
   // embeds the values into the bytecode. For AOT to support kaddr()/uaddr(),
@@ -74,7 +74,7 @@ void PortabilityAnalyser::visit(Call &call)
 
 void PortabilityAnalyser::visit(Cast &cast)
 {
-  Visit(*cast.expr);
+  Visit(cast.expr);
 
   // The goal here is to block arbitrary field accesses but still allow `args`
   // access. `args` for tracepoint is fairly stable and should be considered

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -13,7 +13,7 @@ public:
   {
   }
 
-  void print(Node *root);
+  void print(Node &root);
 
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -11,8 +11,8 @@ ReturnPathAnalyser::ReturnPathAnalyser(Node *root, std::ostream &out)
 
 bool ReturnPathAnalyser::visit(Program &prog)
 {
-  for (Subprog *subprog : prog.functions) {
-    if (!visit(*subprog))
+  for (Subprog &subprog : prog.functions) {
+    if (!visit(subprog))
       return false;
   }
   return true;
@@ -23,8 +23,8 @@ bool ReturnPathAnalyser::visit(Subprog &subprog)
   if (subprog.return_type.IsVoidTy())
     return true;
 
-  for (Statement *stmt : subprog.stmts) {
-    if (Visit(*stmt))
+  for (Statement &stmt : subprog.stmts) {
+    if (Visit(stmt))
       return true;
   }
   LOG(ERROR, subprog.loc, err_) << "Not all code paths returned a value";
@@ -39,8 +39,8 @@ bool ReturnPathAnalyser::visit(Jump &jump)
 bool ReturnPathAnalyser::visit(If &if_stmt)
 {
   bool result = false;
-  for (Statement *stmt : if_stmt.stmts) {
-    if (Visit(*stmt))
+  for (Statement &stmt : if_stmt.stmts) {
+    if (Visit(stmt))
       result = true;
   }
   if (!result) {
@@ -48,8 +48,8 @@ bool ReturnPathAnalyser::visit(If &if_stmt)
     return false;
   }
 
-  for (Statement *stmt : if_stmt.else_stmts) {
-    if (Visit(*stmt)) {
+  for (Statement &stmt : if_stmt.else_stmts) {
+    if (Visit(stmt)) {
       // both blocks have a return
       return true;
     }

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -118,7 +118,7 @@ private:
   bool update_string_size(SizedType &type, const SizedType &new_type);
   void resolve_struct_type(SizedType &type, const location &loc);
 
-  void builtin_args_tracepoint(AttachPoint *attach_point, Builtin &builtin);
+  void builtin_args_tracepoint(AttachPoint &attach_point, Builtin &builtin);
   ProbeType single_provider_type(Probe *probe);
   AddrSpace find_addrspace(ProbeType pt);
 

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -31,8 +31,8 @@ void Visitor::visit(Identifier &identifier __attribute__((__unused__)))
 
 void Visitor::visit(Call &call)
 {
-  for (Expression *expr : call.vargs) {
-    Visit(*expr);
+  for (Expression &expr : call.vargs) {
+    Visit(expr);
   }
 }
 
@@ -50,8 +50,8 @@ void Visitor::visit(Offsetof &ofof)
 
 void Visitor::visit(Map &map)
 {
-  for (Expression *expr : map.vargs) {
-    Visit(*expr);
+  for (Expression &expr : map.vargs) {
+    Visit(expr);
   }
 }
 
@@ -61,103 +61,103 @@ void Visitor::visit(Variable &var __attribute__((__unused__)))
 
 void Visitor::visit(Binop &binop)
 {
-  Visit(*binop.left);
-  Visit(*binop.right);
+  Visit(binop.left);
+  Visit(binop.right);
 }
 
 void Visitor::visit(Unop &unop)
 {
-  Visit(*unop.expr);
+  Visit(unop.expr);
 }
 
 void Visitor::visit(Ternary &ternary)
 {
-  Visit(*ternary.cond);
-  Visit(*ternary.left);
-  Visit(*ternary.right);
+  Visit(ternary.cond);
+  Visit(ternary.left);
+  Visit(ternary.right);
 }
 
 void Visitor::visit(FieldAccess &acc)
 {
-  Visit(*acc.expr);
+  Visit(acc.expr);
 }
 
 void Visitor::visit(ArrayAccess &arr)
 {
-  Visit(*arr.expr);
-  Visit(*arr.indexpr);
+  Visit(arr.expr);
+  Visit(arr.indexpr);
 }
 
 void Visitor::visit(Cast &cast)
 {
-  Visit(*cast.expr);
+  Visit(cast.expr);
 }
 
 void Visitor::visit(Tuple &tuple)
 {
-  for (Expression *expr : tuple.elems)
-    Visit(*expr);
+  for (Expression &expr : tuple.elems)
+    Visit(expr);
 }
 
 void Visitor::visit(ExprStatement &expr)
 {
-  Visit(*expr.expr);
+  Visit(expr.expr);
 }
 
 void Visitor::visit(AssignMapStatement &assignment)
 {
-  Visit(*assignment.map);
-  Visit(*assignment.expr);
+  Visit(assignment.map);
+  Visit(assignment.expr);
 }
 
 void Visitor::visit(AssignVarStatement &assignment)
 {
-  Visit(*assignment.var);
-  Visit(*assignment.expr);
+  Visit(assignment.var);
+  Visit(assignment.expr);
 }
 
 void Visitor::visit(AssignConfigVarStatement &assignment)
 {
-  Visit(*assignment.expr);
+  Visit(assignment.expr);
 }
 
 void Visitor::visit(If &if_block)
 {
-  Visit(*if_block.cond);
+  Visit(if_block.cond);
 
-  for (Statement *stmt : if_block.stmts) {
-    Visit(*stmt);
+  for (Statement &stmt : if_block.stmts) {
+    Visit(stmt);
   }
 
-  for (Statement *stmt : if_block.else_stmts) {
-    Visit(*stmt);
+  for (Statement &stmt : if_block.else_stmts) {
+    Visit(stmt);
   }
 }
 
 void Visitor::visit(Unroll &unroll)
 {
-  Visit(*unroll.expr);
-  for (Statement *stmt : unroll.stmts) {
-    Visit(*stmt);
+  Visit(unroll.expr);
+  for (Statement &stmt : unroll.stmts) {
+    Visit(stmt);
   }
 }
 
 void Visitor::visit(While &while_block)
 {
-  Visit(*while_block.cond);
+  Visit(while_block.cond);
 
-  for (Statement *stmt : while_block.stmts) {
-    Visit(*stmt);
+  for (Statement &stmt : while_block.stmts) {
+    Visit(stmt);
   }
 }
 
 void Visitor::visit(For &for_loop)
 {
-  Visit(*for_loop.decl);
-  Visit(*for_loop.expr);
+  Visit(for_loop.decl);
+  Visit(for_loop.expr);
 
-  for (Statement *stmt : for_loop.stmts) {
-    Visit(*stmt);
+  for (Statement &stmt : for_loop.stmts) {
+    Visit(stmt);
   }
 }
 
@@ -169,7 +169,7 @@ void Visitor::visit(Jump &jump)
 
 void Visitor::visit(Predicate &pred)
 {
-  Visit(*pred.expr);
+  Visit(pred.expr);
 }
 
 void Visitor::visit(AttachPoint &ap __attribute__((__unused__)))
@@ -178,22 +178,22 @@ void Visitor::visit(AttachPoint &ap __attribute__((__unused__)))
 
 void Visitor::visit(Probe &probe)
 {
-  for (AttachPoint *ap : probe.attach_points) {
-    Visit(*ap);
+  for (AttachPoint &ap : probe.attach_points) {
+    Visit(ap);
   }
 
   if (probe.pred) {
     Visit(*probe.pred);
   }
-  for (Statement *stmt : probe.stmts) {
-    Visit(*stmt);
+  for (Statement &stmt : probe.stmts) {
+    Visit(stmt);
   }
 }
 
 void Visitor::visit(Config &config)
 {
-  for (Statement *stmt : config.stmts) {
-    Visit(*stmt);
+  for (Statement &stmt : config.stmts) {
+    Visit(stmt);
   }
 }
 
@@ -203,20 +203,20 @@ void Visitor::visit(SubprogArg &subprog_arg __attribute__((__unused__)))
 
 void Visitor::visit(Subprog &subprog)
 {
-  for (SubprogArg *arg : subprog.args) {
-    Visit(*arg);
+  for (SubprogArg &arg : subprog.args) {
+    Visit(arg);
   }
-  for (Statement *stmt : subprog.stmts) {
-    Visit(*stmt);
+  for (Statement &stmt : subprog.stmts) {
+    Visit(stmt);
   }
 }
 
 void Visitor::visit(Program &program)
 {
-  for (Subprog *subprog : program.functions)
-    Visit(*subprog);
-  for (Probe *probe : program.probes)
-    Visit(*probe);
+  for (Subprog &subprog : program.functions)
+    Visit(subprog);
+  for (Probe &probe : program.probes)
+    Visit(probe);
   if (program.config)
     Visit(*program.config);
 }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -136,8 +136,8 @@ public:
   std::string get_param(size_t index, bool is_str) const;
   size_t num_params() const;
   void request_finalize();
-  std::string get_string_literal(const ast::Expression *expr) const;
-  std::optional<int64_t> get_int_literal(const ast::Expression *expr) const;
+  std::string get_string_literal(const ast::Expression &expr) const;
+  std::optional<int64_t> get_int_literal(const ast::Expression &expr) const;
   std::optional<std::string> get_watchpoint_binary_path() const;
   virtual bool is_traceable_func(const std::string &func_name) const;
   virtual std::unordered_set<std::string> get_func_modules(

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -502,9 +502,9 @@ void ClangParser::resolve_incomplete_types_from_btf(
   // The maximum number of iterations can be also controlled by the
   // BPFTRACE_MAX_TYPE_RES_ITERATIONS env variable (0 is unlimited).
   uint64_t field_lvl = 1;
-  for (auto &probe : probes)
-    if (probe->tp_args_structs_level > (int)field_lvl)
-      field_lvl = probe->tp_args_structs_level;
+  for (ast::Probe &probe : probes)
+    if (probe.tp_args_structs_level > (int)field_lvl)
+      field_lvl = probe.tp_args_structs_level;
 
   unsigned max_iterations = std::max(
       bpftrace.config_.get(ConfigKeyInt::max_type_res_iterations), field_lvl);

--- a/src/container/ref.h
+++ b/src/container/ref.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <functional>
+
+namespace bpftrace {
+
+/**
+ * A non-nullable reference type which can be updated and stored in containers.
+ *
+ * ref is based on std::reference_wrapper but has a shorter name and
+ * getter operator to make it easier to use.
+ */
+template <typename T>
+class ref : public std::reference_wrapper<T> {
+public:
+  ref(T &t) : std::reference_wrapper<T>{ t }
+  {
+  }
+
+  constexpr T &operator()() const
+  {
+    return this->get();
+  }
+
+  constexpr T &operator()()
+  {
+    return this->get();
+  }
+
+  constexpr T *ptr() const
+  {
+    return &this->get();
+  }
+
+  constexpr T *ptr()
+  {
+    return &this->get();
+  }
+
+  friend constexpr bool operator==(ref<T> lhs, ref<T> rhs)
+  {
+    return lhs.ptr() == rhs.ptr();
+  }
+};
+
+} // namespace bpftrace

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -81,28 +81,27 @@ void Driver::error(const std::string &m)
 std::set<std::string> Driver::list_modules() const
 {
   std::set<std::string> modules;
-  for (auto &probe : ctx.root->probes) {
-    for (auto &ap : probe->attach_points) {
-      auto probe_type = probetype(ap->provider);
+  for (ast::Probe &probe : ctx.root->probes) {
+    for (ast::AttachPoint &ap : probe.attach_points) {
+      auto probe_type = probetype(ap.provider);
       if (probe_type == ProbeType::kfunc || probe_type == ProbeType::kretfunc ||
           ((probe_type == ProbeType::kprobe ||
             probe_type == ProbeType::kretprobe) &&
-           !ap->target.empty())) {
-        if (ap->expansion != ast::ExpansionType::NONE) {
-          for (auto &match :
-               bpftrace_.probe_matcher_->get_matches_for_ap(*ap)) {
+           !ap.target.empty())) {
+        if (ap.expansion != ast::ExpansionType::NONE) {
+          for (auto &match : bpftrace_.probe_matcher_->get_matches_for_ap(ap)) {
             std::string func = match;
             erase_prefix(func);
             auto match_modules = bpftrace_.get_func_modules(func);
             modules.insert(match_modules.begin(), match_modules.end());
           }
         } else
-          modules.insert(ap->target);
+          modules.insert(ap.target);
       } else if (probe_type == ProbeType::tracepoint) {
         // For now, we support this for a single target only since tracepoints
         // need dumping of C definitions BTF and that is not available for
         // multiple modules at once.
-        modules.insert(ap->target);
+        modules.insert(ap.target);
       }
     }
   }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -177,7 +177,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 
 program:
                 c_definitions config probes_and_subprogs END {
-                    driver.ctx.root = driver.ctx.make_node<ast::Program>($1, $2, std::move($3.second), std::move($3.first));
+                    driver.ctx.root = &driver.ctx.make_node<ast::Program>($1, $2, std::move($3.second), std::move($3.first));
                 }
                 ;
 
@@ -256,7 +256,7 @@ struct_type:
                 ;
 
 config:
-                CONFIG ASSIGN config_block     { $$ = driver.ctx.make_node<ast::Config>(std::move($3)); }
+                CONFIG ASSIGN config_block     { $$ = &driver.ctx.make_node<ast::Config>(std::move($3)); }
         |        %empty                        { $$ = nullptr; }
                 ;
 
@@ -264,48 +264,48 @@ config:
  * The last statement in a config_block does not require a trailing semicolon.
  */
 config_block:   "{" config_assign_stmt_list "}"                    { $$ = std::move($2); }
-            |   "{" config_assign_stmt_list config_assign_stmt "}" { $$ = std::move($2); $$.push_back($3); }
+            |   "{" config_assign_stmt_list config_assign_stmt "}" { $$ = std::move($2); $$.push_back(*$3); }
                 ;
 
 config_assign_stmt_list:
-                config_assign_stmt_list config_assign_stmt ";" { $$ = std::move($1); $$.push_back($2); }
+                config_assign_stmt_list config_assign_stmt ";" { $$ = std::move($1); $$.push_back(*$2); }
         |       %empty                                         { $$ = ast::StatementList{}; }
                 ;
 
 config_assign_stmt:
-                IDENT ASSIGN expr   { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @2); }
+                IDENT ASSIGN expr   { $$ = &driver.ctx.make_node<ast::AssignConfigVarStatement>($1, *$3, @2); }
                 ;
 
 subprog:
                 SUBPROG IDENT "(" subprog_args ")" ":" type block {
-                    $$ = driver.ctx.make_node<ast::Subprog>($2, $7, std::move($4), std::move($8));
+                    $$ = &driver.ctx.make_node<ast::Subprog>($2, $7, std::move($4), std::move($8));
                 }
         |       SUBPROG IDENT "(" ")" ":" type block {
-                    $$ = driver.ctx.make_node<ast::Subprog>($2, $6, ast::SubprogArgList(), std::move($7));
+                    $$ = &driver.ctx.make_node<ast::Subprog>($2, $6, ast::SubprogArgList(), std::move($7));
                 }
                 ;
 
 subprog_args:
-                subprog_args "," subprog_arg { $$ = std::move($1); $$.push_back($3); }
-        |       subprog_arg                  { $$ = ast::SubprogArgList{$1}; }
+                subprog_args "," subprog_arg { $$ = std::move($1); $$.push_back(*$3); }
+        |       subprog_arg                  { $$ = ast::SubprogArgList{*$1}; }
                 ;
 
 subprog_arg:
-                VAR ":" type { $$ = driver.ctx.make_node<ast::SubprogArg>($1, $3); }
+                VAR ":" type { $$ = &driver.ctx.make_node<ast::SubprogArg>($1, $3); }
                 ;
 
 probes_and_subprogs:
-                probes_and_subprogs probe   { $$ = std::move($1); $$.first.push_back($2); }
-        |       probes_and_subprogs subprog { $$ = std::move($1); $$.second.push_back($2); }
-        |       probe        { $$ = { ast::ProbeList{$1}, ast::SubprogList{}}; }
-        |       subprog      { $$ = { ast::ProbeList{}, ast::SubprogList{$1}}; }
+                probes_and_subprogs probe   { $$ = std::move($1); $$.first.push_back(*$2); }
+        |       probes_and_subprogs subprog { $$ = std::move($1); $$.second.push_back(*$2); }
+        |       probe        { $$ = { ast::ProbeList{*$1}, ast::SubprogList{}}; }
+        |       subprog      { $$ = { ast::ProbeList{}, ast::SubprogList{*$1}}; }
                 ;
 
 probe:
                 attach_points pred block
                 {
                   if (!driver.listing_)
-                    $$ = driver.ctx.make_node<ast::Probe>(std::move($1), $2, std::move($3));
+                    $$ = &driver.ctx.make_node<ast::Probe>(std::move($1), $2, std::move($3));
                   else
                   {
                     error(@$, "unexpected listing query format");
@@ -315,7 +315,7 @@ probe:
         |       attach_points END
                 {
                   if (driver.listing_)
-                    $$ = driver.ctx.make_node<ast::Probe>(std::move($1), nullptr, ast::StatementList());
+                    $$ = &driver.ctx.make_node<ast::Probe>(std::move($1), nullptr, ast::StatementList());
                   else
                   {
                     error(@$, "unexpected end of file, expected {");
@@ -325,12 +325,12 @@ probe:
                 ;
 
 attach_points:
-                attach_points "," attach_point { $$ = std::move($1); $$.push_back($3); }
-        |       attach_point                   { $$ = ast::AttachPointList{$1}; }
+                attach_points "," attach_point { $$ = std::move($1); $$.push_back(*$3); }
+        |       attach_point                   { $$ = ast::AttachPointList{*$1}; }
                 ;
 
 attach_point:
-                attach_point_def                { $$ = driver.ctx.make_node<ast::AttachPoint>($1, @$); }
+                attach_point_def                { $$ = &driver.ctx.make_node<ast::AttachPoint>($1, @$); }
                 ;
 
 attach_point_def:
@@ -363,7 +363,7 @@ attach_point_def:
                 ;
 
 pred:
-                DIV expr ENDPRED { $$ = driver.ctx.make_node<ast::Predicate>($2, @$); }
+                DIV expr ENDPRED { $$ = &driver.ctx.make_node<ast::Predicate>(*$2, @$); }
         |        %empty           { $$ = nullptr; }
                 ;
 
@@ -373,14 +373,14 @@ param:
                         try {
                           long n = std::stol($1.substr(1, $1.size()-1));
                           if (n == 0) throw std::exception();
-                          $$ = driver.ctx.make_node<ast::PositionalParameter>(PositionalParameterType::positional, n, @$);
+                          $$ = &driver.ctx.make_node<ast::PositionalParameter>(PositionalParameterType::positional, n, @$);
                         } catch (std::exception const& e) {
                           error(@1, "param " + $1 + " is out of integer range [1, " +
                                 std::to_string(std::numeric_limits<long>::max()) + "]");
                           YYERROR;
                         }
                       }
-        |       PARAMCOUNT { $$ = driver.ctx.make_node<ast::PositionalParameter>(PositionalParameterType::count, 0, @$); }
+        |       PARAMCOUNT { $$ = &driver.ctx.make_node<ast::PositionalParameter>(PositionalParameterType::count, 0, @$); }
                 ;
 
 /*
@@ -388,12 +388,12 @@ param:
  */
 block:
                 "{" stmt_list "}"                   { $$ = std::move($2); }
-        |       "{" stmt_list expr_stmt "}"         { $$ = std::move($2); $$.push_back($3); }
+        |       "{" stmt_list expr_stmt "}"         { $$ = std::move($2); $$.push_back(*$3); }
                 ;
 
 stmt_list:
-                stmt_list expr_stmt ";" { $$ = std::move($1); $$.push_back($2); }
-        |       stmt_list block_stmt    { $$ = std::move($1); $$.push_back($2); }
+                stmt_list expr_stmt ";" { $$ = std::move($1); $$.push_back(*$2); }
+        |       stmt_list block_stmt    { $$ = std::move($1); $$.push_back(*$2); }
         |       %empty                  { $$ = ast::StatementList{}; }
                 ;
 
@@ -404,7 +404,7 @@ block_stmt:
                 ;
 
 expr_stmt:
-                expr               { $$ = driver.ctx.make_node<ast::ExprStatement>($1, @1); }
+                expr               { $$ = &driver.ctx.make_node<ast::ExprStatement>(*$1, @1); }
         |       jump_stmt          { $$ = $1; }
 /*
  * quirk. Assignment is not an expression but the AssignMapStatement makes it difficult
@@ -414,30 +414,30 @@ expr_stmt:
                 ;
 
 jump_stmt:
-                BREAK       { $$ = driver.ctx.make_node<ast::Jump>(ast::JumpType::BREAK, @$); }
-        |       CONTINUE    { $$ = driver.ctx.make_node<ast::Jump>(ast::JumpType::CONTINUE, @$); }
-        |       RETURN      { $$ = driver.ctx.make_node<ast::Jump>(ast::JumpType::RETURN, @$); }
-        |       RETURN expr { $$ = driver.ctx.make_node<ast::Jump>(ast::JumpType::RETURN, $2, @$); }
+                BREAK       { $$ = &driver.ctx.make_node<ast::Jump>(ast::JumpType::BREAK, @$); }
+        |       CONTINUE    { $$ = &driver.ctx.make_node<ast::Jump>(ast::JumpType::CONTINUE, @$); }
+        |       RETURN      { $$ = &driver.ctx.make_node<ast::Jump>(ast::JumpType::RETURN, @$); }
+        |       RETURN expr { $$ = &driver.ctx.make_node<ast::Jump>(ast::JumpType::RETURN, *$2, @$); }
                 ;
 
 loop_stmt:
-                UNROLL "(" int ")" block             { $$ = driver.ctx.make_node<ast::Unroll>($3, std::move($5), @1 + @4); }
-        |       UNROLL "(" param ")" block           { $$ = driver.ctx.make_node<ast::Unroll>($3, std::move($5), @1 + @4); }
-        |       WHILE  "(" expr ")" block            { $$ = driver.ctx.make_node<ast::While>($3, std::move($5), @1); }
+                UNROLL "(" int ")" block             { $$ = &driver.ctx.make_node<ast::Unroll>(*$3, std::move($5), @1 + @4); }
+        |       UNROLL "(" param ")" block           { $$ = &driver.ctx.make_node<ast::Unroll>(*$3, std::move($5), @1 + @4); }
+        |       WHILE  "(" expr ")" block            { $$ = &driver.ctx.make_node<ast::While>(*$3, std::move($5), @1); }
                 ;
 
 for_stmt:
-                FOR "(" var ":" expr ")" block       { $$ = driver.ctx.make_node<ast::For>($3, $5, std::move($7), @1); }
+                FOR "(" var ":" expr ")" block       { $$ = &driver.ctx.make_node<ast::For>(*$3, *$5, std::move($7), @1); }
                 ;
 
 if_stmt:
-                IF "(" expr ")" block                  { $$ = driver.ctx.make_node<ast::If>($3, std::move($5)); }
-        |       IF "(" expr ")" block ELSE block_or_if { $$ = driver.ctx.make_node<ast::If>($3, std::move($5), std::move($7)); }
+                IF "(" expr ")" block                  { $$ = &driver.ctx.make_node<ast::If>(*$3, std::move($5)); }
+        |       IF "(" expr ")" block ELSE block_or_if { $$ = &driver.ctx.make_node<ast::If>(*$3, std::move($5), std::move($7)); }
                 ;
 
 block_or_if:
                 block        { $$ = std::move($1); }
-        |       if_stmt      { $$ = ast::StatementList{$1}; }
+        |       if_stmt      { $$ = ast::StatementList{*$1}; }
                 ;
 
 assign_stmt:
@@ -446,52 +446,52 @@ assign_stmt:
                   error(@1 + @3, "Tuples are immutable once created. Consider creating a new tuple and assigning it instead.");
                   YYERROR;
                 }
-        |       map ASSIGN expr      { $$ = driver.ctx.make_node<ast::AssignMapStatement>($1, $3, @$); }
-        |       var ASSIGN expr      { $$ = driver.ctx.make_node<ast::AssignVarStatement>($1, $3, @$); }
+        |       map ASSIGN expr      { $$ = &driver.ctx.make_node<ast::AssignMapStatement>(*$1, *$3, @$); }
+        |       var ASSIGN expr      { $$ = &driver.ctx.make_node<ast::AssignVarStatement>(*$1, *$3, @$); }
         |       map compound_op expr
                 {
-                  auto b = driver.ctx.make_node<ast::Binop>($1, $2, $3, @2);
-                  $$ = driver.ctx.make_node<ast::AssignMapStatement>($1, b, @$);
+                  auto &b = driver.ctx.make_node<ast::Binop>(*$1, $2, *$3, @2);
+                  $$ = &driver.ctx.make_node<ast::AssignMapStatement>(*$1, b, @$);
                 }
         |       var compound_op expr
                 {
-                  auto b = driver.ctx.make_node<ast::Binop>($1, $2, $3, @2);
-                  $$ = driver.ctx.make_node<ast::AssignVarStatement>($1, b, @$);
+                  auto &b = driver.ctx.make_node<ast::Binop>(*$1, $2, *$3, @2);
+                  $$ = &driver.ctx.make_node<ast::AssignVarStatement>(*$1, b, @$);
                 }
         ;
 
 primary_expr:
-                IDENT              { $$ = driver.ctx.make_node<ast::Identifier>($1, @$); }
+                IDENT              { $$ = &driver.ctx.make_node<ast::Identifier>($1, @$); }
         |       int                { $$ = $1; }
-        |       STRING             { $$ = driver.ctx.make_node<ast::String>($1, @$); }
-        |       STACK_MODE         { $$ = driver.ctx.make_node<ast::StackMode>($1, @$); }
-        |       BUILTIN            { $$ = driver.ctx.make_node<ast::Builtin>($1, @$); }
-        |       CALL_BUILTIN       { $$ = driver.ctx.make_node<ast::Builtin>($1, @$); }
+        |       STRING             { $$ = &driver.ctx.make_node<ast::String>($1, @$); }
+        |       STACK_MODE         { $$ = &driver.ctx.make_node<ast::StackMode>($1, @$); }
+        |       BUILTIN            { $$ = &driver.ctx.make_node<ast::Builtin>($1, @$); }
+        |       CALL_BUILTIN       { $$ = &driver.ctx.make_node<ast::Builtin>($1, @$); }
         |       LPAREN expr RPAREN { $$ = $2; }
         |       param              { $$ = $1; }
         |       map_or_var         { $$ = $1; }
         |       "(" vargs "," expr ")"
                 {
                   auto &args = $2;
-                  args.push_back($4);
-                  $$ = driver.ctx.make_node<ast::Tuple>(std::move(args), @$);
+                  args.push_back(*$4);
+                  $$ = &driver.ctx.make_node<ast::Tuple>(std::move(args), @$);
                 }
                 ;
 
 postfix_expr:
                 primary_expr                   { $$ = $1; }
 /* pointer  */
-        |       postfix_expr DOT external_name { $$ = driver.ctx.make_node<ast::FieldAccess>($1, $3, @2); }
-        |       postfix_expr PTR external_name { $$ = driver.ctx.make_node<ast::FieldAccess>(driver.ctx.make_node<ast::Unop>(ast::Operator::MUL, $1, @2), $3, @$); }
+        |       postfix_expr DOT external_name { $$ = &driver.ctx.make_node<ast::FieldAccess>(*$1, $3, @2); }
+        |       postfix_expr PTR external_name { $$ = &driver.ctx.make_node<ast::FieldAccess>(driver.ctx.make_node<ast::Unop>(ast::Operator::MUL, *$1, @2), $3, @$); }
 /* tuple  */
         |       tuple_access_expr              { $$ = $1; }
 /* array  */
-        |       postfix_expr "[" expr "]"      { $$ = driver.ctx.make_node<ast::ArrayAccess>($1, $3, @2 + @4); }
+        |       postfix_expr "[" expr "]"      { $$ = &driver.ctx.make_node<ast::ArrayAccess>(*$1, *$3, @2 + @4); }
         |       call                           { $$ = $1; }
         |       sizeof_expr                    { $$ = $1; }
         |       offsetof_expr                  { $$ = $1; }
-        |       map_or_var INCREMENT           { $$ = driver.ctx.make_node<ast::Unop>(ast::Operator::INCREMENT, $1, true, @2); }
-        |       map_or_var DECREMENT           { $$ = driver.ctx.make_node<ast::Unop>(ast::Operator::DECREMENT, $1, true, @2); }
+        |       map_or_var INCREMENT           { $$ = &driver.ctx.make_node<ast::Unop>(ast::Operator::INCREMENT, *$1, true, @2); }
+        |       map_or_var DECREMENT           { $$ = &driver.ctx.make_node<ast::Unop>(ast::Operator::DECREMENT, *$1, true, @2); }
 /* errors */
         |       INCREMENT ident                { error(@1, "The ++ operator must be applied to a map or variable"); YYERROR; }
         |       DECREMENT ident                { error(@1, "The -- operator must be applied to a map or variable"); YYERROR; }
@@ -499,16 +499,16 @@ postfix_expr:
 
 /* Tuple factored out so we can use it in the tuple field assignment error */
 tuple_access_expr:
-                postfix_expr DOT INT      { $$ = driver.ctx.make_node<ast::FieldAccess>($1, $3, @3); }
+                postfix_expr DOT INT      { $$ = &driver.ctx.make_node<ast::FieldAccess>(*$1, $3, @3); }
                 ;
 
 
 
 unary_expr:
-                unary_op cast_expr   { $$ = driver.ctx.make_node<ast::Unop>($1, $2, @1); }
+                unary_op cast_expr   { $$ = &driver.ctx.make_node<ast::Unop>($1, *$2, @1); }
         |       postfix_expr         { $$ = $1; }
-        |       INCREMENT map_or_var { $$ = driver.ctx.make_node<ast::Unop>(ast::Operator::INCREMENT, $2, @1); }
-        |       DECREMENT map_or_var { $$ = driver.ctx.make_node<ast::Unop>(ast::Operator::DECREMENT, $2, @1); }
+        |       INCREMENT map_or_var { $$ = &driver.ctx.make_node<ast::Unop>(ast::Operator::INCREMENT, *$2, @1); }
+        |       DECREMENT map_or_var { $$ = &driver.ctx.make_node<ast::Unop>(ast::Operator::DECREMENT, *$2, @1); }
 /* errors */
         |       ident DECREMENT      { error(@1, "The -- operator must be applied to a map or variable"); YYERROR; }
         |       ident INCREMENT      { error(@1, "The ++ operator must be applied to a map or variable"); YYERROR; }
@@ -527,92 +527,92 @@ expr:
 
 conditional_expr:
                 logical_or_expr                                  { $$ = $1; }
-        |       logical_or_expr QUES expr COLON conditional_expr { $$ = driver.ctx.make_node<ast::Ternary>($1, $3, $5, @$); }
+        |       logical_or_expr QUES expr COLON conditional_expr { $$ = &driver.ctx.make_node<ast::Ternary>(*$1, *$3, *$5, @$); }
                 ;
 
 
 logical_or_expr:
                 logical_and_expr                     { $$ = $1; }
-        |       logical_or_expr LOR logical_and_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::LOR, $3, @2); }
+        |       logical_or_expr LOR logical_and_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::LOR, *$3, @2); }
                 ;
 
 logical_and_expr:
                 or_expr                       { $$ = $1; }
-        |       logical_and_expr LAND or_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::LAND, $3, @2); }
+        |       logical_and_expr LAND or_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::LAND, *$3, @2); }
                 ;
 
 or_expr:
                 xor_expr             { $$ = $1; }
-        |       or_expr BOR xor_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::BOR, $3, @2); }
+        |       or_expr BOR xor_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::BOR, *$3, @2); }
                 ;
 
 xor_expr:
                 and_expr               { $$ = $1; }
-        |       xor_expr BXOR and_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::BXOR, $3, @2); }
+        |       xor_expr BXOR and_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::BXOR, *$3, @2); }
                 ;
 
 
 and_expr:
                 equality_expr               { $$ = $1; }
-        |       and_expr BAND equality_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::BAND, $3, @2); }
+        |       and_expr BAND equality_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::BAND, *$3, @2); }
                 ;
 
 equality_expr:
                 relational_expr                  { $$ = $1; }
-        |       equality_expr EQ relational_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::EQ, $3, @2); }
-        |       equality_expr NE relational_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::NE, $3, @2); }
+        |       equality_expr EQ relational_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::EQ, *$3, @2); }
+        |       equality_expr NE relational_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::NE, *$3, @2); }
                 ;
 
 relational_expr:
                 shift_expr                    { $$ = $1; }
-        |       relational_expr LE shift_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::LE, $3, @2); }
-        |       relational_expr GE shift_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::GE, $3, @2); }
-        |       relational_expr LT shift_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::LT, $3, @2); }
-        |       relational_expr GT shift_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::GT, $3, @2); }
+        |       relational_expr LE shift_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::LE, *$3, @2); }
+        |       relational_expr GE shift_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::GE, *$3, @2); }
+        |       relational_expr LT shift_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::LT, *$3, @2); }
+        |       relational_expr GT shift_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::GT, *$3, @2); }
                 ;
 
 shift_expr:
                 addi_expr                  { $$ = $1; }
-        |       shift_expr LEFT addi_expr  { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::LEFT, $3, @2); }
-        |       shift_expr RIGHT addi_expr { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::RIGHT, $3, @2); }
+        |       shift_expr LEFT addi_expr  { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::LEFT, *$3, @2); }
+        |       shift_expr RIGHT addi_expr { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::RIGHT, *$3, @2); }
                 ;
 
 muli_expr:
                 cast_expr                  { $$ = $1; }
-        |       muli_expr MUL cast_expr    { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::MUL, $3, @2); }
-        |       muli_expr DIV cast_expr    { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::DIV, $3, @2); }
-        |       muli_expr MOD cast_expr    { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::MOD, $3, @2); }
+        |       muli_expr MUL cast_expr    { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::MUL, *$3, @2); }
+        |       muli_expr DIV cast_expr    { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::DIV, *$3, @2); }
+        |       muli_expr MOD cast_expr    { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::MOD, *$3, @2); }
                 ;
 
 addi_expr:
                 muli_expr                  { $$ = $1; }
-        |       addi_expr PLUS muli_expr   { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::PLUS, $3, @2); }
-        |       addi_expr MINUS muli_expr  { $$ = driver.ctx.make_node<ast::Binop>($1, ast::Operator::MINUS, $3, @2); }
+        |       addi_expr PLUS muli_expr   { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::PLUS, *$3, @2); }
+        |       addi_expr MINUS muli_expr  { $$ = &driver.ctx.make_node<ast::Binop>(*$1, ast::Operator::MINUS, *$3, @2); }
                 ;
 
 cast_expr:
                 unary_expr                                  { $$ = $1; }
-        |       LPAREN type RPAREN cast_expr                { $$ = driver.ctx.make_node<ast::Cast>($2, $4, @1 + @3); }
+        |       LPAREN type RPAREN cast_expr                { $$ = &driver.ctx.make_node<ast::Cast>($2, *$4, @1 + @3); }
 /* workaround for typedef types, see https://github.com/bpftrace/bpftrace/pull/2560#issuecomment-1521783935 */
-        |       LPAREN IDENT RPAREN cast_expr               { $$ = driver.ctx.make_node<ast::Cast>(ast::ident_to_record($2, 0), $4, @1 + @3); }
-        |       LPAREN IDENT "*" RPAREN cast_expr           { $$ = driver.ctx.make_node<ast::Cast>(ast::ident_to_record($2, 1), $5, @1 + @4); }
-        |       LPAREN IDENT "*" "*" RPAREN cast_expr       { $$ = driver.ctx.make_node<ast::Cast>(ast::ident_to_record($2, 2), $6, @1 + @5); }
+        |       LPAREN IDENT RPAREN cast_expr               { $$ = &driver.ctx.make_node<ast::Cast>(ast::ident_to_record($2, 0), *$4, @1 + @3); }
+        |       LPAREN IDENT "*" RPAREN cast_expr           { $$ = &driver.ctx.make_node<ast::Cast>(ast::ident_to_record($2, 1), *$5, @1 + @4); }
+        |       LPAREN IDENT "*" "*" RPAREN cast_expr       { $$ = &driver.ctx.make_node<ast::Cast>(ast::ident_to_record($2, 2), *$6, @1 + @5); }
                 ;
 
 sizeof_expr:
-                SIZEOF "(" type ")"                         { $$ = driver.ctx.make_node<ast::Sizeof>($3, @$); }
-        |       SIZEOF "(" expr ")"                         { $$ = driver.ctx.make_node<ast::Sizeof>($3, @$); }
+                SIZEOF "(" type ")"                         { $$ = &driver.ctx.make_node<ast::Sizeof>($3, @$); }
+        |       SIZEOF "(" expr ")"                         { $$ = &driver.ctx.make_node<ast::Sizeof>(*$3, @$); }
                 ;
 
 offsetof_expr:
-                OFFSETOF "(" struct_type "," external_name ")"      { $$ = driver.ctx.make_node<ast::Offsetof>($3, $5, @$); }
+                OFFSETOF "(" struct_type "," external_name ")"      { $$ = &driver.ctx.make_node<ast::Offsetof>($3, $5, @$); }
 /* For example: offsetof(*curtask, comm) */
-        |       OFFSETOF "(" expr "," external_name ")"             { $$ = driver.ctx.make_node<ast::Offsetof>($3, $5, @$); }
+        |       OFFSETOF "(" expr "," external_name ")"             { $$ = &driver.ctx.make_node<ast::Offsetof>(*$3, $5, @$); }
                 ;
 
 int:
-                MINUS INT    { $$ = driver.ctx.make_node<ast::Integer>((int64_t)(~(uint64_t)($2) + 1), @$); }
-        |       INT          { $$ = driver.ctx.make_node<ast::Integer>($1, @$); }
+                MINUS INT    { $$ = &driver.ctx.make_node<ast::Integer>((int64_t)(~(uint64_t)($2) + 1), @$); }
+        |       INT          { $$ = &driver.ctx.make_node<ast::Integer>($1, @$); }
                 ;
 
 keyword:
@@ -643,10 +643,10 @@ external_name:
         ;
 
 call:
-                CALL "(" ")"                 { $$ = driver.ctx.make_node<ast::Call>($1, @$); }
-        |       CALL "(" vargs ")"           { $$ = driver.ctx.make_node<ast::Call>($1, std::move($3), @$); }
-        |       CALL_BUILTIN  "(" ")"        { $$ = driver.ctx.make_node<ast::Call>($1, @$); }
-        |       CALL_BUILTIN "(" vargs ")"   { $$ = driver.ctx.make_node<ast::Call>($1, std::move($3), @$); }
+                CALL "(" ")"                 { $$ = &driver.ctx.make_node<ast::Call>($1, @$); }
+        |       CALL "(" vargs ")"           { $$ = &driver.ctx.make_node<ast::Call>($1, std::move($3), @$); }
+        |       CALL_BUILTIN  "(" ")"        { $$ = &driver.ctx.make_node<ast::Call>($1, @$); }
+        |       CALL_BUILTIN "(" vargs ")"   { $$ = &driver.ctx.make_node<ast::Call>($1, std::move($3), @$); }
         |       IDENT "(" ")"                { error(@1, "Unknown function: " + $1); YYERROR;  }
         |       IDENT "(" vargs ")"          { error(@1, "Unknown function: " + $1); YYERROR;  }
         |       BUILTIN "(" ")"              { error(@1, "Unknown function: " + $1); YYERROR;  }
@@ -656,12 +656,12 @@ call:
                 ;
 
 map:
-                MAP               { $$ = driver.ctx.make_node<ast::Map>($1, @$); }
-        |       MAP "[" vargs "]" { $$ = driver.ctx.make_node<ast::Map>($1, std::move($3), @$); }
+                MAP               { $$ = &driver.ctx.make_node<ast::Map>($1, @$); }
+        |       MAP "[" vargs "]" { $$ = &driver.ctx.make_node<ast::Map>($1, std::move($3), @$); }
                 ;
 
 var:
-                VAR { $$ = driver.ctx.make_node<ast::Variable>($1, @$); }
+                VAR { $$ = &driver.ctx.make_node<ast::Variable>($1, @$); }
                 ;
 
 map_or_var:
@@ -670,8 +670,8 @@ map_or_var:
                 ;
 
 vargs:
-                vargs "," expr { $$ = std::move($1); $$.push_back($3); }
-        |       expr           { $$ = ast::ExpressionList{$1}; }
+                vargs "," expr { $$ = std::move($1); $$.push_back(*$3); }
+        |       expr           { $$ = ast::ExpressionList{*$1}; }
                 ;
 
 compound_op:

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -445,10 +445,10 @@ FuncParamLists ProbeMatcher::get_uprobe_params(
 
 void ProbeMatcher::list_probes(ast::Program* prog)
 {
-  for (auto* probe : prog->probes) {
-    for (auto* ap : probe->attach_points) {
-      auto matches = get_matches_for_ap(*ap);
-      auto probe_type = probetype(ap->provider);
+  for (ast::Probe& probe : prog->probes) {
+    for (ast::AttachPoint& ap : probe.attach_points) {
+      auto matches = get_matches_for_ap(ap);
+      auto probe_type = probetype(ap.provider);
       FuncParamLists param_lists;
       if (bt_verbose) {
         if (probe_type == ProbeType::tracepoint)
@@ -464,7 +464,7 @@ void ProbeMatcher::list_probes(ast::Program* prog)
 
       for (auto& match : matches) {
         std::string match_print = match;
-        if (ap->lang == "cpp") {
+        if (ap.lang == "cpp") {
           std::string target = erase_prefix(match_print);
           char* demangled_name = cxxdemangle(match_print.c_str());
 
@@ -474,7 +474,7 @@ void ProbeMatcher::list_probes(ast::Program* prog)
           auto func = demangled_name ? "\"" + std::string(demangled_name) + "\""
                                      : match_print;
 
-          match_print = target + ":" + ap->lang + ":" + func;
+          match_print = target + ":" + ap.lang + ":" + func;
         }
 
         std::cout << probe_type << ":" << match_print << std::endl;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(bpftrace_test
   procmon.cpp
   probe.cpp
   config_analyser.cpp
+  ref.cpp
   resource_analyser.cpp
   required_resources.cpp
   return_path_analyser.cpp

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -14,12 +14,12 @@ TEST(ast, probe_name_special)
 {
   AttachPoint ap1{ "" };
   ap1.provider = "BEGIN";
-  Probe begin({ &ap1 }, nullptr, {});
+  Probe begin({ ap1 }, nullptr, {});
   EXPECT_EQ(begin.name(), "BEGIN");
 
   AttachPoint ap2{ "" };
   ap2.provider = "END";
-  Probe end({ &ap2 }, nullptr, {});
+  Probe end({ ap2 }, nullptr, {});
   EXPECT_EQ(end.name(), "END");
 }
 
@@ -38,13 +38,13 @@ TEST(ast, probe_name_kprobe)
   ap3.func = "sys_read";
   ap3.func_offset = 10;
 
-  Probe kprobe1({ &ap1 }, nullptr, {});
+  Probe kprobe1({ ap1 }, nullptr, {});
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  Probe kprobe2({ &ap1, &ap2 }, nullptr, {});
+  Probe kprobe2({ ap1, ap2 }, nullptr, {});
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
 
-  Probe kprobe3({ &ap1, &ap2, &ap3 }, nullptr, {});
+  Probe kprobe3({ ap1, ap2, ap3 }, nullptr, {});
   EXPECT_EQ(kprobe3.name(),
             "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");
 }
@@ -55,21 +55,21 @@ TEST(ast, probe_name_uprobe)
   ap1.provider = "uprobe";
   ap1.target = "/bin/sh";
   ap1.func = "readline";
-  Probe uprobe1({ &ap1 }, nullptr, {});
+  Probe uprobe1({ ap1 }, nullptr, {});
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
   AttachPoint ap2{ "" };
   ap2.provider = "uprobe";
   ap2.target = "/bin/sh";
   ap2.func = "somefunc";
-  Probe uprobe2({ &ap1, &ap2 }, nullptr, {});
+  Probe uprobe2({ ap1, ap2 }, nullptr, {});
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
 
   AttachPoint ap3{ "" };
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.address = 1000;
-  Probe uprobe3({ &ap1, &ap2, &ap3 }, nullptr, {});
+  Probe uprobe3({ ap1, ap2, ap3 }, nullptr, {});
   EXPECT_EQ(
       uprobe3.name(),
       "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
@@ -79,7 +79,7 @@ TEST(ast, probe_name_uprobe)
   ap4.target = "/bin/sh";
   ap4.func = "somefunc";
   ap4.func_offset = 10;
-  Probe uprobe4({ &ap1, &ap2, &ap3, &ap4 }, nullptr, {});
+  Probe uprobe4({ ap1, ap2, ap3, ap4 }, nullptr, {});
   EXPECT_EQ(uprobe4.name(),
             "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/"
             "sh:1000,uprobe:/bin/sh:somefunc+10");
@@ -88,14 +88,14 @@ TEST(ast, probe_name_uprobe)
   ap5.provider = "uprobe";
   ap5.target = "/bin/sh";
   ap5.address = 10;
-  Probe uprobe5({ &ap5 }, nullptr, {});
+  Probe uprobe5({ ap5 }, nullptr, {});
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
 
   AttachPoint ap6{ "" };
   ap6.provider = "uretprobe";
   ap6.target = "/bin/sh";
   ap6.address = 10;
-  Probe uprobe6({ &ap6 }, nullptr, {});
+  Probe uprobe6({ ap6 }, nullptr, {});
   EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
 }
 
@@ -105,14 +105,14 @@ TEST(ast, probe_name_usdt)
   ap1.provider = "usdt";
   ap1.target = "/bin/sh";
   ap1.func = "probe1";
-  Probe usdt1({ &ap1 }, nullptr, {});
+  Probe usdt1({ ap1 }, nullptr, {});
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
   AttachPoint ap2{ "" };
   ap2.provider = "usdt";
   ap2.target = "/bin/sh";
   ap2.func = "probe2";
-  Probe usdt2({ &ap1, &ap2 }, nullptr, {});
+  Probe usdt2({ ap1, ap2 }, nullptr, {});
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
 }
 
@@ -128,10 +128,10 @@ TEST(ast, attach_point_name)
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.func = "readline";
-  Probe kprobe({ &ap1, &ap2, &ap3 }, nullptr, {});
+  Probe kprobe({ ap1, ap2, ap3 }, nullptr, {});
   EXPECT_EQ(ap2.name(), "kprobe:sys_thisone");
 
-  Probe uprobe({ &ap1, &ap2, &ap3 }, nullptr, {});
+  Probe uprobe({ ap1, ap2, ap3 }, nullptr, {});
   EXPECT_EQ(ap3.name(), "uprobe:/bin/sh:readline");
 }
 

--- a/tests/collect_nodes.cpp
+++ b/tests/collect_nodes.cpp
@@ -31,7 +31,7 @@ TEST(CollectNodes, direct)
 TEST(CollectNodes, indirect)
 {
   auto &var = *new Variable{ "myvar", bpftrace::location{} };
-  auto &unop = *new Unop{ Operator::INCREMENT, &var, bpftrace::location{} };
+  auto &unop = *new Unop{ Operator::INCREMENT, var, bpftrace::location{} };
 
   CollectNodes<Variable> visitor;
   visitor.run(unop);
@@ -42,7 +42,7 @@ TEST(CollectNodes, indirect)
 TEST(CollectNodes, none)
 {
   auto &map = *new Map{ "myvar", bpftrace::location{} };
-  auto &unop = *new Unop{ Operator::INCREMENT, &map, bpftrace::location{} };
+  auto &unop = *new Unop{ Operator::INCREMENT, map, bpftrace::location{} };
 
   CollectNodes<Variable> visitor;
   visitor.run(unop);
@@ -53,10 +53,10 @@ TEST(CollectNodes, none)
 TEST(CollectNodes, multiple_runs)
 {
   auto &var1 = *new Variable{ "myvar1", bpftrace::location{} };
-  auto &unop1 = *new Unop{ Operator::INCREMENT, &var1, bpftrace::location{} };
+  auto &unop1 = *new Unop{ Operator::INCREMENT, var1, bpftrace::location{} };
 
   auto &var2 = *new Variable{ "myvar2", bpftrace::location{} };
-  auto &unop2 = *new Unop{ Operator::INCREMENT, &var2, bpftrace::location{} };
+  auto &unop2 = *new Unop{ Operator::INCREMENT, var2, bpftrace::location{} };
 
   CollectNodes<Variable> visitor;
   visitor.run(unop1);
@@ -70,9 +70,7 @@ TEST(CollectNodes, multiple_children)
   auto &var1 = *new Variable{ "myvar1", bpftrace::location{} };
   auto &var2 = *new Variable{ "myvar2", bpftrace::location{} };
 
-  auto &binop = *new Binop{
-    &var1, Operator::PLUS, &var2, bpftrace::location{}
-  };
+  auto &binop = *new Binop{ var1, Operator::PLUS, var2, bpftrace::location{} };
 
   CollectNodes<Variable> visitor;
   visitor.run(binop);
@@ -85,9 +83,7 @@ TEST(CollectNodes, predicate)
   auto &var1 = *new Variable{ "myvar1", bpftrace::location{} };
   auto &var2 = *new Variable{ "myvar2", bpftrace::location{} };
 
-  auto &binop = *new Binop{
-    &var1, Operator::PLUS, &var2, bpftrace::location{}
-  };
+  auto &binop = *new Binop{ var1, Operator::PLUS, var2, bpftrace::location{} };
 
   CollectNodes<Variable> visitor;
   visitor.run(binop, [](const auto &var) { return var.ident == "myvar2"; });
@@ -101,11 +97,9 @@ TEST(CollectNodes, nested)
   auto &var2 = *new Variable{ "myvar2", bpftrace::location{} };
   auto &var3 = *new Variable{ "myvar3", bpftrace::location{} };
 
-  auto &binop1 = *new Binop{
-    &var1, Operator::PLUS, &var2, bpftrace::location{}
-  };
+  auto &binop1 = *new Binop{ var1, Operator::PLUS, var2, bpftrace::location{} };
   auto &binop2 = *new Binop{
-    &binop1, Operator::MINUS, &var3, bpftrace::location{}
+    binop1, Operator::MINUS, var3, bpftrace::location{}
   };
 
   CollectNodes<Binop> visitor;

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -42,7 +42,7 @@ void test(BPFtrace &bpftrace, std::string_view input, std::string_view expected)
 
   std::ostringstream out;
   Printer printer(out);
-  printer.print(driver.ctx.root);
+  printer.print(*driver.ctx.root);
   EXPECT_EQ(expected, out.str());
 }
 

--- a/tests/ref.cpp
+++ b/tests/ref.cpp
@@ -1,0 +1,80 @@
+#include "container/ref.h"
+#include "gtest/gtest.h"
+
+#include <type_traits>
+
+namespace bpftrace::test::ref {
+
+using bpftrace::ref;
+
+class Base {};
+
+class ClassA : public Base {};
+
+class ClassB : public Base {};
+
+TEST(ref, construct)
+{
+  // From exact type
+  EXPECT_TRUE((std::is_constructible_v<ref<ClassA>, ClassA &>));
+  EXPECT_TRUE((std::is_constructible_v<ref<ClassA>, ref<ClassA>>));
+
+  // From derived type
+  EXPECT_TRUE((std::is_constructible_v<ref<Base>, ClassA &>));
+  EXPECT_TRUE((std::is_constructible_v<ref<Base>, ref<ClassA>>));
+
+  // From non-derived type
+  EXPECT_FALSE((std::is_constructible_v<ref<ClassB>, ClassA &>));
+  EXPECT_FALSE((std::is_constructible_v<ref<ClassB>, ref<ClassA>>));
+}
+
+TEST(ref, operator_get)
+{
+  int n = 123;
+  ref<int> n_ref{ n };
+
+  EXPECT_EQ(123, n_ref());
+}
+
+TEST(ref, const_operator_get)
+{
+  int n = 123;
+  const ref<int> n_ref{ n };
+
+  EXPECT_EQ(123, n_ref());
+}
+
+TEST(ref, ptr)
+{
+  int n = 123;
+  ref<int> n_ref{ n };
+
+  EXPECT_EQ(&n, n_ref.ptr());
+}
+
+TEST(ref, const_ptr)
+{
+  int n = 123;
+  const ref<int> n_ref{ n };
+
+  EXPECT_EQ(&n, n_ref.ptr());
+}
+
+TEST(ref, eq_ref_ref)
+{
+  int n = 123;
+  int m = 456;
+
+  ref<int> a{ n };
+  ref<int> b{ n };
+  ref<int> c{ m };
+
+  EXPECT_EQ(a, b);
+  EXPECT_NE(a, c);
+  EXPECT_EQ(b, a);
+  EXPECT_NE(b, c);
+  EXPECT_NE(c, a);
+  EXPECT_NE(c, b);
+}
+
+} // namespace bpftrace::test::ref

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -266,23 +266,23 @@ TEST(tracepoint_format_parser, args_field_access)
   ast::TracepointArgsVisitor visitor;
 
   EXPECT_EQ(driver.parse_str("BEGIN { args.f1->f2->f3 }"), 0);
-  visitor.visit(*driver.ctx.root->probes.at(0));
-  EXPECT_EQ(driver.ctx.root->probes.at(0)->tp_args_structs_level, 3);
+  visitor.visit(driver.ctx.root->probes.at(0));
+  EXPECT_EQ(driver.ctx.root->probes.at(0)().tp_args_structs_level, 3);
 
   // Should work via intermediary variable, too
   EXPECT_EQ(driver.parse_str("BEGIN { $x = args.f1; $x->f2->f3 }"), 0);
-  visitor.visit(*driver.ctx.root->probes.at(0));
-  EXPECT_EQ(driver.ctx.root->probes.at(0)->tp_args_structs_level, 3);
+  visitor.visit(driver.ctx.root->probes.at(0));
+  EXPECT_EQ(driver.ctx.root->probes.at(0)().tp_args_structs_level, 3);
 
   // "args" used without field access => level should be 0
   EXPECT_EQ(driver.parse_str("BEGIN { args }"), 0);
-  visitor.visit(*driver.ctx.root->probes.at(0));
-  EXPECT_EQ(driver.ctx.root->probes.at(0)->tp_args_structs_level, 0);
+  visitor.visit(driver.ctx.root->probes.at(0));
+  EXPECT_EQ(driver.ctx.root->probes.at(0)().tp_args_structs_level, 0);
 
   // "args" not used => level should be -1
   EXPECT_EQ(driver.parse_str("BEGIN { x->f1->f2->f3 }"), 0);
-  visitor.visit(*driver.ctx.root->probes.at(0));
-  EXPECT_EQ(driver.ctx.root->probes.at(0)->tp_args_structs_level, -1);
+  visitor.visit(driver.ctx.root->probes.at(0));
+  EXPECT_EQ(driver.ctx.root->probes.at(0)().tp_args_structs_level, -1);
 }
 
 } // namespace tracepoint_format_parser


### PR DESCRIPTION
Introduce a new class `ref` which holds references / non-nullable pointers.

-----

This'll cause **a lot** of conflicts so I'm happy to rebase other PRs on top of these changes to ease the process for others.

Instructions for rebasing:
1. Rebase, resolving conflicts by taking the changes from other PRs and discarding the stuff from this/master: `git rebase -i upstream/master -Xtheirs` (yes, `theirs`, not `ours`, even though it sounds wrong)
2. Try to compile: `ninja` / `make`
3. Fix build errors by removing `*`, replacing `->` with `.`, etc.