### PR TITLE
Add an optional size parameter for `path()` to resolve issue 3376

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
   - [#3014](https://github.com/bpftrace/bpftrace/pull/3014)
 - Parse C++ Class and Inheritance from Debug Info
   - [#3094](https://github.com/bpftrace/bpftrace/pull/3094)
+- Add an optional `size` parameter to `path`
+  - [#3401](https://github.com/bpftrace/bpftrace/pull/3401)
 #### Changed
 - Merge output into `stdout` when `-lv`
   - [#3383](https://github.com/bpftrace/bpftrace/pull/3383)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1280,7 +1280,7 @@ Tracing block I/O sizes > 0 bytes
 | Override return value
 | Sync
 
-| <<functions-path, `path(struct path *path)`>>
+| <<functions-path, `path(struct path *path [, int32 size])`>>
 | Return full path
 | Sync
 
@@ -1740,13 +1740,14 @@ Error attaching probe: 'kprobe:vfs_read'
 === path
 
 .variants
-* `char * path(struct path * path)`
+* `char * path(struct path * path [, int32 size])`
 
 *Kernel* 5.10
 
 *Helper* `bpf_d_path`
 
-Return full path referenced by struct path pointer in argument.
+Return full path referenced by struct path pointer in argument. If `size` is set,
+the path will be clamped by `size` otherwise `BPFTRACE_MAX_STRLEN` is used.
 
 This function can only be used by functions that are allowed to, these functions are contained in the `btf_allowlist_d_path` set in the kernel.
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -2490,18 +2490,18 @@ void IRBuilderBPF::CreateHelperErrorCond(Value *ctx,
 void IRBuilderBPF::CreatePath(Value *ctx,
                               Value *buf,
                               Value *path,
+                              Value *sz,
                               const location &loc)
 {
   // int bpf_d_path(struct path *path, char *buf, u32 sz)
   // Return: 0 or error
   FunctionType *d_path_func_type = FunctionType::get(
       getInt64Ty(), { GET_PTR_TY(), buf->getType(), getInt32Ty() }, false);
-  CallInst *call = CreateHelperCall(
-      libbpf::bpf_func_id::BPF_FUNC_d_path,
-      d_path_func_type,
-      { path, buf, getInt32(bpftrace_.config_.get(ConfigKeyInt::max_strlen)) },
-      "d_path",
-      &loc);
+  CallInst *call = CreateHelperCall(libbpf::bpf_func_id::BPF_FUNC_d_path,
+                                    d_path_func_type,
+                                    { path, buf, sz },
+                                    "d_path",
+                                    &loc);
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_d_path, loc);
 }
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -238,7 +238,11 @@ public:
                             Value *len,
                             AllocaInst *data,
                             size_t size);
-  void CreatePath(Value *ctx, Value *buf, Value *path, const location &loc);
+  void CreatePath(Value *ctx,
+                  Value *buf,
+                  Value *path,
+                  Value *sz,
+                  const location &loc);
   void CreateSeqPrintf(Value *ctx,
                        Value *fmt,
                        Value *fmt_size,

--- a/tests/codegen/call_path.cpp
+++ b/tests/codegen/call_path.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_path)
+{
+  test("kfunc:filp_close { path(args->filp->f_path); }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/call_path_with_optional_size.cpp
+++ b/tests/codegen/call_path_with_optional_size.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_path_with_optional_size)
+{
+  test("kfunc:filp_close { path(args->filp->f_path, 48); }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_path.ll
+++ b/tests/codegen/llvm/call_path.ll
@@ -1,0 +1,117 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@str_buffer = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kfunc_mock_vmlinux_filp_close_1(ptr %0) section "s_kfunc_mock_vmlinux_filp_close_1" !dbg !54 {
+entry:
+  %lookup_str_key = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
+  store i32 0, ptr %lookup_str_key, align 4
+  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
+  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
+  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
+
+lookup_str_failure:                               ; preds = %entry
+  ret i64 0
+
+lookup_str_merge:                                 ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
+  %1 = ptrtoint ptr %0 to i64
+  %2 = getelementptr i64, ptr %0, i64 0
+  %filp = load volatile i64, ptr %2, align 8
+  %3 = add i64 %filp, 152
+  %4 = inttoptr i64 %3 to ptr
+  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %4, ptr %lookup_str_map, i32 64)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 6, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !36, size: 512, elements: !37)
+!36 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!37 = !{!38}
+!38 = !DISubrange(count: 64, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
+!42 = !{!43, !25, !30, !48}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 2, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !49, size: 64, offset: 192)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !39}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kfunc_mock_vmlinux_filp_close_1", linkageName: "kfunc_mock_vmlinux_filp_close_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!50, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/call_path_with_optional_size.ll
+++ b/tests/codegen/llvm/call_path_with_optional_size.ll
@@ -1,0 +1,117 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@str_buffer = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kfunc_mock_vmlinux_filp_close_1(ptr %0) section "s_kfunc_mock_vmlinux_filp_close_1" !dbg !54 {
+entry:
+  %lookup_str_key = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
+  store i32 0, ptr %lookup_str_key, align 4
+  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
+  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
+  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
+
+lookup_str_failure:                               ; preds = %entry
+  ret i64 0
+
+lookup_str_merge:                                 ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
+  %1 = ptrtoint ptr %0 to i64
+  %2 = getelementptr i64, ptr %0, i64 0
+  %filp = load volatile i64, ptr %2, align 8
+  %3 = add i64 %filp, 152
+  %4 = inttoptr i64 %3 to ptr
+  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %4, ptr %lookup_str_map, i32 48)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 6, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !36, size: 512, elements: !37)
+!36 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!37 = !{!38}
+!38 = !DISubrange(count: 64, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
+!42 = !{!43, !25, !30, !48}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 2, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !49, size: 64, offset: 192)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !16, !39}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "kfunc_mock_vmlinux_filp_close_1", linkageName: "kfunc_mock_vmlinux_filp_close_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!50, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -488,6 +488,13 @@ REQUIRES_FEATURE dpath kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
+NAME path_with_optional_size
+RUN {{BPFTRACE}} -ve 'kfunc:filp_close { $p = path(args.filp->f_path, 48);  if ( sizeof($p) == 48 && !strncmp($p, "tmp/bpftrace_runtime_test_syscall_gen_read_temp", 48)) { printf("OK\n"); exit(); } }'
+EXPECT OK
+REQUIRES_FEATURE dpath kfunc
+TIMEOUT 5
+AFTER ./testprogs/syscall read
+
 NAME strcontains
 RUN {{BPFTRACE}} -ve 'kfunc:filp_close { if (strcontains(path(args.filp->f_path), "tmp")) { printf("OK\n"); exit(); } }'
 EXPECT OK

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3407,6 +3407,9 @@ TEST_F(semantic_analyser_btf, call_path)
 {
   test("kfunc:func_1 { @k = path( args.foo1 ) }");
   test("kretfunc:func_1 { @k = path( retval->foo1 ) }");
+  test("kfunc:func_1 { path( args.foo1, 16);}");
+  test("kfunc:func_1 { path( args.foo1, \"Na\");}", 1);
+  test("kfunc:func_1 { path( args.foo1, -1);}", 1);
 }
 
 TEST_F(semantic_analyser_btf, call_skb_output)


### PR DESCRIPTION
To resolve https://github.com/bpftrace/bpftrace/issues/3376

The default value of `size` is `BPFTRACE_MAX_STRLEN`.

A working example is like:

```shell
bpftrace -e 'kfunc:filp_close { print(path(args->filp->f_path, 16)); }'
```


##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
