### PR TITLE
ci: Run runtime tests under controlled kernel

### DIFF
--- a/.github/actions/configure_kvm/action.yml
+++ b/.github/actions/configure_kvm/action.yml
@@ -1,0 +1,19 @@
+name: Configure KVM Permissions
+
+description: Configure KVM permissions if KVM is available on host
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure KVM group perms
+      run: |
+        # Only configure kvm perms if kvm is available
+        if [[ -e /dev/kvm ]]; then
+          echo "Updating KVM permissions"
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+        else
+          echo "KVM is not available on this system, skipping permission configuration"
+        fi
+      shell: bash

--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -263,74 +263,9 @@ def test():
 
     results.append(
         test_one(
-            "bpftrace_test",
-            lambda: truthy(RUN_TESTS),
-            lambda: shell(
-                ["./tests/bpftrace_test"],
-                cwd=Path(BUILD_DIR),
-                env={"GTEST_COLOR": GTEST_COLOR},
-            ),
-        )
-    )
-    results.append(
-        test_one(
             "runtime-tests.sh",
             lambda: truthy(RUN_TESTS),
             run_runtime_tests,
-        )
-    )
-    results.append(
-        test_one(
-            "tools-parsing-test.sh",
-            lambda: truthy(RUN_TESTS),
-            lambda: shell(
-                [
-                    "./tests/tools-parsing-test.sh",
-                ],
-                as_root=True,
-                cwd=Path(BUILD_DIR),
-                env={
-                    "TOOLS_TEST_OLDVERSION": TOOLS_TEST_OLDVERSION,
-                    "TOOLS_TEST_DISABLE": TOOLS_TEST_DISABLE,
-                },
-            ),
-        )
-    )
-    results.append(
-        test_one(
-            "runtime-tests.sh (AOT)",
-            lambda: truthy(RUN_AOT_TESTS),
-            lambda: shell(
-                (
-                    [
-                        "./tests/runtime-tests.sh",
-                        "--run-aot-tests",
-                        "--filter",
-                        "aot.*",
-                    ]
-                    + [
-                        "--skiplist_file",
-                        f"{root()}/{AOT_SKIPLIST_FILE}",
-                    ]
-                    if AOT_SKIPLIST_FILE
-                    else []
-                ),
-                as_root=True,
-                cwd=Path(BUILD_DIR),
-                env={
-                    "CI": CI,
-                    "RUNTIME_TEST_COLOR": RUNTIME_TEST_COLOR,
-                },
-            ),
-        )
-    )
-    results.append(
-        test_one(
-            "memleak-tests.sh.sh",
-            lambda: truthy(RUN_MEMLEAK_TEST),
-            lambda: shell(
-                ["./tests/memleak-tests.sh"], as_root=True, cwd=Path(BUILD_DIR)
-            ),
         )
     )
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: DeterminateSystems/nix-installer-action@v11
     - uses: DeterminateSystems/magic-nix-cache-action@v6
+    - uses: ./.github/actions/configure_kvm
     - name: Load kernel modules
       # nf_tables and xfs are necessary for testing kernel modules BTF support
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,17 +8,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clang-format:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: DeterminateSystems/nix-installer-action@v11
-    - uses: DeterminateSystems/magic-nix-cache-action@v6
-    - name: clang-format
-      run: nix develop --command git clang-format --diff origin/master
-
   build_test:
     runs-on: ubuntu-latest
     continue-on-error: true
@@ -28,56 +17,11 @@ jobs:
     strategy:
       matrix:
         env:
-        - NAME: LLVM 13
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm13
-          TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: LLVM 14
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm14
-          TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: LLVM 15
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm15
-          TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: LLVM 16
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm16
-          TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: LLVM 17
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm17
-          TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: LLVM 18 Release
-          CMAKE_BUILD_TYPE: Release
-          NIX_TARGET: .#bpftrace-llvm18
-          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 18 Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm18
           TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: LLVM 18 Clang Debug
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm18
-          CC: clang
-          CXX: clang++
-          TOOLS_TEST_DISABLE: biosnoop.bt
-        - NAME: AOT (LLVM 18 Debug)
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm18
-          RUN_TESTS: 0
-          RUN_AOT_TESTS: 1
-          AOT_SKIPLIST_FILE: .github/include/aot_skip.txt
-        - NAME: Memleak test (LLVM 18 Debug)
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm18
-          RUN_MEMLEAK_TEST: 1
-          RUN_TESTS: 0
-        - NAME: Memleak test (LLVM 18 Release)
-          CMAKE_BUILD_TYPE: Release
-          NIX_TARGET: .#bpftrace-llvm18
-          RUN_MEMLEAK_TEST: 1
-          RUN_TESTS: 0
+          RUNTIME_TEST_KERNEL_URL: https://github.com/danobi/vmtest/releases/download/test_assets/bzImage-v6.6-archlinux
     steps:
     - uses: actions/checkout@v2
     - uses: DeterminateSystems/nix-installer-action@v11
@@ -91,22 +35,3 @@ jobs:
     - name: Build and test
       env: ${{matrix.env}}
       run: ./.github/include/ci.py
-
-  irc:
-    # Notify IRC of build failures on pushes only if we are running from
-    # the main repo. We don't want this rule to trigger from forked repos.
-    needs:
-      - build_test
-    if: "failure() && github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'bpftrace/bpftrace'"
-    runs-on: ubuntu-latest
-    steps:
-    - name: Message channel
-      uses: rectalogic/notify-irc@v1
-      with:
-        nickname: bpftrace-ci-bot
-        server: irc.oftc.net
-        port: 6667
-        tls: false
-        channel: "#bpftrace"
-        message: |
-          master is BROKEN at https://github.com/bpftrace/bpftrace/commit/${{github.sha}}

--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,21 @@
 
           pkgs = import nixpkgs { inherit system; };
 
+          # Download statically linked vmtest binary
+          arch = pkgs.lib.strings.removeSuffix "-linux" system;
+          vmtest = pkgs.stdenv.mkDerivation {
+            name = "vmtest";
+            src = builtins.fetchurl {
+              url = "https://github.com/danobi/vmtest/releases/download/v0.14.0/vmtest-${arch}";
+              sha256 = "0czx903v09mjgl6246g5yk2ljxfn9ilnyh2ni8phrrfv8l0npm8z";
+            };
+            # Remove all other phases b/c we already have a prebuilt binary
+            phases = [ "installPhase" ];
+            installPhase = ''
+              install -m755 -D $src $out/bin/vmtest
+            '';
+          };
+
           # Define lambda that returns a derivation for bpftrace given llvm package as input
           mkBpftrace =
             llvmPackages:
@@ -132,8 +147,10 @@
                   nftables
                   procps
                   python3
+                  qemu_kvm
                   strace
                   util-linux
+                  vmtest
                 ] ++ pkg.nativeBuildInputs ++ pkg.buildInputs;
               };
         in


### PR DESCRIPTION
This PR teaches CI how to run tests under different and tightly controlled
kernels. Under the hood it uses vmtest.

More details about vmtest can be found here:
* https://github.com/danobi/vmtest
* https://dxuuu.xyz/vmtest.html

TODO:
- [x] Address https://github.com/danobi/vmtest/issues/79
- [x] Pull out GHA kvm perms + package install into separate action
- [ ] Configure this for AOT runtime tests
- [ ] Build kernels in bpftrace org (probably a new repo)
  * Probably don't want to couple to vmtest CI
- [ ] Figure out how this interacts with kernel module tracing tests