### PR TITLE
nix: Use upstream packages when possible

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,9 @@
             });
 
           # We need to use two overlays so that bcc inherits the our pinned libbpf
-          pkgs = import nixpkgs { inherit system; overlays = [ libbpfOverlay bccOverlay ]; };
+          overlayedPkgs = import nixpkgs { inherit system; overlays = [ libbpfOverlay bccOverlay ]; };
+
+          pkgs = import nixpkgs { inherit system; };
 
           # Define lambda that returns a derivation for bpftrace given llvm package as input
           mkBpftrace =
@@ -80,11 +82,9 @@
                 buildInputs = with llvmPackages;
                   [
                     asciidoctor
-                    bcc
                     cereal
                     elfutils
                     gtest
-                    libbpf
                     libbfd
                     libclang
                     libelf
@@ -94,6 +94,8 @@
                     libsystemtap
                     lldb
                     llvm
+                    overlayedPkgs.bcc
+                    overlayedPkgs.libbpf
                     pahole
                     xxd
                     zlib


### PR DESCRIPTION
Previously all packages came from the overlays which caused us to eat rebuilds for anything that depended on libbpf or bcc. This was not insignificant -- we often rebuilt qemu and systemd.

Fix by using vanilla packages by default. For almost everything, we don't care which libbpf or bcc they come with b/c they're standalone.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
