### PR TITLE
Disable 'aot.call.iter printf multiple values' test

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -18,6 +18,7 @@ aot.call.hist_10g
 aot.call.iter:task
 aot.call.iter:task_file
 aot.call.iter:task_vma
+aot.call.iter printf multiple values
 aot.call.path_in_unsupported_kfunc
 aot.call.print_map_item_tuple
 aot.call.print_non_map_builtin


### PR DESCRIPTION
This was added here but seems to be segfaulting in an aot context:

https://github.com/bpftrace/bpftrace/commit/31174f2eb21fac037523b907cc7f7817a4219c98

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
