### PR TITLE
Fix: json formatting for hex values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to
   - [#3443](https://github.com/bpftrace/bpftrace/pull/3443)
 - Handle invalid BTF without crashing
   - [#3453](https://github.com/bpftrace/bpftrace/pull/3453)
+- Fix json formatting for hex values
+  - [#3475](https://github.com/bpftrace/bpftrace/pull/3475)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/src/output.h
+++ b/src/output.h
@@ -240,6 +240,12 @@ public:
                     const location &loc) const override;
 
 protected:
+  std::string value_to_str(BPFtrace &bpftrace,
+                           const SizedType &type,
+                           const std::vector<uint8_t> &value,
+                           bool is_per_cpu,
+                           uint32_t div,
+                           bool is_map_key = false) const override;
   static std::string hist_index_label(uint32_t index, uint32_t bits);
   static std::string lhist_index_label(int number, int step);
   virtual std::string hist_to_str(const std::vector<uint64_t> &values,

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -164,3 +164,7 @@ NAME strftime
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { $t = (1, strftime("%m/%d/%y", nsecs)); print($t); exit() }' | python3 -c 'import sys,json; print(json.load(sys.stdin))'
 EXPECT_REGEX ^{'type': 'value', 'data': \[1, '[0-9]{2}\/[0-9]{2}\/[0-9]{2}'\]}$
 TIMEOUT 1
+
+NAME print_hex_values
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @=(int16*) 0x32; exit(); }'
+EXPECT {"type": "map", "data": {"@": 50}}


### PR DESCRIPTION
hex values are not supported in json format, so they should be output as a string when json formatting is selected.

```sh
$ bpftrace -q -f json -e 'BEGIN { @=(int16*) 0x32; exit(); }' | jq .
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
