### PR TITLE
Dry run: do not print maps at the end

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1265,6 +1265,9 @@ void BPFtrace::handle_event_loss()
 
 int BPFtrace::print_maps()
 {
+  if (dry_run)
+    return 0;
+
   for (auto &map : bytecode_.maps()) {
     if (!map.second.is_printable())
       continue;

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -316,3 +316,9 @@ NAME per_cpu_map_cast
 PROG BEGIN { @a = count(); @b = sum(10); printf("%d-%d\n", (uint64)@a, (int64)@b); exit();}
 EXPECT 1-10
 TIMEOUT 5
+
+NAME dry run empty output
+RUN {{BPFTRACE}} --dry-run -e 'BEGIN { printf("hello\n"); @ = 0; }'
+EXPECT_NONE hello
+EXPECT_NONE @: 0
+TIMEOUT 5


### PR DESCRIPTION
Do not print contents of maps when running with `--dry-run` as the probes should not hit at all and the maps will not contain any meaningful data and just pollute the output.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
