### PR TITLE
WIP: Support cgroup_path as a mapkey in output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
   - [#3249](https://github.com/bpftrace/bpftrace/pull/3249)
 - Faster map access for keyless maps by using BPF_MAP_TYPE_ARRAY
   - [#3300](https://github.com/bpftrace/bpftrace/pull/3300)
+- Support `cgroup_path` as a mapkey in output
+  - [#3438](https://github.com/bpftrace/bpftrace/pull/3438)
 #### Deprecated
 #### Removed
 - Remove the `-dd` CLI option

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -148,6 +148,11 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       auto p = static_cast<const uint8_t *>(data);
       return bpftrace.resolve_mac_address(p);
     }
+    case Type::cgroup_path: {
+      return bpftrace.resolve_cgroup_path(
+          read_data<uint64_t>(data),
+          read_data<uint64_t>(static_cast<const uint8_t *>(data) + 8));
+    }
     default:
       LOG(BUG) << "invalid mapkey argument type";
   }

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -498,6 +498,12 @@ EXPECT_REGEX path: ([a-z]*:\/.*;)*[a-z]*:\/.*
 REQUIRES grep -q '^cgroup2' /proc/mounts
 MIN_KERNEL 4.18
 
+NAME cgroup_path map_key
+PROG BEGIN { @[cgroup_path(cgroup & ((1 << 32) - 1))] = 1; exit(); }
+EXPECT_REGEX @\[.*\]\: 1
+REQUIRES grep -q '^cgroup2' /proc/mounts
+MIN_KERNEL 4.18
+
 NAME strerror
 RUN {{BPFTRACE}} --include "errno.h" -e 'BEGIN { print(strerror(EPERM)); exit(); }'
 EXPECT Operation not permitted


### PR DESCRIPTION
To resolve https://github.com/bpftrace/bpftrace/issues/3421

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
