### PR TITLE
FieldAnalyser: Resolve fields for structs inside arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to
   - [#3336](https://github.com/bpftrace/bpftrace/pull/3336)
 - Fix json formatting for `strftime` function
   - [#3381](https://github.com/bpftrace/bpftrace/pull/3381)
+- Fix BTF/DWARF parsing for structs contained in arrays
+  - [#3422](https://github.com/bpftrace/bpftrace/pull/3422)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -65,6 +65,14 @@ struct Arrays *func_arrays(struct Arrays *arr)
   return 0;
 }
 
+struct ArrayWithCompoundData {
+  struct Foo3 *data[2];
+};
+
+void func_array_with_compound_data(struct ArrayWithCompoundData *arr)
+{
+}
+
 struct task_struct {
   int pid;
   int pgid;


### PR DESCRIPTION
Previously this script would have errored out:
```
# bpftrace -e 'BEGIN { @x = curtask->cgroups->dfl_cgrp->ancestors[1]->kn->name; }'
stdin:1:14-64: ERROR: Struct/union of type 'struct kernfs_node' does not contain a field named 'name'
BEGIN { @x = curtask->cgroups->dfl_cgrp->ancestors[1]->kn->name; }
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The immediate bug is fixed by this PR, but the whole FieldAnalyser pass needs reworking really. A slight modification of the script causes it to break again:
```
# bpftrace -e 'BEGIN { @y = @x->dfl_cgrp; @x = curtask->cgroups; }'
stdin:1:14-26: ERROR: Struct/union of type 'struct css_set' does not contain a field named 'dfl_cgrp'
BEGIN { @y = @x->dfl_cgrp; @x = curtask->cgroups; }
             ~~~~~~~~~~~~
```
This is because FieldAnalyser attempts to do some form of type propagation (via. it's `sized_type_` member), but it does not perform the full type propagation done by SemanticAnalyser. We shouldn't have two separate implementations of type propagation at all. #2979.

##### Checklist

- ~[ ]~ Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
