### PR TITLE
clang-tidy: Make codebase bugprone-unchecked-optional-access clean

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -3,6 +3,7 @@ Checks: |
   performance-unnecessary-copy-initialization
   modernize-loop-convert
   google-readability-casting
+  bugprone-unchecked-optional-access
 
 WarningsAsErrors: "*"
 UseColor: true

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <time.h>
+
 #include <cstdint>
 #include <iostream>
 #include <map>

--- a/src/child.cpp
+++ b/src/child.cpp
@@ -107,7 +107,10 @@ static void validate_cmd(std::vector<std::string>& cmd)
       // /usr/bin/ping
       std::unordered_set<std::string> uniq_abs_path;
       for (const auto& path : paths) {
-        uniq_abs_path.insert(abs_path(path).value());
+        auto absolute = abs_path(path);
+        if (!absolute.has_value())
+          continue;
+        uniq_abs_path.insert(*absolute);
       }
 
       if (uniq_abs_path.size() == 1) {

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -354,10 +354,14 @@ TEST(clang_parser, bitfields)
   ASSERT_TRUE(foo->HasField("b"));
   ASSERT_TRUE(foo->HasField("c"));
 
+  // clang-tidy doesn't seem to acknowledge that ASSERT_*() will
+  // return from function so that these are in fact checked accesses.
+  //
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   EXPECT_TRUE(foo->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("a").offset, 0);
-  EXPECT_TRUE(foo->GetField("a").bitfield.has_value());
+  ASSERT_TRUE(foo->GetField("a").bitfield.has_value());
   EXPECT_EQ(foo->GetField("a").bitfield->read_bytes, 0x1U);
   EXPECT_EQ(foo->GetField("a").bitfield->access_rshift, 0U);
   EXPECT_EQ(foo->GetField("a").bitfield->mask, 0xFFU);
@@ -377,6 +381,7 @@ TEST(clang_parser, bitfields)
   EXPECT_EQ(foo->GetField("c").bitfield->read_bytes, 0x2U);
   EXPECT_EQ(foo->GetField("c").bitfield->access_rshift, 0U);
   EXPECT_EQ(foo->GetField("c").bitfield->mask, 0xFFFFU);
+  // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST(clang_parser, bitfields_uneven_fields)
@@ -395,10 +400,14 @@ TEST(clang_parser, bitfields_uneven_fields)
   ASSERT_TRUE(foo->HasField("d"));
   ASSERT_TRUE(foo->HasField("e"));
 
+  // clang-tidy doesn't seem to acknowledge that ASSERT_*() will
+  // return from function so that these are in fact checked accesses.
+  //
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   EXPECT_TRUE(foo->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("a").offset, 0);
-  EXPECT_TRUE(foo->GetField("a").bitfield.has_value());
+  ASSERT_TRUE(foo->GetField("a").bitfield.has_value());
   EXPECT_EQ(foo->GetField("a").bitfield->read_bytes, 1U);
   EXPECT_EQ(foo->GetField("a").bitfield->access_rshift, 0U);
   EXPECT_EQ(foo->GetField("a").bitfield->mask, 0x1U);
@@ -406,7 +415,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_TRUE(foo->GetField("b").type.IsIntTy());
   EXPECT_EQ(foo->GetField("b").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("b").offset, 0);
-  EXPECT_TRUE(foo->GetField("b").bitfield.has_value());
+  ASSERT_TRUE(foo->GetField("b").bitfield.has_value());
   EXPECT_EQ(foo->GetField("b").bitfield->read_bytes, 1U);
   EXPECT_EQ(foo->GetField("b").bitfield->access_rshift, 1U);
   EXPECT_EQ(foo->GetField("b").bitfield->mask, 0x1U);
@@ -414,7 +423,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_TRUE(foo->GetField("c").type.IsIntTy());
   EXPECT_EQ(foo->GetField("c").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("c").offset, 0);
-  EXPECT_TRUE(foo->GetField("c").bitfield.has_value());
+  ASSERT_TRUE(foo->GetField("c").bitfield.has_value());
   EXPECT_EQ(foo->GetField("c").bitfield->read_bytes, 1U);
   EXPECT_EQ(foo->GetField("c").bitfield->access_rshift, 2U);
   EXPECT_EQ(foo->GetField("c").bitfield->mask, 0x7U);
@@ -422,7 +431,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_TRUE(foo->GetField("d").type.IsIntTy());
   EXPECT_EQ(foo->GetField("d").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("d").offset, 0);
-  EXPECT_TRUE(foo->GetField("d").bitfield.has_value());
+  ASSERT_TRUE(foo->GetField("d").bitfield.has_value());
   EXPECT_EQ(foo->GetField("d").bitfield->read_bytes, 4U);
   EXPECT_EQ(foo->GetField("d").bitfield->access_rshift, 5U);
   EXPECT_EQ(foo->GetField("d").bitfield->mask, 0xFFFFFU);
@@ -430,10 +439,11 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_TRUE(foo->GetField("e").type.IsIntTy());
   EXPECT_EQ(foo->GetField("e").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("e").offset, 3);
-  EXPECT_TRUE(foo->GetField("e").bitfield.has_value());
+  ASSERT_TRUE(foo->GetField("e").bitfield.has_value());
   EXPECT_EQ(foo->GetField("e").bitfield->read_bytes, 1U);
   EXPECT_EQ(foo->GetField("e").bitfield->access_rshift, 1U);
   EXPECT_EQ(foo->GetField("e").bitfield->mask, 0x7FU);
+  // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST(clang_parser, bitfields_with_padding)
@@ -444,6 +454,10 @@ TEST(clang_parser, bitfields_with_padding)
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
   auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
+  // clang-tidy doesn't seem to acknowledge that ASSERT_*() will
+  // return from function so that these are in fact checked accesses.
+  //
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   EXPECT_EQ(foo->size, 16);
   ASSERT_EQ(foo->fields.size(), 4U);
   ASSERT_TRUE(foo->HasField("pad"));
@@ -454,7 +468,7 @@ TEST(clang_parser, bitfields_with_padding)
   EXPECT_TRUE(foo->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("a").offset, 4);
-  EXPECT_TRUE(foo->GetField("a").bitfield.has_value());
+  ASSERT_TRUE(foo->GetField("a").bitfield.has_value());
   EXPECT_EQ(foo->GetField("a").bitfield->read_bytes, 4U);
   EXPECT_EQ(foo->GetField("a").bitfield->access_rshift, 0U);
   EXPECT_EQ(foo->GetField("a").bitfield->mask, 0xFFFFFFFU);
@@ -462,10 +476,11 @@ TEST(clang_parser, bitfields_with_padding)
   EXPECT_TRUE(foo->GetField("b").type.IsIntTy());
   EXPECT_EQ(foo->GetField("b").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("b").offset, 7);
-  EXPECT_TRUE(foo->GetField("b").bitfield.has_value());
+  ASSERT_TRUE(foo->GetField("b").bitfield.has_value());
   EXPECT_EQ(foo->GetField("b").bitfield->read_bytes, 1U);
   EXPECT_EQ(foo->GetField("b").bitfield->access_rshift, 4U);
   EXPECT_EQ(foo->GetField("b").bitfield->mask, 0xFU);
+  // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST(clang_parser, builtin_headers)

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -282,11 +282,15 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   ASSERT_TRUE(bpftrace.structs.Has("struct task_struct"));
   auto task_struct = bpftrace.structs.Lookup("struct task_struct").lock();
 
+  // clang-tidy doesn't seem to acknowledge that ASSERT_*() will
+  // return from function so that these are in fact checked accesses.
+  //
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   ASSERT_TRUE(task_struct->HasField("a"));
   EXPECT_TRUE(task_struct->GetField("a").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(task_struct->GetField("a").offset, 9);
-  EXPECT_TRUE(task_struct->GetField("a").bitfield.has_value());
+  ASSERT_TRUE(task_struct->GetField("a").bitfield.has_value());
   EXPECT_EQ(task_struct->GetField("a").bitfield->read_bytes, 0x2U);
   EXPECT_EQ(task_struct->GetField("a").bitfield->access_rshift, 4U);
   EXPECT_EQ(task_struct->GetField("a").bitfield->mask, 0xFFU);
@@ -295,7 +299,7 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   EXPECT_TRUE(task_struct->GetField("b").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("b").type.GetSize(), 4U);
   EXPECT_EQ(task_struct->GetField("b").offset, 10);
-  EXPECT_TRUE(task_struct->GetField("b").bitfield.has_value());
+  ASSERT_TRUE(task_struct->GetField("b").bitfield.has_value());
   EXPECT_EQ(task_struct->GetField("b").bitfield->read_bytes, 0x1U);
   EXPECT_EQ(task_struct->GetField("b").bitfield->access_rshift, 4U);
   EXPECT_EQ(task_struct->GetField("b").bitfield->mask, 0x1U);
@@ -304,7 +308,7 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   EXPECT_TRUE(task_struct->GetField("c").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("c").type.GetSize(), 4U);
   EXPECT_EQ(task_struct->GetField("c").offset, 10);
-  EXPECT_TRUE(task_struct->GetField("c").bitfield.has_value());
+  ASSERT_TRUE(task_struct->GetField("c").bitfield.has_value());
   EXPECT_EQ(task_struct->GetField("c").bitfield->read_bytes, 0x1U);
   EXPECT_EQ(task_struct->GetField("c").bitfield->access_rshift, 5U);
   EXPECT_EQ(task_struct->GetField("c").bitfield->mask, 0x7U);
@@ -313,10 +317,11 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   EXPECT_TRUE(task_struct->GetField("d").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("d").type.GetSize(), 4U);
   EXPECT_EQ(task_struct->GetField("d").offset, 12);
-  EXPECT_TRUE(task_struct->GetField("d").bitfield.has_value());
+  ASSERT_TRUE(task_struct->GetField("d").bitfield.has_value());
   EXPECT_EQ(task_struct->GetField("d").bitfield->read_bytes, 0x3U);
   EXPECT_EQ(task_struct->GetField("d").bitfield->access_rshift, 0U);
   EXPECT_EQ(task_struct->GetField("d").bitfield->mask, 0xFFFFFU);
+  // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST_F(field_analyser_btf, btf_anon_union_first_in_struct)
@@ -520,10 +525,14 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   ASSERT_TRUE(bpftrace.structs.Has("struct task_struct"));
   auto task_struct = bpftrace.structs.Lookup("struct task_struct").lock();
 
+  // clang-tidy doesn't seem to acknowledge that ASSERT_*() will
+  // return from function so that these are in fact checked accesses.
+  //
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   ASSERT_TRUE(task_struct->HasField("a"));
   EXPECT_TRUE(task_struct->GetField("a").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("a").type.GetSize(), 4U);
-  EXPECT_TRUE(task_struct->GetField("a").bitfield.has_value());
+  ASSERT_TRUE(task_struct->GetField("a").bitfield.has_value());
 
   EXPECT_TRUE(task_struct->GetField("a").offset == 8 ||
               task_struct->GetField("a").offset == 9);
@@ -540,7 +549,7 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   ASSERT_TRUE(task_struct->HasField("b"));
   EXPECT_TRUE(task_struct->GetField("b").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("b").type.GetSize(), 4U);
-  EXPECT_TRUE(task_struct->GetField("b").bitfield.has_value());
+  ASSERT_TRUE(task_struct->GetField("b").bitfield.has_value());
 
   EXPECT_TRUE(task_struct->GetField("b").offset == 8 ||
               task_struct->GetField("b").offset == 10);
@@ -557,7 +566,7 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   ASSERT_TRUE(task_struct->HasField("c"));
   EXPECT_TRUE(task_struct->GetField("c").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("c").type.GetSize(), 4U);
-  EXPECT_TRUE(task_struct->GetField("c").bitfield.has_value());
+  ASSERT_TRUE(task_struct->GetField("c").bitfield.has_value());
 
   EXPECT_TRUE(task_struct->GetField("c").offset == 8 ||
               task_struct->GetField("c").offset == 10);
@@ -576,10 +585,11 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   EXPECT_TRUE(task_struct->GetField("d").type.IsIntTy());
   EXPECT_EQ(task_struct->GetField("d").type.GetSize(), 4U);
   EXPECT_EQ(task_struct->GetField("d").offset, 12);
-  EXPECT_TRUE(task_struct->GetField("d").bitfield.has_value());
+  ASSERT_TRUE(task_struct->GetField("d").bitfield.has_value());
   EXPECT_EQ(task_struct->GetField("d").bitfield->read_bytes, 0x3U);
   EXPECT_EQ(task_struct->GetField("d").bitfield->access_rshift, 0U);
   EXPECT_EQ(task_struct->GetField("d").bitfield->mask, 0xFFFFFU);
+  // NOLINTEND(bugprone-unchecked-optional-access)
 }
 
 TEST(field_analyser_subprog, struct_cast)

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -86,6 +86,8 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
 
 void setup_mock_bpftrace(MockBPFtrace &bpftrace)
 {
+  bpftrace.delta_taitime_ = timespec{};
+
   bpftrace.parse_btf({ "vmlinux" });
   // Fill in some default tracepoint struct definitions
   bpftrace.structs.Add("struct _tracepoint_sched_sched_one", 8);

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -42,6 +42,8 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
   ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
+  // clang-tidy doesn't recognize ASSERT_*() as execution terminating
+  // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   bpftrace->resources = resources_optional.value();
 
   ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);

--- a/tests/required_resources.cpp
+++ b/tests/required_resources.cpp
@@ -65,10 +65,13 @@ TEST(required_resources, round_trip_field_sized_type)
     EXPECT_TRUE(field.type.IsIntTy());
     EXPECT_EQ(field.type.GetSize(), 4ul);
     EXPECT_EQ(field.offset, 123);
-    EXPECT_TRUE(field.bitfield.has_value());
+    // clang-tidy does not recognize ASSERT_*() terminates testcase
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    ASSERT_TRUE(field.bitfield.has_value());
     EXPECT_EQ(field.bitfield->read_bytes, 1ul);
     EXPECT_EQ(field.bitfield->access_rshift, 2ul);
     EXPECT_EQ(field.bitfield->mask, 0xFFul);
+    // NOLINTEND(bugprone-unchecked-optional-access)
   }
 }
 
@@ -108,10 +111,13 @@ TEST(required_resources, round_trip_map_info)
     EXPECT_TRUE(map_info.key.args_[0].IsIntegerTy());
     EXPECT_EQ(map_info.key.args_[0].GetSize(), 4);
 
-    EXPECT_TRUE(map_info.lhist_args.has_value());
+    // clang-tidy does not recognize ASSERT_*() terminates testcase
+    // NOLINTBEGIN(bugprone-unchecked-optional-access)
+    ASSERT_TRUE(map_info.lhist_args.has_value());
     EXPECT_EQ(map_info.lhist_args->min, 99);
     EXPECT_EQ(map_info.lhist_args->max, 123);
     EXPECT_EQ(map_info.lhist_args->step, 33);
+    // NOLINTEND(bugprone-unchecked-optional-access)
 
     EXPECT_TRUE(map_info.hist_bits_arg.has_value());
     EXPECT_EQ(map_info.hist_bits_arg, 1);

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -42,7 +42,7 @@ void test(BPFtrace &bpftrace,
   EXPECT_EQ(resources_optional.has_value(), expected_result)
       << msg.str() << out.str();
 
-  if (out_p)
+  if (out_p && resources_optional)
     *out_p = *resources_optional;
 }
 

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -356,9 +356,12 @@ TEST(utils, find_in_path)
 TEST(utils, find_near_self)
 {
   auto runtime_tests = find_near_self("runtime-tests.sh");
+  // clang-tidy is not aware ASSERT_*() terminates testcase
+  // NOLINTBEGIN(bugprone-unchecked-optional-access)
   ASSERT_TRUE(runtime_tests.has_value());
   EXPECT_TRUE(runtime_tests->filename() == "runtime-tests.sh");
   EXPECT_TRUE(std_filesystem::exists(*runtime_tests));
+  // NOLINTEND(bugprone-unchecked-optional-access)
 
   EXPECT_FALSE(find_near_self("SHOULD_NOT_EXIST").has_value());
 }


### PR DESCRIPTION
This lint checks that optionals are checked before access. Trying to access a empty optional is an abort which is bad.

Unfortunately clang-tidy doesn't seem to know that gtest ASSERT_*() terminates the test case so I've had to annotate a few locations.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
