### PR TITLE
clang-tidy: Enable some more bugprone-* checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,9 +1,13 @@
 Checks: |
   -*
+  bugprone-suspicious-memset-usage
+  bugprone-unchecked-optional-access
+  bugprone-undefined-memory-manipulation
+  bugprone-unused-raii
+  bugprone-use-after-move
   performance-unnecessary-copy-initialization
   modernize-loop-convert
   google-readability-casting
-  bugprone-unchecked-optional-access
 
 WarningsAsErrors: "*"
 UseColor: true

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -165,9 +165,10 @@ void FieldAnalyser::visit(Unop &unop)
 
 void FieldAnalyser::resolve_args(Probe &probe)
 {
-  // load probe arguments into a special record type "struct <probename>_args"
-  Struct probe_args;
   for (auto *ap : probe.attach_points) {
+    // load probe arguments into a special record type "struct <probename>_args"
+    Struct probe_args;
+
     auto probe_type = probetype(ap->provider);
     if (probe_type != ProbeType::kfunc && probe_type != ProbeType::kretfunc &&
         probe_type != ProbeType::uprobe)

--- a/tests/procmon.cpp
+++ b/tests/procmon.cpp
@@ -18,6 +18,7 @@ using ::testing::HasSubstr;
 TEST(procmon, no_such_proc)
 {
   try {
+    // NOLINTNEXTLINE(bugprone-unused-raii)
     ProcMon(1 << 21);
     FAIL();
   } catch (const std::runtime_error &e) {


### PR DESCRIPTION
These seem pretty reasonable to turn on. Particularly the use-after-move one. It caught this existing error:

```
/home/dlxu/dev/bpftrace/src/ast/passes/field_analyser.cpp:217:13: error: 'probe_args' used after it was moved [bugprone-use-after-move,-warnings-as-errors]
  217 |         if (probe_args.size == -1)
      |             ^
/home/dlxu/dev/bpftrace/src/ast/passes/field_analyser.cpp:261:25: note: move occurred here
  261 |       bpftrace_.structs.Add(probe.args_typename(), std::move(probe_args));
      |                         ^
/home/dlxu/dev/bpftrace/src/ast/passes/field_analyser.cpp:217:13: note: the use happens in a later loop iteration than the move
  217 |         if (probe_args.size == -1)
```

It looks like `probe_args` doesn't actually need to be preserved across different iterations of the outer loop. So just move declaration/initialization inside the loop to avoid undefined moved-from state.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
