### PR TITLE
.gitignore: add clangd files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,7 @@ tests/**/*.bc
 
 result
 ignored/
+
+# clangd files
+compile_commands.json
+.cache/


### PR DESCRIPTION
I recently started using the clangd LSP and it uses some files and dirs in the project root dir which should not be checked to the repo. I'd appreciate if we could add them to `.gitignore` so that they don't pollute my `git status`.