### PR TITLE
codegen: ternary: Move allocations off stack

### DIFF
--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -248,6 +248,18 @@ void ResourceAnalyser::visit(Map &map)
   map_info.key = map.key_type;
 }
 
+void ResourceAnalyser::visit(Ternary &ternary)
+{
+  Visitor::visit(ternary);
+
+  // Codegen cannot use a phi node for ternary string b/c strings can be of
+  // differing lengths and phi node wants identical types. So we have to
+  // allocate a result temporary, but not on the stack b/c a big string would
+  // blow it up. So we need a scratch buffer for it.
+  if (ternary.type.IsStringTy())
+    resources_.str_buffers++;
+}
+
 bool ResourceAnalyser::uses_usym_table(const std::string &fun)
 {
   return fun == "usym" || fun == "func" || fun == "ustack";

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -33,6 +33,7 @@ private:
   void visit(Builtin &map) override;
   void visit(Call &call) override;
   void visit(Map &map) override;
+  void visit(Ternary &ternary) override;
 
   // Determines whether the given function uses userspace symbol resolution.
   // This is used later for loading the symbol table into memory.

--- a/tests/codegen/llvm/ternary_int.ll
+++ b/tests/codegen/llvm/ternary_int.ll
@@ -19,8 +19,6 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !41 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %buf = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %buf)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ult i64 %1, 10000

--- a/tests/codegen/llvm/ternary_int.ll
+++ b/tests/codegen/llvm/ternary_int.ll
@@ -20,8 +20,6 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %buf = alloca i64, align 8
-  %result = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %result)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %buf)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %1 = lshr i64 %get_pid_tgid, 32
@@ -31,19 +29,17 @@ entry:
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
-  store i64 1, ptr %result, align 8
   br label %done
 
 right:                                            ; preds = %entry
-  store i64 2, ptr %result, align 8
   br label %done
 
 done:                                             ; preds = %right, %left
-  %4 = load i64, ptr %result, align 8
+  %result = phi i64 [ 1, %left ], [ 2, %right ]
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %4, ptr %"@x_val", align 8
+  store i64 %result, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -6,39 +6,40 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !53
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !63 {
 entry:
   %"@x_key" = alloca i64, align 8
   %str1 = alloca [3 x i8], align 1
   %str = alloca [3 x i8], align 1
-  %buf = alloca [3 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %buf)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ult i64 %1, 10000
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
-  br i1 %true_cond, label %left, label %right
+  %lookup_str_key = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
+  store i32 0, ptr %lookup_str_key, align 4
+  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
+  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
+  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
 
-left:                                             ; preds = %entry
+left:                                             ; preds = %lookup_str_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [3 x i8] c"lo\00", ptr %str, align 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %buf, ptr align 1 %str, i64 3, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %lookup_str_map, ptr align 1 %str, i64 3, i1 false)
   br label %done
 
-right:                                            ; preds = %entry
+right:                                            ; preds = %lookup_str_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
   store [3 x i8] c"hi\00", ptr %str1, align 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %buf, ptr align 1 %str1, i64 3, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %lookup_str_map, ptr align 1 %str1, i64 3, i1 false)
   br label %done
 
 done:                                             ; preds = %right, %left
@@ -46,27 +47,42 @@ done:                                             ; preds = %right, %left
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %buf, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %lookup_str_map, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %buf)
   ret i64 0
+
+lookup_str_failure:                               ; preds = %entry
+  ret i64 0
+
+lookup_str_merge:                                 ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %1 = lshr i64 %get_pid_tgid, 32
+  %2 = icmp ult i64 %1, 10000
+  %3 = zext i1 %2 to i64
+  %true_cond = icmp ne i64 %3, 0
+  br i1 %true_cond, label %left, label %right
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48}
+!llvm.dbg.cu = !{!60}
+!llvm.module.flags = !{!62}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -108,18 +124,32 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !37 = !{!38}
 !38 = !DISubrange(count: 262144, lowerBound: 0)
 !39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!40 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
 !41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!5, !11, !16, !43}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !44, size: 64, offset: 192)
+!42 = !{!43, !11, !16, !48}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !25, !39}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
-!50 = !DISubroutineType(types: !51)
-!51 = !{!45, !52}
-!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!53 = !{!54}
-!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 6, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !49, size: 64, offset: 192)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 64, lowerBound: 0)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !56)
+!56 = !{!5, !11, !16, !57}
+!57 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !58, size: 64, offset: 192)
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
+!59 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!60 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !61)
+!61 = !{!0, !25, !39, !53}
+!62 = !{i32 2, !"Debug Info Version", i32 3}
+!63 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !64, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !60, retainedNodes: !67)
+!64 = !DISubroutineType(types: !65)
+!65 = !{!59, !66}
+!66 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!67 = !{!68}
+!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !63, file: !2, type: !66)

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -21,8 +21,6 @@ entry:
   %str1 = alloca [3 x i8], align 1
   %str = alloca [3 x i8], align 1
   %buf = alloca [3 x i8], align 1
-  %result = alloca [3 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %result)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %buf)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %1 = lshr i64 %get_pid_tgid, 32


### PR DESCRIPTION
See individual commits for more details.

Part of https://github.com/bpftrace/bpftrace/issues/3431.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
