### PR TITLE
Make bpftrace work correctly inside containers with PID namespacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   - [#3692](https://github.com/bpftrace/bpftrace/pull/3692)
 - Fix bug where strftime() %f specifier could be off by up to 1s
   - [#3704](https://github.com/bpftrace/bpftrace/pull/3704)
+- Fix `pid`, `tid` and `ustack` when running bpftrace in containers with PID namespacing
+  - [#3428](https://github.com/bpftrace/bpftrace/pull/3428)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -148,7 +148,6 @@ public:
                                MDNode *metadata);
   CallInst *CreateGetNs(TimestampMode ts, const location &loc);
   CallInst *CreateJiffies64(const location &loc);
-  CallInst *CreateGetPidTgid(const location &loc);
   CallInst *CreateGetCurrentCgroupId(const location &loc);
   CallInst *CreateGetUidGid(const location &loc);
   CallInst *CreateGetNumaId(const location &loc);
@@ -236,7 +235,12 @@ public:
                             bool packed = false);
   Value *CreateGetPid(const location &loc);
   Value *CreateGetTid(const location &loc);
-  AllocaInst *CreateUSym(llvm::Value *val, int probe_id, const location &loc);
+  Value *CreateGetPid(Value *ctx, const location &loc);
+  Value *CreateGetTid(Value *ctx, const location &loc);
+  AllocaInst *CreateUSym(Value *ctx,
+                         Value *val,
+                         int probe_id,
+                         const location &loc);
   Value *CreateRegisterRead(Value *ctx, const std::string &builtin);
   Value *CreateRegisterRead(Value *ctx, int offset, const std::string &name);
   Value *CreateKFuncArg(Value *ctx, SizedType &type, std::string &name);
@@ -298,6 +302,13 @@ private:
   BPFtrace &bpftrace_;
   AsyncIds &async_ids_;
 
+  CallInst *CreateGetPidTgid(const location &loc);
+  void CreateGetNsPidTgid(Value *ctx,
+                          Value *dev,
+                          Value *ino,
+                          AllocaInst *ret,
+                          const location &loc);
+  llvm::Type *BpfPidnsInfoType();
   Value *CreateUSDTReadArgument(Value *ctx,
                                 struct bcc_usdt_argument *argument,
                                 Builtin &builtin,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -303,7 +303,7 @@ void CodegenLLVM::kstack_ustack(const std::string &ident,
         b_.CreateGEP(stack_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
     // store pid
     b_.CreateStore(
-        b_.CreateGetPid(loc),
+        b_.CreateGetPid(ctx_, loc),
         b_.CreateGEP(stack_struct, buf, { b_.getInt64(0), b_.getInt32(2) }));
     // store probe id
     b_.CreateStore(
@@ -346,9 +346,9 @@ void CodegenLLVM::visit(Builtin &builtin)
   } else if (builtin.ident == "kstack" || builtin.ident == "ustack") {
     kstack_ustack(builtin.ident, builtin.type.stack_type, builtin.loc);
   } else if (builtin.ident == "pid") {
-    expr_ = b_.CreateGetPid(builtin.loc);
+    expr_ = b_.CreateGetPid(ctx_, builtin.loc);
   } else if (builtin.ident == "tid") {
-    expr_ = b_.CreateGetTid(builtin.loc);
+    expr_ = b_.CreateGetTid(ctx_, builtin.loc);
   } else if (builtin.ident == "cgroup") {
     expr_ = b_.CreateGetCurrentCgroupId(builtin.loc);
   } else if (builtin.ident == "uid" || builtin.ident == "gid" ||
@@ -400,7 +400,7 @@ void CodegenLLVM::visit(Builtin &builtin)
     }
 
     if (builtin.type.IsUsymTy()) {
-      expr_ = b_.CreateUSym(expr_, get_probe_id(), builtin.loc);
+      expr_ = b_.CreateUSym(ctx_, expr_, get_probe_id(), builtin.loc);
       Value *expr = expr_;
       expr_deleter_ = [this, expr]() { b_.CreateLifetimeEnd(expr); };
     }
@@ -431,7 +431,7 @@ void CodegenLLVM::visit(Builtin &builtin)
       expr_ = b_.CreateRegisterRead(ctx_, builtin.ident);
 
     if (builtin.type.IsUsymTy()) {
-      expr_ = b_.CreateUSym(expr_, get_probe_id(), builtin.loc);
+      expr_ = b_.CreateUSym(ctx_, expr_, get_probe_id(), builtin.loc);
       Value *expr = expr_;
       expr_deleter_ = [this, expr]() { b_.CreateLifetimeEnd(expr); };
     }
@@ -1022,7 +1022,7 @@ void CodegenLLVM::visit(Call &call)
     auto scoped_del = accept(call.vargs.front());
   } else if (call.func == "usym") {
     auto scoped_del = accept(call.vargs.front());
-    expr_ = b_.CreateUSym(expr_, get_probe_id(), call.loc);
+    expr_ = b_.CreateUSym(ctx_, expr_, get_probe_id(), call.loc);
   } else if (call.func == "ntop") {
     // struct {
     //   int af_type;

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -602,7 +602,8 @@ std::string BPFfeature::report()
     { "get_tai_ns", to_str(has_helper_ktime_get_tai_ns()) },
     { "get_func_ip", to_str(has_helper_get_func_ip()) },
     { "jiffies64", to_str(has_helper_jiffies64()) },
-    { "for_each_map_elem", to_str(has_helper_for_each_map_elem()) }
+    { "for_each_map_elem", to_str(has_helper_for_each_map_elem()) },
+    { "get_ns_current_pid_tgid", to_str(has_helper_get_ns_current_pid_tgid()) },
   };
 
   std::vector<std::pair<std::string, std::string>> features = {

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -128,6 +128,7 @@ public:
   DEFINE_HELPER_TEST(get_func_ip, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(jiffies64, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(for_each_map_elem, libbpf::BPF_PROG_TYPE_KPROBE);
+  DEFINE_HELPER_TEST(get_ns_current_pid_tgid, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(kprobe, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(tracepoint, libbpf::BPF_PROG_TYPE_TRACEPOINT);
   DEFINE_PROG_TEST(perf_event, libbpf::BPF_PROG_TYPE_PERF_EVENT);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2069,6 +2069,20 @@ std::unordered_set<std::string> BPFtrace::get_func_modules(
 #endif
 }
 
+const struct stat &BPFtrace::get_pidns_self_stat() const
+{
+  static struct stat pidns = []() -> auto {
+    struct stat s;
+    if (::stat("/proc/self/ns/pid", &s))
+      throw std::runtime_error(
+          std::string("Failed to stat /proc/self/ns/pid: ") +
+          std::strerror(errno));
+    return s;
+  }();
+
+  return pidns;
+}
+
 Dwarf *BPFtrace::get_dwarf(const std::string &filename)
 {
   auto dwarf = dwarves_.find(filename);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -9,6 +9,7 @@
 #include <optional>
 #include <set>
 #include <string_view>
+#include <sys/stat.h>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -157,6 +158,8 @@ public:
   virtual bool is_traceable_func(const std::string &func_name) const;
   virtual std::unordered_set<std::string> get_func_modules(
       const std::string &func_name) const;
+  virtual const struct stat &get_pidns_self_stat() const;
+
   bool write_pcaps(uint64_t id, uint64_t ns, uint8_t *pkt, unsigned int size);
 
   void parse_btf(const std::set<std::string> &modules);

--- a/tests/codegen/builtin_pid_tid.cpp
+++ b/tests/codegen/builtin_pid_tid.cpp
@@ -6,9 +6,16 @@ namespace codegen {
 
 TEST(codegen, builtin_pid_tid)
 {
-  test("kprobe:f { @x = pid; @y = tid }",
+  test("kprobe:f { @x = pid; @y = tid }", NAME);
+}
 
-       NAME);
+TEST(codegen, builtin_pid_tid_namespace)
+{
+  MockBPFtrace bpftrace;
+  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  bpftrace.mock_in_init_pid_ns = false;
+
+  test(bpftrace, "kprobe:f { @x = pid; @y = tid }", NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/llvm/builtin_pid_tid_namespace.ll
+++ b/tests/codegen/llvm/builtin_pid_tid_namespace.ll
@@ -1,0 +1,123 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
+%bpf_pidns_info = type { i32, i32 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !18
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !32
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !47 {
+entry:
+  %"@y_val" = alloca i64, align 8
+  %"@y_key" = alloca i64, align 8
+  %bpf_pidns_info1 = alloca %bpf_pidns_info, align 8
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %bpf_pidns_info = alloca %bpf_pidns_info, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info)
+  %get_ns_pid_tgid = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info, i32 8)
+  %1 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info, i32 0, i32 0
+  %2 = load i32, ptr %1, align 4
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
+  store i64 0, ptr %"@x_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %3 = zext i32 %2 to i64
+  store i64 %3, ptr %"@x_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info1)
+  %get_ns_pid_tgid2 = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info1, i32 8)
+  %4 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 1
+  %5 = load i32, ptr %4, align 4
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
+  store i64 0, ptr %"@y_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
+  %6 = zext i32 %5 to i64
+  store i64 %6, ptr %"@y_val", align 8
+  %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !12, !15}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !13, size: 64, offset: 128)
+!13 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !14, size: 64)
+!14 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!15 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !13, size: 64, offset: 192)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!18 = !DIGlobalVariableExpression(var: !19, expr: !DIExpression())
+!19 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!20 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !21)
+!21 = !{!22, !27}
+!22 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !23, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !25)
+!25 = !{!26}
+!26 = !DISubrange(count: 27, lowerBound: 0)
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !28, size: 64, offset: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 262144, lowerBound: 0)
+!32 = !DIGlobalVariableExpression(var: !33, expr: !DIExpression())
+!33 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !34, isLocal: false, isDefinition: true)
+!34 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !35)
+!35 = !{!36, !11, !41, !15}
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !37, size: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 2, lowerBound: 0)
+!41 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !42, size: 64, offset: 128)
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !16, !18, !32}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!14, !50}
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!51 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !50)

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -140,7 +140,7 @@ class TestParser(object):
                 if prev_item_name == 'PROG':
                     prog += '\n' + line
                     continue
-                elif prev_item_name == 'EXPECT':
+                elif prev_item_name in ('EXPECT', 'EXPECT_REGEX'):
                     expects[-1].expect += '\n' + line
                     continue
 

--- a/tests/runtime/pid_namespace
+++ b/tests/runtime/pid_namespace
@@ -1,0 +1,30 @@
+# Run bpftrace inside a PID namespace and get its own PID/TID
+# They should both be "1" as bpftrace is the first and only process in this
+# temporary namespace.
+NAME pid_tid_inside
+RUN unshare --fork --pid --mount-proc {{BPFTRACE}} -e 'BEGIN { printf("pid: %d, tid: %d\n", pid, tid); exit() }'
+EXPECT pid: 1, tid: 1
+
+# Run target program inside a PID namespace and bpftrace outside
+# We should see PID/TID != 1 as we want to view them from the init-namespace,
+# where bpftrace is, not from inside the target's namespace.
+NAME pid_tid_outside
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_loop:uprobeFunction1 { printf("pid: %d, tid: %d\n", pid, tid); exit(); }'
+AFTER unshare --fork --pid --mount-proc ./testprogs/uprobe_loop
+EXPECT_REGEX ^pid: \d+, tid: \d+$
+EXPECT_REGEX_NONE ^pid: 1, tid: 1$
+
+# Both bpftrace and target running inside a PID namespace
+NAME ustack_inside
+RUN unshare --fork --pid --mount-proc bash -c "(./testprogs/uprobe_loop &) && {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_loop:uprobeFunction1 { print(ustack); exit(); }'"
+EXPECT_REGEX         uprobeFunction1\+\d+$
+                     spin\+\d+$
+                     main\+\d+$
+
+# Target inside a PID namespace, bpftrace outside
+NAME ustack_outside
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_loop:uprobeFunction1 { print(ustack); exit(); }'
+AFTER unshare --fork --pid --mount-proc bash -c ./testprogs/uprobe_loop
+EXPECT_REGEX         uprobeFunction1\+\d+$
+                     spin\+\d+$
+                     main\+\d+$


### PR DESCRIPTION
This has been a long time coming - I presented it at eBPF Summit 2023 - but it's finally ready!

This fixes `pid`, `tid` and `ustack` when running bpftrace inside a PID namespace. Previously, these builtins would return PIDs as-seen from the init (global/root) namespace, but this meant that they did not correspond to the correct processes from the bpftrace runtime's point-of-view, as it would see namespaced PIDs.

The core of the PR is covered by this commit:
```
Codegen: Get correct PIDs/TIDs relative to bpftrace's PID namespace

The bpf_get_current_pid_tgid helper only returns PIDs in the root namespace.

The bpf_get_ns_current_pid_tgid helper only returns PIDs in a given
namespace for processes running in that same namespace.

We must switch between the two helpers based on where bpftrace is
running in order to cover the most scenarios.

The following tables show whether we are able to get the correct PID for
a target process using each helper, when bpftrace and the target are and
are-not in PID namespaces.

Always using bpf_get_current_pid_tgid (old behaviour):
        \ target |                |
bpftrace \       | root namespace | child namespace
-----------------+----------------+-----------------
root namespace   | YES            | YES
child namespace  | N/A            | NO

Always using bpf_get_ns_current_pid_tgid:
        \ target |                |
bpftrace \       | root namespace | child namespace
-----------------+----------------+-----------------
root namespace   | YES            | NO
child namespace  | N/A            | YES

Switching between the two helpers (new behaviour):
        \ target |                |
bpftrace \       | root namespace | child namespace
-----------------+----------------+-----------------
root namespace   | YES            | YES
child namespace  | N/A            | YES

This approach is still not complete, however. If the target is running
in a namespace, and bpftrace is running in a different namespace which
still has visibility over the target's namespace, we will not get the
correct PID for the target. This would require kernel changes to work.
```

##### Checklist

- ~[ ]~ Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
