### PR TITLE
Use global scratch buffers for reading and writing map values

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(ast_defs STATIC ast.cpp)
 add_library(ast STATIC
   async_event_types.cpp
   attachpoint_parser.cpp
+  codegen_helper.cpp
   dibuilderbpf.cpp
   int_parser.cpp
   irbuilderbpf.cpp

--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -12,6 +12,7 @@ namespace ast {
   DO(bpf_print)                                                                \
   DO(non_map_print)                                                            \
   DO(printf)                                                                   \
+  DO(read_map_value)                                                           \
   DO(skb_output)                                                               \
   DO(strftime)                                                                 \
   DO(str)                                                                      \

--- a/src/ast/codegen_helper.cpp
+++ b/src/ast/codegen_helper.cpp
@@ -1,0 +1,33 @@
+#include "codegen_helper.h"
+
+namespace bpftrace::ast {
+
+/* needAssignMapStatementAllocation determines if a map assignment requires a
+ * new memory allocation. This happens only in a few cases e.g. if there are
+ * two map assignments of tuples of different sizes e.g.
+ *   @x = ("xxx", 1); @x = ("xxxxxxx", 1);
+ * which requires a 0 memsetting and copying of each tuple element into the
+ * new allocation before calling bpf_map_update_elem.
+ *
+ * Another case when we need an allocation is for a external struct e.g.
+ *   $v = (struct task_struct *)arg1; @ = *$v;.
+ *
+ * Most cases we can reuse existing BPF memory and not create a new allocation.
+ *
+ * Note this function does NOT determine if an allocation should use scratch
+ * buffer or the stack, that logic is in
+ * IRBuilderBPF::CreateWriteMapValueAllocation
+ */
+bool needAssignMapStatementAllocation(const AssignMapStatement &assignment)
+{
+  const auto &map = *assignment.map;
+  const auto &expr_type = assignment.expr->type;
+  if (shouldBeInBpfMemoryAlready(expr_type)) {
+    return !expr_type.IsSameSizeRecursive(map.type);
+  } else if (map.type.IsRecordTy() || map.type.IsArrayTy()) {
+    return !expr_type.is_internal;
+  }
+  return true;
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -33,5 +33,7 @@ inline AddrSpace find_addrspace_stack(const SizedType &ty)
   return (shouldBeInBpfMemoryAlready(ty)) ? AddrSpace::kernel : ty.GetAS();
 }
 
+bool needAssignMapStatementAllocation(const AssignMapStatement &assignment);
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -165,16 +165,16 @@ public:
   CallInst *CreateGetStackScratchMap(StackType stack_type,
                                      BasicBlock *failure_callback,
                                      const location &loc);
-  Value *CreateGetStrAllocation(const std::string &name,
-                                const location &loc,
-                                AsyncIds &async_ids);
+  Value *CreateGetStrAllocation(const std::string &name, const location &loc);
   Value *CreateGetFmtStringArgsAllocation(StructType *struct_type,
                                           const std::string &name,
                                           const location &loc);
   Value *CreateTupleAllocation(const SizedType &tuple_type,
                                const std::string &name,
-                               const location &loc,
-                               AsyncIds &async_ids);
+                               const location &loc);
+  Value *CreateWriteMapValueAllocation(const SizedType &value_type,
+                                       const std::string &name,
+                                       const location &loc);
   void CreateCheckSetRecursion(const location &loc, int early_exit_ret);
   void CreateUnSetRecursion(const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
@@ -305,12 +305,15 @@ private:
                                 const location &loc,
                                 BasicBlock *failure_callback,
                                 int key = 0);
-  Value *createAllocation(
-      globalvars::GlobalVar globalvar,
-      llvm::Type *obj_type,
-      const std::string &name,
-      const location &loc,
-      std::optional<std::function<size_t()>> gen_async_id_cb = std::nullopt);
+  Value *CreateReadMapValueAllocation(const SizedType &value_type,
+                                      const std::string &name,
+                                      const location &loc);
+  Value *createAllocation(globalvars::GlobalVar globalvar,
+                          llvm::Type *obj_type,
+                          const std::string &name,
+                          const location &loc,
+                          std::optional<std::function<size_t(AsyncIds &)>>
+                              gen_async_id_cb = std::nullopt);
   Value *createScratchBuffer(globalvars::GlobalVar globalvar,
                              const location &loc,
                              size_t key);

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -36,10 +36,13 @@ private:
   void visit(Tuple &tuple) override;
   void visit(For &f) override;
   void visit(Ternary &ternary) override;
+  void visit(AssignMapStatement &assignment) override;
 
   // Determines whether the given function uses userspace symbol resolution.
   // This is used later for loading the symbol table into memory.
   bool uses_usym_table(const std::string &fun);
+
+  void update_map_info(Map &map);
 
   RequiredResources resources_;
   Node *root_;

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -140,6 +140,8 @@ static void update_global_vars_rodata(
       case GlobalVar::FMT_STRINGS_BUFFER:
       case GlobalVar::TUPLE_BUFFER:
       case GlobalVar::GET_STR_BUFFER:
+      case GlobalVar::READ_MAP_VALUE_BUFFER:
+      case GlobalVar::WRITE_MAP_VALUE_BUFFER:
         break;
     }
   }
@@ -269,11 +271,22 @@ SizedType get_type(bpftrace::globalvars::GlobalVar global_var,
       assert(resources.tuple_buffers > 0);
       return make_rw_type(resources.tuple_buffers,
                           CreateArray(resources.max_tuple_size, CreateInt8()));
-    case bpftrace::globalvars::GlobalVar::GET_STR_BUFFER:
+    case bpftrace::globalvars::GlobalVar::GET_STR_BUFFER: {
       assert(resources.str_buffers > 0);
       const auto max_strlen = bpftrace_config.get(ConfigKeyInt::max_strlen);
       return make_rw_type(resources.str_buffers,
                           CreateArray(max_strlen, CreateInt8()));
+    }
+    case bpftrace::globalvars::GlobalVar::READ_MAP_VALUE_BUFFER:
+      assert(resources.max_read_map_value_size > 0);
+      assert(resources.read_map_value_buffers > 0);
+      return make_rw_type(resources.read_map_value_buffers,
+                          CreateArray(resources.max_read_map_value_size,
+                                      CreateInt8()));
+    case bpftrace::globalvars::GlobalVar::WRITE_MAP_VALUE_BUFFER:
+      assert(resources.max_write_map_value_size > 0);
+      return make_rw_type(
+          1, CreateArray(resources.max_write_map_value_size, CreateInt8()));
   }
   return {}; // unreachable
 }

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -20,6 +20,10 @@ constexpr std::string_view FMT_STRINGS_BUFFER_SECTION_NAME =
     ".data.fmt_str_buf";
 constexpr std::string_view TUPLE_BUFFER_SECTION_NAME = ".data.tuple_buf";
 constexpr std::string_view GET_STR_BUFFER_SECTION_NAME = ".data.get_str_buf";
+constexpr std::string_view READ_MAP_VALUE_BUFFER_SECTION_NAME =
+    ".data.read_map_val_buf";
+constexpr std::string_view WRITE_MAP_VALUE_BUFFER_SECTION_NAME =
+    ".data.write_map_val_buf";
 
 struct GlobalVarConfig {
   std::string name;
@@ -37,6 +41,14 @@ const std::unordered_map<GlobalVar, GlobalVarConfig> GLOBAL_VAR_CONFIGS = {
     { "tuple_buf", std::string(TUPLE_BUFFER_SECTION_NAME), false } },
   { GlobalVar::GET_STR_BUFFER,
     { "get_str_buf", std::string(GET_STR_BUFFER_SECTION_NAME), false } },
+  { GlobalVar::READ_MAP_VALUE_BUFFER,
+    { "read_map_val_buf",
+      std::string(READ_MAP_VALUE_BUFFER_SECTION_NAME),
+      false } },
+  { GlobalVar::WRITE_MAP_VALUE_BUFFER,
+    { "write_map_val_buf",
+      std::string(WRITE_MAP_VALUE_BUFFER_SECTION_NAME),
+      false } },
 };
 
 void update_global_vars(

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -110,6 +110,11 @@ public:
   // Required for sizing of string scratch buffer
   size_t str_buffers = 0;
 
+  // Required for sizing of map value scratch buffers
+  size_t read_map_value_buffers = 0;
+  size_t max_read_map_value_size = 0;
+  size_t max_write_map_value_size = 0;
+
   // Async argument metadata that codegen creates. Ideally ResourceAnalyser
   // pass should be collecting this, but it's complex to move the logic.
   //

--- a/src/types.h
+++ b/src/types.h
@@ -732,6 +732,8 @@ enum class GlobalVar {
   FMT_STRINGS_BUFFER,
   TUPLE_BUFFER,
   GET_STR_BUFFER,
+  READ_MAP_VALUE_BUFFER,
+  WRITE_MAP_VALUE_BUFFER,
 };
 
 } // namespace globalvars

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -59,8 +59,8 @@ entry:
   %10 = load volatile i16, ptr %9, align 2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_key")
   store i64 0, ptr %"@b_key", align 8
-  %11 = sext i16 %10 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_val")
+  %11 = sext i16 %10 to i64
   store i64 %11, ptr %"@b_val", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_b, ptr %"@b_key", ptr %"@b_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_val")
@@ -72,8 +72,8 @@ entry:
   %16 = load volatile i8, ptr %15, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@c_key")
   store i64 0, ptr %"@c_key", align 8
-  %17 = sext i8 %16 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@c_val")
+  %17 = sext i8 %16 to i64
   store i64 %17, ptr %"@c_val", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_c, ptr %"@c_key", ptr %"@c_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@c_val")
@@ -89,8 +89,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct c.c")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@d_key")
   store i64 0, ptr %"@d_key", align 8
-  %24 = sext i8 %23 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@d_val")
+  %24 = sext i8 %23 to i64
   store i64 %24, ptr %"@d_val", align 8
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_d, ptr %"@d_key", ptr %"@d_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@d_val")

--- a/tests/codegen/llvm/builtin_curtask.ll
+++ b/tests/codegen/llvm/builtin_curtask.ll
@@ -17,15 +17,15 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !41 {
 entry:
-  %"@x_ptr" = alloca i64, align 8
+  %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_cur_task = call i64 inttoptr (i64 35 to ptr)()
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_ptr")
-  store i64 %get_cur_task, ptr %"@x_ptr", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_ptr", i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_ptr")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  store i64 %get_cur_task, ptr %"@x_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -28,8 +28,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  %3 = sext i16 %2 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
+  %3 = sext i16 %2 to i64
   store i64 %3, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -28,8 +28,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  %3 = sext i32 %2 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
+  %3 = sext i32 %2 to i64
   store i64 %3, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")

--- a/tests/codegen/llvm/cast_arr_to_int.ll
+++ b/tests/codegen/llvm/cast_arr_to_int.ll
@@ -33,8 +33,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %addr4)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  %6 = zext i32 %5 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
+  %6 = zext i32 %5 to i64
   store i64 %6, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")

--- a/tests/codegen/llvm/cast_int_to_arr.ll
+++ b/tests/codegen/llvm/cast_int_to_arr.ll
@@ -33,8 +33,8 @@ entry:
   %6 = load volatile i8, ptr %5, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  %7 = zext i8 %6 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
+  %7 = zext i8 %6 to i64
   store i64 %7, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")

--- a/tests/codegen/llvm/comparison_extend.ll
+++ b/tests/codegen/llvm/comparison_extend.ll
@@ -24,8 +24,8 @@ entry:
   %2 = icmp ult i64 1, %arg0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  %3 = zext i1 %2 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
+  %3 = zext i1 %2 to i64
   store i64 %3, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")

--- a/tests/codegen/llvm/intcast_retval.ll
+++ b/tests/codegen/llvm/intcast_retval.ll
@@ -24,8 +24,8 @@ entry:
   %cast = trunc i64 %retval to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  %2 = sext i32 %cast to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
+  %2 = sext i32 %cast to i64
   store i64 %2, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -29,8 +29,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  %4 = sext i8 %3 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
+  %4 = sext i8 %3 to i64
   store i64 %4, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")

--- a/tests/codegen/llvm/map_value_int_scratch_buf.ll
+++ b/tests/codegen/llvm/map_value_int_scratch_buf.ll
@@ -13,36 +13,57 @@ target triple = "bpf-pc-linux"
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !24
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !38
+@write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !40
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !48
+@read_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !50
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !43 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !55 {
 entry:
-  %"@y_val" = alloca i64, align 8
   %"@y_key" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_key1" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %2 = zext i32 %pid to i64
-  store i64 %2, ptr %"@x_val", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  store i64 1, ptr %2, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %tid = trunc i64 %get_pid_tgid1 to i32
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
+  store i64 0, ptr %"@x_key1", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
+  %get_cpu_id2 = call i64 inttoptr (i64 8 to ptr)()
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded3 = and i64 %get_cpu_id2, %3
+  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @read_map_val_buf, i64 0, i64 %cpu.id.bounded3, i64 0, i64 0
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %5 = load i64, ptr %lookup_elem, align 8
+  store i64 %5, ptr %4, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  store i64 0, ptr %4, align 8
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %6 = load i64, ptr %4, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  %3 = zext i32 %tid to i64
-  store i64 %3, ptr %"@y_val", align 8
-  %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
+  %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
+  %7 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded5 = and i64 %get_cpu_id4, %7
+  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded5, i64 0, i64 0
+  store i64 %6, ptr %8, align 8
+  %update_elem6 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %8, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
   ret i64 0
 }
@@ -56,8 +77,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!40}
-!llvm.module.flags = !{!42}
+!llvm.dbg.cu = !{!52}
+!llvm.module.flags = !{!54}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -99,13 +120,24 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !37 = !DISubrange(count: 262144, lowerBound: 0)
 !38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
 !39 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
-!40 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !41)
-!41 = !{!0, !22, !24, !38}
-!42 = !{i32 2, !"Debug Info Version", i32 3}
-!43 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !44, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !40, retainedNodes: !48)
-!44 = !DISubroutineType(types: !45)
-!45 = !{!21, !46}
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!48 = !{!49}
-!49 = !DILocalVariable(name: "ctx", arg: 1, scope: !43, file: !2, type: !46)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !14)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !14)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 64, elements: !46)
+!45 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!46 = !{!47}
+!47 = !DISubrange(count: 8, lowerBound: 0)
+!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
+!49 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
+!51 = distinct !DIGlobalVariable(name: "read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!52 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !53)
+!53 = !{!0, !22, !24, !38, !40, !48, !50}
+!54 = !{i32 2, !"Debug Info Version", i32 3}
+!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !59)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!21, !58}
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!59 = !{!60}
+!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)

--- a/tests/codegen/llvm/map_value_tuple_scratch_buf.ll
+++ b/tests/codegen/llvm/map_value_tuple_scratch_buf.ll
@@ -1,0 +1,199 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
+%"string[4]_int64__tuple_t" = type { [4 x i8], i64 }
+%"string[8]_int64__tuple_t" = type { [8 x i8], i64 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !30
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !32
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !46
+@write_map_val_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !52
+@read_map_val_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !59
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !61
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !63
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !70 {
+entry:
+  %"@y_key" = alloca i64, align 8
+  %"@x_key8" = alloca i64, align 8
+  %"@x_key6" = alloca i64, align 8
+  %str3 = alloca [8 x i8], align 1
+  %"@x_key" = alloca i64, align 8
+  %str = alloca [4 x i8], align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
+  store [4 x i8] c"xxx\00", ptr %str, align 1
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %"string[4]_int64__tuple_t", ptr %2, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 %str, i64 4, i1 false)
+  %4 = getelementptr %"string[4]_int64__tuple_t", ptr %2, i32 0, i32 1
+  store i64 1, ptr %4, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
+  store i64 0, ptr %"@x_key", align 8
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr [16 x i8], ptr %2, i64 0, i64 0
+  %8 = getelementptr %"string[8]_int64__tuple_t", ptr %6, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %7, i64 4, i1 false)
+  %9 = getelementptr [16 x i8], ptr %2, i64 0, i64 8
+  %10 = getelementptr %"string[8]_int64__tuple_t", ptr %6, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 8, i1 false)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %6, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str3)
+  store [8 x i8] c"xxxxxxx\00", ptr %str3, align 1
+  %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
+  %11 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded5 = and i64 %get_cpu_id4, %11
+  %12 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded5, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %12, i8 0, i64 16, i1 false)
+  %13 = getelementptr %"string[8]_int64__tuple_t", ptr %12, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 %str3, i64 8, i1 false)
+  %14 = getelementptr %"string[8]_int64__tuple_t", ptr %12, i32 0, i32 1
+  store i64 1, ptr %14, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str3)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key6")
+  store i64 0, ptr %"@x_key6", align 8
+  %update_elem7 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key6", ptr %12, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key6")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key8")
+  store i64 0, ptr %"@x_key8", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key8")
+  %get_cpu_id9 = call i64 inttoptr (i64 8 to ptr)()
+  %15 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded10 = and i64 %get_cpu_id9, %15
+  %16 = getelementptr [1 x [1 x [16 x i8]]], ptr @read_map_val_buf, i64 0, i64 %cpu.id.bounded10, i64 0, i64 0
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 %lookup_elem, i64 16, i1 false)
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %16, i8 0, i64 16, i1 false)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key8")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
+  store i64 0, ptr %"@y_key", align 8
+  %update_elem11 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %16, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!67}
+!llvm.module.flags = !{!69}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 2, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 1, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !28}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 64, elements: !26)
+!25 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!26 = !{!27}
+!27 = !DISubrange(count: 8, lowerBound: 0)
+!28 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !29, size: 64, offset: 64)
+!29 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
+!31 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!32 = !DIGlobalVariableExpression(var: !33, expr: !DIExpression())
+!33 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !34, isLocal: false, isDefinition: true)
+!34 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !35)
+!35 = !{!36, !41}
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !37, size: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 27, lowerBound: 0)
+!41 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !42, size: 64, offset: 64)
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !44)
+!44 = !{!45}
+!45 = !DISubrange(count: 262144, lowerBound: 0)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !48, isLocal: false, isDefinition: true)
+!48 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !49)
+!49 = !{!5, !11, !16, !50}
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !51, size: 64, offset: 192)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
+!53 = distinct !DIGlobalVariable(name: "write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !54, isLocal: false, isDefinition: true)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 128, elements: !14)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 128, elements: !14)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 128, elements: !57)
+!57 = !{!58}
+!58 = !DISubrange(count: 16, lowerBound: 0)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !54, isLocal: false, isDefinition: true)
+!61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
+!62 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!63 = !DIGlobalVariableExpression(var: !64, expr: !DIExpression())
+!64 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !65, isLocal: false, isDefinition: true)
+!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !66, size: 256, elements: !14)
+!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 256, elements: !9)
+!67 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !68)
+!68 = !{!0, !30, !32, !46, !52, !59, !61, !63}
+!69 = !{i32 2, !"Debug Info Version", i32 3}
+!70 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !71, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !67, retainedNodes: !74)
+!71 = !DISubroutineType(types: !72)
+!72 = !{!29, !73}
+!73 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!74 = !{!75}
+!75 = !DILocalVariable(name: "ctx", arg: 1, scope: !70, file: !2, type: !73)

--- a/tests/codegen/llvm/map_value_tuple_stack.ll
+++ b/tests/codegen/llvm/map_value_tuple_stack.ll
@@ -1,0 +1,176 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
+%"string[8]_int64__tuple_t" = type { [8 x i8], i64 }
+%"string[4]_int64__tuple_t" = type { [4 x i8], i64 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !30
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !32
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !46
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !55 {
+entry:
+  %"@y_key" = alloca i64, align 8
+  %lookup_elem_val = alloca %"string[8]_int64__tuple_t", align 8
+  %"@x_key5" = alloca i64, align 8
+  %"@x_key3" = alloca i64, align 8
+  %tuple2 = alloca %"string[8]_int64__tuple_t", align 8
+  %str1 = alloca [8 x i8], align 1
+  %"@x_val" = alloca %"string[8]_int64__tuple_t", align 8
+  %"@x_key" = alloca i64, align 8
+  %tuple = alloca %"string[4]_int64__tuple_t", align 8
+  %str = alloca [4 x i8], align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
+  store [4 x i8] c"xxx\00", ptr %str, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
+  %1 = getelementptr %"string[4]_int64__tuple_t", ptr %tuple, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 %str, i64 4, i1 false)
+  %2 = getelementptr %"string[4]_int64__tuple_t", ptr %tuple, i32 0, i32 1
+  store i64 1, ptr %2, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
+  store i64 0, ptr %"@x_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  call void @llvm.memset.p0.i64(ptr align 1 %"@x_val", i8 0, i64 16, i1 false)
+  %3 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 0
+  %4 = getelementptr %"string[8]_int64__tuple_t", ptr %"@x_val", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %3, i64 4, i1 false)
+  %5 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 8
+  %6 = getelementptr %"string[8]_int64__tuple_t", ptr %"@x_val", i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 8, i1 false)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
+  store [8 x i8] c"xxxxxxx\00", ptr %str1, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple2)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 16, i1 false)
+  %7 = getelementptr %"string[8]_int64__tuple_t", ptr %tuple2, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %str1, i64 8, i1 false)
+  %8 = getelementptr %"string[8]_int64__tuple_t", ptr %tuple2, i32 0, i32 1
+  store i64 1, ptr %8, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key3")
+  store i64 0, ptr %"@x_key3", align 8
+  %update_elem4 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key3", ptr %tuple2, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key3")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple2)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key5")
+  store i64 0, ptr %"@x_key5", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key5")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %lookup_elem_val, ptr align 1 %lookup_elem, i64 16, i1 false)
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_elem_val, i8 0, i64 16, i1 false)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key5")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
+  store i64 0, ptr %"@y_key", align 8
+  %update_elem6 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %lookup_elem_val, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!52}
+!llvm.module.flags = !{!54}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 2, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 1, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !28}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 64, elements: !26)
+!25 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!26 = !{!27}
+!27 = !DISubrange(count: 8, lowerBound: 0)
+!28 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !29, size: 64, offset: 64)
+!29 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
+!31 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!32 = !DIGlobalVariableExpression(var: !33, expr: !DIExpression())
+!33 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !34, isLocal: false, isDefinition: true)
+!34 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !35)
+!35 = !{!36, !41}
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !37, size: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 27, lowerBound: 0)
+!41 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !42, size: 64, offset: 64)
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !44)
+!44 = !{!45}
+!45 = !DISubrange(count: 262144, lowerBound: 0)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !48, isLocal: false, isDefinition: true)
+!48 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !49)
+!49 = !{!5, !11, !16, !50}
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !51, size: 64, offset: 192)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!52 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !53)
+!53 = !{!0, !30, !32, !46}
+!54 = !{i32 2, !"Debug Info Version", i32 3}
+!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !59)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!29, !58}
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!59 = !{!60}
+!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)

--- a/tests/codegen/llvm/nested_array_struct.ll
+++ b/tests/codegen/llvm/nested_array_struct.ll
@@ -59,8 +59,8 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  %7 = sext i32 %6 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
+  %7 = sext i32 %6 to i64
   store i64 %7, ptr %"@_val", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")

--- a/tests/codegen/llvm/pointer_inc_map.ll
+++ b/tests/codegen/llvm/pointer_inc_map.ll
@@ -22,14 +22,14 @@ entry:
   %"@_key2" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key1" = alloca i64, align 8
-  %"@_ptr" = alloca i64, align 8
+  %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_ptr")
-  store i64 1000, ptr %"@_ptr", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_ptr", i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_ptr")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
+  store i64 1000, ptr %"@_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key1")
   store i64 0, ptr %"@_key1", align 8

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -34,8 +34,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %5 = sext i8 %4 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %5 = sext i8 %4 to i64
   store i64 %5, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -34,8 +34,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %5 = sext i8 %4 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %5 = sext i8 %4 to i64
   store i64 %5, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -39,8 +39,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %6 = sext i32 %5 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %6 = sext i32 %5 to i64
   store i64 %6, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -39,8 +39,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %6 = sext i32 %5 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %6 = sext i32 %5 to i64
   store i64 %6, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -34,8 +34,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %5 = sext i32 %4 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %5 = sext i32 %4 to i64
   store i64 %5, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -34,8 +34,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %5 = sext i32 %4 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %5 = sext i32 %4 to i64
   store i64 %5, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -35,8 +35,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo::(unnamed at definitions.h:2:14).x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %6 = sext i32 %5 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %6 = sext i32 %5 to i64
   store i64 %6, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -35,8 +35,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo::(unnamed at definitions.h:2:14).x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %6 = sext i32 %5 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %6 = sext i32 %5 to i64
   store i64 %6, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -35,8 +35,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Bar.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %6 = sext i32 %5 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %6 = sext i32 %5 to i64
   store i64 %6, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -35,8 +35,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Bar.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %6 = sext i32 %5 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %6 = sext i32 %5 to i64
   store i64 %6, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -40,8 +40,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Bar.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %7 = sext i32 %6 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %7 = sext i32 %6 to i64
   store i64 %7, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -40,8 +40,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Bar.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %7 = sext i32 %6 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %7 = sext i32 %6 to i64
   store i64 %7, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -85,8 +85,8 @@ lookup_merge7:                                    ; preds = %lookup_failure6, %l
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val8)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %6 = sext i32 %5 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %6 = sext i32 %5 to i64
   store i64 %6, ptr %"@x_val", align 8
   %update_elem10 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -34,8 +34,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %5 = sext i16 %4 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %5 = sext i16 %4 to i64
   store i64 %5, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -34,8 +34,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %5 = sext i16 %4 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %5 = sext i16 %4 to i64
   store i64 %5, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/llvm/variable_assign_array.ll
+++ b/tests/codegen/llvm/variable_assign_array.ll
@@ -35,8 +35,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %array_access)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %6 = sext i32 %5 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  %6 = sext i32 %5 to i64
   store i64 %6, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")

--- a/tests/codegen/scratch_buffer.cpp
+++ b/tests/codegen/scratch_buffer.cpp
@@ -65,6 +65,38 @@ TEST(codegen, str_stack)
                                LARGE_ON_STACK_LIMIT);
 }
 
+TEST(codegen, map_value_int_scratch_buf)
+{
+  test_stack_or_scratch_buffer("kprobe:f { @x = 1; @y = @x }",
+                               NAME,
+                               SMALL_ON_STACK_LIMIT);
+}
+
+TEST(codegen, map_value_int_stack)
+{
+  test_stack_or_scratch_buffer("kprobe:f { @x = 1; @y = @x }",
+                               NAME,
+                               LARGE_ON_STACK_LIMIT);
+}
+
+// Using two tuples with different sizes will trigger copying tuples to the
+// scratch buffer or stack prior to updating the map
+TEST(codegen, map_value_tuple_scratch_buf)
+{
+  test_stack_or_scratch_buffer(
+      "kprobe:f { @x = (\"xxx\", 1); @x = (\"xxxxxxx\", 1); @y = @x }",
+      NAME,
+      SMALL_ON_STACK_LIMIT);
+}
+
+TEST(codegen, map_value_tuple_stack)
+{
+  test_stack_or_scratch_buffer(
+      "kprobe:f { @x = (\"xxx\", 1); @x = (\"xxxxxxx\", 1); @y = @x }",
+      NAME,
+      LARGE_ON_STACK_LIMIT);
+}
+
 } // namespace codegen
 } // namespace test
 } // namespace bpftrace

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -115,10 +115,9 @@ EXPECT_REGEX /X{5555}
 AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
 REQUIRES_FEATURE probe_read_kernel
 
-# Currently broken for big strings (>64 B) which is why ENV
-# is not being set. When big strings are fixed, enable this test.
 NAME str_big_read
 PROG BEGIN { @s = str(0); @ss = @s; print("success!"); exit() }
+ENV BPFTRACE_MAX_STRLEN=9999
 EXPECT success!
 REQUIRES_FEATURE probe_read_kernel
 TIMEOUT 1
@@ -145,6 +144,10 @@ TIMEOUT 1
 NAME fmt_str_args_scratch_buf
 PROG config = { on_stack_limit = 0 } BEGIN { printf("%s %d\n", "XXXX", 1) }
 EXPECT XXXX 1
+
+NAME map_val_scratch_buf
+PROG config = { on_stack_limit = 0 } BEGIN { @x = 1; @y = @x; print(@y) }
+EXPECT @y: 1
 
 NAME str_big_for
 PROG t:syscalls:sys_enter_execve { @map[str(args.filename)] = str(args.filename); for ($kv : @map) { print($kv); } }


### PR DESCRIPTION
This PR continues fixing https://github.com/bpftrace/bpftrace/issues/3431, migrating map values to scratch global buffers. This will allow large strings in map values, one of the primary use cases for large strings.

We introduce a write buffer of size 1 and read buffer with size N as its possible multiple values can be read in tandem.

Note in many cases, ResourceAnalyser does not exactly replicate CodegenLLVM meaning it is possible to over-allocate memory at the benefit of code simplicity. However, we did 2 optimizations in ResourceAnalyser which seem to reduce most unnecessary memory based on codegen tests:
1. Don't recurse into map from AssignmentMap to avoid an unnecessary read buffer
2. Check if we actually need to do a copy during AssignmentMap to avoid an unnecessary write buffer

After this, we see no additional global buffers in current codegen tests.

We also add new codegen and runtime tests for big strings in map values.