### PR TITLE
Start removing 'is_internal' part 1

### DIFF
--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -28,10 +28,5 @@ inline bool inBpfMemory(const SizedType &type)
   return type.is_internal || shouldBeInBpfMemoryAlready(type);
 }
 
-inline AddrSpace find_addrspace_stack(const SizedType &ty)
-{
-  return (shouldBeInBpfMemoryAlready(ty)) ? AddrSpace::kernel : ty.GetAS();
-}
-
 } // namespace ast
 } // namespace bpftrace

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -423,9 +423,7 @@ SizedType CreateUsername()
 
 SizedType CreateInet(size_t size)
 {
-  auto st = SizedType(Type::inet, size);
-  st.is_internal = true;
-  return st;
+  return SizedType(Type::inet, size);
 }
 
 SizedType CreateLhist()
@@ -468,9 +466,7 @@ SizedType CreateTuple(std::weak_ptr<Struct> tuple)
 
 SizedType CreateMacAddress()
 {
-  auto st = SizedType(Type::mac_address, 6);
-  st.is_internal = true;
-  return st;
+  return SizedType(Type::mac_address, 6);
 }
 
 SizedType CreateCgroupPath()


### PR DESCRIPTION
- Remove 'find_addrspace_stack' function
- Remove is_internal for 'inet' and 'mac_address'

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
