### PR TITLE
Minor refactoring of BpfBytecode to support loading third-party BPF objects

### DIFF
--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -340,7 +340,7 @@ int load(BPFtrace &bpftrace, const std::string &in)
 
   bpftrace.bytecode_ = BpfBytecode(
       std::span<uint8_t>{ btaot_section + hdr->elf_off, hdr->elf_len },
-      bpftrace);
+      bpftrace.config_.get(ConfigKeyInt::log_size));
   if (err)
     goto out;
 

--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -338,9 +338,9 @@ int load(BPFtrace &bpftrace, const std::string &in)
   if (err)
     goto out;
 
-  bpftrace.bytecode_ = BpfBytecode(btaot_section + hdr->elf_off,
-                                   hdr->elf_len,
-                                   bpftrace);
+  bpftrace.bytecode_ = BpfBytecode(
+      std::span<uint8_t>{ btaot_section + hdr->elf_off, hdr->elf_len },
+      bpftrace);
   if (err)
     goto out;
 

--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -338,9 +338,8 @@ int load(BPFtrace &bpftrace, const std::string &in)
   if (err)
     goto out;
 
-  bpftrace.bytecode_ = BpfBytecode(
-      std::span<uint8_t>{ btaot_section + hdr->elf_off, hdr->elf_len },
-      bpftrace.config_.get(ConfigKeyInt::log_size));
+  bpftrace.bytecode_ = BpfBytecode{ std::span<uint8_t>{
+      btaot_section + hdr->elf_off, hdr->elf_len } };
   if (err)
     goto out;
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3842,7 +3842,7 @@ BpfBytecode CodegenLLVM::emit()
   assert(!output.empty());
 
   state_ = State::DONE;
-  return BpfBytecode(output.data(), output.size(), bpftrace_);
+  return BpfBytecode(output, bpftrace_);
 }
 
 BpfBytecode CodegenLLVM::compile()

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3842,7 +3842,7 @@ BpfBytecode CodegenLLVM::emit()
   assert(!output.empty());
 
   state_ = State::DONE;
-  return BpfBytecode(output, bpftrace_);
+  return BpfBytecode(output, bpftrace_.config_.get(ConfigKeyInt::log_size));
 }
 
 BpfBytecode CodegenLLVM::compile()

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3842,7 +3842,7 @@ BpfBytecode CodegenLLVM::emit()
   assert(!output.empty());
 
   state_ = State::DONE;
-  return BpfBytecode(output, bpftrace_.config_.get(ConfigKeyInt::log_size));
+  return BpfBytecode{ output };
 }
 
 BpfBytecode CodegenLLVM::compile()

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -12,7 +12,17 @@
 
 namespace bpftrace {
 
-BpfBytecode::BpfBytecode(const void *elf, size_t elf_size, BPFtrace &bpftrace)
+BpfBytecode::BpfBytecode(std::span<uint8_t> elf, BPFtrace &bpftrace)
+    : BpfBytecode(std::as_bytes(elf), bpftrace)
+{
+}
+
+BpfBytecode::BpfBytecode(std::span<char> elf, BPFtrace &bpftrace)
+    : BpfBytecode(std::as_bytes(elf), bpftrace)
+{
+}
+
+BpfBytecode::BpfBytecode(std::span<const std::byte> elf, BPFtrace &bpftrace)
     : log_size_(bpftrace.config_.get(ConfigKeyInt::log_size))
 {
   int log_level = 0;
@@ -28,7 +38,7 @@ BpfBytecode::BpfBytecode(const void *elf, size_t elf_size, BPFtrace &bpftrace)
                        .kernel_log_level = static_cast<__u32>(log_level));
 
   bpf_object_ = std::unique_ptr<struct bpf_object, bpf_object_deleter>(
-      bpf_object__open_mem(elf, elf_size, &opts));
+      bpf_object__open_mem(elf.data(), elf.size(), &opts));
   if (!bpf_object_)
     LOG(BUG) << "The produced ELF is not a valid BPF object";
 

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -24,15 +24,16 @@ public:
   BpfBytecode()
   {
   }
-  BpfBytecode(std::span<const std::byte> elf, BPFtrace &bpftrace);
-  BpfBytecode(std::span<uint8_t> elf, BPFtrace &bpftrace);
-  BpfBytecode(std::span<char> elf, BPFtrace &bpftrace);
+  BpfBytecode(std::span<const std::byte> elf, size_t log_size);
+  BpfBytecode(std::span<uint8_t> elf, size_t log_size);
+  BpfBytecode(std::span<char> elf, size_t log_size);
 
   BpfBytecode(const BpfBytecode &) = delete;
   BpfBytecode &operator=(const BpfBytecode &) = delete;
   BpfBytecode(BpfBytecode &&) = default;
   BpfBytecode &operator=(BpfBytecode &&) = default;
 
+  void update_global_vars(BPFtrace &bpftrace);
   void load_progs(const RequiredResources &resources,
                   const BTF &btf,
                   BPFfeature &feature,
@@ -72,6 +73,7 @@ private:
   std::map<std::string, BpfMap> maps_;
   std::map<int, BpfMap *> maps_by_id_;
   std::map<std::string, BpfProgram> programs_;
+  struct bpf_map *global_vars_map_ = nullptr;
 
   size_t log_size_;
 };

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -10,6 +10,7 @@
 #include <bpf/libbpf.h>
 #include <cereal/access.hpp>
 #include <map>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -23,7 +24,9 @@ public:
   BpfBytecode()
   {
   }
-  BpfBytecode(const void *elf, size_t elf_size, BPFtrace &bpftrace);
+  BpfBytecode(std::span<const std::byte> elf, BPFtrace &bpftrace);
+  BpfBytecode(std::span<uint8_t> elf, BPFtrace &bpftrace);
+  BpfBytecode(std::span<char> elf, BPFtrace &bpftrace);
 
   BpfBytecode(const BpfBytecode &) = delete;
   BpfBytecode &operator=(const BpfBytecode &) = delete;

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -24,9 +24,9 @@ public:
   BpfBytecode()
   {
   }
-  BpfBytecode(std::span<const std::byte> elf, size_t log_size);
-  BpfBytecode(std::span<uint8_t> elf, size_t log_size);
-  BpfBytecode(std::span<char> elf, size_t log_size);
+  BpfBytecode(std::span<const std::byte> elf);
+  BpfBytecode(std::span<uint8_t> elf);
+  BpfBytecode(std::span<char> elf);
 
   BpfBytecode(const BpfBytecode &) = delete;
   BpfBytecode &operator=(const BpfBytecode &) = delete;
@@ -74,8 +74,6 @@ private:
   std::map<int, BpfMap *> maps_by_id_;
   std::map<std::string, BpfProgram> programs_;
   struct bpf_map *global_vars_map_ = nullptr;
-
-  size_t log_size_;
 };
 
 } // namespace bpftrace

--- a/src/bpfprogram.cpp
+++ b/src/bpfprogram.cpp
@@ -12,8 +12,7 @@
 
 namespace bpftrace {
 
-BpfProgram::BpfProgram(struct bpf_program *bpf_prog, size_t log_size)
-    : bpf_prog_(bpf_prog), log_buf_(std::make_unique<char[]>(log_size))
+BpfProgram::BpfProgram(struct bpf_program *bpf_prog) : bpf_prog_(bpf_prog)
 {
 }
 
@@ -95,11 +94,6 @@ void BpfProgram::set_no_autoattach()
 struct bpf_program *BpfProgram::bpf_prog() const
 {
   return bpf_prog_;
-}
-
-char *BpfProgram::log_buf() const
-{
-  return log_buf_.get();
 }
 
 } // namespace bpftrace

--- a/src/bpfprogram.h
+++ b/src/bpfprogram.h
@@ -16,7 +16,7 @@ class BPFtrace;
 // 'struct bpf_prog'.
 class BpfProgram {
 public:
-  explicit BpfProgram(struct bpf_program *bpf_prog, size_t log_size);
+  explicit BpfProgram(struct bpf_program *bpf_prog);
 
   void set_prog_type(const Probe &probe, BPFfeature &feature);
   void set_expected_attach_type(const Probe &probe, BPFfeature &feature);
@@ -27,17 +27,14 @@ public:
 
   int fd() const;
   struct bpf_program *bpf_prog() const;
-  char *log_buf() const;
 
   BpfProgram(const BpfProgram &) = delete;
   BpfProgram &operator=(const BpfProgram &) = delete;
   BpfProgram(BpfProgram &&) = default;
-  BpfProgram &operator=(BpfProgram &&) = delete;
+  BpfProgram &operator=(BpfProgram &&) = default;
 
 private:
   struct bpf_program *bpf_prog_;
-
-  std::unique_ptr<char[]> log_buf_;
 };
 
 } // namespace bpftrace

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -926,6 +926,7 @@ int BPFtrace::run(BpfBytecode bytecode)
 
   bytecode_ = std::move(bytecode);
   bytecode_.set_map_ids(resources);
+  bytecode_.update_global_vars(*this);
 
   try {
     bytecode_.load_progs(resources, *btf_, *feature_, config_);


### PR DESCRIPTION
This is the first step towards interop with externally written BPF programs.

```
BpfBytecode: Accept std::span input parameter instead of pointer and size
```
```
BpfBytecode: Move updating global variables into its own function

To support linking against third-party BPF libraries, it would be useful
to have the constructor do nothing but parse a BPF bytecode blob.
```
```
BpfBytecode: Don't require log_size parameter in ctor

The log size is only relevant when loading programs, so move the
parameter onto the load_progs() function.

This lets us more easily use BpfBytecode to represent bytecode which we
don't intend to load, e.g. when analysing third-party BPF libraries.
```