### PR TITLE
Consistently store pid, tid and probe id as int32_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to
 
 ## Unreleased
 
+#### Breaking Changes
+- Return `uint32` instead of `uint64` for `pid` and `tid` builtins
+  - [#3441](https://github.com/bpftrace/bpftrace/pull/3441)
 #### Added
 - Add `--dry-run` CLI option
   - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1104,7 +1104,7 @@ For string arguments use the `str()` call to retrieve the value.
 | ID of the NUMA node executing the BPF program
 
 | pid
-| uint64
+| uint32
 | 4.2
 | get_current_pid_tgid
 | Process ID of the current thread (aka thread group ID), as seen from the init namespace
@@ -1134,7 +1134,7 @@ For string arguments use the `str()` call to retrieve the value.
 | Value returned by the function being traced (kretprobe, uretprobe, kretfunc)
 
 | tid
-| uint64
+| uint32
 | 4.2
 | get_current_pid_tgid
 | Thread ID of the current thread, as seen from the init namespace

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -73,6 +73,20 @@ libbpf::bpf_func_id IRBuilderBPF::selectProbeReadHelper(AddrSpace as, bool str)
   return fn;
 }
 
+Value *IRBuilderBPF::CreateGetPid(const location &loc)
+{
+  Value *pidtgid = CreateGetPidTgid(loc);
+  Value *pid = CreateLShr(pidtgid, 32, "pid");
+  return pid;
+}
+
+Value *IRBuilderBPF::CreateGetTid(const location &loc)
+{
+  Value *pidtgid = CreateGetPidTgid(loc);
+  Value *tid = CreateAnd(pidtgid, 0xffffffff, "tid");
+  return tid;
+}
+
 AllocaInst *IRBuilderBPF::CreateUSym(llvm::Value *val,
                                      int probe_id,
                                      const location &loc)
@@ -85,7 +99,7 @@ AllocaInst *IRBuilderBPF::CreateUSym(llvm::Value *val,
   StructType *usym_t = GetStructType("usym_t", elements, false);
   AllocaInst *buf = CreateAllocaBPF(usym_t, "usym");
 
-  Value *pid = CreateLShr(CreateGetPidTgid(loc), 32);
+  Value *pid = CreateGetPid(loc);
   Value *probe_id_val = Constant::getIntegerValue(getInt64Ty(),
                                                   APInt(64, probe_id));
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -76,14 +76,14 @@ libbpf::bpf_func_id IRBuilderBPF::selectProbeReadHelper(AddrSpace as, bool str)
 Value *IRBuilderBPF::CreateGetPid(const location &loc)
 {
   Value *pidtgid = CreateGetPidTgid(loc);
-  Value *pid = CreateLShr(pidtgid, 32, "pid");
+  Value *pid = CreateTrunc(CreateLShr(pidtgid, 32), getInt32Ty(), "pid");
   return pid;
 }
 
 Value *IRBuilderBPF::CreateGetTid(const location &loc)
 {
   Value *pidtgid = CreateGetPidTgid(loc);
-  Value *tid = CreateAnd(pidtgid, 0xffffffff, "tid");
+  Value *tid = CreateTrunc(pidtgid, getInt32Ty(), "tid");
   return tid;
 }
 
@@ -93,15 +93,15 @@ AllocaInst *IRBuilderBPF::CreateUSym(llvm::Value *val,
 {
   std::vector<llvm::Type *> elements = {
     getInt64Ty(), // addr
-    getInt64Ty(), // pid
-    getInt64Ty(), // probe id
+    getInt32Ty(), // pid
+    getInt32Ty(), // probe id
   };
   StructType *usym_t = GetStructType("usym_t", elements, false);
   AllocaInst *buf = CreateAllocaBPF(usym_t, "usym");
 
   Value *pid = CreateGetPid(loc);
-  Value *probe_id_val = Constant::getIntegerValue(getInt64Ty(),
-                                                  APInt(64, probe_id));
+  Value *probe_id_val = Constant::getIntegerValue(getInt32Ty(),
+                                                  APInt(32, probe_id));
 
   // The extra 0 here ensures the type of addr_offset will be int64
   Value *addr_offset = CreateGEP(usym_t, buf, { getInt64(0), getInt32(0) });

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -221,6 +221,8 @@ public:
   StructType *GetStructType(std::string name,
                             const std::vector<llvm::Type *> &elements,
                             bool packed = false);
+  Value *CreateGetPid(const location &loc);
+  Value *CreateGetTid(const location &loc);
   AllocaInst *CreateUSym(llvm::Value *val, int probe_id, const location &loc);
   Value *CreateRegisterRead(Value *ctx, const std::string &builtin);
   Value *CreateRegisterRead(Value *ctx, int offset, const std::string &name);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -327,8 +327,9 @@ void SemanticAnalyser::visit(Builtin &builtin)
         LOG(ERROR, builtin.loc, err_) << "invalid program type";
         break;
     }
+  } else if (builtin.ident == "pid" || builtin.ident == "tid") {
+    builtin.type = CreateUInt32();
   } else if (builtin.ident == "nsecs" || builtin.ident == "elapsed" ||
-             builtin.ident == "pid" || builtin.ident == "tid" ||
              builtin.ident == "cgroup" || builtin.ident == "uid" ||
              builtin.ident == "gid" || builtin.ident == "cpu" ||
              builtin.ident == "rand" || builtin.ident == "numaid" ||

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -570,8 +570,8 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
       case Type::usym_t:
         arg_values.push_back(std::make_unique<PrintableString>(resolve_usym(
             *reinterpret_cast<uint64_t *>(arg_data + arg.offset),
-            *reinterpret_cast<uint64_t *>(arg_data + arg.offset + 8),
-            *reinterpret_cast<uint64_t *>(arg_data + arg.offset + 16))));
+            *reinterpret_cast<int32_t *>(arg_data + arg.offset + 8),
+            *reinterpret_cast<int32_t *>(arg_data + arg.offset + 12))));
         break;
       case Type::inet:
         arg_values.push_back(std::make_unique<PrintableString>(resolve_inet(
@@ -1545,8 +1545,8 @@ std::optional<std::vector<uint8_t>> BPFtrace::find_empty_key(
 
 std::string BPFtrace::get_stack(int64_t stackid,
                                 uint32_t nr_stack_frames,
-                                int pid,
-                                int probe_id,
+                                int32_t pid,
+                                int32_t probe_id,
                                 bool ustack,
                                 StackType stack_type,
                                 int indent)
@@ -1826,8 +1826,8 @@ std::string BPFtrace::resolve_inet(int af, const uint8_t *inet) const
 }
 
 std::string BPFtrace::resolve_usym(uint64_t addr,
-                                   int pid,
-                                   int probe_id,
+                                   int32_t pid,
+                                   int32_t probe_id,
                                    bool show_offset,
                                    bool show_module)
 {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -106,16 +106,16 @@ public:
   int print_map(const BpfMap &map, uint32_t top, uint32_t div);
   std::string get_stack(int64_t stackid,
                         uint32_t nr_stack_frames,
-                        int pid,
-                        int probe_id,
+                        int32_t pid,
+                        int32_t probe_id,
                         bool ustack,
                         StackType stack_type,
                         int indent = 0);
   std::string resolve_buf(const char *buf, size_t size);
   std::string resolve_ksym(uint64_t addr, bool show_offset = false);
   std::string resolve_usym(uint64_t addr,
-                           int pid,
-                           int probe_id,
+                           int32_t pid,
+                           int32_t probe_id,
                            bool show_offset = false,
                            bool show_module = false);
   std::string resolve_inet(int af, const uint8_t *inet) const;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -262,12 +262,12 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
                                 8);
     }
     case Type::ksym_t: {
-      return bpftrace.resolve_ksym(read_data<uintptr_t>(value.data()));
+      return bpftrace.resolve_ksym(read_data<uint64_t>(value.data()));
     }
     case Type::usym_t: {
-      return bpftrace.resolve_usym(read_data<uintptr_t>(value.data()),
-                                   read_data<uintptr_t>(value.data() + 8),
-                                   read_data<uint64_t>(value.data() + 16));
+      return bpftrace.resolve_usym(read_data<uint64_t>(value.data()),
+                                   read_data<uint32_t>(value.data() + 8),
+                                   read_data<uint32_t>(value.data() + 12));
     }
     case Type::inet: {
       return bpftrace.resolve_inet(read_data<uint64_t>(value.data()),

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -493,7 +493,7 @@ SizedType CreateHist()
 
 SizedType CreateUSym()
 {
-  return SizedType(Type::usym_t, 24);
+  return SizedType(Type::usym_t, 16);
 }
 
 SizedType CreateKSym()

--- a/tests/codegen/cast_int_to_arr.cpp.cpp
+++ b/tests/codegen/cast_int_to_arr.cpp.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, cast_int_to_arr)
 {
-  test("kprobe:f { $a=(uint8[8])pid; @ = $a[0]; }", NAME);
+  test("kprobe:f { $a=(uint8[8])0; @ = $a[0]; }", NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/llvm/builtin_func_uprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uprobe.ll
@@ -24,13 +24,13 @@ entry:
   %func = load volatile i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %2 = lshr i64 %get_pid_tgid, 32
-  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %5 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 %func, ptr %3, align 8
-  store i64 %2, ptr %4, align 8
-  store i64 0, ptr %5, align 8
+  %pid = lshr i64 %get_pid_tgid, 32
+  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 %func, ptr %2, align 8
+  store i64 %pid, ptr %3, align 8
+  store i64 0, ptr %4, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %usym, i64 0)

--- a/tests/codegen/llvm/builtin_func_uprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uprobe.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%usym_t = type { i64, i64, i64 }
+%usym_t = type { i64, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -24,13 +24,14 @@ entry:
   %func = load volatile i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 %func, ptr %2, align 8
-  store i64 %pid, ptr %3, align 8
-  store i64 0, ptr %4, align 8
+  %2 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %2 to i32
+  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %5 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 %func, ptr %3, align 8
+  store i32 %pid, ptr %4, align 4
+  store i32 0, ptr %5, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %usym, i64 0)
@@ -72,10 +73,10 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 192, elements: !23)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 128, elements: !23)
 !22 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !23 = !{!24}
-!24 = !DISubrange(count: 24, lowerBound: 0)
+!24 = !DISubrange(count: 16, lowerBound: 0)
 !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
 !26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
 !27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)

--- a/tests/codegen/llvm/builtin_func_uretprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uretprobe.ll
@@ -23,13 +23,13 @@ entry:
   %get_func_ip = call i64 inttoptr (i64 173 to ptr)(ptr %0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 %get_func_ip, ptr %2, align 8
-  store i64 %1, ptr %3, align 8
-  store i64 0, ptr %4, align 8
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 %get_func_ip, ptr %1, align 8
+  store i64 %pid, ptr %2, align 8
+  store i64 0, ptr %3, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %usym, i64 0)

--- a/tests/codegen/llvm/builtin_func_uretprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uretprobe.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%usym_t = type { i64, i64, i64 }
+%usym_t = type { i64, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -23,13 +23,14 @@ entry:
   %get_func_ip = call i64 inttoptr (i64 173 to ptr)(ptr %0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 %get_func_ip, ptr %1, align 8
-  store i64 %pid, ptr %2, align 8
-  store i64 0, ptr %3, align 8
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 %get_func_ip, ptr %2, align 8
+  store i32 %pid, ptr %3, align 4
+  store i32 0, ptr %4, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %usym, i64 0)
@@ -71,10 +72,10 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 192, elements: !23)
+!21 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 128, elements: !23)
 !22 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !23 = !{!24}
-!24 = !DISubrange(count: 24, lowerBound: 0)
+!24 = !DISubrange(count: 16, lowerBound: 0)
 !25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
 !26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
 !27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)

--- a/tests/codegen/llvm/builtin_pid_tid.ll
+++ b/tests/codegen/llvm/builtin_pid_tid.ll
@@ -24,20 +24,20 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = lshr i64 %get_pid_tgid, 32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %1, ptr %"@x_val", align 8
+  store i64 %pid, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %2 = and i64 %get_pid_tgid1, 4294967295
+  %tid = and i64 %get_pid_tgid1, 4294967295
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  store i64 %2, ptr %"@y_val", align 8
+  store i64 %tid, ptr %"@y_val", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")

--- a/tests/codegen/llvm/builtin_pid_tid.ll
+++ b/tests/codegen/llvm/builtin_pid_tid.ll
@@ -24,20 +24,23 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
+  %2 = zext i32 %pid to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %pid, ptr %"@x_val", align 8
+  store i64 %2, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %tid = and i64 %get_pid_tgid1, 4294967295
+  %tid = trunc i64 %get_pid_tgid1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
+  %3 = zext i32 %tid to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  store i64 %tid, ptr %"@y_val", align 8
+  store i64 %3, ptr %"@y_val", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -54,10 +54,11 @@ merge_block:                                      ; preds = %stack_scratch_failu
   store i32 %8, ptr %7, align 4
   %9 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  store i64 %pid, ptr %9, align 8
-  %10 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
-  store i32 0, ptr %10, align 4
+  %10 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %10 to i32
+  store i32 %pid, ptr %9, align 4
+  %11 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
+  store i32 0, ptr %11, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
@@ -71,17 +72,17 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
   %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %11 = icmp sge i32 %get_stack, 0
-  br i1 %11, label %get_stack_success, label %get_stack_fail
+  %12 = icmp sge i32 %get_stack, 0
+  br i1 %12, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %12 = udiv i32 %get_stack, 8
-  %13 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
-  store i32 %12, ptr %13, align 4
-  %14 = trunc i32 %12 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %14, i64 1)
-  %15 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %15, align 8
+  %13 = udiv i32 %get_stack, 8
+  %14 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %13, ptr %14, align 4
+  %15 = trunc i32 %13 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %15, i64 1)
+  %16 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %16, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -54,10 +54,10 @@ merge_block:                                      ; preds = %stack_scratch_failu
   store i32 %8, ptr %7, align 4
   %9 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %10 = trunc i64 %get_pid_tgid to i32
-  store i32 %10, ptr %9, align 4
-  %11 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
-  store i32 0, ptr %11, align 4
+  %pid = lshr i64 %get_pid_tgid, 32
+  store i64 %pid, ptr %9, align 8
+  %10 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
+  store i32 0, ptr %10, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
@@ -71,17 +71,17 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
   %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %12 = icmp sge i32 %get_stack, 0
-  br i1 %12, label %get_stack_success, label %get_stack_fail
+  %11 = icmp sge i32 %get_stack, 0
+  br i1 %11, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %13 = udiv i32 %get_stack, 8
-  %14 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
-  store i32 %13, ptr %14, align 4
-  %15 = trunc i32 %13 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %15, i64 1)
-  %16 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %16, align 8
+  %12 = udiv i32 %get_stack, 8
+  %13 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %12, ptr %13, align 4
+  %14 = trunc i32 %12 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %14, i64 1)
+  %15 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %15, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 

--- a/tests/codegen/llvm/call_avg.ll
+++ b/tests/codegen/llvm/call_avg.ll
@@ -25,29 +25,29 @@ entry:
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = lshr i64 %get_pid_tgid, 32
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %2 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
-  %3 = load i64, ptr %2, align 8
-  %4 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
-  %5 = load i64, ptr %4, align 8
-  %6 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
-  %7 = add i64 %3, %1
-  store i64 %7, ptr %6, align 8
-  %8 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
-  %9 = add i64 1, %5
-  store i64 %9, ptr %8, align 8
+  %1 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %2 = load i64, ptr %1, align 8
+  %3 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %4 = load i64, ptr %3, align 8
+  %5 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %6 = add i64 %2, %pid
+  store i64 %6, ptr %5, align 8
+  %7 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %8 = add i64 1, %4
+  store i64 %8, ptr %7, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
-  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
-  store i64 %1, ptr %10, align 8
-  %11 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
-  store i64 1, ptr %11, align 8
+  %9 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
+  store i64 %pid, ptr %9, align 8
+  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %10, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
   br label %lookup_merge

--- a/tests/codegen/llvm/call_avg.ll
+++ b/tests/codegen/llvm/call_avg.ll
@@ -25,29 +25,31 @@ entry:
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
-  %2 = load i64, ptr %1, align 8
-  %3 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %3 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
   %4 = load i64, ptr %3, align 8
-  %5 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
-  %6 = add i64 %2, %pid
-  store i64 %6, ptr %5, align 8
-  %7 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
-  %8 = add i64 1, %4
+  %5 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %6 = load i64, ptr %5, align 8
+  %7 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %8 = add i64 %4, %2
   store i64 %8, ptr %7, align 8
+  %9 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %10 = add i64 1, %6
+  store i64 %10, ptr %9, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
-  %9 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
-  store i64 %pid, ptr %9, align 8
-  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
-  store i64 1, ptr %10, align 8
+  %11 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
+  store i64 %2, ptr %11, align 8
+  %12 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %12, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
   br label %lookup_merge

--- a/tests/codegen/llvm/call_hist.ll
+++ b/tests/codegen/llvm/call_hist.ll
@@ -21,8 +21,10 @@ entry:
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %log2 = call i64 @log2(i64 %pid, i64 0)
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %log2 = call i64 @log2(i64 %2, i64 0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 %log2, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
@@ -31,9 +33,9 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  %2 = add i64 %1, 1
-  store i64 %2, ptr %lookup_elem, align 8
+  %3 = load i64, ptr %lookup_elem, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/call_hist.ll
+++ b/tests/codegen/llvm/call_hist.ll
@@ -21,8 +21,8 @@ entry:
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %log2 = call i64 @log2(i64 %1, i64 0)
+  %pid = lshr i64 %get_pid_tgid, 32
+  %log2 = call i64 @log2(i64 %pid, i64 0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 %log2, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
@@ -31,9 +31,9 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, ptr %lookup_elem, align 8
-  %3 = add i64 %2, 1
-  store i64 %3, ptr %lookup_elem, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  %2 = add i64 %1, 1
+  store i64 %2, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/call_lhist.ll
+++ b/tests/codegen/llvm/call_lhist.ll
@@ -21,10 +21,10 @@ entry:
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = lshr i64 %get_pid_tgid, 32
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %2 = lshr i64 %get_pid_tgid1, 32
-  %linear = call i64 @linear(i64 %2, i64 0, i64 100, i64 1)
+  %pid2 = lshr i64 %get_pid_tgid1, 32
+  %linear = call i64 @linear(i64 %pid2, i64 0, i64 100, i64 1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 %linear, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
@@ -33,9 +33,9 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %3 = load i64, ptr %lookup_elem, align 8
-  %4 = add i64 %3, 1
-  store i64 %4, ptr %lookup_elem, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  %2 = add i64 %1, 1
+  store i64 %2, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/call_lhist.ll
+++ b/tests/codegen/llvm/call_lhist.ll
@@ -21,10 +21,13 @@ entry:
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %pid2 = lshr i64 %get_pid_tgid1, 32
-  %linear = call i64 @linear(i64 %pid2, i64 0, i64 100, i64 1)
+  %2 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %2 to i32
+  %3 = zext i32 %pid2 to i64
+  %linear = call i64 @linear(i64 %3, i64 0, i64 100, i64 1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 %linear, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
@@ -33,9 +36,9 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  %2 = add i64 %1, 1
-  store i64 %2, ptr %lookup_elem, align 8
+  %4 = load i64, ptr %lookup_elem, align 8
+  %5 = add i64 %4, 1
+  store i64 %5, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -25,24 +25,24 @@ entry:
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = lshr i64 %get_pid_tgid, 32
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %2 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  %3 = load i64, ptr %2, align 8
-  %4 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  %5 = load i64, ptr %4, align 8
-  %is_set_cond = icmp eq i64 %5, 1
+  %1 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  %2 = load i64, ptr %1, align 8
+  %3 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  %4 = load i64, ptr %3, align 8
+  %is_set_cond = icmp eq i64 %4, 1
   br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %mm_struct)
-  %6 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
-  store i64 %1, ptr %6, align 8
-  %7 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
-  store i64 1, ptr %7, align 8
+  %5 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
+  store i64 %pid, ptr %5, align 8
+  %6 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
+  store i64 1, ptr %6, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %mm_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %mm_struct)
   br label %lookup_merge
@@ -52,14 +52,14 @@ lookup_merge:                                     ; preds = %lookup_failure, %mi
   ret i64 0
 
 is_set:                                           ; preds = %lookup_success
-  %8 = icmp uge i64 %1, %3
-  br i1 %8, label %min_max, label %lookup_merge
+  %7 = icmp uge i64 %pid, %2
+  br i1 %7, label %min_max, label %lookup_merge
 
 min_max:                                          ; preds = %is_set, %lookup_success
-  %9 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  store i64 %1, ptr %9, align 8
-  %10 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  store i64 1, ptr %10, align 8
+  %8 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  store i64 %pid, ptr %8, align 8
+  %9 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  store i64 1, ptr %9, align 8
   br label %lookup_merge
 }
 

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -25,24 +25,26 @@ entry:
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  %2 = load i64, ptr %1, align 8
-  %3 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  %3 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
   %4 = load i64, ptr %3, align 8
-  %is_set_cond = icmp eq i64 %4, 1
+  %5 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  %6 = load i64, ptr %5, align 8
+  %is_set_cond = icmp eq i64 %6, 1
   br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %mm_struct)
-  %5 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
-  store i64 %pid, ptr %5, align 8
-  %6 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
-  store i64 1, ptr %6, align 8
+  %7 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
+  store i64 %2, ptr %7, align 8
+  %8 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
+  store i64 1, ptr %8, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %mm_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %mm_struct)
   br label %lookup_merge
@@ -52,14 +54,14 @@ lookup_merge:                                     ; preds = %lookup_failure, %mi
   ret i64 0
 
 is_set:                                           ; preds = %lookup_success
-  %7 = icmp uge i64 %pid, %2
-  br i1 %7, label %min_max, label %lookup_merge
+  %9 = icmp uge i64 %2, %4
+  br i1 %9, label %min_max, label %lookup_merge
 
 min_max:                                          ; preds = %is_set, %lookup_success
-  %8 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  store i64 %pid, ptr %8, align 8
-  %9 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  store i64 1, ptr %9, align 8
+  %10 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  store i64 %2, ptr %10, align 8
+  %11 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  store i64 1, ptr %11, align 8
   br label %lookup_merge
 }
 

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -25,24 +25,24 @@ entry:
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = lshr i64 %get_pid_tgid, 32
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %2 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  %3 = load i64, ptr %2, align 8
-  %4 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  %5 = load i64, ptr %4, align 8
-  %is_set_cond = icmp eq i64 %5, 1
+  %1 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  %2 = load i64, ptr %1, align 8
+  %3 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  %4 = load i64, ptr %3, align 8
+  %is_set_cond = icmp eq i64 %4, 1
   br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %mm_struct)
-  %6 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
-  store i64 %1, ptr %6, align 8
-  %7 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
-  store i64 1, ptr %7, align 8
+  %5 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
+  store i64 %pid, ptr %5, align 8
+  %6 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
+  store i64 1, ptr %6, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %mm_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %mm_struct)
   br label %lookup_merge
@@ -52,14 +52,14 @@ lookup_merge:                                     ; preds = %lookup_failure, %mi
   ret i64 0
 
 is_set:                                           ; preds = %lookup_success
-  %8 = icmp uge i64 %3, %1
-  br i1 %8, label %min_max, label %lookup_merge
+  %7 = icmp uge i64 %2, %pid
+  br i1 %7, label %min_max, label %lookup_merge
 
 min_max:                                          ; preds = %is_set, %lookup_success
-  %9 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  store i64 %1, ptr %9, align 8
-  %10 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  store i64 1, ptr %10, align 8
+  %8 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  store i64 %pid, ptr %8, align 8
+  %9 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  store i64 1, ptr %9, align 8
   br label %lookup_merge
 }
 

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -25,24 +25,26 @@ entry:
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  %2 = load i64, ptr %1, align 8
-  %3 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  %3 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
   %4 = load i64, ptr %3, align 8
-  %is_set_cond = icmp eq i64 %4, 1
+  %5 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  %6 = load i64, ptr %5, align 8
+  %is_set_cond = icmp eq i64 %6, 1
   br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %mm_struct)
-  %5 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
-  store i64 %pid, ptr %5, align 8
-  %6 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
-  store i64 1, ptr %6, align 8
+  %7 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
+  store i64 %2, ptr %7, align 8
+  %8 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
+  store i64 1, ptr %8, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %mm_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %mm_struct)
   br label %lookup_merge
@@ -52,14 +54,14 @@ lookup_merge:                                     ; preds = %lookup_failure, %mi
   ret i64 0
 
 is_set:                                           ; preds = %lookup_success
-  %7 = icmp uge i64 %2, %pid
-  br i1 %7, label %min_max, label %lookup_merge
+  %9 = icmp uge i64 %4, %2
+  br i1 %9, label %min_max, label %lookup_merge
 
 min_max:                                          ; preds = %is_set, %lookup_success
-  %8 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  store i64 %pid, ptr %8, align 8
-  %9 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  store i64 1, ptr %9, align 8
+  %10 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  store i64 %2, ptr %10, align 8
+  %11 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  store i64 1, ptr %11, align 8
   br label %lookup_merge
 }
 

--- a/tests/codegen/llvm/call_stats.ll
+++ b/tests/codegen/llvm/call_stats.ll
@@ -24,29 +24,31 @@ entry:
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
-  %2 = load i64, ptr %1, align 8
-  %3 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %3 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
   %4 = load i64, ptr %3, align 8
-  %5 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
-  %6 = add i64 %2, %pid
-  store i64 %6, ptr %5, align 8
-  %7 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
-  %8 = add i64 1, %4
+  %5 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %6 = load i64, ptr %5, align 8
+  %7 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %8 = add i64 %4, %2
   store i64 %8, ptr %7, align 8
+  %9 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %10 = add i64 1, %6
+  store i64 %10, ptr %9, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
-  %9 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
-  store i64 %pid, ptr %9, align 8
-  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
-  store i64 1, ptr %10, align 8
+  %11 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
+  store i64 %2, ptr %11, align 8
+  %12 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %12, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
   br label %lookup_merge

--- a/tests/codegen/llvm/call_stats.ll
+++ b/tests/codegen/llvm/call_stats.ll
@@ -24,29 +24,29 @@ entry:
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = lshr i64 %get_pid_tgid, 32
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %2 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
-  %3 = load i64, ptr %2, align 8
-  %4 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
-  %5 = load i64, ptr %4, align 8
-  %6 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
-  %7 = add i64 %3, %1
-  store i64 %7, ptr %6, align 8
-  %8 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
-  %9 = add i64 1, %5
-  store i64 %9, ptr %8, align 8
+  %1 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %2 = load i64, ptr %1, align 8
+  %3 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %4 = load i64, ptr %3, align 8
+  %5 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %6 = add i64 %2, %pid
+  store i64 %6, ptr %5, align 8
+  %7 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %8 = add i64 1, %4
+  store i64 %8, ptr %7, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
-  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
-  store i64 %1, ptr %10, align 8
-  %11 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
-  store i64 1, ptr %11, align 8
+  %9 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
+  store i64 %pid, ptr %9, align 8
+  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %10, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
   br label %lookup_merge

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -24,21 +24,23 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  %2 = add i64 %1, %pid
-  store i64 %2, ptr %lookup_elem, align 8
+  %3 = load i64, ptr %lookup_elem, align 8
+  %4 = add i64 %3, %2
+  store i64 %4, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
-  store i64 %pid, ptr %initial_value, align 8
+  store i64 %2, ptr %initial_value, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -24,21 +24,21 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = lshr i64 %get_pid_tgid, 32
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, ptr %lookup_elem, align 8
-  %3 = add i64 %2, %1
-  store i64 %3, ptr %lookup_elem, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  %2 = add i64 %1, %pid
+  store i64 %2, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
-  store i64 %1, ptr %initial_value, align 8
+  store i64 %pid, ptr %initial_value, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -70,20 +70,21 @@ merge_block:                                      ; preds = %stack_scratch_failu
   store i32 %8, ptr %7, align 4
   %9 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  store i64 %pid, ptr %9, align 8
-  %10 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
-  store i32 0, ptr %10, align 4
+  %10 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %10 to i32
+  store i32 %pid, ptr %9, align 4
+  %11 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
+  store i32 0, ptr %11, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %stack_args, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key2)
-  %11 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 0, ptr %11, align 8
-  %12 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 0, ptr %12, align 4
+  %12 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 0, ptr %12, align 8
+  %13 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 0, ptr %13, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key5)
   store i32 0, ptr %lookup_stack_scratch_key5, align 4
   %lookup_stack_scratch_map6 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key5)
@@ -97,17 +98,17 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
   %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %13 = icmp sge i32 %get_stack, 0
-  br i1 %13, label %get_stack_success, label %get_stack_fail
+  %14 = icmp sge i32 %get_stack, 0
+  br i1 %14, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %14 = udiv i32 %get_stack, 8
-  %15 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
-  store i32 %14, ptr %15, align 4
-  %16 = trunc i32 %14 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %16, i64 1)
-  %17 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %17, align 8
+  %15 = udiv i32 %get_stack, 8
+  %16 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %15, ptr %16, align 4
+  %17 = trunc i32 %15 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %17, i64 1)
+  %18 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %18, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -119,30 +120,31 @@ stack_scratch_failure3:                           ; preds = %lookup_stack_scratc
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args15)
-  %18 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  %19 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 0
-  %20 = load i64, ptr %18, align 8
-  store i64 %20, ptr %19, align 8
-  %21 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  %22 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 1
-  %23 = load i32, ptr %21, align 4
-  store i32 %23, ptr %22, align 4
-  %24 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 2
+  %19 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
+  %20 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 0
+  %21 = load i64, ptr %19, align 8
+  store i64 %21, ptr %20, align 8
+  %22 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  %23 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 1
+  %24 = load i32, ptr %22, align 4
+  store i32 %24, ptr %23, align 4
+  %25 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 2
   %get_pid_tgid16 = call i64 inttoptr (i64 14 to ptr)()
-  %pid17 = lshr i64 %get_pid_tgid16, 32
-  store i64 %pid17, ptr %24, align 8
-  %25 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 3
-  store i32 0, ptr %25, align 4
+  %26 = lshr i64 %get_pid_tgid16, 32
+  %pid17 = trunc i64 %26 to i32
+  store i32 %pid17, ptr %25, align 4
+  %27 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 3
+  store i32 0, ptr %27, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   %update_elem18 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %stack_args15, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key19)
-  %26 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
-  store i64 0, ptr %26, align 8
-  %27 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
-  store i32 0, ptr %27, align 4
+  %28 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
+  store i64 0, ptr %28, align 8
+  %29 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
+  store i32 0, ptr %29, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key22)
   store i32 0, ptr %lookup_stack_scratch_key22, align 4
   %lookup_stack_scratch_map23 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key22)
@@ -156,17 +158,17 @@ lookup_stack_scratch_failure7:                    ; preds = %merge_block
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
   call void @llvm.memset.p0.i64(ptr align 1 %lookup_stack_scratch_map6, i8 0, i64 48, i1 false)
   %get_stack12 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 48, i64 256)
-  %28 = icmp sge i32 %get_stack12, 0
-  br i1 %28, label %get_stack_success10, label %get_stack_fail11
+  %30 = icmp sge i32 %get_stack12, 0
+  br i1 %30, label %get_stack_success10, label %get_stack_fail11
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
-  %29 = udiv i32 %get_stack12, 8
-  %30 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 %29, ptr %30, align 4
-  %31 = trunc i32 %29 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %31, i64 1)
-  %32 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_213, ptr %32, align 8
+  %31 = udiv i32 %get_stack12, 8
+  %32 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 %31, ptr %32, align 4
+  %33 = trunc i32 %31 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %33, i64 1)
+  %34 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, ptr %34, align 8
   %update_elem14 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_6, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
@@ -178,20 +180,21 @@ stack_scratch_failure20:                          ; preds = %lookup_stack_scratc
 
 merge_block21:                                    ; preds = %stack_scratch_failure20, %get_stack_success28, %get_stack_fail29
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args33)
-  %33 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
-  %34 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 0
-  %35 = load i64, ptr %33, align 8
-  store i64 %35, ptr %34, align 8
-  %36 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
-  %37 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 1
-  %38 = load i32, ptr %36, align 4
-  store i32 %38, ptr %37, align 4
-  %39 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 2
+  %35 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
+  %36 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 0
+  %37 = load i64, ptr %35, align 8
+  store i64 %37, ptr %36, align 8
+  %38 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
+  %39 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 1
+  %40 = load i32, ptr %38, align 4
+  store i32 %40, ptr %39, align 4
+  %41 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 2
   %get_pid_tgid34 = call i64 inttoptr (i64 14 to ptr)()
-  %pid35 = lshr i64 %get_pid_tgid34, 32
-  store i64 %pid35, ptr %39, align 8
-  %40 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 3
-  store i32 0, ptr %40, align 4
+  %42 = lshr i64 %get_pid_tgid34, 32
+  %pid35 = trunc i64 %42 to i32
+  store i32 %pid35, ptr %41, align 4
+  %43 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 3
+  store i32 0, ptr %43, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key19)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@z_key")
   store i64 0, ptr %"@z_key", align 8
@@ -205,17 +208,17 @@ lookup_stack_scratch_failure24:                   ; preds = %merge_block4
 lookup_stack_scratch_merge25:                     ; preds = %merge_block4
   %probe_read_kernel27 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map23, i32 1016, ptr null)
   %get_stack30 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map23, i32 1016, i64 256)
-  %41 = icmp sge i32 %get_stack30, 0
-  br i1 %41, label %get_stack_success28, label %get_stack_fail29
+  %44 = icmp sge i32 %get_stack30, 0
+  br i1 %44, label %get_stack_success28, label %get_stack_fail29
 
 get_stack_success28:                              ; preds = %lookup_stack_scratch_merge25
-  %42 = udiv i32 %get_stack30, 8
-  %43 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
-  store i32 %42, ptr %43, align 4
-  %44 = trunc i32 %42 to i8
-  %murmur_hash_231 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map23, i8 %44, i64 1)
-  %45 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
-  store i64 %murmur_hash_231, ptr %45, align 8
+  %45 = udiv i32 %get_stack30, 8
+  %46 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
+  store i32 %45, ptr %46, align 4
+  %47 = trunc i32 %45 to i8
+  %murmur_hash_231 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map23, i8 %47, i64 1)
+  %48 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
+  store i64 %murmur_hash_231, ptr %48, align 8
   %update_elem32 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_perf_127, ptr %stack_key19, ptr %lookup_stack_scratch_map23, i64 0)
   br label %merge_block21
 

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -32,9 +32,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !95 {
 entry:
   %"@z_key" = alloca i64, align 8
-  %stack_args32 = alloca %stack_t, align 8
-  %lookup_stack_scratch_key21 = alloca i32, align 4
-  %stack_key18 = alloca %stack_key, align 8
+  %stack_args33 = alloca %stack_t, align 8
+  %lookup_stack_scratch_key22 = alloca i32, align 4
+  %stack_key19 = alloca %stack_key, align 8
   %"@y_key" = alloca i64, align 8
   %stack_args15 = alloca %stack_t, align 8
   %lookup_stack_scratch_key5 = alloca i32, align 4
@@ -70,20 +70,20 @@ merge_block:                                      ; preds = %stack_scratch_failu
   store i32 %8, ptr %7, align 4
   %9 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %10 = trunc i64 %get_pid_tgid to i32
-  store i32 %10, ptr %9, align 4
-  %11 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
-  store i32 0, ptr %11, align 4
+  %pid = lshr i64 %get_pid_tgid, 32
+  store i64 %pid, ptr %9, align 8
+  %10 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
+  store i32 0, ptr %10, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %stack_args, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key2)
-  %12 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 0, ptr %12, align 8
-  %13 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 0, ptr %13, align 4
+  %11 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 0, ptr %11, align 8
+  %12 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 0, ptr %12, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key5)
   store i32 0, ptr %lookup_stack_scratch_key5, align 4
   %lookup_stack_scratch_map6 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key5)
@@ -97,17 +97,17 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
   %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %14 = icmp sge i32 %get_stack, 0
-  br i1 %14, label %get_stack_success, label %get_stack_fail
+  %13 = icmp sge i32 %get_stack, 0
+  br i1 %13, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %15 = udiv i32 %get_stack, 8
-  %16 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
-  store i32 %15, ptr %16, align 4
-  %17 = trunc i32 %15 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %17, i64 1)
-  %18 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %18, align 8
+  %14 = udiv i32 %get_stack, 8
+  %15 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %14, ptr %15, align 4
+  %16 = trunc i32 %14 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %16, i64 1)
+  %17 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %17, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -119,36 +119,36 @@ stack_scratch_failure3:                           ; preds = %lookup_stack_scratc
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args15)
-  %19 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  %20 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 0
-  %21 = load i64, ptr %19, align 8
-  store i64 %21, ptr %20, align 8
-  %22 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  %23 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 1
-  %24 = load i32, ptr %22, align 4
-  store i32 %24, ptr %23, align 4
-  %25 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 2
+  %18 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
+  %19 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 0
+  %20 = load i64, ptr %18, align 8
+  store i64 %20, ptr %19, align 8
+  %21 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  %22 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 1
+  %23 = load i32, ptr %21, align 4
+  store i32 %23, ptr %22, align 4
+  %24 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 2
   %get_pid_tgid16 = call i64 inttoptr (i64 14 to ptr)()
-  %26 = trunc i64 %get_pid_tgid16 to i32
-  store i32 %26, ptr %25, align 4
-  %27 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 3
-  store i32 0, ptr %27, align 4
+  %pid17 = lshr i64 %get_pid_tgid16, 32
+  store i64 %pid17, ptr %24, align 8
+  %25 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 3
+  store i32 0, ptr %25, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
-  %update_elem17 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %stack_args15, i64 0)
+  %update_elem18 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %stack_args15, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key18)
-  %28 = getelementptr %stack_key, ptr %stack_key18, i64 0, i32 0
-  store i64 0, ptr %28, align 8
-  %29 = getelementptr %stack_key, ptr %stack_key18, i64 0, i32 1
-  store i32 0, ptr %29, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key21)
-  store i32 0, ptr %lookup_stack_scratch_key21, align 4
-  %lookup_stack_scratch_map22 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key21)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_stack_scratch_key21)
-  %lookup_stack_scratch_cond25 = icmp ne ptr %lookup_stack_scratch_map22, null
-  br i1 %lookup_stack_scratch_cond25, label %lookup_stack_scratch_merge24, label %lookup_stack_scratch_failure23
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key19)
+  %26 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
+  store i64 0, ptr %26, align 8
+  %27 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
+  store i32 0, ptr %27, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key22)
+  store i32 0, ptr %lookup_stack_scratch_key22, align 4
+  %lookup_stack_scratch_map23 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key22)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_stack_scratch_key22)
+  %lookup_stack_scratch_cond26 = icmp ne ptr %lookup_stack_scratch_map23, null
+  br i1 %lookup_stack_scratch_cond26, label %lookup_stack_scratch_merge25, label %lookup_stack_scratch_failure24
 
 lookup_stack_scratch_failure7:                    ; preds = %merge_block
   br label %stack_scratch_failure3
@@ -156,71 +156,71 @@ lookup_stack_scratch_failure7:                    ; preds = %merge_block
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
   call void @llvm.memset.p0.i64(ptr align 1 %lookup_stack_scratch_map6, i8 0, i64 48, i1 false)
   %get_stack12 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 48, i64 256)
-  %30 = icmp sge i32 %get_stack12, 0
-  br i1 %30, label %get_stack_success10, label %get_stack_fail11
+  %28 = icmp sge i32 %get_stack12, 0
+  br i1 %28, label %get_stack_success10, label %get_stack_fail11
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
-  %31 = udiv i32 %get_stack12, 8
-  %32 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 %31, ptr %32, align 4
-  %33 = trunc i32 %31 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %33, i64 1)
-  %34 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_213, ptr %34, align 8
+  %29 = udiv i32 %get_stack12, 8
+  %30 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 %29, ptr %30, align 4
+  %31 = trunc i32 %29 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %31, i64 1)
+  %32 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, ptr %32, align 8
   %update_elem14 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_6, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
 get_stack_fail11:                                 ; preds = %lookup_stack_scratch_merge8
   br label %merge_block4
 
-stack_scratch_failure19:                          ; preds = %lookup_stack_scratch_failure23
-  br label %merge_block20
+stack_scratch_failure20:                          ; preds = %lookup_stack_scratch_failure24
+  br label %merge_block21
 
-merge_block20:                                    ; preds = %stack_scratch_failure19, %get_stack_success27, %get_stack_fail28
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args32)
-  %35 = getelementptr %stack_key, ptr %stack_key18, i64 0, i32 0
-  %36 = getelementptr %stack_t, ptr %stack_args32, i64 0, i32 0
-  %37 = load i64, ptr %35, align 8
-  store i64 %37, ptr %36, align 8
-  %38 = getelementptr %stack_key, ptr %stack_key18, i64 0, i32 1
-  %39 = getelementptr %stack_t, ptr %stack_args32, i64 0, i32 1
-  %40 = load i32, ptr %38, align 4
-  store i32 %40, ptr %39, align 4
-  %41 = getelementptr %stack_t, ptr %stack_args32, i64 0, i32 2
-  %get_pid_tgid33 = call i64 inttoptr (i64 14 to ptr)()
-  %42 = trunc i64 %get_pid_tgid33 to i32
-  store i32 %42, ptr %41, align 4
-  %43 = getelementptr %stack_t, ptr %stack_args32, i64 0, i32 3
-  store i32 0, ptr %43, align 4
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key18)
+merge_block21:                                    ; preds = %stack_scratch_failure20, %get_stack_success28, %get_stack_fail29
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args33)
+  %33 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
+  %34 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 0
+  %35 = load i64, ptr %33, align 8
+  store i64 %35, ptr %34, align 8
+  %36 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
+  %37 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 1
+  %38 = load i32, ptr %36, align 4
+  store i32 %38, ptr %37, align 4
+  %39 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 2
+  %get_pid_tgid34 = call i64 inttoptr (i64 14 to ptr)()
+  %pid35 = lshr i64 %get_pid_tgid34, 32
+  store i64 %pid35, ptr %39, align 8
+  %40 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 3
+  store i32 0, ptr %40, align 4
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key19)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@z_key")
   store i64 0, ptr %"@z_key", align 8
-  %update_elem34 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_z, ptr %"@z_key", ptr %stack_args32, i64 0)
+  %update_elem36 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_z, ptr %"@z_key", ptr %stack_args33, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@z_key")
   ret i64 0
 
-lookup_stack_scratch_failure23:                   ; preds = %merge_block4
-  br label %stack_scratch_failure19
+lookup_stack_scratch_failure24:                   ; preds = %merge_block4
+  br label %stack_scratch_failure20
 
-lookup_stack_scratch_merge24:                     ; preds = %merge_block4
-  %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map22, i32 1016, ptr null)
-  %get_stack29 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map22, i32 1016, i64 256)
-  %44 = icmp sge i32 %get_stack29, 0
-  br i1 %44, label %get_stack_success27, label %get_stack_fail28
+lookup_stack_scratch_merge25:                     ; preds = %merge_block4
+  %probe_read_kernel27 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map23, i32 1016, ptr null)
+  %get_stack30 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map23, i32 1016, i64 256)
+  %41 = icmp sge i32 %get_stack30, 0
+  br i1 %41, label %get_stack_success28, label %get_stack_fail29
 
-get_stack_success27:                              ; preds = %lookup_stack_scratch_merge24
-  %45 = udiv i32 %get_stack29, 8
-  %46 = getelementptr %stack_key, ptr %stack_key18, i64 0, i32 1
-  store i32 %45, ptr %46, align 4
-  %47 = trunc i32 %45 to i8
-  %murmur_hash_230 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map22, i8 %47, i64 1)
-  %48 = getelementptr %stack_key, ptr %stack_key18, i64 0, i32 0
-  store i64 %murmur_hash_230, ptr %48, align 8
-  %update_elem31 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_perf_127, ptr %stack_key18, ptr %lookup_stack_scratch_map22, i64 0)
-  br label %merge_block20
+get_stack_success28:                              ; preds = %lookup_stack_scratch_merge25
+  %42 = udiv i32 %get_stack30, 8
+  %43 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
+  store i32 %42, ptr %43, align 4
+  %44 = trunc i32 %42 to i8
+  %murmur_hash_231 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map23, i8 %44, i64 1)
+  %45 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
+  store i64 %murmur_hash_231, ptr %45, align 8
+  %update_elem32 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_perf_127, ptr %stack_key19, ptr %lookup_stack_scratch_map23, i64 0)
+  br label %merge_block21
 
-get_stack_fail28:                                 ; preds = %lookup_stack_scratch_merge24
-  br label %merge_block20
+get_stack_fail29:                                 ; preds = %lookup_stack_scratch_merge25
+  br label %merge_block21
 }
 
 ; Function Attrs: alwaysinline

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -22,13 +22,13 @@ entry:
   %usym = alloca %usym_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 0, ptr %2, align 8
-  store i64 %1, ptr %3, align 8
-  store i64 0, ptr %4, align 8
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 0, ptr %1, align 8
+  store i64 %pid, ptr %2, align 8
+  store i64 0, ptr %3, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   store i64 1, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %usym, ptr %"@x_val", i64 0)

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%usym_t = type { i64, i64, i64 }
+%usym_t = type { i64, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -22,13 +22,14 @@ entry:
   %usym = alloca %usym_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 0, ptr %1, align 8
-  store i64 %pid, ptr %2, align 8
-  store i64 0, ptr %3, align 8
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 0, ptr %2, align 8
+  store i32 %pid, ptr %3, align 4
+  store i32 0, ptr %4, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   store i64 1, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %usym, ptr %"@x_val", i64 0)
@@ -66,10 +67,10 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !15 = !DISubrange(count: 4096, lowerBound: 0)
 !16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
 !17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
-!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 192, elements: !20)
+!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 128, elements: !20)
 !19 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !20 = !{!21}
-!21 = !DISubrange(count: 24, lowerBound: 0)
+!21 = !DISubrange(count: 16, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
 !24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)

--- a/tests/codegen/llvm/cast_int_to_arr.ll
+++ b/tests/codegen/llvm/cast_int_to_arr.ll
@@ -24,20 +24,20 @@ entry:
   store i64 0, ptr %"$a", align 8
   %1 = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %2 = lshr i64 %get_pid_tgid, 32
+  %pid = lshr i64 %get_pid_tgid, 32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %1)
-  store i64 %2, ptr %1, align 8
-  %3 = ptrtoint ptr %1 to i64
-  store i64 %3, ptr %"$a", align 8
-  %4 = load i64, ptr %"$a", align 8
-  %5 = inttoptr i64 %4 to ptr
-  %6 = getelementptr [8 x i8], ptr %5, i32 0, i64 0
-  %7 = load volatile i8, ptr %6, align 1
+  store i64 %pid, ptr %1, align 8
+  %2 = ptrtoint ptr %1 to i64
+  store i64 %2, ptr %"$a", align 8
+  %3 = load i64, ptr %"$a", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = getelementptr [8 x i8], ptr %4, i32 0, i64 0
+  %6 = load volatile i8, ptr %5, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  %8 = zext i8 %7 to i64
+  %7 = zext i8 %6 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 %8, ptr %"@_val", align 8
+  store i64 %7, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")

--- a/tests/codegen/llvm/cast_int_to_arr.ll
+++ b/tests/codegen/llvm/cast_int_to_arr.ll
@@ -23,10 +23,8 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
   store i64 0, ptr %"$a", align 8
   %1 = alloca i64, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %1)
-  store i64 %pid, ptr %1, align 8
+  store i64 0, ptr %1, align 8
   %2 = ptrtoint ptr %1 to i64
   store i64 %2, ptr %"$a", align 8
   %3 = load i64, ptr %"$a", align 8

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -22,22 +22,22 @@ entry:
   %key8 = alloca i32, align 4
   %key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ugt i64 %1, 10
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp ugt i64 %pid, 10
+  %2 = zext i1 %1 to i64
+  %true_cond = icmp ne i64 %2, 0
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %4 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
-  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
-  store i64 0, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 8, i64 0)
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
+  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 8, i1 false)
+  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
+  store i64 0, ptr %5, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -46,14 +46,14 @@ if_end:                                           ; preds = %counter_merge6, %co
 
 else_body:                                        ; preds = %entry
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
-  %7 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %7
-  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %7
-  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 8, i1 false)
-  %9 = getelementptr %printf_t.1, ptr %8, i32 0, i32 0
-  store i64 1, ptr %9, align 8
-  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %8, i64 8, i64 0)
+  %6 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %6
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %6
+  %7 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 8, i1 false)
+  %8 = getelementptr %printf_t.1, ptr %7, i32 0, i32 0
+  store i64 1, ptr %8, align 8
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %7, i64 8, i64 0)
   %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
   br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
 
@@ -68,7 +68,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -89,7 +89,7 @@ counter_merge6:                                   ; preds = %lookup_merge12, %el
   br label %if_end
 
 lookup_success10:                                 ; preds = %event_loss_counter5
-  %11 = atomicrmw add ptr %lookup_elem9, i64 1 seq_cst, align 8
+  %10 = atomicrmw add ptr %lookup_elem9, i64 1 seq_cst, align 8
   br label %lookup_merge12
 
 lookup_failure11:                                 ; preds = %event_loss_counter5

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -22,22 +22,24 @@ entry:
   %key8 = alloca i32, align 4
   %key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp ugt i64 %pid, 10
-  %2 = zext i1 %1 to i64
-  %true_cond = icmp ne i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ugt i64 %2, 10
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %3 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 8, i1 false)
-  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
-  store i64 0, ptr %5, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 8, i64 0)
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
+  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
+  store i64 0, ptr %7, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -46,14 +48,14 @@ if_end:                                           ; preds = %counter_merge6, %co
 
 else_body:                                        ; preds = %entry
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
-  %6 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %6
-  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %6
-  %7 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 8, i1 false)
-  %8 = getelementptr %printf_t.1, ptr %7, i32 0, i32 0
-  store i64 1, ptr %8, align 8
-  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %7, i64 8, i64 0)
+  %8 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %8
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %8
+  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
+  %10 = getelementptr %printf_t.1, ptr %9, i32 0, i32 0
+  store i64 1, ptr %10, align 8
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %9, i64 8, i64 0)
   %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
   br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
 
@@ -68,7 +70,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %11 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -89,7 +91,7 @@ counter_merge6:                                   ; preds = %lookup_merge12, %el
   br label %if_end
 
 lookup_success10:                                 ; preds = %event_loss_counter5
-  %10 = atomicrmw add ptr %lookup_elem9, i64 1 seq_cst, align 8
+  %12 = atomicrmw add ptr %lookup_elem9, i64 1 seq_cst, align 8
   br label %lookup_merge12
 
 lookup_failure11:                                 ; preds = %event_loss_counter5

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -23,10 +23,12 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp ugt i64 %pid, 10000
-  %2 = zext i1 %1 to i64
-  %true_cond = icmp ne i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ugt i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
@@ -35,17 +37,17 @@ if_body:                                          ; preds = %entry
 
 if_end:                                           ; preds = %else_body, %if_body
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %3 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
-  store i64 0, ptr %5, align 8
-  %6 = load i64, ptr %"$s", align 8
-  %7 = getelementptr %printf_t, ptr %4, i32 0, i32 1
-  store i64 %6, ptr %7, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 16, i64 0)
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
+  store i64 0, ptr %7, align 8
+  %8 = load i64, ptr %"$s", align 8
+  %9 = getelementptr %printf_t, ptr %6, i32 0, i32 1
+  store i64 %8, ptr %9, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -64,7 +66,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_e
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -23,10 +23,10 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ugt i64 %1, 10000
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp ugt i64 %pid, 10000
+  %2 = zext i1 %1 to i64
+  %true_cond = icmp ne i64 %2, 0
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
@@ -35,17 +35,17 @@ if_body:                                          ; preds = %entry
 
 if_end:                                           ; preds = %else_body, %if_body
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %4 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
-  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
-  store i64 0, ptr %6, align 8
-  %7 = load i64, ptr %"$s", align 8
-  %8 = getelementptr %printf_t, ptr %5, i32 0, i32 1
-  store i64 %7, ptr %8, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 16, i64 0)
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
+  %4 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
+  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
+  store i64 0, ptr %5, align 8
+  %6 = load i64, ptr %"$s", align 8
+  %7 = getelementptr %printf_t, ptr %4, i32 0, i32 1
+  store i64 %6, ptr %7, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -64,7 +64,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_e
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -20,34 +20,34 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ugt i64 %1, 10000
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp ugt i64 %pid, 10000
+  %2 = zext i1 %1 to i64
+  %true_cond = icmp ne i64 %2, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
   %get_pid_tgid3 = call i64 inttoptr (i64 14 to ptr)()
-  %4 = lshr i64 %get_pid_tgid3, 32
-  %5 = urem i64 %4, 2
-  %6 = icmp eq i64 %5, 0
-  %7 = zext i1 %6 to i64
-  %true_cond4 = icmp ne i64 %7, 0
-  br i1 %true_cond4, label %if_body1, label %if_end2
+  %pid4 = lshr i64 %get_pid_tgid3, 32
+  %3 = urem i64 %pid4, 2
+  %4 = icmp eq i64 %3, 0
+  %5 = zext i1 %4 to i64
+  %true_cond5 = icmp ne i64 %5, 0
+  br i1 %true_cond5, label %if_body1, label %if_end2
 
 if_end:                                           ; preds = %if_end2, %entry
   ret i64 0
 
 if_body1:                                         ; preds = %if_body
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %8 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %8
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %8
-  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
-  %10 = getelementptr %printf_t, ptr %9, i32 0, i32 0
-  store i64 0, ptr %10, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %9, i64 8, i64 0)
+  %6 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %6
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
+  %7 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 8, i1 false)
+  %8 = getelementptr %printf_t, ptr %7, i32 0, i32 0
+  store i64 0, ptr %8, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %7, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -65,7 +65,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end2
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %11 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -20,19 +20,23 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp ugt i64 %pid, 10000
-  %2 = zext i1 %1 to i64
-  %true_cond = icmp ne i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ugt i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
   %get_pid_tgid3 = call i64 inttoptr (i64 14 to ptr)()
-  %pid4 = lshr i64 %get_pid_tgid3, 32
-  %3 = urem i64 %pid4, 2
-  %4 = icmp eq i64 %3, 0
-  %5 = zext i1 %4 to i64
-  %true_cond5 = icmp ne i64 %5, 0
+  %5 = lshr i64 %get_pid_tgid3, 32
+  %pid4 = trunc i64 %5 to i32
+  %6 = zext i32 %pid4 to i64
+  %7 = urem i64 %6, 2
+  %8 = icmp eq i64 %7, 0
+  %9 = zext i1 %8 to i64
+  %true_cond5 = icmp ne i64 %9, 0
   br i1 %true_cond5, label %if_body1, label %if_end2
 
 if_end:                                           ; preds = %if_end2, %entry
@@ -40,14 +44,14 @@ if_end:                                           ; preds = %if_end2, %entry
 
 if_body1:                                         ; preds = %if_body
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %6 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %6
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
-  %7 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 8, i1 false)
-  %8 = getelementptr %printf_t, ptr %7, i32 0, i32 0
-  store i64 0, ptr %8, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %7, i64 8, i64 0)
+  %10 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %10
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %10
+  %11 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %11, i8 0, i64 8, i1 false)
+  %12 = getelementptr %printf_t, ptr %11, i32 0, i32 0
+  store i64 0, ptr %12, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %11, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -65,7 +69,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end2
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %13 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -20,26 +20,30 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp ugt i64 %pid, 10000
-  %2 = zext i1 %1 to i64
-  %true_cond = icmp ne i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ugt i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %3 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
-  store i64 0, ptr %5, align 8
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
+  store i64 0, ptr %7, align 8
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %pid2 = lshr i64 %get_pid_tgid1, 32
-  %6 = getelementptr %printf_t, ptr %4, i32 0, i32 1
-  store i64 %pid2, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 16, i64 0)
+  %8 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %8 to i32
+  %9 = getelementptr %printf_t, ptr %6, i32 0, i32 1
+  %10 = zext i32 %pid2 to i64
+  store i64 %10, ptr %9, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -57,7 +61,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %7 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %11 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -20,26 +20,26 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ugt i64 %1, 10000
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp ugt i64 %pid, 10000
+  %2 = zext i1 %1 to i64
+  %true_cond = icmp ne i64 %2, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %4 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
-  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
-  store i64 0, ptr %6, align 8
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
+  %4 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
+  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
+  store i64 0, ptr %5, align 8
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %7 = lshr i64 %get_pid_tgid1, 32
-  %8 = getelementptr %printf_t, ptr %5, i32 0, i32 1
-  store i64 %7, ptr %8, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 16, i64 0)
+  %pid2 = lshr i64 %get_pid_tgid1, 32
+  %6 = getelementptr %printf_t, ptr %4, i32 0, i32 1
+  store i64 %pid2, ptr %6, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -57,7 +57,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %7 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -23,10 +23,12 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp ugt i64 %pid, 10000
-  %2 = zext i1 %1 to i64
-  %true_cond = icmp ne i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ugt i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
@@ -35,17 +37,17 @@ if_body:                                          ; preds = %entry
 
 if_end:                                           ; preds = %if_body, %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %3 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
-  store i64 0, ptr %5, align 8
-  %6 = load i64, ptr %"$s", align 8
-  %7 = getelementptr %printf_t, ptr %4, i32 0, i32 1
-  store i64 %6, ptr %7, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 16, i64 0)
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
+  store i64 0, ptr %7, align 8
+  %8 = load i64, ptr %"$s", align 8
+  %9 = getelementptr %printf_t, ptr %6, i32 0, i32 1
+  store i64 %8, ptr %9, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -60,7 +62,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_e
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -23,10 +23,10 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ugt i64 %1, 10000
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp ugt i64 %pid, 10000
+  %2 = zext i1 %1 to i64
+  %true_cond = icmp ne i64 %2, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
@@ -35,17 +35,17 @@ if_body:                                          ; preds = %entry
 
 if_end:                                           ; preds = %if_body, %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %4 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
-  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
-  store i64 0, ptr %6, align 8
-  %7 = load i64, ptr %"$s", align 8
-  %8 = getelementptr %printf_t, ptr %5, i32 0, i32 1
-  store i64 %7, ptr %8, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 16, i64 0)
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
+  %4 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
+  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
+  store i64 0, ptr %5, align 8
+  %6 = load i64, ptr %"$s", align 8
+  %7 = getelementptr %printf_t, ptr %4, i32 0, i32 1
+  store i64 %6, ptr %7, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -60,7 +60,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_e
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
@@ -43,10 +43,12 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_success
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %2 = icmp eq i64 %pid, 1234
-  %3 = zext i1 %2 to i64
-  %predcond = icmp eq i64 %3, 0
+  %2 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %2 to i32
+  %3 = zext i32 %pid to i64
+  %4 = icmp eq i64 %3, 1234
+  %5 = zext i1 %4 to i64
+  %predcond = icmp eq i64 %5, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 value_is_set:                                     ; preds = %lookup_success
@@ -57,7 +59,7 @@ value_is_set:                                     ; preds = %lookup_success
   br i1 %map_lookup_cond5, label %lookup_success2, label %lookup_failure3
 
 lookup_success2:                                  ; preds = %value_is_set
-  %4 = atomicrmw add ptr %lookup_elem1, i64 1 seq_cst, align 8
+  %6 = atomicrmw add ptr %lookup_elem1, i64 1 seq_cst, align 8
   br label %lookup_merge4
 
 lookup_failure3:                                  ; preds = %value_is_set
@@ -76,18 +78,18 @@ pred_false:                                       ; preds = %lookup_merge
 
 pred_true:                                        ; preds = %lookup_merge
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %7 = getelementptr %print_int_8_t, ptr %6, i64 0, i32 0
-  store i64 30007, ptr %7, align 8
-  %8 = getelementptr %print_int_8_t, ptr %6, i64 0, i32 1
-  store i64 0, ptr %8, align 8
-  %9 = getelementptr %print_int_8_t, ptr %6, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
-  store i64 2, ptr %9, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 24, i64 0)
+  %7 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %7
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %7
+  %8 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %9 = getelementptr %print_int_8_t, ptr %8, i64 0, i32 0
+  store i64 30007, ptr %9, align 8
+  %10 = getelementptr %print_int_8_t, ptr %8, i64 0, i32 1
+  store i64 0, ptr %10, align 8
+  %11 = getelementptr %print_int_8_t, ptr %8, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %11, i8 0, i64 8, i1 false)
+  store i64 2, ptr %11, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %8, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -118,7 +120,7 @@ counter_merge:                                    ; preds = %lookup_merge17, %pr
   br i1 %map_lookup_cond24, label %lookup_success21, label %lookup_failure22
 
 lookup_success15:                                 ; preds = %event_loss_counter
-  %10 = atomicrmw add ptr %lookup_elem14, i64 1 seq_cst, align 8
+  %12 = atomicrmw add ptr %lookup_elem14, i64 1 seq_cst, align 8
   br label %lookup_merge17
 
 lookup_failure16:                                 ; preds = %event_loss_counter

--- a/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
@@ -43,10 +43,10 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_success
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %2 = lshr i64 %get_pid_tgid, 32
-  %3 = icmp eq i64 %2, 1234
-  %4 = zext i1 %3 to i64
-  %predcond = icmp eq i64 %4, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %2 = icmp eq i64 %pid, 1234
+  %3 = zext i1 %2 to i64
+  %predcond = icmp eq i64 %3, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 value_is_set:                                     ; preds = %lookup_success
@@ -57,7 +57,7 @@ value_is_set:                                     ; preds = %lookup_success
   br i1 %map_lookup_cond5, label %lookup_success2, label %lookup_failure3
 
 lookup_success2:                                  ; preds = %value_is_set
-  %5 = atomicrmw add ptr %lookup_elem1, i64 1 seq_cst, align 8
+  %4 = atomicrmw add ptr %lookup_elem1, i64 1 seq_cst, align 8
   br label %lookup_merge4
 
 lookup_failure3:                                  ; preds = %value_is_set
@@ -76,18 +76,18 @@ pred_false:                                       ; preds = %lookup_merge
 
 pred_true:                                        ; preds = %lookup_merge
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %6 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %6
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
-  %7 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %8 = getelementptr %print_int_8_t, ptr %7, i64 0, i32 0
-  store i64 30007, ptr %8, align 8
-  %9 = getelementptr %print_int_8_t, ptr %7, i64 0, i32 1
-  store i64 0, ptr %9, align 8
-  %10 = getelementptr %print_int_8_t, ptr %7, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 8, i1 false)
-  store i64 2, ptr %10, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %7, i64 24, i64 0)
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %7 = getelementptr %print_int_8_t, ptr %6, i64 0, i32 0
+  store i64 30007, ptr %7, align 8
+  %8 = getelementptr %print_int_8_t, ptr %6, i64 0, i32 1
+  store i64 0, ptr %8, align 8
+  %9 = getelementptr %print_int_8_t, ptr %6, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
+  store i64 2, ptr %9, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -118,7 +118,7 @@ counter_merge:                                    ; preds = %lookup_merge17, %pr
   br i1 %map_lookup_cond24, label %lookup_success21, label %lookup_failure22
 
 lookup_success15:                                 ; preds = %event_loss_counter
-  %11 = atomicrmw add ptr %lookup_elem14, i64 1 seq_cst, align 8
+  %10 = atomicrmw add ptr %lookup_elem14, i64 1 seq_cst, align 8
   br label %lookup_merge17
 
 lookup_failure16:                                 ; preds = %event_loss_counter

--- a/tests/codegen/llvm/logical_and.ll
+++ b/tests/codegen/llvm/logical_and.ll
@@ -22,18 +22,18 @@ entry:
   %"&&_result" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ne i64 %1, 1234
-  %3 = zext i1 %2 to i64
-  %lhs_true_cond = icmp ne i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp ne i64 %pid, 1234
+  %2 = zext i1 %1 to i64
+  %lhs_true_cond = icmp ne i64 %2, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %4 = lshr i64 %get_pid_tgid1, 32
-  %5 = icmp ne i64 %4, 1235
-  %6 = zext i1 %5 to i64
-  %rhs_true_cond = icmp ne i64 %6, 0
+  %pid2 = lshr i64 %get_pid_tgid1, 32
+  %3 = icmp ne i64 %pid2, 1235
+  %4 = zext i1 %3 to i64
+  %rhs_true_cond = icmp ne i64 %4, 0
   br i1 %rhs_true_cond, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
@@ -45,11 +45,11 @@ entry:
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %7 = load i64, ptr %"&&_result", align 8
+  %5 = load i64, ptr %"&&_result", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %7, ptr %"@x_val", align 8
+  store i64 %5, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/logical_and.ll
+++ b/tests/codegen/llvm/logical_and.ll
@@ -22,18 +22,22 @@ entry:
   %"&&_result" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp ne i64 %pid, 1234
-  %2 = zext i1 %1 to i64
-  %lhs_true_cond = icmp ne i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ne i64 %2, 1234
+  %4 = zext i1 %3 to i64
+  %lhs_true_cond = icmp ne i64 %4, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %pid2 = lshr i64 %get_pid_tgid1, 32
-  %3 = icmp ne i64 %pid2, 1235
-  %4 = zext i1 %3 to i64
-  %rhs_true_cond = icmp ne i64 %4, 0
+  %5 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %5 to i32
+  %6 = zext i32 %pid2 to i64
+  %7 = icmp ne i64 %6, 1235
+  %8 = zext i1 %7 to i64
+  %rhs_true_cond = icmp ne i64 %8, 0
   br i1 %rhs_true_cond, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
@@ -45,11 +49,11 @@ entry:
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %5 = load i64, ptr %"&&_result", align 8
+  %9 = load i64, ptr %"&&_result", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %5, ptr %"@x_val", align 8
+  store i64 %9, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/logical_or.ll
+++ b/tests/codegen/llvm/logical_or.ll
@@ -22,18 +22,22 @@ entry:
   %"||_result" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp eq i64 %pid, 1234
-  %2 = zext i1 %1 to i64
-  %lhs_true_cond = icmp ne i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp eq i64 %2, 1234
+  %4 = zext i1 %3 to i64
+  %lhs_true_cond = icmp ne i64 %4, 0
   br i1 %lhs_true_cond, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %entry
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %pid2 = lshr i64 %get_pid_tgid1, 32
-  %3 = icmp eq i64 %pid2, 1235
-  %4 = zext i1 %3 to i64
-  %rhs_true_cond = icmp ne i64 %4, 0
+  %5 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %5 to i32
+  %6 = zext i32 %pid2 to i64
+  %7 = icmp eq i64 %6, 1235
+  %8 = zext i1 %7 to i64
+  %rhs_true_cond = icmp ne i64 %8, 0
   br i1 %rhs_true_cond, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
@@ -45,11 +49,11 @@ entry:
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %5 = load i64, ptr %"||_result", align 8
+  %9 = load i64, ptr %"||_result", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %5, ptr %"@x_val", align 8
+  store i64 %9, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/logical_or.ll
+++ b/tests/codegen/llvm/logical_or.ll
@@ -22,18 +22,18 @@ entry:
   %"||_result" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp eq i64 %1, 1234
-  %3 = zext i1 %2 to i64
-  %lhs_true_cond = icmp ne i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp eq i64 %pid, 1234
+  %2 = zext i1 %1 to i64
+  %lhs_true_cond = icmp ne i64 %2, 0
   br i1 %lhs_true_cond, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %entry
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %4 = lshr i64 %get_pid_tgid1, 32
-  %5 = icmp eq i64 %4, 1235
-  %6 = zext i1 %5 to i64
-  %rhs_true_cond = icmp ne i64 %6, 0
+  %pid2 = lshr i64 %get_pid_tgid1, 32
+  %3 = icmp eq i64 %pid2, 1235
+  %4 = zext i1 %3 to i64
+  %rhs_true_cond = icmp ne i64 %4, 0
   br i1 %rhs_true_cond, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
@@ -45,11 +45,11 @@ entry:
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %7 = load i64, ptr %"||_result", align 8
+  %5 = load i64, ptr %"||_result", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %7, ptr %"@x_val", align 8
+  store i64 %5, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/pred_binop.ll
+++ b/tests/codegen/llvm/pred_binop.ll
@@ -20,10 +20,10 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp eq i64 %1, 1234
-  %3 = zext i1 %2 to i64
-  %predcond = icmp eq i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp eq i64 %pid, 1234
+  %2 = zext i1 %1 to i64
+  %predcond = icmp eq i64 %2, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 pred_false:                                       ; preds = %entry

--- a/tests/codegen/llvm/pred_binop.ll
+++ b/tests/codegen/llvm/pred_binop.ll
@@ -20,10 +20,12 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp eq i64 %pid, 1234
-  %2 = zext i1 %1 to i64
-  %predcond = icmp eq i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp eq i64 %2, 1234
+  %4 = zext i1 %3 to i64
+  %predcond = icmp eq i64 %4, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 pred_false:                                       ; preds = %entry

--- a/tests/codegen/llvm/ternary_int.ll
+++ b/tests/codegen/llvm/ternary_int.ll
@@ -20,10 +20,12 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp ult i64 %pid, 10000
-  %2 = zext i1 %1 to i64
-  %true_cond = icmp ne i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ult i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry

--- a/tests/codegen/llvm/ternary_int.ll
+++ b/tests/codegen/llvm/ternary_int.ll
@@ -20,10 +20,10 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ult i64 %1, 10000
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp ult i64 %pid, 10000
+  %2 = zext i1 %1 to i64
+  %true_cond = icmp ne i64 %2, 0
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -22,22 +22,24 @@ entry:
   %perfdata = alloca i64, align 8
   %key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp ult i64 %pid, 10000
-  %2 = zext i1 %1 to i64
-  %true_cond = icmp ne i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ult i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %3 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 8, i1 false)
-  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
-  store i64 0, ptr %5, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 8, i64 0)
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
+  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
+  store i64 0, ptr %7, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -62,7 +64,7 @@ counter_merge:                                    ; preds = %lookup_merge, %left
   br label %done
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %6 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -84,7 +86,7 @@ counter_merge3:                                   ; preds = %lookup_merge9, %rig
   ret i64 0
 
 lookup_success7:                                  ; preds = %event_loss_counter2
-  %7 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
+  %9 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter2

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -22,22 +22,22 @@ entry:
   %perfdata = alloca i64, align 8
   %key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ult i64 %1, 10000
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp ult i64 %pid, 10000
+  %2 = zext i1 %1 to i64
+  %true_cond = icmp ne i64 %2, 0
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %4 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
-  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
-  store i64 0, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 8, i64 0)
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
+  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 8, i1 false)
+  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
+  store i64 0, ptr %5, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -62,7 +62,7 @@ counter_merge:                                    ; preds = %lookup_merge, %left
   br label %done
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %7 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %6 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -84,7 +84,7 @@ counter_merge3:                                   ; preds = %lookup_merge9, %rig
   ret i64 0
 
 lookup_success7:                                  ; preds = %event_loss_counter2
-  %8 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
+  %7 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter2

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -57,10 +57,10 @@ lookup_str_failure:                               ; preds = %entry
 lookup_str_merge:                                 ; preds = %entry
   call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ult i64 %1, 10000
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %pid = lshr i64 %get_pid_tgid, 32
+  %1 = icmp ult i64 %pid, 10000
+  %2 = zext i1 %1 to i64
+  %true_cond = icmp ne i64 %2, 0
   br i1 %true_cond, label %left, label %right
 }
 

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -57,10 +57,12 @@ lookup_str_failure:                               ; preds = %entry
 lookup_str_merge:                                 ; preds = %entry
   call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %1 = icmp ult i64 %pid, 10000
-  %2 = zext i1 %1 to i64
-  %true_cond = icmp ne i64 %2, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ult i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %left, label %right
 }
 

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -27,28 +27,28 @@ entry:
   %reg_ip = load volatile i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %2 = lshr i64 %get_pid_tgid, 32
-  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %5 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 %reg_ip, ptr %3, align 8
-  store i64 %2, ptr %4, align 8
-  store i64 0, ptr %5, align 8
+  %pid = lshr i64 %get_pid_tgid, 32
+  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 %reg_ip, ptr %2, align 8
+  store i64 %pid, ptr %3, align 8
+  store i64 0, ptr %4, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %6 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %6
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
-  %7 = getelementptr [1 x [1 x [40 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 40, i1 false)
-  %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 0
-  store i8 1, ptr %8, align 1
-  %9 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %usym, i64 24, i1 false)
-  %10 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 2
-  store i64 10, ptr %10, align 8
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [40 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 40, i1 false)
+  %7 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i8 1, ptr %7, align 1
+  %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %6, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %usym, i64 24, i1 false)
+  %9 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %6, i32 0, i32 2
+  store i64 10, ptr %9, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %7, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %6, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@t_key")
   ret i64 0
 }

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -6,15 +6,15 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%usym_t = type { i64, i64, i64 }
-%uint8_usym_t_int64__tuple_t = type { i8, [24 x i8], i64 }
+%usym_t = type { i64, i32, i32 }
+%uint8_usym_t_int64__tuple_t = type { i8, [16 x i8], i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_t = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !31
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !45
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !51
-@tuple_buf = dso_local externally_initialized global [1 x [1 x [40 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !53
+@tuple_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !53
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -27,28 +27,29 @@ entry:
   %reg_ip = load volatile i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %pid = lshr i64 %get_pid_tgid, 32
-  %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 %reg_ip, ptr %2, align 8
-  store i64 %pid, ptr %3, align 8
-  store i64 0, ptr %4, align 8
+  %2 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %2 to i32
+  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %5 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 %reg_ip, ptr %3, align 8
+  store i32 %pid, ptr %4, align 4
+  store i32 0, ptr %5, align 4
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [1 x [40 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 40, i1 false)
-  %7 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %6, i32 0, i32 0
-  store i8 1, ptr %7, align 1
-  %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %6, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %usym, i64 24, i1 false)
-  %9 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %6, i32 0, i32 2
-  store i64 10, ptr %9, align 8
+  %6 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %6
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
+  %7 = getelementptr [1 x [1 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 32, i1 false)
+  %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 0
+  store i8 1, ptr %8, align 1
+  %9 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %usym, i64 16, i1 false)
+  %10 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 2
+  store i64 10, ptr %10, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %6, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %7, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@t_key")
   ret i64 0
 }
@@ -94,15 +95,15 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
 !20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 320, elements: !22)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !22)
 !22 = !{!23, !25, !29}
 !23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 8)
 !24 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !26, size: 192, offset: 8)
-!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 192, elements: !27)
+!25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !26, size: 128, offset: 8)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 128, elements: !27)
 !27 = !{!28}
-!28 = !DISubrange(count: 24, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !30, size: 64, offset: 256)
+!28 = !DISubrange(count: 16, lowerBound: 0)
+!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !30, size: 64, offset: 192)
 !30 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
 !32 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
@@ -128,11 +129,11 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !52 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !30, isLocal: false, isDefinition: true)
 !53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
 !54 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
-!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 320, elements: !14)
-!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 320, elements: !14)
-!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 320, elements: !58)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 256, elements: !14)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 256, elements: !14)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 256, elements: !58)
 !58 = !{!59}
-!59 = !DISubrange(count: 40, lowerBound: 0)
+!59 = !DISubrange(count: 32, lowerBound: 0)
 !60 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !61)
 !61 = !{!0, !31, !45, !51, !53}
 !62 = !{i32 2, !"Debug Info Version", i32 3}


### PR DESCRIPTION
Previously, they were mostly 64-bit but had a few places where they were treated as 32-bit.
    
This saves some memory and may marginally improve performance when pushing usyms onto the ring buffer, etc., but it's mainly just a nice little clean up for consistency. Maybe it even eliminates some undiscovered lurking bugs.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
