### PR TITLE
Remove array syntax need for string/buffer/inet

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -212,6 +212,15 @@ type:
                     };
                     $$ = type_map[$1];
                 }
+        |       SIZED_TYPE {
+                    if ($1 == "string") {
+                        $$ = CreateString(0);
+                    } else if ($1 == "inet") {
+                        $$ = CreateInet(0);
+                    } else if ($1 == "buffer") {
+                        $$ = CreateBuffer(0);
+                    }
+                }
         |       SIZED_TYPE "[" INT "]" {
                     if ($1 == "string") {
                         $$ = CreateString($3);

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1808,14 +1808,23 @@ TEST(Parser, cast_simple_type_pointer)
 
 TEST(Parser, cast_sized_type)
 {
-  test("kprobe:sys_read { (string[1])arg0; }",
+  test("kprobe:sys_read { (string)arg0; }",
        "Program\n"
        " kprobe:sys_read\n"
-       "  (string[1])\n"
+       "  (string[0])\n"
        "   builtin: arg0\n");
 }
 
 TEST(Parser, cast_sized_type_pointer)
+{
+  test("kprobe:sys_read { (string *)arg0; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (string[0] *)\n"
+       "   builtin: arg0\n");
+}
+
+TEST(Parser, cast_sized_type_pointer_with_size)
 {
   test("kprobe:sys_read { (string[1] *)arg0; }",
        "Program\n"


### PR DESCRIPTION
These types can, and should be, used without an explicit size. The size will get inferred in later AST passes.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
