### PR TITLE
Explicitly include <cstdint> for gcc-15

### DIFF
--- a/src/disasm.h
+++ b/src/disasm.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <string>
 


### PR DESCRIPTION
Fixes: https://github.com/bpftrace/bpftrace/issues/3406

With this trivial fix bpftrace-0.21.2 builds with gcc-15.
The executabe also still works. :smile: 

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
