### PR TITLE
Use 'missing_probes' config for check_alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to
   - [#3325](https://github.com/bpftrace/bpftrace/pull/3325)
 - Remove `ALLOW_UNSAFE_PROBE` compiler flag
   - [#3476](https://github.com/bpftrace/bpftrace/pull/3476)
+- Remove the ability to force attachment on misaligned uprobes
+  - [#3481](https://github.com/bpftrace/bpftrace/pull/3481)
 #### Fixed
 - Fix verifier error when array indexing through pointer
   - [#3465](https://github.com/bpftrace/bpftrace/pull/3465)


### PR DESCRIPTION
Instead of attemping to attach uprobes if they fail `check_alignment` never attach and use the `missing_probes` config to determine if we error, warn, or ignore.

This removes the ability to use the "--unsafe" flag
and force attachment anyway. This was done because
attaching in the middle of an instruction can be very unsafe
and cause data corruption or crashes. Even the kernel
doesn't allow this for kprobes.


##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
