### PR TITLE
Use scratch global variable for script-dependent tuple allocations

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -27,6 +27,8 @@ aot.call.print_non_map_builtin
 aot.call.print_non_map_struct_kfunc
 aot.call.print_non_map_tuple
 # Same problem as #3392
+aot.call.str_big_for
+# Same problem as #3392
 aot.call.str_big_tuple
 aot.call.str_truncated
 aot.call.str_truncated_custom
@@ -85,6 +87,10 @@ aot.regression.kfunc double pointer dereference
 aot.tuples.basic tuple map
 # Same problem as #3392
 aot.tuples.tuple map key
+# Same problem as #3392
+aot.tuples.tuple map key and value
+# Same problem as #3392
+aot.tuples.implicit conversion of multi map key to tuple
 # Same problem as #3392
 aot.tuples.tuple map key same as assoc array
 # Same problem as #3392

--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -17,6 +17,7 @@ namespace ast {
   DO(str)                                                                      \
   DO(system)                                                                   \
   DO(time)                                                                     \
+  DO(tuple)                                                                    \
   DO(watchpoint)
 
 #define DEFINE_MEMBER_VAR(id, ...) int _##id = 0;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -498,10 +498,14 @@ Value *IRBuilderBPF::createScratchBuffer(
   auto cmp = CreateICmp(CmpInst::ICMP_ULE, cpu_id, max, "cpuid.min.cmp");
   auto select = CreateSelect(cmp, cpu_id, max, "cpuid.min.select");
 
+  // Note the 1st index is 0 because we're pointing to
+  // ValueType var[MAX_CPU_ID + 1][num_elements]
+  // 2nd/3rd/4th indexes actually index into the array
+  // See https://llvm.org/docs/LangRef.html#id236
   return CreateGEP(GetType(type),
                    CreatePointerCast(module_.getGlobalVariable(config.name),
                                      GetType(type)->getPointerTo()),
-                   { select, getInt64(key), getInt64(0) });
+                   { getInt64(0), select, getInt64(key), getInt64(0) });
 }
 
 /*

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -479,6 +479,13 @@ Value *IRBuilderBPF::CreateGetFmtStringArgsScratchBuffer(const location &loc)
       bpftrace::globalvars::GlobalVar::FMT_STRINGS_BUFFER, loc);
 }
 
+Value *IRBuilderBPF::CreateTupleScratchBuffer(const location &loc, int key)
+{
+  return createScratchBuffer(bpftrace::globalvars::GlobalVar::TUPLE_BUFFER,
+                             loc,
+                             key);
+}
+
 Value *IRBuilderBPF::createScratchBuffer(
     bpftrace::globalvars::GlobalVar globalvar,
     const location &loc,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -169,6 +169,7 @@ public:
                                    BasicBlock *failure_callback,
                                    const location &loc);
   Value *CreateGetFmtStringArgsScratchBuffer(const location &loc);
+  Value *CreateTupleScratchBuffer(const location &loc, int key);
   void CreateCheckSetRecursion(const location &loc, int early_exit_ret);
   void CreateUnSetRecursion(const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -91,10 +91,10 @@ public:
                            uint64_t max_entries,
                            const SizedType &key_type,
                            const SizedType &value_type);
-  AllocaInst *createTuple(
+  Value *createTuple(
       const SizedType &tuple_type,
       const std::vector<std::pair<llvm::Value *, const location *>> &vals,
-      const std::string &name);
+      const location &loc);
   void createTupleCopy(const SizedType &expr_type,
                        const SizedType &var_type,
                        Value *dst_val,

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -33,6 +33,8 @@ private:
   void visit(Builtin &map) override;
   void visit(Call &call) override;
   void visit(Map &map) override;
+  void visit(Tuple &tuple) override;
+  void visit(For &f) override;
 
   // Determines whether the given function uses userspace symbol resolution.
   // This is used later for loading the symbol table into memory.

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -137,6 +137,7 @@ static void update_global_vars_rodata(
         *var = bpftrace.max_cpu_id_;
         break;
       case GlobalVar::FMT_STRINGS_BUFFER:
+      case GlobalVar::TUPLE_BUFFER:
         break;
     }
   }
@@ -260,6 +261,11 @@ SizedType get_type(bpftrace::globalvars::GlobalVar global_var,
       assert(resources.max_fmtstring_args_size > 0);
       return make_rw_type(
           1, CreateArray(resources.max_fmtstring_args_size, CreateInt8()));
+    case bpftrace::globalvars::GlobalVar::TUPLE_BUFFER:
+      assert(resources.max_tuple_size > 0);
+      assert(resources.tuple_buffers > 0);
+      return make_rw_type(resources.tuple_buffers,
+                          CreateArray(resources.max_tuple_size, CreateInt8()));
   }
   return {}; // unreachable
 }

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -18,6 +18,7 @@ GlobalVar from_string(std::string_view name);
 constexpr std::string_view RO_SECTION_NAME = ".rodata";
 constexpr std::string_view FMT_STRINGS_BUFFER_SECTION_NAME =
     ".data.fmt_str_buf";
+constexpr std::string_view TUPLE_BUFFER_SECTION_NAME = ".data.tuple_buf";
 
 struct GlobalVarConfig {
   std::string name;
@@ -31,6 +32,8 @@ const std::unordered_map<GlobalVar, GlobalVarConfig> GLOBAL_VAR_CONFIGS = {
     { "max_cpu_id", std::string(RO_SECTION_NAME), true } },
   { GlobalVar::FMT_STRINGS_BUFFER,
     { "fmt_str_buf", std::string(FMT_STRINGS_BUFFER_SECTION_NAME), false } },
+  { GlobalVar::TUPLE_BUFFER,
+    { "tuple_buf", std::string(TUPLE_BUFFER_SECTION_NAME), false } },
 };
 
 void update_global_vars(

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -103,6 +103,10 @@ public:
   // rather than duplicating it in CodegenResources.
   uint64_t max_fmtstring_args_size = 0;
 
+  // Required for sizing of tuple scratch buffer
+  size_t tuple_buffers = 0;
+  size_t max_tuple_size = 0;
+
   // Async argument metadata that codegen creates. Ideally ResourceAnalyser
   // pass should be collecting this, but it's complex to move the logic.
   //

--- a/src/types.h
+++ b/src/types.h
@@ -715,8 +715,9 @@ enum class GlobalVar {
   // Max CPU ID returned by bpf_get_smp_processor_id, used for simulating
   // per-CPU maps in read-write global variables
   MAX_CPU_ID,
-  // Scratch buffer used for format strings to avoid BPF stack allocation limits
+  // Scratch buffers used to avoid BPF stack allocation limits
   FMT_STRINGS_BUFFER,
+  TUPLE_BUFFER,
 };
 
 } // namespace globalvars

--- a/tests/codegen/llvm/avg_cast.ll
+++ b/tests/codegen/llvm/avg_cast.ll
@@ -76,7 +76,7 @@ if_body:                                          ; preds = %is_negative_merge_b
   %11 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %11
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %11
-  %12 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %12 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %13 = getelementptr %print_integer_8_t, ptr %12, i64 0, i32 0
   store i64 30007, ptr %13, align 8
   %14 = getelementptr %print_integer_8_t, ptr %12, i64 0, i32 1

--- a/tests/codegen/llvm/avg_cast_loop.ll
+++ b/tests/codegen/llvm/avg_cast_loop.ll
@@ -175,7 +175,7 @@ is_negative_merge_block:                          ; preds = %is_positive, %is_ne
   %39 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %39
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %39
-  %40 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %40 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %41 = getelementptr %print_tuple_16_t, ptr %40, i64 0, i32 0
   store i64 30007, ptr %41, align 8
   %42 = getelementptr %print_tuple_16_t, ptr %40, i64 0, i32 1

--- a/tests/codegen/llvm/avg_cast_loop.ll
+++ b/tests/codegen/llvm/avg_cast_loop.ll
@@ -14,14 +14,15 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
-@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !59
-@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !67
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !57
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !65
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !67
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !74
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !79 {
 entry:
   %avg_struct = alloca %avg_stas_val, align 8
   %"@x_key" = alloca i64, align 8
@@ -66,10 +67,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !78 {
-  %key1 = alloca i32, align 4
-  %tuple = alloca %int64_avg__tuple_t, align 8
-  %"$kv" = alloca %int64_avg__tuple_t, align 8
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !85 {
+  %key7 = alloca i32, align 4
   %ret = alloca i64, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
@@ -155,58 +154,65 @@ is_negative_merge_block:                          ; preds = %is_positive, %is_ne
   call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %31 = getelementptr %int64_avg__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %31, align 8
-  %32 = getelementptr %int64_avg__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %30, ptr %32, align 8
-  %33 = getelementptr %int64_avg__tuple_t, ptr %"$kv", i32 0, i32 0
-  %34 = load i64, ptr %33, align 8
-  %35 = getelementptr %int64_avg__tuple_t, ptr %"$kv", i32 0, i32 1
-  %36 = load i64, ptr %35, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %37 = getelementptr %int64_avg__tuple_t, ptr %tuple, i32 0, i32 0
-  store i64 %34, ptr %37, align 8
-  %38 = getelementptr %int64_avg__tuple_t, ptr %tuple, i32 0, i32 1
-  store i64 %36, ptr %38, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %31 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %31
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %31
+  %32 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %32, i8 0, i64 16, i1 false)
+  %33 = getelementptr %int64_avg__tuple_t, ptr %32, i32 0, i32 0
+  store i64 %key, ptr %33, align 8
+  %34 = getelementptr %int64_avg__tuple_t, ptr %32, i32 0, i32 1
+  store i64 %30, ptr %34, align 8
+  %35 = getelementptr %int64_avg__tuple_t, ptr %32, i32 0, i32 0
+  %36 = load i64, ptr %35, align 8
+  %37 = getelementptr %int64_avg__tuple_t, ptr %32, i32 0, i32 1
+  %38 = load i64, ptr %37, align 8
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %39 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %39
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %39
-  %40 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %41 = getelementptr %print_tuple_16_t, ptr %40, i64 0, i32 0
-  store i64 30007, ptr %41, align 8
-  %42 = getelementptr %print_tuple_16_t, ptr %40, i64 0, i32 1
-  store i64 0, ptr %42, align 8
-  %43 = getelementptr %print_tuple_16_t, ptr %40, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %43, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %43, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %40, i64 32, i64 0)
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %39
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %39
+  %40 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %40, i8 0, i64 16, i1 false)
+  %41 = getelementptr %int64_avg__tuple_t, ptr %40, i32 0, i32 0
+  store i64 %36, ptr %41, align 8
+  %42 = getelementptr %int64_avg__tuple_t, ptr %40, i32 0, i32 1
+  store i64 %38, ptr %42, align 8
+  %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
+  %43 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp5 = icmp ule i64 %get_cpu_id4, %43
+  %cpuid.min.select6 = select i1 %cpuid.min.cmp5, i64 %get_cpu_id4, i64 %43
+  %44 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select6, i64 0, i64 0
+  %45 = getelementptr %print_tuple_16_t, ptr %44, i64 0, i32 0
+  store i64 30007, ptr %45, align 8
+  %46 = getelementptr %print_tuple_16_t, ptr %44, i64 0, i32 1
+  store i64 0, ptr %46, align 8
+  %47 = getelementptr %print_tuple_16_t, ptr %44, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %47, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %47, ptr align 1 %40, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %44, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %is_negative_merge_block
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
-  store i32 0, ptr %key1, align 4
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
-  %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
-  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key7)
+  store i32 0, ptr %key7, align 4
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key7)
+  %map_lookup_cond10 = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond10, label %lookup_success8, label %lookup_failure9
 
 counter_merge:                                    ; preds = %lookup_merge, %is_negative_merge_block
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
-lookup_success2:                                  ; preds = %event_loss_counter
-  %44 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+lookup_success8:                                  ; preds = %event_loss_counter
+  %48 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
-lookup_failure3:                                  ; preds = %event_loss_counter
+lookup_failure9:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key1)
+lookup_merge:                                     ; preds = %lookup_failure9, %lookup_success8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key7)
   br label %counter_merge
 }
 
@@ -221,8 +227,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!69}
-!llvm.module.flags = !{!71}
+!llvm.dbg.cu = !{!76}
+!llvm.module.flags = !{!78}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -282,26 +288,33 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
-!60 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
-!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 256, elements: !52)
-!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 256, elements: !52)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 256, elements: !65)
-!64 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!65 = !{!66}
-!66 = !DISubrange(count: 32, lowerBound: 0)
+!58 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 256, elements: !52)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !61, size: 256, elements: !47)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 128, elements: !63)
+!62 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!63 = !{!64}
+!64 = !DISubrange(count: 16, lowerBound: 0)
+!65 = !DIGlobalVariableExpression(var: !66, expr: !DIExpression())
+!66 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
 !67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
-!68 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!69 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !70)
-!70 = !{!0, !26, !40, !57, !59, !67}
-!71 = !{i32 2, !"Debug Info Version", i32 3}
-!72 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !69, retainedNodes: !76)
-!73 = !DISubroutineType(types: !74)
-!74 = !{!18, !75}
-!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
-!76 = !{!77}
-!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !75)
-!78 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !69, retainedNodes: !79)
-!79 = !{!80}
-!80 = !DILocalVariable(name: "ctx", arg: 1, scope: !78, file: !2, type: !75)
+!68 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !69, isLocal: false, isDefinition: true)
+!69 = !DICompositeType(tag: DW_TAG_array_type, baseType: !70, size: 256, elements: !52)
+!70 = !DICompositeType(tag: DW_TAG_array_type, baseType: !71, size: 256, elements: !52)
+!71 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 256, elements: !72)
+!72 = !{!73}
+!73 = !DISubrange(count: 32, lowerBound: 0)
+!74 = !DIGlobalVariableExpression(var: !75, expr: !DIExpression())
+!75 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!76 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !77)
+!77 = !{!0, !26, !40, !57, !65, !67, !74}
+!78 = !{i32 2, !"Debug Info Version", i32 3}
+!79 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !80, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !76, retainedNodes: !83)
+!80 = !DISubroutineType(types: !81)
+!81 = !{!18, !82}
+!82 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
+!83 = !{!84}
+!84 = !DILocalVariable(name: "ctx", arg: 1, scope: !79, file: !2, type: !82)
+!85 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !80, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !76, retainedNodes: !86)
+!86 = !{!87}
+!87 = !DILocalVariable(name: "ctx", arg: 1, scope: !85, file: !2, type: !82)

--- a/tests/codegen/llvm/call_cat.ll
+++ b/tests/codegen/llvm/call_cat.ll
@@ -23,7 +23,7 @@ entry:
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 8, i1 false)
   %3 = getelementptr %cat_t, ptr %2, i32 0, i32 0
   store i64 20000, ptr %3, align 8

--- a/tests/codegen/llvm/call_cgroup_path.ll
+++ b/tests/codegen/llvm/call_cgroup_path.ll
@@ -31,7 +31,7 @@ entry:
   %3 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %5 = getelementptr %print_cgroup_path_16_t, ptr %4, i64 0, i32 0
   store i64 30007, ptr %5, align 8
   %6 = getelementptr %print_cgroup_path_16_t, ptr %4, i64 0, i32 1

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -35,7 +35,7 @@ entry:
   %3 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %5 = getelementptr %print_tuple_16_t, ptr %4, i64 0, i32 0
   store i64 30007, ptr %5, align 8
   %6 = getelementptr %print_tuple_16_t, ptr %4, i64 0, i32 1

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -11,39 +11,43 @@ target triple = "bpf-pc-linux"
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
-@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
+@tuple_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !44
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !46
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
 entry:
   %key = alloca i32, align 4
-  %tuple = alloca %"int64_string[4]__tuple_t", align 8
   %str = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [4 x i8] c"abc\00", ptr %str, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %"int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 0
-  store i64 1, ptr %1, align 8
-  %2 = getelementptr %"int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 4, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %3 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %5 = getelementptr %print_tuple_16_t, ptr %4, i64 0, i32 0
-  store i64 30007, ptr %5, align 8
-  %6 = getelementptr %print_tuple_16_t, ptr %4, i64 0, i32 1
-  store i64 0, ptr %6, align 8
-  %7 = getelementptr %print_tuple_16_t, ptr %4, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 32, i64 0)
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %"int64_string[4]__tuple_t", ptr %2, i32 0, i32 0
+  store i64 1, ptr %3, align 8
+  %4 = getelementptr %"int64_string[4]__tuple_t", ptr %2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %str, i64 4, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %5
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %5
+  %6 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
+  %7 = getelementptr %print_tuple_16_t, ptr %6, i64 0, i32 0
+  store i64 30007, ptr %7, align 8
+  %8 = getelementptr %print_tuple_16_t, ptr %6, i64 0, i32 1
+  store i64 0, ptr %8, align 8
+  %9 = getelementptr %print_tuple_16_t, ptr %6, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %2, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -55,11 +59,10 @@ event_loss_counter:                               ; preds = %entry
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 counter_merge:                                    ; preds = %lookup_merge, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -87,8 +90,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!55}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -127,21 +130,28 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 256, elements: !28)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 256, elements: !28)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 256, elements: !44)
-!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!44 = !{!45}
-!45 = !DISubrange(count: 32, lowerBound: 0)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !16, !36, !38}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
-!50 = !DISubroutineType(types: !51)
-!51 = !{!35, !52}
-!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!53 = !{!54}
-!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)
+!37 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 128, elements: !28)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 128, elements: !28)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 128, elements: !42)
+!41 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!42 = !{!43}
+!43 = !DISubrange(count: 16, lowerBound: 0)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !48, isLocal: false, isDefinition: true)
+!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !49, size: 256, elements: !28)
+!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !50, size: 256, elements: !28)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 256, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 32, lowerBound: 0)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
+!54 = !{!0, !16, !36, !44, !46}
+!55 = !{i32 2, !"Debug Info Version", i32 3}
+!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
+!57 = !DISubroutineType(types: !58)
+!58 = !{!35, !59}
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
+!60 = !{!61}
+!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -23,7 +23,7 @@ entry:
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %3 = getelementptr %print_integer_8_t, ptr %2, i64 0, i32 0
   store i64 30007, ptr %3, align 8
   %4 = getelementptr %print_integer_8_t, ptr %2, i64 0, i32 1

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -31,7 +31,7 @@ entry:
   %2 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %2
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %2
-  %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %3, i8 0, i64 24, i1 false)
   %4 = getelementptr %printf_t, ptr %3, i32 0, i32 0
   store i64 0, ptr %4, align 8

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -25,7 +25,7 @@ entry:
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 24, i1 false)
   %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
   store i64 0, ptr %3, align 8

--- a/tests/codegen/llvm/call_system.ll
+++ b/tests/codegen/llvm/call_system.ll
@@ -23,7 +23,7 @@ entry:
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %system_t, ptr %2, i32 0, i32 0
   store i64 10000, ptr %3, align 8

--- a/tests/codegen/llvm/count_cast.ll
+++ b/tests/codegen/llvm/count_cast.ll
@@ -67,7 +67,7 @@ if_body:                                          ; preds = %while_end
   %3 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %4 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %5 = getelementptr %print_integer_8_t, ptr %4, i64 0, i32 0
   store i64 30007, ptr %5, align 8
   %6 = getelementptr %print_integer_8_t, ptr %4, i64 0, i32 1

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -114,7 +114,7 @@ while_end:                                        ; preds = %error_failure, %err
   %17 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
-  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
   store i64 30007, ptr %19, align 8
   %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -13,14 +13,15 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !51
-@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !53
-@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !61
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !51
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !59
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !61
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !68
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !66 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !73 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -58,10 +59,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !72 {
-  %key1 = alloca i32, align 4
-  %tuple = alloca %int64_count__tuple_t, align 8
-  %"$kv" = alloca %int64_count__tuple_t, align 8
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !79 {
+  %key7 = alloca i32, align 4
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -94,80 +93,87 @@ while_end:                                        ; preds = %error_failure, %err
   %8 = load i64, ptr %val_1, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %9 = getelementptr %int64_count__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %int64_count__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %8, ptr %10, align 8
-  %11 = getelementptr %int64_count__tuple_t, ptr %"$kv", i32 0, i32 0
-  %12 = load i64, ptr %11, align 8
-  %13 = getelementptr %int64_count__tuple_t, ptr %"$kv", i32 0, i32 1
-  %14 = load i64, ptr %13, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %15 = getelementptr %int64_count__tuple_t, ptr %tuple, i32 0, i32 0
-  store i64 %12, ptr %15, align 8
-  %16 = getelementptr %int64_count__tuple_t, ptr %tuple, i32 0, i32 1
-  store i64 %14, ptr %16, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %9 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
+  %10 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
+  %11 = getelementptr %int64_count__tuple_t, ptr %10, i32 0, i32 0
+  store i64 %key, ptr %11, align 8
+  %12 = getelementptr %int64_count__tuple_t, ptr %10, i32 0, i32 1
+  store i64 %8, ptr %12, align 8
+  %13 = getelementptr %int64_count__tuple_t, ptr %10, i32 0, i32 0
+  %14 = load i64, ptr %13, align 8
+  %15 = getelementptr %int64_count__tuple_t, ptr %10, i32 0, i32 1
+  %16 = load i64, ptr %15, align 8
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %17 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
-  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
-  store i64 30007, ptr %19, align 8
-  %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1
-  store i64 0, ptr %20, align 8
-  %21 = getelementptr %print_tuple_16_t, ptr %18, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %21, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %21, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %18, i64 32, i64 0)
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %17
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %17
+  %18 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 16, i1 false)
+  %19 = getelementptr %int64_count__tuple_t, ptr %18, i32 0, i32 0
+  store i64 %14, ptr %19, align 8
+  %20 = getelementptr %int64_count__tuple_t, ptr %18, i32 0, i32 1
+  store i64 %16, ptr %20, align 8
+  %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
+  %21 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp5 = icmp ule i64 %get_cpu_id4, %21
+  %cpuid.min.select6 = select i1 %cpuid.min.cmp5, i64 %get_cpu_id4, i64 %21
+  %22 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select6, i64 0, i64 0
+  %23 = getelementptr %print_tuple_16_t, ptr %22, i64 0, i32 0
+  store i64 30007, ptr %23, align 8
+  %24 = getelementptr %print_tuple_16_t, ptr %22, i64 0, i32 1
+  store i64 0, ptr %24, align 8
+  %25 = getelementptr %print_tuple_16_t, ptr %22, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %25, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %25, ptr align 1 %18, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %22, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %22 = load i64, ptr %val_1, align 8
-  %23 = load i64, ptr %lookup_percpu_elem, align 8
-  %24 = add i64 %23, %22
-  store i64 %24, ptr %val_1, align 8
-  %25 = load i32, ptr %i, align 4
-  %26 = add i32 %25, 1
-  store i32 %26, ptr %i, align 4
+  %26 = load i64, ptr %val_1, align 8
+  %27 = load i64, ptr %lookup_percpu_elem, align 8
+  %28 = add i64 %27, %26
+  store i64 %28, ptr %val_1, align 8
+  %29 = load i32, ptr %i, align 4
+  %30 = add i32 %29, 1
+  store i32 %30, ptr %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %27 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %27, 0
+  %31 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %31, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %28 = load i32, ptr %i, align 4
+  %32 = load i32, ptr %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
-  store i32 0, ptr %key1, align 4
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
-  %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
-  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key7)
+  store i32 0, ptr %key7, align 4
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key7)
+  %map_lookup_cond10 = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond10, label %lookup_success8, label %lookup_failure9
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
-lookup_success2:                                  ; preds = %event_loss_counter
-  %29 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+lookup_success8:                                  ; preds = %event_loss_counter
+  %33 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
-lookup_failure3:                                  ; preds = %event_loss_counter
+lookup_failure9:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key1)
+lookup_merge:                                     ; preds = %lookup_failure9, %lookup_success8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key7)
   br label %counter_merge
 }
 
@@ -182,8 +188,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!63}
-!llvm.module.flags = !{!65}
+!llvm.dbg.cu = !{!70}
+!llvm.module.flags = !{!72}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -237,26 +243,33 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
-!54 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
-!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 256, elements: !46)
-!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 256, elements: !46)
-!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 256, elements: !59)
-!58 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!59 = !{!60}
-!60 = !DISubrange(count: 32, lowerBound: 0)
+!52 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 256, elements: !46)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 256, elements: !41)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 128, elements: !57)
+!56 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!57 = !{!58}
+!58 = !DISubrange(count: 16, lowerBound: 0)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
 !61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
-!62 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!63 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !64)
-!64 = !{!0, !20, !34, !51, !53, !61}
-!65 = !{i32 2, !"Debug Info Version", i32 3}
-!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !63, retainedNodes: !70)
-!67 = !DISubroutineType(types: !68)
-!68 = !{!18, !69}
-!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
-!70 = !{!71}
-!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)
-!72 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !63, retainedNodes: !73)
-!73 = !{!74}
-!74 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !69)
+!62 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !63, isLocal: false, isDefinition: true)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 256, elements: !46)
+!64 = !DICompositeType(tag: DW_TAG_array_type, baseType: !65, size: 256, elements: !46)
+!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 256, elements: !66)
+!66 = !{!67}
+!67 = !DISubrange(count: 32, lowerBound: 0)
+!68 = !DIGlobalVariableExpression(var: !69, expr: !DIExpression())
+!69 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!70 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !71)
+!71 = !{!0, !20, !34, !51, !59, !61, !68}
+!72 = !{i32 2, !"Debug Info Version", i32 3}
+!73 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !74, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !70, retainedNodes: !77)
+!74 = !DISubroutineType(types: !75)
+!75 = !{!18, !76}
+!76 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
+!77 = !{!78}
+!78 = !DILocalVariable(name: "ctx", arg: 1, scope: !73, file: !2, type: !76)
+!79 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !74, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !70, retainedNodes: !80)
+!80 = !{!81}
+!81 = !DILocalVariable(name: "ctx", arg: 1, scope: !79, file: !2, type: !76)

--- a/tests/codegen/llvm/for_map_one_key.ll
+++ b/tests/codegen/llvm/for_map_one_key.ll
@@ -14,11 +14,13 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !53
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
+@tuple_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !59
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !60 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !70 {
 entry:
   %"@map_val" = alloca i64, align 8
   %"@map_key" = alloca i64, align 8
@@ -39,20 +41,23 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !67 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !76 {
   %"@x_key" = alloca i64, align 8
-  %"$kv" = alloca %int64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %5, align 8
-  %6 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %6, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"$kv", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %6, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
@@ -64,8 +69,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!57}
-!llvm.module.flags = !{!59}
+!llvm.dbg.cu = !{!67}
+!llvm.module.flags = !{!69}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -124,16 +129,25 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !54 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
 !55 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !56)
 !56 = !{!24, !29, !30, !19}
-!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
-!58 = !{!0, !20, !39, !53}
-!59 = !{i32 2, !"Debug Info Version", i32 3}
-!60 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !65)
-!61 = !DISubroutineType(types: !62)
-!62 = !{!18, !63}
-!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 128, elements: !9)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 128, elements: !9)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 128, elements: !65)
 !64 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !65 = !{!66}
-!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !63)
-!67 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !57, retainedNodes: !68)
-!68 = !{!69}
-!69 = !DILocalVariable(name: "ctx", arg: 1, scope: !67, file: !2, type: !63)
+!66 = !DISubrange(count: 16, lowerBound: 0)
+!67 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !68)
+!68 = !{!0, !20, !39, !53, !57, !59}
+!69 = !{i32 2, !"Debug Info Version", i32 3}
+!70 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !71, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !67, retainedNodes: !74)
+!71 = !DISubroutineType(types: !72)
+!72 = !{!18, !73}
+!73 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
+!74 = !{!75}
+!75 = !DILocalVariable(name: "ctx", arg: 1, scope: !70, file: !2, type: !73)
+!76 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !71, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !67, retainedNodes: !77)
+!77 = !{!78}
+!78 = !DILocalVariable(name: "ctx", arg: 1, scope: !76, file: !2, type: !73)

--- a/tests/codegen/llvm/for_map_strings.ll
+++ b/tests/codegen/llvm/for_map_strings.ll
@@ -14,11 +14,13 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !23
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !42
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !56
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !63
+@tuple_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !65
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !66 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !75 {
 entry:
   %str1 = alloca [4 x i8], align 1
   %str = alloca [4 x i8], align 1
@@ -38,18 +40,21 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !72 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !81 {
   %"@x_key" = alloca i64, align 8
-  %"$kv" = alloca %"string[4]_string[4]__tuple_t", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 8, i1 false)
-  %5 = getelementptr %"string[4]_string[4]__tuple_t", ptr %"$kv", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %1, i64 4, i1 false)
-  %6 = getelementptr %"string[4]_string[4]__tuple_t", ptr %"$kv", i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %2, i64 4, i1 false)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
+  %7 = getelementptr %"string[4]_string[4]__tuple_t", ptr %6, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %1, i64 4, i1 false)
+  %8 = getelementptr %"string[4]_string[4]__tuple_t", ptr %6, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %2, i64 4, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"$kv", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %6, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
@@ -65,8 +70,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!63}
-!llvm.module.flags = !{!65}
+!llvm.dbg.cu = !{!72}
+!llvm.module.flags = !{!74}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -131,15 +136,24 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !60 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !61, size: 64, offset: 192)
 !61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
 !62 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!63 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !64)
-!64 = !{!0, !23, !42, !56}
-!65 = !{i32 2, !"Debug Info Version", i32 3}
-!66 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !63, retainedNodes: !70)
-!67 = !DISubroutineType(types: !68)
-!68 = !{!62, !69}
-!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!63 = !DIGlobalVariableExpression(var: !64, expr: !DIExpression())
+!64 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !62, isLocal: false, isDefinition: true)
+!65 = !DIGlobalVariableExpression(var: !66, expr: !DIExpression())
+!66 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !67, isLocal: false, isDefinition: true)
+!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !68, size: 64, elements: !9)
+!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 64, elements: !9)
+!69 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 64, elements: !70)
 !70 = !{!71}
-!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)
-!72 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !63, retainedNodes: !73)
-!73 = !{!74}
-!74 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !69)
+!71 = !DISubrange(count: 8, lowerBound: 0)
+!72 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !73)
+!73 = !{!0, !23, !42, !56, !63, !65}
+!74 = !{i32 2, !"Debug Info Version", i32 3}
+!75 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !76, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !72, retainedNodes: !79)
+!76 = !DISubroutineType(types: !77)
+!77 = !{!62, !78}
+!78 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!79 = !{!80}
+!80 = !DILocalVariable(name: "ctx", arg: 1, scope: !75, file: !2, type: !78)
+!81 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !76, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !72, retainedNodes: !82)
+!82 = !{!83}
+!83 = !DILocalVariable(name: "ctx", arg: 1, scope: !81, file: !2, type: !78)

--- a/tests/codegen/llvm/for_map_two_keys.ll
+++ b/tests/codegen/llvm/for_map_two_keys.ll
@@ -15,50 +15,58 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !44
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !58
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !62
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [24 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !64
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !65 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !75 {
 entry:
   %"@map_val" = alloca i64, align 8
-  %tuple = alloca %int64_int64__tuple_t, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %int64_int64__tuple_t, ptr %tuple, i32 0, i32 0
-  store i64 16, ptr %1, align 8
-  %2 = getelementptr %int64_int64__tuple_t, ptr %tuple, i32 0, i32 1
-  store i64 17, ptr %2, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %int64_int64__tuple_t, ptr %2, i32 0, i32 0
+  store i64 16, ptr %3, align 8
+  %4 = getelementptr %int64_int64__tuple_t, ptr %2, i32 0, i32 1
+  store i64 17, ptr %4, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
   store i64 32, ptr %"@map_val", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %tuple, ptr %"@map_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %2, ptr %"@map_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_val")
   %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_map, ptr @map_for_each_cb, ptr null, i64 0)
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !72 {
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !81 {
   %"@x_key" = alloca i64, align 8
-  %"$kv" = alloca %"(int64,int64)_int64__tuple_t", align 8
   %val = load i64, ptr %2, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 24, i1 false)
-  %5 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %"$kv", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %1, i64 16, i1 false)
-  %6 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %6, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 24, i1 false)
+  %7 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %6, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %1, i64 16, i1 false)
+  %8 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"$kv", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %6, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
@@ -67,12 +75,12 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!62}
-!llvm.module.flags = !{!64}
+!llvm.dbg.cu = !{!72}
+!llvm.module.flags = !{!74}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -136,16 +144,25 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !59 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !60, isLocal: false, isDefinition: true)
 !60 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !61)
 !61 = !{!29, !34, !35, !23}
-!62 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !63)
-!63 = !{!0, !25, !44, !58}
-!64 = !{i32 2, !"Debug Info Version", i32 3}
-!65 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !66, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !62, retainedNodes: !70)
-!66 = !DISubroutineType(types: !67)
-!67 = !{!21, !68}
-!68 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
+!62 = !DIGlobalVariableExpression(var: !63, expr: !DIExpression())
+!63 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!64 = !DIGlobalVariableExpression(var: !65, expr: !DIExpression())
+!65 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !66, isLocal: false, isDefinition: true)
+!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !67, size: 384, elements: !9)
+!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !68, size: 384, elements: !32)
+!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 192, elements: !70)
 !69 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !70 = !{!71}
-!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !65, file: !2, type: !68)
-!72 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !66, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !62, retainedNodes: !73)
-!73 = !{!74}
-!74 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !68)
+!71 = !DISubrange(count: 24, lowerBound: 0)
+!72 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !73)
+!73 = !{!0, !25, !44, !58, !62, !64}
+!74 = !{i32 2, !"Debug Info Version", i32 3}
+!75 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !76, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !72, retainedNodes: !79)
+!76 = !DISubroutineType(types: !77)
+!77 = !{!21, !78}
+!78 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
+!79 = !{!80}
+!80 = !DILocalVariable(name: "ctx", arg: 1, scope: !75, file: !2, type: !78)
+!81 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !76, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !72, retainedNodes: !82)
+!82 = !{!83}
+!83 = !DILocalVariable(name: "ctx", arg: 1, scope: !81, file: !2, type: !78)

--- a/tests/codegen/llvm/for_map_variables.ll
+++ b/tests/codegen/llvm/for_map_variables.ll
@@ -16,13 +16,14 @@ target triple = "bpf-pc-linux"
 @AT_map = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !33
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !47
-@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !49
-@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [20 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !51
+@tuple_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !49
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [20 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !59
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !62 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !69 {
 entry:
   %"@len_val" = alloca i64, align 8
   %"@len_key" = alloca i64, align 8
@@ -85,44 +86,47 @@ declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 i
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !68 {
-  %key1 = alloca i32, align 4
-  %"$kv" = alloca %int64_int64__tuple_t, align 8
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !75 {
+  %key4 = alloca i32, align 4
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %5, align 8
-  %6 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %6, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   %"ctx.$var1" = getelementptr %ctx_t, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8
   %"ctx.$var3" = getelementptr %ctx_t, ptr %3, i64 0, i32 1
   %"$var3" = load ptr, ptr %"ctx.$var3", align 8
-  %7 = load i64, ptr %"$var1", align 8
-  %8 = add i64 %7, 1
-  store i64 %8, ptr %"$var1", align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %9 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
-  %10 = getelementptr [1 x [1 x [20 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %11 = getelementptr %print_string_4_t, ptr %10, i64 0, i32 0
-  store i64 30007, ptr %11, align 8
-  %12 = getelementptr %print_string_4_t, ptr %10, i64 0, i32 1
-  store i64 0, ptr %12, align 8
-  %13 = getelementptr %print_string_4_t, ptr %10, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %13, i8 0, i64 4, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 %"$var3", i64 4, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %10, i64 20, i64 0)
+  %9 = load i64, ptr %"$var1", align 8
+  %10 = add i64 %9, 1
+  store i64 %10, ptr %"$var1", align 8
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %11 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %11
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %11
+  %12 = getelementptr [1 x [1 x [20 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
+  %13 = getelementptr %print_string_4_t, ptr %12, i64 0, i32 0
+  store i64 30007, ptr %13, align 8
+  %14 = getelementptr %print_string_4_t, ptr %12, i64 0, i32 1
+  store i64 0, ptr %14, align 8
+  %15 = getelementptr %print_string_4_t, ptr %12, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %15, i8 0, i64 4, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %15, ptr align 1 %"$var3", i64 4, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %12, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
-  store i32 0, ptr %key1, align 4
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key4)
+  store i32 0, ptr %key4, align 4
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key4)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
@@ -130,14 +134,14 @@ counter_merge:                                    ; preds = %lookup_merge, %4
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %14 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %16 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key4)
   br label %counter_merge
 }
 
@@ -146,8 +150,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!59}
-!llvm.module.flags = !{!61}
+!llvm.dbg.cu = !{!66}
+!llvm.module.flags = !{!68}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_len", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -199,24 +203,31 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
 !48 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
 !49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
-!50 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 160, elements: !14)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 160, elements: !14)
-!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 160, elements: !57)
-!56 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!57 = !{!58}
-!58 = !DISubrange(count: 20, lowerBound: 0)
-!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
-!60 = !{!0, !22, !33, !47, !49, !51}
-!61 = !{i32 2, !"Debug Info Version", i32 3}
-!62 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !66)
-!63 = !DISubroutineType(types: !64)
-!64 = !{!21, !65}
-!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
-!66 = !{!67}
-!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !65)
-!68 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !59, retainedNodes: !69)
-!69 = !{!70}
-!70 = !DILocalVariable(name: "ctx", arg: 1, scope: !68, file: !2, type: !65)
+!50 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !51, isLocal: false, isDefinition: true)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !52, size: 128, elements: !14)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 128, elements: !14)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 128, elements: !55)
+!54 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!55 = !{!56}
+!56 = !DISubrange(count: 16, lowerBound: 0)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 160, elements: !14)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 160, elements: !14)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 160, elements: !64)
+!64 = !{!65}
+!65 = !DISubrange(count: 20, lowerBound: 0)
+!66 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !67)
+!67 = !{!0, !22, !33, !47, !49, !57, !59}
+!68 = !{i32 2, !"Debug Info Version", i32 3}
+!69 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !70, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !66, retainedNodes: !73)
+!70 = !DISubroutineType(types: !71)
+!71 = !{!21, !72}
+!72 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!73 = !{!74}
+!74 = !DILocalVariable(name: "ctx", arg: 1, scope: !69, file: !2, type: !72)
+!75 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !70, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !66, retainedNodes: !76)
+!76 = !{!77}
+!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !75, file: !2, type: !72)

--- a/tests/codegen/llvm/for_map_variables.ll
+++ b/tests/codegen/llvm/for_map_variables.ll
@@ -107,7 +107,7 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %9 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
-  %10 = getelementptr [1 x [1 x [20 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %10 = getelementptr [1 x [1 x [20 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %11 = getelementptr %print_string_4_t, ptr %10, i64 0, i32 0
   store i64 30007, ptr %11, align 8
   %12 = getelementptr %print_string_4_t, ptr %10, i64 0, i32 1

--- a/tests/codegen/llvm/for_map_variables_multiple_loops.ll
+++ b/tests/codegen/llvm/for_map_variables_multiple_loops.ll
@@ -14,11 +14,13 @@ target triple = "bpf-pc-linux"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !47
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !49
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !50 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !60 {
 entry:
   %ctx1 = alloca %ctx_t.2, align 8
   %ctx = alloca %ctx_t, align 8
@@ -58,47 +60,53 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !57 {
-  %"$_" = alloca %int64_int64__tuple_t, align 8
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !66 {
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$_")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$_", i8 0, i64 16, i1 false)
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$_", i32 0, i32 0
-  store i64 %key, ptr %5, align 8
-  %6 = getelementptr %int64_int64__tuple_t, ptr %"$_", i32 0, i32 1
-  store i64 %val, ptr %6, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   %"ctx.$var1" = getelementptr %ctx_t, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8
-  %7 = load i64, ptr %"$var1", align 8
-  %8 = add i64 %7, 1
-  store i64 %8, ptr %"$var1", align 8
+  %9 = load i64, ptr %"$var1", align 8
+  %10 = add i64 %9, 1
+  store i64 %10, ptr %"$var1", align 8
   ret i64 0
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
-define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !60 {
-  %"$_" = alloca %int64_int64__tuple_t, align 8
+define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !69 {
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$_")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$_", i8 0, i64 16, i1 false)
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$_", i32 0, i32 0
-  store i64 %key, ptr %5, align 8
-  %6 = getelementptr %int64_int64__tuple_t, ptr %"$_", i32 0, i32 1
-  store i64 %val, ptr %6, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   %"ctx.$var1" = getelementptr %ctx_t.2, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8
   %"ctx.$var2" = getelementptr %ctx_t.2, ptr %3, i64 0, i32 1
   %"$var2" = load ptr, ptr %"ctx.$var2", align 8
-  %7 = load i64, ptr %"$var1", align 8
-  %8 = add i64 %7, 1
-  store i64 %8, ptr %"$var1", align 8
-  %9 = load i64, ptr %"$var2", align 8
+  %9 = load i64, ptr %"$var1", align 8
   %10 = add i64 %9, 1
-  store i64 %10, ptr %"$var2", align 8
+  store i64 %10, ptr %"$var1", align 8
+  %11 = load i64, ptr %"$var2", align 8
+  %12 = add i64 %11, 1
+  store i64 %12, ptr %"$var2", align 8
   ret i64 0
 }
 
@@ -106,8 +114,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!47}
-!llvm.module.flags = !{!49}
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!59}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -156,19 +164,28 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !44 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !45, size: 64, offset: 128)
 !45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
 !46 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
-!48 = !{!0, !20, !34}
-!49 = !{i32 2, !"Debug Info Version", i32 3}
-!50 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !55)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!18, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
+!48 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
+!50 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !51, isLocal: false, isDefinition: true)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !52, size: 256, elements: !9)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 256, elements: !41)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 128, elements: !55)
 !54 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !55 = !{!56}
-!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
-!57 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !47, retainedNodes: !58)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !53)
-!60 = distinct !DISubprogram(name: "map_for_each_cb_1", linkageName: "map_for_each_cb_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !47, retainedNodes: !61)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !53)
+!56 = !DISubrange(count: 16, lowerBound: 0)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
+!58 = !{!0, !20, !34, !47, !49}
+!59 = !{i32 2, !"Debug Info Version", i32 3}
+!60 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !64)
+!61 = !DISubroutineType(types: !62)
+!62 = !{!18, !63}
+!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!64 = !{!65}
+!65 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !63)
+!66 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !57, retainedNodes: !67)
+!67 = !{!68}
+!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !63)
+!69 = distinct !DISubprogram(name: "map_for_each_cb_1", linkageName: "map_for_each_cb_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !57, retainedNodes: !70)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !69, file: !2, type: !63)

--- a/tests/codegen/llvm/for_map_variables_scope.ll
+++ b/tests/codegen/llvm/for_map_variables_scope.ll
@@ -12,11 +12,13 @@ target triple = "bpf-pc-linux"
 @AT_map = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !47
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !49
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !50 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !60 {
 entry:
   %"@map_val" = alloca i64, align 8
   %"@map_key" = alloca i64, align 8
@@ -38,19 +40,22 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !57 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !66 {
   %"$var" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
   store i64 0, ptr %"$var", align 8
-  %"$kv" = alloca %int64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %5, align 8
-  %6 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %6, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   store i64 1, ptr %"$var", align 8
   ret i64 0
 }
@@ -58,19 +63,22 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
-define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !60 {
+define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !69 {
   %"$var" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
   store i64 0, ptr %"$var", align 8
-  %"$kv" = alloca %int64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %5, align 8
-  %6 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %6, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   store i64 1, ptr %"$var", align 8
   ret i64 0
 }
@@ -79,8 +87,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!47}
-!llvm.module.flags = !{!49}
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!59}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -129,19 +137,28 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !44 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !45, size: 64, offset: 128)
 !45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
 !46 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
-!48 = !{!0, !20, !34}
-!49 = !{i32 2, !"Debug Info Version", i32 3}
-!50 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !55)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!18, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
+!48 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
+!50 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !51, isLocal: false, isDefinition: true)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !52, size: 256, elements: !9)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 256, elements: !41)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 128, elements: !55)
 !54 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !55 = !{!56}
-!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
-!57 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !47, retainedNodes: !58)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !53)
-!60 = distinct !DISubprogram(name: "map_for_each_cb_1", linkageName: "map_for_each_cb_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !47, retainedNodes: !61)
-!61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !53)
+!56 = !DISubrange(count: 16, lowerBound: 0)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
+!58 = !{!0, !20, !34, !47, !49}
+!59 = !{i32 2, !"Debug Info Version", i32 3}
+!60 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !64)
+!61 = !DISubroutineType(types: !62)
+!62 = !{!18, !63}
+!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!64 = !{!65}
+!65 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !63)
+!66 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !57, retainedNodes: !67)
+!67 = !{!68}
+!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !63)
+!69 = distinct !DISubprogram(name: "map_for_each_cb_1", linkageName: "map_for_each_cb_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !57, retainedNodes: !70)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !69, file: !2, type: !63)

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -33,7 +33,7 @@ if_body:                                          ; preds = %entry
   %4 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
   %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
   store i64 0, ptr %6, align 8
@@ -49,7 +49,7 @@ else_body:                                        ; preds = %entry
   %7 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %7
   %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %7
-  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select3, i64 0, i64 0
+  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 8, i1 false)
   %9 = getelementptr %printf_t.1, ptr %8, i32 0, i32 0
   store i64 1, ptr %9, align 8

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -38,7 +38,7 @@ if_end:                                           ; preds = %else_body, %if_body
   %4 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
   %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
   store i64 0, ptr %6, align 8

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -43,7 +43,7 @@ if_body1:                                         ; preds = %if_body
   %8 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %8
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %8
-  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
   %10 = getelementptr %printf_t, ptr %9, i32 0, i32 0
   store i64 0, ptr %10, align 8

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -31,7 +31,7 @@ if_body:                                          ; preds = %entry
   %4 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
   %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
   store i64 0, ptr %6, align 8

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -38,7 +38,7 @@ if_end:                                           ; preds = %if_body, %entry
   %4 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
   %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
   store i64 0, ptr %6, align 8

--- a/tests/codegen/llvm/kfunc_recursion_check.ll
+++ b/tests/codegen/llvm/kfunc_recursion_check.ll
@@ -45,7 +45,7 @@ lookup_merge:                                     ; preds = %lookup_success
   %2 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %2
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %2
-  %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %4 = getelementptr %print_integer_8_t, ptr %3, i64 0, i32 0
   store i64 30007, ptr %4, align 8
   %5 = getelementptr %print_integer_8_t, ptr %3, i64 0, i32 1
@@ -149,7 +149,7 @@ lookup_merge:                                     ; preds = %lookup_success
   %2 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %2
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %2
-  %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %4 = getelementptr %print_integer_8_t, ptr %3, i64 0, i32 0
   store i64 30007, ptr %4, align 8
   %5 = getelementptr %print_integer_8_t, ptr %3, i64 0, i32 1

--- a/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
@@ -79,7 +79,7 @@ pred_true:                                        ; preds = %lookup_merge
   %6 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %6
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
-  %7 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %7 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %8 = getelementptr %print_integer_8_t, ptr %7, i64 0, i32 0
   store i64 30007, ptr %8, align 8
   %9 = getelementptr %print_integer_8_t, ptr %7, i64 0, i32 1

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -35,7 +35,7 @@ entry:
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [40 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %2 = getelementptr [1 x [1 x [40 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 40, i1 false)
   %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
   store i64 0, ptr %3, align 8

--- a/tests/codegen/llvm/map_key_int.ll
+++ b/tests/codegen/llvm/map_key_int.ll
@@ -12,44 +12,49 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !53
+@tuple_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !55
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !66 {
 entry:
   %"@x_val" = alloca i64, align 8
-  %tuple = alloca %int64_int64_int64__tuple_t, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 24, i1 false)
-  %1 = getelementptr %int64_int64_int64__tuple_t, ptr %tuple, i32 0, i32 0
-  store i64 11, ptr %1, align 8
-  %2 = getelementptr %int64_int64_int64__tuple_t, ptr %tuple, i32 0, i32 1
-  store i64 22, ptr %2, align 8
-  %3 = getelementptr %int64_int64_int64__tuple_t, ptr %tuple, i32 0, i32 2
-  store i64 33, ptr %3, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 24, i1 false)
+  %3 = getelementptr %int64_int64_int64__tuple_t, ptr %2, i32 0, i32 0
+  store i64 11, ptr %3, align 8
+  %4 = getelementptr %int64_int64_int64__tuple_t, ptr %2, i32 0, i32 1
+  store i64 22, ptr %4, align 8
+  %5 = getelementptr %int64_int64_int64__tuple_t, ptr %2, i32 0, i32 2
+  store i64 33, ptr %5, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   store i64 44, ptr %"@x_val", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %tuple, ptr %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!55}
+!llvm.dbg.cu = !{!63}
+!llvm.module.flags = !{!65}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -104,13 +109,22 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !50 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !51, size: 64, offset: 128)
 !51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
 !52 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
-!54 = !{!0, !26, !40}
-!55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!21, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
+!56 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !57, isLocal: false, isDefinition: true)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 192, elements: !9)
+!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 192, elements: !9)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 192, elements: !61)
 !60 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!62 = !DISubrange(count: 24, lowerBound: 0)
+!63 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !64)
+!64 = !{!0, !26, !40, !53, !55}
+!65 = !{i32 2, !"Debug Info Version", i32 3}
+!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !63, retainedNodes: !70)
+!67 = !DISubroutineType(types: !68)
+!68 = !{!21, !69}
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)

--- a/tests/codegen/llvm/map_key_string.ll
+++ b/tests/codegen/llvm/map_key_string.ll
@@ -12,31 +12,36 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !29
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !43
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !54
+@tuple_buf = dso_local externally_initialized global [1 x [1 x [4 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !56
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !57 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !66 {
 entry:
   %"@x_val" = alloca i64, align 8
-  %tuple = alloca %"string[2]_string[2]__tuple_t", align 8
   %str1 = alloca [2 x i8], align 1
   %str = alloca [2 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [2 x i8] c"a\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
   store [2 x i8] c"b\00", ptr %str1, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 4, i1 false)
-  %1 = getelementptr %"string[2]_string[2]__tuple_t", ptr %tuple, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 %str, i64 2, i1 false)
-  %2 = getelementptr %"string[2]_string[2]__tuple_t", ptr %tuple, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str1, i64 2, i1 false)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [4 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 4, i1 false)
+  %3 = getelementptr %"string[2]_string[2]__tuple_t", ptr %2, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 %str, i64 2, i1 false)
+  %4 = getelementptr %"string[2]_string[2]__tuple_t", ptr %2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %str1, i64 2, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   store i64 44, ptr %"@x_val", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %tuple, ptr %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   ret i64 0
 }
@@ -58,8 +63,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!54}
-!llvm.module.flags = !{!56}
+!llvm.dbg.cu = !{!63}
+!llvm.module.flags = !{!65}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -115,12 +120,21 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !51 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !52, size: 64, offset: 128)
 !52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
 !53 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!54 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !55)
-!55 = !{!0, !29, !43}
-!56 = !{i32 2, !"Debug Info Version", i32 3}
-!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !54, retainedNodes: !61)
-!58 = !DISubroutineType(types: !59)
-!59 = !{!28, !60}
-!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
+!55 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!56 = !DIGlobalVariableExpression(var: !57, expr: !DIExpression())
+!57 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !58, isLocal: false, isDefinition: true)
+!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 32, elements: !9)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 32, elements: !9)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 32, elements: !61)
 !61 = !{!62}
-!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)
+!62 = !DISubrange(count: 4, lowerBound: 0)
+!63 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !64)
+!64 = !{!0, !29, !43, !54, !56}
+!65 = !{i32 2, !"Debug Info Version", i32 3}
+!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !63, retainedNodes: !70)
+!67 = !DISubroutineType(types: !68)
+!68 = !{!28, !69}
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)

--- a/tests/codegen/llvm/max_cast.ll
+++ b/tests/codegen/llvm/max_cast.ll
@@ -81,7 +81,7 @@ if_body:                                          ; preds = %while_end
   %10 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %10
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %10
-  %11 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %11 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %12 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 0
   store i64 30007, ptr %12, align 8
   %13 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 1

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -128,7 +128,7 @@ while_end:                                        ; preds = %error_failure, %err
   %17 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
-  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
   store i64 30007, ptr %19, align 8
   %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -14,14 +14,15 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
-@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !59
-@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !67
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !57
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !65
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !67
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !74
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !79 {
 entry:
   %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
@@ -72,10 +73,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !78 {
-  %key1 = alloca i32, align 4
-  %tuple = alloca %int64_max__tuple_t, align 8
-  %"$kv" = alloca %int64_max__tuple_t, align 8
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !85 {
+  %key7 = alloca i32, align 4
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -108,60 +107,68 @@ while_end:                                        ; preds = %error_failure, %err
   %8 = load i64, ptr %val_1, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %9 = getelementptr %int64_max__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %int64_max__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %8, ptr %10, align 8
-  %11 = getelementptr %int64_max__tuple_t, ptr %"$kv", i32 0, i32 0
-  %12 = load i64, ptr %11, align 8
-  %13 = getelementptr %int64_max__tuple_t, ptr %"$kv", i32 0, i32 1
-  %14 = load i64, ptr %13, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %15 = getelementptr %int64_max__tuple_t, ptr %tuple, i32 0, i32 0
-  store i64 %12, ptr %15, align 8
-  %16 = getelementptr %int64_max__tuple_t, ptr %tuple, i32 0, i32 1
-  store i64 %14, ptr %16, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %9 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
+  %10 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
+  %11 = getelementptr %int64_max__tuple_t, ptr %10, i32 0, i32 0
+  store i64 %key, ptr %11, align 8
+  %12 = getelementptr %int64_max__tuple_t, ptr %10, i32 0, i32 1
+  store i64 %8, ptr %12, align 8
+  %13 = getelementptr %int64_max__tuple_t, ptr %10, i32 0, i32 0
+  %14 = load i64, ptr %13, align 8
+  %15 = getelementptr %int64_max__tuple_t, ptr %10, i32 0, i32 1
+  %16 = load i64, ptr %15, align 8
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %17 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
-  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
-  store i64 30007, ptr %19, align 8
-  %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1
-  store i64 0, ptr %20, align 8
-  %21 = getelementptr %print_tuple_16_t, ptr %18, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %21, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %21, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %18, i64 32, i64 0)
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %17
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %17
+  %18 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 16, i1 false)
+  %19 = getelementptr %int64_max__tuple_t, ptr %18, i32 0, i32 0
+  store i64 %14, ptr %19, align 8
+  %20 = getelementptr %int64_max__tuple_t, ptr %18, i32 0, i32 1
+  store i64 %16, ptr %20, align 8
+  %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
+  %21 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp5 = icmp ule i64 %get_cpu_id4, %21
+  %cpuid.min.select6 = select i1 %cpuid.min.cmp5, i64 %get_cpu_id4, i64 %21
+  %22 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select6, i64 0, i64 0
+  %23 = getelementptr %print_tuple_16_t, ptr %22, i64 0, i32 0
+  store i64 30007, ptr %23, align 8
+  %24 = getelementptr %print_tuple_16_t, ptr %22, i64 0, i32 1
+  store i64 0, ptr %24, align 8
+  %25 = getelementptr %print_tuple_16_t, ptr %22, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %25, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %25, ptr align 1 %18, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %22, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %22 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %23 = load i64, ptr %22, align 8
-  %24 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %25 = load i64, ptr %24, align 8
-  %val_set_cond = icmp eq i64 %25, 1
-  %26 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %26, 1
-  %27 = load i64, ptr %val_1, align 8
-  %max_cond = icmp sgt i64 %23, %27
+  %26 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %27 = load i64, ptr %26, align 8
+  %28 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %29 = load i64, ptr %28, align 8
+  %val_set_cond = icmp eq i64 %29, 1
+  %30 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %30, 1
+  %31 = load i64, ptr %val_1, align 8
+  %max_cond = icmp sgt i64 %27, %31
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %28 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %28, 0
+  %32 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %32, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %23, ptr %val_1, align 8
+  store i64 %27, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -169,38 +176,37 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %max_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
-  %29 = load i32, ptr %i, align 4
-  %30 = add i32 %29, 1
-  store i32 %30, ptr %i, align 4
+  %33 = load i32, ptr %i, align 4
+  %34 = add i32 %33, 1
+  store i32 %34, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %31 = load i32, ptr %i, align 4
+  %35 = load i32, ptr %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
-  store i32 0, ptr %key1, align 4
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
-  %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
-  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key7)
+  store i32 0, ptr %key7, align 4
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key7)
+  %map_lookup_cond10 = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond10, label %lookup_success8, label %lookup_failure9
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
-lookup_success2:                                  ; preds = %event_loss_counter
-  %32 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+lookup_success8:                                  ; preds = %event_loss_counter
+  %36 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
-lookup_failure3:                                  ; preds = %event_loss_counter
+lookup_failure9:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key1)
+lookup_merge:                                     ; preds = %lookup_failure9, %lookup_success8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key7)
   br label %counter_merge
 }
 
@@ -215,8 +221,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!69}
-!llvm.module.flags = !{!71}
+!llvm.dbg.cu = !{!76}
+!llvm.module.flags = !{!78}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -276,26 +282,33 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
-!60 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
-!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 256, elements: !52)
-!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 256, elements: !52)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 256, elements: !65)
-!64 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!65 = !{!66}
-!66 = !DISubrange(count: 32, lowerBound: 0)
+!58 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 256, elements: !52)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !61, size: 256, elements: !47)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 128, elements: !63)
+!62 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!63 = !{!64}
+!64 = !DISubrange(count: 16, lowerBound: 0)
+!65 = !DIGlobalVariableExpression(var: !66, expr: !DIExpression())
+!66 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
 !67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
-!68 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!69 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !70)
-!70 = !{!0, !26, !40, !57, !59, !67}
-!71 = !{i32 2, !"Debug Info Version", i32 3}
-!72 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !69, retainedNodes: !76)
-!73 = !DISubroutineType(types: !74)
-!74 = !{!18, !75}
-!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
-!76 = !{!77}
-!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !75)
-!78 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !69, retainedNodes: !79)
-!79 = !{!80}
-!80 = !DILocalVariable(name: "ctx", arg: 1, scope: !78, file: !2, type: !75)
+!68 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !69, isLocal: false, isDefinition: true)
+!69 = !DICompositeType(tag: DW_TAG_array_type, baseType: !70, size: 256, elements: !52)
+!70 = !DICompositeType(tag: DW_TAG_array_type, baseType: !71, size: 256, elements: !52)
+!71 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 256, elements: !72)
+!72 = !{!73}
+!73 = !DISubrange(count: 32, lowerBound: 0)
+!74 = !DIGlobalVariableExpression(var: !75, expr: !DIExpression())
+!75 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!76 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !77)
+!77 = !{!0, !26, !40, !57, !65, !67, !74}
+!78 = !{i32 2, !"Debug Info Version", i32 3}
+!79 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !80, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !76, retainedNodes: !83)
+!80 = !DISubroutineType(types: !81)
+!81 = !{!18, !82}
+!82 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
+!83 = !{!84}
+!84 = !DILocalVariable(name: "ctx", arg: 1, scope: !79, file: !2, type: !82)
+!85 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !80, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !76, retainedNodes: !86)
+!86 = !{!87}
+!87 = !DILocalVariable(name: "ctx", arg: 1, scope: !85, file: !2, type: !82)

--- a/tests/codegen/llvm/min_cast.ll
+++ b/tests/codegen/llvm/min_cast.ll
@@ -81,7 +81,7 @@ if_body:                                          ; preds = %while_end
   %10 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %10
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %10
-  %11 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %11 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %12 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 0
   store i64 30007, ptr %12, align 8
   %13 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 1

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -14,14 +14,15 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
-@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !59
-@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !67
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !57
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !65
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !67
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !74
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !79 {
 entry:
   %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
@@ -72,10 +73,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !78 {
-  %key1 = alloca i32, align 4
-  %tuple = alloca %int64_min__tuple_t, align 8
-  %"$kv" = alloca %int64_min__tuple_t, align 8
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !85 {
+  %key7 = alloca i32, align 4
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -108,60 +107,68 @@ while_end:                                        ; preds = %error_failure, %err
   %8 = load i64, ptr %val_1, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %9 = getelementptr %int64_min__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %int64_min__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %8, ptr %10, align 8
-  %11 = getelementptr %int64_min__tuple_t, ptr %"$kv", i32 0, i32 0
-  %12 = load i64, ptr %11, align 8
-  %13 = getelementptr %int64_min__tuple_t, ptr %"$kv", i32 0, i32 1
-  %14 = load i64, ptr %13, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %15 = getelementptr %int64_min__tuple_t, ptr %tuple, i32 0, i32 0
-  store i64 %12, ptr %15, align 8
-  %16 = getelementptr %int64_min__tuple_t, ptr %tuple, i32 0, i32 1
-  store i64 %14, ptr %16, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %9 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
+  %10 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
+  %11 = getelementptr %int64_min__tuple_t, ptr %10, i32 0, i32 0
+  store i64 %key, ptr %11, align 8
+  %12 = getelementptr %int64_min__tuple_t, ptr %10, i32 0, i32 1
+  store i64 %8, ptr %12, align 8
+  %13 = getelementptr %int64_min__tuple_t, ptr %10, i32 0, i32 0
+  %14 = load i64, ptr %13, align 8
+  %15 = getelementptr %int64_min__tuple_t, ptr %10, i32 0, i32 1
+  %16 = load i64, ptr %15, align 8
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %17 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
-  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
-  store i64 30007, ptr %19, align 8
-  %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1
-  store i64 0, ptr %20, align 8
-  %21 = getelementptr %print_tuple_16_t, ptr %18, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %21, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %21, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %18, i64 32, i64 0)
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %17
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %17
+  %18 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 16, i1 false)
+  %19 = getelementptr %int64_min__tuple_t, ptr %18, i32 0, i32 0
+  store i64 %14, ptr %19, align 8
+  %20 = getelementptr %int64_min__tuple_t, ptr %18, i32 0, i32 1
+  store i64 %16, ptr %20, align 8
+  %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
+  %21 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp5 = icmp ule i64 %get_cpu_id4, %21
+  %cpuid.min.select6 = select i1 %cpuid.min.cmp5, i64 %get_cpu_id4, i64 %21
+  %22 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select6, i64 0, i64 0
+  %23 = getelementptr %print_tuple_16_t, ptr %22, i64 0, i32 0
+  store i64 30007, ptr %23, align 8
+  %24 = getelementptr %print_tuple_16_t, ptr %22, i64 0, i32 1
+  store i64 0, ptr %24, align 8
+  %25 = getelementptr %print_tuple_16_t, ptr %22, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %25, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %25, ptr align 1 %18, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %22, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %22 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %23 = load i64, ptr %22, align 8
-  %24 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %25 = load i64, ptr %24, align 8
-  %val_set_cond = icmp eq i64 %25, 1
-  %26 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %26, 1
-  %27 = load i64, ptr %val_1, align 8
-  %min_cond = icmp slt i64 %23, %27
+  %26 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %27 = load i64, ptr %26, align 8
+  %28 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %29 = load i64, ptr %28, align 8
+  %val_set_cond = icmp eq i64 %29, 1
+  %30 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %30, 1
+  %31 = load i64, ptr %val_1, align 8
+  %min_cond = icmp slt i64 %27, %31
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %28 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %28, 0
+  %32 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %32, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %23, ptr %val_1, align 8
+  store i64 %27, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -169,38 +176,37 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %min_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
-  %29 = load i32, ptr %i, align 4
-  %30 = add i32 %29, 1
-  store i32 %30, ptr %i, align 4
+  %33 = load i32, ptr %i, align 4
+  %34 = add i32 %33, 1
+  store i32 %34, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %31 = load i32, ptr %i, align 4
+  %35 = load i32, ptr %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
-  store i32 0, ptr %key1, align 4
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
-  %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
-  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key7)
+  store i32 0, ptr %key7, align 4
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key7)
+  %map_lookup_cond10 = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond10, label %lookup_success8, label %lookup_failure9
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
-lookup_success2:                                  ; preds = %event_loss_counter
-  %32 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+lookup_success8:                                  ; preds = %event_loss_counter
+  %36 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
-lookup_failure3:                                  ; preds = %event_loss_counter
+lookup_failure9:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key1)
+lookup_merge:                                     ; preds = %lookup_failure9, %lookup_success8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key7)
   br label %counter_merge
 }
 
@@ -215,8 +221,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!69}
-!llvm.module.flags = !{!71}
+!llvm.dbg.cu = !{!76}
+!llvm.module.flags = !{!78}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -276,26 +282,33 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
-!60 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
-!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 256, elements: !52)
-!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 256, elements: !52)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 256, elements: !65)
-!64 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!65 = !{!66}
-!66 = !DISubrange(count: 32, lowerBound: 0)
+!58 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 256, elements: !52)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !61, size: 256, elements: !47)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 128, elements: !63)
+!62 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!63 = !{!64}
+!64 = !DISubrange(count: 16, lowerBound: 0)
+!65 = !DIGlobalVariableExpression(var: !66, expr: !DIExpression())
+!66 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
 !67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
-!68 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!69 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !70)
-!70 = !{!0, !26, !40, !57, !59, !67}
-!71 = !{i32 2, !"Debug Info Version", i32 3}
-!72 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !69, retainedNodes: !76)
-!73 = !DISubroutineType(types: !74)
-!74 = !{!18, !75}
-!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
-!76 = !{!77}
-!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !75)
-!78 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !69, retainedNodes: !79)
-!79 = !{!80}
-!80 = !DILocalVariable(name: "ctx", arg: 1, scope: !78, file: !2, type: !75)
+!68 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !69, isLocal: false, isDefinition: true)
+!69 = !DICompositeType(tag: DW_TAG_array_type, baseType: !70, size: 256, elements: !52)
+!70 = !DICompositeType(tag: DW_TAG_array_type, baseType: !71, size: 256, elements: !52)
+!71 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 256, elements: !72)
+!72 = !{!73}
+!73 = !DISubrange(count: 32, lowerBound: 0)
+!74 = !DIGlobalVariableExpression(var: !75, expr: !DIExpression())
+!75 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!76 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !77)
+!77 = !{!0, !26, !40, !57, !65, !67, !74}
+!78 = !{i32 2, !"Debug Info Version", i32 3}
+!79 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !80, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !76, retainedNodes: !83)
+!80 = !DISubroutineType(types: !81)
+!81 = !{!18, !82}
+!82 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
+!83 = !{!84}
+!84 = !DILocalVariable(name: "ctx", arg: 1, scope: !79, file: !2, type: !82)
+!85 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !80, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !76, retainedNodes: !86)
+!86 = !{!87}
+!87 = !DILocalVariable(name: "ctx", arg: 1, scope: !85, file: !2, type: !82)

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -128,7 +128,7 @@ while_end:                                        ; preds = %error_failure, %err
   %17 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
-  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
   store i64 30007, ptr %19, align 8
   %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1

--- a/tests/codegen/llvm/nested_tuple_different_sizes.ll
+++ b/tests/codegen/llvm/nested_tuple_different_sizes.ll
@@ -7,74 +7,84 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
 %"int64_(string[13],int64)__tuple_t" = type { i64, %"string[13]_int64__tuple_t" }
 %"string[13]_int64__tuple_t" = type { [13 x i8], i64 }
-%"int64_(string[3],int64)__tuple_t" = type { i64, %"string[3]_int64__tuple_t" }
 %"string[3]_int64__tuple_t" = type { [3 x i8], i64 }
+%"int64_(string[3],int64)__tuple_t" = type { i64, %"string[3]_int64__tuple_t" }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@tuple_buf = dso_local externally_initialized global [1 x [4 x [32 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !51 {
 entry:
-  %tuple4 = alloca %"int64_(string[13],int64)__tuple_t", align 8
-  %tuple3 = alloca %"string[13]_int64__tuple_t", align 8
-  %str2 = alloca [13 x i8], align 1
+  %str4 = alloca [13 x i8], align 1
   %"$t" = alloca %"int64_(string[13],int64)__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 32, i1 false)
-  %tuple1 = alloca %"int64_(string[3],int64)__tuple_t", align 8
-  %tuple = alloca %"string[3]_int64__tuple_t", align 8
   %str = alloca [3 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [3 x i8] c"hi\00", ptr %str, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %"string[3]_int64__tuple_t", ptr %tuple, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 %str, i64 3, i1 false)
-  %2 = getelementptr %"string[3]_int64__tuple_t", ptr %tuple, i32 0, i32 1
-  store i64 3, ptr %2, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %"string[3]_int64__tuple_t", ptr %2, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 %str, i64 3, i1 false)
+  %4 = getelementptr %"string[3]_int64__tuple_t", ptr %2, i32 0, i32 1
+  store i64 3, ptr %4, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 24, i1 false)
-  %3 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %tuple1, i32 0, i32 0
-  store i64 1, ptr %3, align 8
-  %4 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %tuple1, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %tuple, i64 16, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %5
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %5
+  %6 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 24, i1 false)
+  %7 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %6, i32 0, i32 0
+  store i64 1, ptr %7, align 8
+  %8 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %6, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %2, i64 16, i1 false)
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 32, i1 false)
-  %5 = getelementptr [24 x i8], ptr %tuple1, i64 0, i64 0
-  %6 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 8, i1 false)
-  %7 = getelementptr [24 x i8], ptr %tuple1, i64 0, i64 8
-  %8 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 1
-  %9 = getelementptr [16 x i8], ptr %7, i64 0, i64 0
-  %10 = getelementptr %"string[13]_int64__tuple_t", ptr %8, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 3, i1 false)
-  %11 = getelementptr [16 x i8], ptr %7, i64 0, i64 8
-  %12 = getelementptr %"string[13]_int64__tuple_t", ptr %8, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %11, i64 8, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple1)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str2)
-  store [13 x i8] c"hellolongstr\00", ptr %str2, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple3)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple3, i8 0, i64 24, i1 false)
-  %13 = getelementptr %"string[13]_int64__tuple_t", ptr %tuple3, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 %str2, i64 13, i1 false)
-  %14 = getelementptr %"string[13]_int64__tuple_t", ptr %tuple3, i32 0, i32 1
-  store i64 4, ptr %14, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str2)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple4)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple4, i8 0, i64 32, i1 false)
-  %15 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %tuple4, i32 0, i32 0
-  store i64 1, ptr %15, align 8
-  %16 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %tuple4, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 %tuple3, i64 24, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple3)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple4, i64 32, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple4)
+  %9 = getelementptr [24 x i8], ptr %6, i64 0, i64 0
+  %10 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 8, i1 false)
+  %11 = getelementptr [24 x i8], ptr %6, i64 0, i64 8
+  %12 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 1
+  %13 = getelementptr [16 x i8], ptr %11, i64 0, i64 0
+  %14 = getelementptr %"string[13]_int64__tuple_t", ptr %12, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %14, ptr align 1 %13, i64 3, i1 false)
+  %15 = getelementptr [16 x i8], ptr %11, i64 0, i64 8
+  %16 = getelementptr %"string[13]_int64__tuple_t", ptr %12, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 %15, i64 8, i1 false)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str4)
+  store [13 x i8] c"hellolongstr\00", ptr %str4, align 1
+  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)()
+  %17 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp6 = icmp ule i64 %get_cpu_id5, %17
+  %cpuid.min.select7 = select i1 %cpuid.min.cmp6, i64 %get_cpu_id5, i64 %17
+  %18 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select7, i64 2, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 24, i1 false)
+  %19 = getelementptr %"string[13]_int64__tuple_t", ptr %18, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %19, ptr align 1 %str4, i64 13, i1 false)
+  %20 = getelementptr %"string[13]_int64__tuple_t", ptr %18, i32 0, i32 1
+  store i64 4, ptr %20, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str4)
+  %get_cpu_id8 = call i64 inttoptr (i64 8 to ptr)()
+  %21 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp9 = icmp ule i64 %get_cpu_id8, %21
+  %cpuid.min.select10 = select i1 %cpuid.min.cmp9, i64 %get_cpu_id8, i64 %21
+  %22 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select10, i64 3, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %22, i8 0, i64 32, i1 false)
+  %23 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %22, i32 0, i32 0
+  store i64 1, ptr %23, align 8
+  %24 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %22, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %24, ptr align 1 %18, i64 24, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %22, i64 32, i1 false)
   ret i64 0
 }
 
@@ -95,8 +105,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!48}
+!llvm.module.flags = !{!50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -134,13 +144,24 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 1024, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 1024, elements: !46)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 256, elements: !44)
 !43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!45 = !DISubrange(count: 32, lowerBound: 0)
+!46 = !{!47}
+!47 = !DISubrange(count: 4, lowerBound: 0)
+!48 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !49)
+!49 = !{!0, !16, !36, !38}
+!50 = !{i32 2, !"Debug Info Version", i32 3}
+!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !48, retainedNodes: !55)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!35, !54}
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)

--- a/tests/codegen/llvm/ptr_to_ptr.ll
+++ b/tests/codegen/llvm/ptr_to_ptr.ll
@@ -29,7 +29,7 @@ entry:
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
   store i64 0, ptr %3, align 8

--- a/tests/codegen/llvm/sum_cast.ll
+++ b/tests/codegen/llvm/sum_cast.ll
@@ -67,7 +67,7 @@ if_body:                                          ; preds = %while_end
   %3 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %4 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %5 = getelementptr %print_integer_8_t, ptr %4, i64 0, i32 0
   store i64 30007, ptr %5, align 8
   %6 = getelementptr %print_integer_8_t, ptr %4, i64 0, i32 1

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -114,7 +114,7 @@ while_end:                                        ; preds = %error_failure, %err
   %17 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
-  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
   store i64 30007, ptr %19, align 8
   %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -13,14 +13,15 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !51
-@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !53
-@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !61
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !51
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !59
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !61
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !68
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !66 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !73 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -58,10 +59,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !72 {
-  %key1 = alloca i32, align 4
-  %tuple = alloca %int64_sum__tuple_t, align 8
-  %"$kv" = alloca %int64_sum__tuple_t, align 8
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !79 {
+  %key7 = alloca i32, align 4
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -94,80 +93,87 @@ while_end:                                        ; preds = %error_failure, %err
   %8 = load i64, ptr %val_1, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %9 = getelementptr %int64_sum__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %int64_sum__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %8, ptr %10, align 8
-  %11 = getelementptr %int64_sum__tuple_t, ptr %"$kv", i32 0, i32 0
-  %12 = load i64, ptr %11, align 8
-  %13 = getelementptr %int64_sum__tuple_t, ptr %"$kv", i32 0, i32 1
-  %14 = load i64, ptr %13, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %15 = getelementptr %int64_sum__tuple_t, ptr %tuple, i32 0, i32 0
-  store i64 %12, ptr %15, align 8
-  %16 = getelementptr %int64_sum__tuple_t, ptr %tuple, i32 0, i32 1
-  store i64 %14, ptr %16, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %9 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
+  %10 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
+  %11 = getelementptr %int64_sum__tuple_t, ptr %10, i32 0, i32 0
+  store i64 %key, ptr %11, align 8
+  %12 = getelementptr %int64_sum__tuple_t, ptr %10, i32 0, i32 1
+  store i64 %8, ptr %12, align 8
+  %13 = getelementptr %int64_sum__tuple_t, ptr %10, i32 0, i32 0
+  %14 = load i64, ptr %13, align 8
+  %15 = getelementptr %int64_sum__tuple_t, ptr %10, i32 0, i32 1
+  %16 = load i64, ptr %15, align 8
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %17 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
-  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
-  store i64 30007, ptr %19, align 8
-  %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1
-  store i64 0, ptr %20, align 8
-  %21 = getelementptr %print_tuple_16_t, ptr %18, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %21, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %21, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %18, i64 32, i64 0)
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %17
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %17
+  %18 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 16, i1 false)
+  %19 = getelementptr %int64_sum__tuple_t, ptr %18, i32 0, i32 0
+  store i64 %14, ptr %19, align 8
+  %20 = getelementptr %int64_sum__tuple_t, ptr %18, i32 0, i32 1
+  store i64 %16, ptr %20, align 8
+  %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
+  %21 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp5 = icmp ule i64 %get_cpu_id4, %21
+  %cpuid.min.select6 = select i1 %cpuid.min.cmp5, i64 %get_cpu_id4, i64 %21
+  %22 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select6, i64 0, i64 0
+  %23 = getelementptr %print_tuple_16_t, ptr %22, i64 0, i32 0
+  store i64 30007, ptr %23, align 8
+  %24 = getelementptr %print_tuple_16_t, ptr %22, i64 0, i32 1
+  store i64 0, ptr %24, align 8
+  %25 = getelementptr %print_tuple_16_t, ptr %22, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %25, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %25, ptr align 1 %18, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %22, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %22 = load i64, ptr %val_1, align 8
-  %23 = load i64, ptr %lookup_percpu_elem, align 8
-  %24 = add i64 %23, %22
-  store i64 %24, ptr %val_1, align 8
-  %25 = load i32, ptr %i, align 4
-  %26 = add i32 %25, 1
-  store i32 %26, ptr %i, align 4
+  %26 = load i64, ptr %val_1, align 8
+  %27 = load i64, ptr %lookup_percpu_elem, align 8
+  %28 = add i64 %27, %26
+  store i64 %28, ptr %val_1, align 8
+  %29 = load i32, ptr %i, align 4
+  %30 = add i32 %29, 1
+  store i32 %30, ptr %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %27 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %27, 0
+  %31 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %31, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %28 = load i32, ptr %i, align 4
+  %32 = load i32, ptr %i, align 4
   br label %while_end
 
 event_loss_counter:                               ; preds = %while_end
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
-  store i32 0, ptr %key1, align 4
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
-  %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
-  br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key7)
+  store i32 0, ptr %key7, align 4
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key7)
+  %map_lookup_cond10 = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond10, label %lookup_success8, label %lookup_failure9
 
 counter_merge:                                    ; preds = %lookup_merge, %while_end
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
-lookup_success2:                                  ; preds = %event_loss_counter
-  %29 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+lookup_success8:                                  ; preds = %event_loss_counter
+  %33 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
-lookup_failure3:                                  ; preds = %event_loss_counter
+lookup_failure9:                                  ; preds = %event_loss_counter
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure3, %lookup_success2
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key1)
+lookup_merge:                                     ; preds = %lookup_failure9, %lookup_success8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key7)
   br label %counter_merge
 }
 
@@ -182,8 +188,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!63}
-!llvm.module.flags = !{!65}
+!llvm.dbg.cu = !{!70}
+!llvm.module.flags = !{!72}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -237,26 +243,33 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
-!54 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
-!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 256, elements: !46)
-!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 256, elements: !46)
-!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 256, elements: !59)
-!58 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!59 = !{!60}
-!60 = !DISubrange(count: 32, lowerBound: 0)
+!52 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 256, elements: !46)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 256, elements: !41)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 128, elements: !57)
+!56 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!57 = !{!58}
+!58 = !DISubrange(count: 16, lowerBound: 0)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
 !61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
-!62 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!63 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !64)
-!64 = !{!0, !20, !34, !51, !53, !61}
-!65 = !{i32 2, !"Debug Info Version", i32 3}
-!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !63, retainedNodes: !70)
-!67 = !DISubroutineType(types: !68)
-!68 = !{!18, !69}
-!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
-!70 = !{!71}
-!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)
-!72 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !63, retainedNodes: !73)
-!73 = !{!74}
-!74 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !69)
+!62 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !63, isLocal: false, isDefinition: true)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 256, elements: !46)
+!64 = !DICompositeType(tag: DW_TAG_array_type, baseType: !65, size: 256, elements: !46)
+!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 256, elements: !66)
+!66 = !{!67}
+!67 = !DISubrange(count: 32, lowerBound: 0)
+!68 = !DIGlobalVariableExpression(var: !69, expr: !DIExpression())
+!69 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!70 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !71)
+!71 = !{!0, !20, !34, !51, !59, !61, !68}
+!72 = !{i32 2, !"Debug Info Version", i32 3}
+!73 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !74, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !70, retainedNodes: !77)
+!74 = !DISubroutineType(types: !75)
+!75 = !{!18, !76}
+!76 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
+!77 = !{!78}
+!78 = !DILocalVariable(name: "ctx", arg: 1, scope: !73, file: !2, type: !76)
+!79 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !74, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !70, retainedNodes: !80)
+!80 = !{!81}
+!81 = !DILocalVariable(name: "ctx", arg: 1, scope: !79, file: !2, type: !76)

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -33,7 +33,7 @@ left:                                             ; preds = %entry
   %4 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
   %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
   store i64 0, ptr %6, align 8

--- a/tests/codegen/llvm/tuple.ll
+++ b/tests/codegen/llvm/tuple.ll
@@ -12,31 +12,35 @@ target triple = "bpf-pc-linux"
 @AT_t = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !31
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !45
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !51
+@tuple_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !53
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !63 {
 entry:
   %"@t_key" = alloca i64, align 8
-  %tuple = alloca %"int64_int64_string[4]__tuple_t", align 8
   %str = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [4 x i8] c"str\00", ptr %str, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 24, i1 false)
-  %1 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 0
-  store i64 1, ptr %1, align 8
-  %2 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 1
-  store i64 2, ptr %2, align 8
-  %3 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 2
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 %str, i64 4, i1 false)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 24, i1 false)
+  %3 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %2, i32 0, i32 0
+  store i64 1, ptr %3, align 8
+  %4 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %2, i32 0, i32 1
+  store i64 2, ptr %4, align 8
+  %5 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %2, i32 0, i32 2
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %str, i64 4, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %tuple, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@t_key")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 }
 
@@ -57,8 +61,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!60}
+!llvm.module.flags = !{!62}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_t", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -111,12 +115,21 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !48 = !{!5, !11, !16, !49}
 !49 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !50, size: 64, offset: 192)
 !50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !31, !45}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!24, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 192, elements: !14)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 192, elements: !14)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !28, size: 192, elements: !58)
 !58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!59 = !DISubrange(count: 24, lowerBound: 0)
+!60 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !61)
+!61 = !{!0, !31, !45, !51, !53}
+!62 = !{i32 2, !"Debug Info Version", i32 3}
+!63 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !64, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !60, retainedNodes: !67)
+!64 = !DISubroutineType(types: !65)
+!65 = !{!24, !66}
+!66 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!67 = !{!68}
+!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !63, file: !2, type: !66)

--- a/tests/codegen/llvm/tuple_array_struct.ll
+++ b/tests/codegen/llvm/tuple_array_struct.ll
@@ -12,48 +12,52 @@ target triple = "bpf-pc-linux"
 @AT_t = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !32
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !46
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !53
+@tuple_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !55
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !65 {
 entry:
   %"@t_key" = alloca i64, align 8
-  %tuple = alloca %"struct Foo_int32[4]__tuple_t", align 8
   %1 = getelementptr i64, ptr %0, i64 14
   %arg0 = load volatile i64, ptr %1, align 8
   %2 = getelementptr i64, ptr %0, i64 13
   %arg1 = load volatile i64, ptr %2, align 8
   %3 = add i64 %arg1, 0
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 24, i1 false)
-  %4 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %tuple, i32 0, i32 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 8, i64 %arg0)
-  %5 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %tuple, i32 0, i32 1
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %5, i32 16, i64 %3)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
+  %5 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 24, i1 false)
+  %6 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %5, i32 0, i32 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %6, i32 8, i64 %arg0)
+  %7 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %5, i32 0, i32 1
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %7, i32 16, i64 %3)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %tuple, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %5, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@t_key")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!55}
+!llvm.dbg.cu = !{!62}
+!llvm.module.flags = !{!64}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_t", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -108,12 +112,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !50 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !51, size: 64, offset: 192)
 !51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
 !52 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
-!54 = !{!0, !32, !46}
-!55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!52, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
+!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
+!56 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !57, isLocal: false, isDefinition: true)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 192, elements: !14)
+!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 192, elements: !14)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 192, elements: !60)
 !60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!61 = !DISubrange(count: 24, lowerBound: 0)
+!62 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !63)
+!63 = !{!0, !32, !46, !53, !55}
+!64 = !{i32 2, !"Debug Info Version", i32 3}
+!65 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !66, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !62, retainedNodes: !69)
+!66 = !DISubroutineType(types: !67)
+!67 = !{!52, !68}
+!68 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!69 = !{!70}
+!70 = !DILocalVariable(name: "ctx", arg: 1, scope: !65, file: !2, type: !68)

--- a/tests/codegen/llvm/tuple_map_val_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_map_val_different_sizes.ll
@@ -13,56 +13,62 @@ target triple = "bpf-pc-linux"
 @AT_a = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !30
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !44
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !50
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [24 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !52
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !53 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
-  %"@a_key3" = alloca i64, align 8
-  %tuple2 = alloca %"int64_string[13]__tuple_t", align 8
+  %"@a_key5" = alloca i64, align 8
   %str1 = alloca [13 x i8], align 1
   %"@a_val" = alloca %"int64_string[13]__tuple_t", align 8
   %"@a_key" = alloca i64, align 8
-  %tuple = alloca %"int64_string[3]__tuple_t", align 8
   %str = alloca [3 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [3 x i8] c"hi\00", ptr %str, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 0
-  store i64 1, ptr %1, align 8
-  %2 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 3, i1 false)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %"int64_string[3]__tuple_t", ptr %2, i32 0, i32 0
+  store i64 1, ptr %3, align 8
+  %4 = getelementptr %"int64_string[3]__tuple_t", ptr %2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %str, i64 3, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
   store i64 0, ptr %"@a_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
   call void @llvm.memset.p0.i64(ptr align 1 %"@a_val", i8 0, i64 24, i1 false)
-  %3 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 0
-  %4 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %3, i64 8, i1 false)
-  %5 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 8
-  %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 3, i1 false)
+  %5 = getelementptr [16 x i8], ptr %2, i64 0, i64 0
+  %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 8, i1 false)
+  %7 = getelementptr [16 x i8], ptr %2, i64 0, i64 8
+  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %7, i64 3, i1 false)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %"@a_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
   store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple2)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 24, i1 false)
-  %7 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 0
-  store i64 1, ptr %7, align 8
-  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %str1, i64 13, i1 false)
+  %get_cpu_id2 = call i64 inttoptr (i64 8 to ptr)()
+  %9 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp3 = icmp ule i64 %get_cpu_id2, %9
+  %cpuid.min.select4 = select i1 %cpuid.min.cmp3, i64 %get_cpu_id2, i64 %9
+  %10 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select4, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 24, i1 false)
+  %11 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 0
+  store i64 1, ptr %11, align 8
+  %12 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %str1, i64 13, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key3")
-  store i64 0, ptr %"@a_key3", align 8
-  %update_elem4 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key3", ptr %tuple2, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key3")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple2)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key5")
+  store i64 0, ptr %"@a_key5", align 8
+  %update_elem6 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key5", ptr %10, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key5")
   ret i64 0
 }
 
@@ -83,8 +89,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!50}
-!llvm.module.flags = !{!52}
+!llvm.dbg.cu = !{!59}
+!llvm.module.flags = !{!61}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -136,12 +142,21 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !47 = !{!5, !11, !16, !48}
 !48 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !49, size: 64, offset: 192)
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!50 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !51)
-!51 = !{!0, !30, !44}
-!52 = !{i32 2, !"Debug Info Version", i32 3}
-!53 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !54, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !57)
-!54 = !DISubroutineType(types: !55)
-!55 = !{!24, !56}
-!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
+!51 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
+!53 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !54, isLocal: false, isDefinition: true)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 384, elements: !14)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 384, elements: !9)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !27, size: 192, elements: !57)
 !57 = !{!58}
-!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !53, file: !2, type: !56)
+!58 = !DISubrange(count: 24, lowerBound: 0)
+!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
+!60 = !{!0, !30, !44, !50, !52}
+!61 = !{i32 2, !"Debug Info Version", i32 3}
+!62 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !66)
+!63 = !DISubroutineType(types: !64)
+!64 = !{!24, !65}
+!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!66 = !{!67}
+!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !62, file: !2, type: !65)

--- a/tests/codegen/llvm/tuple_variable_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_variable_different_sizes.ll
@@ -11,47 +11,53 @@ target triple = "bpf-pc-linux"
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [24 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
-  %tuple2 = alloca %"int64_string[13]__tuple_t", align 8
   %str1 = alloca [13 x i8], align 1
   %"$t" = alloca %"int64_string[13]__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 24, i1 false)
-  %tuple = alloca %"int64_string[3]__tuple_t", align 8
   %str = alloca [3 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [3 x i8] c"hi\00", ptr %str, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 0
-  store i64 1, ptr %1, align 8
-  %2 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 3, i1 false)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %"int64_string[3]__tuple_t", ptr %2, i32 0, i32 0
+  store i64 1, ptr %3, align 8
+  %4 = getelementptr %"int64_string[3]__tuple_t", ptr %2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %str, i64 3, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 24, i1 false)
-  %3 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 0
-  %4 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %3, i64 8, i1 false)
-  %5 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 8
-  %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 3, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
+  %5 = getelementptr [16 x i8], ptr %2, i64 0, i64 0
+  %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 8, i1 false)
+  %7 = getelementptr [16 x i8], ptr %2, i64 0, i64 8
+  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %7, i64 3, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
   store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple2)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 24, i1 false)
-  %7 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 0
-  store i64 1, ptr %7, align 8
-  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %str1, i64 13, i1 false)
+  %get_cpu_id2 = call i64 inttoptr (i64 8 to ptr)()
+  %9 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp3 = icmp ule i64 %get_cpu_id2, %9
+  %cpuid.min.select4 = select i1 %cpuid.min.cmp3, i64 %get_cpu_id2, i64 %9
+  %10 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select4, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 24, i1 false)
+  %11 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 0
+  store i64 1, ptr %11, align 8
+  %12 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %str1, i64 13, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple2, i64 24, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple2)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %10, i64 24, i1 false)
   ret i64 0
 }
 
@@ -72,8 +78,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!36}
-!llvm.module.flags = !{!38}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -111,13 +117,22 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
-!37 = !{!0, !16}
-!38 = !{i32 2, !"Debug Info Version", i32 3}
-!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
-!40 = !DISubroutineType(types: !41)
-!41 = !{!35, !42}
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 384, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 384, elements: !23)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 192, elements: !44)
 !43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !44 = !{!45}
-!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)
+!45 = !DISubrange(count: 24, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/unroll_async_id.ll
+++ b/tests/codegen/llvm/unroll_async_id.ll
@@ -42,7 +42,7 @@ entry:
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 8, i1 false)
   %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
   store i64 0, ptr %3, align 8
@@ -62,7 +62,7 @@ counter_merge:                                    ; preds = %lookup_merge, %entr
   %4 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %4
   %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %4
-  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select3, i64 0, i64 0
+  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
   %6 = getelementptr %printf_t.2, ptr %5, i32 0, i32 0
   store i64 0, ptr %6, align 8
@@ -93,7 +93,7 @@ counter_merge6:                                   ; preds = %lookup_merge12, %co
   %8 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp15 = icmp ule i64 %get_cpu_id14, %8
   %cpuid.min.select16 = select i1 %cpuid.min.cmp15, i64 %get_cpu_id14, i64 %8
-  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select16, i64 0, i64 0
+  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select16, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
   %10 = getelementptr %printf_t.3, ptr %9, i32 0, i32 0
   store i64 0, ptr %10, align 8
@@ -124,7 +124,7 @@ counter_merge19:                                  ; preds = %lookup_merge25, %co
   %12 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp28 = icmp ule i64 %get_cpu_id27, %12
   %cpuid.min.select29 = select i1 %cpuid.min.cmp28, i64 %get_cpu_id27, i64 %12
-  %13 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select29, i64 0, i64 0
+  %13 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select29, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %13, i8 0, i64 8, i1 false)
   %14 = getelementptr %printf_t.4, ptr %13, i32 0, i32 0
   store i64 0, ptr %14, align 8
@@ -155,7 +155,7 @@ counter_merge32:                                  ; preds = %lookup_merge38, %co
   %16 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp41 = icmp ule i64 %get_cpu_id40, %16
   %cpuid.min.select42 = select i1 %cpuid.min.cmp41, i64 %get_cpu_id40, i64 %16
-  %17 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select42, i64 0, i64 0
+  %17 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select42, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %17, i8 0, i64 8, i1 false)
   %18 = getelementptr %printf_t.5, ptr %17, i32 0, i32 0
   store i64 0, ptr %18, align 8

--- a/tests/codegen/llvm/variable_increment_decrement.ll
+++ b/tests/codegen/llvm/variable_increment_decrement.ll
@@ -33,7 +33,7 @@ entry:
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
   store i64 0, ptr %3, align 8
@@ -58,7 +58,7 @@ counter_merge:                                    ; preds = %lookup_merge, %entr
   %7 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %7
   %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %7
-  %8 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select3, i64 0, i64 0
+  %8 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
   %9 = getelementptr %printf_t.1, ptr %8, i32 0, i32 0
   store i64 1, ptr %9, align 8
@@ -94,7 +94,7 @@ counter_merge6:                                   ; preds = %lookup_merge12, %co
   %14 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp15 = icmp ule i64 %get_cpu_id14, %14
   %cpuid.min.select16 = select i1 %cpuid.min.cmp15, i64 %get_cpu_id14, i64 %14
-  %15 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select16, i64 0, i64 0
+  %15 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select16, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %15, i8 0, i64 16, i1 false)
   %16 = getelementptr %printf_t.2, ptr %15, i32 0, i32 0
   store i64 2, ptr %16, align 8
@@ -130,7 +130,7 @@ counter_merge19:                                  ; preds = %lookup_merge25, %co
   %21 = load i64, ptr @max_cpu_id, align 8
   %cpuid.min.cmp28 = icmp ule i64 %get_cpu_id27, %21
   %cpuid.min.select29 = select i1 %cpuid.min.cmp28, i64 %get_cpu_id27, i64 %21
-  %22 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select29, i64 0, i64 0
+  %22 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select29, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %22, i8 0, i64 16, i1 false)
   %23 = getelementptr %printf_t.3, ptr %22, i32 0, i32 0
   store i64 3, ptr %23, align 8

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -101,10 +101,19 @@ EXPECT success!
 REQUIRES_FEATURE probe_read_kernel
 TIMEOUT 1
 
-# See str_big_read test above
 NAME str_big_tuple
-PROG BEGIN { print((str(0), str(0))); print("success!"); exit() }
-EXPECT success!
+PROG t:syscalls:sys_enter_execve { print((1, (2, str(args.filename)))) }
+ENV BPFTRACE_MAX_STRLEN=9999
+EXPECT_REGEX \(1, \(2, /X{5555}\)\)
+AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
+REQUIRES_FEATURE probe_read_kernel
+TIMEOUT 1
+
+NAME str_big_for
+PROG t:syscalls:sys_enter_execve { @map[str(args.filename)] = str(args.filename); for ($kv : @map) { print($kv); } }
+ENV BPFTRACE_MAX_STRLEN=9999
+EXPECT_REGEX \(/X{5555}, /X{5555}\)
+AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
 REQUIRES_FEATURE probe_read_kernel
 TIMEOUT 1
 

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -22,6 +22,14 @@ NAME tuple map key
 PROG BEGIN { @[(1, "hello")] = 1; exit();}
 EXPECT @[1, hello]: 1
 
+NAME tuple map key and value
+PROG BEGIN { @[(1, 2)] = (3, 4); exit();}
+EXPECT @[1, 2]: (3, 4)
+
+NAME implicit conversion of multi map key to tuple
+PROG BEGIN { @["abcd", 2] = (3, 4, 5); exit();}
+EXPECT @[abcd, 2]: (3, 4, 5)
+
 NAME tuple map key same as assoc array
 PROG BEGIN { @[(1, "hello")] = 1;  @[2, "hello"] = 2; delete(@[1, "hello"]); exit();}
 EXPECT @[2, hello]: 2


### PR DESCRIPTION
This PR starts fixing https://github.com/bpftrace/bpftrace/issues/3431, ensuring tuples use scratch maps vs stack allocation. This will allow large strings to be stored in tuples and improve user experience.

This PR starts migrating script-dependent data structures to global variables, starting with tuples and implicit tuples generated from for loop variables. This will allow tuples larger than the BPF stack size, which will specifically allow increasing default max string size to 1024.

To deal with nested tuples we create a scratch global variable with size = number of tuples explored via AST - similar to string buffers. This is done to avoid overwriting multiple tuples used simultaneously by the same CPU.
