### PR TITLE
clang-tidy: Enable some modernization lints

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,9 +5,17 @@ Checks: |
   bugprone-undefined-memory-manipulation
   bugprone-unused-raii
   bugprone-use-after-move
-  performance-unnecessary-copy-initialization
-  modernize-loop-convert
   google-readability-casting
+  modernize-concat-nested-namespaces
+  modernize-deprecated-headers
+  modernize-loop-convert
+  modernize-make-shared
+  modernize-make-unique
+  modernize-raw-string-literal
+  modernize-use-nullptr
+  modernize-use-override
+  modernize-redundant-void-arg
+  performance-unnecessary-copy-initialization
 
 WarningsAsErrors: "*"
 UseColor: true

--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -46,8 +46,7 @@ struct Header {
 static_assert(sizeof(Header) == 48);
 static_assert(sizeof(std::size_t) <= sizeof(uint64_t));
 
-namespace bpftrace {
-namespace aot {
+namespace bpftrace::aot {
 namespace {
 
 uint32_t rs_hash(std::string_view str)
@@ -235,12 +234,12 @@ int load(BPFtrace &bpftrace, const std::string &in)
   }
 
   // Find .btaot section
-  Elf *elf = NULL;
-  Elf_Scn *scn = NULL;
+  Elf *elf = nullptr;
+  Elf_Scn *scn = nullptr;
   GElf_Shdr shdr;
-  char *secname = NULL;
-  Elf_Data *data = NULL;
-  uint8_t *btaot_section = NULL;
+  char *secname = nullptr;
+  Elf_Data *data = nullptr;
+  uint8_t *btaot_section = nullptr;
   const Header *hdr;
 
   if (elf_version(EV_CURRENT) == EV_NONE) {
@@ -249,7 +248,7 @@ int load(BPFtrace &bpftrace, const std::string &in)
     goto out;
   }
 
-  elf = elf_begin(infd, ELF_C_READ, NULL);
+  elf = elf_begin(infd, ELF_C_READ, nullptr);
   if (!elf) {
     LOG(ERROR) << "Cannot read ELF file: " << elf_errmsg(-1);
     err = 1;
@@ -284,7 +283,7 @@ int load(BPFtrace &bpftrace, const std::string &in)
     }
 
     if (std::string_view(secname) == AOT_ELF_SECTION) {
-      data = elf_getdata(scn, 0);
+      data = elf_getdata(scn, nullptr);
       if (!data) {
         LOG(ERROR) << "Failed to get BTAOT ELF section(" << i
                    << ") data: " << elf_errmsg(-1);
@@ -353,5 +352,4 @@ out:
   return err;
 }
 
-} // namespace aot
-} // namespace bpftrace
+} // namespace bpftrace::aot

--- a/src/arch/x86_64.cpp
+++ b/src/arch/x86_64.cpp
@@ -6,8 +6,7 @@
 // SP + 8 points to the first argument that is passed on the stack
 #define ARG0_STACK 8
 
-namespace bpftrace {
-namespace arch {
+namespace bpftrace::arch {
 
 // clang-format off
 static std::array<std::string, 27> registers = {
@@ -103,5 +102,4 @@ int get_kernel_ptr_width()
   return 64;
 }
 
-} // namespace arch
-} // namespace bpftrace
+} // namespace bpftrace::arch

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -5,8 +5,7 @@
 #include "ast/visitors.h"
 #include "log.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 #define MAKE_ACCEPT(Ty)                                                        \
   void Ty::accept(VisitorBase &v)                                              \
@@ -498,5 +497,4 @@ SizedType ident_to_record(const std::string &ident, int pointer_level)
   return result;
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/async_event_types.cpp
+++ b/src/ast/async_event_types.cpp
@@ -5,8 +5,7 @@
 
 #include "ast/irbuilderbpf.h"
 
-namespace bpftrace {
-namespace AsyncEvent {
+namespace bpftrace::AsyncEvent {
 
 std::vector<llvm::Type*> Print::asLLVMType(ast::IRBuilderBPF& b)
 {
@@ -104,5 +103,4 @@ std::vector<llvm::Type*> SkbOutput::asLLVMType(ast::IRBuilderBPF& b)
   };
 }
 
-} // namespace AsyncEvent
-} // namespace bpftrace
+} // namespace bpftrace::AsyncEvent

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -13,8 +13,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 AttachPointParser::State AttachPointParser::argument_count_error(
     int expected,
@@ -765,5 +764,4 @@ AttachPointParser::State AttachPointParser::raw_tracepoint_parser()
   return OK;
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -7,8 +7,7 @@
 
 #include <llvm/IR/Function.h>
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 DIBuilderBPF::DIBuilderBPF(Module &module) : DIBuilder(module)
 {
@@ -298,5 +297,4 @@ DIGlobalVariableExpression *DIBuilderBPF::createGlobalInt64(
       file, name, "global", file, 0, getInt64Ty(), false);
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/int_parser.cpp
+++ b/src/ast/int_parser.cpp
@@ -103,9 +103,7 @@ std::variant<T, std::string> _parse_exp(const std::string &coeff,
 
 } // namespace
 
-namespace bpftrace {
-namespace ast {
-namespace int_parser {
+namespace bpftrace::ast::int_parser {
 
 template <typename T>
 T to_int(const std::string &num, int base)
@@ -143,6 +141,4 @@ uint64_t to_uint(const std::string &num, int base)
   return to_int<uint64_t>(num, base);
 }
 
-} // namespace int_parser
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast::int_parser

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -20,8 +20,7 @@ namespace libbpf {
 #include "libbpf/bpf.h"
 } // namespace libbpf
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 namespace {
 std::string probeReadHelperName(libbpf::bpf_func_id id)
@@ -2642,5 +2641,4 @@ llvm::Type *IRBuilderBPF::getUserPointerStorageTy()
   return getKernelPointerStorageTy();
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/pass_manager.cpp
+++ b/src/ast/pass_manager.cpp
@@ -5,8 +5,7 @@
 #include "ast/passes/printer.h"
 #include "bpftrace.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 namespace {
 void print(Node *root, const std::string &name, std::ostream &out)
@@ -63,5 +62,4 @@ PassResult PassResult::Success(Node *root)
   return PassResult(root);
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -45,8 +45,7 @@
 #include "types.h"
 #include "usdt.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 CodegenLLVM::CodegenLLVM(Node *root, BPFtrace &bpftrace)
     : CodegenLLVM(root, bpftrace, std::make_unique<USDTHelper>())
@@ -3807,7 +3806,7 @@ void CodegenLLVM::optimize()
   state_ = State::OPT;
 }
 
-bool CodegenLLVM::verify(void)
+bool CodegenLLVM::verify()
 {
   bool ret = llvm::verifyModule(*module_, &errs());
   if (ret) {
@@ -3832,7 +3831,7 @@ void CodegenLLVM::emit(raw_pwrite_stream &stream)
   PM.run(*module_.get());
 }
 
-BpfBytecode CodegenLLVM::emit(void)
+BpfBytecode CodegenLLVM::emit()
 {
   assert(state_ == State::OPT);
   SmallVector<char, 0> output;
@@ -3846,14 +3845,14 @@ BpfBytecode CodegenLLVM::emit(void)
   return BpfBytecode(output.data(), output.size(), bpftrace_);
 }
 
-BpfBytecode CodegenLLVM::compile(void)
+BpfBytecode CodegenLLVM::compile()
 {
   generate_ir();
   optimize();
   return emit();
 }
 
-void CodegenLLVM::DumpIR(void)
+void CodegenLLVM::DumpIR()
 {
   DumpIR(std::cout);
 }
@@ -4410,5 +4409,4 @@ Value *CodegenLLVM::createFmtString(int print_id)
   return res;
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -8,8 +8,7 @@
 #include "log.h"
 #include "types.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 template <class... Ts>
 struct overloaded : Ts... {
@@ -195,5 +194,4 @@ Pass CreateConfigPass()
   return Pass("ConfigAnalyser", fn);
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -8,8 +8,7 @@
 #include "log.h"
 #include "probe_matcher.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 void FieldAnalyser::visit(Identifier &identifier)
 {
@@ -345,5 +344,4 @@ int FieldAnalyser::analyse()
   return 0;
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/portability_analyser.cpp
+++ b/src/ast/passes/portability_analyser.cpp
@@ -5,8 +5,7 @@
 #include "log.h"
 #include "types.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 PortabilityAnalyser::PortabilityAnalyser(Node *root, std::ostream &out)
     : root_(root), out_(out)
@@ -126,5 +125,4 @@ Pass CreatePortabilityPass()
   return Pass("PortabilityAnalyser", fn);
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -8,8 +8,7 @@
 #include "ast/ast.h"
 #include "struct.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 void Printer::print(Node *root)
 {
@@ -474,5 +473,4 @@ void Printer::visit(Program &program)
   --depth_;
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -8,8 +8,7 @@
 #include "log.h"
 #include "struct.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 namespace {
 
@@ -270,5 +269,4 @@ Pass CreateResourcePass()
   return Pass("ResourceAnalyser", fn);
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -1,8 +1,7 @@
 #include "return_path_analyser.h"
 #include "log.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 ReturnPathAnalyser::ReturnPathAnalyser(Node *root, std::ostream &out)
     : root_(root), out_(out)
@@ -85,5 +84,4 @@ Pass CreateReturnPathPass()
   return Pass("ReturnPath", fn);
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -20,8 +20,7 @@
 #include "types.h"
 #include "usdt.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 static const std::map<std::string, std::tuple<size_t, bool>> &getIntcasts()
 {
@@ -3518,5 +3517,4 @@ void SemanticAnalyser::dereference_if_needed(Expression *&expr)
   }
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -2,8 +2,7 @@
 
 #include "ast/ast.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 void Visitor::visit(Integer &integer __attribute__((__unused__)))
 {
@@ -221,5 +220,4 @@ void Visitor::visit(Program &program)
     Visit(*program.config);
 }
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -93,7 +93,7 @@ std::string progtypeName(libbpf::bpf_prog_type t)
   }
 }
 
-void AttachedProbe::attach_kfunc(void)
+void AttachedProbe::attach_kfunc()
 {
   tracing_fd_ = bpf_raw_tracepoint_open(nullptr, progfd_);
   if (tracing_fd_ < 0) {
@@ -101,31 +101,31 @@ void AttachedProbe::attach_kfunc(void)
   }
 }
 
-int AttachedProbe::detach_kfunc(void)
+int AttachedProbe::detach_kfunc()
 {
   close(tracing_fd_);
   return 0;
 }
 
-void AttachedProbe::attach_iter(void)
+void AttachedProbe::attach_iter()
 {
   linkfd_ = bpf_link_create(progfd_,
                             0,
                             static_cast<enum ::bpf_attach_type>(
                                 libbpf::BPF_TRACE_ITER),
-                            NULL);
+                            nullptr);
   if (linkfd_ < 0) {
     throw FatalUserException("Error attaching probe: " + probe_.name);
   }
 }
 
-int AttachedProbe::detach_iter(void)
+int AttachedProbe::detach_iter()
 {
   close(linkfd_);
   return 0;
 }
 
-void AttachedProbe::attach_raw_tracepoint(void)
+void AttachedProbe::attach_raw_tracepoint()
 {
   tracing_fd_ = bpf_raw_tracepoint_open(probe_.attach_point.c_str(), progfd_);
   if (tracing_fd_ < 0) {
@@ -140,7 +140,7 @@ void AttachedProbe::attach_raw_tracepoint(void)
   }
 }
 
-int AttachedProbe::detach_raw_tracepoint(void)
+int AttachedProbe::detach_raw_tracepoint()
 {
   close(tracing_fd_);
   return 0;
@@ -598,7 +598,7 @@ void AttachedProbe::resolve_offset_kprobe(bool safe_mode)
       path, symbol, sym_offset, func_offset, safe_mode, probe_.type);
 }
 
-void AttachedProbe::attach_multi_kprobe(void)
+void AttachedProbe::attach_multi_kprobe()
 {
   BPFTRACE_LIBBPF_OPTS(bpf_link_create_opts, opts);
   std::vector<const char *> syms;

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -233,7 +233,7 @@ bool BPFfeature::detect_map(enum libbpf::bpf_map_type map_type)
   return map_fd >= 0;
 }
 
-bool BPFfeature::has_loop(void)
+bool BPFfeature::has_loop()
 {
   if (has_loop_.has_value())
     return *has_loop_;
@@ -251,7 +251,7 @@ bool BPFfeature::has_loop(void)
   return has_loop();
 }
 
-bool BPFfeature::has_btf(void)
+bool BPFfeature::has_btf()
 {
   return btf_.has_data();
 }
@@ -277,7 +277,7 @@ bool BPFfeature::has_btf_func_global()
   return *has_btf_func_global_;
 }
 
-int BPFfeature::instruction_limit(void)
+int BPFfeature::instruction_limit()
 {
   if (insns_limit_.has_value())
     return *insns_limit_;
@@ -360,7 +360,7 @@ bool BPFfeature::has_map_batch()
   return *has_map_batch_;
 }
 
-bool BPFfeature::has_d_path(void)
+bool BPFfeature::has_d_path()
 {
   if (has_d_path_.has_value())
     return *has_d_path_;
@@ -515,7 +515,7 @@ bool BPFfeature::has_uprobe_multi()
   return *has_uprobe_multi_;
 }
 
-bool BPFfeature::has_skb_output(void)
+bool BPFfeature::has_skb_output()
 {
   if (!has_kfunc())
     return false;
@@ -589,7 +589,7 @@ bool BPFfeature::has_raw_tp_special()
   return *has_raw_tp_special_;
 }
 
-std::string BPFfeature::report(void)
+std::string BPFfeature::report()
 {
   std::stringstream buf;
   auto to_str = [](bool f) -> auto { return f ? "yes\n" : "no\n"; };

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -17,9 +17,9 @@
 #include <sys/epoll.h>
 
 #include <bcc/bcc_elf.h>
+#include <csignal>
 #include <elf.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <sys/personality.h>
 #include <sys/prctl.h>
 #include <sys/stat.h>
@@ -307,7 +307,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     char timestr[64]; // not respecting config_.get(ConfigKeyInt::max_strlen)
     time_t t;
     struct tm tmp;
-    t = time(NULL);
+    t = time(nullptr);
     if (!localtime_r(&t, &tmp)) {
       LOG(WARNING) << "localtime_r: " << strerror(errno);
       return;
@@ -1785,7 +1785,7 @@ std::string BPFtrace::resolve_cgroup_path(uint64_t cgroup_path_id,
 uint64_t BPFtrace::read_address_from_output(std::string output)
 {
   std::string first_word = output.substr(0, output.find(" "));
-  return std::stoull(first_word, 0, 16);
+  return std::stoull(first_word, nullptr, 16);
 }
 
 static std::string resolve_inetv4(const uint8_t *inet)
@@ -2074,7 +2074,7 @@ Dwarf *BPFtrace::get_dwarf(const ast::AttachPoint &attachpoint)
   return get_dwarf(attachpoint.target);
 }
 
-int BPFtrace::create_pcaps(void)
+int BPFtrace::create_pcaps()
 {
   for (auto arg : resources.skboutput_args_) {
     auto file = std::get<0>(arg);
@@ -2094,7 +2094,7 @@ int BPFtrace::create_pcaps(void)
   return 0;
 }
 
-void BPFtrace::close_pcaps(void)
+void BPFtrace::close_pcaps()
 {
   for (auto &writer : pcap_writers) {
     writer.second->close();

--- a/src/child.cpp
+++ b/src/child.cpp
@@ -195,7 +195,7 @@ void ChildProc::terminate(bool force)
   check_child(force);
 }
 
-void ChildProc::resume(void)
+void ChildProc::resume()
 {
   assert(state_ == State::PTRACE_PAUSE);
   ptrace(PTRACE_DETACH, child_pid_, nullptr, 0);

--- a/src/debugfs.cpp
+++ b/src/debugfs.cpp
@@ -1,8 +1,7 @@
 #include "debugfs.h"
 #include <unistd.h>
 
-namespace bpftrace {
-namespace debugfs {
+namespace bpftrace::debugfs {
 
 #define DEBUGFS "/sys/kernel/debug"
 
@@ -16,5 +15,4 @@ std::string path(const std::string &file)
   return path() + "/" + file;
 }
 
-} // namespace debugfs
-} // namespace bpftrace
+} // namespace bpftrace::debugfs

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -11,8 +11,7 @@
 #include <stdexcept>
 #include <sys/mman.h>
 
-namespace bpftrace {
-namespace globalvars {
+namespace bpftrace::globalvars {
 
 void update_global_vars(const struct bpf_object *bpf_object,
                         struct bpf_map *global_vars_map,
@@ -91,5 +90,4 @@ void update_global_vars(const struct bpf_object *bpf_object,
   }
 }
 
-} // namespace globalvars
-} // namespace bpftrace
+} // namespace bpftrace::globalvars

--- a/src/lockdown.cpp
+++ b/src/lockdown.cpp
@@ -11,8 +11,7 @@
 
 #include "lockdown.h"
 
-namespace bpftrace {
-namespace lockdown {
+namespace bpftrace::lockdown {
 
 static LockdownState from_string(const std::string &s)
 {
@@ -26,7 +25,7 @@ static LockdownState from_string(const std::string &s)
   return LockdownState::Unknown;
 }
 
-static LockdownState read_security_lockdown(void)
+static LockdownState read_security_lockdown()
 {
   std::ifstream file("/sys/kernel/security/lockdown");
   if (file.fail())
@@ -59,5 +58,4 @@ LockdownState detect()
   return read_security_lockdown();
 }
 
-} //  namespace lockdown
-} //  namespace bpftrace
+} // namespace bpftrace::lockdown

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,6 +2,7 @@
 #include <bpf/libbpf.h>
 #include <cstdio>
 #include <cstring>
+#include <ctime>
 #include <fstream>
 #include <getopt.h>
 #include <iostream>
@@ -9,7 +10,6 @@
 #include <optional>
 #include <sys/resource.h>
 #include <sys/utsname.h>
-#include <time.h>
 #include <unistd.h>
 
 #include "aot/aot.h"
@@ -144,7 +144,7 @@ void usage()
   std::cerr << "EXAMPLES:" << std::endl;
   std::cerr << "bpftrace -l '*sleep*'" << std::endl;
   std::cerr << "    list probes containing \"sleep\"" << std::endl;
-  std::cerr << "bpftrace -e 'kprobe:do_nanosleep { printf(\"PID %d sleeping...\\n\", pid); }'" << std::endl;
+  std::cerr << R"(bpftrace -e 'kprobe:do_nanosleep { printf("PID %d sleeping...\n", pid); }')" << std::endl;
   std::cerr << "    trace processes calling sleep" << std::endl;
   std::cerr << "bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'" << std::endl;
   std::cerr << "    count syscalls by process name" << std::endl;
@@ -723,13 +723,13 @@ int main(int argc, char* argv[])
   switch (args.obc) {
     case OutputBufferConfig::UNSET:
     case OutputBufferConfig::LINE:
-      std::setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
+      std::setvbuf(stdout, nullptr, _IOLBF, BUFSIZ);
       break;
     case OutputBufferConfig::FULL:
-      std::setvbuf(stdout, NULL, _IOFBF, BUFSIZ);
+      std::setvbuf(stdout, nullptr, _IOFBF, BUFSIZ);
       break;
     case OutputBufferConfig::NONE:
-      std::setvbuf(stdout, NULL, _IONBF, BUFSIZ);
+      std::setvbuf(stdout, nullptr, _IONBF, BUFSIZ);
       break;
   }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -794,7 +794,7 @@ void JsonOutput::map(
 
   const auto &map_key = bpftrace.resources.maps_info.at(map.name()).key;
 
-  out_ << "{\"type\": \"" << MessageType::map << "\", \"data\": {";
+  out_ << R"({"type": ")" << MessageType::map << R"(", "data": {)";
   out_ << "\"" << json_escape(map.name()) << "\": ";
   if (map_key.size() > 0) // check if this map has keys
     out_ << "{";
@@ -904,7 +904,7 @@ void JsonOutput::map_hist(
 
   const auto &map_key = bpftrace.resources.maps_info.at(map.name()).key;
 
-  out_ << "{\"type\": \"" << MessageType::hist << "\", \"data\": {";
+  out_ << R"({"type": ")" << MessageType::hist << R"(", "data": {)";
   out_ << "\"" << json_escape(map.name()) << "\": ";
   if (map_key.size() > 0) // check if this map has keys
     out_ << "{";
@@ -930,7 +930,7 @@ void JsonOutput::map_stats(
 
   const auto &map_key = bpftrace.resources.maps_info.at(map.name()).key;
 
-  out_ << "{\"type\": \"" << MessageType::stats << "\", \"data\": {";
+  out_ << R"({"type": ")" << MessageType::stats << R"(", "data": {)";
   out_ << "\"" << json_escape(map.name()) << "\": ";
   if (map_key.size() > 0) // check if this map has keys
     out_ << "{";
@@ -946,16 +946,15 @@ void JsonOutput::value(BPFtrace &bpftrace,
                        const SizedType &ty,
                        std::vector<uint8_t> &value) const
 {
-  out_ << "{\"type\": \"" << MessageType::value
-       << "\", \"data\": " << value_to_str(bpftrace, ty, value, false, 1) << "}"
-       << std::endl;
+  out_ << R"({"type": ")" << MessageType::value << R"(", "data": )"
+       << value_to_str(bpftrace, ty, value, false, 1) << "}" << std::endl;
 }
 
 void JsonOutput::message(MessageType type,
                          const std::string &msg,
                          bool nl __attribute__((unused))) const
 {
-  out_ << "{\"type\": \"" << type << "\", \"data\": \"" << json_escape(msg)
+  out_ << R"({"type": ")" << type << R"(", "data": ")" << json_escape(msg)
        << "\"}" << std::endl;
 }
 
@@ -963,7 +962,7 @@ void JsonOutput::message(MessageType type,
                          const std::string &field,
                          uint64_t value) const
 {
-  out_ << "{\"type\": \"" << type << "\", \"data\": "
+  out_ << R"({"type": ")" << type << R"(", "data": )"
        << "{\"" << field << "\": " << value << "}"
        << "}" << std::endl;
 }
@@ -982,9 +981,9 @@ void JsonOutput::helper_error(int func_id,
                               int retcode,
                               const location &loc) const
 {
-  out_ << "{\"type\": \"helper_error\", \"msg\": \""
-       << get_helper_error_msg(func_id, retcode) << "\", \"helper\": \""
-       << libbpf::bpf_func_name[func_id] << "\", \"retcode\": " << retcode
+  out_ << R"({"type": "helper_error", "msg": ")"
+       << get_helper_error_msg(func_id, retcode) << R"(", "helper": ")"
+       << libbpf::bpf_func_name[func_id] << R"(", "retcode": )" << retcode
        << ", \"line\": " << loc.begin.line << ", \"col\": " << loc.begin.column
        << "}" << std::endl;
 }

--- a/src/pcap_writer.cpp
+++ b/src/pcap_writer.cpp
@@ -15,7 +15,7 @@ bool PCAPwriter::open(std::string file)
   return true;
 }
 
-void PCAPwriter::close(void)
+void PCAPwriter::close()
 {
   pcap_close(pd_);
   pcap_dump_close(pdumper_);

--- a/src/procmon.cpp
+++ b/src/procmon.cpp
@@ -63,7 +63,7 @@ ProcMon::~ProcMon()
     close(pidfd_);
 }
 
-bool ProcMon::is_alive(void)
+bool ProcMon::is_alive()
 {
   // store death to avoid pid reuse issues on polling /proc
   if (died_)

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -41,12 +41,12 @@ int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
   // Signal handler that lets us know an exit signal was received.
   struct sigaction act = {};
   act.sa_handler = [](int) { BPFtrace::exitsig_recv = true; };
-  sigaction(SIGINT, &act, NULL);
-  sigaction(SIGTERM, &act, NULL);
+  sigaction(SIGINT, &act, nullptr);
+  sigaction(SIGTERM, &act, nullptr);
 
   // Signal handler that prints all maps when SIGUSR1 was received.
   act.sa_handler = [](int) { BPFtrace::sigusr1_recv = true; };
-  sigaction(SIGUSR1, &act, NULL);
+  sigaction(SIGUSR1, &act, nullptr);
 
   err = bpftrace.run(std::move(bytecode));
   if (err)
@@ -55,7 +55,7 @@ int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
   // We are now post-processing. If we receive another SIGINT,
   // handle it normally (exit)
   act.sa_handler = SIG_DFL;
-  sigaction(SIGINT, &act, NULL);
+  sigaction(SIGINT, &act, nullptr);
 
   std::cout << "\n\n";
 

--- a/src/tracefs.cpp
+++ b/src/tracefs.cpp
@@ -1,8 +1,7 @@
 #include "tracefs.h"
 #include <unistd.h>
 
-namespace bpftrace {
-namespace tracefs {
+namespace bpftrace::tracefs {
 
 #define DEBUGFS_TRACEFS "/sys/kernel/debug/tracing"
 #define TRACEFS "/sys/kernel/tracing"
@@ -24,5 +23,4 @@ std::string event_format_file(const std::string &category,
   return path("events/" + category + "/" + event + "/format");
 }
 
-} // namespace tracefs
-} // namespace bpftrace
+} // namespace bpftrace::tracefs

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -42,7 +42,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
         if (has_wildcard(category) || has_wildcard(event_name)) {
           // tracepoint wildcard expansion, part 1 of 3. struct definitions.
           memset(&glob_result, 0, sizeof(glob_result));
-          int ret = glob(format_file_path.c_str(), 0, NULL, &glob_result);
+          int ret = glob(format_file_path.c_str(), 0, nullptr, &glob_result);
           if (ret != 0) {
             if (ret == GLOB_NOMATCH) {
               LOG(ERROR, ap->loc, std::cerr)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -264,7 +264,7 @@ SizedType CreateInteger(size_t bits, bool is_signed)
   return t;
 }
 
-SizedType CreateBool(void)
+SizedType CreateBool()
 {
   return CreateInteger(1, false);
 }
@@ -488,7 +488,7 @@ SizedType CreateTimestampMode()
   return SizedType(Type::timestamp_mode, 0);
 }
 
-bool SizedType::IsSigned(void) const
+bool SizedType::IsSigned() const
 {
   return is_signed_;
 }

--- a/src/usdt.cpp
+++ b/src/usdt.cpp
@@ -2,7 +2,7 @@
 #include "log.h"
 #include "utils.h"
 
-#include <signal.h>
+#include <csignal>
 
 #include <algorithm>
 #include <iostream>

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,9 +1,9 @@
 #include <algorithm>
 #include <array>
+#include <cerrno>
 #include <climits>
 #include <cmath>
 #include <cstring>
-#include <errno.h>
 #include <fcntl.h>
 #include <fstream>
 #include <gelf.h>
@@ -909,8 +909,8 @@ static std::optional<int> is_elf(const std::string &path)
     return result;
   }
 
-  elf = elf_begin(fd, ELF_C_READ, NULL);
-  if (elf == NULL) {
+  elf = elf_begin(fd, ELF_C_READ, nullptr);
+  if (elf == nullptr) {
     goto err_close;
   }
 
@@ -1330,7 +1330,7 @@ static uint32_t _find_version_note(unsigned long base)
   return 0;
 }
 
-static uint32_t kernel_version_from_vdso(void)
+static uint32_t kernel_version_from_vdso()
 {
   // Fetch LINUX_VERSION_CODE from the vDSO .note section, falling back on
   // the build-time constant if unavailable. This always matches the
@@ -1344,7 +1344,7 @@ static uint32_t kernel_version_from_vdso(void)
   return code;
 }
 
-static uint32_t kernel_version_from_uts(void)
+static uint32_t kernel_version_from_uts()
 {
   struct utsname utsname;
   if (uname(&utsname) < 0)
@@ -1355,14 +1355,14 @@ static uint32_t kernel_version_from_uts(void)
   return KERNEL_VERSION(x, y, z);
 }
 
-static uint32_t kernel_version_from_khdr(void)
+static uint32_t kernel_version_from_khdr()
 {
   // Try to get the definition of LINUX_VERSION_CODE at runtime.
   std::ifstream linux_version_header{ "/usr/include/linux/version.h" };
   const std::string content{ std::istreambuf_iterator<char>(
                                  linux_version_header),
                              std::istreambuf_iterator<char>() };
-  const std::regex regex{ "#define\\s+LINUX_VERSION_CODE\\s+(\\d+)" };
+  const std::regex regex{ R"(#define\s+LINUX_VERSION_CODE\s+(\d+))" };
   std::smatch match;
 
   if (std::regex_search(content.begin(), content.end(), match, regex))

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -2,9 +2,7 @@
 
 #include "gtest/gtest.h"
 
-namespace bpftrace {
-namespace test {
-namespace ast {
+namespace bpftrace::test::ast {
 
 using bpftrace::ast::AttachPoint;
 using bpftrace::ast::AttachPointList;
@@ -135,6 +133,4 @@ TEST(ast, attach_point_name)
   EXPECT_EQ(ap3.name(), "uprobe:/bin/sh:readline");
 }
 
-} // namespace ast
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::ast

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -6,9 +6,7 @@
 
 #include "gtest/gtest.h"
 
-namespace bpftrace {
-namespace test {
-namespace bpfbytecode {
+namespace bpftrace::test::bpfbytecode {
 
 BpfBytecode codegen(std::string_view input)
 {
@@ -41,6 +39,4 @@ TEST(bpfbytecode, create_programs)
             "s_kprobe_foo_1");
 }
 
-} // namespace bpfbytecode
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::bpfbytecode

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -11,9 +11,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace bpftrace {
-namespace test {
-namespace bpftrace {
+namespace bpftrace::test::bpftrace {
 
 #include "btf_common.h"
 
@@ -1254,6 +1252,4 @@ TEST(bpftrace, add_probes_rawtracepoint_wildcard_no_matches)
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 }
 
-} // namespace bpftrace
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::bpftrace

--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -6,8 +6,8 @@
 #include <string>
 #include <system_error>
 
+#include <csignal>
 #include <fcntl.h>
-#include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 
@@ -16,9 +16,7 @@
 #include "filesystem.h"
 #include "utils.h"
 
-namespace bpftrace {
-namespace test {
-namespace child {
+namespace bpftrace::test::child {
 
 using ::testing::HasSubstr;
 
@@ -258,6 +256,4 @@ TEST(childproc, multi_exec_match)
   EXPECT_GT(std_filesystem::remove_all(tmpdir), 0);
 }
 
-} // namespace child
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::child

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -7,9 +7,7 @@
 #include <iostream>
 #include <llvm/Config/llvm-config.h>
 
-namespace bpftrace {
-namespace test {
-namespace clang_parser {
+namespace bpftrace::test::clang_parser {
 
 #include "btf_common.h"
 
@@ -807,6 +805,4 @@ struct _tracepoint_irq_irq_handler_entry
   EXPECT_EQ(s->GetField("name").type.GetIntBitWidth(), 64ULL);
 }
 
-} // namespace clang_parser
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::clang_parser

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -4,8 +4,7 @@
 #include "gtest/gtest.h"
 #include <iostream>
 
-namespace bpftrace {
-namespace test {
+namespace bpftrace::test {
 
 TEST(Config, get_and_set)
 {
@@ -134,5 +133,4 @@ TEST(ConfigSetter, same_source_cannot_set_twice)
   EXPECT_FALSE(config_setter.set(ConfigKeyInt::max_map_keys, 11));
 }
 
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -7,9 +7,7 @@
 #include "driver.h"
 #include "mocks.h"
 
-namespace bpftrace {
-namespace test {
-namespace config_analyser {
+namespace bpftrace::test::config_analyser {
 
 using ::testing::_;
 
@@ -129,6 +127,4 @@ TEST(config_analyser, config_setting)
   EXPECT_EQ(bpftrace->config_.get(ConfigKeyInt::log_size), 150);
 }
 
-} // namespace config_analyser
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::config_analyser

--- a/tests/data/data_source_cxx.cpp
+++ b/tests/data/data_source_cxx.cpp
@@ -77,7 +77,7 @@ int func_3(Multi &m, Bottom &b __attribute__((unused)))
   return m.abc;
 }
 
-int main(void)
+int main()
 {
   Parent p{ 1, 2, 3, 4 };
   Child c{ 1, 2, 3, 4, 5, 6 };

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -3,9 +3,7 @@
 #include "mocks.h"
 #include "gtest/gtest.h"
 
-namespace bpftrace {
-namespace test {
-namespace field_analyser {
+namespace bpftrace::test::field_analyser {
 
 #include "btf_common.h"
 
@@ -766,6 +764,4 @@ TEST(field_analyser_subprog, struct_cast)
 
 #endif // HAVE_LIBLLDB
 
-} // namespace field_analyser
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::field_analyser

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -4,9 +4,7 @@
 #include "gtest/gtest.h"
 #include <iostream>
 
-namespace bpftrace {
-namespace test {
-namespace log {
+namespace bpftrace::test::log {
 
 TEST(LogStream, basic)
 {
@@ -69,6 +67,4 @@ TEST(Log, disable_log_type)
   ss.str({});
 }
 
-} // namespace log
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::log

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -1,8 +1,7 @@
 #include "mocks.h"
 #include "tracefs.h"
 
-namespace bpftrace {
-namespace test {
+namespace bpftrace::test {
 
 using ::testing::_;
 using ::testing::NiceMock;
@@ -11,27 +10,23 @@ using ::testing::StrictMock;
 
 void setup_mock_probe_matcher(MockProbeMatcher &matcher)
 {
-  ON_CALL(matcher, get_symbols_from_traceable_funcs(false))
-      .WillByDefault([](void) {
-        std::string ksyms = "SyS_read\n"
-                            "sys_read\n"
-                            "sys_write\n"
-                            "my_one\n"
-                            "my_two\n";
-        auto myval = std::unique_ptr<std::istream>(
-            new std::istringstream(ksyms));
-        return myval;
-      });
+  ON_CALL(matcher, get_symbols_from_traceable_funcs(false)).WillByDefault([]() {
+    std::string ksyms = "SyS_read\n"
+                        "sys_read\n"
+                        "sys_write\n"
+                        "my_one\n"
+                        "my_two\n";
+    auto myval = std::unique_ptr<std::istream>(new std::istringstream(ksyms));
+    return myval;
+  });
 
-  ON_CALL(matcher, get_symbols_from_traceable_funcs(true))
-      .WillByDefault([](void) {
-        std::string ksyms = "kernel_mod:func_in_mod\n"
-                            "kernel_mod:other_func_in_mod\n"
-                            "other_kernel_mod:func_in_mod\n";
-        auto myval = std::unique_ptr<std::istream>(
-            new std::istringstream(ksyms));
-        return myval;
-      });
+  ON_CALL(matcher, get_symbols_from_traceable_funcs(true)).WillByDefault([]() {
+    std::string ksyms = "kernel_mod:func_in_mod\n"
+                        "kernel_mod:other_func_in_mod\n"
+                        "other_kernel_mod:func_in_mod\n";
+    auto myval = std::unique_ptr<std::istream>(new std::istringstream(ksyms));
+    return myval;
+  });
 
   ON_CALL(matcher, get_symbols_from_file(tracefs::available_events()))
       .WillByDefault([](const std::string &) {
@@ -187,5 +182,4 @@ std::unique_ptr<MockUSDTHelper> get_mock_usdt_helper(int num_locations)
   return usdt_helper;
 }
 
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1,13 +1,11 @@
-#include <limits.h>
+#include <climits>
 #include <sstream>
 
 #include "ast/passes/printer.h"
 #include "driver.h"
 #include "gtest/gtest.h"
 
-namespace bpftrace {
-namespace test {
-namespace parser {
+namespace bpftrace::test::parser {
 
 using Printer = ast::Printer;
 
@@ -1059,7 +1057,7 @@ TEST(Parser, unroll)
 
 TEST(Parser, ternary_str)
 {
-  test("kprobe:sys_open { @x = pid < 10000 ? \"lo\" : \"high\" }",
+  test(R"(kprobe:sys_open { @x = pid < 10000 ? "lo" : "high" })",
        "Program\n"
        " kprobe:sys_open\n"
        "  =\n"
@@ -1236,7 +1234,7 @@ TEST(Parser, usdt)
   // Without the escapes needed for C++ to compile:
   //    usdt:/my/program:"\"probe\"" { 1; }
   //
-  test("usdt:/my/program:\"\\\"probe\\\"\" { 1; }",
+  test(R"(usdt:/my/program:"\"probe\"" { 1; })",
        "Program\n"
        " usdt:/my/program:\"probe\"\n"
        "  int: 1\n");
@@ -2409,7 +2407,7 @@ i:s:1 { ((1, 0), 3).0 = (0, 1) }
         ~~~~~~~~~~~~~~~~~~~~~~
 )");
 
-  test_parse_failure("i:s:1 { (1, \"two\", (3, 4)).5 = \"six\"; }", R"(
+  test_parse_failure(R"(i:s:1 { (1, "two", (3, 4)).5 = "six"; })", R"(
 stdin:1:9-37: ERROR: Tuples are immutable once created. Consider creating a new tuple and assigning it instead.
 i:s:1 { (1, "two", (3, 4)).5 = "six"; }
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2746,6 +2744,4 @@ BEGIN { for (@kv : @map) { } }
 )");
 }
 
-} // namespace parser
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::parser

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -9,9 +9,7 @@
 #include "driver.h"
 #include "mocks.h"
 
-namespace bpftrace {
-namespace test {
-namespace portability_analyser {
+namespace bpftrace::test::portability_analyser {
 
 using ::testing::_;
 
@@ -100,6 +98,4 @@ TEST(portability_analyser, selective_probes_disabled)
   test(*bpftrace, "asyncwatchpoint:increment+arg1:4:w { 1 }", 1);
 }
 
-} // namespace portability_analyser
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::portability_analyser

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -11,9 +11,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-namespace bpftrace {
-namespace test {
-namespace probe {
+namespace bpftrace::test::probe {
 
 #include "btf_common.h"
 
@@ -86,6 +84,4 @@ TEST_F(probe_btf, short_name)
   compare_bytecode("iter:task_vma { 1 }", "it:task_vma { 1 }");
 }
 
-} // namespace probe
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::probe

--- a/tests/procmon.cpp
+++ b/tests/procmon.cpp
@@ -1,7 +1,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-#include <time.h>
+#include <ctime>
 
 #include "child.h"
 #include "procmon.h"
@@ -9,9 +9,7 @@
 #include "childhelper.h"
 #include "utils.h"
 
-namespace bpftrace {
-namespace test {
-namespace procmon {
+namespace bpftrace::test::procmon {
 
 using ::testing::HasSubstr;
 
@@ -38,6 +36,4 @@ TEST(procmon, child_terminates)
   EXPECT_FALSE(procmon->is_alive());
 }
 
-} // namespace procmon
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::procmon

--- a/tests/required_resources.cpp
+++ b/tests/required_resources.cpp
@@ -9,8 +9,7 @@
 #include "struct.h"
 #include "types.h"
 
-namespace bpftrace {
-namespace test {
+namespace bpftrace::test {
 
 // ========================================================================
 // It's a bit overkill to completely test every field in `RequiredResources`
@@ -207,5 +206,4 @@ TEST(required_resources, round_trip_multiple_members)
   }
 }
 
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -8,9 +8,7 @@
 #include "driver.h"
 #include "mocks.h"
 
-namespace bpftrace {
-namespace test {
-namespace resource_analyser {
+namespace bpftrace::test::resource_analyser {
 
 using ::testing::_;
 
@@ -69,7 +67,7 @@ TEST(resource_analyser, multiple_lhist_bounds_in_single_map)
 
 TEST(resource_analyser, printf_in_subprog)
 {
-  test("fn greet(): void { printf(\"Hello, world\\n\"); }", true);
+  test(R"(fn greet(): void { printf("Hello, world\n"); })", true);
 }
 
 TEST(resource_analyser, fmt_string_args_size_ints)
@@ -116,6 +114,4 @@ TEST(resource_analyser, fmt_string_args_non_map_print_arr)
   EXPECT_EQ(resources.max_fmtstring_args_size, 40);
 }
 
-} // namespace resource_analyser
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::resource_analyser

--- a/tests/return_path_analyser.cpp
+++ b/tests/return_path_analyser.cpp
@@ -8,9 +8,7 @@
 #include "driver.h"
 #include "mocks.h"
 
-namespace bpftrace {
-namespace test {
-namespace return_path_analyser {
+namespace bpftrace::test::return_path_analyser {
 
 using ::testing::_;
 
@@ -110,6 +108,4 @@ TEST(return_path_analyser, void_return_type)
   test("fn test() : void {}", 0);
 }
 
-} // namespace return_path_analyser
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::return_path_analyser

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -5,9 +5,7 @@
 
 using namespace testing;
 
-namespace bpftrace {
-namespace test {
-namespace tracepoint_format_parser {
+namespace bpftrace::test::tracepoint_format_parser {
 
 class MockTracepointFormatParser : public TracepointFormatParser {
 public:
@@ -285,6 +283,4 @@ TEST(tracepoint_format_parser, args_field_access)
   EXPECT_EQ(driver.ctx.root->probes.at(0)->tp_args_structs_level, -1);
 }
 
-} // namespace tracepoint_format_parser
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::tracepoint_format_parser

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1,19 +1,17 @@
 #include "utils.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
 #include <fstream>
-#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 #include "filesystem.h"
 
-namespace bpftrace {
-namespace test {
-namespace utils {
+namespace bpftrace::test::utils {
 
 TEST(utils, split_string)
 {
@@ -411,6 +409,4 @@ TEST(utils, get_pids_for_program)
   ASSERT_EQ(pids.size(), 0);
 }
 
-} // namespace utils
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::utils


### PR DESCRIPTION
Just picked a few (hopefully unobjectionable) lints that we are liable to see in our codebase.

Also alphabetize list.

Changes are all generated with `./scripts/clang-tidy.sh -u`.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
