### PR TITLE
Printing improvements to help with debugging

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -354,9 +354,13 @@ std::string opstr(const Unop &unop)
     case Operator::MUL:
       return "dereference";
     case Operator::INCREMENT:
-      return "++";
+      if (unop.is_post_op)
+        return "++ (post)";
+      return "++ (pre)";
     case Operator::DECREMENT:
-      return "--";
+      if (unop.is_post_op)
+        return "-- (post)";
+      return "-- (pre)";
     default:
       return {};
   }

--- a/src/ast/pass_manager.cpp
+++ b/src/ast/pass_manager.cpp
@@ -29,15 +29,14 @@ PassResult PassManager::Run(Node *root, PassContext &ctx)
     print(root, "parser", std::cout);
   for (auto &pass : passes_) {
     auto result = pass.Run(*root, ctx);
-    if (!result.Ok())
-      return result;
-
-    if (result.Root()) {
+    if (result.Root())
       root = result.Root();
-    }
 
     if (bt_debug.find(DebugStage::Ast) != bt_debug.end())
       print(root, pass.name, std::cout);
+
+    if (!result.Ok())
+      return result;
   }
   return PassResult::Success(root);
 }

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -176,25 +176,18 @@ void Printer::visit(Binop &binop)
 
 void Printer::visit(Unop &unop)
 {
-  if (unop.is_post_op) {
-    std::string indent(depth_ + 1, ' ');
+  std::string indent(depth_, ' ');
+  out_ << indent << opstr(unop) << type(unop.type) << std::endl;
 
-    unop.expr->accept(*this);
-    out_ << indent << opstr(unop) << std::endl;
-  } else {
-    std::string indent(depth_, ' ');
-    out_ << indent << opstr(unop) << std::endl;
-
-    ++depth_;
-    unop.expr->accept(*this);
-    --depth_;
-  }
+  ++depth_;
+  unop.expr->accept(*this);
+  --depth_;
 }
 
 void Printer::visit(Ternary &ternary)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "?:" << std::endl;
+  out_ << indent << "?:" << type(ternary.type) << std::endl;
 
   ++depth_;
   ternary.cond->accept(*this);
@@ -221,7 +214,7 @@ void Printer::visit(FieldAccess &acc)
 void Printer::visit(ArrayAccess &arr)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "[]" << std::endl;
+  out_ << indent << "[]" << type(arr.type) << std::endl;
 
   ++depth_;
   arr.expr->accept(*this);
@@ -242,7 +235,7 @@ void Printer::visit(Cast &cast)
 void Printer::visit(Tuple &tuple)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "tuple:" << std::endl;
+  out_ << indent << "tuple:" << type(tuple.type) << std::endl;
 
   ++depth_;
   for (Expression *expr : tuple.elems)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -41,7 +41,7 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   } else if (type.IsRefTy()) {
     os << *type.GetDereferencedTy() << " &";
   } else if (type.IsIntTy()) {
-    os << (type.is_signed_ ? "" : "unsigned ") << "int" << 8 * type.GetSize();
+    os << (type.is_signed_ ? "" : "u") << "int" << 8 * type.GetSize();
   } else if (type.IsArrayTy()) {
     os << *type.GetElementTy() << "[" << type.GetNumElements() << "]";
   } else if (type.IsStringTy() || type.IsBufferTy()) {

--- a/tests/codegen/llvm/avg_cast_loop.ll
+++ b/tests/codegen/llvm/avg_cast_loop.ll
@@ -8,7 +8,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %avg_stas_val = type { i64, i64 }
-%"unsigned int64_avg__tuple_t" = type { i64, i64 }
+%uint64_avg__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -69,8 +69,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !83 {
   %key1 = alloca i32, align 4
   %lookup_fmtstr_key = alloca i32, align 4
-  %tuple = alloca %"unsigned int64_avg__tuple_t", align 8
-  %"$kv" = alloca %"unsigned int64_avg__tuple_t", align 8
+  %tuple = alloca %uint64_avg__tuple_t, align 8
+  %"$kv" = alloca %uint64_avg__tuple_t, align 8
   %ret = alloca i64, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
@@ -158,19 +158,19 @@ is_negative_merge_block:                          ; preds = %is_positive, %is_ne
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %31 = getelementptr %"unsigned int64_avg__tuple_t", ptr %"$kv", i32 0, i32 0
+  %31 = getelementptr %uint64_avg__tuple_t, ptr %"$kv", i32 0, i32 0
   store i64 %key, ptr %31, align 8
-  %32 = getelementptr %"unsigned int64_avg__tuple_t", ptr %"$kv", i32 0, i32 1
+  %32 = getelementptr %uint64_avg__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %30, ptr %32, align 8
-  %33 = getelementptr %"unsigned int64_avg__tuple_t", ptr %"$kv", i32 0, i32 0
+  %33 = getelementptr %uint64_avg__tuple_t, ptr %"$kv", i32 0, i32 0
   %34 = load i64, ptr %33, align 8
-  %35 = getelementptr %"unsigned int64_avg__tuple_t", ptr %"$kv", i32 0, i32 1
+  %35 = getelementptr %uint64_avg__tuple_t, ptr %"$kv", i32 0, i32 1
   %36 = load i64, ptr %35, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %37 = getelementptr %"unsigned int64_avg__tuple_t", ptr %tuple, i32 0, i32 0
+  %37 = getelementptr %uint64_avg__tuple_t, ptr %tuple, i32 0, i32 0
   store i64 %34, ptr %37, align 8
-  %38 = getelementptr %"unsigned int64_avg__tuple_t", ptr %tuple, i32 0, i32 1
+  %38 = getelementptr %uint64_avg__tuple_t, ptr %tuple, i32 0, i32 1
   store i64 %36, ptr %38, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
   store i32 0, ptr %lookup_fmtstr_key, align 4

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr, ptr, ptr }
-%"unsigned int64_count__tuple_t" = type { i64, i64 }
+%uint64_count__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -61,8 +61,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !77 {
   %key1 = alloca i32, align 4
   %lookup_fmtstr_key = alloca i32, align 4
-  %tuple = alloca %"unsigned int64_count__tuple_t", align 8
-  %"$kv" = alloca %"unsigned int64_count__tuple_t", align 8
+  %tuple = alloca %uint64_count__tuple_t, align 8
+  %"$kv" = alloca %uint64_count__tuple_t, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -97,19 +97,19 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %9 = getelementptr %"unsigned int64_count__tuple_t", ptr %"$kv", i32 0, i32 0
+  %9 = getelementptr %uint64_count__tuple_t, ptr %"$kv", i32 0, i32 0
   store i64 %key, ptr %9, align 8
-  %10 = getelementptr %"unsigned int64_count__tuple_t", ptr %"$kv", i32 0, i32 1
+  %10 = getelementptr %uint64_count__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %8, ptr %10, align 8
-  %11 = getelementptr %"unsigned int64_count__tuple_t", ptr %"$kv", i32 0, i32 0
+  %11 = getelementptr %uint64_count__tuple_t, ptr %"$kv", i32 0, i32 0
   %12 = load i64, ptr %11, align 8
-  %13 = getelementptr %"unsigned int64_count__tuple_t", ptr %"$kv", i32 0, i32 1
+  %13 = getelementptr %uint64_count__tuple_t, ptr %"$kv", i32 0, i32 1
   %14 = load i64, ptr %13, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_count__tuple_t", ptr %tuple, i32 0, i32 0
+  %15 = getelementptr %uint64_count__tuple_t, ptr %tuple, i32 0, i32 0
   store i64 %12, ptr %15, align 8
-  %16 = getelementptr %"unsigned int64_count__tuple_t", ptr %tuple, i32 0, i32 1
+  %16 = getelementptr %uint64_count__tuple_t, ptr %tuple, i32 0, i32 1
   store i64 %14, ptr %16, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
   store i32 0, ptr %lookup_fmtstr_key, align 4

--- a/tests/codegen/llvm/for_map_one_key.ll
+++ b/tests/codegen/llvm/for_map_one_key.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr, ptr, ptr }
-%"unsigned int64_int64__tuple_t" = type { i64, i64 }
+%uint64_int64__tuple_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_map = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -41,14 +41,14 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !67 {
   %"@x_key" = alloca i64, align 8
-  %"$kv" = alloca %"unsigned int64_int64__tuple_t", align 8
+  %"$kv" = alloca %uint64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %5 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$kv", i32 0, i32 0
+  %5 = getelementptr %uint64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
   store i64 %key, ptr %5, align 8
-  %6 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$kv", i32 0, i32 1
+  %6 = getelementptr %uint64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %val, ptr %6, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8

--- a/tests/codegen/llvm/for_map_two_keys.ll
+++ b/tests/codegen/llvm/for_map_two_keys.ll
@@ -7,8 +7,8 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr, ptr, ptr }
-%"(unsigned int64,unsigned int64)_int64__tuple_t" = type { %"unsigned int64_unsigned int64__tuple_t", i64 }
-%"unsigned int64_unsigned int64__tuple_t" = type { i64, i64 }
+%"(uint64,uint64)_int64__tuple_t" = type { %uint64_uint64__tuple_t, i64 }
+%uint64_uint64__tuple_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_map = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -45,13 +45,13 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !75 {
   %"@x_key" = alloca i64, align 8
-  %"$kv" = alloca %"(unsigned int64,unsigned int64)_int64__tuple_t", align 8
+  %"$kv" = alloca %"(uint64,uint64)_int64__tuple_t", align 8
   %val = load i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 24, i1 false)
-  %5 = getelementptr %"(unsigned int64,unsigned int64)_int64__tuple_t", ptr %"$kv", i32 0, i32 0
+  %5 = getelementptr %"(uint64,uint64)_int64__tuple_t", ptr %"$kv", i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %1, i64 16, i1 false)
-  %6 = getelementptr %"(unsigned int64,unsigned int64)_int64__tuple_t", ptr %"$kv", i32 0, i32 1
+  %6 = getelementptr %"(uint64,uint64)_int64__tuple_t", ptr %"$kv", i32 0, i32 1
   store i64 %val, ptr %6, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8

--- a/tests/codegen/llvm/for_map_variables.ll
+++ b/tests/codegen/llvm/for_map_variables.ll
@@ -9,7 +9,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.3" = type { ptr, ptr, ptr, ptr }
 %ctx_t = type { ptr, ptr }
-%"unsigned int64_int64__tuple_t" = type { i64, i64 }
+%uint64_int64__tuple_t = type { i64, i64 }
 %print_string_4_t = type <{ i64, i64, [4 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -88,14 +88,14 @@ declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noal
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !73 {
   %key1 = alloca i32, align 4
   %lookup_fmtstr_key = alloca i32, align 4
-  %"$kv" = alloca %"unsigned int64_int64__tuple_t", align 8
+  %"$kv" = alloca %uint64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %5 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$kv", i32 0, i32 0
+  %5 = getelementptr %uint64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
   store i64 %key, ptr %5, align 8
-  %6 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$kv", i32 0, i32 1
+  %6 = getelementptr %uint64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %val, ptr %6, align 8
   %"ctx.$var1" = getelementptr %ctx_t, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8

--- a/tests/codegen/llvm/for_map_variables_multiple_loops.ll
+++ b/tests/codegen/llvm/for_map_variables_multiple_loops.ll
@@ -8,7 +8,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %ctx_t.2 = type { ptr, ptr }
 %ctx_t = type { ptr }
-%"unsigned int64_int64__tuple_t" = type { i64, i64 }
+%uint64_int64__tuple_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -59,14 +59,14 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !57 {
-  %"$_" = alloca %"unsigned int64_int64__tuple_t", align 8
+  %"$_" = alloca %uint64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$_")
   call void @llvm.memset.p0.i64(ptr align 1 %"$_", i8 0, i64 16, i1 false)
-  %5 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$_", i32 0, i32 0
+  %5 = getelementptr %uint64_int64__tuple_t, ptr %"$_", i32 0, i32 0
   store i64 %key, ptr %5, align 8
-  %6 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$_", i32 0, i32 1
+  %6 = getelementptr %uint64_int64__tuple_t, ptr %"$_", i32 0, i32 1
   store i64 %val, ptr %6, align 8
   %"ctx.$var1" = getelementptr %ctx_t, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8
@@ -80,14 +80,14 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !60 {
-  %"$_" = alloca %"unsigned int64_int64__tuple_t", align 8
+  %"$_" = alloca %uint64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$_")
   call void @llvm.memset.p0.i64(ptr align 1 %"$_", i8 0, i64 16, i1 false)
-  %5 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$_", i32 0, i32 0
+  %5 = getelementptr %uint64_int64__tuple_t, ptr %"$_", i32 0, i32 0
   store i64 %key, ptr %5, align 8
-  %6 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$_", i32 0, i32 1
+  %6 = getelementptr %uint64_int64__tuple_t, ptr %"$_", i32 0, i32 1
   store i64 %val, ptr %6, align 8
   %"ctx.$var1" = getelementptr %ctx_t.2, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8

--- a/tests/codegen/llvm/for_map_variables_scope.ll
+++ b/tests/codegen/llvm/for_map_variables_scope.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"unsigned int64_int64__tuple_t" = type { i64, i64 }
+%uint64_int64__tuple_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_map = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -42,14 +42,14 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %"$var" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
   store i64 0, ptr %"$var", align 8
-  %"$kv" = alloca %"unsigned int64_int64__tuple_t", align 8
+  %"$kv" = alloca %uint64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %5 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$kv", i32 0, i32 0
+  %5 = getelementptr %uint64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
   store i64 %key, ptr %5, align 8
-  %6 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$kv", i32 0, i32 1
+  %6 = getelementptr %uint64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %val, ptr %6, align 8
   store i64 1, ptr %"$var", align 8
   ret i64 0
@@ -62,14 +62,14 @@ define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section "
   %"$var" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
   store i64 0, ptr %"$var", align 8
-  %"$kv" = alloca %"unsigned int64_int64__tuple_t", align 8
+  %"$kv" = alloca %uint64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %5 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$kv", i32 0, i32 0
+  %5 = getelementptr %uint64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
   store i64 %key, ptr %5, align 8
-  %6 = getelementptr %"unsigned int64_int64__tuple_t", ptr %"$kv", i32 0, i32 1
+  %6 = getelementptr %uint64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %val, ptr %6, align 8
   store i64 1, ptr %"$var", align 8
   ret i64 0

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -8,7 +8,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
-%"unsigned int64_max__tuple_t" = type { i64, i64 }
+%uint64_max__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -75,8 +75,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !83 {
   %key1 = alloca i32, align 4
   %lookup_fmtstr_key = alloca i32, align 4
-  %tuple = alloca %"unsigned int64_max__tuple_t", align 8
-  %"$kv" = alloca %"unsigned int64_max__tuple_t", align 8
+  %tuple = alloca %uint64_max__tuple_t, align 8
+  %"$kv" = alloca %uint64_max__tuple_t, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -111,19 +111,19 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %9 = getelementptr %"unsigned int64_max__tuple_t", ptr %"$kv", i32 0, i32 0
+  %9 = getelementptr %uint64_max__tuple_t, ptr %"$kv", i32 0, i32 0
   store i64 %key, ptr %9, align 8
-  %10 = getelementptr %"unsigned int64_max__tuple_t", ptr %"$kv", i32 0, i32 1
+  %10 = getelementptr %uint64_max__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %8, ptr %10, align 8
-  %11 = getelementptr %"unsigned int64_max__tuple_t", ptr %"$kv", i32 0, i32 0
+  %11 = getelementptr %uint64_max__tuple_t, ptr %"$kv", i32 0, i32 0
   %12 = load i64, ptr %11, align 8
-  %13 = getelementptr %"unsigned int64_max__tuple_t", ptr %"$kv", i32 0, i32 1
+  %13 = getelementptr %uint64_max__tuple_t, ptr %"$kv", i32 0, i32 1
   %14 = load i64, ptr %13, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_max__tuple_t", ptr %tuple, i32 0, i32 0
+  %15 = getelementptr %uint64_max__tuple_t, ptr %tuple, i32 0, i32 0
   store i64 %12, ptr %15, align 8
-  %16 = getelementptr %"unsigned int64_max__tuple_t", ptr %tuple, i32 0, i32 1
+  %16 = getelementptr %uint64_max__tuple_t, ptr %tuple, i32 0, i32 1
   store i64 %14, ptr %16, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
   store i32 0, ptr %lookup_fmtstr_key, align 4

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -8,7 +8,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
-%"unsigned int64_min__tuple_t" = type { i64, i64 }
+%uint64_min__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -75,8 +75,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !83 {
   %key1 = alloca i32, align 4
   %lookup_fmtstr_key = alloca i32, align 4
-  %tuple = alloca %"unsigned int64_min__tuple_t", align 8
-  %"$kv" = alloca %"unsigned int64_min__tuple_t", align 8
+  %tuple = alloca %uint64_min__tuple_t, align 8
+  %"$kv" = alloca %uint64_min__tuple_t, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -111,19 +111,19 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %9 = getelementptr %"unsigned int64_min__tuple_t", ptr %"$kv", i32 0, i32 0
+  %9 = getelementptr %uint64_min__tuple_t, ptr %"$kv", i32 0, i32 0
   store i64 %key, ptr %9, align 8
-  %10 = getelementptr %"unsigned int64_min__tuple_t", ptr %"$kv", i32 0, i32 1
+  %10 = getelementptr %uint64_min__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %8, ptr %10, align 8
-  %11 = getelementptr %"unsigned int64_min__tuple_t", ptr %"$kv", i32 0, i32 0
+  %11 = getelementptr %uint64_min__tuple_t, ptr %"$kv", i32 0, i32 0
   %12 = load i64, ptr %11, align 8
-  %13 = getelementptr %"unsigned int64_min__tuple_t", ptr %"$kv", i32 0, i32 1
+  %13 = getelementptr %uint64_min__tuple_t, ptr %"$kv", i32 0, i32 1
   %14 = load i64, ptr %13, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_min__tuple_t", ptr %tuple, i32 0, i32 0
+  %15 = getelementptr %uint64_min__tuple_t, ptr %tuple, i32 0, i32 0
   store i64 %12, ptr %15, align 8
-  %16 = getelementptr %"unsigned int64_min__tuple_t", ptr %tuple, i32 0, i32 1
+  %16 = getelementptr %uint64_min__tuple_t, ptr %tuple, i32 0, i32 1
   store i64 %14, ptr %16, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
   store i32 0, ptr %lookup_fmtstr_key, align 4

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr, ptr, ptr }
-%"unsigned int64_sum__tuple_t" = type { i64, i64 }
+%uint64_sum__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -61,8 +61,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !77 {
   %key1 = alloca i32, align 4
   %lookup_fmtstr_key = alloca i32, align 4
-  %tuple = alloca %"unsigned int64_sum__tuple_t", align 8
-  %"$kv" = alloca %"unsigned int64_sum__tuple_t", align 8
+  %tuple = alloca %uint64_sum__tuple_t, align 8
+  %"$kv" = alloca %uint64_sum__tuple_t, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -97,19 +97,19 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %9 = getelementptr %"unsigned int64_sum__tuple_t", ptr %"$kv", i32 0, i32 0
+  %9 = getelementptr %uint64_sum__tuple_t, ptr %"$kv", i32 0, i32 0
   store i64 %key, ptr %9, align 8
-  %10 = getelementptr %"unsigned int64_sum__tuple_t", ptr %"$kv", i32 0, i32 1
+  %10 = getelementptr %uint64_sum__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %8, ptr %10, align 8
-  %11 = getelementptr %"unsigned int64_sum__tuple_t", ptr %"$kv", i32 0, i32 0
+  %11 = getelementptr %uint64_sum__tuple_t, ptr %"$kv", i32 0, i32 0
   %12 = load i64, ptr %11, align 8
-  %13 = getelementptr %"unsigned int64_sum__tuple_t", ptr %"$kv", i32 0, i32 1
+  %13 = getelementptr %uint64_sum__tuple_t, ptr %"$kv", i32 0, i32 1
   %14 = load i64, ptr %13, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"unsigned int64_sum__tuple_t", ptr %tuple, i32 0, i32 0
+  %15 = getelementptr %uint64_sum__tuple_t, ptr %tuple, i32 0, i32 0
   store i64 %12, ptr %15, align 8
-  %16 = getelementptr %"unsigned int64_sum__tuple_t", ptr %tuple, i32 0, i32 1
+  %16 = getelementptr %uint64_sum__tuple_t, ptr %tuple, i32 0, i32 1
   store i64 %14, ptr %16, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
   store i32 0, ptr %lookup_fmtstr_key, align 4

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"unsigned int8_usym_int64__tuple_t" = type { i8, [24 x i8], i64 }
+%uint8_usym_int64__tuple_t = type { i8, [24 x i8], i64 }
 %usym_t = type { i64, i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -20,7 +20,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
 entry:
   %"@t_key" = alloca i64, align 8
-  %tuple = alloca %"unsigned int8_usym_int64__tuple_t", align 8
+  %tuple = alloca %uint8_usym_int64__tuple_t, align 8
   %usym = alloca %usym_t, align 8
   %1 = getelementptr i64, ptr %0, i64 16
   %reg_ip = load volatile i64, ptr %1, align 8
@@ -35,11 +35,11 @@ entry:
   store i64 0, ptr %5, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 40, i1 false)
-  %6 = getelementptr %"unsigned int8_usym_int64__tuple_t", ptr %tuple, i32 0, i32 0
+  %6 = getelementptr %uint8_usym_int64__tuple_t, ptr %tuple, i32 0, i32 0
   store i8 1, ptr %6, align 1
-  %7 = getelementptr %"unsigned int8_usym_int64__tuple_t", ptr %tuple, i32 0, i32 1
+  %7 = getelementptr %uint8_usym_int64__tuple_t, ptr %tuple, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %usym, i64 24, i1 false)
-  %8 = getelementptr %"unsigned int8_usym_int64__tuple_t", ptr %tuple, i32 0, i32 2
+  %8 = getelementptr %uint8_usym_int64__tuple_t, ptr %tuple, i32 0, i32 2
   store i64 10, ptr %8, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -769,22 +769,22 @@ TEST(Parser, variable_post_increment_decrement)
   test("kprobe:sys_open { $x++; }",
        "Program\n"
        " kprobe:sys_open\n"
-       "  variable: $x\n"
-       "   ++\n");
+       "  ++ (post)\n"
+       "   variable: $x\n");
   test("kprobe:sys_open { ++$x; }",
        "Program\n"
        " kprobe:sys_open\n"
-       "  ++\n"
+       "  ++ (pre)\n"
        "   variable: $x\n");
   test("kprobe:sys_open { $x--; }",
        "Program\n"
        " kprobe:sys_open\n"
-       "  variable: $x\n"
-       "   --\n");
+       "  -- (post)\n"
+       "   variable: $x\n");
   test("kprobe:sys_open { --$x; }",
        "Program\n"
        " kprobe:sys_open\n"
-       "  --\n"
+       "  -- (pre)\n"
        "   variable: $x\n");
 }
 
@@ -793,22 +793,22 @@ TEST(Parser, map_increment_decrement)
   test("kprobe:sys_open { @x++; }",
        "Program\n"
        " kprobe:sys_open\n"
-       "  map: @x\n"
-       "   ++\n");
+       "  ++ (post)\n"
+       "   map: @x\n");
   test("kprobe:sys_open { ++@x; }",
        "Program\n"
        " kprobe:sys_open\n"
-       "  ++\n"
+       "  ++ (pre)\n"
        "   map: @x\n");
   test("kprobe:sys_open { @x--; }",
        "Program\n"
        " kprobe:sys_open\n"
-       "  map: @x\n"
-       "   --\n");
+       "  -- (post)\n"
+       "   map: @x\n");
   test("kprobe:sys_open { --@x; }",
        "Program\n"
        " kprobe:sys_open\n"
-       "  --\n"
+       "  -- (pre)\n"
        "   map: @x\n");
 }
 
@@ -2368,8 +2368,8 @@ TEST(Parser, while_loop)
     variable: $a
     int: 10
    )
-    variable: $a
-     ++
+    ++ (post)
+     variable: $a
 )PROG");
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2626,14 +2626,14 @@ TEST(Parser, subprog_one_arg)
 {
   test("fn f($a : uint8): void {}",
        "Program\n"
-       " f: void($a : unsigned int8)\n");
+       " f: void($a : uint8)\n");
 }
 
 TEST(Parser, subprog_two_args)
 {
   test("fn f($a : uint8, $b : uint8): void {}",
        "Program\n"
-       " f: void($a : unsigned int8, $b : unsigned int8)\n");
+       " f: void($a : uint8, $b : uint8)\n");
 }
 
 TEST(Parser, subprog_string_arg)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1704,7 +1704,7 @@ TEST_F(semantic_analyser_dwarf, reference_into_deref)
   test(bpftrace, uprobe + " { args.c }", R"(
 Program
  )" + uprobe + R"(
-  dereference
+  dereference :: [Child, AS(user)]
    . :: [Child *, AS(user)]
     builtin: args :: [struct )" + uprobe + R"(_args, ctx: 1, AS(user)]
     c

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -408,12 +408,12 @@ TEST(semantic_analyser, consistent_map_keys)
   test("BEGIN { @x[1] = 0; @x[2]; }");
 
   test_error("BEGIN { @x = 0; @x[1]; }", R"(
-stdin:1:17-22: ERROR: Argument mismatch for @x: trying to access with arguments: [unsigned int64] when map expects arguments: []
+stdin:1:17-22: ERROR: Argument mismatch for @x: trying to access with arguments: [uint64] when map expects arguments: []
 BEGIN { @x = 0; @x[1]; }
                 ~~~~~
 )");
   test_error("BEGIN { @x[1] = 0; @x; }", R"(
-stdin:1:20-22: ERROR: Argument mismatch for @x: trying to access with arguments: [] when map expects arguments: [unsigned int64]
+stdin:1:20-22: ERROR: Argument mismatch for @x: trying to access with arguments: [] when map expects arguments: [uint64]
 BEGIN { @x[1] = 0; @x; }
                    ~~
 )");
@@ -421,12 +421,12 @@ BEGIN { @x[1] = 0; @x; }
   test("BEGIN { @x[1,2] = 0; @x[3,4]; }");
 
   test_error("BEGIN { @x[1,2] = 0; @x[3]; }", R"(
-stdin:1:22-27: ERROR: Argument mismatch for @x: trying to access with arguments: [unsigned int64] when map expects arguments: [unsigned int64, unsigned int64]
+stdin:1:22-27: ERROR: Argument mismatch for @x: trying to access with arguments: [uint64] when map expects arguments: [uint64, uint64]
 BEGIN { @x[1,2] = 0; @x[3]; }
                      ~~~~~
 )");
   test_error("BEGIN { @x[1] = 0; @x[2,3]; }", R"(
-stdin:1:20-27: ERROR: Argument mismatch for @x: trying to access with arguments: [unsigned int64, unsigned int64] when map expects arguments: [unsigned int64]
+stdin:1:20-27: ERROR: Argument mismatch for @x: trying to access with arguments: [uint64, uint64] when map expects arguments: [uint64]
 BEGIN { @x[1] = 0; @x[2,3]; }
                    ~~~~~~~
 )");
@@ -439,7 +439,7 @@ BEGIN { @x[1] = 0; @x[2,3]; }
       @x["b", 2, kstack];
     })",
              R"(
-stdin:3:7-25: ERROR: Argument mismatch for @x: trying to access with arguments: [string[2], unsigned int64, kstack] when map expects arguments: [unsigned int64, string[2], kstack]
+stdin:3:7-25: ERROR: Argument mismatch for @x: trying to access with arguments: [string[2], uint64, kstack] when map expects arguments: [uint64, string[2], kstack]
       @x["b", 2, kstack];
       ~~~~~~~~~~~~~~~~~~
 )");
@@ -846,7 +846,7 @@ TEST(semantic_analyser, call_delete)
   test("kprobe:f { @x = 1; delete(@x) ? 0 : 1; }", 10);
 
   test_error("kprobe:f { @x = 1; @y[5] = 5; delete(@x, @y); }", R"(
-stdin:1:42-44: ERROR: Argument mismatch for @y: trying to access with arguments: [] when map expects arguments: [unsigned int64]
+stdin:1:42-44: ERROR: Argument mismatch for @y: trying to access with arguments: [] when map expects arguments: [uint64]
 kprobe:f { @x = 1; @y[5] = 5; delete(@x, @y); }
                                          ~~
 )");
@@ -904,7 +904,7 @@ TEST(semantic_analyser, call_print_map_item)
   test(R"_(BEGIN { @x[1,2] = "asdf"; print((1, 2, @x[1,2])); })_");
 
   test_error("BEGIN { @x[1] = 1; print(@x[\"asdf\"]); }", R"(
-stdin:1:20-36: ERROR: Argument mismatch for @x: trying to access with arguments: [string[5]] when map expects arguments: [unsigned int64]
+stdin:1:20-36: ERROR: Argument mismatch for @x: trying to access with arguments: [string[5]] when map expects arguments: [uint64]
 BEGIN { @x[1] = 1; print(@x["asdf"]); }
                    ~~~~~~~~~~~~~~~~
 )");
@@ -2134,7 +2134,7 @@ TEST(semantic_analyser, map_aggregations_explicit_cast)
   test("kprobe:f { @ = avg(5); print((1, (uint16)@)); }");
 
   test_error("kprobe:f { @ = hist(5); print((1, (uint16)@)); }", R"(
-stdin:1:35-43: ERROR: Cannot cast from "hist" to "unsigned int16"
+stdin:1:35-43: ERROR: Cannot cast from "hist" to "uint16"
 kprobe:f { @ = hist(5); print((1, (uint16)@)); }
                                   ~~~~~~~~
 )");
@@ -2619,7 +2619,7 @@ TEST(semantic_analyser, mixed_int_var_assignments)
   test("kprobe:f { $x = (int8)1; $x = -2; }");
   test("kprobe:f { $x = (int16)1; $x = 20000; }");
   test_error("kprobe:f { $x = (uint8)1; $x = -1; }", R"(
-stdin:1:27-34: ERROR: Type mismatch for $x: trying to assign value of type 'int64' when variable already contains a value of type 'unsigned int8'
+stdin:1:27-34: ERROR: Type mismatch for $x: trying to assign value of type 'int64' when variable already contains a value of type 'uint8'
 kprobe:f { $x = (uint8)1; $x = -1; }
                           ~~~~~~~
 )");
@@ -2629,12 +2629,12 @@ kprobe:f { $x = (int16)1; $x = 100000; }
                           ~~~~~~~~~~~
 )");
   test_error("kprobe:f { $a = (uint16)5; $x = (uint8)0; $x = $a; }", R"(
-stdin:1:43-50: ERROR: Integer size mismatch. Assignment type 'unsigned int16' is larger than the variable type 'unsigned int8'.
+stdin:1:43-50: ERROR: Integer size mismatch. Assignment type 'uint16' is larger than the variable type 'uint8'.
 kprobe:f { $a = (uint16)5; $x = (uint8)0; $x = $a; }
                                           ~~~~~~~
 )");
   test_error("kprobe:f { $a = (int8)-1; $x = (uint8)0; $x = $a; }", R"(
-stdin:1:42-49: ERROR: Type mismatch for $x: trying to assign value of type 'int8' when variable already contains a value of type 'unsigned int8'
+stdin:1:42-49: ERROR: Type mismatch for $x: trying to assign value of type 'int8' when variable already contains a value of type 'uint8'
 kprobe:f { $a = (int8)-1; $x = (uint8)0; $x = $a; }
                                          ~~~~~~~
 )");
@@ -2644,7 +2644,7 @@ kprobe:f { $x = -1; $x = 10223372036854775807; }
                     ~~~~~~~~~~~~~~~~~~~~~~~~~
 )");
   test_error("kprobe:f { $x = (0, (uint32)123); $x = (0, (int32)-123); }", R"(
-stdin:1:35-56: ERROR: Tuple type mismatch: (int64,unsigned int32) != (int64,int32).
+stdin:1:35-56: ERROR: Tuple type mismatch: (int64,uint32) != (int64,int32).
 kprobe:f { $x = (0, (uint32)123); $x = (0, (int32)-123); }
                                   ~~~~~~~~~~~~~~~~~~~~~
 )");
@@ -2652,12 +2652,12 @@ kprobe:f { $x = (0, (uint32)123); $x = (0, (int32)-123); }
 Program
  BEGIN
   =
-   variable: $x :: [unsigned int8]
-   (unsigned int8)
+   variable: $x :: [uint8]
+   (uint8)
     int: 1 :: [int64]
   =
-   variable: $x :: [unsigned int8]
-   (unsigned int8)
+   variable: $x :: [uint8]
+   (uint8)
     int: 5 :: [int64]
 )");
   test("BEGIN { $x = (int8)1; $x = 5; }", R"(
@@ -3592,12 +3592,12 @@ Program
    int: 1 :: [int64]
   for
    decl
-    variable: $kv :: [(unsigned int64,int64)]
+    variable: $kv :: [(uint64,int64)]
    expr
     map: @map :: [int64]
    stmts
     call: print
-     variable: $kv :: [(unsigned int64,int64)]
+     variable: $kv :: [(uint64,int64)]
 )");
 }
 
@@ -3613,12 +3613,12 @@ Program
    int: 1 :: [int64]
   for
    decl
-    variable: $kv :: [((unsigned int64,unsigned int64),int64)]
+    variable: $kv :: [((uint64,uint64),int64)]
    expr
     map: @map :: [int64]
    stmts
     call: print
-     variable: $kv :: [((unsigned int64,unsigned int64),int64)]
+     variable: $kv :: [((uint64,uint64),int64)]
 )");
 }
 


### PR DESCRIPTION
```
Print unsigned integers as "uintX" instead of "unsigned intX"

This matches the BpfScript syntax and cleans up error messages and AST
debug output.
```
```
Printer: Print types of all expression nodes

This improves the debugging experience and will hopefully help with unit
tests in the future.

Plus another minor change to print post-op Unop nodes in AST order
(like all other nodes) and distinguish them with the string "(post)"
```
```
PassManager: When AST debug is requested, print it for failed passes too

The AST might be in an inconsistent state when it is dumped from a
failed pass, but it is this state at the point of failure that is
often the most useful for understanding issues.
```

##### Checklist

- ~[ ]~ Language changes are updated in `man/adoc/bpftrace.adoc`
- ~[ ]~ User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
