### PR TITLE
Feature: scratch variable declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to
   - [#3358](https://github.com/bpftrace/bpftrace/pull/3358)
 - Add ability to attach kprobes to inlined functions
   - [#3301](https://github.com/bpftrace/bpftrace/pull/3095)
+- Variable declarations with `let`
+  - [#3461](https://github.com/bpftrace/bpftrace/pull/3461)
 #### Changed
 - Merge output into `stdout` when `-lv`
   - [#3383](https://github.com/bpftrace/bpftrace/pull/3383)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -434,9 +434,10 @@ inside a script config block.
 
 === Data Types
 
-The following fundamental integer types are provided by the language.
-Integers are internally represented as 64 bit signed.
-If you need another representation, you may cast to the following built in types:
+The following fundamental types are provided by the language.
+Note: Integers are by default represented as 64 bit signed but that can be 
+changed by either casting them or, for scratch variables, explicitly specifying 
+the type upon declaration.
 
 [cols="~,~"]
 |===
@@ -939,6 +940,21 @@ bpftrace knows two types of variables, 'scratch' and 'map'.
 
 'scratch' variables are kept on the BPF stack and only exists during the execution of the action block and cannot be accessed outside of the program.
 Scratch variable names always start with a `$`, e.g. `$myvar`.
+
+'scratch' variables can also declared before or during initialization with `let` e.g.
+```
+let $x;
+let $y = 11;
+```
+
+If no assignment is specified variables will initialize to 0.
+
+You can also specify the type in the declaration e.g.
+```
+let $x: uint8;
+let $y: uint8 = 7;
+let $a: string = "hiya";
+```
 
 'map' variables use BPF 'maps'.
 These exist for the lifetime of `bpftrace` itself and can be accessed from all action blocks and user-space.

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -35,6 +35,7 @@ MAKE_ACCEPT(ExprStatement)
 MAKE_ACCEPT(AssignMapStatement)
 MAKE_ACCEPT(AssignVarStatement)
 MAKE_ACCEPT(AssignConfigVarStatement)
+MAKE_ACCEPT(VarDeclStatement)
 MAKE_ACCEPT(Predicate)
 MAKE_ACCEPT(AttachPoint)
 MAKE_ACCEPT(If)
@@ -201,12 +202,35 @@ AssignVarStatement::AssignVarStatement(Variable *var,
   expr->var = var;
 }
 
+AssignVarStatement::AssignVarStatement(VarDeclStatement *var_decl_stmt,
+                                       Expression *expr,
+                                       location loc)
+    : Statement(loc),
+      var_decl_stmt(var_decl_stmt),
+      var(var_decl_stmt->var),
+      expr(expr)
+{
+  expr->var = var;
+}
+
 AssignConfigVarStatement::AssignConfigVarStatement(
     const std::string &config_var,
     Expression *expr,
     location loc)
     : Statement(loc), config_var(config_var), expr(expr)
 {
+}
+
+VarDeclStatement::VarDeclStatement(Variable *var, SizedType type, location loc)
+    : Statement(loc), var(var), set_type(true)
+{
+  var->type = std::move(type);
+}
+
+VarDeclStatement::VarDeclStatement(Variable *var, location loc)
+    : Statement(loc), var(var)
+{
+  var->type = CreateNone();
 }
 
 Predicate::Predicate(Expression *expr, location loc) : Node(loc), expr(expr)

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -369,6 +369,20 @@ private:
   ExprStatement(const ExprStatement &other) = default;
 };
 
+class VarDeclStatement : public Statement {
+public:
+  DEFINE_ACCEPT
+
+  VarDeclStatement(Variable *var, SizedType type, location loc = location());
+  VarDeclStatement(Variable *var, location loc = location());
+
+  Variable *var = nullptr;
+  bool set_type = false;
+
+private:
+  VarDeclStatement(const VarDeclStatement &other) = default;
+};
+
 class AssignMapStatement : public Statement {
 public:
   DEFINE_ACCEPT
@@ -389,7 +403,11 @@ public:
   AssignVarStatement(Variable *var,
                      Expression *expr,
                      location loc = location());
+  AssignVarStatement(VarDeclStatement *var_decl_stmt,
+                     Expression *expr,
+                     location loc = location());
 
+  VarDeclStatement *var_decl_stmt = nullptr;
   Variable *var = nullptr;
   Expression *expr = nullptr;
 

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -57,6 +57,7 @@ public:
   void visit(ExprStatement &expr) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
+  void visit(VarDeclStatement &decl) override;
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
@@ -251,6 +252,9 @@ private:
 
   bool canAggPerCpuMapElems(const SizedType &val_type,
                             const SizedType &key_type);
+
+  void maybeAllocVariable(const std::string &var_ident,
+                          const SizedType &var_type);
 
   Node *root_ = nullptr;
 

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -262,12 +262,20 @@ void Printer::visit(AssignMapStatement &assignment)
 void Printer::visit(AssignVarStatement &assignment)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "=" << std::endl;
 
-  ++depth_;
-  assignment.var->accept(*this);
-  assignment.expr->accept(*this);
-  --depth_;
+  if (assignment.var_decl_stmt) {
+    assignment.var_decl_stmt->accept(*this);
+    ++depth_;
+    assignment.expr->accept(*this);
+    --depth_;
+  } else {
+    out_ << indent << "=" << std::endl;
+
+    ++depth_;
+    assignment.var->accept(*this);
+    assignment.expr->accept(*this);
+    --depth_;
+  }
 }
 
 void Printer::visit(AssignConfigVarStatement &assignment)
@@ -279,6 +287,15 @@ void Printer::visit(AssignConfigVarStatement &assignment)
   std::string indentVar(depth_, ' ');
   out_ << indentVar << "config var: " << assignment.config_var << std::endl;
   assignment.expr->accept(*this);
+  --depth_;
+}
+
+void Printer::visit(VarDeclStatement &decl)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "decl" << std::endl;
+  ++depth_;
+  decl.var->accept(*this);
   --depth_;
 }
 

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -37,6 +37,7 @@ public:
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
   void visit(AssignConfigVarStatement &assignment) override;
+  void visit(VarDeclStatement &decl) override;
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -84,6 +84,7 @@ public:
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
   void visit(AssignConfigVarStatement &assignment) override;
+  void visit(VarDeclStatement &decl) override;
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(Predicate &pred) override;
@@ -166,7 +167,14 @@ private:
   // SemanticAnalyser.
   int func_arg_idx_ = -1;
 
-  std::map<Scope *, std::map<std::string, SizedType>> variable_val_;
+  struct variable {
+    SizedType type;
+    bool can_resize;
+    bool was_assigned;
+  };
+
+  std::map<Scope *, std::map<std::string, variable>> variables_;
+  std::map<Scope *, std::map<std::string, location>> variable_decls_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, SizedType> map_key_;
 

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -119,6 +119,11 @@ void Visitor::visit(AssignConfigVarStatement &assignment)
   Visit(*assignment.expr);
 }
 
+void Visitor::visit(VarDeclStatement &decl)
+{
+  Visit(*decl.var);
+}
+
 void Visitor::visit(If &if_block)
 {
   Visit(*if_block.cond);

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -36,6 +36,7 @@ public:
   virtual void visit(AssignMapStatement &assignment) = 0;
   virtual void visit(AssignVarStatement &assignment) = 0;
   virtual void visit(AssignConfigVarStatement &assignment) = 0;
+  virtual void visit(VarDeclStatement &decl) = 0;
   virtual void visit(If &if_block) = 0;
   virtual void visit(Jump &jump) = 0;
   virtual void visit(Unroll &unroll) = 0;
@@ -104,6 +105,7 @@ public:
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
   void visit(AssignConfigVarStatement &assignment) override;
+  void visit(VarDeclStatement &decl) override;
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
@@ -171,6 +173,7 @@ public:
   virtual R visit(AssignMapStatement &node) DEFAULT_FN;
   virtual R visit(AssignVarStatement &node) DEFAULT_FN;
   virtual R visit(AssignConfigVarStatement &node) DEFAULT_FN;
+  virtual R visit(VarDeclStatement &node) DEFAULT_FN;
   virtual R visit(If &node) DEFAULT_FN;
   virtual R visit(Jump &node) DEFAULT_FN;
   virtual R visit(Unroll &node) DEFAULT_FN;
@@ -222,6 +225,7 @@ private:
     DEFINE_DISPATCH(AssignMapStatement);
     DEFINE_DISPATCH(AssignVarStatement);
     DEFINE_DISPATCH(AssignConfigVarStatement);
+    DEFINE_DISPATCH(VarDeclStatement);
     DEFINE_DISPATCH(If);
     DEFINE_DISPATCH(Unroll);
     DEFINE_DISPATCH(Jump);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -159,6 +159,7 @@ bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, loc); }
 "break"                 { return Parser::make_BREAK(yytext, loc); }
 "sizeof"                { return Parser::make_SIZEOF(yytext, loc); }
 "offsetof"              { return Parser::make_OFFSETOF(yytext, loc); }
+"let"                   { return Parser::make_LET(yytext, loc); }
 
 {int_type}              { return Parser::make_INT_TYPE(yytext, loc); }
 {builtin_type}          { return Parser::make_BUILTIN_TYPE(yytext, loc); }
@@ -208,13 +209,13 @@ struct|union|enum       {
   .                     { unput(yytext[0]); yy_pop_state(yyscanner); }
 }
 <STRUCT_AFTER_COLON>{
-  "{"|","|")"           {
+  {hspace}+             { loc.step(); }
+  {vspace}+             { loc.lines(yyleng); loc.step(); }
+  {ident}               {
+                          buffer = yytext;
                           yy_pop_state(yyscanner);
-                          unput(yytext[0]);
                           return Parser::make_IDENT(struct_type + " " + trim(buffer), loc);
                         }
-  .                     { buffer += yytext[0]; }
-  \n                    buffer += '\n'; loc.lines(1); loc.step();
 }
 <STRUCT,BRACE>{
   "*"|")"|","           {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -396,6 +396,7 @@ SizedType CreateArray(size_t num_elements, const SizedType &element_type)
   size_t size = num_elements * element_type.GetSize();
   auto ty = SizedType(Type::array, size);
   ty.element_type_ = std::make_shared<SizedType>(element_type);
+  ty.num_elements_ = num_elements;
   return ty;
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2767,4 +2767,51 @@ BEGIN { for (@kv : @map) { } }
 )");
 }
 
+TEST(Parser, variable_declarations)
+{
+  test("BEGIN { let $x; }", R"(
+Program
+ BEGIN
+  decl
+   variable: $x
+)");
+
+  test("BEGIN { let $x: int8; }", R"(
+Program
+ BEGIN
+  decl
+   variable: $x :: [int8]
+)");
+
+  test("BEGIN { let $x = 1; }", R"(
+Program
+ BEGIN
+  decl
+   variable: $x
+   int: 1
+)");
+
+  test("BEGIN { let $x: int8 = 1; }", R"(
+Program
+ BEGIN
+  decl
+   variable: $x :: [int8]
+   int: 1
+)");
+
+  // Needs the let keyword
+  test_parse_failure("BEGIN { $x: int8; }", R"(
+stdin:1:9-12: ERROR: syntax error, unexpected :, expecting ; or }
+BEGIN { $x: int8; }
+        ~~~
+)");
+
+  // Needs the let keyword
+  test_parse_failure("BEGIN { $x: int8 = 1; }", R"(
+stdin:1:9-12: ERROR: syntax error, unexpected :, expecting ; or }
+BEGIN { $x: int8 = 1; }
+        ~~~
+)");
+}
+
 } // namespace bpftrace::test::parser

--- a/tests/runtime/complex_types
+++ b/tests/runtime/complex_types
@@ -6,6 +6,10 @@ NAME struct-array with variables
 RUN {{BPFTRACE}} runtime/scripts/struct_array_vars.bt -c ./testprogs/struct_array
 EXPECT 100 102 104 106 108 -- 1 3 5 7 9 -- 100 98 96 94 92 -- 42
 
+NAME struct-array with declared variables
+RUN {{BPFTRACE}} runtime/scripts/struct_let.bt -c ./testprogs/struct_array
+EXPECT 100 102 104 106 108
+
 NAME pointer_to_pointer
 RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:./testprogs/ptr_to_ptr:function { $pp = (struct Foo **)arg0; printf("%d\n", (*$pp)->a); }' -c ./testprogs/ptr_to_ptr
 EXPECT 123

--- a/tests/runtime/scripts/struct_let.bt
+++ b/tests/runtime/scripts/struct_let.bt
@@ -1,0 +1,29 @@
+struct T {
+  uint32_t a;
+  uint32_t b[2];
+};
+
+struct W {
+  uint32_t a;
+  struct T t;
+};
+
+struct C {
+  uint32_t a;
+  void * b;
+  struct W w[10];
+};
+
+uprobe:./testprogs/struct_array:clear {
+  let $c: struct C *;
+  let $w: struct W[10];
+  
+  $c = (struct C *) arg0;
+  $w = $c->w;
+
+  printf("%d ", $w[0].a);
+  printf("%d ", $w[2].a);
+  printf("%d ", $w[4].a);
+  printf("%d ", $w[6].a);
+  printf("%d ", $w[8].a);
+}

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -105,3 +105,19 @@ EXPECT @a[-4, (-5, -6)]: 12
 EXPECT @a[-1, (-2, 3)]: 10
 EXPECT @a[5, (6, 7)]: 11
 TIMEOUT 2
+
+NAME variable declaration
+PROG BEGIN { let $a; $a = 10; printf("a=%d\n", $a); exit();}
+EXPECT a=10
+
+NAME variable declaration with builtin
+PROG BEGIN { let $f: struct task_struct *; $f = curtask; print($f->pid); exit();}
+EXPECT_REGEX [0-9]+
+
+NAME variable declaration with unresolved type
+PROG BEGIN { let $x: struct Foo[1]; exit(); }
+EXPECT Attaching 1 probe...
+
+NAME variable declaration not initialized
+PROG BEGIN { let $a; if (false) { $a = 1; } @b = $a; exit();}
+EXPECT @b: 0


### PR DESCRIPTION
This commit implements scratch variable declarations,
which will be useful when fixing/adding block/lexical scoping.

As per this RFC/discussion: https://github.com/bpftrace/bpftrace/issues/3423
this new syntax is all valid:
```
let $x;
let $x: uint8;
let $x = 11;
let $x: uint8 = 7;
```

Additionally, there are some restrictions:
- variable declarations, if used, have to come before variable use
- variable declarations, if used, have to come before variable assignment
- the same variable name can't be declared twice
- for variable declarations that specify the type, this type
is not resizeable e.g. this is not valid
`let $a: str_t[5] = "hiya"; $a = "longerstr";` but this is
`let $a: str_t[5] = "hiya"; $a = "by";`
- declared variables must be assigned to

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
