### PR TITLE
debug: Support comma separated stages

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3623,7 +3623,8 @@ See src/attached_probe.cpp:find_vmlinux() for details.
 The `-d STAGE` option produces debug output. It prints the output of the
 bpftrace execution stage given by the _STAGE_ argument. The option can be used
 multiple times (with different stage names) and the special value `all` prints
-the output of all the supported stages.
+the output of all the supported stages. The option also takes multiple stages
+in one invocation as comma separated values.
 
 Note: This is primarily used for bpftrace developers.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -469,6 +469,25 @@ struct Args {
   std::vector<std::string> debug_stages;
 };
 
+static bool parse_debug_stages(const std::string& arg)
+{
+  auto stages = split_string(arg, ',', /* remove_empty= */ true);
+
+  for (const auto& stage : stages) {
+    if (debug_stages.contains(stage)) {
+      bt_debug.insert(debug_stages.at(stage));
+    } else if (stage == "all") {
+      for (const auto& [_, s] : debug_stages)
+        bt_debug.insert(s);
+    } else {
+      LOG(ERROR) << "USAGE: invalid option for -d: " << stage;
+      return false;
+    }
+  }
+
+  return true;
+}
+
 Args parse_args(int argc, char* argv[])
 {
   Args args;
@@ -539,15 +558,8 @@ Args parse_args(int argc, char* argv[])
         break;
       case 'd':
       case Options::DEBUG:
-        if (debug_stages.contains(optarg)) {
-          bt_debug.insert(debug_stages.at(optarg));
-        } else if (std::strcmp(optarg, "all") == 0) {
-          for (const auto& [_, stage] : debug_stages)
-            bt_debug.insert(stage);
-        } else {
-          LOG(ERROR) << "USAGE: invalid option for -d: " << optarg;
+        if (!parse_debug_stages(optarg))
           exit(1);
-        }
         break;
       case 'q':
         bt_quiet = true;


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Something like `-d codegen,dis` is more convenient than `-d codegen -d
dis`. It's easy enough to support both, so might as well.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
