### PR TITLE
config: Fix typo in error message

### DIFF
--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -148,7 +148,7 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
 
   if (!assignment.expr->is_literal) {
     LOG(ERROR, assignment.loc, err_)
-        << "Assignemnt for " << assignment.config_var << " must be literal.";
+        << "Assignment for " << assignment.config_var << " must be literal.";
     return;
   }
 


### PR DESCRIPTION
'Assignment' was spelled wrong.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
