### PR TITLE
Dry run: terminate bpftrace as soon as possible

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1014,6 +1014,11 @@ int BPFtrace::run(BpfBytecode bytecode)
     }
   }
 
+  if (dry_run) {
+    request_finalize();
+    return 0;
+  }
+
   // Kick the child to execute the command.
   if (child_) {
     try {
@@ -1037,9 +1042,6 @@ int BPFtrace::run(BpfBytecode bytecode)
     LOG(WARNING) << "Failed to send readiness notification, ignoring: "
                  << strerror(-err);
 #endif
-
-  if (dry_run)
-    exitsig_recv = true;
 
   if (has_iter_) {
     int err = run_iter();


### PR DESCRIPTION
The --dry-run option is supposed to terminate bpftrace before actually running the program. This is a tricky thing to do as the probes start to hit as soon as BPF programs are attached to them.

Despite that, we can still minimize the amount of time that the probes are running by terminating bpftrace immediately after all probes are attached instead of doing it only after we start polling perf events.

Resolves #3330.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
