### PR TITLE
Migrate fmt string scratch map to global variable

### DIFF
--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -288,11 +288,12 @@ DIGlobalVariableExpression *DIBuilderBPF::createMapEntry(
       file, name, "global", file, 0, map_entry_type, false);
 }
 
-DIGlobalVariableExpression *DIBuilderBPF::createGlobalInt64(
-    std::string_view name)
+DIGlobalVariableExpression *DIBuilderBPF::createGlobalVariable(
+    std::string_view name,
+    const SizedType &stype)
 {
   return createGlobalVariableExpression(
-      file, name, "global", file, 0, getInt64Ty(), false);
+      file, name, "global", file, 0, GetType(stype), false);
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -47,7 +47,8 @@ public:
                                              uint64_t max_entries,
                                              DIType *key_type,
                                              const SizedType &value_type);
-  DIGlobalVariableExpression *createGlobalInt64(std::string_view name);
+  DIGlobalVariableExpression *createGlobalVariable(std::string_view name,
+                                                   const SizedType &stype);
 
   DIFile *file = nullptr;
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -168,8 +168,7 @@ public:
   CallInst *CreateGetStrScratchMap(int idx,
                                    BasicBlock *failure_callback,
                                    const location &loc);
-  CallInst *CreateGetFmtStringArgsScratchMap(BasicBlock *failure_callback,
-                                             const location &loc);
+  Value *CreateGetFmtStringArgsScratchBuffer(const location &loc);
   void CreateCheckSetRecursion(const location &loc, int early_exit_ret);
   void CreateUnSetRecursion(const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
@@ -298,6 +297,9 @@ private:
                                 const location &loc,
                                 BasicBlock *failure_callback,
                                 int key = 0);
+  Value *createScratchBuffer(globalvars::GlobalVar globalvar,
+                             const location &loc,
+                             size_t key = 0);
   libbpf::bpf_func_id selectProbeReadHelper(AddrSpace as, bool str);
 
   llvm::Type *getKernelPointerStorageTy();

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -48,6 +48,13 @@ std::optional<RequiredResources> ResourceAnalyser::analyse()
     return std::nullopt;
   }
 
+  if (resources_.max_fmtstring_args_size > 0) {
+    resources_.needed_global_vars.insert(
+        bpftrace::globalvars::GlobalVar::FMT_STRINGS_BUFFER);
+    resources_.needed_global_vars.insert(
+        bpftrace::globalvars::GlobalVar::MAX_CPU_ID);
+  }
+
   return std::optional{ std::move(resources_) };
 }
 
@@ -136,7 +143,7 @@ void ResourceAnalyser::visit(Call &call)
   } else if (call.func == "count" || call.func == "sum" || call.func == "min" ||
              call.func == "max" || call.func == "avg") {
     resources_.needed_global_vars.insert(
-        std::string(bpftrace::globalvars::NUM_CPUS));
+        bpftrace::globalvars::GlobalVar::NUM_CPUS);
   } else if (call.func == "hist") {
     auto &map_info = resources_.maps_info[call.map->ident];
     int bits = static_cast<Integer *>(call.vargs.at(1))->n;

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -73,7 +73,8 @@ private:
   std::map<std::string, BpfMap> maps_;
   std::map<int, BpfMap *> maps_by_id_;
   std::map<std::string, BpfProgram> programs_;
-  struct bpf_map *global_vars_map_ = nullptr;
+  std::unordered_map<std::string, struct bpf_map *>
+      section_names_to_global_vars_map_;
 };
 
 } // namespace bpftrace

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -64,8 +64,6 @@ std::string to_string(MapType t)
   switch (t) {
     case MapType::PerfEvent:
       return "perf_event";
-    case MapType::FmtStringArgs:
-      return "fmt_string_args";
     case MapType::Join:
       return "join";
     case MapType::Elapsed:

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -68,7 +68,6 @@ private:
 enum class MapType {
   // Also update to_string
   PerfEvent,
-  FmtStringArgs,
   Join,
   Elapsed,
   Ringbuf,

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -83,6 +83,7 @@ public:
         feature_(std::make_unique<BPFfeature>(no_feature)),
         probe_matcher_(std::make_unique<ProbeMatcher>(this)),
         ncpus_(get_possible_cpus().size()),
+        max_cpu_id_(get_max_cpu_id()),
         config_(config)
   {
   }
@@ -211,6 +212,7 @@ public:
   }
   int ncpus_;
   int online_cpus_;
+  int max_cpu_id_;
   Config config_;
 
 private:

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -13,9 +13,47 @@
 
 namespace bpftrace::globalvars {
 
-void update_global_vars(const struct bpf_object *bpf_object,
-                        struct bpf_map *global_vars_map,
-                        BPFtrace &bpftrace)
+const GlobalVarConfig &get_config(GlobalVar global_var)
+{
+  auto it = GLOBAL_VAR_CONFIGS.find(global_var);
+  if (it == GLOBAL_VAR_CONFIGS.end()) {
+    LOG(BUG) << "Global variable enum not found in GLOBAL_VAR_CONFIGS";
+  }
+  return it->second;
+}
+
+static void verify_maps_found(
+    const std::unordered_map<std::string, struct bpf_map *>
+        &section_name_to_global_vars_map,
+    const BPFtrace &bpftrace)
+{
+  for (const auto global_var : bpftrace.resources.needed_global_vars) {
+    auto config = get_config(global_var);
+    if (!section_name_to_global_vars_map.count(config.section)) {
+      LOG(BUG) << "No map found for " << config.section
+               << " which is needed to set global variable " << config.name;
+    }
+  }
+}
+
+static std::unordered_set<GlobalVar> get_global_vars_for_section(
+    std::string_view target_section,
+    const BPFtrace &bpftrace)
+{
+  std::unordered_set<GlobalVar> ret;
+  for (const auto global_var : bpftrace.resources.needed_global_vars) {
+    auto config = get_config(global_var);
+    if (config.section == target_section) {
+      ret.insert(global_var);
+    }
+  }
+  return ret;
+}
+
+static std::map<GlobalVar, int> find_btf_var_offsets(
+    const struct bpf_object *bpf_object,
+    std::string_view section_name,
+    const std::unordered_set<GlobalVar> &needed_global_vars)
 {
   struct btf *self_btf = bpf_object__btf(bpf_object);
 
@@ -24,27 +62,23 @@ void update_global_vars(const struct bpf_object *bpf_object,
   }
 
   __s32 section_id = btf__find_by_name(self_btf,
-                                       std::string(SECTION_NAME).c_str());
+                                       std::string(section_name).c_str());
   if (section_id < 0) {
-    LOG(BUG) << "Failed to find section " << SECTION_NAME
+    LOG(BUG) << "Failed to find section " << section_name
              << " to update global vars";
   }
 
   const struct btf_type *section_type = btf__type_by_id(
       self_btf, static_cast<__u32>(section_id));
   if (!section_type) {
-    LOG(BUG) << "Failed to get BTF type for section " << SECTION_NAME;
+    LOG(BUG) << "Failed to get BTF type for section " << section_name;
   }
 
   // First locate the offsets of each global variable in the section with btf
-  std::map<std::string_view, int> vars_and_offsets;
+  std::map<GlobalVar, int> vars_and_offsets;
 
-  for (const auto &name : GLOBAL_VAR_NAMES) {
-    if (bpftrace.resources.needed_global_vars.find(name) ==
-        bpftrace.resources.needed_global_vars.end()) {
-      continue;
-    }
-    vars_and_offsets[name] = -1;
+  for (const auto global_var : needed_global_vars) {
+    vars_and_offsets[global_var] = -1;
   }
 
   int i;
@@ -59,13 +93,29 @@ void update_global_vars(const struct bpf_object *bpf_object,
     }
 
     std::string_view name = btf__name_by_offset(self_btf, type_id->name_off);
+    vars_and_offsets[from_string(name)] = member->offset;
+  }
 
-    if (vars_and_offsets.find(name) != vars_and_offsets.end()) {
-      vars_and_offsets[name] = member->offset;
-    } else {
-      LOG(BUG) << "Unknown global variable " << name;
+  for (const auto [global_var, offset] : vars_and_offsets) {
+    if (offset < 0) {
+      LOG(BUG) << "Global variable " << to_string(global_var)
+               << " has not been added to the BPF code "
+                  "(codegen_llvm)";
     }
   }
+  return vars_and_offsets;
+}
+
+static void update_global_vars_rodata(
+    const struct bpf_object *bpf_object,
+    std::string_view section_name,
+    struct bpf_map *global_vars_map,
+    const std::unordered_set<GlobalVar> &needed_global_vars,
+    const BPFtrace &bpftrace)
+{
+  auto vars_and_offsets = find_btf_var_offsets(bpf_object,
+                                               section_name,
+                                               needed_global_vars);
 
   size_t v_size;
   char *global_vars_buf = reinterpret_cast<char *>(
@@ -76,18 +126,151 @@ void update_global_vars(const struct bpf_object *bpf_object,
   }
 
   // Update the values for the global vars (using the above offsets)
-  for (auto [name, offset] : vars_and_offsets) {
-    if (offset < 0) {
-      LOG(BUG) << "Global variable has not been added to the BPF code "
-                  "(codegen_llvm)";
-    }
-
+  for (const auto [global_var, offset] : vars_and_offsets) {
     int64_t *var = reinterpret_cast<int64_t *>(global_vars_buf + offset);
 
-    if (name == NUM_CPUS) {
-      *var = bpftrace.ncpus_;
+    switch (global_var) {
+      case GlobalVar::NUM_CPUS:
+        *var = bpftrace.ncpus_;
+        break;
+      case GlobalVar::MAX_CPU_ID:
+        *var = bpftrace.max_cpu_id_;
+        break;
+      case GlobalVar::FMT_STRINGS_BUFFER:
+        break;
     }
   }
+}
+
+static void update_global_vars_custom_rw_section(
+    const struct bpf_object *bpf_object,
+    const std::string &section_name,
+    struct bpf_map *global_vars_map,
+    const std::unordered_set<GlobalVar> &needed_global_vars,
+    const BPFtrace &bpftrace)
+{
+  if (needed_global_vars.size() > 1) {
+    LOG(BUG) << "Multiple read-write global variables are in same section "
+             << section_name;
+  }
+  auto global_var = *needed_global_vars.begin();
+
+  size_t actual_size;
+  auto buf = bpf_map__initial_value(global_vars_map, &actual_size);
+  if (!buf) {
+    LOG(BUG) << "Failed to get size for section " << section_name
+             << " before resizing";
+  }
+  if (actual_size == 0) {
+    LOG(BUG) << "Section " << section_name << " has size of 0 ";
+  }
+
+  auto desired_size = (bpftrace.max_cpu_id_ + 1) * actual_size;
+  auto err = bpf_map__set_value_size(global_vars_map, desired_size);
+  if (err != 0) {
+    throw bpftrace::FatalUserException("Failed to set size to " +
+                                       std::to_string(desired_size) +
+                                       " for section " + section_name);
+  }
+
+  buf = bpf_map__initial_value(global_vars_map, &actual_size);
+  if (!buf) {
+    LOG(BUG) << "Failed to get size for section " << section_name
+             << " after resizing";
+  }
+  if (actual_size != desired_size) {
+    throw bpftrace::FatalUserException(
+        "Failed to set size from " + std::to_string(actual_size) + " to " +
+        std::to_string(desired_size) + " for section " + section_name);
+  }
+
+  // No need to memset to zero as we memset on each usage
+
+  // Verify we can still find variable name via BTF and it hasn't been cleared
+  // after size changes
+  auto vars_and_offset = find_btf_var_offsets(bpf_object,
+                                              section_name,
+                                              needed_global_vars);
+  if (vars_and_offset.at(global_var) != 0) {
+    LOG(BUG) << "Read-write global variable " << to_string(global_var)
+             << " must be at offset 0 in section " << section_name;
+  }
+}
+
+void update_global_vars(const struct bpf_object *bpf_object,
+                        const std::unordered_map<std::string, struct bpf_map *>
+                            &section_name_to_global_vars_map,
+                        const BPFtrace &bpftrace)
+{
+  verify_maps_found(section_name_to_global_vars_map, bpftrace);
+  for (const auto &[section_name, global_vars_map] :
+       section_name_to_global_vars_map) {
+    const auto needed_global_variables = get_global_vars_for_section(
+        section_name, bpftrace);
+    if (needed_global_variables.empty()) {
+      continue;
+    }
+    if (section_name == RO_SECTION_NAME) {
+      update_global_vars_rodata(bpf_object,
+                                section_name,
+                                global_vars_map,
+                                needed_global_variables,
+                                bpftrace);
+    } else {
+      update_global_vars_custom_rw_section(bpf_object,
+                                           section_name,
+                                           global_vars_map,
+                                           needed_global_variables,
+                                           bpftrace);
+    }
+  }
+}
+
+std::string to_string(GlobalVar global_var)
+{
+  return get_config(global_var).name;
+}
+
+GlobalVar from_string(std::string_view name)
+{
+  for (const auto &[global_var, config] : GLOBAL_VAR_CONFIGS) {
+    if (config.name == name)
+      return global_var;
+  }
+  LOG(BUG) << "Unknown global variable " << name;
+  return {}; // unreachable
+}
+
+static SizedType make_rw_type(size_t num_elements,
+                              const SizedType &element_type)
+{
+  auto subtype = CreateArray(num_elements, element_type);
+  // For 1 CPU, will be adjusted to actual CPU count at runtime
+  return CreateArray(1, subtype);
+}
+
+SizedType get_type(bpftrace::globalvars::GlobalVar global_var,
+                   const RequiredResources &resources)
+{
+  switch (global_var) {
+    case bpftrace::globalvars::GlobalVar::NUM_CPUS:
+    case bpftrace::globalvars::GlobalVar::MAX_CPU_ID:
+      return CreateInt64();
+    case bpftrace::globalvars::GlobalVar::FMT_STRINGS_BUFFER:
+      assert(resources.max_fmtstring_args_size > 0);
+      return make_rw_type(
+          1, CreateArray(resources.max_fmtstring_args_size, CreateInt8()));
+  }
+  return {}; // unreachable
+}
+
+std::unordered_set<std::string> get_section_names()
+{
+  std::unordered_set<std::string> ret;
+  for (const auto &[_, config] : GLOBAL_VAR_CONFIGS) {
+    ret.insert(config.section);
+  }
+  return ret;
 }
 
 } // namespace bpftrace::globalvars

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -112,7 +112,7 @@ public:
 
   // Map metadata
   std::map<std::string, MapInfo> maps_info;
-  std::unordered_set<std::string> needed_global_vars;
+  std::unordered_set<bpftrace::globalvars::GlobalVar> needed_global_vars;
   bool needs_perf_event_map = false;
 
   // Probe metadata

--- a/src/types.h
+++ b/src/types.h
@@ -706,6 +706,21 @@ uint64_t asyncactionint(AsyncAction a);
 
 enum class PositionalParameterType { positional, count };
 
+namespace globalvars {
+
+enum class GlobalVar {
+  // Number of online CPUs at runtime, used for metric aggregation for functions
+  // like sum and avg
+  NUM_CPUS,
+  // Max CPU ID returned by bpf_get_smp_processor_id, used for simulating
+  // per-CPU maps in read-write global variables
+  MAX_CPU_ID,
+  // Scratch buffer used for format strings to avoid BPF stack allocation limits
+  FMT_STRINGS_BUFFER,
+};
+
+} // namespace globalvars
+
 } // namespace bpftrace
 
 // SizedType hash function

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -507,6 +507,14 @@ std::vector<int> get_possible_cpus()
   return read_cpu_range("/sys/devices/system/cpu/possible");
 }
 
+int get_max_cpu_id()
+{
+  const auto cpus = get_possible_cpus();
+  auto it = std::max_element(cpus.begin(), cpus.end());
+  assert(it != cpus.end());
+  return *it;
+}
+
 std::vector<std::string> get_kernel_cflags(const char *uname_machine,
                                            const std::string &ksrc,
                                            const std::string &kobj,

--- a/src/utils.h
+++ b/src/utils.h
@@ -193,6 +193,7 @@ std::vector<std::string> get_wildcard_tokens(const std::string &input,
                                              bool &end_wildcard);
 std::vector<int> get_online_cpus();
 std::vector<int> get_possible_cpus();
+int get_max_cpu_id();
 bool is_dir(const std::string &path);
 bool file_exists_and_ownedby_root(const char *f);
 bool get_kernel_dirs(const struct utsname &utsname,

--- a/tests/codegen/llvm/avg_cast.ll
+++ b/tests/codegen/llvm/avg_cast.ll
@@ -6,7 +6,6 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %avg_stas_val = type { i64, i64 }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
@@ -14,16 +13,16 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !72
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !59
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !67
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !77 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %ret = alloca i64, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
@@ -73,118 +72,112 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br label %while_cond
 
 if_body:                                          ; preds = %is_negative_merge_block
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %11 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %11
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %11
+  %12 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %13 = getelementptr %print_integer_8_t, ptr %12, i64 0, i32 0
+  store i64 30007, ptr %13, align 8
+  %14 = getelementptr %print_integer_8_t, ptr %12, i64 0, i32 1
+  store i64 0, ptr %14, align 8
+  %15 = getelementptr %print_integer_8_t, ptr %12, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %15, i8 0, i64 8, i1 false)
+  store i64 6, ptr %15, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %12, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 if_end:                                           ; preds = %counter_merge, %is_negative_merge_block
   ret i64 0
 
 while_cond:                                       ; preds = %lookup_success2, %lookup_merge
-  %11 = load i32, ptr @num_cpus, align 4
-  %12 = load i32, ptr %i, align 4
-  %num_cpu.cmp = icmp ult i32 %12, %11
+  %16 = load i32, ptr @num_cpus, align 4
+  %17 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %17, %16
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %13 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %13)
+  %18 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %18)
   %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  %14 = load i64, ptr %val_1, align 8
-  %is_negative_cond = icmp slt i64 %14, 0
+  %19 = load i64, ptr %val_1, align 8
+  %is_negative_cond = icmp slt i64 %19, 0
   br i1 %is_negative_cond, label %is_negative, label %is_positive
 
 lookup_success2:                                  ; preds = %while_body
-  %15 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %16 = load i64, ptr %15, align 8
-  %17 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %18 = load i64, ptr %17, align 8
-  %19 = load i64, ptr %val_1, align 8
-  %20 = add i64 %16, %19
-  store i64 %20, ptr %val_1, align 8
-  %21 = load i64, ptr %val_2, align 8
-  %22 = add i64 %18, %21
-  store i64 %22, ptr %val_2, align 8
-  %23 = load i32, ptr %i, align 4
-  %24 = add i32 %23, 1
-  store i32 %24, ptr %i, align 4
+  %20 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %21 = load i64, ptr %20, align 8
+  %22 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %23 = load i64, ptr %22, align 8
+  %24 = load i64, ptr %val_1, align 8
+  %25 = add i64 %21, %24
+  store i64 %25, ptr %val_1, align 8
+  %26 = load i64, ptr %val_2, align 8
+  %27 = add i64 %23, %26
+  store i64 %27, ptr %val_2, align 8
+  %28 = load i32, ptr %i, align 4
+  %29 = add i32 %28, 1
+  store i32 %29, ptr %i, align 4
   br label %while_cond
 
 lookup_failure3:                                  ; preds = %while_body
-  %25 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %25, 0
+  %30 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %30, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %26 = load i32, ptr %i, align 4
+  %31 = load i32, ptr %i, align 4
   br label %while_end
 
 is_negative:                                      ; preds = %while_end
-  %27 = load i64, ptr %val_1, align 8
-  %28 = xor i64 %27, -1
-  %29 = add i64 %28, 1
-  %30 = load i64, ptr %val_2, align 8
-  %31 = udiv i64 %29, %30
-  %32 = sub i64 0, %31
-  store i64 %32, ptr %ret, align 8
+  %32 = load i64, ptr %val_1, align 8
+  %33 = xor i64 %32, -1
+  %34 = add i64 %33, 1
+  %35 = load i64, ptr %val_2, align 8
+  %36 = udiv i64 %34, %35
+  %37 = sub i64 0, %36
+  store i64 %37, ptr %ret, align 8
   br label %is_negative_merge_block
 
 is_positive:                                      ; preds = %while_end
-  %33 = load i64, ptr %val_2, align 8
-  %34 = load i64, ptr %val_1, align 8
-  %35 = udiv i64 %34, %33
-  store i64 %35, ptr %ret, align 8
+  %38 = load i64, ptr %val_2, align 8
+  %39 = load i64, ptr %val_1, align 8
+  %40 = udiv i64 %39, %38
+  store i64 %40, ptr %ret, align 8
   br label %is_negative_merge_block
 
 is_negative_merge_block:                          ; preds = %is_positive, %is_negative
-  %36 = load i64, ptr %ret, align 8
+  %41 = load i64, ptr %ret, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  %37 = icmp eq i64 %36, 2
-  %38 = zext i1 %37 to i64
-  %true_cond = icmp ne i64 %38, 0
+  %42 = icmp eq i64 %41, 2
+  %43 = zext i1 %42 to i64
+  %true_cond = icmp ne i64 %43, 0
   br i1 %true_cond, label %if_body, label %if_end
 
-lookup_fmtstr_failure:                            ; preds = %if_body
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %if_body
-  %39 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %39, align 8
-  %40 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %40, align 8
-  %41 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %41, i8 0, i64 8, i1 false)
-  store i64 6, ptr %41, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %if_body
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem4 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond8 = icmp ne ptr %lookup_elem4, null
   br i1 %map_lookup_cond8, label %lookup_success5, label %lookup_failure6
 
-counter_merge:                                    ; preds = %lookup_merge7, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge7, %if_body
   br label %if_end
 
 lookup_success5:                                  ; preds = %event_loss_counter
-  %42 = atomicrmw add ptr %lookup_elem4, i64 1 seq_cst, align 8
+  %44 = atomicrmw add ptr %lookup_elem4, i64 1 seq_cst, align 8
   br label %lookup_merge7
 
 lookup_failure6:                                  ; preds = %event_loss_counter
@@ -208,8 +201,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!74}
-!llvm.module.flags = !{!76}
+!llvm.dbg.cu = !{!69}
+!llvm.module.flags = !{!71}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -269,28 +262,23 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
-!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
-!60 = !{!61, !49, !54, !66}
-!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !64)
-!64 = !{!65}
-!65 = !DISubrange(count: 6, lowerBound: 0)
-!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !67, size: 64, offset: 192)
-!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
-!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 192, elements: !70)
-!69 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!70 = !{!71}
-!71 = !DISubrange(count: 24, lowerBound: 0)
-!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
-!73 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!74 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !75)
-!75 = !{!0, !26, !40, !57, !72}
-!76 = !{i32 2, !"Debug Info Version", i32 3}
-!77 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !74, retainedNodes: !81)
-!78 = !DISubroutineType(types: !79)
-!79 = !{!18, !80}
-!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
-!81 = !{!82}
-!82 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !80)
+!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 192, elements: !52)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 192, elements: !52)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 192, elements: !65)
+!64 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!65 = !{!66}
+!66 = !DISubrange(count: 24, lowerBound: 0)
+!67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
+!68 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!69 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !70)
+!70 = !{!0, !26, !40, !57, !59, !67}
+!71 = !{i32 2, !"Debug Info Version", i32 3}
+!72 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !69, retainedNodes: !76)
+!73 = !DISubroutineType(types: !74)
+!74 = !{!18, !75}
+!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
+!76 = !{!77}
+!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !75)

--- a/tests/codegen/llvm/avg_cast_loop.ll
+++ b/tests/codegen/llvm/avg_cast_loop.ll
@@ -6,7 +6,6 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %avg_stas_val = type { i64, i64 }
 %int64_avg__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
@@ -15,13 +14,14 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !72
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !59
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !67
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !77 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
 entry:
   %avg_struct = alloca %avg_stas_val, align 8
   %"@x_key" = alloca i64, align 8
@@ -66,9 +66,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !83 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !78 {
   %key1 = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %tuple = alloca %int64_avg__tuple_t, align 8
   %"$kv" = alloca %int64_avg__tuple_t, align 8
   %ret = alloca i64, align 8
@@ -172,41 +171,35 @@ is_negative_merge_block:                          ; preds = %is_positive, %is_ne
   store i64 %34, ptr %37, align 8
   %38 = getelementptr %int64_avg__tuple_t, ptr %tuple, i32 0, i32 1
   store i64 %36, ptr %38, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %is_negative_merge_block
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %is_negative_merge_block
-  %39 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %39, align 8
-  %40 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %40, align 8
-  %41 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %41, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %41, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %39 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %39
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %39
+  %40 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %41 = getelementptr %print_tuple_16_t, ptr %40, i64 0, i32 0
+  store i64 30007, ptr %41, align 8
+  %42 = getelementptr %print_tuple_16_t, ptr %40, i64 0, i32 1
+  store i64 0, ptr %42, align 8
+  %43 = getelementptr %print_tuple_16_t, ptr %40, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %43, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %43, ptr align 1 %tuple, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %40, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %is_negative_merge_block
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
   store i32 0, ptr %key1, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
   %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %is_negative_merge_block
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %42 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %44 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
@@ -228,8 +221,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!74}
-!llvm.module.flags = !{!76}
+!llvm.dbg.cu = !{!69}
+!llvm.module.flags = !{!71}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -289,31 +282,26 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
-!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
-!60 = !{!61, !49, !54, !66}
-!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !64)
-!64 = !{!65}
-!65 = !DISubrange(count: 6, lowerBound: 0)
-!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !67, size: 64, offset: 192)
-!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
-!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 256, elements: !70)
-!69 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!70 = !{!71}
-!71 = !DISubrange(count: 32, lowerBound: 0)
-!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
-!73 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!74 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !75)
-!75 = !{!0, !26, !40, !57, !72}
-!76 = !{i32 2, !"Debug Info Version", i32 3}
-!77 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !74, retainedNodes: !81)
-!78 = !DISubroutineType(types: !79)
-!79 = !{!18, !80}
-!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
-!81 = !{!82}
-!82 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !80)
-!83 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !74, retainedNodes: !84)
-!84 = !{!85}
-!85 = !DILocalVariable(name: "ctx", arg: 1, scope: !83, file: !2, type: !80)
+!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 256, elements: !52)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 256, elements: !52)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 256, elements: !65)
+!64 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!65 = !{!66}
+!66 = !DISubrange(count: 32, lowerBound: 0)
+!67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
+!68 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!69 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !70)
+!70 = !{!0, !26, !40, !57, !59, !67}
+!71 = !{i32 2, !"Debug Info Version", i32 3}
+!72 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !69, retainedNodes: !76)
+!73 = !DISubroutineType(types: !74)
+!74 = !{!18, !75}
+!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
+!76 = !{!77}
+!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !75)
+!78 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !69, retainedNodes: !79)
+!79 = !{!80}
+!80 = !DILocalVariable(name: "ctx", arg: 1, scope: !78, file: !2, type: !75)

--- a/tests/codegen/llvm/call_avg.ll
+++ b/tests/codegen/llvm/call_avg.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0

--- a/tests/codegen/llvm/call_cat.ll
+++ b/tests/codegen/llvm/call_cat.ll
@@ -5,51 +5,44 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %cat_t = type { i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 8, i1 false)
-  %1 = getelementptr %cat_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 20000, ptr %1, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 8, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 8, i1 false)
+  %3 = getelementptr %cat_t, ptr %2, i32 0, i32 0
+  store i64 20000, ptr %3, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %entry
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %2 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %4 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -60,21 +53,21 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br label %counter_merge
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -113,26 +106,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 64, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 8, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 8, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/call_cgroup_path.ll
+++ b/tests/codegen/llvm/call_cgroup_path.ll
@@ -5,22 +5,21 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %cgroup_path_t = type <{ i64, i64 }>
 %print_cgroup_path_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %cgroup_path_args = alloca %cgroup_path_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %cgroup_path_args)
   %1 = getelementptr %cgroup_path_t, ptr %cgroup_path_args, i64 0, i32 0
@@ -28,40 +27,34 @@ entry:
   %get_cgroup_id = call i64 inttoptr (i64 80 to ptr)()
   %2 = getelementptr %cgroup_path_t, ptr %cgroup_path_args, i64 0, i32 1
   store i64 %get_cgroup_id, ptr %2, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  %3 = getelementptr %print_cgroup_path_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %3, align 8
-  %4 = getelementptr %print_cgroup_path_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %4, align 8
-  %5 = getelementptr %print_cgroup_path_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %cgroup_path_args, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
+  %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %5 = getelementptr %print_cgroup_path_16_t, ptr %4, i64 0, i32 0
+  store i64 30007, ptr %5, align 8
+  %6 = getelementptr %print_cgroup_path_16_t, ptr %4, i64 0, i32 1
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr %print_cgroup_path_16_t, ptr %4, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %cgroup_path_args, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %entry
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %6 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -75,22 +68,22 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
 
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -129,26 +122,21 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 256, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 32, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 256, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 256, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 256, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 32, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/call_count.ll
+++ b/tests/codegen/llvm/call_count.ll
@@ -11,7 +11,7 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !45
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !57
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -5,22 +5,21 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"int64_string[4]__tuple_t" = type { i64, [4 x i8] }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %tuple = alloca %"int64_string[4]__tuple_t", align 8
   %str = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
@@ -32,41 +31,35 @@ entry:
   %2 = getelementptr %"int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 4, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  %3 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %3, align 8
-  %4 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %4, align 8
-  %5 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
+  %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %5 = getelementptr %print_tuple_16_t, ptr %4, i64 0, i32 0
+  store i64 30007, ptr %5, align 8
+  %6 = getelementptr %print_tuple_16_t, ptr %4, i64 0, i32 1
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr %print_tuple_16_t, ptr %4, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %tuple, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %entry
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %6 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -94,8 +87,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -134,26 +127,21 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 256, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 32, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 256, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 256, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 256, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 32, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -5,55 +5,48 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  %1 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %1, align 8
-  %2 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %2, align 8
-  %3 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %3, i8 0, i64 8, i1 false)
-  store i64 3, ptr %3, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %3 = getelementptr %print_integer_8_t, ptr %2, i64 0, i32 0
+  store i64 30007, ptr %3, align 8
+  %4 = getelementptr %print_integer_8_t, ptr %2, i64 0, i32 1
+  store i64 0, ptr %4, align 8
+  %5 = getelementptr %print_integer_8_t, ptr %2, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
+  store i64 3, ptr %5, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %entry
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %4 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %6 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -64,21 +57,21 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br label %counter_merge
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -117,26 +110,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 192, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 24, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 192, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 192, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 192, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 24, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -5,76 +5,69 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
   %"struct Foo.l" = alloca i64, align 8
   %"struct Foo.c" = alloca i8, align 1
-  %lookup_fmtstr_key = alloca i32, align 4
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = getelementptr i64, ptr %0, i64 14
   %arg0 = load volatile i64, ptr %1, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 24, i1 false)
-  %2 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %2, align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = add i64 %3, 0
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %2 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %2
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %2
+  %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %3, i8 0, i64 24, i1 false)
+  %4 = getelementptr %printf_t, ptr %3, i32 0, i32 0
+  store i64 0, ptr %4, align 8
+  %5 = load i64, ptr %"$foo", align 8
+  %6 = add i64 %5, 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.c", i32 1, i64 %4)
-  %5 = load i8, ptr %"struct Foo.c", align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.c", i32 1, i64 %6)
+  %7 = load i8, ptr %"struct Foo.c", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.c")
-  %6 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
-  %7 = sext i8 %5 to i64
-  store i64 %7, ptr %6, align 8
-  %8 = load i64, ptr %"$foo", align 8
-  %9 = add i64 %8, 8
+  %8 = getelementptr %printf_t, ptr %3, i32 0, i32 1
+  %9 = sext i8 %7 to i64
+  store i64 %9, ptr %8, align 8
+  %10 = load i64, ptr %"$foo", align 8
+  %11 = add i64 %10, 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.l")
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, i64 %9)
-  %10 = load i64, ptr %"struct Foo.l", align 8
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, i64 %11)
+  %12 = load i64, ptr %"struct Foo.l", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.l")
-  %11 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  store i64 %10, ptr %11, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
+  %13 = getelementptr %printf_t, ptr %3, i32 0, i32 2
+  store i64 %12, ptr %13, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %3, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %entry
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %12 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %14 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -88,18 +81,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -138,26 +131,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 192, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 24, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 192, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 192, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 192, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 24, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -5,63 +5,56 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %strftime_t = type <{ i32, i32, i64 }>
 %printf_t = type { i64, [16 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
   %strftime_args = alloca %strftime_t, align 8
-  %lookup_fmtstr_key = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 24, i1 false)
-  %1 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %1, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 24, i1 false)
+  %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
+  store i64 0, ptr %3, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %strftime_args)
-  %2 = getelementptr %strftime_t, ptr %strftime_args, i64 0, i32 0
-  store i32 0, ptr %2, align 4
-  %3 = getelementptr %strftime_t, ptr %strftime_args, i64 0, i32 1
-  store i32 1, ptr %3, align 4
+  %4 = getelementptr %strftime_t, ptr %strftime_args, i64 0, i32 0
+  store i32 0, ptr %4, align 4
+  %5 = getelementptr %strftime_t, ptr %strftime_args, i64 0, i32 1
+  store i32 1, ptr %5, align 4
   %get_ns = call i64 inttoptr (i64 125 to ptr)()
-  %4 = getelementptr %strftime_t, ptr %strftime_args, i64 0, i32 2
-  store i64 %get_ns, ptr %4, align 8
-  %5 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %strftime_args, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
+  %6 = getelementptr %strftime_t, ptr %strftime_args, i64 0, i32 2
+  store i64 %get_ns, ptr %6, align 8
+  %7 = getelementptr %printf_t, ptr %2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %strftime_args, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %entry
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %6 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -72,25 +65,25 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br label %counter_merge
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
 
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -129,26 +122,21 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 192, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 24, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 192, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 192, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 192, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 24, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -11,7 +11,7 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0

--- a/tests/codegen/llvm/call_system.ll
+++ b/tests/codegen/llvm/call_system.ll
@@ -5,53 +5,46 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %system_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
-  %1 = getelementptr %system_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 10000, ptr %1, align 8
-  %2 = getelementptr %system_t, ptr %lookup_fmtstr_map, i32 0, i32 1
-  store i64 100, ptr %2, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %system_t, ptr %2, i32 0, i32 0
+  store i64 10000, ptr %3, align 8
+  %4 = getelementptr %system_t, ptr %2, i32 0, i32 1
+  store i64 100, ptr %4, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %entry
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %3 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %5 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -62,21 +55,21 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br label %counter_merge
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -115,26 +108,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 16, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 128, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 128, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 128, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 16, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -6,7 +6,6 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %int64_count__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
@@ -14,13 +13,14 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !51
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !66
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !51
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !53
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !61
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !71 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !66 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -58,9 +58,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !77 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !72 {
   %key1 = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %tuple = alloca %int64_count__tuple_t, align 8
   %"$kv" = alloca %int64_count__tuple_t, align 8
   %val_2 = alloca i64, align 8
@@ -111,63 +110,57 @@ while_end:                                        ; preds = %error_failure, %err
   store i64 %12, ptr %15, align 8
   %16 = getelementptr %int64_count__tuple_t, ptr %tuple, i32 0, i32 1
   store i64 %14, ptr %16, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %17 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
+  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
+  store i64 30007, ptr %19, align 8
+  %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1
+  store i64 0, ptr %20, align 8
+  %21 = getelementptr %print_tuple_16_t, ptr %18, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %21, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %21, ptr align 1 %tuple, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %18, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %17 = load i64, ptr %val_1, align 8
-  %18 = load i64, ptr %lookup_percpu_elem, align 8
-  %19 = add i64 %18, %17
-  store i64 %19, ptr %val_1, align 8
-  %20 = load i32, ptr %i, align 4
-  %21 = add i32 %20, 1
-  store i32 %21, ptr %i, align 4
+  %22 = load i64, ptr %val_1, align 8
+  %23 = load i64, ptr %lookup_percpu_elem, align 8
+  %24 = add i64 %23, %22
+  store i64 %24, ptr %val_1, align 8
+  %25 = load i32, ptr %i, align 4
+  %26 = add i32 %25, 1
+  store i32 %26, ptr %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %22 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %22, 0
+  %27 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %27, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %23 = load i32, ptr %i, align 4
+  %28 = load i32, ptr %i, align 4
   br label %while_end
 
-lookup_fmtstr_failure:                            ; preds = %while_end
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %while_end
-  %24 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %24, align 8
-  %25 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %25, align 8
-  %26 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %26, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %26, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %while_end
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
   store i32 0, ptr %key1, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
   %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %while_end
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %27 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %29 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
@@ -189,8 +182,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!68}
-!llvm.module.flags = !{!70}
+!llvm.dbg.cu = !{!63}
+!llvm.module.flags = !{!65}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -244,31 +237,26 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !54)
-!54 = !{!55, !43, !48, !60}
-!55 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !56, size: 64)
-!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !57, size: 64)
-!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !58)
-!58 = !{!59}
-!59 = !DISubrange(count: 6, lowerBound: 0)
-!60 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !61, size: 64, offset: 192)
-!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
-!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 256, elements: !64)
-!63 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!64 = !{!65}
-!65 = !DISubrange(count: 32, lowerBound: 0)
-!66 = !DIGlobalVariableExpression(var: !67, expr: !DIExpression())
-!67 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!68 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !69)
-!69 = !{!0, !20, !34, !51, !66}
-!70 = !{i32 2, !"Debug Info Version", i32 3}
-!71 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !68, retainedNodes: !75)
-!72 = !DISubroutineType(types: !73)
-!73 = !{!18, !74}
-!74 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!75 = !{!76}
-!76 = !DILocalVariable(name: "ctx", arg: 1, scope: !71, file: !2, type: !74)
-!77 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !68, retainedNodes: !78)
-!78 = !{!79}
-!79 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !74)
+!52 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 256, elements: !46)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 256, elements: !46)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 256, elements: !59)
+!58 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!59 = !{!60}
+!60 = !DISubrange(count: 32, lowerBound: 0)
+!61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
+!62 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!63 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !64)
+!64 = !{!0, !20, !34, !51, !53, !61}
+!65 = !{i32 2, !"Debug Info Version", i32 3}
+!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !63, retainedNodes: !70)
+!67 = !DISubroutineType(types: !68)
+!68 = !{!18, !69}
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)
+!72 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !63, retainedNodes: !73)
+!73 = !{!74}
+!74 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !69)

--- a/tests/codegen/llvm/count_no_cast_for_print.ll
+++ b/tests/codegen/llvm/count_no_cast_for_print.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !45
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -5,24 +5,22 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64 }
-%printf_t.2 = type { i64 }
+%printf_t.1 = type { i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
-  %key10 = alloca i32, align 4
-  %lookup_fmtstr_key1 = alloca i32, align 4
+  %key8 = alloca i32, align 4
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ugt i64 %1, 10
@@ -31,47 +29,46 @@ entry:
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-if_end:                                           ; preds = %counter_merge8, %counter_merge
-  ret i64 0
-
-else_body:                                        ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key1)
-  store i32 0, ptr %lookup_fmtstr_key1, align 4
-  %lookup_fmtstr_map2 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key1)
-  %lookup_fmtstr_cond5 = icmp ne ptr %lookup_fmtstr_map2, null
-  br i1 %lookup_fmtstr_cond5, label %lookup_fmtstr_merge4, label %lookup_fmtstr_failure3
-
-lookup_fmtstr_failure:                            ; preds = %if_body
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %if_body
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 8, i1 false)
-  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 8, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
+  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
+  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
+  store i64 0, ptr %6, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+if_end:                                           ; preds = %counter_merge6, %counter_merge
+  ret i64 0
+
+else_body:                                        ; preds = %entry
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %7 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %7
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %7
+  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select3, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 8, i1 false)
+  %9 = getelementptr %printf_t.1, ptr %8, i32 0, i32 0
+  store i64 1, ptr %9, align 8
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %8, i64 8, i64 0)
+  %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
+  br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
+
+event_loss_counter:                               ; preds = %if_body
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %if_body
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %5 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -81,54 +78,43 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
   br label %counter_merge
 
-lookup_fmtstr_failure3:                           ; preds = %else_body
-  ret i64 0
+event_loss_counter5:                              ; preds = %else_body
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key8)
+  store i32 0, ptr %key8, align 4
+  %lookup_elem9 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key8)
+  %map_lookup_cond13 = icmp ne ptr %lookup_elem9, null
+  br i1 %map_lookup_cond13, label %lookup_success10, label %lookup_failure11
 
-lookup_fmtstr_merge4:                             ; preds = %else_body
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map2, i8 0, i64 8, i1 false)
-  %6 = getelementptr %printf_t.2, ptr %lookup_fmtstr_map2, i32 0, i32 0
-  store i64 1, ptr %6, align 8
-  %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map2, i64 8, i64 0)
-  %ringbuf_loss9 = icmp slt i64 %ringbuf_output6, 0
-  br i1 %ringbuf_loss9, label %event_loss_counter7, label %counter_merge8
-
-event_loss_counter7:                              ; preds = %lookup_fmtstr_merge4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key10)
-  store i32 0, ptr %key10, align 4
-  %lookup_elem11 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key10)
-  %map_lookup_cond15 = icmp ne ptr %lookup_elem11, null
-  br i1 %map_lookup_cond15, label %lookup_success12, label %lookup_failure13
-
-counter_merge8:                                   ; preds = %lookup_merge14, %lookup_fmtstr_merge4
+counter_merge6:                                   ; preds = %lookup_merge12, %else_body
   br label %if_end
 
-lookup_success12:                                 ; preds = %event_loss_counter7
-  %7 = atomicrmw add ptr %lookup_elem11, i64 1 seq_cst, align 8
-  br label %lookup_merge14
+lookup_success10:                                 ; preds = %event_loss_counter5
+  %11 = atomicrmw add ptr %lookup_elem9, i64 1 seq_cst, align 8
+  br label %lookup_merge12
 
-lookup_failure13:                                 ; preds = %event_loss_counter7
-  br label %lookup_merge14
+lookup_failure11:                                 ; preds = %event_loss_counter5
+  br label %lookup_merge12
 
-lookup_merge14:                                   ; preds = %lookup_failure13, %lookup_success12
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key10)
-  br label %counter_merge8
+lookup_merge12:                                   ; preds = %lookup_failure11, %lookup_success10
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key8)
+  br label %counter_merge6
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -167,26 +153,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 64, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 8, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 8, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -5,21 +5,20 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %"$s" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
@@ -35,43 +34,37 @@ if_body:                                          ; preds = %entry
   br label %if_end
 
 if_end:                                           ; preds = %else_body, %if_body
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
+  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
+  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
+  store i64 0, ptr %6, align 8
+  %7 = load i64, ptr %"$s", align 8
+  %8 = getelementptr %printf_t, ptr %5, i32 0, i32 1
+  store i64 %7, ptr %8, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 else_body:                                        ; preds = %entry
   store i64 20, ptr %"$s", align 8
   br label %if_end
 
-lookup_fmtstr_failure:                            ; preds = %if_end
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %if_end
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
-  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %5 = load i64, ptr %"$s", align 8
-  %6 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
-  store i64 %5, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %if_end
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %if_end
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %7 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -85,18 +78,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -135,26 +128,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 16, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 128, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 128, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 128, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 16, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -5,21 +5,20 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ugt i64 %1, 10000
@@ -40,39 +39,33 @@ if_end:                                           ; preds = %if_end2, %entry
   ret i64 0
 
 if_body1:                                         ; preds = %if_body
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %8 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %8
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %8
+  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
+  %10 = getelementptr %printf_t, ptr %9, i32 0, i32 0
+  store i64 0, ptr %10, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %9, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 if_end2:                                          ; preds = %counter_merge, %if_body
   br label %if_end
 
-lookup_fmtstr_failure:                            ; preds = %if_body1
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %if_body1
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 8, i1 false)
-  %8 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %8, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 8, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %if_body1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %if_body1
   br label %if_end2
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %11 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -83,21 +76,21 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br label %counter_merge
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -136,26 +129,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 64, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 8, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 8, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -5,21 +5,20 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ugt i64 %1, 10000
@@ -28,43 +27,37 @@ entry:
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
+  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
+  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
+  store i64 0, ptr %6, align 8
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %7 = lshr i64 %get_pid_tgid1, 32
+  %8 = getelementptr %printf_t, ptr %5, i32 0, i32 1
+  store i64 %7, ptr %8, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 if_end:                                           ; preds = %counter_merge, %entry
   ret i64 0
 
-lookup_fmtstr_failure:                            ; preds = %if_body
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %if_body
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
-  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %5 = lshr i64 %get_pid_tgid1, 32
-  %6 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
-  store i64 %5, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %if_body
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %if_body
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %7 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -75,21 +68,21 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br label %counter_merge
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -128,26 +121,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 16, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 128, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 128, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 128, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 16, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -5,21 +5,20 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %"$s" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
@@ -35,39 +34,33 @@ if_body:                                          ; preds = %entry
   br label %if_end
 
 if_end:                                           ; preds = %if_body, %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %if_end
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %if_end
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
-  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %5 = load i64, ptr %"$s", align 8
-  %6 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
-  store i64 %5, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
+  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
+  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
+  store i64 0, ptr %6, align 8
+  %7 = load i64, ptr %"$s", align 8
+  %8 = getelementptr %printf_t, ptr %5, i32 0, i32 1
+  store i64 %7, ptr %8, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %if_end
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %if_end
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %7 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -81,18 +74,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -131,26 +124,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 16, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 128, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 128, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 128, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 16, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -11,7 +11,7 @@ target triple = "bpf-pc-linux"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -11,7 +11,7 @@ target triple = "bpf-pc-linux"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !51
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !51
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0

--- a/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
@@ -6,14 +6,14 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @recursion_prevention = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
-@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !45
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !45
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !47
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -22,7 +22,6 @@ define i64 @kfunc_queued_spin_lock_slowpath_1(ptr %0) section "s_kfunc_queued_sp
 entry:
   %lookup_key19 = alloca i32, align 4
   %key13 = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %lookup_key6 = alloca i32, align 4
   %key = alloca i32, align 4
   %lookup_key = alloca i32, align 4
@@ -76,12 +75,21 @@ pred_false:                                       ; preds = %lookup_merge
   br i1 %map_lookup_cond11, label %lookup_success8, label %lookup_failure9
 
 pred_true:                                        ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %6 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %6
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
+  %7 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %8 = getelementptr %print_integer_8_t, ptr %7, i64 0, i32 0
+  store i64 30007, ptr %8, align 8
+  %9 = getelementptr %print_integer_8_t, ptr %7, i64 0, i32 1
+  store i64 0, ptr %9, align 8
+  %10 = getelementptr %print_integer_8_t, ptr %7, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 8, i1 false)
+  store i64 2, ptr %10, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %7, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success8:                                  ; preds = %pred_false
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key6)
@@ -95,29 +103,14 @@ lookup_failure9:                                  ; preds = %pred_false
 lookup_merge10:                                   ; preds = %lookup_failure9, %lookup_success8
   ret i64 0
 
-lookup_fmtstr_failure:                            ; preds = %pred_true
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %pred_true
-  %6 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %6, align 8
-  %7 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %7, align 8
-  %8 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 8, i1 false)
-  store i64 2, ptr %8, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %pred_true
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key13)
   store i32 0, ptr %key13, align 4
   %lookup_elem14 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key13)
   %map_lookup_cond18 = icmp ne ptr %lookup_elem14, null
   br i1 %map_lookup_cond18, label %lookup_success15, label %lookup_failure16
 
-counter_merge:                                    ; preds = %lookup_merge17, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge17, %pred_true
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key19)
   store i32 0, ptr %lookup_key19, align 4
   %lookup_elem20 = call ptr inttoptr (i64 1 to ptr)(ptr @recursion_prevention, ptr %lookup_key19)
@@ -125,7 +118,7 @@ counter_merge:                                    ; preds = %lookup_merge17, %lo
   br i1 %map_lookup_cond24, label %lookup_success21, label %lookup_failure22
 
 lookup_success15:                                 ; preds = %event_loss_counter
-  %9 = atomicrmw add ptr %lookup_elem14, i64 1 seq_cst, align 8
+  %11 = atomicrmw add ptr %lookup_elem14, i64 1 seq_cst, align 8
   br label %lookup_merge17
 
 lookup_failure16:                                 ; preds = %event_loss_counter
@@ -210,17 +203,17 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !43 = !{!44}
 !44 = !DISubrange(count: 2, lowerBound: 0)
 !45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
-!46 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
-!47 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !48)
-!48 = !{!5, !11, !16, !49}
-!49 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !50, size: 64, offset: 192)
-!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
+!46 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
+!48 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !49, isLocal: false, isDefinition: true)
+!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !50, size: 192, elements: !14)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 192, elements: !14)
 !51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !52, size: 192, elements: !53)
 !52 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !53 = !{!54}
 !54 = !DISubrange(count: 24, lowerBound: 0)
 !55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
-!56 = !{!0, !22, !36, !45}
+!56 = !{!0, !22, !36, !45, !47}
 !57 = !{i32 2, !"Debug Info Version", i32 3}
 !58 = distinct !DISubprogram(name: "kfunc_queued_spin_lock_slowpath_1", linkageName: "kfunc_queued_spin_lock_slowpath_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
 !59 = !DISubroutineType(types: !60)

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -5,18 +5,18 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64, i64, i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [40 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !54 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
   %"struct Foo.m16" = alloca i32, align 4
@@ -27,61 +27,54 @@ entry:
   %"&&_result5" = alloca i64, align 8
   %"struct Foo.m" = alloca i32, align 4
   %"&&_result" = alloca i64, align 8
-  %lookup_fmtstr_key = alloca i32, align 4
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   store i64 0, ptr %"$foo", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 40, i1 false)
-  %1 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %1, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [40 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 40, i1 false)
+  %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
+  store i64 0, ptr %3, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %4 = load i64, ptr %"$foo", align 8
+  %5 = add i64 %4, 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m")
-  %probe_read = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m", i32 4, i64 %3)
-  %4 = load i32, ptr %"struct Foo.m", align 4
+  %probe_read = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m", i32 4, i64 %5)
+  %6 = load i32, ptr %"struct Foo.m", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m")
-  %lhs_true_cond = icmp ne i32 %4, 0
+  %lhs_true_cond = icmp ne i32 %6, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
-"&&_lhs_true":                                    ; preds = %lookup_fmtstr_merge
+"&&_lhs_true":                                    ; preds = %entry
   br i1 false, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
   store i64 1, ptr %"&&_result", align 8
   br label %"&&_merge"
 
-"&&_false":                                       ; preds = %"&&_lhs_true", %lookup_fmtstr_merge
+"&&_false":                                       ; preds = %"&&_lhs_true", %entry
   store i64 0, ptr %"&&_result", align 8
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %5 = load i64, ptr %"&&_result", align 8
-  %6 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
-  store i64 %5, ptr %6, align 8
+  %7 = load i64, ptr %"&&_result", align 8
+  %8 = getelementptr %printf_t, ptr %2, i32 0, i32 1
+  store i64 %7, ptr %8, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result5")
   br i1 true, label %"&&_lhs_true1", label %"&&_false3"
 
 "&&_lhs_true1":                                   ; preds = %"&&_merge"
-  %7 = load i64, ptr %"$foo", align 8
-  %8 = add i64 %7, 0
+  %9 = load i64, ptr %"$foo", align 8
+  %10 = add i64 %9, 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m6")
-  %probe_read7 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m6", i32 4, i64 %8)
-  %9 = load i32, ptr %"struct Foo.m6", align 4
+  %probe_read7 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m6", i32 4, i64 %10)
+  %11 = load i32, ptr %"struct Foo.m6", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m6")
-  %rhs_true_cond = icmp ne i32 %9, 0
+  %rhs_true_cond = icmp ne i32 %11, 0
   br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
 
 "&&_true2":                                       ; preds = %"&&_lhs_true1"
@@ -93,17 +86,17 @@ lookup_fmtstr_merge:                              ; preds = %entry
   br label %"&&_merge4"
 
 "&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %10 = load i64, ptr %"&&_result5", align 8
-  %11 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  store i64 %10, ptr %11, align 8
+  %12 = load i64, ptr %"&&_result5", align 8
+  %13 = getelementptr %printf_t, ptr %2, i32 0, i32 2
+  store i64 %12, ptr %13, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
-  %12 = load i64, ptr %"$foo", align 8
-  %13 = add i64 %12, 0
+  %14 = load i64, ptr %"$foo", align 8
+  %15 = add i64 %14, 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m8")
-  %probe_read9 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m8", i32 4, i64 %13)
-  %14 = load i32, ptr %"struct Foo.m8", align 4
+  %probe_read9 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m8", i32 4, i64 %15)
+  %16 = load i32, ptr %"struct Foo.m8", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m8")
-  %lhs_true_cond10 = icmp ne i32 %14, 0
+  %lhs_true_cond10 = icmp ne i32 %16, 0
   br i1 %lhs_true_cond10, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %"&&_merge4"
@@ -118,20 +111,20 @@ lookup_fmtstr_merge:                              ; preds = %entry
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %15 = load i64, ptr %"||_result", align 8
-  %16 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 3
-  store i64 %15, ptr %16, align 8
+  %17 = load i64, ptr %"||_result", align 8
+  %18 = getelementptr %printf_t, ptr %2, i32 0, i32 3
+  store i64 %17, ptr %18, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result15")
   br i1 false, label %"||_true13", label %"||_lhs_false11"
 
 "||_lhs_false11":                                 ; preds = %"||_merge"
-  %17 = load i64, ptr %"$foo", align 8
-  %18 = add i64 %17, 0
+  %19 = load i64, ptr %"$foo", align 8
+  %20 = add i64 %19, 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m16")
-  %probe_read17 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m16", i32 4, i64 %18)
-  %19 = load i32, ptr %"struct Foo.m16", align 4
+  %probe_read17 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m16", i32 4, i64 %20)
+  %21 = load i32, ptr %"struct Foo.m16", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m16")
-  %rhs_true_cond18 = icmp ne i32 %19, 0
+  %rhs_true_cond18 = icmp ne i32 %21, 0
   br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
 
 "||_false12":                                     ; preds = %"||_lhs_false11"
@@ -143,10 +136,10 @@ lookup_fmtstr_merge:                              ; preds = %entry
   br label %"||_merge14"
 
 "||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %20 = load i64, ptr %"||_result15", align 8
-  %21 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 4
-  store i64 %20, ptr %21, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 40, i64 0)
+  %22 = load i64, ptr %"||_result15", align 8
+  %23 = getelementptr %printf_t, ptr %2, i32 0, i32 4
+  store i64 %22, ptr %23, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 40, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -161,7 +154,7 @@ counter_merge:                                    ; preds = %lookup_merge, %"||_
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %22 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %24 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -175,18 +168,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -225,26 +218,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 320, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 40, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 320, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 320, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 320, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 40, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/max_cast.ll
+++ b/tests/codegen/llvm/max_cast.ll
@@ -6,7 +6,6 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
@@ -14,16 +13,16 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !72
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !59
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !67
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !77 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -78,61 +77,70 @@ min_max:                                          ; preds = %is_set, %lookup_suc
   br label %lookup_merge
 
 if_body:                                          ; preds = %while_end
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %10 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %10
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %10
+  %11 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %12 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 0
+  store i64 30007, ptr %12, align 8
+  %13 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 1
+  store i64 0, ptr %13, align 8
+  %14 = getelementptr %print_integer_8_t, ptr %11, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %14, i8 0, i64 8, i1 false)
+  store i64 6, ptr %14, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %11, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 if_end:                                           ; preds = %counter_merge, %while_end
   ret i64 0
 
 while_cond:                                       ; preds = %min_max_merge, %lookup_merge
-  %10 = load i32, ptr @num_cpus, align 4
-  %11 = load i32, ptr %i, align 4
-  %num_cpu.cmp = icmp ult i32 %11, %10
+  %15 = load i32, ptr @num_cpus, align 4
+  %16 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %16, %15
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %12 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %12)
+  %17 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %17)
   %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  %13 = load i64, ptr %val_1, align 8
+  %18 = load i64, ptr %val_1, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  %14 = icmp sgt i64 %13, 5
-  %15 = zext i1 %14 to i64
-  %true_cond = icmp ne i64 %15, 0
+  %19 = icmp sgt i64 %18, 5
+  %20 = zext i1 %19 to i64
+  %true_cond = icmp ne i64 %20, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %16 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %17 = load i64, ptr %16, align 8
-  %18 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %19 = load i64, ptr %18, align 8
-  %val_set_cond = icmp eq i64 %19, 1
-  %20 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %20, 1
-  %21 = load i64, ptr %val_1, align 8
-  %max_cond = icmp sgt i64 %17, %21
+  %21 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %22 = load i64, ptr %21, align 8
+  %23 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %24 = load i64, ptr %23, align 8
+  %val_set_cond = icmp eq i64 %24, 1
+  %25 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %25, 1
+  %26 = load i64, ptr %val_1, align 8
+  %max_cond = icmp sgt i64 %22, %26
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure3:                                  ; preds = %while_body
-  %22 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %22, 0
+  %27 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %27, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success2
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %17, ptr %val_1, align 8
+  store i64 %22, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -140,45 +148,30 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %max_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success2
-  %23 = load i32, ptr %i, align 4
-  %24 = add i32 %23, 1
-  store i32 %24, ptr %i, align 4
+  %28 = load i32, ptr %i, align 4
+  %29 = add i32 %28, 1
+  store i32 %29, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %25 = load i32, ptr %i, align 4
+  %30 = load i32, ptr %i, align 4
   br label %while_end
 
-lookup_fmtstr_failure:                            ; preds = %if_body
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %if_body
-  %26 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %26, align 8
-  %27 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %27, align 8
-  %28 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %28, i8 0, i64 8, i1 false)
-  store i64 6, ptr %28, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %if_body
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem4 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond8 = icmp ne ptr %lookup_elem4, null
   br i1 %map_lookup_cond8, label %lookup_success5, label %lookup_failure6
 
-counter_merge:                                    ; preds = %lookup_merge7, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge7, %if_body
   br label %if_end
 
 lookup_success5:                                  ; preds = %event_loss_counter
-  %29 = atomicrmw add ptr %lookup_elem4, i64 1 seq_cst, align 8
+  %31 = atomicrmw add ptr %lookup_elem4, i64 1 seq_cst, align 8
   br label %lookup_merge7
 
 lookup_failure6:                                  ; preds = %event_loss_counter
@@ -202,8 +195,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!74}
-!llvm.module.flags = !{!76}
+!llvm.dbg.cu = !{!69}
+!llvm.module.flags = !{!71}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -263,28 +256,23 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
-!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
-!60 = !{!61, !49, !54, !66}
-!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !64)
-!64 = !{!65}
-!65 = !DISubrange(count: 6, lowerBound: 0)
-!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !67, size: 64, offset: 192)
-!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
-!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 192, elements: !70)
-!69 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!70 = !{!71}
-!71 = !DISubrange(count: 24, lowerBound: 0)
-!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
-!73 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!74 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !75)
-!75 = !{!0, !26, !40, !57, !72}
-!76 = !{i32 2, !"Debug Info Version", i32 3}
-!77 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !74, retainedNodes: !81)
-!78 = !DISubroutineType(types: !79)
-!79 = !{!18, !80}
-!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
-!81 = !{!82}
-!82 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !80)
+!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 192, elements: !52)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 192, elements: !52)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 192, elements: !65)
+!64 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!65 = !{!66}
+!66 = !DISubrange(count: 24, lowerBound: 0)
+!67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
+!68 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!69 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !70)
+!70 = !{!0, !26, !40, !57, !59, !67}
+!71 = !{i32 2, !"Debug Info Version", i32 3}
+!72 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !69, retainedNodes: !76)
+!73 = !DISubroutineType(types: !74)
+!74 = !{!18, !75}
+!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
+!76 = !{!77}
+!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !75)

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -6,7 +6,6 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
 %int64_max__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
@@ -15,13 +14,14 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !72
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !59
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !67
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !77 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
 entry:
   %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
@@ -72,9 +72,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !83 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !78 {
   %key1 = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %tuple = alloca %int64_max__tuple_t, align 8
   %"$kv" = alloca %int64_max__tuple_t, align 8
   %val_2 = alloca i64, align 8
@@ -125,35 +124,44 @@ while_end:                                        ; preds = %error_failure, %err
   store i64 %12, ptr %15, align 8
   %16 = getelementptr %int64_max__tuple_t, ptr %tuple, i32 0, i32 1
   store i64 %14, ptr %16, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %17 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
+  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
+  store i64 30007, ptr %19, align 8
+  %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1
+  store i64 0, ptr %20, align 8
+  %21 = getelementptr %print_tuple_16_t, ptr %18, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %21, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %21, ptr align 1 %tuple, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %18, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %17 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %18 = load i64, ptr %17, align 8
-  %19 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %20 = load i64, ptr %19, align 8
-  %val_set_cond = icmp eq i64 %20, 1
-  %21 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %21, 1
-  %22 = load i64, ptr %val_1, align 8
-  %max_cond = icmp sgt i64 %18, %22
+  %22 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %23 = load i64, ptr %22, align 8
+  %24 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %25 = load i64, ptr %24, align 8
+  %val_set_cond = icmp eq i64 %25, 1
+  %26 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %26, 1
+  %27 = load i64, ptr %val_1, align 8
+  %max_cond = icmp sgt i64 %23, %27
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %23 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %23, 0
+  %28 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %28, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %18, ptr %val_1, align 8
+  store i64 %23, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -161,46 +169,31 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %max_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
-  %24 = load i32, ptr %i, align 4
-  %25 = add i32 %24, 1
-  store i32 %25, ptr %i, align 4
+  %29 = load i32, ptr %i, align 4
+  %30 = add i32 %29, 1
+  store i32 %30, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %26 = load i32, ptr %i, align 4
+  %31 = load i32, ptr %i, align 4
   br label %while_end
 
-lookup_fmtstr_failure:                            ; preds = %while_end
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %while_end
-  %27 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %27, align 8
-  %28 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %28, align 8
-  %29 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %29, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %29, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %while_end
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
   store i32 0, ptr %key1, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
   %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %while_end
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %30 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %32 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
@@ -222,8 +215,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!74}
-!llvm.module.flags = !{!76}
+!llvm.dbg.cu = !{!69}
+!llvm.module.flags = !{!71}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -283,31 +276,26 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
-!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
-!60 = !{!61, !49, !54, !66}
-!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !64)
-!64 = !{!65}
-!65 = !DISubrange(count: 6, lowerBound: 0)
-!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !67, size: 64, offset: 192)
-!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
-!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 256, elements: !70)
-!69 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!70 = !{!71}
-!71 = !DISubrange(count: 32, lowerBound: 0)
-!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
-!73 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!74 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !75)
-!75 = !{!0, !26, !40, !57, !72}
-!76 = !{i32 2, !"Debug Info Version", i32 3}
-!77 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !74, retainedNodes: !81)
-!78 = !DISubroutineType(types: !79)
-!79 = !{!18, !80}
-!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
-!81 = !{!82}
-!82 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !80)
-!83 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !74, retainedNodes: !84)
-!84 = !{!85}
-!85 = !DILocalVariable(name: "ctx", arg: 1, scope: !83, file: !2, type: !80)
+!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 256, elements: !52)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 256, elements: !52)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 256, elements: !65)
+!64 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!65 = !{!66}
+!66 = !DISubrange(count: 32, lowerBound: 0)
+!67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
+!68 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!69 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !70)
+!70 = !{!0, !26, !40, !57, !59, !67}
+!71 = !{i32 2, !"Debug Info Version", i32 3}
+!72 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !69, retainedNodes: !76)
+!73 = !DISubroutineType(types: !74)
+!74 = !{!18, !75}
+!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
+!76 = !{!77}
+!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !75)
+!78 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !69, retainedNodes: !79)
+!79 = !{!80}
+!80 = !DILocalVariable(name: "ctx", arg: 1, scope: !78, file: !2, type: !75)

--- a/tests/codegen/llvm/min_cast.ll
+++ b/tests/codegen/llvm/min_cast.ll
@@ -6,7 +6,6 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
@@ -14,16 +13,16 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
-@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !57
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !72
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !57
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !59
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !67
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !77 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -78,61 +77,70 @@ min_max:                                          ; preds = %is_set, %lookup_suc
   br label %lookup_merge
 
 if_body:                                          ; preds = %while_end
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %10 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %10
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %10
+  %11 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %12 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 0
+  store i64 30007, ptr %12, align 8
+  %13 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 1
+  store i64 0, ptr %13, align 8
+  %14 = getelementptr %print_integer_8_t, ptr %11, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %14, i8 0, i64 8, i1 false)
+  store i64 6, ptr %14, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %11, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 if_end:                                           ; preds = %counter_merge, %while_end
   ret i64 0
 
 while_cond:                                       ; preds = %min_max_merge, %lookup_merge
-  %10 = load i32, ptr @num_cpus, align 4
-  %11 = load i32, ptr %i, align 4
-  %num_cpu.cmp = icmp ult i32 %11, %10
+  %15 = load i32, ptr @num_cpus, align 4
+  %16 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %16, %15
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %12 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %12)
+  %17 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %17)
   %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  %13 = load i64, ptr %val_1, align 8
+  %18 = load i64, ptr %val_1, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  %14 = icmp sgt i64 %13, 5
-  %15 = zext i1 %14 to i64
-  %true_cond = icmp ne i64 %15, 0
+  %19 = icmp sgt i64 %18, 5
+  %20 = zext i1 %19 to i64
+  %true_cond = icmp ne i64 %20, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %16 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %17 = load i64, ptr %16, align 8
-  %18 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %19 = load i64, ptr %18, align 8
-  %val_set_cond = icmp eq i64 %19, 1
-  %20 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %20, 1
-  %21 = load i64, ptr %val_1, align 8
-  %min_cond = icmp slt i64 %17, %21
+  %21 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %22 = load i64, ptr %21, align 8
+  %23 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %24 = load i64, ptr %23, align 8
+  %val_set_cond = icmp eq i64 %24, 1
+  %25 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %25, 1
+  %26 = load i64, ptr %val_1, align 8
+  %min_cond = icmp slt i64 %22, %26
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure3:                                  ; preds = %while_body
-  %22 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %22, 0
+  %27 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %27, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success2
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %17, ptr %val_1, align 8
+  store i64 %22, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -140,45 +148,30 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %min_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success2
-  %23 = load i32, ptr %i, align 4
-  %24 = add i32 %23, 1
-  store i32 %24, ptr %i, align 4
+  %28 = load i32, ptr %i, align 4
+  %29 = add i32 %28, 1
+  store i32 %29, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %25 = load i32, ptr %i, align 4
+  %30 = load i32, ptr %i, align 4
   br label %while_end
 
-lookup_fmtstr_failure:                            ; preds = %if_body
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %if_body
-  %26 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %26, align 8
-  %27 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %27, align 8
-  %28 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %28, i8 0, i64 8, i1 false)
-  store i64 6, ptr %28, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %if_body
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem4 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond8 = icmp ne ptr %lookup_elem4, null
   br i1 %map_lookup_cond8, label %lookup_success5, label %lookup_failure6
 
-counter_merge:                                    ; preds = %lookup_merge7, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge7, %if_body
   br label %if_end
 
 lookup_success5:                                  ; preds = %event_loss_counter
-  %29 = atomicrmw add ptr %lookup_elem4, i64 1 seq_cst, align 8
+  %31 = atomicrmw add ptr %lookup_elem4, i64 1 seq_cst, align 8
   br label %lookup_merge7
 
 lookup_failure6:                                  ; preds = %event_loss_counter
@@ -202,8 +195,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!74}
-!llvm.module.flags = !{!76}
+!llvm.dbg.cu = !{!69}
+!llvm.module.flags = !{!71}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -263,28 +256,23 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
 !56 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
 !57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
-!59 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !60)
-!60 = !{!61, !49, !54, !66}
-!61 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !62, size: 64)
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !64)
-!64 = !{!65}
-!65 = !DISubrange(count: 6, lowerBound: 0)
-!66 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !67, size: 64, offset: 192)
-!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !68, size: 64)
-!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 192, elements: !70)
-!69 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!70 = !{!71}
-!71 = !DISubrange(count: 24, lowerBound: 0)
-!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
-!73 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!74 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !75)
-!75 = !{!0, !26, !40, !57, !72}
-!76 = !{i32 2, !"Debug Info Version", i32 3}
-!77 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !78, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !74, retainedNodes: !81)
-!78 = !DISubroutineType(types: !79)
-!79 = !{!18, !80}
-!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !69, size: 64)
-!81 = !{!82}
-!82 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !80)
+!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 192, elements: !52)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 192, elements: !52)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 192, elements: !65)
+!64 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!65 = !{!66}
+!66 = !DISubrange(count: 24, lowerBound: 0)
+!67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
+!68 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!69 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !70)
+!70 = !{!0, !26, !40, !57, !59, !67}
+!71 = !{i32 2, !"Debug Info Version", i32 3}
+!72 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !69, retainedNodes: !76)
+!73 = !DISubroutineType(types: !74)
+!74 = !{!18, !75}
+!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
+!76 = !{!77}
+!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !75)

--- a/tests/codegen/llvm/ptr_to_ptr.ll
+++ b/tests/codegen/llvm/ptr_to_ptr.ll
@@ -5,69 +5,62 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
   %deref1 = alloca i32, align 4
   %deref = alloca i64, align 8
-  %lookup_fmtstr_key = alloca i32, align 4
   %"$pp" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$pp")
   store i64 0, ptr %"$pp", align 8
   store i64 0, ptr %"$pp", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
-  %1 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %1, align 8
-  %2 = load i64, ptr %"$pp", align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
+  store i64 0, ptr %3, align 8
+  %4 = load i64, ptr %"$pp", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 8, i64 %2)
-  %3 = load i64, ptr %deref, align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 8, i64 %4)
+  %5 = load i64, ptr %deref, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref1)
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %deref1, i32 4, i64 %3)
-  %4 = load i32, ptr %deref1, align 4
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %deref1, i32 4, i64 %5)
+  %6 = load i32, ptr %deref1, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref1)
-  %5 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
-  %6 = sext i32 %4 to i64
-  store i64 %6, ptr %5, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
+  %7 = getelementptr %printf_t, ptr %2, i32 0, i32 1
+  %8 = sext i32 %6 to i64
+  store i64 %8, ptr %7, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %entry
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %7 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -81,18 +74,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -131,26 +124,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 16, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 128, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 128, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 128, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 16, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/sum_cast.ll
+++ b/tests/codegen/llvm/sum_cast.ll
@@ -6,23 +6,22 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %print_integer_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !51
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !66
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !51
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !53
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !61
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !71 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !66 {
 entry:
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -64,88 +63,82 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br label %while_cond
 
 if_body:                                          ; preds = %while_end
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
+  %4 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %5 = getelementptr %print_integer_8_t, ptr %4, i64 0, i32 0
+  store i64 30007, ptr %5, align 8
+  %6 = getelementptr %print_integer_8_t, ptr %4, i64 0, i32 1
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr %print_integer_8_t, ptr %4, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 8, i1 false)
+  store i64 6, ptr %7, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 if_end:                                           ; preds = %counter_merge, %while_end
   ret i64 0
 
 while_cond:                                       ; preds = %lookup_success2, %lookup_merge
-  %3 = load i32, ptr @num_cpus, align 4
-  %4 = load i32, ptr %i, align 4
-  %num_cpu.cmp = icmp ult i32 %4, %3
+  %8 = load i32, ptr @num_cpus, align 4
+  %9 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %9, %8
   br i1 %num_cpu.cmp, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %5 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %5)
+  %10 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %"@x_key1", i32 %10)
   %map_lookup_cond4 = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
-  %6 = load i64, ptr %val_1, align 8
+  %11 = load i64, ptr %val_1, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  %7 = icmp sgt i64 %6, 5
-  %8 = zext i1 %7 to i64
-  %true_cond = icmp ne i64 %8, 0
+  %12 = icmp sgt i64 %11, 5
+  %13 = zext i1 %12 to i64
+  %true_cond = icmp ne i64 %13, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 lookup_success2:                                  ; preds = %while_body
-  %9 = load i64, ptr %val_1, align 8
-  %10 = load i64, ptr %lookup_percpu_elem, align 8
-  %11 = add i64 %10, %9
-  store i64 %11, ptr %val_1, align 8
-  %12 = load i32, ptr %i, align 4
-  %13 = add i32 %12, 1
-  store i32 %13, ptr %i, align 4
+  %14 = load i64, ptr %val_1, align 8
+  %15 = load i64, ptr %lookup_percpu_elem, align 8
+  %16 = add i64 %15, %14
+  store i64 %16, ptr %val_1, align 8
+  %17 = load i32, ptr %i, align 4
+  %18 = add i32 %17, 1
+  store i32 %18, ptr %i, align 4
   br label %while_cond
 
 lookup_failure3:                                  ; preds = %while_body
-  %14 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %14, 0
+  %19 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %19, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %15 = load i32, ptr %i, align 4
+  %20 = load i32, ptr %i, align 4
   br label %while_end
 
-lookup_fmtstr_failure:                            ; preds = %if_body
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %if_body
-  %16 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %16, align 8
-  %17 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %17, align 8
-  %18 = getelementptr %print_integer_8_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 8, i1 false)
-  store i64 6, ptr %18, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 24, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %if_body
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem5 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond9 = icmp ne ptr %lookup_elem5, null
   br i1 %map_lookup_cond9, label %lookup_success6, label %lookup_failure7
 
-counter_merge:                                    ; preds = %lookup_merge8, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge8, %if_body
   br label %if_end
 
 lookup_success6:                                  ; preds = %event_loss_counter
-  %19 = atomicrmw add ptr %lookup_elem5, i64 1 seq_cst, align 8
+  %21 = atomicrmw add ptr %lookup_elem5, i64 1 seq_cst, align 8
   br label %lookup_merge8
 
 lookup_failure7:                                  ; preds = %event_loss_counter
@@ -169,8 +162,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!68}
-!llvm.module.flags = !{!70}
+!llvm.dbg.cu = !{!63}
+!llvm.module.flags = !{!65}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -224,28 +217,23 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !54)
-!54 = !{!55, !43, !48, !60}
-!55 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !56, size: 64)
-!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !57, size: 64)
-!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !58)
-!58 = !{!59}
-!59 = !DISubrange(count: 6, lowerBound: 0)
-!60 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !61, size: 64, offset: 192)
-!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
-!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 192, elements: !64)
-!63 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!64 = !{!65}
-!65 = !DISubrange(count: 24, lowerBound: 0)
-!66 = !DIGlobalVariableExpression(var: !67, expr: !DIExpression())
-!67 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!68 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !69)
-!69 = !{!0, !20, !34, !51, !66}
-!70 = !{i32 2, !"Debug Info Version", i32 3}
-!71 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !68, retainedNodes: !75)
-!72 = !DISubroutineType(types: !73)
-!73 = !{!18, !74}
-!74 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!75 = !{!76}
-!76 = !DILocalVariable(name: "ctx", arg: 1, scope: !71, file: !2, type: !74)
+!52 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 192, elements: !46)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 192, elements: !46)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 192, elements: !59)
+!58 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!59 = !{!60}
+!60 = !DISubrange(count: 24, lowerBound: 0)
+!61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
+!62 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!63 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !64)
+!64 = !{!0, !20, !34, !51, !53, !61}
+!65 = !{i32 2, !"Debug Info Version", i32 3}
+!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !63, retainedNodes: !70)
+!67 = !DISubroutineType(types: !68)
+!68 = !{!18, !69}
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -6,7 +6,6 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %int64_sum__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
@@ -14,13 +13,14 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
-@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !51
-@num_cpus = dso_local externally_initialized constant i64 1, section ".rodata", !dbg !66
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !51
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [32 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !53
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !61
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !71 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !66 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -58,9 +58,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !77 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !72 {
   %key1 = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %tuple = alloca %int64_sum__tuple_t, align 8
   %"$kv" = alloca %int64_sum__tuple_t, align 8
   %val_2 = alloca i64, align 8
@@ -111,63 +110,57 @@ while_end:                                        ; preds = %error_failure, %err
   store i64 %12, ptr %15, align 8
   %16 = getelementptr %int64_sum__tuple_t, ptr %tuple, i32 0, i32 1
   store i64 %14, ptr %16, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %17 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %17
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %17
+  %18 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  %19 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 0
+  store i64 30007, ptr %19, align 8
+  %20 = getelementptr %print_tuple_16_t, ptr %18, i64 0, i32 1
+  store i64 0, ptr %20, align 8
+  %21 = getelementptr %print_tuple_16_t, ptr %18, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %21, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %21, ptr align 1 %tuple, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %18, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 lookup_success:                                   ; preds = %while_body
-  %17 = load i64, ptr %val_1, align 8
-  %18 = load i64, ptr %lookup_percpu_elem, align 8
-  %19 = add i64 %18, %17
-  store i64 %19, ptr %val_1, align 8
-  %20 = load i32, ptr %i, align 4
-  %21 = add i32 %20, 1
-  store i32 %21, ptr %i, align 4
+  %22 = load i64, ptr %val_1, align 8
+  %23 = load i64, ptr %lookup_percpu_elem, align 8
+  %24 = add i64 %23, %22
+  store i64 %24, ptr %val_1, align 8
+  %25 = load i32, ptr %i, align 4
+  %26 = add i32 %25, 1
+  store i32 %26, ptr %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %22 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %22, 0
+  %27 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %27, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %23 = load i32, ptr %i, align 4
+  %28 = load i32, ptr %i, align 4
   br label %while_end
 
-lookup_fmtstr_failure:                            ; preds = %while_end
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %while_end
-  %24 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 0
-  store i64 30007, ptr %24, align 8
-  %25 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i64 0, i32 1
-  store i64 0, ptr %25, align 8
-  %26 = getelementptr %print_tuple_16_t, ptr %lookup_fmtstr_map, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %26, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %26, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 32, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %while_end
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key1)
   store i32 0, ptr %key1, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key1)
   %map_lookup_cond4 = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond4, label %lookup_success2, label %lookup_failure3
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %while_end
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 
 lookup_success2:                                  ; preds = %event_loss_counter
-  %27 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %29 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure3:                                  ; preds = %event_loss_counter
@@ -189,8 +182,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!68}
-!llvm.module.flags = !{!70}
+!llvm.dbg.cu = !{!63}
+!llvm.module.flags = !{!65}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -244,31 +237,26 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
 !50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !54)
-!54 = !{!55, !43, !48, !60}
-!55 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !56, size: 64)
-!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !57, size: 64)
-!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !58)
-!58 = !{!59}
-!59 = !DISubrange(count: 6, lowerBound: 0)
-!60 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !61, size: 64, offset: 192)
-!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
-!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 256, elements: !64)
-!63 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!64 = !{!65}
-!65 = !DISubrange(count: 32, lowerBound: 0)
-!66 = !DIGlobalVariableExpression(var: !67, expr: !DIExpression())
-!67 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
-!68 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !69)
-!69 = !{!0, !20, !34, !51, !66}
-!70 = !{i32 2, !"Debug Info Version", i32 3}
-!71 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !68, retainedNodes: !75)
-!72 = !DISubroutineType(types: !73)
-!73 = !{!18, !74}
-!74 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !63, size: 64)
-!75 = !{!76}
-!76 = !DILocalVariable(name: "ctx", arg: 1, scope: !71, file: !2, type: !74)
-!77 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !72, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !68, retainedNodes: !78)
-!78 = !{!79}
-!79 = !DILocalVariable(name: "ctx", arg: 1, scope: !77, file: !2, type: !74)
+!52 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 256, elements: !46)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 256, elements: !46)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 256, elements: !59)
+!58 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!59 = !{!60}
+!60 = !DISubrange(count: 32, lowerBound: 0)
+!61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
+!62 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!63 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !64)
+!64 = !{!0, !20, !34, !51, !53, !61}
+!65 = !{i32 2, !"Debug Info Version", i32 3}
+!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !63, retainedNodes: !70)
+!67 = !DISubroutineType(types: !68)
+!68 = !{!18, !69}
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)
+!72 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !63, retainedNodes: !73)
+!73 = !{!74}
+!74 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !69)

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -5,23 +5,22 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key5 = alloca i32, align 4
   %perfdata = alloca i64, align 8
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ult i64 %1, 10000
@@ -30,12 +29,17 @@ entry:
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
+  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
+  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
+  store i64 0, ptr %6, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 right:                                            ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %perfdata)
@@ -47,29 +51,18 @@ right:                                            ; preds = %entry
 done:                                             ; preds = %deadcode, %counter_merge
   ret i64 0
 
-lookup_fmtstr_failure:                            ; preds = %left
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %left
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 8, i1 false)
-  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 8, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
-
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %left
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
+counter_merge:                                    ; preds = %lookup_merge, %left
   br label %done
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %5 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %7 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -91,7 +84,7 @@ counter_merge3:                                   ; preds = %lookup_merge9, %rig
   ret i64 0
 
 lookup_success7:                                  ; preds = %event_loss_counter2
-  %6 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
+  %8 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter2
@@ -105,21 +98,21 @@ deadcode:                                         ; No predecessors!
   br label %done
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -158,26 +151,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 64, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 8, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 8, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/unroll_async_id.ll
+++ b/tests/codegen/llvm/unroll_async_id.ll
@@ -6,34 +6,29 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64 }
+%printf_t.2 = type { i64 }
 %printf_t.3 = type { i64 }
 %printf_t.4 = type { i64 }
 %printf_t.5 = type { i64 }
-%printf_t.6 = type { i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_i = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
-@fmt_string_args = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !38
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !38
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !40
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !56 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !51 {
 entry:
-  %key55 = alloca i32, align 4
-  %lookup_fmtstr_key46 = alloca i32, align 4
-  %key40 = alloca i32, align 4
-  %lookup_fmtstr_key31 = alloca i32, align 4
-  %key25 = alloca i32, align 4
-  %lookup_fmtstr_key16 = alloca i32, align 4
-  %key10 = alloca i32, align 4
-  %lookup_fmtstr_key1 = alloca i32, align 4
+  %key47 = alloca i32, align 4
+  %key34 = alloca i32, align 4
+  %key21 = alloca i32, align 4
+  %key8 = alloca i32, align 4
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %"@i_val" = alloca i64, align 8
   %"@i_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@i_key")
@@ -43,41 +38,40 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_i, ptr %"@i_key", ptr %"@i_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@i_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@i_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 8, i1 false)
-  %1 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %1, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 8, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 8, i1 false)
+  %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
+  store i64 0, ptr %3, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key1)
-  store i32 0, ptr %lookup_fmtstr_key1, align 4
-  %lookup_fmtstr_map2 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key1)
-  %lookup_fmtstr_cond5 = icmp ne ptr %lookup_fmtstr_map2, null
-  br i1 %lookup_fmtstr_cond5, label %lookup_fmtstr_merge4, label %lookup_fmtstr_failure3
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %4
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %4
+  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select3, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
+  %6 = getelementptr %printf_t.2, ptr %5, i32 0, i32 0
+  store i64 0, ptr %6, align 8
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 8, i64 0)
+  %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
+  br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %2 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %7 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -87,148 +81,119 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
   br label %counter_merge
 
-lookup_fmtstr_failure3:                           ; preds = %counter_merge
+event_loss_counter5:                              ; preds = %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key8)
+  store i32 0, ptr %key8, align 4
+  %lookup_elem9 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key8)
+  %map_lookup_cond13 = icmp ne ptr %lookup_elem9, null
+  br i1 %map_lookup_cond13, label %lookup_success10, label %lookup_failure11
+
+counter_merge6:                                   ; preds = %lookup_merge12, %counter_merge
+  %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)()
+  %8 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp15 = icmp ule i64 %get_cpu_id14, %8
+  %cpuid.min.select16 = select i1 %cpuid.min.cmp15, i64 %get_cpu_id14, i64 %8
+  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select16, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
+  %10 = getelementptr %printf_t.3, ptr %9, i32 0, i32 0
+  store i64 0, ptr %10, align 8
+  %ringbuf_output17 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %9, i64 8, i64 0)
+  %ringbuf_loss20 = icmp slt i64 %ringbuf_output17, 0
+  br i1 %ringbuf_loss20, label %event_loss_counter18, label %counter_merge19
+
+lookup_success10:                                 ; preds = %event_loss_counter5
+  %11 = atomicrmw add ptr %lookup_elem9, i64 1 seq_cst, align 8
+  br label %lookup_merge12
+
+lookup_failure11:                                 ; preds = %event_loss_counter5
+  br label %lookup_merge12
+
+lookup_merge12:                                   ; preds = %lookup_failure11, %lookup_success10
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key8)
+  br label %counter_merge6
+
+event_loss_counter18:                             ; preds = %counter_merge6
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key21)
+  store i32 0, ptr %key21, align 4
+  %lookup_elem22 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key21)
+  %map_lookup_cond26 = icmp ne ptr %lookup_elem22, null
+  br i1 %map_lookup_cond26, label %lookup_success23, label %lookup_failure24
+
+counter_merge19:                                  ; preds = %lookup_merge25, %counter_merge6
+  %get_cpu_id27 = call i64 inttoptr (i64 8 to ptr)()
+  %12 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp28 = icmp ule i64 %get_cpu_id27, %12
+  %cpuid.min.select29 = select i1 %cpuid.min.cmp28, i64 %get_cpu_id27, i64 %12
+  %13 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select29, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %13, i8 0, i64 8, i1 false)
+  %14 = getelementptr %printf_t.4, ptr %13, i32 0, i32 0
+  store i64 0, ptr %14, align 8
+  %ringbuf_output30 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %13, i64 8, i64 0)
+  %ringbuf_loss33 = icmp slt i64 %ringbuf_output30, 0
+  br i1 %ringbuf_loss33, label %event_loss_counter31, label %counter_merge32
+
+lookup_success23:                                 ; preds = %event_loss_counter18
+  %15 = atomicrmw add ptr %lookup_elem22, i64 1 seq_cst, align 8
+  br label %lookup_merge25
+
+lookup_failure24:                                 ; preds = %event_loss_counter18
+  br label %lookup_merge25
+
+lookup_merge25:                                   ; preds = %lookup_failure24, %lookup_success23
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key21)
+  br label %counter_merge19
+
+event_loss_counter31:                             ; preds = %counter_merge19
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key34)
+  store i32 0, ptr %key34, align 4
+  %lookup_elem35 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key34)
+  %map_lookup_cond39 = icmp ne ptr %lookup_elem35, null
+  br i1 %map_lookup_cond39, label %lookup_success36, label %lookup_failure37
+
+counter_merge32:                                  ; preds = %lookup_merge38, %counter_merge19
+  %get_cpu_id40 = call i64 inttoptr (i64 8 to ptr)()
+  %16 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp41 = icmp ule i64 %get_cpu_id40, %16
+  %cpuid.min.select42 = select i1 %cpuid.min.cmp41, i64 %get_cpu_id40, i64 %16
+  %17 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select42, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %17, i8 0, i64 8, i1 false)
+  %18 = getelementptr %printf_t.5, ptr %17, i32 0, i32 0
+  store i64 0, ptr %18, align 8
+  %ringbuf_output43 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %17, i64 8, i64 0)
+  %ringbuf_loss46 = icmp slt i64 %ringbuf_output43, 0
+  br i1 %ringbuf_loss46, label %event_loss_counter44, label %counter_merge45
+
+lookup_success36:                                 ; preds = %event_loss_counter31
+  %19 = atomicrmw add ptr %lookup_elem35, i64 1 seq_cst, align 8
+  br label %lookup_merge38
+
+lookup_failure37:                                 ; preds = %event_loss_counter31
+  br label %lookup_merge38
+
+lookup_merge38:                                   ; preds = %lookup_failure37, %lookup_success36
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key34)
+  br label %counter_merge32
+
+event_loss_counter44:                             ; preds = %counter_merge32
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key47)
+  store i32 0, ptr %key47, align 4
+  %lookup_elem48 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key47)
+  %map_lookup_cond52 = icmp ne ptr %lookup_elem48, null
+  br i1 %map_lookup_cond52, label %lookup_success49, label %lookup_failure50
+
+counter_merge45:                                  ; preds = %lookup_merge51, %counter_merge32
   ret i64 0
 
-lookup_fmtstr_merge4:                             ; preds = %counter_merge
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map2, i8 0, i64 8, i1 false)
-  %3 = getelementptr %printf_t.3, ptr %lookup_fmtstr_map2, i32 0, i32 0
-  store i64 0, ptr %3, align 8
-  %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map2, i64 8, i64 0)
-  %ringbuf_loss9 = icmp slt i64 %ringbuf_output6, 0
-  br i1 %ringbuf_loss9, label %event_loss_counter7, label %counter_merge8
+lookup_success49:                                 ; preds = %event_loss_counter44
+  %20 = atomicrmw add ptr %lookup_elem48, i64 1 seq_cst, align 8
+  br label %lookup_merge51
 
-event_loss_counter7:                              ; preds = %lookup_fmtstr_merge4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key10)
-  store i32 0, ptr %key10, align 4
-  %lookup_elem11 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key10)
-  %map_lookup_cond15 = icmp ne ptr %lookup_elem11, null
-  br i1 %map_lookup_cond15, label %lookup_success12, label %lookup_failure13
+lookup_failure50:                                 ; preds = %event_loss_counter44
+  br label %lookup_merge51
 
-counter_merge8:                                   ; preds = %lookup_merge14, %lookup_fmtstr_merge4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key16)
-  store i32 0, ptr %lookup_fmtstr_key16, align 4
-  %lookup_fmtstr_map17 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key16)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key16)
-  %lookup_fmtstr_cond20 = icmp ne ptr %lookup_fmtstr_map17, null
-  br i1 %lookup_fmtstr_cond20, label %lookup_fmtstr_merge19, label %lookup_fmtstr_failure18
-
-lookup_success12:                                 ; preds = %event_loss_counter7
-  %4 = atomicrmw add ptr %lookup_elem11, i64 1 seq_cst, align 8
-  br label %lookup_merge14
-
-lookup_failure13:                                 ; preds = %event_loss_counter7
-  br label %lookup_merge14
-
-lookup_merge14:                                   ; preds = %lookup_failure13, %lookup_success12
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key10)
-  br label %counter_merge8
-
-lookup_fmtstr_failure18:                          ; preds = %counter_merge8
-  ret i64 0
-
-lookup_fmtstr_merge19:                            ; preds = %counter_merge8
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map17, i8 0, i64 8, i1 false)
-  %5 = getelementptr %printf_t.4, ptr %lookup_fmtstr_map17, i32 0, i32 0
-  store i64 0, ptr %5, align 8
-  %ringbuf_output21 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map17, i64 8, i64 0)
-  %ringbuf_loss24 = icmp slt i64 %ringbuf_output21, 0
-  br i1 %ringbuf_loss24, label %event_loss_counter22, label %counter_merge23
-
-event_loss_counter22:                             ; preds = %lookup_fmtstr_merge19
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key25)
-  store i32 0, ptr %key25, align 4
-  %lookup_elem26 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key25)
-  %map_lookup_cond30 = icmp ne ptr %lookup_elem26, null
-  br i1 %map_lookup_cond30, label %lookup_success27, label %lookup_failure28
-
-counter_merge23:                                  ; preds = %lookup_merge29, %lookup_fmtstr_merge19
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key31)
-  store i32 0, ptr %lookup_fmtstr_key31, align 4
-  %lookup_fmtstr_map32 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key31)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key31)
-  %lookup_fmtstr_cond35 = icmp ne ptr %lookup_fmtstr_map32, null
-  br i1 %lookup_fmtstr_cond35, label %lookup_fmtstr_merge34, label %lookup_fmtstr_failure33
-
-lookup_success27:                                 ; preds = %event_loss_counter22
-  %6 = atomicrmw add ptr %lookup_elem26, i64 1 seq_cst, align 8
-  br label %lookup_merge29
-
-lookup_failure28:                                 ; preds = %event_loss_counter22
-  br label %lookup_merge29
-
-lookup_merge29:                                   ; preds = %lookup_failure28, %lookup_success27
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key25)
-  br label %counter_merge23
-
-lookup_fmtstr_failure33:                          ; preds = %counter_merge23
-  ret i64 0
-
-lookup_fmtstr_merge34:                            ; preds = %counter_merge23
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map32, i8 0, i64 8, i1 false)
-  %7 = getelementptr %printf_t.5, ptr %lookup_fmtstr_map32, i32 0, i32 0
-  store i64 0, ptr %7, align 8
-  %ringbuf_output36 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map32, i64 8, i64 0)
-  %ringbuf_loss39 = icmp slt i64 %ringbuf_output36, 0
-  br i1 %ringbuf_loss39, label %event_loss_counter37, label %counter_merge38
-
-event_loss_counter37:                             ; preds = %lookup_fmtstr_merge34
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key40)
-  store i32 0, ptr %key40, align 4
-  %lookup_elem41 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key40)
-  %map_lookup_cond45 = icmp ne ptr %lookup_elem41, null
-  br i1 %map_lookup_cond45, label %lookup_success42, label %lookup_failure43
-
-counter_merge38:                                  ; preds = %lookup_merge44, %lookup_fmtstr_merge34
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key46)
-  store i32 0, ptr %lookup_fmtstr_key46, align 4
-  %lookup_fmtstr_map47 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key46)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key46)
-  %lookup_fmtstr_cond50 = icmp ne ptr %lookup_fmtstr_map47, null
-  br i1 %lookup_fmtstr_cond50, label %lookup_fmtstr_merge49, label %lookup_fmtstr_failure48
-
-lookup_success42:                                 ; preds = %event_loss_counter37
-  %8 = atomicrmw add ptr %lookup_elem41, i64 1 seq_cst, align 8
-  br label %lookup_merge44
-
-lookup_failure43:                                 ; preds = %event_loss_counter37
-  br label %lookup_merge44
-
-lookup_merge44:                                   ; preds = %lookup_failure43, %lookup_success42
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key40)
-  br label %counter_merge38
-
-lookup_fmtstr_failure48:                          ; preds = %counter_merge38
-  ret i64 0
-
-lookup_fmtstr_merge49:                            ; preds = %counter_merge38
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map47, i8 0, i64 8, i1 false)
-  %9 = getelementptr %printf_t.6, ptr %lookup_fmtstr_map47, i32 0, i32 0
-  store i64 0, ptr %9, align 8
-  %ringbuf_output51 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map47, i64 8, i64 0)
-  %ringbuf_loss54 = icmp slt i64 %ringbuf_output51, 0
-  br i1 %ringbuf_loss54, label %event_loss_counter52, label %counter_merge53
-
-event_loss_counter52:                             ; preds = %lookup_fmtstr_merge49
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key55)
-  store i32 0, ptr %key55, align 4
-  %lookup_elem56 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key55)
-  %map_lookup_cond60 = icmp ne ptr %lookup_elem56, null
-  br i1 %map_lookup_cond60, label %lookup_success57, label %lookup_failure58
-
-counter_merge53:                                  ; preds = %lookup_merge59, %lookup_fmtstr_merge49
-  ret i64 0
-
-lookup_success57:                                 ; preds = %event_loss_counter52
-  %10 = atomicrmw add ptr %lookup_elem56, i64 1 seq_cst, align 8
-  br label %lookup_merge59
-
-lookup_failure58:                                 ; preds = %event_loss_counter52
-  br label %lookup_merge59
-
-lookup_merge59:                                   ; preds = %lookup_failure58, %lookup_success57
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key55)
-  br label %counter_merge53
+lookup_merge51:                                   ; preds = %lookup_failure50, %lookup_success49
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key47)
+  br label %counter_merge45
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -244,8 +209,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!55}
+!llvm.dbg.cu = !{!48}
+!llvm.module.flags = !{!50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_i", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -286,26 +251,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
 !37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
 !38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !41)
-!41 = !{!42, !11, !16, !47}
-!42 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !43, size: 64)
-!43 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !44, size: 64)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !45)
-!45 = !{!46}
-!46 = !DISubrange(count: 6, lowerBound: 0)
-!47 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !48, size: 64, offset: 192)
-!48 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !49, size: 64)
-!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !50, size: 64, elements: !51)
-!50 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!51 = !{!52}
-!52 = !DISubrange(count: 8, lowerBound: 0)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
-!54 = !{!0, !22, !36, !38}
-!55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!21, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!39 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !14)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !14)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 64, elements: !46)
+!45 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!46 = !{!47}
+!47 = !DISubrange(count: 8, lowerBound: 0)
+!48 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !49)
+!49 = !{!0, !22, !36, !38, !40}
+!50 = !{i32 2, !"Debug Info Version", i32 3}
+!51 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !48, retainedNodes: !55)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!21, !54}
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)

--- a/tests/codegen/llvm/variable_increment_decrement.ll
+++ b/tests/codegen/llvm/variable_increment_decrement.ll
@@ -5,74 +5,74 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %printf_t = type { i64, i64 }
+%printf_t.1 = type { i64, i64 }
 %printf_t.2 = type { i64, i64 }
 %printf_t.3 = type { i64, i64 }
-%printf_t.4 = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@fmt_string_args = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@fmt_str_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !54 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !49 {
 entry:
-  %key40 = alloca i32, align 4
-  %lookup_fmtstr_key31 = alloca i32, align 4
-  %key25 = alloca i32, align 4
-  %lookup_fmtstr_key16 = alloca i32, align 4
-  %key10 = alloca i32, align 4
-  %lookup_fmtstr_key1 = alloca i32, align 4
+  %key34 = alloca i32, align 4
+  %key21 = alloca i32, align 4
+  %key8 = alloca i32, align 4
   %key = alloca i32, align 4
-  %lookup_fmtstr_key = alloca i32, align 4
   %"$x" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
   store i64 0, ptr %"$x", align 8
   store i64 10, ptr %"$x", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key)
-  store i32 0, ptr %lookup_fmtstr_key, align 4
-  %lookup_fmtstr_map = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key)
-  %lookup_fmtstr_cond = icmp ne ptr %lookup_fmtstr_map, null
-  br i1 %lookup_fmtstr_cond, label %lookup_fmtstr_merge, label %lookup_fmtstr_failure
-
-lookup_fmtstr_failure:                            ; preds = %entry
-  ret i64 0
-
-lookup_fmtstr_merge:                              ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map, i8 0, i64 16, i1 false)
-  %1 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 0
-  store i64 0, ptr %1, align 8
-  %2 = load i64, ptr %"$x", align 8
-  %3 = add i64 %2, 1
-  store i64 %3, ptr %"$x", align 8
-  %4 = getelementptr %printf_t, ptr %lookup_fmtstr_map, i32 0, i32 1
-  store i64 %2, ptr %4, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map, i64 16, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
+  store i64 0, ptr %3, align 8
+  %4 = load i64, ptr %"$x", align 8
+  %5 = add i64 %4, 1
+  store i64 %5, ptr %"$x", align 8
+  %6 = getelementptr %printf_t, ptr %2, i32 0, i32 1
+  store i64 %4, ptr %6, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-event_loss_counter:                               ; preds = %lookup_fmtstr_merge
+event_loss_counter:                               ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
   store i32 0, ptr %key, align 4
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-counter_merge:                                    ; preds = %lookup_merge, %lookup_fmtstr_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key1)
-  store i32 0, ptr %lookup_fmtstr_key1, align 4
-  %lookup_fmtstr_map2 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key1)
-  %lookup_fmtstr_cond5 = icmp ne ptr %lookup_fmtstr_map2, null
-  br i1 %lookup_fmtstr_cond5, label %lookup_fmtstr_merge4, label %lookup_fmtstr_failure3
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %7 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %7
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %7
+  %8 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select3, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
+  %9 = getelementptr %printf_t.1, ptr %8, i32 0, i32 0
+  store i64 1, ptr %9, align 8
+  %10 = load i64, ptr %"$x", align 8
+  %11 = add i64 %10, 1
+  store i64 %11, ptr %"$x", align 8
+  %12 = getelementptr %printf_t.1, ptr %8, i32 0, i32 1
+  store i64 %11, ptr %12, align 8
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %8, i64 16, i64 0)
+  %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
+  br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %5 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %13 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -82,143 +82,115 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
   br label %counter_merge
 
-lookup_fmtstr_failure3:                           ; preds = %counter_merge
-  ret i64 0
+event_loss_counter5:                              ; preds = %counter_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key8)
+  store i32 0, ptr %key8, align 4
+  %lookup_elem9 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key8)
+  %map_lookup_cond13 = icmp ne ptr %lookup_elem9, null
+  br i1 %map_lookup_cond13, label %lookup_success10, label %lookup_failure11
 
-lookup_fmtstr_merge4:                             ; preds = %counter_merge
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map2, i8 0, i64 16, i1 false)
-  %6 = getelementptr %printf_t.2, ptr %lookup_fmtstr_map2, i32 0, i32 0
-  store i64 1, ptr %6, align 8
-  %7 = load i64, ptr %"$x", align 8
-  %8 = add i64 %7, 1
-  store i64 %8, ptr %"$x", align 8
-  %9 = getelementptr %printf_t.2, ptr %lookup_fmtstr_map2, i32 0, i32 1
-  store i64 %8, ptr %9, align 8
-  %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map2, i64 16, i64 0)
-  %ringbuf_loss9 = icmp slt i64 %ringbuf_output6, 0
-  br i1 %ringbuf_loss9, label %event_loss_counter7, label %counter_merge8
-
-event_loss_counter7:                              ; preds = %lookup_fmtstr_merge4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key10)
-  store i32 0, ptr %key10, align 4
-  %lookup_elem11 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key10)
-  %map_lookup_cond15 = icmp ne ptr %lookup_elem11, null
-  br i1 %map_lookup_cond15, label %lookup_success12, label %lookup_failure13
-
-counter_merge8:                                   ; preds = %lookup_merge14, %lookup_fmtstr_merge4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key16)
-  store i32 0, ptr %lookup_fmtstr_key16, align 4
-  %lookup_fmtstr_map17 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key16)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key16)
-  %lookup_fmtstr_cond20 = icmp ne ptr %lookup_fmtstr_map17, null
-  br i1 %lookup_fmtstr_cond20, label %lookup_fmtstr_merge19, label %lookup_fmtstr_failure18
-
-lookup_success12:                                 ; preds = %event_loss_counter7
-  %10 = atomicrmw add ptr %lookup_elem11, i64 1 seq_cst, align 8
-  br label %lookup_merge14
-
-lookup_failure13:                                 ; preds = %event_loss_counter7
-  br label %lookup_merge14
-
-lookup_merge14:                                   ; preds = %lookup_failure13, %lookup_success12
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key10)
-  br label %counter_merge8
-
-lookup_fmtstr_failure18:                          ; preds = %counter_merge8
-  ret i64 0
-
-lookup_fmtstr_merge19:                            ; preds = %counter_merge8
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map17, i8 0, i64 16, i1 false)
-  %11 = getelementptr %printf_t.3, ptr %lookup_fmtstr_map17, i32 0, i32 0
-  store i64 2, ptr %11, align 8
-  %12 = load i64, ptr %"$x", align 8
-  %13 = sub i64 %12, 1
-  store i64 %13, ptr %"$x", align 8
-  %14 = getelementptr %printf_t.3, ptr %lookup_fmtstr_map17, i32 0, i32 1
-  store i64 %12, ptr %14, align 8
-  %ringbuf_output21 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map17, i64 16, i64 0)
-  %ringbuf_loss24 = icmp slt i64 %ringbuf_output21, 0
-  br i1 %ringbuf_loss24, label %event_loss_counter22, label %counter_merge23
-
-event_loss_counter22:                             ; preds = %lookup_fmtstr_merge19
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key25)
-  store i32 0, ptr %key25, align 4
-  %lookup_elem26 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key25)
-  %map_lookup_cond30 = icmp ne ptr %lookup_elem26, null
-  br i1 %map_lookup_cond30, label %lookup_success27, label %lookup_failure28
-
-counter_merge23:                                  ; preds = %lookup_merge29, %lookup_fmtstr_merge19
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_fmtstr_key31)
-  store i32 0, ptr %lookup_fmtstr_key31, align 4
-  %lookup_fmtstr_map32 = call ptr inttoptr (i64 1 to ptr)(ptr @fmt_string_args, ptr %lookup_fmtstr_key31)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_fmtstr_key31)
-  %lookup_fmtstr_cond35 = icmp ne ptr %lookup_fmtstr_map32, null
-  br i1 %lookup_fmtstr_cond35, label %lookup_fmtstr_merge34, label %lookup_fmtstr_failure33
-
-lookup_success27:                                 ; preds = %event_loss_counter22
-  %15 = atomicrmw add ptr %lookup_elem26, i64 1 seq_cst, align 8
-  br label %lookup_merge29
-
-lookup_failure28:                                 ; preds = %event_loss_counter22
-  br label %lookup_merge29
-
-lookup_merge29:                                   ; preds = %lookup_failure28, %lookup_success27
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key25)
-  br label %counter_merge23
-
-lookup_fmtstr_failure33:                          ; preds = %counter_merge23
-  ret i64 0
-
-lookup_fmtstr_merge34:                            ; preds = %counter_merge23
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_fmtstr_map32, i8 0, i64 16, i1 false)
-  %16 = getelementptr %printf_t.4, ptr %lookup_fmtstr_map32, i32 0, i32 0
-  store i64 3, ptr %16, align 8
+counter_merge6:                                   ; preds = %lookup_merge12, %counter_merge
+  %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)()
+  %14 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp15 = icmp ule i64 %get_cpu_id14, %14
+  %cpuid.min.select16 = select i1 %cpuid.min.cmp15, i64 %get_cpu_id14, i64 %14
+  %15 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select16, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %15, i8 0, i64 16, i1 false)
+  %16 = getelementptr %printf_t.2, ptr %15, i32 0, i32 0
+  store i64 2, ptr %16, align 8
   %17 = load i64, ptr %"$x", align 8
   %18 = sub i64 %17, 1
   store i64 %18, ptr %"$x", align 8
-  %19 = getelementptr %printf_t.4, ptr %lookup_fmtstr_map32, i32 0, i32 1
-  store i64 %18, ptr %19, align 8
-  %ringbuf_output36 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_fmtstr_map32, i64 16, i64 0)
-  %ringbuf_loss39 = icmp slt i64 %ringbuf_output36, 0
-  br i1 %ringbuf_loss39, label %event_loss_counter37, label %counter_merge38
+  %19 = getelementptr %printf_t.2, ptr %15, i32 0, i32 1
+  store i64 %17, ptr %19, align 8
+  %ringbuf_output17 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %15, i64 16, i64 0)
+  %ringbuf_loss20 = icmp slt i64 %ringbuf_output17, 0
+  br i1 %ringbuf_loss20, label %event_loss_counter18, label %counter_merge19
 
-event_loss_counter37:                             ; preds = %lookup_fmtstr_merge34
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key40)
-  store i32 0, ptr %key40, align 4
-  %lookup_elem41 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key40)
-  %map_lookup_cond45 = icmp ne ptr %lookup_elem41, null
-  br i1 %map_lookup_cond45, label %lookup_success42, label %lookup_failure43
+lookup_success10:                                 ; preds = %event_loss_counter5
+  %20 = atomicrmw add ptr %lookup_elem9, i64 1 seq_cst, align 8
+  br label %lookup_merge12
 
-counter_merge38:                                  ; preds = %lookup_merge44, %lookup_fmtstr_merge34
+lookup_failure11:                                 ; preds = %event_loss_counter5
+  br label %lookup_merge12
+
+lookup_merge12:                                   ; preds = %lookup_failure11, %lookup_success10
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key8)
+  br label %counter_merge6
+
+event_loss_counter18:                             ; preds = %counter_merge6
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key21)
+  store i32 0, ptr %key21, align 4
+  %lookup_elem22 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key21)
+  %map_lookup_cond26 = icmp ne ptr %lookup_elem22, null
+  br i1 %map_lookup_cond26, label %lookup_success23, label %lookup_failure24
+
+counter_merge19:                                  ; preds = %lookup_merge25, %counter_merge6
+  %get_cpu_id27 = call i64 inttoptr (i64 8 to ptr)()
+  %21 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp28 = icmp ule i64 %get_cpu_id27, %21
+  %cpuid.min.select29 = select i1 %cpuid.min.cmp28, i64 %get_cpu_id27, i64 %21
+  %22 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 %cpuid.min.select29, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %22, i8 0, i64 16, i1 false)
+  %23 = getelementptr %printf_t.3, ptr %22, i32 0, i32 0
+  store i64 3, ptr %23, align 8
+  %24 = load i64, ptr %"$x", align 8
+  %25 = sub i64 %24, 1
+  store i64 %25, ptr %"$x", align 8
+  %26 = getelementptr %printf_t.3, ptr %22, i32 0, i32 1
+  store i64 %25, ptr %26, align 8
+  %ringbuf_output30 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %22, i64 16, i64 0)
+  %ringbuf_loss33 = icmp slt i64 %ringbuf_output30, 0
+  br i1 %ringbuf_loss33, label %event_loss_counter31, label %counter_merge32
+
+lookup_success23:                                 ; preds = %event_loss_counter18
+  %27 = atomicrmw add ptr %lookup_elem22, i64 1 seq_cst, align 8
+  br label %lookup_merge25
+
+lookup_failure24:                                 ; preds = %event_loss_counter18
+  br label %lookup_merge25
+
+lookup_merge25:                                   ; preds = %lookup_failure24, %lookup_success23
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key21)
+  br label %counter_merge19
+
+event_loss_counter31:                             ; preds = %counter_merge19
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key34)
+  store i32 0, ptr %key34, align 4
+  %lookup_elem35 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key34)
+  %map_lookup_cond39 = icmp ne ptr %lookup_elem35, null
+  br i1 %map_lookup_cond39, label %lookup_success36, label %lookup_failure37
+
+counter_merge32:                                  ; preds = %lookup_merge38, %counter_merge19
   ret i64 0
 
-lookup_success42:                                 ; preds = %event_loss_counter37
-  %20 = atomicrmw add ptr %lookup_elem41, i64 1 seq_cst, align 8
-  br label %lookup_merge44
+lookup_success36:                                 ; preds = %event_loss_counter31
+  %28 = atomicrmw add ptr %lookup_elem35, i64 1 seq_cst, align 8
+  br label %lookup_merge38
 
-lookup_failure43:                                 ; preds = %event_loss_counter37
-  br label %lookup_merge44
+lookup_failure37:                                 ; preds = %event_loss_counter31
+  br label %lookup_merge38
 
-lookup_merge44:                                   ; preds = %lookup_failure43, %lookup_success42
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key40)
-  br label %counter_merge38
+lookup_merge38:                                   ; preds = %lookup_failure37, %lookup_success36
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key34)
+  br label %counter_merge32
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -257,26 +229,21 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
 !35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "fmt_string_args", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !25, !30, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 128, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 16, lowerBound: 0)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !36}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!35, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 128, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 128, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 128, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 16, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)


### PR DESCRIPTION
To resolve the issues with too much branching introduced from scratch maps in https://github.com/bpftrace/bpftrace/pull/3456, this PR attempts to use writable array global variables in .data.* section to avoid jumps (since the verifier can guarantee the pointer points to real memory): https://github.com/torvalds/linux/commit/6316f78306c171f5a857a2442dbeebc7baab3566#diff-4f15343cf34fde0cbb97aba726a48c63a4c320ed91fce341450c547f60ddb5ab

To demonstrate this, I migrate fmt strings to this approach since it is the simplest map to migrate.

To simulate per-CPU maps, which aren't available in global variables, we need to do the following:
1. For AOT compatibility, re-initialize size for variable to num_cpus * max_fmt_string_size via bpf_map__set_initial_value() on program load.
2. We give each array its own custom .data.<name> section in ELF since bpf_map__set_initial_value() can only resize the last array variable in the section.
3. When accessing the global array, we call bpf_get_smp_processor_id to get the CPU offset into the array.

Now running a program with the following line repeated N times:
```
printf("hello %s %d", "a", 123);
```

At ~350 lines, master will crash due to verifier errors due to long jumps.

On this PR, I tried 1000 lines and it worked. I'm guessing we can go infinitely long now!

Notes:
1. We do not do a bounds check to verify cpu_id <= num_cpus. It seems kernel 6.9 verifier is smart enough to know this but I need to check 5.2 and above.
2. AOT does not seem backwards compatible as I needed to add `max_fmtstring_args_size` to AOT serialization. Is this okay? If not, we can use scratch map around if max_fmtstring_args_size == 0