### PR TITLE
BTF: Handle btf__parse_raw() errors

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -51,6 +51,10 @@ BTF::BTF(const std::set<std::string> &modules) : state(NODATA)
     btf_objects.push_back(
         BTFObj{ .btf = btf__parse_raw(path), .id = 0, .name = "" });
     vmlinux_btf = btf_objects.back().btf;
+    if (!vmlinux_btf) {
+      LOG(V1) << "BTF: failed to parse BTF";
+      return;
+    }
   } else
     load_kernel_btfs(modules);
 


### PR DESCRIPTION
btf__parse_raw() can fail and result in NULL pointer dereference somewhere down the road, check its return value.

Without this, I get a segmentation fault when accidentally passing an incorrect BTF file using BPFTRACE_BTF.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
