### PR TITLE
irbuilder: NFC: Add asserts for big allocas

### DIFF
--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -38,12 +38,6 @@ public:
                               const std::string &name = "");
   AllocaInst *CreateAllocaBPFInit(const SizedType &stype,
                                   const std::string &name);
-  AllocaInst *CreateAllocaBPF(llvm::Type *ty,
-                              llvm::Value *arraysize,
-                              const std::string &name = "");
-  AllocaInst *CreateAllocaBPF(const SizedType &stype,
-                              llvm::Value *arraysize,
-                              const std::string &name = "");
   AllocaInst *CreateAllocaBPF(int bytes, const std::string &name = "");
   void CreateMemsetBPF(Value *ptr, Value *val, uint32_t size);
   void CreateMemcpyBPF(Value *dst, Value *src, uint32_t size);


### PR DESCRIPTION
First we remove the unused arraysize parameter for allocas. It was a Value so we can't statically know the real value. Since it was unused, delete some of the overloads.

With arraysize deleted, we can now statically assert on alloca size. The new asserts help ensure that we don't try to allocate something too big on the stack. All such allocations need to go onto a scratch map.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
