### PR TITLE
BTF: Handle btf__parse_raw() errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to
   - [#3416](https://github.com/bpftrace/bpftrace/pull/3416)
 - Fix tuple resizing
   - [#3443](https://github.com/bpftrace/bpftrace/pull/3443)
+- Handle invalid BTF without crashing
+  - [#3453](https://github.com/bpftrace/bpftrace/pull/3453)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -51,6 +51,10 @@ BTF::BTF(const std::set<std::string> &modules) : state(NODATA)
     btf_objects.push_back(
         BTFObj{ .btf = btf__parse_raw(path), .id = 0, .name = "" });
     vmlinux_btf = btf_objects.back().btf;
+    if (!vmlinux_btf) {
+      LOG(WARNING) << "BTF: failed to parse BTF from " << path;
+      return;
+    }
   } else
     load_kernel_btfs(modules);
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1212,6 +1212,16 @@ TEST_F(bpftrace_btf, add_probes_iter_task_vma)
   check_probe(bpftrace->get_probes().at(0), ProbeType::iter, "iter:task_vma");
 }
 
+class bpftrace_bad_btf : public test_bad_btf {};
+
+// Test that we can handle bad data and don't just crash
+TEST_F(bpftrace_bad_btf, parse_invalid_btf)
+{
+  BPFtrace bpftrace;
+  bpftrace.parse_btf({});
+  EXPECT_FALSE(bpftrace.has_btf_data());
+}
+
 TEST(bpftrace, add_probes_rawtracepoint)
 {
   StrictMock<MockBPFtrace> bpftrace;

--- a/tests/btf_common.h
+++ b/tests/btf_common.h
@@ -2,31 +2,33 @@
 
 #include "data/btf_data.h"
 
-class test_btf : public ::testing::Test {
-protected:
-  static bool create_tmp_with_data(char *path,
-                                   const unsigned char *data,
-                                   unsigned int data_len)
-  {
-    if (!path)
-      return false;
+namespace {
+bool create_tmp_with_data(char *path,
+                          const unsigned char *data,
+                          unsigned int data_len)
+{
+  if (!path)
+    return false;
 
-    int fd = mkstemp(path);
-    if (fd < 0) {
-      std::remove(path);
-      return false;
-    }
-
-    if (write(fd, data, data_len) != data_len) {
-      close(fd);
-      std::remove(path);
-      return false;
-    }
-
-    close(fd);
-    return true;
+  int fd = mkstemp(path);
+  if (fd < 0) {
+    std::remove(path);
+    return false;
   }
 
+  if (write(fd, data, data_len) != data_len) {
+    close(fd);
+    std::remove(path);
+    return false;
+  }
+
+  close(fd);
+  return true;
+}
+} // namespace
+
+class test_btf : public ::testing::Test {
+protected:
   void SetUp() override
   {
     // BTF data file

--- a/tests/btf_common.h
+++ b/tests/btf_common.h
@@ -1,8 +1,13 @@
 #pragma once
 
+#include <array>
+#include <cstdint>
+
 #include "data/btf_data.h"
 
 namespace {
+constexpr std::array<uint8_t, 4> INVALID_BTF_DATA = { 0xDE, 0xAD, 0xBE, 0xEF };
+
 bool create_tmp_with_data(char *path,
                           const unsigned char *data,
                           unsigned int data_len)
@@ -59,4 +64,29 @@ protected:
 
   char *btf_path_ = nullptr;
   char *funcs_path_ = nullptr;
+};
+
+class test_bad_btf : public ::testing::Test {
+protected:
+  void SetUp() override
+  {
+    // BTF data file
+    char *btf_path = strdup("/tmp/btf_dataXXXXXX");
+    if (create_tmp_with_data(btf_path,
+                             INVALID_BTF_DATA.data(),
+                             INVALID_BTF_DATA.size())) {
+      setenv("BPFTRACE_BTF", btf_path, true);
+      btf_path_ = btf_path;
+    }
+  }
+
+  void TearDown() override
+  {
+    // clear the environment and remove the temp files
+    unsetenv("BPFTRACE_BTF");
+    if (btf_path_)
+      std::remove(btf_path_);
+  }
+
+  char *btf_path_ = nullptr;
 };


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

btf__parse_raw() can fail and result in NULL pointer dereference
somewhere down the road, check its return value.

Without this, I get a segmentation fault when accidentally passing an
incorrect BTF file using BPFTRACE_BTF.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
