### PR TITLE
Don't use BTF checking for indexed pointers

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -72,6 +72,7 @@ aot.probe.kprobe_ignore_missing_probes
 aot.probe.kretfunc
 aot.probe.uprobe_error_missing_probes
 aot.probe.uprobe_ignore_missing_probes
+aot.regression.kfunc array access via pointer
 aot.regression.kfunc double pointer array access
 aot.regression.kfunc double pointer dereference
 aot.tuples.basic tuple map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to
 - Drop support for LLVM 12 and below
   - [#3325](https://github.com/bpftrace/bpftrace/pull/3325)
 #### Fixed
+- Fix verifier error when array indexing through pointer
+  - [#3465](https://github.com/bpftrace/bpftrace/pull/3465)
 - Fix segfault for multi-tracepoint probes
   - [#3274](https://github.com/bpftrace/bpftrace/pull/3274)
 - Fix verifier error from misaligned stack access when using strings as map keys

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1649,8 +1649,9 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
 
   // BPF verifier cannot track BTF information for double pointers so we cannot
   // propagate is_btftype for arrays of pointers and we need to reset it on the
-  // array type as well.
-  if (arr.type.IsPtrTy())
+  // array type as well. Indexing a pointer as an array also can't be verified,
+  // so the same applies there.
+  if (arr.type.IsPtrTy() || type.IsPtrTy())
     type.is_btftype = false;
   arr.type.is_btftype = type.is_btftype;
 }

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -97,6 +97,13 @@ REQUIRES_FEATURE kfunc
 EXPECT Attaching 1 probe...
 TIMEOUT 1
 
+NAME kfunc array access via pointer
+PROG kfunc:__module_get { print(args.module->version[0]); exit(); }
+AFTER lsmod
+REQUIRES_FEATURE kfunc
+EXPECT Attaching 1 probe...
+TIMEOUT 1
+
 NAME unaligned key with aligned value
 PROG BEGIN { @mapA["aaaabbb", 0] = 1; @mapA["ccccdddd", 0] = 1; }
 EXPECT Attaching 1 probe...


### PR DESCRIPTION
The BPF verifier can use BTF type information to check the validity of pointer / array accesses for kfunc probes. However, it can't do any BTF-based bounds checking on pointers indexed as an array.  So, a simple probe like:

kfunc:kfree_skb_reason
{
	printf("%hx\n", args.skb->head[0]);
}

..would then fail with a verifier error.

67629c1927f4 ("Fix error in dereferencing kernel double pointers") fixed a similar case for double pointers, let's fix it for this case too.
