### PR TITLE
nix: appimage: Get LLDB to stop running python

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -71,9 +71,9 @@
 
           pkgs = import nixpkgs { inherit system; };
 
-          # Define lambda that returns a derivation for bpftrace given llvm package as input
+          # Define lambda that returns a derivation for bpftrace given llvm version as input
           mkBpftrace =
-            llvmPackages:
+            llvmVersion:
               with pkgs;
               pkgs.stdenv.mkDerivation rec {
                 name = "bpftrace";
@@ -82,27 +82,26 @@
 
                 nativeBuildInputs = [ cmake ninja bison flex gcc clang ];
 
-                buildInputs = with llvmPackages;
-                  [
-                    asciidoctor
-                    cereal
-                    elfutils
-                    gtest
-                    libbfd
-                    libclang
-                    libelf
-                    libffi
-                    libopcodes
-                    libpcap
-                    libsystemtap
-                    lldb
-                    llvm
-                    overlayedPkgs.bcc
-                    overlayedPkgs.libbpf
-                    pahole
-                    xxd
-                    zlib
-                  ];
+                buildInputs = [
+                  asciidoctor
+                  cereal
+                  elfutils
+                  gtest
+                  libbfd
+                  libelf
+                  libffi
+                  libopcodes
+                  libpcap
+                  libsystemtap
+                  pkgs."llvmPackages_${toString llvmVersion}".libclang
+                  pkgs."llvmPackages_${toString llvmVersion}".lldb
+                  pkgs."llvmPackages_${toString llvmVersion}".llvm
+                  overlayedPkgs.bcc
+                  overlayedPkgs.libbpf
+                  pahole
+                  xxd
+                  zlib
+                ];
 
                 # Release flags
                 cmakeFlags = [
@@ -154,12 +153,12 @@
             default = self.packages.${system}."bpftrace-llvm${toString defaultLlvmVersion}";
 
             # Support matrix of llvm versions
-            bpftrace-llvm18 = mkBpftrace pkgs.llvmPackages_18;
-            bpftrace-llvm17 = mkBpftrace pkgs.llvmPackages_17;
-            bpftrace-llvm16 = mkBpftrace pkgs.llvmPackages_16;
-            bpftrace-llvm15 = mkBpftrace pkgs.llvmPackages_15;
-            bpftrace-llvm14 = mkBpftrace pkgs.llvmPackages_14;
-            bpftrace-llvm13 = mkBpftrace pkgs.llvmPackages_13;
+            bpftrace-llvm18 = mkBpftrace 18;
+            bpftrace-llvm17 = mkBpftrace 17;
+            bpftrace-llvm16 = mkBpftrace 16;
+            bpftrace-llvm15 = mkBpftrace 15;
+            bpftrace-llvm14 = mkBpftrace 14;
+            bpftrace-llvm13 = mkBpftrace 13;
 
             # Self-contained static binary with all dependencies
             appimage = nix-appimage.mkappimage.${system} {

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,9 @@
     flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ]
       (system:
         let
+          # The default LLVM version is the latest supported release
+          defaultLlvmVersion = 18;
+
           # Overlay to specify build should use the specific libbpf we want
           libbpfVersion = "1.4.2";
           libbpfOverlay =
@@ -148,8 +151,7 @@
 
           # Define package set
           packages = rec {
-            # Default package is latest supported LLVM release
-            default = bpftrace-llvm18;
+            default = self.packages.${system}."bpftrace-llvm${toString defaultLlvmVersion}";
 
             # Support matrix of llvm versions
             bpftrace-llvm18 = mkBpftrace pkgs.llvmPackages_18;
@@ -198,7 +200,7 @@
           };
 
           devShells = rec {
-            default = bpftrace-llvm18;
+            default = self.devShells.${system}."bpftrace-llvm${toString defaultLlvmVersion}";
 
             bpftrace-llvm18 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm18;
             bpftrace-llvm17 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm17;

--- a/src/patches/lldb_defer_python_init.patch
+++ b/src/patches/lldb_defer_python_init.patch
@@ -1,0 +1,38 @@
+commit dee686b7a5110ed5aa3f2a084487683a843c8047
+Author: Daniel Xu <dxu@dxuuu.xyz>
+Date:   Thu Aug 22 17:32:22 2024 -0700
+
+    [lldb][NFC] Defer python init until ScriptInterpreter is created
+
+    Previously python was initialized during static registration of the
+    plugin. This causes the python interpreter to run even if python support
+    is explicitly disabled thru:
+
+        SBDebugger::SetScriptLanguage(ScriptLanguage::eScriptLanguageNone)
+
+    This commit defers python initialization until a ScriptInterpreterPython
+    instance is created.
+
+diff --git a/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp b/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+index ef7a2c128a22..97e5641005d6 100644
+--- a/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
++++ b/source/Plugins/ScriptInterpreter/Python/ScriptInterpreterPython.cpp
+@@ -350,7 +350,6 @@ void ScriptInterpreterPython::Initialize() {
+                                   GetPluginDescriptionStatic(),
+                                   lldb::eScriptLanguagePython,
+                                   ScriptInterpreterPythonImpl::CreateInstance);
+-    ScriptInterpreterPythonImpl::Initialize();
+   });
+ }
+
+@@ -427,6 +426,10 @@ ScriptInterpreterPythonImpl::ScriptInterpreterPythonImpl(Debugger &debugger)
+       m_active_io_handler(eIOHandlerNone), m_session_is_active(false),
+       m_pty_secondary_is_open(false), m_valid_session(true), m_lock_count(0),
+       m_command_thread_state(nullptr) {
++  static llvm::once_flag g_once_flag;
++  llvm::call_once(g_once_flag, []() {
++    ScriptInterpreterPythonImpl::Initialize();
++  });
+
+   m_dictionary_name.append("_dict");
+   StreamString run_string;


### PR DESCRIPTION
This PR overlays https://github.com/llvm/llvm-project/pull/105757 into our nix build.

This means that the appimages we ship will stop running python. Which lets us
delete all the python files in the appimage and makes the final result slightly smaller
(216MB -> 214MB). But more importantly, it'll make bpftrace faster since we start
doing python stuff. Less of an attack vector as well.

This does have the downside of requiring an LLDB rebuild. It's not that big of a deal
in CI, as the result will be cached. But for local users this can be annoying. I'm open
to feedback on whether this is worthwhile or not. It _is_ useful, but just unsure how
useful relative to the additional compute for new users.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
