### PR TITLE
Fix `call.path*` tests in newer kernel

### DIFF
--- a/tests/testprogs/syscall.c
+++ b/tests/testprogs/syscall.c
@@ -1,6 +1,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <linux/version.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -116,7 +117,11 @@ int gen_read()
   }
   char buf[10];
   int r = syscall(SYS_read, fd, (void *)buf, 0);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
   close(fd);
+#else
+  close_range(fd, fd, 0);
+#endif
   remove(file_path);
   free(file_path);
   if (r < 0) {


### PR DESCRIPTION
The runtimetests of `call.path` and `call.path_with_optional_size` will timeout on newer kernels.

See kernel 021a160abf62 ("fs: use __fput_sync in close(2)"). `close` stopped using `flip_close` since kernel 6.5-rc1.

Just like kernel d11ae1b16b0a ("selftests/bpf: Fix d_path test"), using `close_range` to replace `close` is reasonable.



##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
