### PR TITLE
Fix variable type mismatches for scratch vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ and this project adheres to
   - [#3381](https://github.com/bpftrace/bpftrace/pull/3381)
 - Fix BTF/DWARF parsing for structs contained in arrays
   - [#3422](https://github.com/bpftrace/bpftrace/pull/3422)
+- Fix integer comparisons and auto casting for scratch variables
+  - [#3416](https://github.com/bpftrace/bpftrace/pull/3416)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -50,7 +50,8 @@ MAKE_ACCEPT(Program)
 
 #undef MAKE_ACCEPT
 
-Integer::Integer(int64_t n, location loc) : Expression(loc), n(n)
+Integer::Integer(int64_t n, location loc, bool is_negative)
+    : Expression(loc), n(n), is_negative(is_negative)
 {
   is_literal = true;
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -106,9 +106,10 @@ class Integer : public Expression {
 public:
   DEFINE_ACCEPT
 
-  explicit Integer(int64_t n, location loc);
+  explicit Integer(int64_t n, location loc, bool is_negative = true);
 
   int64_t n;
+  bool is_negative;
 
 private:
   Integer(const Integer &other) = default;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -611,8 +611,8 @@ offsetof_expr:
                 ;
 
 int:
-                MINUS INT    { $$ = driver.ctx.make_node<ast::Integer>((int64_t)(~(uint64_t)($2) + 1), @$); }
-        |       INT          { $$ = driver.ctx.make_node<ast::Integer>($1, @$); }
+                MINUS INT    { $$ = driver.ctx.make_node<ast::Integer>((int64_t)(~(uint64_t)($2) + 1), @$, true); }
+        |       INT          { $$ = driver.ctx.make_node<ast::Integer>($1, @$, false); }
                 ;
 
 keyword:

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -559,12 +559,12 @@ std::weak_ptr<const Struct> SizedType::GetStruct() const
   return inner_struct_;
 }
 
-// Checks if values of this type can be copied into values of another type
-// Currently checks if strings in the other type (at corresponding places) are
-// larger.
 bool SizedType::FitsInto(const SizedType &t) const
 {
   if (IsStringTy() && t.IsStringTy())
+    return GetSize() <= t.GetSize();
+
+  if (IsIntegerTy() && t.IsIntegerTy() && (IsSigned() == t.IsSigned()))
     return GetSize() <= t.GetSize();
 
   if (IsTupleTy() && t.IsTupleTy()) {

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -300,3 +300,8 @@ NAME print_per_cpu_map_vals
 PROG BEGIN { @a = avg(5); @c = count(); @s = sum(5); @mn = min(1); @mx = max(-1); print((@a, @c, @s, @mn, @mx)); exit(); }
 EXPECT (5, 1, 5, 1, -1)
 TIMEOUT 3
+
+NAME print large int
+PROG BEGIN { $a = 10223372036854775807; print(($a)); exit(); }
+EXPECT 10223372036854775807
+TIMEOUT 1

--- a/tests/runtime/intcast
+++ b/tests/runtime/intcast
@@ -14,3 +14,8 @@ NAME Casting ints
 PROG BEGIN{printf("Values: %d %d\n", (uint8) -10, (uint16) 131087); exit(); }
 EXPECT Values: 246 15
 TIMEOUT 5
+
+NAME Implicit truncation of ints
+PROG BEGIN{ $a = (int16)0; $a = 2; $b = (int8)3; $b = -100; print(($a, $b)); exit(); }
+EXPECT (2, -100)
+TIMEOUT 5

--- a/tools/runqlen.bt
+++ b/tools/runqlen.bt
@@ -33,7 +33,7 @@ profile:hz:99
 {
 	$task = (struct task_struct *)curtask;
 	$my_q = (struct cfs_rq *)$task->se.cfs_rq;
-	$len = $my_q->nr_running;
+	$len = (uint64)$my_q->nr_running;
 	$len = $len > 0 ? $len - 1 : 0;	// subtract currently running task
 	@runqlen = lhist($len, 0, 100, 1);
 }


### PR DESCRIPTION
Right now the script below prints 0, when it
should print 2.
```
BEGIN { $a = (int16)0; $a = 2; print(($a)); exit(); }
```

This is because the type of '2' is an int64.
This change will cast the literal to the smaller
type if possible, otherwise it causes an error.
This also adds additional integer error checking
to prevent incorrect results.

Fixes: https://github.com/bpftrace/bpftrace/issues/3415

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
