### PR TITLE
codegen: NFC: Move codegen resource analysis to new pass

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(ast STATIC
   signal.cpp
   visitors.cpp
 
+  passes/codegen_resources.cpp
   passes/config_analyser.cpp
   passes/field_analyser.cpp
   passes/portability_analyser.cpp

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -17,6 +17,7 @@
 #include "ast/irbuilderbpf.h"
 #include "ast/visitors.h"
 #include "bpftrace.h"
+#include "codegen_resources.h"
 #include "format_string.h"
 #include "location.hh"
 #include "required_resources.h"
@@ -102,7 +103,7 @@ public:
   void generate_ir(void);
   libbpf::bpf_map_type get_map_type(const SizedType &val_type,
                                     const MapKey &key);
-  void generate_maps(const RequiredResources &resources);
+  void generate_maps(const RequiredResources &rr, const CodegenResources &cr);
   void generate_global_vars(const RequiredResources &resources);
   void optimize(void);
   bool verify(void);

--- a/src/ast/passes/codegen_resources.cpp
+++ b/src/ast/passes/codegen_resources.cpp
@@ -1,0 +1,57 @@
+#include "codegen_resources.h"
+
+#include "async_event_types.h"
+#include "struct.h"
+#include "types.h"
+
+namespace bpftrace::ast {
+
+CodegenResourceAnalyser::CodegenResourceAnalyser(
+    Node *root,
+    const ::bpftrace::Config &config)
+    : config_(config), root_(root)
+{
+}
+
+CodegenResources CodegenResourceAnalyser::analyse()
+{
+  Visit(*root_);
+  return std::move(resources_);
+}
+
+void CodegenResourceAnalyser::visit(Builtin &builtin)
+{
+  if (builtin.ident == "elapsed") {
+    resources_.needs_elapsed_map = true;
+  } else if (builtin.ident == "kstack" || builtin.ident == "ustack") {
+    resources_.stackid_maps.insert(
+        StackType{ .mode = config_.get(ConfigKeyStackMode::default_) });
+  }
+}
+
+void CodegenResourceAnalyser::visit(Call &call)
+{
+  Visitor::visit(call);
+
+  if (call.func == "join") {
+    resources_.needs_join_map = true;
+  } else if (call.func == "str" || call.func == "buf" || call.func == "path") {
+    resources_.str_buffers++;
+  } else if (call.func == "kstack" || call.func == "ustack") {
+    resources_.stackid_maps.insert(call.type.stack_type);
+  }
+}
+
+void CodegenResourceAnalyser::visit(Ternary &ternary)
+{
+  Visitor::visit(ternary);
+
+  // Codegen cannot use a phi node for ternary string b/c strings can be of
+  // differing lengths and phi node wants identical types. So we have to
+  // allocate a result temporary, but not on the stack b/c a big string would
+  // blow it up. So we need a scratch buffer for it.
+  if (ternary.type.IsStringTy())
+    resources_.str_buffers++;
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/codegen_resources.h
+++ b/src/ast/passes/codegen_resources.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+#include <unordered_set>
+
+#include "ast/visitors.h"
+#include "config.h"
+
+namespace bpftrace {
+namespace ast {
+
+struct CodegenResources {
+  bool needs_elapsed_map = false;
+  bool needs_join_map = false;
+  uint32_t str_buffers = 0;
+  std::unordered_set<StackType> stackid_maps;
+};
+
+// Codegen resource analysis pass
+//
+// This pass collects specific information codegen later needs. All this
+// could be done in codegen pass itself, but splitting out some "prerun"
+// logic makes things easier to understand and maintain.
+class CodegenResourceAnalyser : public Visitor {
+public:
+  CodegenResourceAnalyser(Node *root, const ::bpftrace::Config &config);
+  CodegenResources analyse();
+
+private:
+  void visit(Builtin &map) override;
+  void visit(Call &call) override;
+  void visit(Ternary &ternary) override;
+
+  const ::bpftrace::Config &config_;
+  CodegenResources resources_;
+  Node *root_;
+};
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -33,7 +33,6 @@ private:
   void visit(Builtin &map) override;
   void visit(Call &call) override;
   void visit(Map &map) override;
-  void visit(Ternary &ternary) override;
 
   // Determines whether the given function uses userspace symbol resolution.
   // This is used later for loading the symbol table into memory.

--- a/tests/required_resources.cpp
+++ b/tests/required_resources.cpp
@@ -123,31 +123,6 @@ TEST(required_resources, round_trip_map_info)
   }
 }
 
-TEST(required_resources, round_trip_set_stack_type)
-{
-  std::ostringstream serialized(std::ios::binary);
-  {
-    RequiredResources r;
-    r.stackid_maps.insert(StackType{
-        .limit = 33,
-        .mode = StackMode::perf,
-    });
-    r.save_state(serialized);
-  }
-
-  std::istringstream input(serialized.str());
-  {
-    RequiredResources r;
-    r.load_state(input);
-
-    ASSERT_EQ(r.stackid_maps.size(), 1ul);
-    for (const auto &st : r.stackid_maps) {
-      EXPECT_EQ(st.limit, 33ul);
-      EXPECT_EQ(st.mode, StackMode::perf);
-    }
-  }
-}
-
 TEST(required_resources, round_trip_probes)
 {
   std::ostringstream serialized(std::ios::binary);
@@ -182,11 +157,7 @@ TEST(required_resources, round_trip_multiple_members)
   {
     RequiredResources r;
     r.join_args.emplace_back("joinarg0");
-    r.stackid_maps.insert(StackType{
-        .limit = 33,
-        .mode = StackMode::perf,
-    });
-    r.needs_elapsed_map = true;
+    r.time_args.emplace_back("timearg0");
     r.save_state(serialized);
   }
 
@@ -197,12 +168,8 @@ TEST(required_resources, round_trip_multiple_members)
 
     ASSERT_EQ(r.join_args.size(), 1ul);
     EXPECT_EQ(r.join_args[0], "joinarg0");
-    ASSERT_EQ(r.stackid_maps.size(), 1ul);
-    for (const auto &st : r.stackid_maps) {
-      EXPECT_EQ(st.limit, 33ul);
-      EXPECT_EQ(st.mode, StackMode::perf);
-    }
-    EXPECT_TRUE(r.needs_elapsed_map);
+    ASSERT_EQ(r.time_args.size(), 1ul);
+    EXPECT_EQ(r.time_args[0], "timearg0");
   }
 }
 


### PR DESCRIPTION
RequiredResources is meant to encapsulate resources required at runtime. Over time and after some refactors, non-runtime resources started to be held in RequiredResources.

Since we will be doing more codegen resource analysis in #3431, let's factor out the non-runtime resources out into a new codegen internal pass. This helps keep the code modular.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
