### PR TITLE
Runtime tests: Set default timeout if none is specified

### DIFF
--- a/tests/runtime/addrspace
+++ b/tests/runtime/addrspace
@@ -2,4 +2,3 @@ NAME openat uptr
 RUN {{BPFTRACE}} -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { print(str(uptr(args.filename))) }' -c "./testprogs/syscall openat"
 EXPECT_REGEX ^.*/bpftrace_runtime_test_syscall_gen_open_temp$
 REQUIRES_FEATURE probe_read_kernel
-TIMEOUT 5

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -1,170 +1,142 @@
 NAME array element access - assign to map
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; @x = $a->x[0]; exit(); }
 EXPECT @x: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access - assign to var
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[0]; printf("Result: %d\n", $x); exit(); }
 EXPECT Result: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access - out of bounds
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[5]; printf("%d\n", $x); exit(); }
 EXPECT stdin:1:100-108: ERROR: the index 5 is out of bounds for array of size 4
-TIMEOUT 5
 AFTER ./testprogs/array_access
 WILL_FAIL
 
 NAME array element access via assignment into var
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; $x = $a[0]; printf("Result: %d\n", $x); exit(); }
 EXPECT Result: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into map
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; printf("Result: %d\n", @a[0][0]); exit(); }
 EXPECT Result: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into map and var
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }
 EXPECT Result: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array assignment into map
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; exit(); }
 EXPECT @a: [1,2,3,4]
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a map key
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x] = 0; exit(); }
 EXPECT @x[[1,2,3,4]]: 0
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a part of map multikey
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x, 42] = 0; exit(); }
 EXPECT @x[[1,2,3,4], 42]: 0
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a map key assigned from another map
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; @x[@a] = 0; exit(); }
 EXPECT @x[[1,2,3,4]]: 0
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array in a tuple
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x = (1, ((struct A *) arg0)->x); exit(); }
 EXPECT @x: (1, [1,2,3,4])
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $x = ((struct B *) arg1)->y[1][0]; printf("Result: %d\n", $x); exit(); }
 EXPECT Result: 7
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into var
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; $y = $b[1][0]; printf("Result: %d\n", $y); exit(); }
 EXPECT Result: 7
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into map
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; printf("Result: %d\n", @b[0][1][0]); exit(); }
 EXPECT Result: 7
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into map and var
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; $x = @b[0]; printf("Result: %d\n", $x[1][0]); exit(); }
 EXPECT Result: 7
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array assignment into map
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; exit(); }
 EXPECT @b: [[5,6],[7,8]]
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array as a map key
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @x[((struct B *) arg1)->y] = 0; exit(); }
 EXPECT @x[[[5,6],[7,8]]]: 0
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array as a map key assigned from another map
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; @x[@b] = 0; exit(); }
 EXPECT @x[[[5,6],[7,8]]]: 0
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access - assign to map
 PROG uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; @x = $a[0]; exit(); }
 EXPECT @x: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access - assign to var
 PROG uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }
 EXPECT Result: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer access via assignment into var
 PROG uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }
 EXPECT Result: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access via assignment into map
 PROG uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; printf("Result: %d\n", @a[0][0]); exit(); }
 EXPECT Result: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access via assignment into map and var
 PROG uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }
 EXPECT Result: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access via positional index
 RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[$1]; printf("Result: %d\n", $x); exit(); }' 0
 EXPECT Result: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array of pointers element access
 PROG struct C { int *z[4]; } uprobe:./testprogs/array_access:test_ptr_array { @x = *((struct C*)arg0)->z[1]; exit(); }
 EXPECT @x: 2
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array compare eq
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_arrays { $a = (struct A *) arg0; $b = (struct A *) arg0; if ($a->x == $b->x) { printf("two int arrays are equal.\n"); } exit(); }
 EXPECT two int arrays are equal.
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array compare ne
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_arrays { $a = (struct A *) arg0; $b = (struct A *) arg1; if ($a->x != $b->x) { printf("two int arrays are not equal.\n"); } exit(); }
 EXPECT two int arrays are not equal.
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME variable array element access - assign to map
 PROG struct D { int x; int y[0]; } uprobe:./testprogs/array_access:test_variable_array { $a = (struct D *) arg0; @y = $a->y[0]; exit(); }
 EXPECT @y: 1
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME cast literal to int array
@@ -180,11 +152,9 @@ TIMEOUT 1
 NAME cast int array to int internal
 PROG BEGIN { printf("ip: %x\n", (uint32)pton("127.0.0.1")); exit(); }
 EXPECT ip: 100007f
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME cast int array to int proberead
 RUN {{BPFTRACE}} --include "stdint.h" -e 'struct A { int x[4]; uint8_t y[4]; } uprobe:./testprogs/array_access:test_arrays { $y = (int32)((struct A *)arg0)->y; printf("y: %x\n", $y); exit()}'
 EXPECT y: ddccbbaa
-TIMEOUT 5
 AFTER ./testprogs/array_access

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -144,19 +144,16 @@ NAME it only lists probes in the program
 RUN {{BPFTRACE}} -l -e 'kfunc:vmlinux:vfs_read { exit(); }'
 EXPECT kfunc:vmlinux:vfs_read
 EXPECT_NONE kfunc:vmlinux:vfs_write
-TIMEOUT 5
 
 NAME it lists uprobes in the program
 RUN {{BPFTRACE}} -l -e 'uretprobe:*:uprobeFunction* { exit(); }' -p {{BEFORE_PID}}
 EXPECT_REGEX uretprobe:[\S]+uprobe_test:uprobeFunction1
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME it lists multiple probes in the program
 RUN {{BPFTRACE}} -l -e 'hardware:cache-misses:10 { exit(); } tracepoint:xdp:mem_connect { exit(); }'
 EXPECT hardware:cache-misses:
 EXPECT tracepoint:xdp:mem_connect
-TIMEOUT 5
 
 NAME it lists struct definitions
 RUN {{BPFTRACE}} -lv 'struct task_struct'
@@ -168,7 +165,6 @@ RUN {{BPFTRACE}} -l runtime/scripts/interval_order.bt
 EXPECT interval:ms:
 EXPECT interval:ms:
 EXPECT interval:ms:
-TIMEOUT 5
 
 NAME warning on non existent file
 RUN {{BPFTRACE}} -l non_existent_file.bt
@@ -271,7 +267,6 @@ TIMEOUT 1
 NAME basic while loop
 PROG BEGIN { $a = 0; while ($a <= 100) { @=avg($a++) } exit(); }
 EXPECT @: 50
-TIMEOUT 5
 REQUIRES_FEATURE loop
 
 NAME disable warnings

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -1,37 +1,31 @@
 NAME user_supplied_c_def_using_btf
 PROG struct foo { struct task_struct t; } BEGIN { exit(); }
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME tracepoint_pointer_type_resolution
 PROG tracepoint:syscalls:sys_enter_nanosleep { args.rqtp->tv_sec; exit(); }
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME tracepoint_nested_pointer_type_resolution
 PROG tracepoint:napi:napi_poll { args.napi->dev->name; exit(); }
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME enum_value_reference
 PROG BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }
 EXPECT_REGEX ^8$
-TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME redefine_btf_type
 PROG struct task_struct { int x; } BEGIN { printf("%d\n", curtask->x); exit() }
 EXPECT_REGEX -?[0-9][0-9]*
-TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME redefine_btf_type_missing_def
 PROG struct task_struct { struct thread_info x; } BEGIN { printf("%d\n", curtask->x.status); }
 EXPECT_REGEX error:.*'struct thread_info'
-TIMEOUT 5
 REQUIRES_FEATURE btf
 WILL_FAIL
 
@@ -39,7 +33,6 @@ NAME kernel_module_attach
 RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("hit\n"); exit(); }'
 AFTER /usr/sbin/nft add table bpftrace
 EXPECT hit
-TIMEOUT 5
 REQUIRES_FEATURE kfunc
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
@@ -49,7 +42,6 @@ NAME kernel_module_attach_wildcard
 RUN {{BPFTRACE}} -e 'kfunc:nf_table*:nft_trans_alloc_gfp { printf("hit\n"); exit(); }'
 AFTER /usr/sbin/nft add table bpftrace
 EXPECT hit
-TIMEOUT 5
 REQUIRES_FEATURE kfunc
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
@@ -59,7 +51,6 @@ NAME kernel_module_args
 RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("size: %d\n", args.size); exit(); }'
 AFTER /usr/sbin/nft add table bpftrace
 EXPECT_REGEX size: [0-9]+
-TIMEOUT 5
 REQUIRES_FEATURE kfunc
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
@@ -69,7 +60,6 @@ NAME kernel_module_types
 RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("portid: %d\n", args.ctx->portid); exit(); }'
 AFTER /usr/sbin/nft add table bpftrace
 EXPECT_REGEX portid: [0-9]+
-TIMEOUT 5
 REQUIRES_FEATURE kfunc
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
@@ -78,7 +68,6 @@ CLEANUP nft delete table bpftrace
 NAME kernel_module_tracepoint
 PROG tracepoint:xfs:xfs_setfilesize { print(args.offset) } i:ms:1 { exit(); }
 EXPECT Attaching 2 probes...
-TIMEOUT 5
 REQUIRES_FEATURE btf
 REQUIRES lsmod | grep "^xfs"
 
@@ -103,5 +92,4 @@ REQUIRES lsmod | grep '^kvm'
 NAME btf_type_tag_access
 PROG BEGIN { printf("SUCCESS %d\n", curtask->parent->pid); exit() }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 REQUIRES_FEATURE btf

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -1,80 +1,65 @@
 NAME pid
 PROG i:ms:1 { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 
 NAME tid
 PROG i:ms:1 { printf("SUCCESS %d\n", tid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 
 NAME uid
 PROG i:ms:1 { printf("SUCCESS %d\n", uid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 
 NAME gid
 PROG i:ms:1 { printf("SUCCESS %d\n", gid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 
 NAME nsecs
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 
 NAME elapsed
 PROG i:ms:1 { printf("SUCCESS %llu\n", elapsed); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 
 NAME numaid
 PROG i:ms:1 { printf("SUCCESS %lu\n", numaid); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 
 NAME cpu
 PROG i:ms:1 { printf("SUCCESS %lu\n", cpu); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 
 NAME comm
 PROG BEGIN { printf("SUCCESS %s\n", comm); exit(); }
 EXPECT SUCCESS bpftrace
-TIMEOUT 5
 
 NAME kstack
 PROG BEGIN { printf("%s\n", kstack); exit(); }
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 
 NAME ustack
 PROG BEGIN { printf("%s\n", ustack); exit(); }
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 
 NAME arg
 PROG k:vfs_read { printf("SUCCESS %p\n", arg0); exit(); }
 EXPECT_REGEX ^SUCCESS 0x[0-9a-f]+$
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME retval
 PROG kretprobe:vfs_read { printf("SUCCESS %d\n", retval); exit(); }
 EXPECT_REGEX SUCCESS .*
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME func_kprobe
 PROG k:vfs_read { printf("func: '%s'\n", func); exit(); }
 EXPECT func: 'vfs_read'
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME func_kretprobe
 PROG kr:vfs_read { printf("func: '%s'\n", func); exit(); }
 EXPECT func: 'vfs_read'
-TIMEOUT 5
 REQUIRES_FEATURE get_func_ip
 AFTER ./testprogs/syscall read
 
@@ -82,7 +67,6 @@ NAME func_uprobe
 PROG uprobe:./testprogs/uprobe_symres:test { printf("func: '%s'\n", func); exit(); }
 EXPECT func: 'test'
 AFTER ./testprogs/uprobe_symres
-TIMEOUT 5
 
 NAME func_uretprobe
 PROG uretprobe:./testprogs/uprobe_symres:test { printf("func: '%s'\n", func); exit(); }
@@ -90,7 +74,6 @@ PROG uretprobe:./testprogs/uprobe_symres:test { printf("func: '%s'\n", func); ex
 # work for uretprobes: it will always return 0.
 EXPECT_REGEX ^func: 'test'$|^func: '0'$
 AFTER ./testprogs/uprobe_symres
-TIMEOUT 5
 REQUIRES_FEATURE get_func_ip
 
 # Disabled, since BCC code it depends on is prone to race condition,
@@ -100,7 +83,6 @@ ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PID
 PROG uprobe:./testprogs/uprobe_symres_exited_process:test { print(func); exit(); }
 EXPECT test
 BEFORE ./testprogs/uprobe_symres_exited_process
-TIMEOUT 5
 REQUIRES bash -c "exit 1"
 
 NAME func_uprobe_elf_symtable
@@ -108,177 +90,147 @@ ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM
 PROG uprobe:./testprogs/uprobe_symres_exited_process:test { print(func); exit(); }
 EXPECT test
 AFTER ./testprogs/disable_aslr ./testprogs/uprobe_symres_exited_process
-TIMEOUT 5
 
 NAME username
 PROG i:ms:1 { printf("SUCCESS %s\n", username); exit(); }
 EXPECT_REGEX SUCCESS .*
-TIMEOUT 5
 
 NAME probe
 PROG k:do_nanosleep { printf("SUCCESS %s\n", probe); exit(); }
 EXPECT SUCCESS kprobe:do_nanosleep
-TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME begin probe
 PROG BEGIN { printf("%s", probe);exit(); } END{printf("-%s\n", probe); }
 EXPECT_REGEX ^BEGIN-END$
-TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME curtask
 PROG i:ms:1 { printf("SUCCESS %p\n", curtask); exit(); }
 EXPECT_REGEX SUCCESS 0x[0-9a-f]+
-TIMEOUT 5
 
 NAME curtask_field
 PROG struct task_struct {int x;} i:ms:1 { printf("SUCCESS %d\n", curtask->x); exit(); }
 EXPECT_REGEX SUCCESS -?[0-9][0-9]*
-TIMEOUT 5
 
 NAME rand
 PROG i:ms:1 { printf("SUCCESS %lu\n", rand); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 
 NAME cgroup
 PROG i:ms:1 { printf("SUCCESS %llu\n", cgroup); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 MIN_KERNEL 4.18
 
 NAME ctx
 PROG struct x {unsigned long x}; i:ms:1 { printf("SUCCESS %lu\n", ((struct x*)ctx)->x); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 
 NAME cat
 PROG i:ms:1 { cat("/proc/loadavg"); exit(); }
 EXPECT_REGEX ^([0-9]+\.[0-9]+ ?)+.*$
-TIMEOUT 5
 
 NAME cat limited output
 ENV BPFTRACE_MAX_CAT_BYTES=1
 PROG i:ms:1 { cat("/proc/loadavg"); exit(); }
 EXPECT_REGEX ^[0-9]$
-TIMEOUT 5
 
 NAME cat format str
 PROG i:ms:1 { $s = "loadavg"; cat("/proc/%s", $s); exit(); }
 EXPECT_REGEX ^([0-9]+\.[0-9]+ ?)+.*$
-TIMEOUT 5
 
 NAME log size too small
 ENV BPFTRACE_LOG_SIZE=2
 RUN {{BPFTRACE}} -v -e 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
 EXPECT ERROR: Error loading BPF program for BEGIN_1.
 EXPECT_REGEX ^WARNING: Kernel log seems to be trimmed.*
-TIMEOUT 5
 WILL_FAIL
 
 NAME increase log size
 ENV BPFTRACE_LOG_SIZE=10000000
 RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
 EXPECT hello
-TIMEOUT 5
 
 NAME cat "no such file"
 PROG i:ms:1 { cat("/does/not/exist/file"); exit(); }
 EXPECT ERROR: failed to open file '/does/not/exist/file': No such file or directory
-TIMEOUT 5
 
 NAME sizeof
 PROG struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x)); exit(); }
 EXPECT 8 4 1 8 8
-TIMEOUT 5
 
 NAME sizeof_ints
 PROG BEGIN { printf("%d %d %d %d %d %d\n", sizeof(uint8), sizeof(int8), sizeof(uint16), sizeof(int16), sizeof(uint32), sizeof(int32)); exit(); }
 EXPECT 1 1 2 2 4 4
-TIMEOUT 5
 
 # printf only takes 7 args
 NAME sizeof_ints_pt2
 PROG BEGIN { printf("%d %d\n", sizeof(uint64), sizeof(int64)); exit(); }
 EXPECT 8 8
-TIMEOUT 5
 
 NAME sizeof_btf
 PROG BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }
 EXPECT_REGEX ^size=
-TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME offsetof
 PROG struct Foo { int x; long l; char c; } BEGIN { printf("%ld\n", offsetof(struct Foo, x)); exit(); }
 EXPECT_REGEX ^0$
-TIMEOUT 5
 
 NAME print args in kfunc
 PROG kfunc:vfs_open { print(args); exit(); }
 EXPECT_REGEX { .path = 0x[0-9a-f]+, .file = 0x[0-9a-f]+ }
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall open
 
 NAME args in kfunc store in map
 PROG kfunc:vfs_open { @= args; exit(); }
 EXPECT_REGEX @: { .path = 0x[0-9a-f]+, .file = 0x[0-9a-f]+ }
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall open
 
 NAME args in kfunc as a map key
 PROG kfunc:vfs_open { @[args] = 1; exit(); }
 EXPECT_REGEX @[{.path=0x[0-9a-f]+,.file=0x[0-9a-f]+}]: 1
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall open
 
 NAME args in uprobe print
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { print(args); exit(); }
 EXPECT_REGEX { .n = 0x[0-9a-f]+, .c = 120 }
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME args in uprobe store in map
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = args; exit(); }
 EXPECT_REGEX @: { .n = 0x[0-9a-f]+, .c = 120 }
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME args in uprobe store in map and access field
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = args; print(@.c); exit(); }
 EXPECT 120
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME args in uprobe as a map key
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @[args] = 1; exit(); }
 EXPECT_REGEX @[{.n=0x[0-9a-f]+,.c=120}]: 1
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME jiffies
 PROG i:ms:1 { printf("SUCCESS %llu\n", jiffies); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
 REQUIRES_FEATURE jiffies64
-TIMEOUT 5
 MIN_KERNEL 5.9
 
 NAME ustack builtin with stack_mode config
 RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { @c[ustack] = 1; exit(); }' -p {{BEFORE_PID}}
 EXPECT_REGEX ^@c\[\n[0-9a-f]+$
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME kstack builtin with stack_mode config
 RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } k:do_nanosleep { @c[kstack] = 1; exit(); }'
 EXPECT_REGEX ^@c\[\n[0-9a-f]+$
-TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -1,82 +1,67 @@
 NAME printf
 PROG i:ms:1 { printf("hi!\n"); exit();}
 EXPECT hi!
-TIMEOUT 5
 
 NAME printf_long_fmt
 PROG i:ms:1 { printf("hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!\n"); exit();}
 EXPECT hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!
-TIMEOUT 5
 
 NAME printf_argument
 PROG i:ms:1 { printf("value: %dms100\n", 100); exit();}
 EXPECT value: 100ms100
-TIMEOUT 5
 
 NAME printf_llu
 PROG BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed time: %llus\n", (nsecs - @start)/1000000000); clear(@start); exit();}
 EXPECT Elapsed time: 1s
-TIMEOUT 5
 
 NAME printf_argument_alignment
 RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:testprogs/uprobe_test:uprobeFunction2 { $foo = (struct Foo *)arg0; $foo2 = (struct Foo *)arg1; printf("%d %s %d %s\n", $foo->a, $foo->b, $foo2->a, $foo2->b) }' -c ./testprogs/uprobe_test
 EXPECT 123 hello 456 world
-TIMEOUT 5
 
 NAME printf_more_arguments
 PROG BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd"); exit(); }
 EXPECT 1st: aa; 2nd: abb;; 3rd: abcc;;; 4th: abcdd;;;;
-TIMEOUT 5
 
 NAME printf_length_modifiers
 PROG BEGIN { $x = 0x12345678abcdef; printf("%hhx %hx %x %jx\n", $x, $x, $x, $x); exit(); }
 EXPECT ef cdef 78abcdef 12345678abcdef
-TIMEOUT 5
 
 NAME printf_char
 PROG BEGIN { printf("%c%c%c%c\n", 0x41, 0x42, 0x43, 0x44); exit(); }
 EXPECT ABCD
-TIMEOUT 5
 
 NAME time
 PROG i:ms:1 { time("%H:%M:%S\n"); exit();}
 EXPECT_REGEX [0-9]*:[0-9]*:[0-9]*
-TIMEOUT 5
 
 NAME time_short
 PROG i:ms:1 { time("%H-%M:%S\n"); exit();}
 EXPECT_REGEX [0-9]*-[0-9]*
-TIMEOUT 5
 
 NAME join
 RUN {{BPFTRACE}} --unsafe -e 'i:ms:1 { system("echo '_A_'"); } t:syscalls:sys_enter_execve { join(args.argv); exit();}'
 EXPECT _A_
-TIMEOUT 5
 
 NAME join_delim
 RUN {{BPFTRACE}} --unsafe -e 'i:ms:1 { system("echo '_A_'"); } t:syscalls:sys_enter_execve { join(args.argv, ","); exit();}'
 EXPECT _A_
-TIMEOUT 5
 
 NAME str
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
 AFTER ./testprogs/syscall execve /bin/ls
 EXPECT_REGEX P: /*.
-TIMEOUT 5
 
 NAME str_truncated
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
 ENV BPFTRACE_MAX_STRLEN=5
 AFTER ./testprogs/syscall execve /bin/ls &>/dev/null
 EXPECT_REGEX P: /...\.\.
-TIMEOUT 5
 
 NAME str_truncated_custom
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
 ENV BPFTRACE_MAX_STRLEN=5 BPFTRACE_STR_TRUNC_TRAILER=_xxx
 AFTER ./testprogs/syscall execve /bin/ls &>/dev/null
 EXPECT_REGEX P: /..._xxx
-TIMEOUT 5
 
 NAME str_big
 PROG t:syscalls:sys_enter_execve { @[str(args.filename)] = count() }
@@ -93,7 +78,6 @@ ENV BPFTRACE_MAX_STRLEN=9999
 EXPECT matched
 AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
 REQUIRES_FEATURE probe_read_kernel
-TIMEOUT 5
 
 NAME str_big_printf
 PROG t:syscalls:sys_enter_execve { printf("%s\n", str(args.filename)) }
@@ -101,7 +85,6 @@ ENV BPFTRACE_MAX_STRLEN=9999
 EXPECT_REGEX /X{5555}
 AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
 REQUIRES_FEATURE probe_read_kernel
-TIMEOUT 5
 
 NAME str_big_print
 PROG t:syscalls:sys_enter_execve { print(str(args.filename)) }
@@ -109,7 +92,6 @@ ENV BPFTRACE_MAX_STRLEN=9999
 EXPECT_REGEX /X{5555}
 AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
 REQUIRES_FEATURE probe_read_kernel
-TIMEOUT 5
 
 # Currently broken for big strings (>64 B) which is why ENV
 # is not being set. When big strings are fixed, enable this test.
@@ -129,112 +111,92 @@ TIMEOUT 1
 NAME buf
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \x09\x08\x07\x06-\x05\x04\x03\x02-\x01\x02\x03\x04-\x05\x00\x00\x00\x06\x00\x00\x00\x07\x00\x00\x00\x08\x00\x00\x00-\x09\x00\x0a\x00\x0b\x00\x0c\x00-\x0d\x00\x00\x00\x00\x00\x00\x00\x0e\x00\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00
-TIMEOUT 5
 ARCH x86_64|ppc64le|aarch64|armv7l
 
 NAME buf
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \x09\x08\x07\x06-\x05\x04\x03\x02-\x01\x02\x03\x04-\x00\x00\x00\x05\x00\x00\x00\x06\x00\x00\x00\x07\x00\x00\x00\x08-\x00\x09\x00\x0a\x00\x0b\x00\x0c-\x00\x00\x00\x00\x00\x00\x00\x0d\x00\x00\x00\x00\x00\x00\x00\x0e\x00\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x10
-TIMEOUT 5
 ARCH s390x|ppc64
 
 NAME buf_map_key
 PROG i:ms:100 { @[buf("ok_key", 6)] = 1; exit(); }
 EXPECT @[ok_key]: 1
-TIMEOUT 5
 
 NAME buf_map_multikey
 PROG BEGIN { @[buf("ok_key", 7), 1] = hist(1); exit(); }
 EXPECT @[ok_key\x00, 1]:
-TIMEOUT 5
 
 NAME buf_hist_map_key
 PROG BEGIN { @[buf("ok_key", 7)] = hist(1); exit(); }
 EXPECT @[ok_key\x00]:
-TIMEOUT 5
 
 NAME buf_map_value
 PROG i:ms:100 { @ = buf("ok_value", 8); exit(); }
 EXPECT @: ok_value
-TIMEOUT 5
 
 NAME buf_no_ascii
 PROG BEGIN { printf("%rx", buf("Hello\0", 6)); exit(); }
 EXPECT \x48\x65\x6c\x6c\x6f\x00
-TIMEOUT 5
 
 NAME buf_no_ascii_no_escaping
 PROG BEGIN { printf("%rh", buf("Hello\0", 6)); exit(); }
 EXPECT 48 65 6c 6c 6f 00
-TIMEOUT 5
 
 NAME ksym
 PROG kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}
 EXPECT do_nanosleep
-TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
 PROG kprobe:do_nanosleep { printf("%s\n", ksym(reg("pswaddr"))); exit();}
 EXPECT do_nanosleep
-TIMEOUT 5
 ARCH s390x
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
 PROG kprobe:do_nanosleep { printf("%s\n", ksym(reg("pc"))); exit();}
 EXPECT do_nanosleep
-TIMEOUT 5
 ARCH aarch64|armv7l
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
 PROG kprobe:do_nanosleep { printf("%s\n", ksym(reg("nip"))); exit();}
 EXPECT do_nanosleep
-TIMEOUT 5
 ARCH ppc64|ppc64le
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME system
 RUN {{BPFTRACE}} --unsafe -e 'i:ms:100 { system("echo 'ok_system'"); exit();}'
 EXPECT ok_system
-TIMEOUT 5
 
 NAME system_more_args
 RUN {{BPFTRACE}} --unsafe -e 'i:ms:100 { system("echo %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7); exit();}'
 EXPECT 1 2 3 4 5 6 7
-TIMEOUT 5
 
 NAME count
 PROG i:ms:100 { @ = count(); exit();}
 EXPECT_REGEX @:\s[0-9]+
-TIMEOUT 5
 
 NAME sum
 PROG BEGIN { @sum = sum(1); @sum = sum(2); @sum = sum(3); exit();}
 EXPECT @sum: 6
-TIMEOUT 5
 
 NAME avg
 PROG BEGIN { @avg = avg(1); @avg = avg(2); @avg = avg(3); exit();}
 EXPECT @avg: 2
-TIMEOUT 5
 
 NAME min
 PROG BEGIN { @min = min(2); @min = min(1); @min = min(3); exit();}
 EXPECT @min: 1
-TIMEOUT 5
 
 NAME max
 PROG BEGIN { @max = max(1); @max = max(3); @max = max(2); exit();}
 EXPECT @max: 3
-TIMEOUT 5
 
 NAME stats
 PROG BEGIN { @stats = stats(1); @stats = stats(2); @stats = stats(3); exit();}
 EXPECT @stats: count 3, average 2, total 6
-TIMEOUT 5
 
 NAME hist
 PROG BEGIN { @=hist(-1); @=hist(2); @=hist(3); @=hist(7); @=hist(20); exit();}
@@ -254,31 +216,26 @@ TIMEOUT 1
 NAME lhist
 PROG BEGIN { @=lhist(2,0,10,2); @=lhist(3,0,10,2); @=lhist(7,0,10,2); @=lhist(-1,0,10,2); @=lhist(11,0,10,2); exit()}
 EXPECT_FILE runtime/outputs/lhist.txt
-TIMEOUT 5
 
 NAME kstack
 PROG k:do_nanosleep { printf("%s\n%s\n", kstack(), kstack(1)); exit(); }
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME kstack perf mode
 PROG k:do_nanosleep { printf("%s\n", kstack(perf, 1)); exit(); }
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack(1)); exit(); }
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
 
 NAME ustack_stack_mode_env_bpftrace
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=bpftrace
 EXPECT_REGEX ^\s+uprobeFunction1\+[0-9]+$
-TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
 # This was debugged as far down as std::cout having badbit [0] set after a
 # write. It's really confusing why. Cannot be reproduced locally. While
@@ -298,7 +255,6 @@ NAME ustack_stack_mode_env_perf
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=perf
 EXPECT_REGEX ^\s+[0-9a-f]+ uprobeFunction1\+[0-9]+ \(.*/uprobe_loop\)$
-TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
 # See https://github.com/bpftrace/bpftrace/issues/3080
 SKIP_IF_ENV_HAS CI=true
@@ -307,7 +263,6 @@ NAME ustack_stack_mode_env_raw
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=raw
 EXPECT_REGEX ^[\da-fA-F]+$
-TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
 # See https://github.com/bpftrace/bpftrace/issues/3080
 SKIP_IF_ENV_HAS CI=true
@@ -316,7 +271,6 @@ NAME ustack_stack_mode_env_override
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(raw, 1)); exit(); }
 ENV BPFTRACE_STACK_MODE=perf
 EXPECT_REGEX ^[\da-fA-F]+$
-TIMEOUT 5
 AFTER ./testprogs/uprobe_loop
 # See https://github.com/bpftrace/bpftrace/issues/3080
 SKIP_IF_ENV_HAS CI=true
@@ -328,49 +282,40 @@ EXPECT_REGEX ^\s+test\+[0-9]+\s+test2\+[0-9]+\s+main\+[0-9]+
 AFTER ./testprogs/disable_aslr ./testprogs/uprobe_symres_exited_process
 # Required to skip function prologue
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 
 NAME cat
 PROG i:ms:1 { cat("/proc/uptime"); exit();}
 EXPECT_REGEX [0-9]*.[0-9]* [0-9]*.[0-9]*
-TIMEOUT 5
 
 NAME cat_more_args
 PROG i:ms:1 { cat("/%s%s%s%s/%s%s%s", "p", "r", "o", "c", "u", "p", "time"); exit();}
 EXPECT_REGEX [0-9]*.[0-9]* [0-9]*.[0-9]*
-TIMEOUT 5
 
 NAME uaddr
 RUN {{BPFTRACE}} -e 'uprobe:testprogs/uprobe_test:uprobeFunction1 { printf("0x%lx -- 0x%lx\n", *uaddr("GLOBAL_A"), *uaddr("GLOBAL_C")); exit(); }' -c ./testprogs/uprobe_test
 EXPECT 0x55555555 -- 0x33333333
-TIMEOUT 5
 
 NAME ntop static ip
 PROG i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(1), ntop(0x0100007f), ntop(0xffff0000), ntop(0x0000ffff)); exit() }
 EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
 ARCH x86_64|aarch64|ppc64le|armv7l
-TIMEOUT 5
 
 NAME ntop static ip
 PROG i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(0x01000000), ntop(0x7f000001), ntop(0x0000ffff), ntop(0xffff0000)); exit() }
 EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
 ARCH s390x|ppc64
-TIMEOUT 5
 
 NAME pton ipv4
 PROG i:ms:100 { printf("IP: %s\n", ntop(2, pton("127.0.0.1"))); exit(); }
 EXPECT IP: 127.0.0.1
-TIMEOUT 5
 
 NAME pton ipv6
 PROG i:ms:100 { printf("IP: %s\n", ntop(10, pton("::1"))); exit(); }
 EXPECT IP: ::1
-TIMEOUT 5
 
 NAME usym
 PROG i:ms:100 { @=usym(1); @a=@; exit(); }
 EXPECT @a: 0x1
-TIMEOUT 5
 
 NAME print_non_map
 PROG BEGIN { $x = 5; print($x); exit() }
@@ -390,26 +335,22 @@ TIMEOUT 1
 NAME print_non_map_array
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; print($a); exit(); }
 EXPECT [1,2,3,4]
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME print_non_map_multi_dimensional_array
 PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; print($b); exit(); }
 EXPECT [[5,6],[7,8]]
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME print_non_map_struct
 PROG struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }
 EXPECT { .m = 2, .n = 3 }
-TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME print_non_map_struct_kfunc
 PROG kfunc:vfs_open { print(*args.path); exit(); }
 EXPECT_REGEX { .mnt = 0x[0-9a-f]+, .dentry = 0x[0-9a-f]+ }
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall open
 
 NAME print_map_item
@@ -425,17 +366,14 @@ TIMEOUT 1
 NAME strftime
 PROG BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts); exit(); }
 EXPECT_REGEX [0-9]{2}\/[0-9]{2}\/[0-9]{2}
-TIMEOUT 5
 
 NAME strftime_as_map_key
 PROG BEGIN { @[strftime("%m/%d/%y", nsecs)] = 1; exit();}
 EXPECT_REGEX \[[0-9]{2}\/[0-9]{2}\/[0-9]{2}\]: 1
-TIMEOUT 5
 
 NAME strftime_as_map_value
 PROG BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}
 EXPECT_REGEX @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
-TIMEOUT 5
 
 # Output two microsecond timestamps, 123000 nsecs apart. Use python to evaluate and verify there's a 123us delta
 #
@@ -485,21 +423,18 @@ NAME path
 RUN {{BPFTRACE}} -ve 'kfunc:filp_close { if (!strncmp(path(args.filp->f_path), "/tmp/bpftrace_runtime_test_syscall_gen_read_temp", 49)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME path_with_optional_size
 RUN {{BPFTRACE}} -ve 'kfunc:filp_close { $p = path(args.filp->f_path, 48);  if ( sizeof($p) == 48 && !strncmp($p, "tmp/bpftrace_runtime_test_syscall_gen_read_temp", 48)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME strcontains
 RUN {{BPFTRACE}} -ve 'kfunc:filp_close { if (strcontains(path(args.filp->f_path), "tmp")) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME strcontains literals
@@ -516,67 +451,56 @@ EXPECT kfunc:vfs_read { print("a"); print(path(args.file->f_path)); print("b"); 
 EXPECT                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 REQUIRES_FEATURE dpath
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 WILL_FAIL
 AFTER ./testprogs/syscall read
 
 NAME macaddr
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); printf("P: %s\n", macaddr($s->mac)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: 05:04:03:02:01:02
-TIMEOUT 5
 
 NAME macaddr as map key
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[macaddr($s->mac)] = 1; exit(); }' -c ./testprogs/complex_struct
 EXPECT @[05:04:03:02:01:02]: 1
-TIMEOUT 5
 
 NAME macaddr as map value
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[1] = macaddr($s->mac); exit(); }' -c ./testprogs/complex_struct
 EXPECT @[1]: 05:04:03:02:01:02
-TIMEOUT 5
 
 NAME iter:task
 PROG iter:task { printf("comm: %s\n", ctx->task->comm); exit(); }
 EXPECT comm: bpftrace
 REQUIRES_FEATURE iter
-TIMEOUT 5
 
 NAME iter:task_file
 PROG iter:task_file { printf("comm: %s\n", ctx->task->comm); exit(); }
 EXPECT comm: bpftrace
 REQUIRES_FEATURE iter
-TIMEOUT 5
 
 NAME iter:task_vma
 PROG iter:task_vma { printf("comm: %s\n", ctx->task->comm); exit(); }
 EXPECT comm: bpftrace
 REQUIRES_FEATURE iter
-TIMEOUT 5
 
 NAME iter printf multiple values
 PROG iter:task { printf("%s: %d\n", "hello", 0); exit(); }
 EXPECT hello: 0
 REQUIRES_FEATURE iter
-TIMEOUT 5
 
 NAME cgroup_path
 PROG BEGIN { print(cgroup_path(cgroup & ((1 << 32) - 1))); exit(); }
 EXPECT_REGEX ([a-z]*:\/.*;)*[a-z]*:\/.*
 REQUIRES grep -q '^cgroup2' /proc/mounts
-TIMEOUT 5
 MIN_KERNEL 4.18
 
 NAME cgroup_path printf
 PROG BEGIN { printf("path: %s", cgroup_path(cgroup & ((1 << 32) - 1))); exit(); }
 EXPECT_REGEX path: ([a-z]*:\/.*;)*[a-z]*:\/.*
 REQUIRES grep -q '^cgroup2' /proc/mounts
-TIMEOUT 5
 MIN_KERNEL 4.18
 
 NAME strerror
 RUN {{BPFTRACE}} --include "errno.h" -e 'BEGIN { print(strerror(EPERM)); exit(); }'
 EXPECT Operation not permitted
-TIMEOUT 5
 
 NAME bswap_int64
 RUN {{BPFTRACE}} -e 'BEGIN { printf("%llx", bswap(0x1122334455667788)); exit(); }'
@@ -614,7 +538,6 @@ AFTER ./testprogs/syscall connect 127.0.0.1 80
 EXPECT OK
 REQUIRES_FEATURE kfunc
 REQUIRES_FEATURE skboutput
-TIMEOUT 5
 MIN_KERNEL 5.5
 
 NAME debugf
@@ -635,29 +558,24 @@ TIMEOUT 3
 NAME nsecs
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs()); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 
 NAME nsecs_monotonic
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(monotonic)); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 
 NAME nsecs_boot
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(boot)); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 
 NAME nsecs_tai
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(tai)); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 REQUIRES_FEATURE get_tai_ns
 MIN_KERNEL 6.1
 
 NAME nsecs_sw_tai
 PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(sw_tai)); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
-TIMEOUT 5
 
 NAME map len
 PROG BEGIN { @[0] = 0; @[1] = 1; printf("map len: %d\n", len(@)); exit(); }

--- a/tests/runtime/complex_types
+++ b/tests/runtime/complex_types
@@ -1,14 +1,11 @@
 NAME struct-array
 RUN {{BPFTRACE}} runtime/scripts/struct_array.bt -c ./testprogs/struct_array
 EXPECT 100 102 104 106 108 -- 1 3 5 7 9 -- 100 98 96 94 92
-TIMEOUT 5
 
 NAME struct-array with variables
 RUN {{BPFTRACE}} runtime/scripts/struct_array_vars.bt -c ./testprogs/struct_array
 EXPECT 100 102 104 106 108 -- 1 3 5 7 9 -- 100 98 96 94 92 -- 42
-TIMEOUT 5
 
 NAME pointer_to_pointer
 RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:./testprogs/ptr_to_ptr:function { $pp = (struct Foo **)arg0; printf("%d\n", (*$pp)->a); }' -c ./testprogs/ptr_to_ptr
 EXPECT 123
-TIMEOUT 5

--- a/tests/runtime/config
+++ b/tests/runtime/config
@@ -1,32 +1,27 @@
 NAME config as env var
 RUN {{BPFTRACE}} -e 'config = { BPFTRACE_STACK_MODE=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
 EXPECT_REGEX ^\s+[0-9a-f]+$
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME config short name
 RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
 EXPECT_REGEX ^\s+[0-9a-f]+$
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME env var takes precedence
 RUN {{BPFTRACE}} -e 'config = { BPFTRACE_STACK_MODE=perf } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
 ENV BPFTRACE_STACK_MODE=raw
 EXPECT_REGEX ^\s+[0-9a-f]+$
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME bad config
 RUN {{BPFTRACE}} -e 'config = { bad_config=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
 EXPECT stdin:1:12-23: ERROR: Unrecognized config variable: bad_config
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 WILL_FAIL
 
 NAME env only config
 RUN {{BPFTRACE}} -e 'config = { debug_output=1 } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
 EXPECT stdin:1:12-25: ERROR: debug_output can only be set as an environment variable
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 WILL_FAIL

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -2,19 +2,16 @@ NAME list uprobe args - basic type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:main'
 EXPECT int argc
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 
 NAME list uprobe args - pointer type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:uprobeFunction1'
 EXPECT int * n
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 
 NAME list uprobe args - struct pointer type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:uprobeFunction2'
 EXPECT struct Foo * foo1
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 
 NAME list uprobe args - anonymous param type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:uprobeFunction3'
@@ -22,7 +19,6 @@ EXPECT enum { A, B, C } e
        union { int a; char b; } u
 REQUIRES bash -c "exit 1" # SKIP: anonymous parameter type not supported #3083
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 
 NAME list uprobe args - class reference type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeFunction1'
@@ -30,33 +26,28 @@ EXPECT     int & x
            Foo & foo
            Bar & bar
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 
 NAME list uprobe args - array reference type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeArray'
 EXPECT int (&)[10] array
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 
 NAME uprobe arg by name - char
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("c = %c\n", args.c); exit(); }
 EXPECT c = x
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobe arg by name - pointer
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("n = %d\n", *(args.n)); exit(); }
 EXPECT n = 13
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobe arg by name - struct
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->a = %d\n", args.foo1->a); exit(); }
 EXPECT foo1->a = 123
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 # NAME uprobe arg by index - 128-bits integer
@@ -66,7 +57,6 @@ BEFORE ./testprogs/uprobe_test
 #        z = cdcdcdcd
 #        w = abababab
 # REQUIRES_FEATURE dwarf
-# TIMEOUT 5
 # BEFORE ./testprogs/uprobe_test
 
 # NAME uprobe arg by name - 128-bits integer
@@ -76,14 +66,12 @@ BEFORE ./testprogs/uprobe_test
 #        z = cdcdcdcd
 #        w = abababab
 # REQUIRES_FEATURE dwarf
-# TIMEOUT 5
 # BEFORE ./testprogs/uprobe_test
 
 NAME uprobe arg by name - struct with 128-bits integer
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->d = %x\n", args.foo1->d); exit(); }
 EXPECT foo1->d = 9abcdef0
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobe skip inlined function
@@ -92,7 +80,6 @@ PROG config = { probe_inline = 0 }
      uretprobe:./testprogs/inline_function:main { exit() }
 EXPECT @count: 1
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 AFTER ./testprogs/inline_function
 
 NAME uprobe inlined function
@@ -101,7 +88,6 @@ PROG config = { probe_inline = 1 }
      uretprobe:./testprogs/inline_function:main { exit() }
 EXPECT @count: 3
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 AFTER ./testprogs/inline_function
 
 NAME uprobe inlined function - probe
@@ -114,7 +100,6 @@ EXPECT uprobe:./testprogs/inline_function:square
        uprobe:./testprogs/inline_function:square
        uprobe:./testprogs/inline_function:square
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 AFTER ./testprogs/inline_function
 
 NAME uprobe inlined function - func
@@ -127,7 +112,6 @@ EXPECT main
        main
        square
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 AFTER ./testprogs/inline_function
 
 NAME uprobe inlined function - ustack
@@ -139,7 +123,6 @@ PROG config = { probe_inline = 1; cache_user_symbols = "PER_PROGRAM"; }
 EXPECT_REGEX ^\n[ ]+main\+\d+$
 EXPECT_REGEX ^\n[ ]+square\+\d+\n[ ]+main\+\d+$
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 AFTER ./testprogs/inline_function
 
 NAME print uprobe arg as deref pointer - struct
@@ -149,7 +132,6 @@ PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 {
      }
 EXPECT { .a = 123, .b = hello, .c = [1,2,3], .d = 1311768467463790320 }
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 AFTER ./testprogs/uprobe_test
 
 NAME uprobe arg as reference - int
@@ -159,7 +141,6 @@ PROG uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeFunction1 {
      }
 EXPECT x = 42
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 AFTER ./testprogs/uprobe_test_cxx
 
 NAME print uprobe arg as reference - struct
@@ -169,7 +150,6 @@ PROG uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeFunction1 {
      }
 EXPECT_REGEX ^\{ \.a = 1, \.b = 2, \.c = 3, \.x = 0x[0-9a-f]{1,16} \}$
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 AFTER ./testprogs/uprobe_test_cxx
 
 NAME uprobe arg as reference - struct member
@@ -183,7 +163,6 @@ EXPECT foo.a = 1
        foo.c = 3
        foo.x = 42
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 AFTER ./testprogs/uprobe_test_cxx
 
 NAME uprobe arg as reference - array
@@ -194,7 +173,6 @@ PROG uprobe:./testprogs/uprobe_test_cxx:cpp:uprobeArray {
      }
 EXPECT arr[0] = 1, arr[1] = 2, arr[9] = 10
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 AFTER ./testprogs/uprobe_test_cxx
 
 # Checking backwards compatibility
@@ -202,33 +180,28 @@ NAME uprobe args as pointer
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("c = %c\n", args->c); exit(); }
 EXPECT c = x
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME struct field string
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->b = %s\n", args.foo1->b); exit(); }
 EXPECT foo1->b = hello
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME struct field array
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { print(args.foo1->c); exit(); }
 EXPECT [1,2,3]
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME cast to struct
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->a = %d\n", ((struct Foo *)arg0)->a); exit(); }
 EXPECT foo1->a = 123
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME struct override
 PROG struct Foo { int b; } uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->b = %d\n", ((struct Foo *)arg0)->b); exit(); }
 EXPECT foo1->b = 123
 REQUIRES_FEATURE dwarf
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 import os
 import platform
 
+DEFAULT_TIMEOUT = 5
 
 class RequiredFieldError(Exception):
     pass
@@ -236,7 +237,7 @@ class TestParser(object):
         elif len(expects) > 1 and has_exact_expect:
             raise InvalidFieldError('EXPECT_JSON or EXPECT_FILE can not be used with other EXPECTs. Suite: ' + test_suite)
         elif timeout == '':
-            raise RequiredFieldError('Test TIMEOUT is required. Suite: ' + test_suite)
+            timeout = DEFAULT_TIMEOUT
 
         return TestStruct(
             name,

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -15,7 +15,6 @@ import cmake_vars
 BPFTRACE_BIN = os.environ["BPFTRACE_RUNTIME_TEST_EXECUTABLE"]
 COLOR_SETTING = os.environ.get("RUNTIME_TEST_COLOR", "auto")
 ATTACH_TIMEOUT = 10
-DEFAULT_TIMEOUT = 5
 
 
 OK_COLOR = '\033[92m'
@@ -392,7 +391,7 @@ class Runner(object):
                     attached = True
                     if test.has_exact_expect:
                         output = ""  # ignore earlier ouput
-                    signal.alarm(test.timeout or DEFAULT_TIMEOUT)
+                    signal.alarm(test.timeout)
                     if test.after:
                         after_cmd = get_pid_ns_cmd(test.after) if test.new_pidns else test.after
                         after = subprocess.Popen(after_cmd, shell=True,

--- a/tests/runtime/file-output
+++ b/tests/runtime/file-output
@@ -1,19 +1,15 @@
 NAME printf to file
 RUN {{BPFTRACE}} -e 'i:ms:10 { printf("%s %d\n", "SUCCESS", 1); exit() }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT SUCCESS 1
-TIMEOUT 5
 
 NAME cat to file
 RUN {{BPFTRACE}} -e 'i:ms:10 { cat("/proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT_REGEX ^([0-9]+\.[0-9]+ )+.*$
-TIMEOUT 5
 
 NAME print map to file
 RUN {{BPFTRACE}} -e 'i:ms:10 { @=lhist(50, 0, 100, 10); exit();}' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT_REGEX ^\[50, 60\).*\@+\|$
-TIMEOUT 5
 
 NAME system stdout to file
 RUN {{BPFTRACE}} --unsafe -e 'i:ms:10 { system("cat /proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT_REGEX ^([0-9]+\.[0-9]+ )+.*$
-TIMEOUT 5

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -2,35 +2,29 @@ NAME map one key
 PROG BEGIN { @map[16] = 32; @map[64] = 128; for ($kv : @map) { print($kv); } exit(); }
 EXPECT (16, 32)
 EXPECT (64, 128)
-TIMEOUT 5
 
 NAME map two keys
 PROG BEGIN { @map[16,17] = 32; @map[64,65] = 128; for ($kv : @map) { print($kv); } exit(); }
 EXPECT ((16, 17), 32)
 EXPECT ((64, 65), 128)
-TIMEOUT 5
 
 NAME map one key elements
 PROG BEGIN { @map[16] = 32; for ($kv : @map) { printf("key: %d, val: %d\n", $kv.0, $kv.1); } exit(); }
 EXPECT key: 16, val: 32
-TIMEOUT 5
 
 NAME map two key elements
 PROG BEGIN { @map[16,17] = 32; for ($kv : @map) { printf("key: (%d,%d), val: %d\n", $kv.0.0, $kv.0.1, $kv.1); } exit(); }
 EXPECT key: (16,17), val: 32
-TIMEOUT 5
 
 NAME map strings
 PROG BEGIN { @map["abc"] = "aa"; @map["def"] = "dd"; for ($kv : @map) { print($kv); } exit(); }
 EXPECT (abc, aa)
 EXPECT (def, dd)
-TIMEOUT 5
 
 NAME map create map in body
 PROG BEGIN { @map[16] = 32; @map[64] = 128; for ($kv : @map) { @new[$kv.1] = $kv.0; } print(@new); exit(); }
 EXPECT @new[32]: 16
 EXPECT @new[128]: 64
-TIMEOUT 5
 
 NAME map multiple loops
 PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); } for ($kv : @mapB) { print($kv); } exit(); }
@@ -38,7 +32,6 @@ EXPECT (16, 32)
 EXPECT (17, 33)
 EXPECT (64, 128)
 EXPECT (65, 129)
-TIMEOUT 5
 
 NAME map multiple probes
 PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); } exit(); } END { for ($kv : @mapB) { print($kv); } }
@@ -46,19 +39,16 @@ EXPECT (16, 32)
 EXPECT (17, 33)
 EXPECT (64, 128)
 EXPECT (65, 129)
-TIMEOUT 5
 
 NAME map nested vals
 PROG BEGIN { @mapA[16] = 32; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); for ($kv2 : @mapB) { print($kv2); } } exit(); }
 EXPECT (16, 32)
 EXPECT (64, 128)
 EXPECT (65, 129)
-TIMEOUT 5
 
 NAME map nested count
 PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; @mapB[66] = 130; for ($kv : @mapA) { printf("A"); for ($kv2 : @mapB) { printf("B"); } } exit(); }
 EXPECT ABBBABBB
-TIMEOUT 5
 
 NAME map delete
 PROG BEGIN { @[0,0,0] = 1; @[0,0,1] = 1; @[0,1,0] = 1; @[1,0,0] = 1; for ($kv : @) { if ($kv.0.1 == 1) { delete(@[$kv.0.0, $kv.0.1, $kv.0.2]); } } exit(); }
@@ -66,24 +56,19 @@ EXPECT @[0, 0, 0]: 1
 EXPECT @[0, 0, 1]: 1
 EXPECT @[1, 0, 0]: 1
 EXPECT_NONE @[0, 1, 0]: 1
-TIMEOUT 5
 
 NAME variable context read only
 PROG BEGIN { @map[0] = 0; $var = 123; for ($kv : @map) { print($var); } exit(); }
 EXPECT 123
-TIMEOUT 5
 
 NAME variable context update
 PROG BEGIN { @map[0] = 0; @map[1] = 1; $var = 123; for ($kv : @map) { print($var); $var *= 2; } print($var); exit(); }
 EXPECT_REGEX ^123\n246\n492$
-TIMEOUT 5
 
 NAME variable context string
 PROG BEGIN { @map[0] = 0; @map[1] = 1; $var = "abc"; for ($kv : @map) { print($var); $var = "def"; } print($var); exit(); }
 EXPECT_REGEX ^abc\ndef\ndef$
-TIMEOUT 5
 
 NAME variable context multiple
 PROG BEGIN { @map[0] = 0; $var1 = 123; $var2 = "abc"; for ($kv : @map) { print(($var1, $var2)); } exit(); }
 EXPECT (123, abc)
-TIMEOUT 5

--- a/tests/runtime/intcast
+++ b/tests/runtime/intcast
@@ -2,20 +2,16 @@ NAME Casting retval should work
 PROG ur:./testprogs/uprobe_negative_retval:main   /(int32)retval < 0/ { @[(int32)retval]=count(); exit();}
 AFTER ./testprogs/uprobe_negative_retval
 EXPECT @[-100]: 1
-TIMEOUT 5
 
 NAME Sum casted retval
 PROG ur:./testprogs/uprobe_negative_retval:function1 { @=stats((int32)retval); exit();} ur:./testprogs/uprobe_negative_retval:main { exit() }
 AFTER ./testprogs/uprobe_negative_retval
 EXPECT @: count 221, average -10, total -2210
-TIMEOUT 5
 
 NAME Casting ints
 PROG BEGIN{printf("Values: %d %d\n", (uint8) -10, (uint16) 131087); exit(); }
 EXPECT Values: 246 15
-TIMEOUT 5
 
 NAME Implicit truncation of ints
 PROG BEGIN{ $a = (int16)0; $a = 2; $b = (int8)3; $b = -100; print(($a, $b)); exit(); }
 EXPECT (2, -100)
-TIMEOUT 5

--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -1,11 +1,9 @@
 NAME Sum casted value
 PROG uprobe:./testprogs/intptrcast:fn { @=sum(*((uint16*)arg0 + 1)); exit();}
 EXPECT @: 1110
-TIMEOUT 5
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
 PROG uprobe:./testprogs/intptrcast:fn { $a=*((uint16*)arg0 + 1); printf("%d\n", $a); exit();}
 EXPECT 1110
-TIMEOUT 5
 AFTER ./testprogs/intptrcast

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -1,131 +1,106 @@
 NAME invalid_format
 RUN {{BPFTRACE}} -q -f jsonx -e 'BEGIN { @scalar = 5; exit(); }'
 EXPECT ERROR: Invalid output format "jsonx"
-TIMEOUT 5
 WILL_FAIL
 
 NAME scalar
 PROG BEGIN { @scalar = 5; exit(); }
 EXPECT_JSON runtime/outputs/scalar.json
-TIMEOUT 5
 
 NAME scalar_str
 PROG BEGIN { @scalar_str = "a b \n d e"; exit(); }
 EXPECT_JSON runtime/outputs/scalar_str.json
-TIMEOUT 5
 
 NAME complex
 PROG BEGIN { @complex[comm,2] = 5; exit(); }
 EXPECT_JSON runtime/outputs/complex.json
-TIMEOUT 5
 
 NAME map
 PROG BEGIN { @map["key1"] = 2; @map["key2"] = 3; exit(); }
 EXPECT_JSON runtime/outputs/map.json
-TIMEOUT 5
 
 NAME multiple maps
 PROG BEGIN { @map1["key1"] = 2; @map2["key2"] = 3; exit(); }
 EXPECT_JSON runtime/outputs/multiple_maps.ndjson
-TIMEOUT 5
 
 NAME histogram
 PROG BEGIN { @hist = hist(2); @hist = hist(1025); exit(); }
 EXPECT_JSON runtime/outputs/hist.json
-TIMEOUT 5
 
 NAME histogram zero
 PROG BEGIN { @hist = hist(2); zero(@hist); exit(); }
 EXPECT_JSON runtime/outputs/hist_zero.json
-TIMEOUT 5
 
 NAME multiple histograms
 PROG BEGIN { @["bpftrace"] = hist(2); @["curl"] = hist(-1); @["curl"] = hist(0); @["curl"] = hist(511); @["curl"] = hist(1024); @["curl"] = hist(1025); exit(); }
 EXPECT_JSON runtime/outputs/hist_multiple.json
-TIMEOUT 5
 
 NAME histogram-finegrain
 PROG BEGIN { $i = 0; while ($i < 1024) { @ = hist($i, 3); $i++; } exit(); }
 EXPECT_JSON runtime/outputs/hist_2args.json
-TIMEOUT 5
 
 NAME linear histogram
 PROG BEGIN { @h = lhist(2, 0, 100, 10); @h = lhist(50, 0, 100, 10); @h = lhist(1000, 0, 100, 10); exit(); }
 EXPECT_JSON runtime/outputs/lhist.json
-TIMEOUT 5
 
 NAME linear histogram zero
 PROG BEGIN { @h = lhist(2, 0, 100, 10); zero(@h); exit(); }
 EXPECT_JSON runtime/outputs/lhist_zero.json
-TIMEOUT 5
 
 NAME multiple linear histograms
 PROG BEGIN { @stats["bpftrace"] = lhist(2, 0, 100, 10); @stats["curl"] = lhist(50, 0, 100, 10); @stats["bpftrace"] = lhist(1000, 0, 100, 10); exit(); }
 EXPECT_JSON runtime/outputs/lhist_multiple.json
-TIMEOUT 5
 
 NAME stats
 PROG BEGIN { @stats = stats(2); @stats = stats(10); exit(); }
 EXPECT_JSON runtime/outputs/stats.json
-TIMEOUT 5
 
 NAME multiple stats
 PROG BEGIN { @stats["curl"] = stats(2); @stats["zsh"] = stats(10); exit(); }
 EXPECT_JSON runtime/outputs/stats_multiple.json
-TIMEOUT 5
 
 NAME printf
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { printf("test %d", 5); exit(); }'
 EXPECT {"type": "printf", "data": "test 5"}
-TIMEOUT 5
 
 NAME printf_escaping
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { printf("test \r \n \t \\ \" bar"); exit(); }'
 EXPECT {"type": "printf", "data": "test \r \n \t \\ \" bar"}
-TIMEOUT 5
 
 NAME time
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { time(); exit(); }'
 EXPECT_REGEX ^{"type": "time", "data": "[0-9]*:[0-9]*:[0-9]*\\n"}$
-TIMEOUT 5
 
 NAME syscall
 RUN {{BPFTRACE}} --unsafe -f json -e 'BEGIN { system("echo a b c"); exit(); }'
 EXPECT {"type": "syscall", "data": "a b c\n"}
-TIMEOUT 5
 
 NAME join_delim
 RUN {{BPFTRACE}} --unsafe -f json -e 'tracepoint:syscalls:sys_enter_execve { join(args.argv, ","); }' -c "./testprogs/syscall execve /bin/echo 'A'"
 EXPECT {"type": "join", "data": "/bin/echo,'A'"}
-TIMEOUT 5
 
 NAME cat
 RUN {{BPFTRACE}} -f json -e 'BEGIN { cat("/proc/uptime"); exit(); }'
 EXPECT_REGEX ^{"type": "cat", "data": "[0-9]*.[0-9]* [0-9]*.[0-9]*\\n"}$
-TIMEOUT 5
 
 NAME strerror
 RUN {{BPFTRACE}} -f json -e 'BEGIN { print((strerror(7))); exit(); }'
 EXPECT {"type": "value", "data": "Argument list too long"}
-TIMEOUT 5
 
 # Careful with '[' and ']', they are read by the test engine as a regex
 # character class, so make sure to escape them.
 NAME tuple
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
 EXPECT {"type": "map", "data": {"@": [1,2,"string",[4,5]]}}
-TIMEOUT 5
 
 NAME tuple_with_struct
 RUN {{BPFTRACE}} -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); @ = (0, $f); exit(); }'
 EXPECT {"type": "map", "data": {"@": [0,{ "m": 2, "n": 3 }]}}
-TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME tuple_with_escaped_string
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @ = (1, 2, "string with \"quotes\""); exit(); }'
 EXPECT {"type": "map", "data": {"@": [1,2,"string with \"quotes\""]}}
-TIMEOUT 5
 
 NAME print_non_map
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { $x = 5; print($x); exit() }'
@@ -145,13 +120,11 @@ TIMEOUT 1
 NAME print_non_map_struct
 RUN {{BPFTRACE}} -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
 EXPECT {"type": "value", "data": { "m": 2, "n": 3 }}
-TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME print_non_map_nested_struct
 RUN {{BPFTRACE}} -f json -e 'struct Foo { struct { int m[1] } y; struct { int n; } a; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
 EXPECT {"type": "value", "data": { "y": { "m": [2] }, "a": { "n": 3 } }}
-TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME print_avg_map_args
@@ -182,7 +155,6 @@ TIMEOUT 1
 NAME cgroup_path
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print(cgroup_path(cgroup)); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin))'
 EXPECT_REGEX ^{'type': 'value', 'data': '.*'}$
-TIMEOUT 5
 
 NAME strftime
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { $t = (1, strftime("%m/%d/%y", nsecs)); print($t); exit() }' | python3 -c 'import sys,json; print(json.load(sys.stdin))'

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -1,69 +1,56 @@
 NAME if_gt
 PROG i:ms:1 {$a = 10; if ($a > 2) { $a = 20 } printf("a=%d\n", $a); exit();}
 EXPECT a=20
-TIMEOUT 5
 
 NAME if_lt
 PROG i:ms:1 {$a = 10; if ($a < 2) { $a = 20 } printf("a=%d\n", $a); exit();}
 EXPECT a=10
-TIMEOUT 5
 
 NAME ifelse_go_else
 PROG i:ms:1 {$a = ""; if (10 < 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}
 EXPECT a=hello
-TIMEOUT 5
 
 NAME ifelse_go_if
 PROG i:ms:1 {$a = ""; if (10 > 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}
 EXPECT a=hi
-TIMEOUT 5
 
 NAME ifelseif_go_elseif
 PROG i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (2 < 3) { $a = "hello" } printf("a=%s\n", $a); exit();}
 EXPECT a=hello
-TIMEOUT 5
 
 NAME ifelseifelse_go_else
 PROG i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (5 < 3) { $a = "hello" } else { $a = "asdf" } printf("a=%s\n", $a); exit();}
 EXPECT a=asdf
-TIMEOUT 5
 
 NAME if_cast
 PROG i:ms:1 { if ((int32)pid) {} printf("done\n"); exit();}
 EXPECT done
-TIMEOUT 5
 
 NAME ternary
 PROG i:ms:1 { $a = 1 ? "yes" : "no"; printf("%s\n", $a); exit();}
 EXPECT yes
-TIMEOUT 5
 
 NAME ternary_lnot
 PROG i:ms:1 { $a = !nsecs ? 0 : 1; printf("%d\n", $a); exit() }
 EXPECT 1
-TIMEOUT 5
 
 NAME ternary_int8
 PROG i:ms:1 { $a = 1 ? (int8)1 : 0; printf("%d\n", $a); exit();}
 EXPECT 1
-TIMEOUT 5
 
 NAME ternary_none_type
 PROG i:ms:1 { nsecs ? printf("yes\n") : printf("no") ; exit(); }
 EXPECT  yes
-TIMEOUT 5
 
 NAME unroll
 PROG i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}
 EXPECT a=11
-TIMEOUT 5
 
 NAME unroll_max_value
 PROG i:ms:1 {$a = 1; unroll (101) { $a = $a + 2; } printf("a=%d\n", $a); exit();}
 EXPECT stdin:1:17-29: ERROR: unroll maximum value is 100
        i:ms:1 {$a = 1; unroll (101) { $a = $a + 2; } printf("a=%d\n", $a); exit();}
                        ~~~~~~~~~~~~
-TIMEOUT 5
 WILL_FAIL
 
 NAME unroll_min_value
@@ -71,48 +58,39 @@ PROG i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}
 EXPECT stdin:1:17-27: ERROR: unroll minimum value is 1
        i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}
                        ~~~~~~~~~~
-TIMEOUT 5
 WILL_FAIL
 
 NAME unroll_param
 RUN {{BPFTRACE}} -e 'i:ms:1 {$a = 1; unroll ($1) { $a = $a + 1; } printf("a=%d\n", $a); exit();}' 10
 EXPECT a=11
-TIMEOUT 5
 
 NAME unroll_printf
 PROG BEGIN { unroll (1) { printf("a"); } printf("b\n"); exit(); }
 EXPECT ab
-TIMEOUT 5
 
 NAME if_compare_and_print_string
 PROG BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} exit();}
 EXPECT comm: bpftrace
-TIMEOUT 5
 
 NAME struct positional string compare - equal returns true
 RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
 EXPECT I got hello
-TIMEOUT 5
 
 NAME struct positional string compare - equal returns false
 RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
 EXPECT not equal
-TIMEOUT 5
 
 NAME struct positional string compare - not equal
 RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
 EXPECT not equal
-TIMEOUT 5
 
 NAME positional string compare via variable - equal
 RUN {{BPFTRACE}} -e 'BEGIN { $x = str($1, 6); if ($x == "hello") { printf("I got %s\n", "hello");} else { printf("not equal\n");} exit();}' "hello"
 EXPECT I got hello
-TIMEOUT 5
 
 NAME positional string compare via variable - not equal
 RUN {{BPFTRACE}} -e 'BEGIN { $x = str($1, 5); if ($x == "hello") { printf("I got hello\n");} else { printf("not %s\n", "equal");} exit();}' "hell"
 EXPECT not equal
-TIMEOUT 5
 
 NAME positional attachpoint
 RUN {{BPFTRACE}} -e 'i:ms:$1 { printf("hello world\n"); exit(); }' 1
@@ -137,27 +115,22 @@ TIMEOUT 1
 NAME string compare map lookup
 RUN {{BPFTRACE}} -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { @[comm] = 1; }' -c "./testprogs/syscall openat"
 EXPECT @[syscall]: 1
-TIMEOUT 5
 
 NAME struct partial string compare - pass
 RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm" "hhvm-proc"
 EXPECT I got hhvm
-TIMEOUT 5
 
 NAME struct partial string compare - pass reverse
 RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm-proc" "hhvm"
 EXPECT I got hhvm-proc
-TIMEOUT 5
 
 NAME strncmp function argument
 RUN {{BPFTRACE}} -e 'struct F {char s[8];} u:./testprogs/string_args:print { @=strncmp(((struct F*)arg0)->s, "hello", 5); }' -c ./testprogs/string_args
 EXPECT @: 0
-TIMEOUT 5
 
 NAME short non null-terminated string print
 RUN {{BPFTRACE}} -e 'struct F {char s[5];} u:./testprogs/string_args:print { $a = ((struct F*)arg0)->s; printf("%s %s\n", $a, $a); }' -c ./testprogs/string_args
 EXPECT hello hello
-TIMEOUT 5
 
 NAME optional_positional_int
 PROG BEGIN { printf("-%d-\n", $1); exit() }
@@ -177,17 +150,14 @@ TIMEOUT 1
 NAME positional as string literal
 RUN {{BPFTRACE}} -e 'BEGIN { @ = kaddr(str($1)); exit() }' vfs_read
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 
 NAME positional arg count
 RUN {{BPFTRACE}} -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); exit();}' "one" 2
 EXPECT got 2 args: one 2
-TIMEOUT 5
 
 NAME positional multiple bases
 RUN {{BPFTRACE}} -e 'BEGIN { printf("got: %d %o 0x%x\n", $1, $2, $3); exit() }' 123 0775 0x123
 EXPECT got: 123 775 0x123
-TIMEOUT 5
 
 NAME positional pointer arithmetic
 RUN {{BPFTRACE}} -e 'BEGIN { printf("%s", str($1 + 1)); exit(); }' hello
@@ -202,7 +172,6 @@ TIMEOUT 1
 NAME positional lhist
 RUN {{BPFTRACE}} -e 'BEGIN { @ = lhist(0, $1, $2, $3); exit()}' 0 10000 1000
 EXPECT_REGEX @: *\n[\[(].*
-TIMEOUT 5
 
 NAME positional buf
 RUN {{BPFTRACE}} -e 'BEGIN { @ = buf("hello", $1); exit(); }' 5
@@ -212,13 +181,11 @@ TIMEOUT 1
 NAME positional kstack
 RUN {{BPFTRACE}} -e 'k:do_nanosleep { printf("SUCCESS %s\n%s\n", kstack(), kstack($1)); exit(); }' 1
 EXPECT SUCCESS
-TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME positional ustack
 RUN {{BPFTRACE}} -e 'u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack($1)); exit(); }' 1
 EXPECT_REGEX .*uprobeFunction1\+[0-9]+\n\s+spin\+[0-9]+\n\s+main\+[0-9]+\n(?s:.*)\n\n\n\s+uprobeFunction1\+[0-9]+
-TIMEOUT 5
 # Required to skip function prologue
 REQUIRES_FEATURE dwarf
 AFTER ./testprogs/uprobe_loop
@@ -246,19 +213,16 @@ TIMEOUT 1
 NAME sigint under heavy load
 RUN {{BPFTRACE}} --unsafe -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
 EXPECT end
-TIMEOUT 5
 AFTER  ./testprogs/syscall nanosleep 2e9; pkill -SIGINT bpftrace
 
 NAME bitfield access
 PROG struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe:./testprogs/bitfield_test:func{ $foo = (struct Foo *)arg0; printf("%d %d %d %d %d\n", $foo->a, $foo->b, $foo->c, $foo->d, $foo->e); exit()}
 EXPECT 1 2 5 0 65535
-TIMEOUT 5
 AFTER ./testprogs/bitfield_test
 
 NAME bitfield_access_2
 PROG struct Bar { short a:4, b:8, c:3, d:1; int e:9, f:15, g:1, h:2, i:5 } uprobe:./testprogs/bitfield_test:func2 { $bar = (struct Bar *)arg0; printf("%d %d %d %d %d", $bar->a, $bar->b, $bar->c, $bar->d, $bar->e); printf(" %d %d %d %d", $bar->f, $bar->g, $bar->h, $bar->i); exit()}
 EXPECT 1 217 5 1 500 31117 1 2 27
-TIMEOUT 5
 AFTER ./testprogs/bitfield_test
 
 NAME exit exits immediately
@@ -290,35 +254,28 @@ TIMEOUT 1
 NAME per_cpu_map_count_if
 PROG i:ms:1 { @ = count(); if (@ > 5) { printf("done\n"); exit(); }}
 EXPECT done
-TIMEOUT 5
 
 NAME per_cpu_map_min_if
 PROG BEGIN { @ = 10; } i:ms:1 { @--; @mn = min(@); if (@mn < 5) { printf("done\n"); exit(); }}
 EXPECT done
-TIMEOUT 5
 
 NAME per_cpu_map_max_if
 PROG BEGIN { @ = 1; } i:ms:1 { @++; @mx = max(@); if (@mx > 5) { printf("done\n"); exit(); }}
 EXPECT done
-TIMEOUT 5
 
 NAME per_cpu_map_avg_if
 PROG BEGIN { @ = avg(1); @ = avg(1); @ = avg(10); if (@ == 4) { printf("done\n"); exit(); }}
 EXPECT done
-TIMEOUT 5
 
 NAME per_cpu_map_arithmetic
 PROG BEGIN { @a = sum(10); @b = count(); $c = @a + @b; if ($c == 11) { printf("done\n"); } exit();}
 EXPECT done
-TIMEOUT 5
 
 NAME per_cpu_map_cast
 PROG BEGIN { @a = count(); @b = sum(10); printf("%d-%d\n", (uint64)@a, (int64)@b); exit();}
 EXPECT 1-10
-TIMEOUT 5
 
 NAME dry run empty output
 RUN {{BPFTRACE}} --dry-run -e 'BEGIN { printf("hello\n"); @ = 0; }'
 EXPECT_NONE hello
 EXPECT_NONE @: 0
-TIMEOUT 5

--- a/tests/runtime/pointers
+++ b/tests/runtime/pointers
@@ -1,106 +1,85 @@
 NAME u8 pointer increment
 PROG BEGIN { @=(int8*) 0x32; @+=1; exit(); }
 EXPECT @: 0x33
-TIMEOUT 5
 
 NAME u16 pointer increment
 PROG BEGIN { @=(int16*) 0x32; @+=1; exit(); }
 EXPECT @: 0x34
-TIMEOUT 5
 
 NAME u32 pointer increment
 PROG BEGIN { @=(int32*) 0x32; @+=1; exit(); }
 EXPECT @: 0x36
-TIMEOUT 5
 
 NAME u64 pointer increment
 PROG BEGIN { @=(int64*) 0x32; @+=1; exit(); }
 EXPECT @: 0x3a
-TIMEOUT 5
 
 NAME u8 pointer unop post increment
 PROG BEGIN { @=(int8*) 0x32; @++; exit(); }
 EXPECT @: 0x33
-TIMEOUT 5
 
 NAME u16 pointer unop post increment
 PROG BEGIN { @=(int16*) 0x32; @++; exit(); }
 EXPECT @: 0x34
-TIMEOUT 5
 
 NAME u32 pointer unop post increment
 PROG BEGIN { @=(int32*) 0x32; @++; exit(); }
 EXPECT @: 0x36
-TIMEOUT 5
 
 NAME u64 pointer unop post increment
 PROG BEGIN { @=(int64*) 0x32; @++; exit(); }
 EXPECT @: 0x3a
-TIMEOUT 5
 
 NAME u8 pointer unop pre increment
 PROG BEGIN { @=(int8*) 0x32; @++; exit(); }
 EXPECT @: 0x33
-TIMEOUT 5
 
 NAME u16 pointer unop pre increment
 PROG BEGIN { @=(int16*) 0x32; @++; exit(); }
 EXPECT @: 0x34
-TIMEOUT 5
 
 NAME u32 pointer unop pre increment
 PROG BEGIN { @=(int32*) 0x32; @++; exit(); }
 EXPECT @: 0x36
-TIMEOUT 5
 
 NAME u64 pointer unop pre increment
 PROG BEGIN { @=(int64*) 0x32; @++; exit(); }
 EXPECT @: 0x3a
-TIMEOUT 5
 
 NAME Pointer decrement 1
 PROG BEGIN { @=(int32*) 0x32; @-=1; exit(); }
 EXPECT @: 0x2e
-TIMEOUT 5
 
 NAME Pointer decrement
 PROG BEGIN { @=(int32*) 0x32; @--; exit(); }
 EXPECT @: 0x2e
-TIMEOUT 5
 
 NAME Pointer increment 6
 PROG BEGIN { @=(int32*) 0x32; @+=6; exit(); }
 EXPECT @: 0x4a
-TIMEOUT 5
 
 NAME Pointer decrement 6
 PROG BEGIN { @=(int32*) 0x32; @-=6; exit(); }
 EXPECT @: 0x1a
-TIMEOUT 5
 
 NAME Struct pointer math
 PROG struct A {int32_t a; int32_t b; char c[28] }; BEGIN { $a=(struct A*) 1024; printf("%lu - 5 x %lu = %lu\n", $a, sizeof(struct A), $a-5); exit(); }
 EXPECT 1024 - 5 x 36 = 844
-TIMEOUT 5
 
 NAME Pointer decrement with map
 PROG BEGIN { @dec = 4; @=(int32*) 0x32; @-=@dec; exit(); }
 EXPECT @: 0x22
-TIMEOUT 5
 
 NAME Pointer walk through struct
 RUN {{BPFTRACE}} runtime/scripts/struct_walk.bt -c ./testprogs/struct_walk
 EXPECT a: 45 b: 1000
-TIMEOUT 5
 
 NAME Pointer arith with int32
 PROG struct C { uint32_t a; }; uprobe:./testprogs/struct_walk:clear { $c = (struct C *)arg0; printf("ptr: %p\n", $c + $c->a); exit() }
 AFTER ./testprogs/struct_walk
 EXPECT_REGEX ^ptr: 0x[0-9a-z]+
-TIMEOUT 5
 
 NAME Pointer to pointer arithmetic and dereference
 PROG uprobe:./testprogs/array_access:test_ptr_array { $p = (int32 **)arg0; @x = **($p + 1); exit(); }
 EXPECT @x: 2
 AFTER ./testprogs/array_access
-TIMEOUT 5

--- a/tests/runtime/precedence
+++ b/tests/runtime/precedence
@@ -1,19 +1,15 @@
 NAME operator_precedence_1
 PROG BEGIN { print(1 + 2 * 3 ); exit() }
 EXPECT 7
-TIMEOUT 5
 
 NAME operator_precedence_2
 PROG BEGIN { print(1 + 2 * 3 + 1); exit() }
 EXPECT 8
-TIMEOUT 5
 
 NAME operator_precedence_3
 PROG BEGIN { print(1 + 2 * 3 + 1 * 10); exit() }
 EXPECT 17
-TIMEOUT 5
 
 NAME operator_precedence_3
 PROG BEGIN { print(1 + 2 / 2 * 3); exit() }
 EXPECT 4
-TIMEOUT 5

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -2,35 +2,30 @@ NAME kfunc
 PROG kfunc:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretfunc
 PROG kretfunc:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kfunc_wildcard
 PROG kfunc:vfs_re*ad { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kfunc_module
 PROG kfunc:vmlinux:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kfunc_module_wildcard
 PROG kfunc:vmlinu*:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 # https://github.com/bpftrace/bpftrace/issues/2447
@@ -39,7 +34,6 @@ PROG BEGIN { @a = 2; @b = 1; @c = 1 } i:s:1 { exit() } kfunc:vfs_read, kfunc:vfs
 EXPECT @a: 0
        @b: 0
        @c: 0
-TIMEOUT 5
 REQUIRES_FEATURE kfunc
 # Note: this calls both vfs_read and vfs_open
 AFTER ./testprogs/syscall read
@@ -49,7 +43,6 @@ PROG kfunc:vfs_read { printf("%d\n", args.count); exit(); }
 EXPECT_REGEX [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 REQUIRES_FEATURE btf
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 # Checking backwards compatibility
@@ -58,7 +51,6 @@ PROG kfunc:vfs_read { printf("%d\n", args->count); exit(); }
 EXPECT_REGEX [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 REQUIRES_FEATURE btf
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kfunc func builtin
@@ -67,7 +59,6 @@ EXPECT func: vfs_read
 REQUIRES_FEATURE kfunc
 REQUIRES_FEATURE btf
 REQUIRES_FEATURE get_func_ip
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretfunc large args
@@ -75,7 +66,6 @@ PROG kretfunc:__sys_bpf { if (args.cmd == 1111 && args.size == 2222 && (int64)re
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
 REQUIRES_FEATURE btf
-TIMEOUT 5
 AFTER ./testprogs/kfunc_args 1111 2222
 
 # Sanity check for fentry/fexit alias
@@ -83,106 +73,89 @@ NAME fentry
 PROG fentry:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME fexit
 PROG fexit:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE kfunc
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe
 PROG kprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_short_name
 PROG k:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_order
 RUN {{BPFTRACE}} runtime/scripts/kprobe_order.bt
 EXPECT first second
-TIMEOUT 5
 AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
 
 NAME kprobe_offset
 PROG kprobe:vfs_read+0 { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_wildcard
 PROG kprobe:vmlinux:vfs_rea* { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_wildcard_multi
 RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { printf("progs: "); system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
 EXPECT progs: 1
-TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 REQUIRES_FEATURE kprobe_multi
 
 NAME kprobe_module
 PROG kprobe:vmlinux:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_module_wildcard
 PROG kprobe:vmlinu*:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_module_missing
 PROG kprobe:nonsense:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT ERROR: Error attaching probe: kprobe:nonsense:vfs_read: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
-TIMEOUT 5
 WILL_FAIL
 
 NAME kprobe_wildcard_all_leading_underscore
 PROG kprobe:_* { } interval:s:1{ printf("SUCCESS"); exit(); }
 EXPECT_REGEX SUCCESS
 ENV BPFTRACE_MAX_PROBES=20000
-TIMEOUT 5
 REQUIRES_FEATURE kprobe_multi
 
 NAME kprobe_disallow_rcu_functions
 PROG kprobe:rcu_* { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT No probes to attach
-TIMEOUT 5
 WILL_FAIL
 
 NAME kprobe_hide_ftrace_invalid_address
 RUN {{BPFTRACE}} -l | grep -c __ftrace_invalid_address__ || true
 EXPECT 0
-TIMEOUT 5
 
 NAME kprobe_func_missing
 PROG kprobe:vmlinux:nonsense { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT ERROR: Error attaching probe: kprobe:vmlinux:nonsense
-TIMEOUT 5
 WILL_FAIL
 
 NAME kprobe_multi_wildcard
 RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { printf("link: "); system("/usr/sbin/bpftool link | grep kprobe_multi | wc -l"); exit(); }'
 EXPECT link: 1
-TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 REQUIRES_FEATURE kprobe_multi
 
 NAME uprobe_multi_wildcard
 RUN {{BPFTRACE}} --unsafe -e 'uprobe:./testprogs/uprobe_test:uprobeFunction* { printf("link: "); system("/usr/sbin/bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }'
 EXPECT link: 1
-TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 REQUIRES_FEATURE uprobe_multi
 AFTER ./testprogs/uprobe_test
@@ -190,7 +163,6 @@ AFTER ./testprogs/uprobe_test
 NAME kprobe_wildcard probe builtin
 RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { @ = probe; printf("progs: "); system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
 EXPECT_REGEX progs: [1-9][0-9]+
-TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 
 # Note: this test may fail if you've installed a new kernel but not rebooted
@@ -199,7 +171,6 @@ REQUIRES /usr/sbin/bpftool
 NAME kprobe_offset_fail_size
 PROG kprobe:vfs_read+1000000 { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX Offset outside the function bounds \('vfs_read' size is*
-TIMEOUT 5
 WILL_FAIL
 # See https://github.com/bpftrace/bpftrace/pull/956
 SKIP_IF_ENV_HAS CI=true
@@ -209,7 +180,6 @@ RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x5 { printf("hit\n"); exit(); }
 AFTER /usr/sbin/nft add table bpftrace
 EXPECT hit
 ARCH x86_64
-TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
 CLEANUP /usr/sbin/nft delete table bpftrace
@@ -220,7 +190,6 @@ RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x8 { printf("hit\n"); exit(); }
 AFTER /usr/sbin/nft add table bpftrace
 EXPECT hit
 ARCH ppc64|ppc64le|aarch64
-TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
 CLEANUP /usr/sbin/nft delete table bpftrace
@@ -229,7 +198,6 @@ NAME kprobe_offset_module_error
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
 EXPECT ERROR: Possible attachment attempt in the middle of an instruction, try a different offset.
 ARCH x86_64
-TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 WILL_FAIL
 
@@ -237,68 +205,57 @@ NAME kprobe_offset_module_error
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
 EXPECT cannot attach kprobe, Invalid argument
 ARCH aarch64
-TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 WILL_FAIL
 
 NAME kprobe_warn_missing_probes
 PROG kprobe:vfs_read,kprobe:nonsense { exit(); }
 EXPECT WARNING: could not attach probe kprobe:nonsense, skipping.
-TIMEOUT 5
 
 NAME kprobe_ignore_missing_probes
 PROG config = { missing_probes = "ignore" } kprobe:vfs_read,kprobe:nonsense { exit(); }
 EXPECT_NONE WARNING: could not attach probe kprobe:nonsense, skipping.
-TIMEOUT 5
 
 NAME kprobe_error_missing_probes
 PROG config = { missing_probes = "error" } kprobe:vfs_read,kprobe:nonsense { exit(); }
 EXPECT ERROR: Error attaching probe: kprobe:nonsense
-TIMEOUT 5
 WILL_FAIL
 
 NAME kretprobe
 PROG kretprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretprobe_short_name
 PROG kr:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretprobe_order
 RUN {{BPFTRACE}} runtime/scripts/kretprobe_order.bt
 EXPECT first second
-TIMEOUT 5
 AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
 
 NAME kretprobe_wildcard
 PROG kretprobe:vmlinux:vfs_rea* { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
-TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretprobe_wildcard_multi
 RUN {{BPFTRACE}} --unsafe -e 'kretprobe:ksys_* { system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
 EXPECT 1
-TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 REQUIRES_FEATURE kprobe_multi
 
 NAME kretprobe_wildcard_multi_link
 RUN {{BPFTRACE}} --unsafe -e 'kretprobe:ksys_* { printf("link: "); system("/usr/sbin/bpftool link | grep kprobe_multi | wc -l"); exit(); }'
 EXPECT link: 1
-TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 REQUIRES_FEATURE kprobe_multi
 
 NAME uretprobe_multi_wildcard
 RUN {{BPFTRACE}} --unsafe -e 'uretprobe:./testprogs/uprobe_test:uprobeFunction* { printf("link: "); system("/usr/sbin/bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }'
 EXPECT link: 1
-TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 REQUIRES_FEATURE uprobe_multi
 AFTER ./testprogs/uprobe_test
@@ -306,7 +263,6 @@ AFTER ./testprogs/uprobe_test
 NAME uprobe_multi_wildcard_target_wildcard
 RUN {{BPFTRACE}} --unsafe -e 'uretprobe:*:uprobeFunction* { printf("link: "); system("/usr/sbin/bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }' -p {{BEFORE_PID}}
 EXPECT link: 1
-TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 REQUIRES_FEATURE uprobe_multi
 BEFORE ./testprogs/uprobe_test
@@ -314,224 +270,186 @@ BEFORE ./testprogs/uprobe_test
 NAME uprobe
 PROG uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}
 EXPECT_REGEX arg0: [0-9]*
-TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset
 PROG uprobe:/bin/bash:echo_builtin+0 { printf("arg0: %d\n", arg0); exit();}
 EXPECT_REGEX arg0: [0-9]*
-TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset
 PROG uprobe:/bin/bash:"echo_builtin"+0 { printf("arg0: %d\n", arg0); exit();}
 EXPECT_REGEX arg0: [0-9]*
-TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset_fail_size
 PROG uprobe:/bin/bash:echo_builtin+1000000 { printf("arg0: %d\n", arg0); exit();}
 EXPECT_REGEX Offset outside the function bounds \('echo_builtin' size is*
-TIMEOUT 5
 WILL_FAIL
 
 NAME uprobe_address_fail_resolve
 PROG uprobe:/bin/bash:10 { printf("arg0: %d\n", arg0); exit();}
 EXPECT ERROR: Could not resolve address: /bin/bash:0xa
-TIMEOUT 5
 WILL_FAIL
 
 NAME uprobe_library
 PROG uprobe:libc:fread { printf("size: %d\n", arg1); exit(); }
 EXPECT_REGEX size: [0-9]+
-TIMEOUT 5
 AFTER ./testprogs/uprobe_library
 REQUIRES_FEATURE libpath_resolv
 
 NAME uprobe_order
 RUN {{BPFTRACE}} runtime/scripts/uprobe_order.bt
 EXPECT first second
-TIMEOUT 5
 AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 
 NAME uprobe_zero_size
 PROG uprobe:./testprogs/uprobe_test:_init { printf("arg0: %d\n", arg0); exit();}
 EXPECT ERROR: Could not determine boundary for _init (symbol has size 0). Use --unsafe to force attachment.
-TIMEOUT 5
 WILL_FAIL
 
 NAME uprobe_zero_size_unsafe
 RUN {{BPFTRACE}} --unsafe -e 'uprobe:./testprogs/uprobe_test:_init { printf("arg0: %d\n", arg0); exit();}'
 EXPECT_REGEX arg0: [0-9]*
-TIMEOUT 5
 AFTER ./testprogs/uprobe_test
 
 NAME uprobe_warn_missing_probes
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
 EXPECT WARNING: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3, skipping probe.
-TIMEOUT 5
 AFTER ./testprogs/uprobe_test
 
 NAME uprobe_ignore_missing_probes
 PROG config = { missing_probes = "ignore" } uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
 EXPECT_NONE WARNING: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3, skipping probe.
-TIMEOUT 5
 AFTER ./testprogs/uprobe_test
 
 NAME uprobe_error_missing_probes
 PROG config = { missing_probes = "error" } uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
 EXPECT ERROR: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3, cannot attach probe.
-TIMEOUT 5
 AFTER ./testprogs/uprobe_test
 WILL_FAIL
 
 NAME uretprobe
 PROG uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}
 EXPECT_REGEX readline: [0-9]*
-TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uretprobe_order
 RUN {{BPFTRACE}} runtime/scripts/uretprobe_order.bt
 EXPECT first second
-TIMEOUT 5
 AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 
 NAME tracepoint
 PROG tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS %d\n", gid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
-TIMEOUT 5
 
 NAME tracepoint_short_name
 PROG t:syscalls:sys_exit_nanosleep { printf("SUCCESS %d\n", gid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
-TIMEOUT 5
 
 NAME tracepoint_order
 RUN {{BPFTRACE}} runtime/scripts/tracepoint_order.bt
 EXPECT first second
-TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8; ./testprogs/syscall nanosleep 1e8
 
 NAME tracepoint_expansion
 RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit\n"); }' -c "./testprogs/syscall nanosleep 1e8"
 EXPECT hit
-TIMEOUT 5
 
 NAME tracepoint_missing
 PROG t:syscalls:nonsense { printf("hit"); exit(); }
 EXPECT stdin:1:1-20: ERROR: tracepoint not found: syscalls:nonsense
-TIMEOUT 5
 WILL_FAIL
 
 NAME tracepoint_multiattach_missing
 PROG t:syscalls:sys_exit_nanosleep,t:syscalls:nonsense { printf("hit"); exit(); }
 EXPECT hit
 AFTER ./testprogs/syscall nanosleep 1e8
-TIMEOUT 5
 WILL_FAIL
 
 NAME tracepoint args
 PROG tracepoint:syscalls:sys_enter_read { printf("%d\n", args.count); exit(); }
 EXPECT_REGEX [0-9][0-9]*
 AFTER ./testprogs/syscall read
-TIMEOUT 5
 
 # Checking backwards compatibility
 NAME tracepoint args as pointer
 PROG tracepoint:syscalls:sys_enter_read { printf("%d\n", args->count); exit(); }
 EXPECT_REGEX [0-9][0-9]*
 AFTER ./testprogs/syscall read
-TIMEOUT 5
 
 # Test that we get at least two characters out
 NAME tracepoint_data_loc
 PROG tracepoint:irq:irq_handler_entry { print(str(args.name)); exit(); }
 EXPECT_REGEX ..+
-TIMEOUT 5
 
 NAME rawtracepoint
 PROG rawtracepoint:sys_exit { printf("SUCCESS %d\n", gid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
-TIMEOUT 5
 
 NAME rawtracepoint_short_name
 PROG rt:sys_exit { printf("SUCCESS %d\n", gid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
-TIMEOUT 5
 
 NAME rawtracepoint_missing
 PROG rawtracepoint:nonsense { printf("hit"); exit(); }
 EXPECT ERROR: Probe does not exist: rawtracepoint:nonsense
-TIMEOUT 5
 WILL_FAIL
 
 NAME rawtracepoint_wildcard
 PROG rawtracepoint:sys_* { printf("SUCCESS %d\n", gid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep
-TIMEOUT 5
 
 NAME profile
 PROG profile:hz:599 { print("hit"); exit(); }
 EXPECT hit
-TIMEOUT 5
 
 NAME profile_short_name
 PROG p:hz:599 { print("hit"); exit(); }
 EXPECT hit
-TIMEOUT 5
 
 NAME profile_probe_builtin
 PROG profile:hz:599 { print(probe); exit();}
 EXPECT profile:hz:599
-TIMEOUT 5
 
 NAME interval
 PROG interval:ms:1 { print("hit"); exit(); }
 EXPECT hit
-TIMEOUT 5
 
 NAME interval_short_name
 PROG i:ms:1{ print("hit"); exit();}
 EXPECT hit
-TIMEOUT 5
 
 NAME interval_probe_builtin
 PROG interval:ms:1 { print(probe); exit();}
 EXPECT interval:ms:1
-TIMEOUT 5
 
 NAME software
 PROG software:cpu-clock:1 { print("hit"); exit();}
 EXPECT hit
-TIMEOUT 5
 
 NAME software_probe_builtin
 PROG software:cpu-clock:1 { print(probe); exit();}
 EXPECT software:cpu-clock:1
-TIMEOUT 5
 
 NAME software_alias_probe_builtin
 PROG software:cpu:1 { print(probe); exit();}
 EXPECT software:cpu:1
-TIMEOUT 5
 
 NAME hardware
 REQUIRES ls /sys/devices/cpu/events/cache-misses
 PROG hardware:cache-misses:10 { print("hit"); exit(); }
 EXPECT hit
-TIMEOUT 5
 
 NAME hardware_probe_builtin
 REQUIRES ls /sys/devices/cpu/events/cache-misses
 PROG hardware:cache-misses:10 { print(probe); exit();}
 EXPECT hardware:cache-misses:10
-TIMEOUT 5
 
 NAME BEGIN
 PROG BEGIN { printf("Hello\n"); exit();}
@@ -561,4 +479,3 @@ NAME sanitise probe name
 PROG uprobe:./testprogs/uprobe_namesan:fn* { printf("ok\n"); exit(); }
 EXPECT ok
 AFTER ./testprogs/uprobe_namesan
-TIMEOUT 5

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -8,7 +8,6 @@ NAME logical_and_or_different_sizes
 PROG struct Foo { int m; } uprobe:./testprogs/simple_struct:func { $foo = (struct Foo*)arg0; printf("%d %d %d %d %d\n", $foo->m, $foo->m && 0, 1 && $foo->m, $foo->m || 0, 0 || $foo->m); exit(); }
 AFTER ./testprogs/simple_struct
 EXPECT 2 0 1 1 1
-TIMEOUT 5
 
 # https://github.com/bpftrace/bpftrace/issues/759
 # Update test once https://github.com/bpftrace/bpftrace/pull/781 lands
@@ -21,12 +20,10 @@ TIMEOUT 5
 NAME modulo_operator
 PROG BEGIN { @x = 4; printf("%d\n", @x % 2); exit() }
 EXPECT 0
-TIMEOUT 5
 
 NAME c_array_indexing
 RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:uprobeFunction2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
 EXPECT h e l l o
-TIMEOUT 5
 
 # https://github.com/bpftrace/bpftrace/issues/1773
 NAME single_arg_wildcard_listing

--- a/tests/runtime/signals
+++ b/tests/runtime/signals
@@ -13,4 +13,3 @@ NAME print all maps on sigusr1
 RUN {{BPFTRACE}} -e 'BEGIN { @scalar = 5; } interval:s:2 { delete(@scalar); exit(); }'
 AFTER kill -s USR1 $(pidof bpftrace)
 EXPECT @scalar: 5
-TIMEOUT 5

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -1,17 +1,14 @@
 NAME stats with negative values
 PROG BEGIN { @=stats(-10); @=stats(-5); @=stats(5); exit() }
 EXPECT @: count 3, average -3, total -10
-TIMEOUT 5
 
 NAME avg with negative values
 PROG BEGIN { @=avg(-30); @=avg(-10); exit(); }
 EXPECT @: -20
-TIMEOUT 5
 
 NAME avg cast negative values
 PROG BEGIN { @ = avg(-1); @ = avg(-1); @ = avg(-10); if (@ == -4) { printf("done\n"); exit(); }}
 EXPECT done
-TIMEOUT 5
 
 NAME negative map value
 PROG BEGIN { @ = -11; exit(); }
@@ -36,4 +33,3 @@ TIMEOUT 1
 NAME mixed values
 PROG BEGIN { printf("%d %d %d %d\n", (int8) -10, -5555, (int16)-123, 100); exit(); }
 EXPECT -10 -5555 -123 100
-TIMEOUT 5

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -1,104 +1,85 @@
 NAME basic tuple
 PROG BEGIN { $v = 99; $t = (0, 1, "str", (5, 6), $v); printf("%d %d %s %d %d %d\n", $t.0, $t.1, $t.2, $t.3.0, $t.3.1, $t.4); exit(); }
 EXPECT 0 1 str 5 6 99
-TIMEOUT 5
 
 NAME basic tuple map
 PROG BEGIN { $v = 99; @t = (0, 1, "str"); printf("%d %d %s\n", @t.0, @t.1, @t.2); exit(); }
 EXPECT 0 1 str
-TIMEOUT 5
 
 NAME mixed int tuple map
 PROG BEGIN { @ = ( (int32) -100, (int8) 10, 50 ); exit();}
 EXPECT @: (-100, 10, 50)
-TIMEOUT 5
 
 NAME mixed int tuple map 2
 PROG BEGIN { @ = ( -100, (int8) 10, (int32) 50 ); exit();}
 EXPECT @: (-100, 10, 50)
-TIMEOUT 5
 
 NAME mixed int tuple map 3
 PROG BEGIN { @ = ( -100, (int8) 10, (int32) 50, 100 ); exit();}
 EXPECT @: (-100, 10, 50, 100)
-TIMEOUT 5
 
 NAME complex tuple 1
 PROG BEGIN { print(((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555)); exit(); }
 EXPECT (-100, 100, abcdef, 3, 1, -10, 10, -555)
-TIMEOUT 5
 
 NAME tuple struct sizing 1
 PROG BEGIN { $t = ((int8) 1, (int64) 1, (int8) 1, (int64) 1); print(sizeof($t)); exit() }
 EXPECT 32
-TIMEOUT 5
 
 NAME tuple struct sizing 2
 PROG BEGIN { $t = ((int8) 1, (int16) 1, (int32) 1); print(sizeof($t)); exit() }
 EXPECT 8
-TIMEOUT 5
 
 NAME tuple struct sizing 3
 PROG BEGIN { $t = ((int32) 1, (int16) 1, (int8) 1); print(sizeof($t)); exit() }
 EXPECT 8
-TIMEOUT 5
 
 NAME complex tuple 4
 PROG BEGIN { $a = ((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555, "abc"); print(sizeof($a)); exit(); }
 EXPECT 48
-TIMEOUT 5
 
 NAME struct in tuple
 PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @t = (1, *((struct Foo *)arg0)); exit(); }
 EXPECT @t: (1, { .m = 2, .n = 3 })
-TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME struct in tuple sizing
 PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { $t = ((int32)1, *((struct Foo *)arg0)); print(sizeof($t)); exit(); }
 EXPECT 12
-TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME array in tuple
 PROG struct A { int x[4]; } u:./testprogs/array_access:test_struct { @t = (1, ((struct A *)arg0)->x); exit(); }
 EXPECT @t: (1, [1,2,3,4])
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array in tuple sizing
 PROG struct A { int x[4]; } u:./testprogs/array_access:test_struct { $t = ((int32)1, ((struct A *)arg0)->x); print(sizeof($t)); exit(); }
 EXPECT 20
-TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME nested tuple
 PROG BEGIN{ @ = ((int8)1, ((int8)-20, (int8)30)); exit(); }
 EXPECT @: (1, (-20, 30))
-TIMEOUT 5
 
 # Careful with '(' and ')', they are read by the test engine as a regex group,
 # so make sure to escape them.
 NAME tuple print
 PROG BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }
 EXPECT @: (1, 2, string, (4, 5))
-TIMEOUT 5
 
 NAME tuple strftime type is packed
 PROG BEGIN { @ = (nsecs, strftime("%M:%S", nsecs)); exit(); }
 EXPECT_REGEX ^@: \(\d+, \d+:\d+\)$
-TIMEOUT 5
 
 NAME bytearray in tuple
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = ((int8)1, usym(reg("ip")), 10); exit(); }
 EXPECT_REGEX ^@: \(1, 0x[0-9a-f]+, 10\)$
-TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/uprobe_test
 
 NAME bytearray in tuple
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = ((int8)1, usym(reg("nip")), 10); exit(); }
 EXPECT_REGEX ^@: \(1, 0x[0-9a-f]+, 10\)$
-TIMEOUT 5
 ARCH ppc64|ppc64le
 AFTER ./testprogs/uprobe_test

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -1,55 +1,45 @@
 NAME uprobes - list probes by file
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:*'
 EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
-TIMEOUT 5
 
 NAME uprobes - list probes by file with wildcarded filter
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:uprobeFunc*'
 EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
-TIMEOUT 5
 
 NAME uprobes - list probes with wildcarded file matching multiple files
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe*:*'
 EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
-TIMEOUT 5
 
 NAME uprobes - list probes by file with wildcarded file and filter
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test*:uprobeFunc*'
 EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
-TIMEOUT 5
 
 NAME uprobes - list probes by file with specific filter
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:uprobeFunction1'
 EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
-TIMEOUT 5
 
 NAME uprobes - list probes by file with wildcarded probe type
 RUN {{BPFTRACE}} -l '*:./testprogs/uprobe_test:*' | grep -e '^uprobe:'
 EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
-TIMEOUT 5
 
 NAME uprobes - list probes by pid
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^uprobe'
 EXPECT_REGEX uprobe:.*/testprogs/uprobe_test:uprobeFunction1
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - list probes by pid; uprobes only
 RUN {{BPFTRACE}} -l 'uprobe:*' -p {{BEFORE_PID}}
 EXPECT_REGEX uprobe:.*/testprogs/uprobe_test:uprobeFunction1
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - list probes by pid in separate mount namespace
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^uprobe'
 EXPECT_REGEX uprobe:.*/bpftrace-unshare-mountns-test/uprobe_test:uprobeFunction1
-TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
 NAME uprobes - attach to probe for executable in separate mount namespace
 RUN {{BPFTRACE}} -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:uprobeFunction1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
 # Note that we don't expect the exact uprobeFunction1 name because CI runs in a docker
@@ -59,33 +49,27 @@ BEFORE ./testprogs/mountns_wrapper uprobe_test
 NAME uprobes - attach to probe for executable in a pivot_root'd mount namespace
 RUN {{BPFTRACE}} -e 'uprobe:/proc/{{BEFORE_PID}}/root/uprobe_test:uprobeFunction1 { printf("func %s\n", func); exit(); }'
 EXPECT_REGEX ^func (0x[0-9a-f]+|function1)$
-TIMEOUT 5
 BEFORE ./testprogs/mountns_pivot_wrapper uprobe_test
 
 NAME uprobes - attach to probe by pid with only wildcard
 RUN {{BPFTRACE}} -e 'uprobe:*:uprobeFunction1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - attach to multiple probes by pid with only wildcard
 RUN {{BPFTRACE}} -e 'uprobe:*:uprobeFunc* { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT here
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - list probes in non-executable library
 RUN {{BPFTRACE}} -l 'uprobe:./testlibs/libsimple.so:fun'
 EXPECT uprobe:./testlibs/libsimple.so:fun
-TIMEOUT 5
 
 NAME uprobes - probe function in non-executable library
 PROG uprobe:./testlibs/libsimple.so:fun {}
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 
 NAME uprobes - attach to single process with pid arg
 RUN {{BPFTRACE}} runtime/scripts/uprobe_pid_check.bt -p {{BEFORE_PID}} {{BEFORE_PID}}
 EXPECT hello
-TIMEOUT 5
 BEFORE ./testprogs/uprobe_fork_loop

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -1,65 +1,55 @@
 NAME usdt probes - list probes by file
 RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test:*'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt - list probes by file with wildcarded probe type
 RUN {{BPFTRACE}} -l '*:./testprogs/usdt_test:*' | grep -e '^usdt:'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
-TIMEOUT 5
 
 NAME usdt probes - list probes by pid
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^usdt:'
 EXPECT_REGEX ^usdt:.*/testprogs/usdt_test:tracetest:testprobe$
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - list probes by pid; usdt only
 RUN {{BPFTRACE}} -l 'usdt:*' -p {{BEFORE_PID}}
 EXPECT_REGEX ^usdt:.*/testprogs/usdt_test:tracetest:testprobe$
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - lists linked library probes by pid
 RUN {{BPFTRACE}} -l 'usdt:*' -p $(pidof usdt_lib)
 EXPECT_REGEX usdt:.*/libusdt_tp.so:tracetestlib:lib_probe_1$
-TIMEOUT 5
 BEFORE ./testprogs/usdt_lib
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - filter probes by file on provider
 RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test:tracetest2:*'
 EXPECT usdt:./testprogs/usdt_test:tracetest2:testprobe2
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - filter probes by pid on provider
 RUN {{BPFTRACE}} -l 'usdt:*:tracetest2:*' -p {{BEFORE_PID}}
 EXPECT_REGEX ^usdt:.*/usdt_test:tracetest2:testprobe2$
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - filter probes by wildcard file and wildcard probe name
 RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test*:tracetest:test*'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe2
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - filter probes by file and wildcard probe name
 RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test:tracetest:test*'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe2
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - filter probes by pid and wildcard probe name
 RUN {{BPFTRACE}} -l 'usdt:*:tracetest:test*' -p {{BEFORE_PID}}
 EXPECT_REGEX ^usdt:.*/usdt_test:tracetest:testprobe$
 EXPECT_REGEX ^usdt:.*/usdt_test:tracetest:testprobe2$
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
@@ -68,45 +58,38 @@ PROG usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit();
 EXPECT here
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
-TIMEOUT 5
 
 NAME usdt probes - attach to fully specified probe of child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT here
-TIMEOUT 5
 
 NAME usdt probes - attach to fully specified probe by pid
 RUN {{BPFTRACE}} -e 'usdt::tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT here
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
-TIMEOUT 5
 
 NAME usdt probes - attach to fully specified probe all pids
 RUN {{BPFTRACE}} -e 'usdt:*:tracetest:testprobe { printf("here\n" ); exit(); }'
 EXPECT here
 BEFORE ./testprogs/usdt_test
-TIMEOUT 5
 NEW_PIDNS
 
 NAME usdt probes - attach to fully specified library probe by pid
 RUN {{BPFTRACE}} -e 'usdt:./testlibs/libusdt_tp.so:tracetestlib:lib_probe_1 { printf("here\n" ); exit(); }' -p $(pidof usdt_lib)
 BEFORE ./testprogs/usdt_lib
 EXPECT here
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - all probes by wildcard and file
 PROG usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }
 EXPECT Attaching 3 probes...
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - all probes by wildcard and file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT Attaching 3 probes...
-TIMEOUT 5
 
 # TODO(mmarchini): re-enable this test
 # This test has two problems: it relies on the latest version of bcc and it
@@ -119,7 +102,6 @@ TIMEOUT 5
 NAME usdt probes - all probes by wildcard and pid
 RUN {{BPFTRACE}} -e 'usdt:* { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 3 probes...
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES bash -c "exit 1"
 # REQUIRES ./testprogs/systemtap_sys_sdt_check
@@ -127,36 +109,30 @@ REQUIRES bash -c "exit 1"
 NAME usdt probes - attach to probe by wildcard and file
 PROG usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }
 EXPECT Attaching 2 probes...
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - attach to probe by wildcard and file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT Attaching 2 probes...
-TIMEOUT 5
 
 NAME usdt probes - attach to probes by wildcard file
 PROG usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }
 EXPECT Attaching 3 probes...
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
-TIMEOUT 5
 
 NAME usdt probes - attach to probes by wildcard file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT Attaching 3 probes...
-TIMEOUT 5
 
 NAME usdt probes - attach to probe on multiple files by wildcard
 PROG usdt:./testprogs/usdt*::* { printf("here\n" ); exit(); }
 EXPECT Attaching 48 probes...
-TIMEOUT 5
 
 NAME usdt probes - attach to probe on multiple providers by wildcard and pid
 RUN {{BPFTRACE}} -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 2 probes...
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
@@ -164,7 +140,6 @@ NAME usdt probes - attach to multiple probes with different number of locations 
 PROG usdt:./testprogs/usdt_multiple_locations:tracetest:testprobe* { printf("here\n" ); exit(); }
 BEFORE ./testprogs/usdt_multiple_locations
 EXPECT Attaching 6 probes...
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 # TODO(mmarchini): re-enable this test
@@ -174,7 +149,6 @@ REQUIRES ./testprogs/systemtap_sys_sdt_check
 NAME usdt probes - attach to probe with args by file
 PROG usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }
 EXPECT Hello world
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES bash -c "exit 1"
 # REQUIRES ./testprogs/systemtap_sys_sdt_check
@@ -186,7 +160,6 @@ REQUIRES bash -c "exit 1"
 NAME usdt probes - attach to probe with args by pid
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Hello world
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES bash -c "exit 1"
 # REQUIRES ./testprogs/systemtap_sys_sdt_check
@@ -194,40 +167,34 @@ REQUIRES bash -c "exit 1"
 NAME usdt probes - attach to probe with probe builtin and args by file
 PROG usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }
 EXPECT_REGEX ^\d+ usdt:./testprogs/usdt_test:tracetest.?:testprobe.?$
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - attach to probe with probe builtin and args by file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -c ./testprogs/usdt_test
 EXPECT_REGEX ^\d+ usdt:./testprogs/usdt_test:tracetest.?:testprobe.?$
-TIMEOUT 5
 
 NAME usdt probes - attach to probe with probe builtin and args by pid
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -p {{BEFORE_PID}}
 EXPECT_REGEX ^\d+ usdt:.*/testprogs/usdt_test:tracetest.?:testprobe.?$
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - attach to probe with semaphore
 RUN {{BPFTRACE}} -e 'usdt::tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
 EXPECT tracetest_testprobe_semaphore: 1
-TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - file based semaphore activation
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' --usdt-file-activation
 EXPECT tracetest_testprobe_semaphore: 1
-TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - file based semaphore activation no process
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
 EXPECT Failed to find processes running
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 REQUIRES_FEATURE !uprobe_refcount
 WILL_FAIL
@@ -237,7 +204,6 @@ WILL_FAIL
 NAME usdt probes - file based semaphore activation no process, kernel usdt semaphore
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
 EXPECT Attaching 1 probe...
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 REQUIRES_FEATURE uprobe_refcount
 
@@ -246,7 +212,6 @@ REQUIRES_FEATURE uprobe_refcount
 NAME usdt probes - file based semaphore activation
 PROG usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }
 EXPECT tracetest_testprobe_semaphore: 1
-TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 REQUIRES_FEATURE uprobe_refcount
@@ -254,7 +219,6 @@ REQUIRES_FEATURE uprobe_refcount
 NAME usdt probes - file based semaphore activation multi process
 RUN {{BPFTRACE}} runtime/scripts/usdt_file_activation_multiprocess.bt --usdt-file-activation
 EXPECT found 2 processes
-TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
@@ -264,7 +228,6 @@ SKIP_IF_ENV_HAS CI=true
 NAME usdt probes - list probes by pid in separate mountns
 RUN {{BPFTRACE}} -l 'usdt:*' -p {{BEFORE_PID}}
 EXPECT_REGEX ^usdt:.*/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe$
-TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper usdt_test
 
 # TODO(dalehamel): re-enable this test
@@ -273,45 +236,38 @@ BEFORE ./testprogs/mountns_wrapper usdt_test
 NAME usdt probes - attach to fully specified probe by pid in separate mountns
 RUN {{BPFTRACE}} -e 'usdt:/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT here
-TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper usdt_test
 REQUIRES bash -c "exit 1"
 
 NAME usdt quoted probe name
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_quoted_probe:test:"\"probe1\"" { printf("%d\n", arg0); exit(); }' -p {{BEFORE_PID}}
 EXPECT 1
-TIMEOUT 5
 BEFORE ./testprogs/usdt_quoted_probe
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt sized arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_sized_args:test:probe2 { printf("%ld\n", arg0); exit(); }' -p {{BEFORE_PID}}
 EXPECT 1
-TIMEOUT 5
 BEFORE ./testprogs/usdt_sized_args
 
 NAME usdt constant arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:const_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt reg arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:reg_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt addr arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:addr_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt addr+index arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:index_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
-TIMEOUT 5
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 # USDT probes can be inlined which creates duplicate identical probes. We must

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -1,58 +1,47 @@
 NAME global_int
 PROG i:ms:1 {@a = 10; printf("%d\n", @a); exit();}
 EXPECT @a: 10
-TIMEOUT 5
 
 NAME global_string
 PROG i:ms:1 {@a = "hi"; printf("%s\n", @a); exit();}
 EXPECT @a: hi
-TIMEOUT 5
 
 NAME global_buf
 PROG i:ms:1 {@a = buf("hi", 2); printf("%r\n", @a); exit();}
 EXPECT @a: hi
-TIMEOUT 5
 
 NAME local_int
 PROG i:ms:1  {$a = 10; printf("a=%d\n", $a); exit();}
 EXPECT a=10
-TIMEOUT 5
 
 NAME local_string
 PROG i:ms:1  {$a = "hi"; printf("a=%s\n", $a); exit();}
 EXPECT a=hi
-TIMEOUT 5
 
 NAME local_buf
 PROG i:ms:1 {$a = buf("hi", 2); printf("a=%r\n", $a); exit();}
 EXPECT a=hi
-TIMEOUT 5
 
 NAME buf_equality
 PROG i:ms:1 {$a = buf("hi", 2); $b = buf("bye", 3); printf("equal=%d, unequal=%d\n", $a == $a, $a != $b); exit();}
 EXPECT equal=1, unequal=1
-TIMEOUT 5
 
 NAME global_associative_arrays
 PROG BEGIN { @map[123] = 456; } END { printf("val: %d\n", @map[123]); exit(); }
 EXPECT val: 456
-TIMEOUT 5
 
 NAME scratch
 PROG BEGIN { @map[123] = 456; } END { $val = @map[123]; printf("val: %d\n", $val); exit(); }
 EXPECT val: 456
-TIMEOUT 5
 
 NAME 32-bit tracepoint arg
 PROG tracepoint:syscalls:sys_enter_openat /comm == "syscall"/ { $i = args.flags; printf("openflags: %d\n", $i); if ($i == 64) { exit() } }
 EXPECT openflags: 64
-TIMEOUT 5
 AFTER ./testprogs/syscall openat
 
 NAME tracepoint arg casts in predicates
 RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_wait4 /args.ru/ { @ru[tid] = args.ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru
 EXPECT @: 1
-TIMEOUT 5
 
 NAME variable string type resize
 PROG BEGIN { $x = "hello"; $x = "hi"; printf("%s\n", $x); exit(); }

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -4,27 +4,23 @@ RUN {{BPFTRACE}} -e "watchpoint:$(awk '{print $1}' /tmp/watchpoint_mem):8:w { pr
 EXPECT hit!
 ARCH aarch64|ppc64|ppc64le|x86_64
 CLEANUP rm -f /tmp/watchpoint_mem
-TIMEOUT 5
 
 NAME kwatchpoint - knl absolute address
 RUN {{BPFTRACE}} -e "watchpoint:0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):4:w { printf(\"hit\n\"); exit(); }"
 EXPECT hit
 ARCH aarch64|ppc64|ppc64le|x86_64
-TIMEOUT 5
 REQUIRES awk '$3 == "jiffies" {got=1} END {exit !got}' /proc/kallsyms
 
 NAME function_arg_addr
 RUN {{BPFTRACE}} -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
 EXPECT hit!
 ARCH aarch64|x86_64
-TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME async_function_arg_addr
 RUN {{BPFTRACE}} -e 'asyncwatchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
 EXPECT hit!
 ARCH aarch64|x86_64
-TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME function_arg_addr_process_flag
@@ -32,40 +28,34 @@ RUN {{BPFTRACE}} -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }'
 BEFORE ./testprogs/watchpoint_func
 EXPECT hit!
 ARCH aarch64|x86_64
-TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME many_function_probes
 RUN {{BPFTRACE}} -e 'watchpoint:increment+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_many_probes
 EXPECT Failed to attach watchpoint probe. You are out of watchpoint registers.
 ARCH aarch64|x86_64
-TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME unwatch
 RUN {{BPFTRACE}} runtime/scripts/watchpoint_unwatch.bt -c ./testprogs/watchpoint_unwatch
 EXPECT count=1
 ARCH aarch64|x86_64
-TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME function_multiattach
 RUN {{BPFTRACE}} runtime/scripts/watchpoint_multiattach.bt -c ./testprogs/watchpoint_func_wildcard
 EXPECT count=3
 ARCH aarch64|x86_64
-TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME wildcarded_function
 RUN {{BPFTRACE}} -e 'watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT Failed to attach watchpoint probe. You are out of watchpoint registers.
 ARCH aarch64|x86_64
-TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME unique_probe_bodies
 RUN {{BPFTRACE}} -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT_REGEX .*increment_0:4:w!
 ARCH aarch64|x86_64
-TIMEOUT 5
 REQUIRES_FEATURE signal


### PR DESCRIPTION
It looks like there was the idea to do this years ago, but it wasn't implemented throughout the test framework so the parser still rejected tests without a TIMEOUT clause.

This is just to make it a little easier to write runtime tests. The vast majority shouldn't need to specify a timeout.