### PR TITLE
Semantic Analyser: Add missing space to error message

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -529,9 +529,9 @@ void SemanticAnalyser::visit(Builtin &builtin)
     } else if (type != ProbeType::tracepoint) // no special action for
                                               // tracepoint
     {
-      LOG(ERROR, builtin.loc, err_)
-          << "The args builtin can only be used with tracepoint/kfunc/uprobe"
-          << "probes (" << type << " used here)";
+      LOG(ERROR, builtin.loc, err_) << "The args builtin can only be used with "
+                                       "tracepoint/kfunc/uprobe probes ("
+                                    << type << " used here)";
     }
   } else {
     builtin.type = CreateNone();

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3545,7 +3545,7 @@ TEST_F(semantic_analyser_btf, iter)
   test("iter:task_vma { $x = ctx->vma->vm_start }");
   test("iter:task { printf(\"%d\", ctx->task->pid); }");
   test_error("iter:task { $x = args.foo; }", R"(
-stdin:1:18-22: ERROR: The args builtin can only be used with tracepoint/kfunc/uprobeprobes (iter used here)
+stdin:1:18-22: ERROR: The args builtin can only be used with tracepoint/kfunc/uprobe probes (iter used here)
 iter:task { $x = args.foo; }
                  ~~~~
 )");


### PR DESCRIPTION
```
Previously:
  The args builtin can only be used with tracepoint/kfunc/uprobeprobes (uretprobe used here)
                                                               ^^
                                                               missing space

Now:
  The args builtin can only be used with tracepoint/kfunc/uprobe probes (uretprobe used here)
```

##### Checklist

- ~[ ]~ Language changes are updated in `man/adoc/bpftrace.adoc`
- ~[ ]~ User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
