### PR TITLE
Utilize MissingProbes config for offset errors

### DIFF
--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -42,11 +42,11 @@ public:
 private:
   std::string eventprefix() const;
   std::string eventname() const;
-  void resolve_offset_kprobe(bool safe_mode);
+  bool resolve_offset_kprobe();
   bool resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps);
   void attach_multi_kprobe(void);
   void attach_multi_uprobe(int pid);
-  void attach_kprobe(bool safe_mode);
+  void attach_kprobe();
   void attach_uprobe(int pid, bool safe_mode);
 
   // Note: the following usdt attachment functions will only activate a

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -23,7 +23,6 @@ std::ostream &operator<<(std::ostream &os, AddrSpace as)
   return os;
 }
 
-std::string probetypeName(ProbeType t);
 std::ostream &operator<<(std::ostream &os, ProbeType type)
 {
   os << probetypeName(type);

--- a/src/types.h
+++ b/src/types.h
@@ -560,6 +560,7 @@ enum class ProbeType {
   rawtracepoint,
 };
 
+std::string probetypeName(ProbeType t);
 std::ostream &operator<<(std::ostream &os, ProbeType type);
 
 struct ProbeItem {


### PR DESCRIPTION
Instead of auto aborting if uprobe/kprobe alignment is invalid or if there is a kprobe offset error, use the value of the MissingProbes config to determine if we should abort, warn, or ignore.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
