### PR TITLE
Fix resizing for tuples

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -78,6 +78,10 @@ aot.tuples.basic tuple map
 aot.tuples.tuple print
 aot.tuples.tuple strftime type is packed
 aot.variable.tuple string resize
+aot.variable.map tuple string resize
+aot.variable.variable tuple string resize
+aot.variable.variable nested tuple string resize
+aot.variable.map nested tuple string resize
 aot.dwarf.uprobe inlined function - func
 aot.dwarf.uprobe inlined function - probe
 aot.dwarf.uprobe inlined function - ustack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to
   - [#3422](https://github.com/bpftrace/bpftrace/pull/3422)
 - Fix integer comparisons and auto casting for scratch variables
   - [#3416](https://github.com/bpftrace/bpftrace/pull/3416)
+- Fix tuple resizing
+  - [#3443](https://github.com/bpftrace/bpftrace/pull/3443)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -94,6 +94,10 @@ public:
       const SizedType &tuple_type,
       const std::vector<std::pair<llvm::Value *, const location *>> &vals,
       const std::string &name);
+  void createTupleCopy(const SizedType &expr_type,
+                       const SizedType &var_type,
+                       Value *dst_val,
+                       Value *src_val);
 
   void generate_ir(void);
   libbpf::bpf_map_type get_map_type(const SizedType &val_type,

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3581,8 +3581,9 @@ bool SemanticAnalyser::update_string_size(SizedType &type,
         updated = true;
       new_elems.push_back(type.GetField(i).type);
     }
-    if (updated)
+    if (updated) {
       type = CreateTuple(bpftrace_.structs.AddTuple(new_elems));
+    }
     return updated;
   }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -561,13 +561,17 @@ std::weak_ptr<const Struct> SizedType::GetStruct() const
 
 bool SizedType::FitsInto(const SizedType &t) const
 {
+  if (!IsSameType(t))
+    return false;
+
   if (IsStringTy() && t.IsStringTy())
     return GetSize() <= t.GetSize();
 
-  if (IsIntegerTy() && t.IsIntegerTy() && (IsSigned() == t.IsSigned()))
-    return GetSize() <= t.GetSize();
+  if (IsIntegerTy()) {
+    return (IsSigned() == t.IsSigned()) && (GetSize() <= t.GetSize());
+  }
 
-  if (IsTupleTy() && t.IsTupleTy()) {
+  if (IsTupleTy()) {
     if (GetFieldCount() != t.GetFieldCount())
       return false;
 

--- a/tests/codegen/llvm/nested_tuple_different_sizes.ll
+++ b/tests/codegen/llvm/nested_tuple_different_sizes.ll
@@ -1,0 +1,146 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"int64_(string[13],int64)__tuple_t" = type { i64, %"string[13]_int64__tuple_t" }
+%"string[13]_int64__tuple_t" = type { [13 x i8], i64 }
+%"int64_(string[3],int64)__tuple_t" = type { i64, %"string[3]_int64__tuple_t" }
+%"string[3]_int64__tuple_t" = type { [3 x i8], i64 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+entry:
+  %tuple4 = alloca %"int64_(string[13],int64)__tuple_t", align 8
+  %tuple3 = alloca %"string[13]_int64__tuple_t", align 8
+  %str2 = alloca [13 x i8], align 1
+  %"$t" = alloca %"int64_(string[13],int64)__tuple_t", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
+  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 32, i1 false)
+  %tuple1 = alloca %"int64_(string[3],int64)__tuple_t", align 8
+  %tuple = alloca %"string[3]_int64__tuple_t", align 8
+  %str = alloca [3 x i8], align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
+  store [3 x i8] c"hi\00", ptr %str, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
+  %1 = getelementptr %"string[3]_int64__tuple_t", ptr %tuple, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 %str, i64 3, i1 false)
+  %2 = getelementptr %"string[3]_int64__tuple_t", ptr %tuple, i32 0, i32 1
+  store i64 3, ptr %2, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 24, i1 false)
+  %3 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %tuple1, i32 0, i32 0
+  store i64 1, ptr %3, align 8
+  %4 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %tuple1, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %tuple, i64 16, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
+  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 32, i1 false)
+  %5 = getelementptr [24 x i8], ptr %tuple1, i64 0, i64 0
+  %6 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 8, i1 false)
+  %7 = getelementptr [24 x i8], ptr %tuple1, i64 0, i64 8
+  %8 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 1
+  %9 = getelementptr [16 x i8], ptr %7, i64 0, i64 0
+  %10 = getelementptr %"string[13]_int64__tuple_t", ptr %8, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 3, i1 false)
+  %11 = getelementptr [16 x i8], ptr %7, i64 0, i64 8
+  %12 = getelementptr %"string[13]_int64__tuple_t", ptr %8, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %11, i64 8, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str2)
+  store [13 x i8] c"hellolongstr\00", ptr %str2, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple3)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple3, i8 0, i64 24, i1 false)
+  %13 = getelementptr %"string[13]_int64__tuple_t", ptr %tuple3, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 %str2, i64 13, i1 false)
+  %14 = getelementptr %"string[13]_int64__tuple_t", ptr %tuple3, i32 0, i32 1
+  store i64 4, ptr %14, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str2)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple4)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple4, i8 0, i64 32, i1 false)
+  %15 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %tuple4, i32 0, i32 0
+  store i64 1, ptr %15, align 8
+  %16 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %tuple4, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 %tuple3, i64 24, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple3)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple4, i64 32, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple4)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/llvm/tuple_map_val_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_map_val_different_sizes.ll
@@ -1,0 +1,147 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%"int64_string[13]__tuple_t" = type { i64, [13 x i8] }
+%"int64_string[3]__tuple_t" = type { i64, [3 x i8] }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_a = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !30
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !44
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !53 {
+entry:
+  %"@a_key3" = alloca i64, align 8
+  %tuple2 = alloca %"int64_string[13]__tuple_t", align 8
+  %str1 = alloca [13 x i8], align 1
+  %"@a_val" = alloca %"int64_string[13]__tuple_t", align 8
+  %"@a_key" = alloca i64, align 8
+  %tuple = alloca %"int64_string[3]__tuple_t", align 8
+  %str = alloca [3 x i8], align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
+  store [3 x i8] c"hi\00", ptr %str, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
+  %1 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 0
+  store i64 1, ptr %1, align 8
+  %2 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 3, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
+  store i64 0, ptr %"@a_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
+  call void @llvm.memset.p0.i64(ptr align 1 %"@a_val", i8 0, i64 24, i1 false)
+  %3 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 0
+  %4 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %3, i64 8, i1 false)
+  %5 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 8
+  %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 3, i1 false)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %"@a_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
+  store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple2)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 24, i1 false)
+  %7 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 0
+  store i64 1, ptr %7, align 8
+  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %str1, i64 13, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key3")
+  store i64 0, ptr %"@a_key3", align 8
+  %update_elem4 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key3", ptr %tuple2, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key3")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple2)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!50}
+!llvm.module.flags = !{!52}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 2, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 1, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 192, elements: !22)
+!22 = !{!23, !25}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64)
+!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !26, size: 104, offset: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !27, size: 104, elements: !28)
+!27 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!28 = !{!29}
+!29 = !DISubrange(count: 13, lowerBound: 0)
+!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
+!31 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !33)
+!33 = !{!34, !39}
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !35, size: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 27, lowerBound: 0)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !40, size: 64, offset: 64)
+!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !42)
+!42 = !{!43}
+!43 = !DISubrange(count: 262144, lowerBound: 0)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
+!46 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !47)
+!47 = !{!5, !11, !16, !48}
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !49, size: 64, offset: 192)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!50 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !51)
+!51 = !{!0, !30, !44}
+!52 = !{i32 2, !"Debug Info Version", i32 3}
+!53 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !54, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !57)
+!54 = !DISubroutineType(types: !55)
+!55 = !{!24, !56}
+!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!57 = !{!58}
+!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !53, file: !2, type: !56)

--- a/tests/codegen/llvm/tuple_variable_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_variable_different_sizes.ll
@@ -1,0 +1,123 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"int64_string[13]__tuple_t" = type { i64, [13 x i8] }
+%"int64_string[3]__tuple_t" = type { i64, [3 x i8] }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+entry:
+  %tuple2 = alloca %"int64_string[13]__tuple_t", align 8
+  %str1 = alloca [13 x i8], align 1
+  %"$t" = alloca %"int64_string[13]__tuple_t", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
+  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 24, i1 false)
+  %tuple = alloca %"int64_string[3]__tuple_t", align 8
+  %str = alloca [3 x i8], align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
+  store [3 x i8] c"hi\00", ptr %str, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
+  %1 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 0
+  store i64 1, ptr %1, align 8
+  %2 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 3, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 24, i1 false)
+  %3 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 0
+  %4 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %3, i64 8, i1 false)
+  %5 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 8
+  %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 3, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
+  store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple2)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 24, i1 false)
+  %7 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 0
+  store i64 1, ptr %7, align 8
+  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %str1, i64 13, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple2, i64 24, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple2)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/tuple.cpp
+++ b/tests/codegen/tuple.cpp
@@ -11,6 +11,27 @@ TEST(codegen, tuple)
        NAME);
 }
 
+TEST(codegen, tuple_map_val_different_sizes)
+{
+  test(R"_(k:f { @a = (1, "hi"); @a = (1, "hellolongstr"); })_",
+
+       NAME);
+}
+
+TEST(codegen, tuple_variable_different_sizes)
+{
+  test(R"_(k:f { $t = (1, "hi"); $t = (1, "hellolongstr"); })_",
+
+       NAME);
+}
+
+TEST(codegen, nested_tuple_different_sizes)
+{
+  test(R"_(k:f { $t = (1, ("hi", 3)); $t = (1, ("hellolongstr", 4)); })_",
+
+       NAME);
+}
+
 } // namespace codegen
 } // namespace test
 } // namespace bpftrace

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -63,7 +63,25 @@ PROG BEGIN { @["hello", 0] = 0; } i:ms:1 { @["hi", 1] = 1; exit(); }
 EXPECT @[hi, 1]: 1
 TIMEOUT 2
 
-NAME tuple string resize
-PROG BEGIN { @ = ("hello", 0); } i:ms:1 { @ = ("hi", 1); exit(); }
-EXPECT @: (hi, 1)
+NAME map tuple string resize
+PROG BEGIN { @[1] = ("hi", 1); @[1] = ("hellolongstr", 2); @[1] = ("by", 3); exit(); }
+EXPECT @[1]: (by, 3)
+TIMEOUT 2
+
+NAME variable tuple string resize
+PROG BEGIN { $a = ("hi", 1); print(($a)); $a = ("hellolongstr", 2); print(($a)); $a = ("by", 3); print(($a)); exit(); }
+EXPECT (hi, 1)
+EXPECT (hellolongstr, 2)
+EXPECT (by, 3)
+TIMEOUT 2
+
+NAME variable nested tuple string resize
+PROG BEGIN { $a = ("hi", ("hellolongstr", 2)); print(($a)); $a = ("hellolongstr", ("hi", 5)); print(($a)); exit(); }
+EXPECT (hi, (hellolongstr, 2))
+EXPECT (hellolongstr, (hi, 5))
+TIMEOUT 2
+
+NAME map nested tuple string resize
+PROG BEGIN { @[1] = ("hi", ("hellolongstr", 2)); @[1] = ("hellolongstr", ("hi", 5)); exit(); }
+EXPECT @[1]: (hellolongstr, (hi, 5))
 TIMEOUT 2

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -390,7 +390,8 @@ kprobe:f / @mymap1 == 1234 / { 1234; @mymap1 = @mymap2; }
 TEST(semantic_analyser, consistent_map_values)
 {
   test("kprobe:f { @x = 0; @x = 1; }");
-  test(R"(BEGIN { $a = (3, "hello"); @m[1] = $a; $a = (1,"aaaaaaaaaa"); @m[2] = $a; })");
+  test(
+      R"(BEGIN { $a = (3, "hello"); @m[1] = $a; $a = (1,"aaaaaaaaaa"); @m[2] = $a; })");
   test_error("kprobe:f { @x = 0; @x = \"a\"; }", R"(
 stdin:1:20-22: ERROR: Type mismatch for @x: trying to assign value of type 'string[2]' when map already contains a value of type 'int64'
 kprobe:f { @x = 0; @x = "a"; }
@@ -3125,29 +3126,22 @@ BEGIN { $t = (1, (int32)2); $t = (2, (int64)3); }
 
   test(R"_(BEGIN { $t = (1, (2, 3)); $t = (4, ((int8)5, 6)); })_");
 
-  test_error(R"_(BEGIN { $t = (1, ((int8)2, 3)); $t = (4, (5, (int8)6)); })_",
+  test_error(R"_(BEGIN { $t = (1, ((int8)2, 3)); $t = (4, (5, 6)); })_",
              R"(
-stdin:1:33-55: ERROR: Tuple type mismatch: (int64,(int8,int64)) != (int64,(int64,int8)).
-BEGIN { $t = (1, ((int8)2, 3)); $t = (4, (5, (int8)6)); }
-                                ~~~~~~~~~~~~~~~~~~~~~~
+stdin:1:33-49: ERROR: Tuple type mismatch: (int64,(int8,int64)) != (int64,(int64,int64)).
+BEGIN { $t = (1, ((int8)2, 3)); $t = (4, (5, 6)); }
+                                ~~~~~~~~~~~~~~~~
 )");
 
   test_error(R"_(BEGIN { $t = ((uint8)1, (2, 3)); $t = (4, ((int8)5, 6)); })_",
              R"(
-stdin:1:34-56: ERROR: Tuple type mismatch: (unsigned int8,(int64,int64)) != (int64,(int8,int64)).
+stdin:1:34-56: ERROR: Tuple type mismatch: (uint8,(int64,int64)) != (int64,(int8,int64)).
 BEGIN { $t = ((uint8)1, (2, 3)); $t = (4, ((int8)5, 6)); }
                                  ~~~~~~~~~~~~~~~~~~~~~~
 )");
 
   test(R"_(BEGIN { @t = (1, 2, "hi"); @t = (3, 4, "hellolongstr"); })_");
-  // This should not be an error when nested tuple resizing is fixed
-  // https://github.com/bpftrace/bpftrace/issues/3444
-  test_error(
-      R"_(BEGIN { $t = (1, ("hi", 2)); $t = (3, ("hellolongstr", 4)); })_", R"(
-stdin:1:30-59: ERROR: Tuple type mismatch: (int64,(string[3],int64)) != (int64,(string[13],int64)).
-BEGIN { $t = (1, ("hi", 2)); $t = (3, ("hellolongstr", 4)); }
-                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-)");
+  test(R"_(BEGIN { $t = (1, ("hi", 2)); $t = (3, ("hellolongstr", 4)); })_");
 }
 
 TEST(semantic_analyser, tuple_indexing)


### PR DESCRIPTION
This fixes these issues: 
- https://github.com/bpftrace/bpftrace/issues/3439
- https://github.com/bpftrace/bpftrace/issues/3444

The fix involves creating individual memcpys
for each of the tuple elements if the variable type
is a different size from the expression type -
do this recursively for nested tuples.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
