### PR TITLE
Support bool type in ClangParser and codegen

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -299,6 +299,8 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
     ty = getInt64Ty();
   } else if (stype.IsVoidTy()) {
     ty = getVoidTy();
+  } else if (stype.IsBoolTy()) {
+    ty = getInt1Ty();
   } else {
     switch (stype.GetSize()) {
       case 16:

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -376,8 +376,11 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
   auto stype = CreateNone();
 
   if (btf_is_int(t)) {
-    stype = CreateInteger(btf_int_bits(t),
-                          btf_int_encoding(t) & BTF_INT_SIGNED);
+    if (btf_int_encoding(t) & BTF_INT_BOOL)
+      stype = CreateBool();
+    else
+      stype = CreateInteger(btf_int_bits(t),
+                            btf_int_encoding(t) & BTF_INT_SIGNED);
   } else if (btf_is_enum(t)) {
     stype = CreateInteger(t->size * 8, false);
   } else if (btf_is_composite(t)) {

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -165,6 +165,7 @@ static SizedType get_sized_type(CXType clang_type, StructManager &structs)
 
   switch (clang_type.kind) {
     case CXType_Bool:
+      return CreateBool();
     case CXType_Char_U:
     case CXType_UChar:
     case CXType_UShort:

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -156,6 +156,7 @@ SizedType Dwarf::get_stype(lldb::SBType type, bool resolve_structs)
     case lldb::eTypeClassBuiltin: {
       switch (type.GetBasicType()) {
         case lldb::eBasicTypeBool:
+          return CreateBool();
         case lldb::eBasicTypeChar:
         case lldb::eBasicTypeSignedChar:
         case lldb::eBasicTypeWChar:

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -343,6 +343,8 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
           return std::to_string(
               reduce_value<int8_t>(value, nvalues) / static_cast<int8_t>(div));
         return std::to_string(reduce_value<uint8_t>(value, nvalues) / div);
+      case 1:
+        return std::to_string(reduce_value<bool>(value, nvalues) / div);
         // clang-format on
       default:
         LOG(BUG) << "value_to_str: Invalid int bitwidth: "

--- a/src/types.h
+++ b/src/types.h
@@ -254,7 +254,8 @@ public:
 
   size_t GetSize() const
   {
-    return size_bits_ / 8;
+    // Round up to return the least amount of bytes necessary to hold the value
+    return (size_bits_ + 7) / 8;
   }
 
   void SetSize(size_t byte_size)

--- a/tests/codegen/llvm/struct_bool_1.ll
+++ b/tests/codegen/llvm/struct_bool_1.ll
@@ -1,0 +1,106 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_b = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !41 {
+entry:
+  %"@b_val" = alloca i64, align 8
+  %"@b_key" = alloca i64, align 8
+  %"struct Foo.b" = alloca i8, align 1
+  %"$foo" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
+  store i64 0, ptr %"$foo", align 8
+  %1 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %1, align 8
+  store i64 %arg0, ptr %"$foo", align 8
+  %2 = load i64, ptr %"$foo", align 8
+  %3 = add i64 %2, 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.b")
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.b", i32 1, i64 %3)
+  %4 = load i8, ptr %"struct Foo.b", align 1
+  %5 = and i8 %4, 1
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.b")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_key")
+  store i64 0, ptr %"@b_key", align 8
+  %6 = zext i8 %5 to i64
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_val")
+  store i64 %6, ptr %"@b_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_b, ptr %"@b_key", ptr %"@b_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!38}
+!llvm.module.flags = !{!40}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_b", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 2, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 1, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
+!25 = !{!26, !31}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !29)
+!29 = !{!30}
+!30 = !DISubrange(count: 27, lowerBound: 0)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 262144, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!38 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !39)
+!39 = !{!0, !22, !36}
+!40 = !{i32 2, !"Debug Info Version", i32 3}
+!41 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !42, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !38, retainedNodes: !46)
+!42 = !DISubroutineType(types: !43)
+!43 = !{!21, !44}
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!46 = !{!47}
+!47 = !DILocalVariable(name: "ctx", arg: 1, scope: !41, file: !2, type: !44)

--- a/tests/codegen/llvm/struct_bool_2.ll
+++ b/tests/codegen/llvm/struct_bool_2.ll
@@ -1,0 +1,106 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_b = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !41 {
+entry:
+  %"@b_val" = alloca i64, align 8
+  %"@b_key" = alloca i64, align 8
+  %"struct Foo.b" = alloca i8, align 1
+  %"$foo" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
+  store i64 0, ptr %"$foo", align 8
+  %1 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %1, align 8
+  store i64 %arg0, ptr %"$foo", align 8
+  %2 = load i64, ptr %"$foo", align 8
+  %3 = add i64 %2, 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.b")
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.b", i32 1, i64 %3)
+  %4 = load i8, ptr %"struct Foo.b", align 1
+  %5 = and i8 %4, 1
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.b")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_key")
+  store i64 0, ptr %"@b_key", align 8
+  %6 = zext i8 %5 to i64
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_val")
+  store i64 %6, ptr %"@b_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_b, ptr %"@b_key", ptr %"@b_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!38}
+!llvm.module.flags = !{!40}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_b", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 2, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 1, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
+!25 = !{!26, !31}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !29)
+!29 = !{!30}
+!30 = !DISubrange(count: 27, lowerBound: 0)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 262144, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!38 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !39)
+!39 = !{!0, !22, !36}
+!40 = !{i32 2, !"Debug Info Version", i32 3}
+!41 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !42, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !38, retainedNodes: !46)
+!42 = !DISubroutineType(types: !43)
+!43 = !{!21, !44}
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!46 = !{!47}
+!47 = !DILocalVariable(name: "ctx", arg: 1, scope: !41, file: !2, type: !44)

--- a/tests/codegen/struct_bool.cpp
+++ b/tests/codegen/struct_bool.cpp
@@ -1,0 +1,28 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, struct_bool)
+{
+  test("struct Foo { int x; bool b; }"
+       "kprobe:f"
+       "{"
+       "  $foo = *(struct Foo*)arg0;"
+       "  @b = $foo.b;"
+       "}",
+       std::string(NAME) + "_1");
+
+  test("struct Foo { int x; bool b; }"
+       "kprobe:f"
+       "{"
+       "  $foo = (struct Foo*)arg0;"
+       "  @b = $foo->b;"
+       "}",
+       std::string(NAME) + "_2");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -2,6 +2,7 @@ struct Foo1 {
   int a;
   char b;
   long c;
+  _Bool d;
 };
 
 struct Foo2 {

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -71,11 +71,12 @@ TEST_F(field_analyser_btf, btf_types)
   auto foo2 = bpftrace.structs.Lookup("struct Foo2").lock();
   auto foo3 = bpftrace.structs.Lookup("struct Foo3").lock();
 
-  EXPECT_EQ(foo1->size, 16);
-  ASSERT_EQ(foo1->fields.size(), 3U);
+  EXPECT_EQ(foo1->size, 24);
+  ASSERT_EQ(foo1->fields.size(), 4U);
   ASSERT_TRUE(foo1->HasField("a"));
   ASSERT_TRUE(foo1->HasField("b"));
   ASSERT_TRUE(foo1->HasField("c"));
+  ASSERT_TRUE(foo1->HasField("d"));
 
   EXPECT_TRUE(foo1->GetField("a").type.IsIntTy());
   EXPECT_EQ(foo1->GetField("a").type.GetSize(), 4U);
@@ -89,7 +90,11 @@ TEST_F(field_analyser_btf, btf_types)
   EXPECT_EQ(foo1->GetField("c").type.GetSize(), 8U);
   EXPECT_EQ(foo1->GetField("c").offset, 8);
 
-  EXPECT_EQ(foo2->size, 24);
+  EXPECT_TRUE(foo1->GetField("d").type.IsBoolTy());
+  EXPECT_EQ(foo1->GetField("d").type.GetSize(), 1U);
+  EXPECT_EQ(foo1->GetField("d").offset, 16);
+
+  EXPECT_EQ(foo2->size, 32);
   ASSERT_EQ(foo2->fields.size(), 3U);
   ASSERT_TRUE(foo2->HasField("a"));
   ASSERT_TRUE(foo2->HasField("f"));
@@ -100,7 +105,7 @@ TEST_F(field_analyser_btf, btf_types)
   EXPECT_EQ(foo2->GetField("a").offset, 0);
 
   EXPECT_TRUE(foo2->GetField("f").type.IsRecordTy());
-  EXPECT_EQ(foo2->GetField("f").type.GetSize(), 16U);
+  EXPECT_EQ(foo2->GetField("f").type.GetSize(), 24U);
   EXPECT_EQ(foo2->GetField("f").offset, 8);
 
   EXPECT_TRUE(foo2->GetField("g").type.IsIntTy());
@@ -284,7 +289,7 @@ TEST_F(field_analyser_btf, btf_types_struct_ptr)
   auto foo2 = bpftrace.structs.Lookup("struct Foo2").lock();
   auto foo3 = bpftrace.structs.Lookup("struct Foo3").lock();
 
-  EXPECT_EQ(foo2->size, 24);
+  EXPECT_EQ(foo2->size, 32);
   ASSERT_EQ(foo2->fields.size(), 0U); // fields are not resolved
   EXPECT_EQ(foo3->size, 16);
   ASSERT_EQ(foo3->fields.size(), 2U); // fields are resolved
@@ -309,7 +314,7 @@ TEST_F(field_analyser_btf, btf_types_arr_access)
   auto foo2 = bpftrace.structs.Lookup("struct Foo2").lock();
   auto foo3 = bpftrace.structs.Lookup("struct Foo3").lock();
 
-  EXPECT_EQ(foo2->size, 24);
+  EXPECT_EQ(foo2->size, 32);
   ASSERT_EQ(foo2->fields.size(), 0U); // fields are not resolved
   EXPECT_EQ(foo3->size, 16);
   ASSERT_EQ(foo3->fields.size(), 2U); // fields are resolved
@@ -447,8 +452,8 @@ TEST_F(field_analyser_dwarf, parse_struct)
   auto str = bpftrace.structs.Lookup("struct Foo1").lock();
 
   ASSERT_TRUE(str->HasFields());
-  ASSERT_EQ(str->fields.size(), 3);
-  ASSERT_EQ(str->size, 16);
+  ASSERT_EQ(str->fields.size(), 4);
+  ASSERT_EQ(str->size, 24);
   CheckFieldsOrderedByOffset(str->fields);
 
   ASSERT_TRUE(str->HasField("a"));
@@ -464,6 +469,11 @@ TEST_F(field_analyser_dwarf, parse_struct)
   ASSERT_TRUE(str->HasField("c"));
   ASSERT_TRUE(str->GetField("c").type.IsIntTy());
   ASSERT_EQ(str->GetField("c").type.GetSize(), 8);
+
+  ASSERT_TRUE(str->HasField("d"));
+  ASSERT_TRUE(str->GetField("d").type.IsBoolTy());
+  ASSERT_EQ(str->GetField("d").type.GetSize(), 1);
+  ASSERT_EQ(str->GetField("d").offset, 16);
 }
 
 TEST_F(field_analyser_dwarf, parse_arrays)

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -279,3 +279,13 @@ NAME dry run empty output
 RUN {{BPFTRACE}} --dry-run -e 'BEGIN { printf("hello\n"); @ = 0; }'
 EXPECT_NONE hello
 EXPECT_NONE @: 0
+
+NAME bool type proberead
+PROG struct Foo { int a; bool b; } uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("value: %d\n", ((struct Foo *)arg1)->b); exit() }
+AFTER ./testprogs/uprobe_test
+EXPECT value: 1
+
+NAME bool type print
+PROG struct Foo { int a; bool b; } uprobe:./testprogs/uprobe_test:uprobeFunction2 { print(((struct Foo *)arg1)->b); exit() }
+AFTER ./testprogs/uprobe_test
+EXPECT 1


### PR DESCRIPTION
Until now, `ClangParser` represented bools as 1-byte ints. This makes us always read 8 bits instead of 1 which may return incorrect values when those remaining 7 bits contain some trash. This is especially an issue for bool-typed tracepoint args as tracepoint definitions are parsed by `ClangParser` (other types are typically parsed from BTF these days).

Fix the issue by properly representing bools with 1-bit type.

This also required a small update in codegen to emit LLVM's `Int1Ty` for our bool type.

Fixes #3435.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
