### PR TITLE
nix: Disable hardening flags for nix dev builds

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,11 @@
                   strace
                   util-linux
                 ] ++ pkg.nativeBuildInputs ++ pkg.buildInputs;
+
+                # Some hardening features (like _FORTIFY_SOURCE) requires building with
+                # optimizations on. That's fine for actual flake build, but for most of the
+                # dev builds we do in nix shell, it just causes warning spew.
+                hardeningDisable = [ "all" ];
               };
         in
         {


### PR DESCRIPTION
Hardening is not really useful for dev builds and for CI. It causes pointless spew, so disable it.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
