### PR TITLE
Make type names consistent

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1401,7 +1401,7 @@ The return type is an unsigned integer of the same width as `n`.
 === buf
 
 .variants
-* `buf_t buf(void * data, [int64 length])`
+* `buffer buf(void * data, [int64 length])`
 
 `buf` reads `length` amount of bytes from address `data`.
 The maximum value of `length` is limited to the `BPFTRACE_MAX_STRLEN` variable.
@@ -1409,7 +1409,7 @@ For arrays the `length` is optional, it is automatically inferred from the signa
 
 `buf` is address space aware and will call the correct helper based on the address space associated with `data`.
 
-The `buf_t` object returned by `buf` can safely be printed as a hex encoded string with the `%r` format specifier.
+The `buffer` object returned by `buf` can safely be printed as a hex encoded string with the `%r` format specifier.
 
 Bytes with values >=32 and \<=126 are printed using their ASCII character, other bytes are printed in hex form (e.g. `\x00`). The `%rx` format specifier can be used to print everything in hex form, including ASCII characters. The similar `%rh` format specifier prints everything in hex form without `\x` and with spaces between bytes (e.g. `0a fe`).
 
@@ -1470,7 +1470,7 @@ BEGIN {
 === cgroup_path
 
 .variants
-* `cgroup_path cgroup_path(int cgroupid, string filter)`
+* `cgroup_path_t cgroup_path(int cgroupid, string filter)`
 
 Convert cgroup id to cgroup path.
 This is done asynchronously in userspace when the cgroup_path value is printed,
@@ -1697,9 +1697,9 @@ interval:s:1 {
 === ntop
 
 .variants
-* `inet_t ntop([int64 af, ] int addr)`
-* `inet_t ntop([int64 af, ] char addr[4])`
-* `inet_t ntop([int64 af, ] char addr[16])`
+* `inet ntop([int64 af, ] int addr)`
+* `inet ntop([int64 af, ] char addr[4])`
+* `inet ntop([int64 af, ] char addr[16])`
 
 `ntop` returns the string representation of an IPv4 or IPv6 address.
 `ntop` will infer the address type (IPv4 or IPv6) based on the `addr` type and size.
@@ -2060,7 +2060,7 @@ bpftrace doesn't read past the length of the shortest string.
 === strerror
 
 .variants
-* `strerror strerror(int error)`
+* `strerror_t strerror(int error)`
 
 Convert errno code to string.
 This is done asynchronously in userspace when the strerror value is printed, hence the returned value can only be used for printing.
@@ -2076,12 +2076,12 @@ BEGIN {
 === strftime
 
 .variants
-* `strtime_t strftime(const string fmt, int64 timestamp_ns)`
+* `timestamp strftime(const string fmt, int64 timestamp_ns)`
 
 *async*
 
 Format the nanoseconds since boot timestamp `timestamp_ns` according to the format specified by `fmt`.
-The time conversion and formatting happens in user space, therefore  the `timestr_t` value returned can only be used for printing using the `%s` format specifier.
+The time conversion and formatting happens in user space, therefore  the `timestamp` value returned can only be used for printing using the `%s` format specifier.
 
 bpftrace uses the `strftime(3)` function for formatting time and supports the same format specifiers.
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -994,7 +994,7 @@ void CodegenLLVM::visit(Call &call)
     //}
     std::vector<llvm::Type *> elements = { b_.getInt64Ty(),
                                            ArrayType::get(b_.getInt8Ty(), 16) };
-    StructType *inet_struct = b_.GetStructType("inet_t", elements, false);
+    StructType *inet_struct = b_.GetStructType("inet", elements, false);
 
     AllocaInst *buf = b_.CreateAllocaBPF(inet_struct, "inet");
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -563,11 +563,11 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
             length));
         break;
       }
-      case Type::ksym:
+      case Type::ksym_t:
         arg_values.push_back(std::make_unique<PrintableString>(resolve_ksym(
             *reinterpret_cast<uint64_t *>(arg_data + arg.offset))));
         break;
-      case Type::usym:
+      case Type::usym_t:
         arg_values.push_back(std::make_unique<PrintableString>(resolve_usym(
             *reinterpret_cast<uint64_t *>(arg_data + arg.offset),
             *reinterpret_cast<uint64_t *>(arg_data + arg.offset + 8),
@@ -586,7 +586,7 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
         arg_values.push_back(std::make_unique<PrintableString>(resolve_probe(
             *reinterpret_cast<uint64_t *>(arg_data + arg.offset))));
         break;
-      case Type::kstack:
+      case Type::kstack_t:
         arg_values.push_back(std::make_unique<PrintableString>(
             get_stack(*reinterpret_cast<int64_t *>(arg_data + arg.offset),
                       *reinterpret_cast<uint32_t *>(arg_data + arg.offset + 8),
@@ -596,7 +596,7 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
                       arg.type.stack_type,
                       8)));
         break;
-      case Type::ustack:
+      case Type::ustack_t:
         arg_values.push_back(std::make_unique<PrintableString>(
             get_stack(*reinterpret_cast<int64_t *>(arg_data + arg.offset),
                       *reinterpret_cast<uint32_t *>(arg_data + arg.offset + 8),
@@ -625,7 +625,7 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
             std::make_unique<PrintableString>(resolve_mac_address(
                 reinterpret_cast<uint8_t *>(arg_data + arg.offset))));
         break;
-      case Type::cgroup_path:
+      case Type::cgroup_path_t:
         arg_values.push_back(std::make_unique<PrintableString>(
             resolve_cgroup_path(reinterpret_cast<AsyncEvent::CgroupPath *>(
                                     arg_data + arg.offset)
@@ -634,7 +634,7 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
                                     arg_data + arg.offset)
                                     ->cgroup_id)));
         break;
-      case Type::strerror:
+      case Type::strerror_t:
         arg_values.push_back(std::make_unique<PrintableString>(
             strerror(*reinterpret_cast<uint64_t *>(arg_data + arg.offset))));
         break;

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -75,12 +75,12 @@ std::string validate_format_string(const std::string &fmt,
   auto token_iter = tokens_begin;
   for (int i = 0; i < num_args; i++, token_iter++) {
     Type arg_type = args.at(i).type.GetTy();
-    if (arg_type == Type::ksym || arg_type == Type::usym ||
+    if (arg_type == Type::ksym_t || arg_type == Type::usym_t ||
         arg_type == Type::probe || arg_type == Type::username ||
-        arg_type == Type::kstack || arg_type == Type::ustack ||
+        arg_type == Type::kstack_t || arg_type == Type::ustack_t ||
         arg_type == Type::inet || arg_type == Type::timestamp ||
-        arg_type == Type::mac_address || arg_type == Type::cgroup_path ||
-        arg_type == Type::strerror)
+        arg_type == Type::mac_address || arg_type == Type::cgroup_path_t ||
+        arg_type == Type::strerror_t)
       arg_type = Type::string; // Symbols should be printed as strings
     if (arg_type == Type::pointer)
       arg_type = Type::integer; // Casts (pointers) can be printed as integers

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -41,8 +41,8 @@ builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|
 call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|len|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
 
 int_type        bool|(u)?int(8|16|32|64)
-builtin_type    void|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp_t|macaddr_t|cgroup_path_t|strerror_t
-sized_type      str_t|inet_t|buf_t
+builtin_type    void|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|strerror_t|kstack_t|ustack_t
+sized_type      string|inet|buffer
 subprog         fn
 
 /* Don't add to this! Use builtin OR call not both */

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -20,34 +20,34 @@ bool is_quoted_type(const SizedType &ty)
 {
   switch (ty.GetTy()) {
     case Type::buffer:
-    case Type::cgroup_path:
+    case Type::cgroup_path_t:
     case Type::inet:
-    case Type::kstack:
-    case Type::ksym:
+    case Type::kstack_t:
+    case Type::ksym_t:
     case Type::probe:
-    case Type::strerror:
+    case Type::strerror_t:
     case Type::string:
     case Type::timestamp:
     case Type::username:
-    case Type::ustack:
-    case Type::usym:
+    case Type::ustack_t:
+    case Type::usym_t:
       return true;
     case Type::array:
-    case Type::avg:
-    case Type::count:
-    case Type::hist:
+    case Type::avg_t:
+    case Type::count_t:
+    case Type::hist_t:
     case Type::integer:
-    case Type::lhist:
+    case Type::lhist_t:
     case Type::mac_address:
-    case Type::max:
-    case Type::min:
+    case Type::max_t:
+    case Type::min_t:
     case Type::none:
     case Type::pointer:
     case Type::reference:
     case Type::record:
     case Type::stack_mode:
-    case Type::stats:
-    case Type::sum:
+    case Type::stats_t:
+    case Type::sum_t:
     case Type::timestamp_mode:
     case Type::tuple:
     case Type::voidtype:
@@ -243,7 +243,7 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
 {
   uint32_t nvalues = is_per_cpu ? bpftrace.ncpus_ : 1;
   switch (type.GetTy()) {
-    case Type::kstack: {
+    case Type::kstack_t: {
       return bpftrace.get_stack(read_data<uint64_t>(value.data()),
                                 read_data<uint32_t>(value.data() + 8),
                                 -1,
@@ -252,7 +252,7 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
                                 type.stack_type,
                                 8);
     }
-    case Type::ustack: {
+    case Type::ustack_t: {
       return bpftrace.get_stack(read_data<int64_t>(value.data()),
                                 read_data<uint32_t>(value.data() + 8),
                                 read_data<int32_t>(value.data() + 12),
@@ -261,10 +261,10 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
                                 type.stack_type,
                                 8);
     }
-    case Type::ksym: {
+    case Type::ksym_t: {
       return bpftrace.resolve_ksym(read_data<uintptr_t>(value.data()));
     }
-    case Type::usym: {
+    case Type::usym_t: {
       return bpftrace.resolve_usym(read_data<uintptr_t>(value.data()),
                                    read_data<uintptr_t>(value.data() + 8),
                                    read_data<uint64_t>(value.data() + 16));
@@ -325,10 +325,10 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
       }
       return tuple_to_str(elems, false);
     }
-    case Type::count: {
+    case Type::count_t: {
       return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
     }
-    case Type::avg: {
+    case Type::avg_t: {
       /*
        * on this code path, avg is calculated in the kernel while
        * printing the entire map is handled in a different function
@@ -370,14 +370,14 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
           return {};
       }
     }
-    case Type::sum: {
+    case Type::sum_t: {
       if (type.IsSigned())
         return std::to_string(reduce_value<int64_t>(value, nvalues) / div);
 
       return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
     }
-    case Type::max:
-    case Type::min: {
+    case Type::max_t:
+    case Type::min_t: {
       if (is_per_cpu) {
         if (type.IsSigned()) {
           return std::to_string(
@@ -404,26 +404,26 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
     case Type::mac_address: {
       return bpftrace.resolve_mac_address(value.data());
     }
-    case Type::cgroup_path: {
+    case Type::cgroup_path_t: {
       return bpftrace.resolve_cgroup_path(
           reinterpret_cast<const AsyncEvent::CgroupPath *>(value.data())
               ->cgroup_path_id,
           reinterpret_cast<const AsyncEvent::CgroupPath *>(value.data())
               ->cgroup_id);
     }
-    case Type::strerror: {
+    case Type::strerror_t: {
       return strerror(read_data<uint64_t>(value.data()));
     }
     case Type::none: {
       return "";
     }
     case Type::voidtype:
-    case Type::hist:
-    case Type::lhist:
+    case Type::hist_t:
+    case Type::lhist_t:
     case Type::stack_mode:
-    case Type::stats:
     case Type::pointer:
     case Type::reference:
+    case Type::stats_t:
     case Type::timestamp_mode: {
       LOG(BUG) << "Invalid value type: " << type;
     }
@@ -438,11 +438,11 @@ std::string Output::map_key_str(BPFtrace &bpftrace,
   std::ostringstream ptr;
   switch (arg.GetTy()) {
     case Type::integer:
-    case Type::kstack:
-    case Type::ustack:
+    case Type::kstack_t:
+    case Type::ustack_t:
     case Type::timestamp:
-    case Type::ksym:
-    case Type::usym:
+    case Type::ksym_t:
+    case Type::usym_t:
     case Type::inet:
     case Type::username:
     case Type::probe:
@@ -464,19 +464,19 @@ std::string Output::map_key_str(BPFtrace &bpftrace,
       }
       return tuple_to_str(elems, true);
     }
-    case Type::cgroup_path:
-    case Type::strerror:
-    case Type::avg:
-    case Type::count:
-    case Type::hist:
-    case Type::lhist:
-    case Type::max:
-    case Type::min:
+    case Type::cgroup_path_t:
+    case Type::strerror_t:
+    case Type::avg_t:
+    case Type::count_t:
+    case Type::hist_t:
+    case Type::lhist_t:
+    case Type::max_t:
+    case Type::min_t:
     case Type::none:
     case Type::reference:
     case Type::stack_mode:
-    case Type::stats:
-    case Type::sum:
+    case Type::stats_t:
+    case Type::sum_t:
     case Type::timestamp_mode:
     case Type::voidtype:
       LOG(BUG) << "Invalid mapkey argument type: " << arg;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -205,7 +205,7 @@ type:
                         {"ucount_t", CreateCount(false)},
                         {"uavg_t", CreateAvg(false)},
                         {"ustats_t", CreateStats(false)},
-                        {"timestamp_t", CreateTimestamp()},
+                        {"timestamp", CreateTimestamp()},
                         {"macaddr_t", CreateMacAddress()},
                         {"cgroup_path_t", CreateCgroupPath()},
                         {"strerror_t", CreateStrerror()},
@@ -213,11 +213,11 @@ type:
                     $$ = type_map[$1];
                 }
         |       SIZED_TYPE "[" INT "]" {
-                    if ($1 == "str_t") {
+                    if ($1 == "string") {
                         $$ = CreateString($3);
-                    } else if ($1 == "inet_t") {
+                    } else if ($1 == "inet") {
                         $$ = CreateInet($3);
-                    } else if ($1 == "buf_t") {
+                    } else if ($1 == "buffer") {
                         $$ = CreateBuffer($3);
                     }
                 }

--- a/src/types.h
+++ b/src/types.h
@@ -24,23 +24,23 @@ enum class Type : uint8_t {
   // clang-format off
   none,
   voidtype,
-  integer,
+  integer, // int is a protected keyword
   pointer,
   reference,
   record, // struct/union, as struct is a protected keyword
-  hist,
-  lhist,
-  count,
-  sum,
-  min,
-  max,
-  avg,
-  stats,
-  kstack,
-  ustack,
+  hist_t,
+  lhist_t,
+  count_t,
+  sum_t,
+  min_t,
+  max_t,
+  avg_t,
+  stats_t,
+  kstack_t,
+  ustack_t,
   string,
-  ksym,
-  usym,
+  ksym_t,
+  usym_t,
   probe,
   username,
   inet,
@@ -50,8 +50,8 @@ enum class Type : uint8_t {
   tuple,
   timestamp,
   mac_address,
-  cgroup_path,
-  strerror,
+  cgroup_path_t,
+  strerror_t,
   timestamp_mode,
   // clang-format on
 };
@@ -354,43 +354,43 @@ public:
   };
   bool IsHistTy(void) const
   {
-    return type_ == Type::hist;
+    return type_ == Type::hist_t;
   };
   bool IsLhistTy(void) const
   {
-    return type_ == Type::lhist;
+    return type_ == Type::lhist_t;
   };
   bool IsCountTy(void) const
   {
-    return type_ == Type::count;
+    return type_ == Type::count_t;
   };
   bool IsSumTy(void) const
   {
-    return type_ == Type::sum;
+    return type_ == Type::sum_t;
   };
   bool IsMinTy(void) const
   {
-    return type_ == Type::min;
+    return type_ == Type::min_t;
   };
   bool IsMaxTy(void) const
   {
-    return type_ == Type::max;
+    return type_ == Type::max_t;
   };
   bool IsAvgTy(void) const
   {
-    return type_ == Type::avg;
+    return type_ == Type::avg_t;
   };
   bool IsStatsTy(void) const
   {
-    return type_ == Type::stats;
+    return type_ == Type::stats_t;
   };
   bool IsKstackTy(void) const
   {
-    return type_ == Type::kstack;
+    return type_ == Type::kstack_t;
   };
   bool IsUstackTy(void) const
   {
-    return type_ == Type::ustack;
+    return type_ == Type::ustack_t;
   };
   bool IsStringTy(void) const
   {
@@ -398,11 +398,11 @@ public:
   };
   bool IsKsymTy(void) const
   {
-    return type_ == Type::ksym;
+    return type_ == Type::ksym_t;
   };
   bool IsUsymTy(void) const
   {
-    return type_ == Type::usym;
+    return type_ == Type::usym_t;
   };
   bool IsProbeTy(void) const
   {
@@ -446,11 +446,11 @@ public:
   };
   bool IsCgroupPathTy(void) const
   {
-    return type_ == Type::cgroup_path;
+    return type_ == Type::cgroup_path_t;
   };
   bool IsStrerrorTy(void) const
   {
-    return type_ == Type::strerror;
+    return type_ == Type::strerror_t;
   };
   bool IsTimestampModeTy(void) const
   {
@@ -458,13 +458,13 @@ public:
   }
   bool IsCastableMapTy() const
   {
-    return type_ == Type::count || type_ == Type::sum || type_ == Type::max ||
-           type_ == Type::min || type_ == Type::avg;
+    return type_ == Type::count_t || type_ == Type::sum_t ||
+           type_ == Type::max_t || type_ == Type::min_t || type_ == Type::avg_t;
   }
   bool IsMapIterableTy() const
   {
-    return !(type_ == Type::hist || type_ == Type::lhist ||
-             type_ == Type::stats);
+    return !(type_ == Type::hist_t || type_ == Type::lhist_t ||
+             type_ == Type::stats_t);
   }
 
   bool NeedsPercpuMap() const;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,7 @@ add_executable(bpftrace_test
   return_path_analyser.cpp
   semantic_analyser.cpp
   tracepoint_format_parser.cpp
+  types.cpp
   utils.cpp
 
   ${CODEGEN_SRC}

--- a/tests/codegen/llvm/avg_cast.ll
+++ b/tests/codegen/llvm/avg_cast.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %avg_stas_val = type { i64, i64 }
-%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%print_int_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -77,11 +77,11 @@ if_body:                                          ; preds = %is_negative_merge_b
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %11
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %11
   %12 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %13 = getelementptr %print_integer_8_t, ptr %12, i64 0, i32 0
+  %13 = getelementptr %print_int_8_t, ptr %12, i64 0, i32 0
   store i64 30007, ptr %13, align 8
-  %14 = getelementptr %print_integer_8_t, ptr %12, i64 0, i32 1
+  %14 = getelementptr %print_int_8_t, ptr %12, i64 0, i32 1
   store i64 0, ptr %14, align 8
-  %15 = getelementptr %print_integer_8_t, ptr %12, i32 0, i32 2
+  %15 = getelementptr %print_int_8_t, ptr %12, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %15, i8 0, i64 8, i1 false)
   store i64 6, ptr %15, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %12, i64 24, i64 0)

--- a/tests/codegen/llvm/avg_cast_loop.ll
+++ b/tests/codegen/llvm/avg_cast_loop.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %avg_stas_val = type { i64, i64 }
-%int64_avg__tuple_t = type { i64, i64 }
+%int64_avg_t__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -160,13 +160,13 @@ is_negative_merge_block:                          ; preds = %is_positive, %is_ne
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %31
   %32 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %32, i8 0, i64 16, i1 false)
-  %33 = getelementptr %int64_avg__tuple_t, ptr %32, i32 0, i32 0
+  %33 = getelementptr %int64_avg_t__tuple_t, ptr %32, i32 0, i32 0
   store i64 %key, ptr %33, align 8
-  %34 = getelementptr %int64_avg__tuple_t, ptr %32, i32 0, i32 1
+  %34 = getelementptr %int64_avg_t__tuple_t, ptr %32, i32 0, i32 1
   store i64 %30, ptr %34, align 8
-  %35 = getelementptr %int64_avg__tuple_t, ptr %32, i32 0, i32 0
+  %35 = getelementptr %int64_avg_t__tuple_t, ptr %32, i32 0, i32 0
   %36 = load i64, ptr %35, align 8
-  %37 = getelementptr %int64_avg__tuple_t, ptr %32, i32 0, i32 1
+  %37 = getelementptr %int64_avg_t__tuple_t, ptr %32, i32 0, i32 1
   %38 = load i64, ptr %37, align 8
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %39 = load i64, ptr @max_cpu_id, align 8
@@ -174,9 +174,9 @@ is_negative_merge_block:                          ; preds = %is_positive, %is_ne
   %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %39
   %40 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %40, i8 0, i64 16, i1 false)
-  %41 = getelementptr %int64_avg__tuple_t, ptr %40, i32 0, i32 0
+  %41 = getelementptr %int64_avg_t__tuple_t, ptr %40, i32 0, i32 0
   store i64 %36, ptr %41, align 8
-  %42 = getelementptr %int64_avg__tuple_t, ptr %40, i32 0, i32 1
+  %42 = getelementptr %int64_avg_t__tuple_t, ptr %40, i32 0, i32 1
   store i64 %38, ptr %42, align 8
   %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
   %43 = load i64, ptr @max_cpu_id, align 8

--- a/tests/codegen/llvm/call_cgroup_path.ll
+++ b/tests/codegen/llvm/call_cgroup_path.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
 %cgroup_path_t = type <{ i64, i64 }>
-%print_cgroup_path_16_t = type <{ i64, i64, [16 x i8] }>
+%print_cgroup_path_t_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -32,11 +32,11 @@ entry:
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
   %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %5 = getelementptr %print_cgroup_path_16_t, ptr %4, i64 0, i32 0
+  %5 = getelementptr %print_cgroup_path_t_16_t, ptr %4, i64 0, i32 0
   store i64 30007, ptr %5, align 8
-  %6 = getelementptr %print_cgroup_path_16_t, ptr %4, i64 0, i32 1
+  %6 = getelementptr %print_cgroup_path_t_16_t, ptr %4, i64 0, i32 1
   store i64 0, ptr %6, align 8
-  %7 = getelementptr %print_cgroup_path_16_t, ptr %4, i32 0, i32 2
+  %7 = getelementptr %print_cgroup_path_t_16_t, ptr %4, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 16, i1 false)
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %cgroup_path_args, i64 16, i1 false)
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 32, i64 0)

--- a/tests/codegen/llvm/call_ntop_char16.ll
+++ b/tests/codegen/llvm/call_ntop_char16.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%inet_t = type { i64, [16 x i8] }
+%inet = type { i64, [16 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -19,11 +19,11 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %inet = alloca %inet_t, align 8
+  %inet = alloca %inet, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %inet)
-  %1 = getelementptr %inet_t, ptr %inet, i64 0, i32 0
+  %1 = getelementptr %inet, ptr %inet, i64 0, i32 0
   store i64 10, ptr %1, align 8
-  %2 = getelementptr %inet_t, ptr %inet, i32 0, i32 1
+  %2 = getelementptr %inet, ptr %inet, i32 0, i32 1
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 16, i64 0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/call_ntop_char4.ll
+++ b/tests/codegen/llvm/call_ntop_char4.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%inet_t = type { i64, [16 x i8] }
+%inet = type { i64, [16 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -19,11 +19,11 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %inet = alloca %inet_t, align 8
+  %inet = alloca %inet, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %inet)
-  %1 = getelementptr %inet_t, ptr %inet, i64 0, i32 0
+  %1 = getelementptr %inet, ptr %inet, i64 0, i32 0
   store i64 2, ptr %1, align 8
-  %2 = getelementptr %inet_t, ptr %inet, i32 0, i32 1
+  %2 = getelementptr %inet, ptr %inet, i32 0, i32 1
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 4, i64 0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/call_ntop_key.ll
+++ b/tests/codegen/llvm/call_ntop_key.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%inet_t = type { i64, [16 x i8] }
+%inet = type { i64, [16 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -19,11 +19,11 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !55 {
 entry:
   %"@x_val" = alloca i64, align 8
-  %inet = alloca %inet_t, align 8
+  %inet = alloca %inet, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %inet)
-  %1 = getelementptr %inet_t, ptr %inet, i64 0, i32 0
+  %1 = getelementptr %inet, ptr %inet, i64 0, i32 0
   store i64 2, ptr %1, align 8
-  %2 = getelementptr %inet_t, ptr %inet, i32 0, i32 1
+  %2 = getelementptr %inet, ptr %inet, i32 0, i32 1
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   store i32 -1, ptr %2, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -5,7 +5,7 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%print_int_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -24,11 +24,11 @@ entry:
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
   %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %3 = getelementptr %print_integer_8_t, ptr %2, i64 0, i32 0
+  %3 = getelementptr %print_int_8_t, ptr %2, i64 0, i32 0
   store i64 30007, ptr %3, align 8
-  %4 = getelementptr %print_integer_8_t, ptr %2, i64 0, i32 1
+  %4 = getelementptr %print_int_8_t, ptr %2, i64 0, i32 1
   store i64 0, ptr %4, align 8
-  %5 = getelementptr %print_integer_8_t, ptr %2, i32 0, i32 2
+  %5 = getelementptr %print_int_8_t, ptr %2, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
   store i64 3, ptr %5, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 24, i64 0)

--- a/tests/codegen/llvm/count_cast.ll
+++ b/tests/codegen/llvm/count_cast.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%print_int_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -68,11 +68,11 @@ if_body:                                          ; preds = %while_end
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
   %4 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %5 = getelementptr %print_integer_8_t, ptr %4, i64 0, i32 0
+  %5 = getelementptr %print_int_8_t, ptr %4, i64 0, i32 0
   store i64 30007, ptr %5, align 8
-  %6 = getelementptr %print_integer_8_t, ptr %4, i64 0, i32 1
+  %6 = getelementptr %print_int_8_t, ptr %4, i64 0, i32 1
   store i64 0, ptr %6, align 8
-  %7 = getelementptr %print_integer_8_t, ptr %4, i32 0, i32 2
+  %7 = getelementptr %print_int_8_t, ptr %4, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 8, i1 false)
   store i64 6, ptr %7, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 24, i64 0)

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%int64_count__tuple_t = type { i64, i64 }
+%int64_count_t__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -99,13 +99,13 @@ while_end:                                        ; preds = %error_failure, %err
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
   %10 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
-  %11 = getelementptr %int64_count__tuple_t, ptr %10, i32 0, i32 0
+  %11 = getelementptr %int64_count_t__tuple_t, ptr %10, i32 0, i32 0
   store i64 %key, ptr %11, align 8
-  %12 = getelementptr %int64_count__tuple_t, ptr %10, i32 0, i32 1
+  %12 = getelementptr %int64_count_t__tuple_t, ptr %10, i32 0, i32 1
   store i64 %8, ptr %12, align 8
-  %13 = getelementptr %int64_count__tuple_t, ptr %10, i32 0, i32 0
+  %13 = getelementptr %int64_count_t__tuple_t, ptr %10, i32 0, i32 0
   %14 = load i64, ptr %13, align 8
-  %15 = getelementptr %int64_count__tuple_t, ptr %10, i32 0, i32 1
+  %15 = getelementptr %int64_count_t__tuple_t, ptr %10, i32 0, i32 1
   %16 = load i64, ptr %15, align 8
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %17 = load i64, ptr @max_cpu_id, align 8
@@ -113,9 +113,9 @@ while_end:                                        ; preds = %error_failure, %err
   %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %17
   %18 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 16, i1 false)
-  %19 = getelementptr %int64_count__tuple_t, ptr %18, i32 0, i32 0
+  %19 = getelementptr %int64_count_t__tuple_t, ptr %18, i32 0, i32 0
   store i64 %14, ptr %19, align 8
-  %20 = getelementptr %int64_count__tuple_t, ptr %18, i32 0, i32 1
+  %20 = getelementptr %int64_count_t__tuple_t, ptr %18, i32 0, i32 1
   store i64 %16, ptr %20, align 8
   %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
   %21 = load i64, ptr @max_cpu_id, align 8

--- a/tests/codegen/llvm/kfunc_recursion_check.ll
+++ b/tests/codegen/llvm/kfunc_recursion_check.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%print_int_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @recursion_prevention = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -46,11 +46,11 @@ lookup_merge:                                     ; preds = %lookup_success
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %2
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %2
   %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %4 = getelementptr %print_integer_8_t, ptr %3, i64 0, i32 0
+  %4 = getelementptr %print_int_8_t, ptr %3, i64 0, i32 0
   store i64 30007, ptr %4, align 8
-  %5 = getelementptr %print_integer_8_t, ptr %3, i64 0, i32 1
+  %5 = getelementptr %print_int_8_t, ptr %3, i64 0, i32 1
   store i64 0, ptr %5, align 8
-  %6 = getelementptr %print_integer_8_t, ptr %3, i32 0, i32 2
+  %6 = getelementptr %print_int_8_t, ptr %3, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
   store i64 2, ptr %6, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %3, i64 24, i64 0)
@@ -150,11 +150,11 @@ lookup_merge:                                     ; preds = %lookup_success
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %2
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %2
   %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %4 = getelementptr %print_integer_8_t, ptr %3, i64 0, i32 0
+  %4 = getelementptr %print_int_8_t, ptr %3, i64 0, i32 0
   store i64 30007, ptr %4, align 8
-  %5 = getelementptr %print_integer_8_t, ptr %3, i64 0, i32 1
+  %5 = getelementptr %print_int_8_t, ptr %3, i64 0, i32 1
   store i64 1, ptr %5, align 8
-  %6 = getelementptr %print_integer_8_t, ptr %3, i32 0, i32 2
+  %6 = getelementptr %print_int_8_t, ptr %3, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
   store i64 1, ptr %6, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %3, i64 24, i64 0)

--- a/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/kfunc_recursion_check_with_predicate.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%print_int_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @recursion_prevention = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -80,11 +80,11 @@ pred_true:                                        ; preds = %lookup_merge
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %6
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
   %7 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %8 = getelementptr %print_integer_8_t, ptr %7, i64 0, i32 0
+  %8 = getelementptr %print_int_8_t, ptr %7, i64 0, i32 0
   store i64 30007, ptr %8, align 8
-  %9 = getelementptr %print_integer_8_t, ptr %7, i64 0, i32 1
+  %9 = getelementptr %print_int_8_t, ptr %7, i64 0, i32 1
   store i64 0, ptr %9, align 8
-  %10 = getelementptr %print_integer_8_t, ptr %7, i32 0, i32 2
+  %10 = getelementptr %print_int_8_t, ptr %7, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 8, i1 false)
   store i64 2, ptr %10, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %7, i64 24, i64 0)

--- a/tests/codegen/llvm/max_cast.ll
+++ b/tests/codegen/llvm/max_cast.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
-%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%print_int_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -82,11 +82,11 @@ if_body:                                          ; preds = %while_end
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %10
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %10
   %11 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %12 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 0
+  %12 = getelementptr %print_int_8_t, ptr %11, i64 0, i32 0
   store i64 30007, ptr %12, align 8
-  %13 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 1
+  %13 = getelementptr %print_int_8_t, ptr %11, i64 0, i32 1
   store i64 0, ptr %13, align 8
-  %14 = getelementptr %print_integer_8_t, ptr %11, i32 0, i32 2
+  %14 = getelementptr %print_int_8_t, ptr %11, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %14, i8 0, i64 8, i1 false)
   store i64 6, ptr %14, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %11, i64 24, i64 0)

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
-%int64_max__tuple_t = type { i64, i64 }
+%int64_max_t__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -113,13 +113,13 @@ while_end:                                        ; preds = %error_failure, %err
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
   %10 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
-  %11 = getelementptr %int64_max__tuple_t, ptr %10, i32 0, i32 0
+  %11 = getelementptr %int64_max_t__tuple_t, ptr %10, i32 0, i32 0
   store i64 %key, ptr %11, align 8
-  %12 = getelementptr %int64_max__tuple_t, ptr %10, i32 0, i32 1
+  %12 = getelementptr %int64_max_t__tuple_t, ptr %10, i32 0, i32 1
   store i64 %8, ptr %12, align 8
-  %13 = getelementptr %int64_max__tuple_t, ptr %10, i32 0, i32 0
+  %13 = getelementptr %int64_max_t__tuple_t, ptr %10, i32 0, i32 0
   %14 = load i64, ptr %13, align 8
-  %15 = getelementptr %int64_max__tuple_t, ptr %10, i32 0, i32 1
+  %15 = getelementptr %int64_max_t__tuple_t, ptr %10, i32 0, i32 1
   %16 = load i64, ptr %15, align 8
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %17 = load i64, ptr @max_cpu_id, align 8
@@ -127,9 +127,9 @@ while_end:                                        ; preds = %error_failure, %err
   %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %17
   %18 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 16, i1 false)
-  %19 = getelementptr %int64_max__tuple_t, ptr %18, i32 0, i32 0
+  %19 = getelementptr %int64_max_t__tuple_t, ptr %18, i32 0, i32 0
   store i64 %14, ptr %19, align 8
-  %20 = getelementptr %int64_max__tuple_t, ptr %18, i32 0, i32 1
+  %20 = getelementptr %int64_max_t__tuple_t, ptr %18, i32 0, i32 1
   store i64 %16, ptr %20, align 8
   %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
   %21 = load i64, ptr @max_cpu_id, align 8

--- a/tests/codegen/llvm/min_cast.ll
+++ b/tests/codegen/llvm/min_cast.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
-%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%print_int_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -82,11 +82,11 @@ if_body:                                          ; preds = %while_end
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %10
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %10
   %11 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %12 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 0
+  %12 = getelementptr %print_int_8_t, ptr %11, i64 0, i32 0
   store i64 30007, ptr %12, align 8
-  %13 = getelementptr %print_integer_8_t, ptr %11, i64 0, i32 1
+  %13 = getelementptr %print_int_8_t, ptr %11, i64 0, i32 1
   store i64 0, ptr %13, align 8
-  %14 = getelementptr %print_integer_8_t, ptr %11, i32 0, i32 2
+  %14 = getelementptr %print_int_8_t, ptr %11, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %14, i8 0, i64 8, i1 false)
   store i64 6, ptr %14, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %11, i64 24, i64 0)

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %min_max_val = type { i64, i64 }
-%int64_min__tuple_t = type { i64, i64 }
+%int64_min_t__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -113,13 +113,13 @@ while_end:                                        ; preds = %error_failure, %err
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
   %10 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
-  %11 = getelementptr %int64_min__tuple_t, ptr %10, i32 0, i32 0
+  %11 = getelementptr %int64_min_t__tuple_t, ptr %10, i32 0, i32 0
   store i64 %key, ptr %11, align 8
-  %12 = getelementptr %int64_min__tuple_t, ptr %10, i32 0, i32 1
+  %12 = getelementptr %int64_min_t__tuple_t, ptr %10, i32 0, i32 1
   store i64 %8, ptr %12, align 8
-  %13 = getelementptr %int64_min__tuple_t, ptr %10, i32 0, i32 0
+  %13 = getelementptr %int64_min_t__tuple_t, ptr %10, i32 0, i32 0
   %14 = load i64, ptr %13, align 8
-  %15 = getelementptr %int64_min__tuple_t, ptr %10, i32 0, i32 1
+  %15 = getelementptr %int64_min_t__tuple_t, ptr %10, i32 0, i32 1
   %16 = load i64, ptr %15, align 8
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %17 = load i64, ptr @max_cpu_id, align 8
@@ -127,9 +127,9 @@ while_end:                                        ; preds = %error_failure, %err
   %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %17
   %18 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 16, i1 false)
-  %19 = getelementptr %int64_min__tuple_t, ptr %18, i32 0, i32 0
+  %19 = getelementptr %int64_min_t__tuple_t, ptr %18, i32 0, i32 0
   store i64 %14, ptr %19, align 8
-  %20 = getelementptr %int64_min__tuple_t, ptr %18, i32 0, i32 1
+  %20 = getelementptr %int64_min_t__tuple_t, ptr %18, i32 0, i32 1
   store i64 %16, ptr %20, align 8
   %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
   %21 = load i64, ptr @max_cpu_id, align 8

--- a/tests/codegen/llvm/sum_cast.ll
+++ b/tests/codegen/llvm/sum_cast.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+%print_int_8_t = type <{ i64, i64, [8 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -68,11 +68,11 @@ if_body:                                          ; preds = %while_end
   %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
   %4 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
-  %5 = getelementptr %print_integer_8_t, ptr %4, i64 0, i32 0
+  %5 = getelementptr %print_int_8_t, ptr %4, i64 0, i32 0
   store i64 30007, ptr %5, align 8
-  %6 = getelementptr %print_integer_8_t, ptr %4, i64 0, i32 1
+  %6 = getelementptr %print_int_8_t, ptr %4, i64 0, i32 1
   store i64 0, ptr %6, align 8
-  %7 = getelementptr %print_integer_8_t, ptr %4, i32 0, i32 2
+  %7 = getelementptr %print_int_8_t, ptr %4, i32 0, i32 2
   call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 8, i1 false)
   store i64 6, ptr %7, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 24, i64 0)

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%int64_sum__tuple_t = type { i64, i64 }
+%int64_sum_t__tuple_t = type { i64, i64 }
 %print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -99,13 +99,13 @@ while_end:                                        ; preds = %error_failure, %err
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
   %10 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
-  %11 = getelementptr %int64_sum__tuple_t, ptr %10, i32 0, i32 0
+  %11 = getelementptr %int64_sum_t__tuple_t, ptr %10, i32 0, i32 0
   store i64 %key, ptr %11, align 8
-  %12 = getelementptr %int64_sum__tuple_t, ptr %10, i32 0, i32 1
+  %12 = getelementptr %int64_sum_t__tuple_t, ptr %10, i32 0, i32 1
   store i64 %8, ptr %12, align 8
-  %13 = getelementptr %int64_sum__tuple_t, ptr %10, i32 0, i32 0
+  %13 = getelementptr %int64_sum_t__tuple_t, ptr %10, i32 0, i32 0
   %14 = load i64, ptr %13, align 8
-  %15 = getelementptr %int64_sum__tuple_t, ptr %10, i32 0, i32 1
+  %15 = getelementptr %int64_sum_t__tuple_t, ptr %10, i32 0, i32 1
   %16 = load i64, ptr %15, align 8
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %17 = load i64, ptr @max_cpu_id, align 8
@@ -113,9 +113,9 @@ while_end:                                        ; preds = %error_failure, %err
   %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %17
   %18 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 16, i1 false)
-  %19 = getelementptr %int64_sum__tuple_t, ptr %18, i32 0, i32 0
+  %19 = getelementptr %int64_sum_t__tuple_t, ptr %18, i32 0, i32 0
   store i64 %14, ptr %19, align 8
-  %20 = getelementptr %int64_sum__tuple_t, ptr %18, i32 0, i32 1
+  %20 = getelementptr %int64_sum_t__tuple_t, ptr %18, i32 0, i32 1
   store i64 %16, ptr %20, align 8
   %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
   %21 = load i64, ptr @max_cpu_id, align 8

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %usym_t = type { i64, i64, i64 }
-%uint8_usym_int64__tuple_t = type { i8, [24 x i8], i64 }
+%uint8_usym_t_int64__tuple_t = type { i8, [24 x i8], i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_t = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -40,11 +40,11 @@ entry:
   %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
   %7 = getelementptr [1 x [1 x [40 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 40, i1 false)
-  %8 = getelementptr %uint8_usym_int64__tuple_t, ptr %7, i32 0, i32 0
+  %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 0
   store i8 1, ptr %8, align 1
-  %9 = getelementptr %uint8_usym_int64__tuple_t, ptr %7, i32 0, i32 1
+  %9 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %usym, i64 24, i1 false)
-  %10 = getelementptr %uint8_usym_int64__tuple_t, ptr %7, i32 0, i32 2
+  %10 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 2
   store i64 10, ptr %10, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -88,7 +88,7 @@ config = { BAD_CONFIG=1 } BEGIN { }
        false);
   test(
       "config = { BPFTRACE_MAX_PROBES=\"hello\" } BEGIN { }",
-      R"(stdin:1:12-32: ERROR: Invalid type for BPFTRACE_MAX_PROBES. Type: string. Expected Type: integer
+      R"(stdin:1:12-32: ERROR: Invalid type for BPFTRACE_MAX_PROBES. Type: string. Expected Type: int
 config = { BPFTRACE_MAX_PROBES="hello" } BEGIN { }
            ~~~~~~~~~~~~~~~~~~~~
 )",

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -16,12 +16,13 @@ TEST(TextOutput, lhist_no_suffix)
   TextOutput output{ out, err };
 
   MockBPFtrace bpftrace;
-  bpftrace.resources.maps_info["@mymap"] = MapInfo{ CreateNone(),
-                                                    SizedType{ Type::lhist, 8 },
-                                                    LinearHistogramArgs{
-                                                        610000, 670000, 10000 },
-                                                    {},
-                                                    {} };
+  bpftrace.resources.maps_info["@mymap"] = MapInfo{
+    CreateNone(),
+    SizedType{ Type::lhist_t, 8 },
+    LinearHistogramArgs{ 610000, 670000, 10000 },
+    {},
+    {}
+  };
   BpfMap map{ libbpf::BPF_MAP_TYPE_HASH, "@mymap", 8, 8, 1000 };
 
   std::map<std::vector<uint8_t>, std::vector<uint64_t>> values_by_key = {
@@ -61,12 +62,13 @@ TEST(TextOutput, lhist_suffix)
   TextOutput output{ out, err };
 
   MockBPFtrace bpftrace;
-  bpftrace.resources.maps_info["@mymap"] = MapInfo{ CreateNone(),
-                                                    SizedType{ Type::lhist, 8 },
-                                                    LinearHistogramArgs{
-                                                        0, 5 * 1024, 1024 },
-                                                    {},
-                                                    {} };
+  bpftrace.resources.maps_info["@mymap"] = MapInfo{
+    CreateNone(),
+    SizedType{ Type::lhist_t, 8 },
+    LinearHistogramArgs{ 0, 5 * 1024, 1024 },
+    {},
+    {}
+  };
   BpfMap map{ libbpf::BPF_MAP_TYPE_HASH, "@mymap", 8, 8, 1000 };
 
   std::map<std::vector<uint8_t>, std::vector<uint64_t>> values_by_key = {

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1808,7 +1808,7 @@ TEST(Parser, cast_simple_type_pointer)
 
 TEST(Parser, cast_sized_type)
 {
-  test("kprobe:sys_read { (str_t[1])arg0; }",
+  test("kprobe:sys_read { (string[1])arg0; }",
        "Program\n"
        " kprobe:sys_read\n"
        "  (string[1])\n"
@@ -1817,7 +1817,7 @@ TEST(Parser, cast_sized_type)
 
 TEST(Parser, cast_sized_type_pointer)
 {
-  test("kprobe:sys_read { (str_t[1] *)arg0; }",
+  test("kprobe:sys_read { (string[1] *)arg0; }",
        "Program\n"
        " kprobe:sys_read\n"
        "  (string[1] *)\n"
@@ -2652,7 +2652,7 @@ TEST(Parser, subprog_two_args)
 
 TEST(Parser, subprog_string_arg)
 {
-  test("fn f($a : str_t[16]): void {}",
+  test("fn f($a : string[16]): void {}",
        "Program\n"
        " f: void($a : string[16])\n");
 }
@@ -2701,7 +2701,7 @@ TEST(Parser, subprog_return)
 
 TEST(Parser, subprog_string)
 {
-  test("fn f(): str_t[16] {}",
+  test("fn f(): string[16] {}",
        "Program\n"
        " f: string[16]()\n");
 }

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -1,0 +1,83 @@
+#include "types.h"
+#include "struct.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::types {
+
+static std::string to_str(SizedType type)
+{
+  std::stringstream out;
+  out << type;
+  return out.str();
+}
+
+TEST(types, to_str)
+{
+  EXPECT_EQ(to_str(CreateInt8()), "int8");
+  EXPECT_EQ(to_str(CreateInt16()), "int16");
+  EXPECT_EQ(to_str(CreateInt32()), "int32");
+  EXPECT_EQ(to_str(CreateInt64()), "int64");
+  EXPECT_EQ(to_str(CreateUInt8()), "uint8");
+  EXPECT_EQ(to_str(CreateUInt16()), "uint16");
+  EXPECT_EQ(to_str(CreateUInt32()), "uint32");
+  EXPECT_EQ(to_str(CreateUInt64()), "uint64");
+
+  EXPECT_EQ(to_str(CreateInet(10)), "inet[10]");
+  EXPECT_EQ(to_str(CreateString(10)), "string[10]");
+  EXPECT_EQ(to_str(CreateBuffer(10)), "buffer[14]"); // metadata headroom
+
+  EXPECT_EQ(to_str(CreatePointer(CreateInt8(), AddrSpace::kernel)), "int8 *");
+
+  auto ptr_ctx = CreatePointer(CreateInt8(), AddrSpace::kernel);
+  ptr_ctx.MarkCtxAccess();
+  EXPECT_EQ(to_str(ptr_ctx), "(ctx) int8 *");
+
+  EXPECT_EQ(to_str(CreateReference(CreateInt8(), AddrSpace::kernel)), "int8 &");
+
+  EXPECT_EQ(to_str(CreateArray(2, CreateInt8())), "int8[2]");
+
+  auto record = std::weak_ptr<Struct>();
+  EXPECT_EQ(to_str(CreateRecord("hello", record)), "hello");
+
+  std::shared_ptr<Struct> tuple = Struct::CreateTuple(
+      { CreateInt8(), CreateString(10) });
+  EXPECT_EQ(to_str(CreateTuple(tuple)), "(int8,string[10])");
+
+  EXPECT_EQ(to_str(CreateSum(true)), "sum_t");
+  EXPECT_EQ(to_str(CreateSum(false)), "usum_t");
+
+  EXPECT_EQ(to_str(CreateMin(true)), "min_t");
+  EXPECT_EQ(to_str(CreateMin(false)), "umin_t");
+
+  EXPECT_EQ(to_str(CreateMax(true)), "max_t");
+  EXPECT_EQ(to_str(CreateMax(false)), "umax_t");
+
+  EXPECT_EQ(to_str(CreateAvg(true)), "avg_t");
+  EXPECT_EQ(to_str(CreateAvg(false)), "uavg_t");
+
+  EXPECT_EQ(to_str(CreateStats(true)), "stats_t");
+  EXPECT_EQ(to_str(CreateStats(false)), "ustats_t");
+
+  EXPECT_EQ(to_str(CreateCount(true)), "count_t");
+  EXPECT_EQ(to_str(CreateCount(false)), "ucount_t");
+
+  EXPECT_EQ(to_str(CreateMacAddress()), "mac_address");
+  EXPECT_EQ(to_str(CreateStack(true)), "kstack");
+  EXPECT_EQ(to_str(CreateStack(false)), "ustack");
+  EXPECT_EQ(to_str(CreateTimestamp()), "timestamp");
+  EXPECT_EQ(to_str(CreateKSym()), "ksym_t");
+  EXPECT_EQ(to_str(CreateUSym()), "usym_t");
+  EXPECT_EQ(to_str(CreateUsername()), "username");
+  EXPECT_EQ(to_str(CreateProbe()), "probe");
+  EXPECT_EQ(to_str(CreateStackMode()), "stack_mode");
+  EXPECT_EQ(to_str(CreateTimestampMode()), "timestamp_mode");
+  EXPECT_EQ(to_str(CreateCgroupPath()), "cgroup_path_t");
+  EXPECT_EQ(to_str(CreateStrerror()), "strerror_t");
+  EXPECT_EQ(to_str(CreateHist()), "hist_t");
+  EXPECT_EQ(to_str(CreateLhist()), "lhist_t");
+  EXPECT_EQ(to_str(CreateNone()), "none");
+  EXPECT_EQ(to_str(CreateVoid()), "void");
+}
+
+} // namespace bpftrace::test::types


### PR DESCRIPTION
This applies mostly to printing the type name
for error messages or debugging.

Also updates a few places in the adoc.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
