### PR TITLE
Add 'has_key' builtin for maps

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -1,3 +1,4 @@
+aot.basic.has_key as a variable
 aot.basic.print_per_cpu_map_vals
 aot.btf.kernel_module_type_fwd
 aot.builtin.args in kfunc as a map key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
   - [#3401](https://github.com/bpftrace/bpftrace/pull/3401)
 - Allow tuples to be used as map keys
   - [#3390](https://github.com/bpftrace/bpftrace/pull/3390/)
+- Add `has_key` function for maps
+  - [#3358](https://github.com/bpftrace/bpftrace/pull/3358)
 #### Changed
 - Merge output into `stdout` when `-lv`
   - [#3383](https://github.com/bpftrace/bpftrace/pull/3383)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -989,7 +989,7 @@ kprobe:do_nanosleep {
   @start[tid] = nsecs;
 }
 
-kretprobe:do_nanosleep /@start[tid] != 0/ {
+kretprobe:do_nanosleep /has_key(@start, tid)/ {
   printf("slept for %d ms\n", (nsecs - @start[tid]) / 1000000);
   delete(@start, tid);
 }
@@ -2371,6 +2371,10 @@ See <<Advanced Topics>> for more information on <<Map Printing>>.
 | Delete a single key from a map.
 | Sync
 
+| <<map-functions-has_key, `has_key(map m, mapkey k)`>>
+| Return true (1) if the key exists in this map. Otherwise return false (0).
+| Sync
+
 | <<map-functions-hist, `hist(int64 n[, int k])`>>
 | Create a log2 histogram of n using buckets per power of 2, 0 <= k <= 5, defaults to 0.
 | Sync
@@ -2509,6 +2513,34 @@ kprobe:dummy {
   // deprecated but ok
   delete(@single["hello"]);
   delete(@associative[1, 2]);
+}
+```
+
+[#map-functions-has_key]
+=== has_key
+
+.variants
+* `int has_key(map m, mapkey k)`
+
+Return true (1) if the key exists in this map.
+Otherwise return false (0).
+Error if called with a map that has no keys (aka scalar map).
+Return value can also be used for scratch variables and map keys/values.
+
+```
+kprobe:dummy {
+  @associative[1,2] = 1;
+  if (!has_key(@associative, (1,3))) { // ok
+    print(("bye"));
+  }
+
+  @scalar = 1;
+  if (has_key(@scalar)) { // error
+    print(("hello"));
+  }
+  
+  $a = has_key(@associative, (1,2)); // ok
+  @b[has_key(@associative, (1,2))] = has_key(@associative, (1,2)); // ok
 }
 ```
 

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -173,6 +173,9 @@ private:
 
   [[nodiscard]] ScopedExprDeleter accept(Node *node);
   [[nodiscard]] std::tuple<Value *, ScopedExprDeleter> getMapKey(Map &map);
+  [[nodiscard]] std::tuple<Value *, ScopedExprDeleter> getMapKey(
+      Map &map,
+      Expression *key_expr);
   AllocaInst *getMultiMapKey(Map &map, const std::vector<Value *> &extra_keys);
 
   void compareStructure(SizedType &our_type, llvm::Type *llvm_type);

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -132,7 +132,12 @@ private:
   SizedType *get_map_key_type(const Map &map);
   void assign_map_type(const Map &map, const SizedType &type);
   SizedType create_key_type(const SizedType &expr_type, const location &loc);
-  void update_key_type(const Map &map, const SizedType &new_key_type);
+  void update_current_key(SizedType &current_key_type,
+                          const SizedType &new_key_type);
+  void validate_new_key(const SizedType &current_key_type,
+                        const SizedType &new_key_type,
+                        const std::string &map_ident,
+                        const location &loc);
   bool update_string_size(SizedType &type, const SizedType &new_type);
   void validate_map_key(const SizedType &key, const location &loc);
   void resolve_struct_type(SizedType &type, const location &loc);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#+\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|len|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|len|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf|has_key
 
 int_type        bool|(u)?int(8|16|32|64)
 builtin_type    void|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|strerror_t|kstack_t|ustack_t

--- a/tests/codegen/call_has_key.cpp
+++ b/tests/codegen/call_has_key.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_has_key)
+{
+  test("kprobe:f { @x[1] = 1; has_key(@x, 1) }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_has_key.ll
+++ b/tests/codegen/llvm/call_has_key.ll
@@ -1,0 +1,106 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !50 {
+entry:
+  %"@x_key1" = alloca i64, align 8
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
+  store i64 1, ptr %"@x_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  store i64 1, ptr %"@x_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
+  store i64 1, ptr %"@x_key1", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
+  %has_key = icmp ne ptr %lookup_elem, null
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
+!23 = !{!24, !29}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
+!27 = !{!28}
+!28 = !DISubrange(count: 27, lowerBound: 0)
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 262144, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
+!37 = !{!38, !43, !44, !19}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 2, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !45, size: 64, offset: 128)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !20, !34}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !55)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!18, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!54 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -300,3 +300,27 @@ NAME print large int
 PROG BEGIN { $a = 10223372036854775807; print(($a)); exit(); }
 EXPECT 10223372036854775807
 TIMEOUT 1
+
+NAME has_key exists
+PROG BEGIN { @a[1] = 0; if (has_key(@a, 1)) { printf("ok\n"); } exit(); }
+EXPECT ok
+
+NAME has_key no_exists
+PROG BEGIN { @a[1] = 0; if (has_key(@a, 2)) { printf("ok\n"); } exit(); }
+EXPECT_NONE ok
+
+NAME has_key complex tuple
+PROG BEGIN { @a[1, ("hello", (int8)5)] = 0; if (has_key(@a, (1, ("hello", 5)))) { printf("ok\n"); } exit(); }
+EXPECT ok
+
+NAME has_key map value as key
+PROG BEGIN { @g = 2; @a[2] = 0; if (has_key(@a, @g)) { printf("ok\n"); } exit(); }
+EXPECT ok
+
+NAME has_key map keys and values
+PROG BEGIN { @a[1] = 1; @b[has_key(@a, 1)] = has_key(@a, 2); exit(); }
+EXPECT @b[1]: 0
+
+NAME has_key as a variable
+PROG BEGIN { @a[1] = 1; $b = has_key(@a, 1); $c = has_key(@a, 2); print(($b, $c)); exit(); }
+EXPECT (1, 0)


### PR DESCRIPTION
This is so we can check if a map has a key
instead of relying on the wrong way by seeing
if the value is 0.

```
kprobe:dummy {
  @associative[1,2] = 1;

  if (!has_key(@associative, (1,3))) {
    print(("bye"));
  }
}
```

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
