### PR TITLE
Revert "Cache bounded CPU ID in register for global scratch buffers"

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -487,29 +487,37 @@ CallInst *IRBuilderBPF::CreateGetStrScratchMap(int idx,
                              idx);
 }
 
-Value *IRBuilderBPF::CreateGetFmtStringArgsScratchBuffer(Value *cpu_id)
+Value *IRBuilderBPF::CreateGetFmtStringArgsScratchBuffer(const location &loc)
 {
   return createScratchBuffer(
-      bpftrace::globalvars::GlobalVar::FMT_STRINGS_BUFFER, cpu_id);
+      bpftrace::globalvars::GlobalVar::FMT_STRINGS_BUFFER, loc);
 }
 
-Value *IRBuilderBPF::CreateTupleScratchBuffer(Value *cpu_id, int key)
+Value *IRBuilderBPF::CreateTupleScratchBuffer(const location &loc, int key)
 {
   return createScratchBuffer(bpftrace::globalvars::GlobalVar::TUPLE_BUFFER,
-                             cpu_id,
+                             loc,
                              key);
 }
 
 Value *IRBuilderBPF::createScratchBuffer(
     bpftrace::globalvars::GlobalVar globalvar,
-    Value *cpu_id,
+    const location &loc,
     size_t key)
 {
-  assert(cpu_id);
-
   auto config = globalvars::get_config(globalvar);
   // ValueType var[MAX_CPU_ID + 1][num_elements]
   auto type = globalvars::get_type(globalvar, bpftrace_.resources);
+
+  // Get CPU ID
+  auto cpu_id = CreateGetCpuId(loc);
+  auto max = CreateLoad(getInt64Ty(),
+                        module_.getGlobalVariable(to_string(
+                            bpftrace::globalvars::GlobalVar::MAX_CPU_ID)));
+  // Verify CPU ID is between 0 and MAX_CPU_ID to ensure we pass BPF
+  // verifer on older 5.2 kernels
+  auto cmp = CreateICmp(CmpInst::ICMP_ULE, cpu_id, max, "cpuid.min.cmp");
+  auto select = CreateSelect(cmp, cpu_id, max, "cpuid.min.select");
 
   // Note the 1st index is 0 because we're pointing to
   // ValueType var[MAX_CPU_ID + 1][num_elements]
@@ -518,7 +526,7 @@ Value *IRBuilderBPF::createScratchBuffer(
   return CreateGEP(GetType(type),
                    CreatePointerCast(module_.getGlobalVariable(config.name),
                                      GetType(type)->getPointerTo()),
-                   { getInt64(0), cpu_id, getInt64(key), getInt64(0) });
+                   { getInt64(0), select, getInt64(key), getInt64(0) });
 }
 
 /*

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -168,8 +168,8 @@ public:
   CallInst *CreateGetStrScratchMap(int idx,
                                    BasicBlock *failure_callback,
                                    const location &loc);
-  Value *CreateGetFmtStringArgsScratchBuffer(Value *cpu_id);
-  Value *CreateTupleScratchBuffer(Value *cpu_id, int key);
+  Value *CreateGetFmtStringArgsScratchBuffer(const location &loc);
+  Value *CreateTupleScratchBuffer(const location &loc, int key);
   void CreateCheckSetRecursion(const location &loc, int early_exit_ret);
   void CreateUnSetRecursion(const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
@@ -301,7 +301,7 @@ private:
                                 BasicBlock *failure_callback,
                                 int key = 0);
   Value *createScratchBuffer(globalvars::GlobalVar globalvar,
-                             Value *cpu_id,
+                             const location &loc,
                              size_t key = 0);
   libbpf::bpf_func_id selectProbeReadHelper(AddrSpace as, bool str);
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2216,17 +2216,18 @@ void CodegenLLVM::compareStructure(SizedType &our_type, llvm::Type *llvm_type)
  */
 Value *CodegenLLVM::createTuple(
     const SizedType &tuple_type,
-    const std::vector<std::pair<llvm::Value *, const location *>> &vals)
+    const std::vector<std::pair<llvm::Value *, const location *>> &vals,
+    const location &loc)
 {
   auto tuple_ty = b_.GetType(tuple_type);
   size_t tuple_size = datalayout().getTypeAllocSize(tuple_ty);
   auto buf = b_.CreatePointerCast(
-      b_.CreateTupleScratchBuffer(cpu_id_stack_.top(), async_ids_.tuple()),
+      b_.CreateTupleScratchBuffer(loc, async_ids_.tuple()),
       tuple_ty->getPointerTo());
   b_.CreateMemsetBPF(buf, b_.getInt8(0), tuple_size);
 
   for (size_t i = 0; i < vals.size(); ++i) {
-    auto [val, loc] = vals[i];
+    auto [val, vloc] = vals[i];
     SizedType &type = tuple_type.GetField(i).type;
 
     Value *dst = b_.CreateGEP(tuple_ty,
@@ -2236,7 +2237,7 @@ Value *CodegenLLVM::createTuple(
     if (inBpfMemory(type))
       b_.CreateMemcpyBPF(dst, val, type.GetSize());
     else if (type.IsArrayTy() || type.IsRecordTy())
-      b_.CreateProbeRead(ctx_, dst, type, val, *loc);
+      b_.CreateProbeRead(ctx_, dst, type, val, *vloc);
     else
       b_.CreateStore(val, dst);
   }
@@ -2290,7 +2291,7 @@ void CodegenLLVM::visit(Tuple &tuple)
     scoped_dels.emplace_back(accept(elem));
     vals.push_back({ expr_, &elem->loc });
   }
-  auto buf = createTuple(tuple.type, vals);
+  auto buf = createTuple(tuple.type, vals, tuple.loc);
 
   // No need to end buf lifetime since tuple allocation is done via scratch maps
   // and not on stack
@@ -2634,37 +2635,6 @@ void CodegenLLVM::visit(AttachPoint &)
   // Empty
 }
 
-// For older 5.2 kernels, we need to bound CPU ID by MAX_CPU_ID to pass
-// BPF verifier on older kernels.
-//
-// However, for programs that do many scratch buffer lookups, this causes
-// many jumps which means a complex program may be rejected by the BPF
-// verifier for >= 8192 jumps (current limit).
-//
-// To minimize jumps, we bound the CPU ID at the beginning of each function
-// and cache the value in a register. This ensures we only add one
-// additional jump per function. Note we cannot cache this value in a global
-// variable since memory is shared between all CPUs or a per-CPU array since
-// that would be recursive.
-//
-// Note the only functions in scope are the ones where scratch buffer is used
-// which is currently subprograms, probes and map_for_each_cb. To account for
-// nesting, we use a stack to ensure we're referencing the correct instance.
-Value *CodegenLLVM::generateCachedCpuId(const location &loc)
-{
-  if (!bpftrace_.resources.needed_global_vars.count(
-          globalvars::GlobalVar::MAX_CPU_ID)) {
-    return nullptr;
-  }
-
-  auto cpu_id = b_.CreateGetCpuId(loc);
-  auto max = b_.CreateLoad(b_.getInt64Ty(),
-                           module_->getGlobalVariable(to_string(
-                               bpftrace::globalvars::GlobalVar::MAX_CPU_ID)));
-  auto cmp = b_.CreateICmp(CmpInst::ICMP_ULE, cpu_id, max);
-  return b_.CreateSelect(cmp, cpu_id, max);
-}
-
 void CodegenLLVM::generateProbe(Probe &probe,
                                 const std::string &full_func_id,
                                 const std::string &name,
@@ -2697,9 +2667,6 @@ void CodegenLLVM::generateProbe(Probe &probe,
                                getReturnValueForProbe(probe_type));
   }
 
-  assert(cpu_id_stack_.empty());
-  cpu_id_stack_.push(generateCachedCpuId(probe.loc));
-
   if (probe.pred) {
     auto scoped_del = accept(probe.pred);
   }
@@ -2709,9 +2676,6 @@ void CodegenLLVM::generateProbe(Probe &probe,
   }
 
   createRet();
-
-  cpu_id_stack_.pop();
-  assert(cpu_id_stack_.empty());
 
   if (dummy) {
     func->eraseFromParent();
@@ -2795,17 +2759,11 @@ void CodegenLLVM::visit(Subprog &subprog)
     ++arg_index;
   }
 
-  assert(cpu_id_stack_.empty());
-  cpu_id_stack_.push(generateCachedCpuId(subprog.loc));
-
   for (Statement *stmt : subprog.stmts) {
     auto scoped_del = accept(stmt);
   }
   if (subprog.return_type.IsVoidTy())
     createRet();
-
-  cpu_id_stack_.pop();
-  assert(cpu_id_stack_.empty());
 
   FunctionPassManager fpm;
   FunctionAnalysisManager fam;
@@ -3463,7 +3421,7 @@ void CodegenLLVM::createFormatStringCall(Call &call,
                << " does not match LLVM offset=" << expected_offset;
   }
 
-  Value *fmt_args = b_.CreateGetFmtStringArgsScratchBuffer(cpu_id_stack_.top());
+  Value *fmt_args = b_.CreateGetFmtStringArgsScratchBuffer(call.loc);
   // The struct is not packed so we need to memset it
   b_.CreateMemsetBPF(fmt_args, b_.getInt8(0), struct_size);
 
@@ -3607,7 +3565,7 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int id)
   StructType *print_struct = b_.GetStructType(struct_name.str(),
                                               elements,
                                               true);
-  Value *buf = b_.CreateGetFmtStringArgsScratchBuffer(cpu_id_stack_.top());
+  Value *buf = b_.CreateGetFmtStringArgsScratchBuffer(call.loc);
   size_t struct_size = datalayout().getTypeAllocSize(print_struct);
 
   // Store asyncactionid:
@@ -4442,11 +4400,10 @@ Function *CodegenLLVM::createForEachMapCallback(const For &f, llvm::Type *ctx_t)
     });
   }
 
-  cpu_id_stack_.push(generateCachedCpuId(f.decl->loc));
-
   // Create decl variable for use in this iteration of the loop
   auto tuple = createTuple(f.decl->type,
-                           { { key, &f.decl->loc }, { val, &f.decl->loc } });
+                           { { key, &f.decl->loc }, { val, &f.decl->loc } },
+                           f.decl->loc);
   variables_[f.decl->ident] = VariableLLVM{ tuple, b_.GetType(f.decl->type) };
 
   // 1. Save original locations of variables which will form part of the
@@ -4476,9 +4433,6 @@ Function *CodegenLLVM::createForEachMapCallback(const For &f, llvm::Type *ctx_t)
     auto scoped_del = accept(stmt);
   }
   b_.CreateRet(b_.getInt64(0));
-
-  // Resore original cached CPU ID
-  cpu_id_stack_.pop();
 
   // Restore original non-context variables
   for (const auto &[ident, expr] : orig_ctx_vars) {

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <optional>
 #include <ostream>
-#include <stack>
 #include <tuple>
 
 #include <llvm/IR/IRBuilder.h>
@@ -94,7 +93,8 @@ public:
                            const SizedType &value_type);
   Value *createTuple(
       const SizedType &tuple_type,
-      const std::vector<std::pair<llvm::Value *, const location *>> &vals);
+      const std::vector<std::pair<llvm::Value *, const location *>> &vals,
+      const location &loc);
   void createTupleCopy(const SizedType &expr_type,
                        const SizedType &var_type,
                        Value *dst_val,
@@ -248,8 +248,6 @@ private:
   bool canAggPerCpuMapElems(const SizedType &val_type,
                             const SizedType &key_type);
 
-  Value *generateCachedCpuId(const location &loc);
-
   Node *root_ = nullptr;
 
   BPFtrace &bpftrace_;
@@ -294,10 +292,6 @@ private:
   Function *murmur_hash_2_func_ = nullptr;
   Function *map_len_func_ = nullptr;
   MDNode *loop_metadata_ = nullptr;
-
-  // Used for caching bounded CPU ID in register to avoid jumps every time
-  // we use global scratch buffer
-  std::stack<Value *> cpu_id_stack_;
 
   size_t getStructSize(StructType *s)
   {

--- a/tests/codegen/llvm/avg_cast_loop.ll
+++ b/tests/codegen/llvm/avg_cast_loop.ll
@@ -24,10 +24,6 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
 entry:
   %avg_struct = alloca %avg_stas_val, align 8
   %"@x_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 1, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
@@ -35,24 +31,24 @@ entry:
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %4 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
-  %5 = load i64, ptr %4, align 8
-  %6 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
-  %7 = load i64, ptr %6, align 8
-  %8 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
-  %9 = add i64 %5, 2
-  store i64 %9, ptr %8, align 8
-  %10 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
-  %11 = add i64 1, %7
-  store i64 %11, ptr %10, align 8
+  %1 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %2 = load i64, ptr %1, align 8
+  %3 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %4 = load i64, ptr %3, align 8
+  %5 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %6 = add i64 %2, 2
+  store i64 %6, ptr %5, align 8
+  %7 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %8 = add i64 1, %4
+  store i64 %8, ptr %7, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
-  %12 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
-  store i64 2, ptr %12, align 8
-  %13 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
-  store i64 1, ptr %13, align 8
+  %9 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
+  store i64 2, ptr %9, align 8
+  %10 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %10, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
   br label %lookup_merge
@@ -160,17 +156,17 @@ is_negative_merge_block:                          ; preds = %is_positive, %is_ne
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %31 = load i64, ptr @max_cpu_id, align 8
-  %32 = icmp ule i64 %get_cpu_id, %31
-  %33 = select i1 %32, i64 %get_cpu_id, i64 %31
-  %34 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %33, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %34, i8 0, i64 16, i1 false)
-  %35 = getelementptr %int64_avg_t__tuple_t, ptr %34, i32 0, i32 0
-  store i64 %key, ptr %35, align 8
-  %36 = getelementptr %int64_avg_t__tuple_t, ptr %34, i32 0, i32 1
-  store i64 %30, ptr %36, align 8
-  %37 = getelementptr %int64_avg_t__tuple_t, ptr %34, i32 0, i32 1
-  %38 = load i64, ptr %37, align 8
-  store i64 %38, ptr %"$res", align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %31
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %31
+  %32 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %32, i8 0, i64 16, i1 false)
+  %33 = getelementptr %int64_avg_t__tuple_t, ptr %32, i32 0, i32 0
+  store i64 %key, ptr %33, align 8
+  %34 = getelementptr %int64_avg_t__tuple_t, ptr %32, i32 0, i32 1
+  store i64 %30, ptr %34, align 8
+  %35 = getelementptr %int64_avg_t__tuple_t, ptr %32, i32 0, i32 1
+  %36 = load i64, ptr %35, align 8
+  store i64 %36, ptr %"$res", align 8
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_cat.ll
+++ b/tests/codegen/llvm/call_cat.ll
@@ -21,13 +21,13 @@ entry:
   %key = alloca i32, align 4
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
-  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 8, i1 false)
-  %5 = getelementptr %cat_t, ptr %4, i32 0, i32 0
-  store i64 20000, ptr %5, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 8, i64 0)
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 8, i1 false)
+  %3 = getelementptr %cat_t, ptr %2, i32 0, i32 0
+  store i64 20000, ptr %3, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -42,7 +42,7 @@ counter_merge:                                    ; preds = %lookup_merge, %entr
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %6 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %4 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/call_cgroup_path.ll
+++ b/tests/codegen/llvm/call_cgroup_path.ll
@@ -21,25 +21,25 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
   %cgroup_path_args = alloca %cgroup_path_t, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %cgroup_path_args)
-  %4 = getelementptr %cgroup_path_t, ptr %cgroup_path_args, i64 0, i32 0
-  store i64 0, ptr %4, align 8
+  %1 = getelementptr %cgroup_path_t, ptr %cgroup_path_args, i64 0, i32 0
+  store i64 0, ptr %1, align 8
   %get_cgroup_id = call i64 inttoptr (i64 80 to ptr)()
-  %5 = getelementptr %cgroup_path_t, ptr %cgroup_path_args, i64 0, i32 1
-  store i64 %get_cgroup_id, ptr %5, align 8
-  %6 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  %7 = getelementptr %print_cgroup_path_t_16_t, ptr %6, i64 0, i32 0
-  store i64 30007, ptr %7, align 8
-  %8 = getelementptr %print_cgroup_path_t_16_t, ptr %6, i64 0, i32 1
-  store i64 0, ptr %8, align 8
-  %9 = getelementptr %print_cgroup_path_t_16_t, ptr %6, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %cgroup_path_args, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 32, i64 0)
+  %2 = getelementptr %cgroup_path_t, ptr %cgroup_path_args, i64 0, i32 1
+  store i64 %get_cgroup_id, ptr %2, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
+  %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %5 = getelementptr %print_cgroup_path_t_16_t, ptr %4, i64 0, i32 0
+  store i64 30007, ptr %5, align 8
+  %6 = getelementptr %print_cgroup_path_t_16_t, ptr %4, i64 0, i32 1
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr %print_cgroup_path_t_16_t, ptr %4, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %cgroup_path_args, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -54,7 +54,7 @@ counter_merge:                                    ; preds = %lookup_merge, %entr
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -22,28 +22,32 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
 entry:
   %key = alloca i32, align 4
   %str = alloca [4 x i8], align 1
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [4 x i8] c"abc\00", ptr %str, align 1
-  %4 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %"int64_string[4]__tuple_t", ptr %4, i32 0, i32 0
-  store i64 1, ptr %5, align 8
-  %6 = getelementptr %"int64_string[4]__tuple_t", ptr %4, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %str, i64 4, i1 false)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %"int64_string[4]__tuple_t", ptr %2, i32 0, i32 0
+  store i64 1, ptr %3, align 8
+  %4 = getelementptr %"int64_string[4]__tuple_t", ptr %2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %str, i64 4, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
-  %7 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  %8 = getelementptr %print_tuple_16_t, ptr %7, i64 0, i32 0
-  store i64 30007, ptr %8, align 8
-  %9 = getelementptr %print_tuple_16_t, ptr %7, i64 0, i32 1
-  store i64 0, ptr %9, align 8
-  %10 = getelementptr %print_tuple_16_t, ptr %7, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %4, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %7, i64 32, i64 0)
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %5
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %5
+  %6 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
+  %7 = getelementptr %print_tuple_16_t, ptr %6, i64 0, i32 0
+  store i64 30007, ptr %7, align 8
+  %8 = getelementptr %print_tuple_16_t, ptr %6, i64 0, i32 1
+  store i64 0, ptr %8, align 8
+  %9 = getelementptr %print_tuple_16_t, ptr %6, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %2, i64 16, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -58,7 +62,7 @@ counter_merge:                                    ; preds = %lookup_merge, %entr
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %11 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -21,17 +21,17 @@ entry:
   %key = alloca i32, align 4
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
-  %4 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  %5 = getelementptr %print_int_8_t, ptr %4, i64 0, i32 0
-  store i64 30007, ptr %5, align 8
-  %6 = getelementptr %print_int_8_t, ptr %4, i64 0, i32 1
-  store i64 0, ptr %6, align 8
-  %7 = getelementptr %print_int_8_t, ptr %4, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 8, i1 false)
-  store i64 3, ptr %7, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 24, i64 0)
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %3 = getelementptr %print_int_8_t, ptr %2, i64 0, i32 0
+  store i64 30007, ptr %3, align 8
+  %4 = getelementptr %print_int_8_t, ptr %2, i64 0, i32 1
+  store i64 0, ptr %4, align 8
+  %5 = getelementptr %print_int_8_t, ptr %2, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
+  store i64 3, ptr %5, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -46,7 +46,7 @@ counter_merge:                                    ; preds = %lookup_merge, %entr
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %6 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -24,35 +24,35 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
-  %4 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %4, align 8
+  %1 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %1, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %5 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 24, i1 false)
-  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
-  store i64 0, ptr %6, align 8
-  %7 = load i64, ptr %"$foo", align 8
-  %8 = add i64 %7, 0
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %2 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %2
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %2
+  %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %3, i8 0, i64 24, i1 false)
+  %4 = getelementptr %printf_t, ptr %3, i32 0, i32 0
+  store i64 0, ptr %4, align 8
+  %5 = load i64, ptr %"$foo", align 8
+  %6 = add i64 %5, 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.c", i32 1, i64 %8)
-  %9 = load i8, ptr %"struct Foo.c", align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.c", i32 1, i64 %6)
+  %7 = load i8, ptr %"struct Foo.c", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.c")
-  %10 = getelementptr %printf_t, ptr %5, i32 0, i32 1
-  %11 = sext i8 %9 to i64
-  store i64 %11, ptr %10, align 8
-  %12 = load i64, ptr %"$foo", align 8
-  %13 = add i64 %12, 8
+  %8 = getelementptr %printf_t, ptr %3, i32 0, i32 1
+  %9 = sext i8 %7 to i64
+  store i64 %9, ptr %8, align 8
+  %10 = load i64, ptr %"$foo", align 8
+  %11 = add i64 %10, 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.l")
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, i64 %13)
-  %14 = load i64, ptr %"struct Foo.l", align 8
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, i64 %11)
+  %12 = load i64, ptr %"struct Foo.l", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.l")
-  %15 = getelementptr %printf_t, ptr %5, i32 0, i32 2
-  store i64 %14, ptr %15, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 24, i64 0)
+  %13 = getelementptr %printf_t, ptr %3, i32 0, i32 2
+  store i64 %12, ptr %13, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %3, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -67,7 +67,7 @@ counter_merge:                                    ; preds = %lookup_merge, %entr
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %16 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %14 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/call_system.ll
+++ b/tests/codegen/llvm/call_system.ll
@@ -21,15 +21,15 @@ entry:
   %key = alloca i32, align 4
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
-  %4 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %system_t, ptr %4, i32 0, i32 0
-  store i64 10000, ptr %5, align 8
-  %6 = getelementptr %system_t, ptr %4, i32 0, i32 1
-  store i64 100, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 16, i64 0)
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %system_t, ptr %2, i32 0, i32 0
+  store i64 10000, ptr %3, align 8
+  %4 = getelementptr %system_t, ptr %2, i32 0, i32 1
+  store i64 100, ptr %4, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -44,7 +44,7 @@ counter_merge:                                    ; preds = %lookup_merge, %entr
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %7 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %5 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -24,10 +24,6 @@ entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 1, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
@@ -36,9 +32,9 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %4 = load i64, ptr %lookup_elem, align 8
-  %5 = add i64 %4, 1
-  store i64 %5, ptr %lookup_elem, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  %2 = add i64 %1, 1
+  store i64 %2, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -99,39 +95,39 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
-  %10 = icmp ule i64 %get_cpu_id, %9
-  %11 = select i1 %10, i64 %get_cpu_id, i64 %9
-  %12 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %11, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %12, i8 0, i64 16, i1 false)
-  %13 = getelementptr %int64_count_t__tuple_t, ptr %12, i32 0, i32 0
-  store i64 %key, ptr %13, align 8
-  %14 = getelementptr %int64_count_t__tuple_t, ptr %12, i32 0, i32 1
-  store i64 %8, ptr %14, align 8
-  %15 = getelementptr %int64_count_t__tuple_t, ptr %12, i32 0, i32 1
-  %16 = load i64, ptr %15, align 8
-  store i64 %16, ptr %"$res", align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
+  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
+  %11 = getelementptr %int64_count_t__tuple_t, ptr %10, i32 0, i32 0
+  store i64 %key, ptr %11, align 8
+  %12 = getelementptr %int64_count_t__tuple_t, ptr %10, i32 0, i32 1
+  store i64 %8, ptr %12, align 8
+  %13 = getelementptr %int64_count_t__tuple_t, ptr %10, i32 0, i32 1
+  %14 = load i64, ptr %13, align 8
+  store i64 %14, ptr %"$res", align 8
   ret i64 0
 
 lookup_success:                                   ; preds = %while_body
-  %17 = load i64, ptr %val_1, align 8
-  %18 = load i64, ptr %lookup_percpu_elem, align 8
-  %19 = add i64 %18, %17
-  store i64 %19, ptr %val_1, align 8
-  %20 = load i32, ptr %i, align 4
-  %21 = add i32 %20, 1
-  store i32 %21, ptr %i, align 4
+  %15 = load i64, ptr %val_1, align 8
+  %16 = load i64, ptr %lookup_percpu_elem, align 8
+  %17 = add i64 %16, %15
+  store i64 %17, ptr %val_1, align 8
+  %18 = load i32, ptr %i, align 4
+  %19 = add i32 %18, 1
+  store i32 %19, ptr %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %22 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %22, 0
+  %20 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %20, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %23 = load i32, ptr %i, align 4
+  %21 = load i32, ptr %i, align 4
   br label %while_end
 }
 

--- a/tests/codegen/llvm/for_map_one_key.ll
+++ b/tests/codegen/llvm/for_map_one_key.ll
@@ -24,10 +24,6 @@ define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !70 {
 entry:
   %"@map_val" = alloca i64, align 8
   %"@map_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
   store i64 16, ptr %"@map_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
@@ -51,17 +47,17 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %6 = icmp ule i64 %get_cpu_id, %5
-  %7 = select i1 %6, i64 %get_cpu_id, i64 %5
-  %8 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %7, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
-  %9 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 1
-  store i64 %val, ptr %10, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %8, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %6, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }

--- a/tests/codegen/llvm/for_map_strings.ll
+++ b/tests/codegen/llvm/for_map_strings.ll
@@ -24,10 +24,6 @@ define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !75 {
 entry:
   %str1 = alloca [4 x i8], align 1
   %str = alloca [4 x i8], align 1
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [4 x i8] c"xyz\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
@@ -48,17 +44,17 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %"@x_key" = alloca i64, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %6 = icmp ule i64 %get_cpu_id, %5
-  %7 = select i1 %6, i64 %get_cpu_id, i64 %5
-  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @tuple_buf, i64 0, i64 %7, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 8, i1 false)
-  %9 = getelementptr %"string[4]_string[4]__tuple_t", ptr %8, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %1, i64 4, i1 false)
-  %10 = getelementptr %"string[4]_string[4]__tuple_t", ptr %8, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %2, i64 4, i1 false)
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
+  %7 = getelementptr %"string[4]_string[4]__tuple_t", ptr %6, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %1, i64 4, i1 false)
+  %8 = getelementptr %"string[4]_string[4]__tuple_t", ptr %6, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %2, i64 4, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %8, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %6, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }

--- a/tests/codegen/llvm/for_map_two_keys.ll
+++ b/tests/codegen/llvm/for_map_two_keys.ll
@@ -26,17 +26,17 @@ entry:
   %"@map_val" = alloca i64, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
-  %4 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %int64_int64__tuple_t, ptr %4, i32 0, i32 0
-  store i64 16, ptr %5, align 8
-  %6 = getelementptr %int64_int64__tuple_t, ptr %4, i32 0, i32 1
-  store i64 17, ptr %6, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %int64_int64__tuple_t, ptr %2, i32 0, i32 0
+  store i64 16, ptr %3, align 8
+  %4 = getelementptr %int64_int64__tuple_t, ptr %2, i32 0, i32 1
+  store i64 17, ptr %4, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
   store i64 32, ptr %"@map_val", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %4, ptr %"@map_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %2, ptr %"@map_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_val")
   %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_map, ptr @map_for_each_cb, ptr null, i64 0)
   ret i64 0
@@ -56,17 +56,17 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %6 = icmp ule i64 %get_cpu_id, %5
-  %7 = select i1 %6, i64 %get_cpu_id, i64 %5
-  %8 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %7, i64 1, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 24, i1 false)
-  %9 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %8, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %1, i64 16, i1 false)
-  %10 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %8, i32 0, i32 1
-  store i64 %val, ptr %10, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 24, i1 false)
+  %7 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %6, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %1, i64 16, i1 false)
+  %8 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %8, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %6, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }

--- a/tests/codegen/llvm/for_map_variables.ll
+++ b/tests/codegen/llvm/for_map_variables.ll
@@ -39,10 +39,6 @@ entry:
   store i64 0, ptr %"$var1", align 8
   %"@map_val" = alloca i64, align 8
   %"@map_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
   store i64 16, ptr %"@map_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
@@ -65,11 +61,11 @@ entry:
   %"ctx.$var3" = getelementptr %ctx_t, ptr %ctx, i64 0, i32 1
   store ptr %"$var3", ptr %"ctx.$var3", align 8
   %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_map, ptr @map_for_each_cb, ptr %ctx, i64 0)
-  %4 = load i64, ptr %"$var1", align 8
+  %1 = load i64, ptr %"$var1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@len_key")
   store i64 0, ptr %"@len_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@len_val")
-  store i64 %4, ptr %"@len_val", align 8
+  store i64 %1, ptr %"@len_val", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_len, ptr %"@len_key", ptr %"@len_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@len_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@len_key")
@@ -96,21 +92,21 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %6 = icmp ule i64 %get_cpu_id, %5
-  %7 = select i1 %6, i64 %get_cpu_id, i64 %5
-  %8 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %7, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
-  %9 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 1
-  store i64 %val, ptr %10, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   %"ctx.$var1" = getelementptr %ctx_t, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8
   %"ctx.$var3" = getelementptr %ctx_t, ptr %3, i64 0, i32 1
   %"$var3" = load ptr, ptr %"ctx.$var3", align 8
-  %11 = load i64, ptr %"$var1", align 8
-  %12 = add i64 %11, 1
-  store i64 %12, ptr %"$var1", align 8
+  %9 = load i64, ptr %"$var1", align 8
+  %10 = add i64 %9, 1
+  store i64 %10, ptr %"$var1", align 8
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$can_read", ptr align 1 %"$var3", i64 4, i1 false)
   ret i64 0
 }

--- a/tests/codegen/llvm/for_map_variables_multiple_loops.ll
+++ b/tests/codegen/llvm/for_map_variables_multiple_loops.ll
@@ -32,10 +32,6 @@ entry:
   store i64 0, ptr %"$var1", align 8
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
@@ -69,19 +65,19 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %6 = icmp ule i64 %get_cpu_id, %5
-  %7 = select i1 %6, i64 %get_cpu_id, i64 %5
-  %8 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %7, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
-  %9 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 1
-  store i64 %val, ptr %10, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   %"ctx.$var1" = getelementptr %ctx_t, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8
-  %11 = load i64, ptr %"$var1", align 8
-  %12 = add i64 %11, 1
-  store i64 %12, ptr %"$var1", align 8
+  %9 = load i64, ptr %"$var1", align 8
+  %10 = add i64 %9, 1
+  store i64 %10, ptr %"$var1", align 8
   ret i64 0
 }
 
@@ -93,24 +89,24 @@ define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section "
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %6 = icmp ule i64 %get_cpu_id, %5
-  %7 = select i1 %6, i64 %get_cpu_id, i64 %5
-  %8 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %7, i64 1, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
-  %9 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 1
-  store i64 %val, ptr %10, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   %"ctx.$var1" = getelementptr %ctx_t.2, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8
   %"ctx.$var2" = getelementptr %ctx_t.2, ptr %3, i64 0, i32 1
   %"$var2" = load ptr, ptr %"ctx.$var2", align 8
-  %11 = load i64, ptr %"$var1", align 8
+  %9 = load i64, ptr %"$var1", align 8
+  %10 = add i64 %9, 1
+  store i64 %10, ptr %"$var1", align 8
+  %11 = load i64, ptr %"$var2", align 8
   %12 = add i64 %11, 1
-  store i64 %12, ptr %"$var1", align 8
-  %13 = load i64, ptr %"$var2", align 8
-  %14 = add i64 %13, 1
-  store i64 %14, ptr %"$var2", align 8
+  store i64 %12, ptr %"$var2", align 8
   ret i64 0
 }
 

--- a/tests/codegen/llvm/for_map_variables_scope.ll
+++ b/tests/codegen/llvm/for_map_variables_scope.ll
@@ -22,10 +22,6 @@ define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !60 {
 entry:
   %"@map_val" = alloca i64, align 8
   %"@map_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
   store i64 16, ptr %"@map_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
@@ -52,14 +48,14 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %6 = icmp ule i64 %get_cpu_id, %5
-  %7 = select i1 %6, i64 %get_cpu_id, i64 %5
-  %8 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %7, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
-  %9 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 1
-  store i64 %val, ptr %10, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   store i64 1, ptr %"$var", align 8
   ret i64 0
 }
@@ -75,14 +71,14 @@ define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section "
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %6 = icmp ule i64 %get_cpu_id, %5
-  %7 = select i1 %6, i64 %get_cpu_id, i64 %5
-  %8 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %7, i64 1, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
-  %9 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 0
-  store i64 %key, ptr %9, align 8
-  %10 = getelementptr %int64_int64__tuple_t, ptr %8, i32 0, i32 1
-  store i64 %val, ptr %10, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
+  store i64 %key, ptr %7, align 8
+  %8 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 1
+  store i64 %val, ptr %8, align 8
   store i64 1, ptr %"$var", align 8
   ret i64 0
 }

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -19,41 +19,45 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
-  %key5 = alloca i32, align 4
+  %key8 = alloca i32, align 4
   %key = alloca i32, align 4
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %4 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %4 to i32
-  %5 = zext i32 %pid to i64
-  %6 = icmp ugt i64 %5, 10
-  %7 = zext i1 %6 to i64
-  %true_cond = icmp ne i64 %7, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ugt i64 %2, 10
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
-  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 8, i1 false)
-  %9 = getelementptr %printf_t, ptr %8, i32 0, i32 0
-  store i64 0, ptr %9, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %8, i64 8, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
+  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
+  store i64 0, ptr %7, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-if_end:                                           ; preds = %counter_merge3, %counter_merge
+if_end:                                           ; preds = %counter_merge6, %counter_merge
   ret i64 0
 
 else_body:                                        ; preds = %entry
-  %10 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 8, i1 false)
-  %11 = getelementptr %printf_t.1, ptr %10, i32 0, i32 0
-  store i64 1, ptr %11, align 8
-  %ringbuf_output1 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %10, i64 8, i64 0)
-  %ringbuf_loss4 = icmp slt i64 %ringbuf_output1, 0
-  br i1 %ringbuf_loss4, label %event_loss_counter2, label %counter_merge3
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %8 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %8
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %8
+  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
+  %10 = getelementptr %printf_t.1, ptr %9, i32 0, i32 0
+  store i64 1, ptr %10, align 8
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %9, i64 8, i64 0)
+  %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
+  br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
 
 event_loss_counter:                               ; preds = %if_body
   call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
@@ -66,7 +70,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %12 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %11 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -76,26 +80,26 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
   br label %counter_merge
 
-event_loss_counter2:                              ; preds = %else_body
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %key5)
-  store i32 0, ptr %key5, align 4
-  %lookup_elem6 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key5)
-  %map_lookup_cond10 = icmp ne ptr %lookup_elem6, null
-  br i1 %map_lookup_cond10, label %lookup_success7, label %lookup_failure8
+event_loss_counter5:                              ; preds = %else_body
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key8)
+  store i32 0, ptr %key8, align 4
+  %lookup_elem9 = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key8)
+  %map_lookup_cond13 = icmp ne ptr %lookup_elem9, null
+  br i1 %map_lookup_cond13, label %lookup_success10, label %lookup_failure11
 
-counter_merge3:                                   ; preds = %lookup_merge9, %else_body
+counter_merge6:                                   ; preds = %lookup_merge12, %else_body
   br label %if_end
 
-lookup_success7:                                  ; preds = %event_loss_counter2
-  %13 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
-  br label %lookup_merge9
+lookup_success10:                                 ; preds = %event_loss_counter5
+  %12 = atomicrmw add ptr %lookup_elem9, i64 1 seq_cst, align 8
+  br label %lookup_merge12
 
-lookup_failure8:                                  ; preds = %event_loss_counter2
-  br label %lookup_merge9
+lookup_failure11:                                 ; preds = %event_loss_counter5
+  br label %lookup_merge12
 
-lookup_merge9:                                    ; preds = %lookup_failure8, %lookup_success7
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %key5)
-  br label %counter_merge3
+lookup_merge12:                                   ; preds = %lookup_failure11, %lookup_success10
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key8)
+  br label %counter_merge6
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -19,39 +19,39 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %4 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %4 to i32
-  %5 = zext i32 %pid to i64
-  %6 = icmp ugt i64 %5, 10000
-  %7 = zext i1 %6 to i64
-  %true_cond = icmp ne i64 %7, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ugt i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
   %get_pid_tgid3 = call i64 inttoptr (i64 14 to ptr)()
-  %8 = lshr i64 %get_pid_tgid3, 32
-  %pid4 = trunc i64 %8 to i32
-  %9 = zext i32 %pid4 to i64
-  %10 = urem i64 %9, 2
-  %11 = icmp eq i64 %10, 0
-  %12 = zext i1 %11 to i64
-  %true_cond5 = icmp ne i64 %12, 0
+  %5 = lshr i64 %get_pid_tgid3, 32
+  %pid4 = trunc i64 %5 to i32
+  %6 = zext i32 %pid4 to i64
+  %7 = urem i64 %6, 2
+  %8 = icmp eq i64 %7, 0
+  %9 = zext i1 %8 to i64
+  %true_cond5 = icmp ne i64 %9, 0
   br i1 %true_cond5, label %if_body1, label %if_end2
 
 if_end:                                           ; preds = %if_end2, %entry
   ret i64 0
 
 if_body1:                                         ; preds = %if_body
-  %13 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %13, i8 0, i64 8, i1 false)
-  %14 = getelementptr %printf_t, ptr %13, i32 0, i32 0
-  store i64 0, ptr %14, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %13, i64 8, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %10 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %10
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %10
+  %11 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %11, i8 0, i64 8, i1 false)
+  %12 = getelementptr %printf_t, ptr %11, i32 0, i32 0
+  store i64 0, ptr %12, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %11, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -69,7 +69,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end2
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %15 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %13 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -19,31 +19,31 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %4 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %4 to i32
-  %5 = zext i32 %pid to i64
-  %6 = icmp ugt i64 %5, 10000
-  %7 = zext i1 %6 to i64
-  %true_cond = icmp ne i64 %7, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ugt i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
-  %8 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
-  %9 = getelementptr %printf_t, ptr %8, i32 0, i32 0
-  store i64 0, ptr %9, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
+  store i64 0, ptr %7, align 8
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %10 = lshr i64 %get_pid_tgid1, 32
-  %pid2 = trunc i64 %10 to i32
-  %11 = getelementptr %printf_t, ptr %8, i32 0, i32 1
-  %12 = zext i32 %pid2 to i64
-  store i64 %12, ptr %11, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %8, i64 16, i64 0)
+  %8 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %8 to i32
+  %9 = getelementptr %printf_t, ptr %6, i32 0, i32 1
+  %10 = zext i32 %pid2 to i64
+  store i64 %10, ptr %9, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -61,7 +61,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %13 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %11 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -30,23 +30,23 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
+  store i64 0, ptr %"$foo", align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
-  store i64 0, ptr %"$foo", align 8
-  %4 = getelementptr [1 x [1 x [40 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 40, i1 false)
-  %5 = getelementptr %printf_t, ptr %4, i32 0, i32 0
-  store i64 0, ptr %5, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [40 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 40, i1 false)
+  %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
+  store i64 0, ptr %3, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
-  %6 = load i64, ptr %"$foo", align 8
-  %7 = add i64 %6, 0
+  %4 = load i64, ptr %"$foo", align 8
+  %5 = add i64 %4, 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m")
-  %probe_read = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m", i32 4, i64 %7)
-  %8 = load i32, ptr %"struct Foo.m", align 4
+  %probe_read = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m", i32 4, i64 %5)
+  %6 = load i32, ptr %"struct Foo.m", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m")
-  %lhs_true_cond = icmp ne i32 %8, 0
+  %lhs_true_cond = icmp ne i32 %6, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
@@ -61,20 +61,20 @@ entry:
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %9 = load i64, ptr %"&&_result", align 8
-  %10 = getelementptr %printf_t, ptr %4, i32 0, i32 1
-  store i64 %9, ptr %10, align 8
+  %7 = load i64, ptr %"&&_result", align 8
+  %8 = getelementptr %printf_t, ptr %2, i32 0, i32 1
+  store i64 %7, ptr %8, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result5")
   br i1 true, label %"&&_lhs_true1", label %"&&_false3"
 
 "&&_lhs_true1":                                   ; preds = %"&&_merge"
-  %11 = load i64, ptr %"$foo", align 8
-  %12 = add i64 %11, 0
+  %9 = load i64, ptr %"$foo", align 8
+  %10 = add i64 %9, 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m6")
-  %probe_read7 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m6", i32 4, i64 %12)
-  %13 = load i32, ptr %"struct Foo.m6", align 4
+  %probe_read7 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m6", i32 4, i64 %10)
+  %11 = load i32, ptr %"struct Foo.m6", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m6")
-  %rhs_true_cond = icmp ne i32 %13, 0
+  %rhs_true_cond = icmp ne i32 %11, 0
   br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
 
 "&&_true2":                                       ; preds = %"&&_lhs_true1"
@@ -86,17 +86,17 @@ entry:
   br label %"&&_merge4"
 
 "&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %14 = load i64, ptr %"&&_result5", align 8
-  %15 = getelementptr %printf_t, ptr %4, i32 0, i32 2
-  store i64 %14, ptr %15, align 8
+  %12 = load i64, ptr %"&&_result5", align 8
+  %13 = getelementptr %printf_t, ptr %2, i32 0, i32 2
+  store i64 %12, ptr %13, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
-  %16 = load i64, ptr %"$foo", align 8
-  %17 = add i64 %16, 0
+  %14 = load i64, ptr %"$foo", align 8
+  %15 = add i64 %14, 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m8")
-  %probe_read9 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m8", i32 4, i64 %17)
-  %18 = load i32, ptr %"struct Foo.m8", align 4
+  %probe_read9 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m8", i32 4, i64 %15)
+  %16 = load i32, ptr %"struct Foo.m8", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m8")
-  %lhs_true_cond10 = icmp ne i32 %18, 0
+  %lhs_true_cond10 = icmp ne i32 %16, 0
   br i1 %lhs_true_cond10, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %"&&_merge4"
@@ -111,20 +111,20 @@ entry:
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %19 = load i64, ptr %"||_result", align 8
-  %20 = getelementptr %printf_t, ptr %4, i32 0, i32 3
-  store i64 %19, ptr %20, align 8
+  %17 = load i64, ptr %"||_result", align 8
+  %18 = getelementptr %printf_t, ptr %2, i32 0, i32 3
+  store i64 %17, ptr %18, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result15")
   br i1 false, label %"||_true13", label %"||_lhs_false11"
 
 "||_lhs_false11":                                 ; preds = %"||_merge"
-  %21 = load i64, ptr %"$foo", align 8
-  %22 = add i64 %21, 0
+  %19 = load i64, ptr %"$foo", align 8
+  %20 = add i64 %19, 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m16")
-  %probe_read17 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m16", i32 4, i64 %22)
-  %23 = load i32, ptr %"struct Foo.m16", align 4
+  %probe_read17 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m16", i32 4, i64 %20)
+  %21 = load i32, ptr %"struct Foo.m16", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m16")
-  %rhs_true_cond18 = icmp ne i32 %23, 0
+  %rhs_true_cond18 = icmp ne i32 %21, 0
   br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
 
 "||_false12":                                     ; preds = %"||_lhs_false11"
@@ -136,10 +136,10 @@ entry:
   br label %"||_merge14"
 
 "||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %24 = load i64, ptr %"||_result15", align 8
-  %25 = getelementptr %printf_t, ptr %4, i32 0, i32 4
-  store i64 %24, ptr %25, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %4, i64 40, i64 0)
+  %22 = load i64, ptr %"||_result15", align 8
+  %23 = getelementptr %printf_t, ptr %2, i32 0, i32 4
+  store i64 %22, ptr %23, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 40, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -154,7 +154,7 @@ counter_merge:                                    ; preds = %lookup_merge, %"||_
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %26 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %24 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/map_key_int.ll
+++ b/tests/codegen/llvm/map_key_int.ll
@@ -23,19 +23,19 @@ entry:
   %"@x_val" = alloca i64, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
-  %4 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 24, i1 false)
-  %5 = getelementptr %int64_int64_int64__tuple_t, ptr %4, i32 0, i32 0
-  store i64 11, ptr %5, align 8
-  %6 = getelementptr %int64_int64_int64__tuple_t, ptr %4, i32 0, i32 1
-  store i64 22, ptr %6, align 8
-  %7 = getelementptr %int64_int64_int64__tuple_t, ptr %4, i32 0, i32 2
-  store i64 33, ptr %7, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 24, i1 false)
+  %3 = getelementptr %int64_int64_int64__tuple_t, ptr %2, i32 0, i32 0
+  store i64 11, ptr %3, align 8
+  %4 = getelementptr %int64_int64_int64__tuple_t, ptr %2, i32 0, i32 1
+  store i64 22, ptr %4, align 8
+  %5 = getelementptr %int64_int64_int64__tuple_t, ptr %2, i32 0, i32 2
+  store i64 33, ptr %5, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   store i64 44, ptr %"@x_val", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %4, ptr %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   ret i64 0
 }

--- a/tests/codegen/llvm/map_key_string.ll
+++ b/tests/codegen/llvm/map_key_string.ll
@@ -23,25 +23,25 @@ entry:
   %"@x_val" = alloca i64, align 8
   %str1 = alloca [2 x i8], align 1
   %str = alloca [2 x i8], align 1
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [2 x i8] c"a\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
   store [2 x i8] c"b\00", ptr %str1, align 1
-  %4 = getelementptr [1 x [1 x [4 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 4, i1 false)
-  %5 = getelementptr %"string[2]_string[2]__tuple_t", ptr %4, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %str, i64 2, i1 false)
-  %6 = getelementptr %"string[2]_string[2]__tuple_t", ptr %4, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %str1, i64 2, i1 false)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [4 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 4, i1 false)
+  %3 = getelementptr %"string[2]_string[2]__tuple_t", ptr %2, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 %str, i64 2, i1 false)
+  %4 = getelementptr %"string[2]_string[2]__tuple_t", ptr %2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %str1, i64 2, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   store i64 44, ptr %"@x_val", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %4, ptr %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   ret i64 0
 }

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -24,10 +24,6 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
 entry:
   %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 1, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
@@ -35,19 +31,19 @@ entry:
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %4 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  %5 = load i64, ptr %4, align 8
-  %6 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  %7 = load i64, ptr %6, align 8
-  %is_set_cond = icmp eq i64 %7, 1
+  %1 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  %2 = load i64, ptr %1, align 8
+  %3 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  %4 = load i64, ptr %3, align 8
+  %is_set_cond = icmp eq i64 %4, 1
   br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %mm_struct)
-  %8 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
-  store i64 2, ptr %8, align 8
-  %9 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
-  store i64 1, ptr %9, align 8
+  %5 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
+  store i64 2, ptr %5, align 8
+  %6 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
+  store i64 1, ptr %6, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %mm_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %mm_struct)
   br label %lookup_merge
@@ -58,14 +54,14 @@ lookup_merge:                                     ; preds = %lookup_failure, %mi
   ret i64 0
 
 is_set:                                           ; preds = %lookup_success
-  %10 = icmp sge i64 2, %5
-  br i1 %10, label %min_max, label %lookup_merge
+  %7 = icmp sge i64 2, %2
+  br i1 %7, label %min_max, label %lookup_merge
 
 min_max:                                          ; preds = %is_set, %lookup_success
-  %11 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  store i64 2, ptr %11, align 8
-  %12 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  store i64 1, ptr %12, align 8
+  %8 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  store i64 2, ptr %8, align 8
+  %9 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  store i64 1, ptr %9, align 8
   br label %lookup_merge
 }
 
@@ -113,41 +109,41 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
-  %10 = icmp ule i64 %get_cpu_id, %9
-  %11 = select i1 %10, i64 %get_cpu_id, i64 %9
-  %12 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %11, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %12, i8 0, i64 16, i1 false)
-  %13 = getelementptr %int64_max_t__tuple_t, ptr %12, i32 0, i32 0
-  store i64 %key, ptr %13, align 8
-  %14 = getelementptr %int64_max_t__tuple_t, ptr %12, i32 0, i32 1
-  store i64 %8, ptr %14, align 8
-  %15 = getelementptr %int64_max_t__tuple_t, ptr %12, i32 0, i32 1
-  %16 = load i64, ptr %15, align 8
-  store i64 %16, ptr %"$res", align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
+  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
+  %11 = getelementptr %int64_max_t__tuple_t, ptr %10, i32 0, i32 0
+  store i64 %key, ptr %11, align 8
+  %12 = getelementptr %int64_max_t__tuple_t, ptr %10, i32 0, i32 1
+  store i64 %8, ptr %12, align 8
+  %13 = getelementptr %int64_max_t__tuple_t, ptr %10, i32 0, i32 1
+  %14 = load i64, ptr %13, align 8
+  store i64 %14, ptr %"$res", align 8
   ret i64 0
 
 lookup_success:                                   ; preds = %while_body
-  %17 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %15 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %16 = load i64, ptr %15, align 8
+  %17 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
   %18 = load i64, ptr %17, align 8
-  %19 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %20 = load i64, ptr %19, align 8
-  %val_set_cond = icmp eq i64 %20, 1
-  %21 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %21, 1
-  %22 = load i64, ptr %val_1, align 8
-  %max_cond = icmp sgt i64 %18, %22
+  %val_set_cond = icmp eq i64 %18, 1
+  %19 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %19, 1
+  %20 = load i64, ptr %val_1, align 8
+  %max_cond = icmp sgt i64 %16, %20
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %23 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %23, 0
+  %21 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %21, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %18, ptr %val_1, align 8
+  store i64 %16, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -155,16 +151,16 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %max_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
-  %24 = load i32, ptr %i, align 4
-  %25 = add i32 %24, 1
-  store i32 %25, ptr %i, align 4
+  %22 = load i32, ptr %i, align 4
+  %23 = add i32 %22, 1
+  store i32 %23, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %26 = load i32, ptr %i, align 4
+  %24 = load i32, ptr %i, align 4
   br label %while_end
 }
 

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -24,10 +24,6 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !72 {
 entry:
   %mm_struct = alloca %min_max_val, align 8
   %"@x_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 1, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
@@ -35,19 +31,19 @@ entry:
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %4 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  %5 = load i64, ptr %4, align 8
-  %6 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  %7 = load i64, ptr %6, align 8
-  %is_set_cond = icmp eq i64 %7, 1
+  %1 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  %2 = load i64, ptr %1, align 8
+  %3 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  %4 = load i64, ptr %3, align 8
+  %is_set_cond = icmp eq i64 %4, 1
   br i1 %is_set_cond, label %is_set, label %min_max
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %mm_struct)
-  %8 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
-  store i64 2, ptr %8, align 8
-  %9 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
-  store i64 1, ptr %9, align 8
+  %5 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 0
+  store i64 2, ptr %5, align 8
+  %6 = getelementptr %min_max_val, ptr %mm_struct, i64 0, i32 1
+  store i64 1, ptr %6, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %mm_struct, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %mm_struct)
   br label %lookup_merge
@@ -58,14 +54,14 @@ lookup_merge:                                     ; preds = %lookup_failure, %mi
   ret i64 0
 
 is_set:                                           ; preds = %lookup_success
-  %10 = icmp sge i64 %5, 2
-  br i1 %10, label %min_max, label %lookup_merge
+  %7 = icmp sge i64 %2, 2
+  br i1 %7, label %min_max, label %lookup_merge
 
 min_max:                                          ; preds = %is_set, %lookup_success
-  %11 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
-  store i64 2, ptr %11, align 8
-  %12 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
-  store i64 1, ptr %12, align 8
+  %8 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 0
+  store i64 2, ptr %8, align 8
+  %9 = getelementptr %min_max_val, ptr %lookup_elem, i64 0, i32 1
+  store i64 1, ptr %9, align 8
   br label %lookup_merge
 }
 
@@ -113,41 +109,41 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
-  %10 = icmp ule i64 %get_cpu_id, %9
-  %11 = select i1 %10, i64 %get_cpu_id, i64 %9
-  %12 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %11, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %12, i8 0, i64 16, i1 false)
-  %13 = getelementptr %int64_min_t__tuple_t, ptr %12, i32 0, i32 0
-  store i64 %key, ptr %13, align 8
-  %14 = getelementptr %int64_min_t__tuple_t, ptr %12, i32 0, i32 1
-  store i64 %8, ptr %14, align 8
-  %15 = getelementptr %int64_min_t__tuple_t, ptr %12, i32 0, i32 1
-  %16 = load i64, ptr %15, align 8
-  store i64 %16, ptr %"$res", align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
+  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
+  %11 = getelementptr %int64_min_t__tuple_t, ptr %10, i32 0, i32 0
+  store i64 %key, ptr %11, align 8
+  %12 = getelementptr %int64_min_t__tuple_t, ptr %10, i32 0, i32 1
+  store i64 %8, ptr %12, align 8
+  %13 = getelementptr %int64_min_t__tuple_t, ptr %10, i32 0, i32 1
+  %14 = load i64, ptr %13, align 8
+  store i64 %14, ptr %"$res", align 8
   ret i64 0
 
 lookup_success:                                   ; preds = %while_body
-  %17 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %15 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %16 = load i64, ptr %15, align 8
+  %17 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
   %18 = load i64, ptr %17, align 8
-  %19 = getelementptr %min_max_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %20 = load i64, ptr %19, align 8
-  %val_set_cond = icmp eq i64 %20, 1
-  %21 = load i64, ptr %val_2, align 8
-  %ret_set_cond = icmp eq i64 %21, 1
-  %22 = load i64, ptr %val_1, align 8
-  %min_cond = icmp slt i64 %18, %22
+  %val_set_cond = icmp eq i64 %18, 1
+  %19 = load i64, ptr %val_2, align 8
+  %ret_set_cond = icmp eq i64 %19, 1
+  %20 = load i64, ptr %val_1, align 8
+  %min_cond = icmp slt i64 %16, %20
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
-  %23 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %23, 0
+  %21 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %21, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 val_set_success:                                  ; preds = %lookup_success
   br i1 %ret_set_cond, label %ret_set_success, label %min_max_success
 
 min_max_success:                                  ; preds = %ret_set_success, %val_set_success
-  store i64 %18, ptr %val_1, align 8
+  store i64 %16, ptr %val_1, align 8
   store i64 1, ptr %val_2, align 8
   br label %min_max_merge
 
@@ -155,16 +151,16 @@ ret_set_success:                                  ; preds = %val_set_success
   br i1 %min_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
-  %24 = load i32, ptr %i, align 4
-  %25 = add i32 %24, 1
-  store i32 %25, ptr %i, align 4
+  %22 = load i32, ptr %i, align 4
+  %23 = add i32 %22, 1
+  store i32 %23, ptr %i, align 4
   br label %while_cond
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %26 = load i32, ptr %i, align 4
+  %24 = load i32, ptr %i, align 4
   br label %while_end
 }
 

--- a/tests/codegen/llvm/nested_tuple_different_sizes.ll
+++ b/tests/codegen/llvm/nested_tuple_different_sizes.ll
@@ -21,58 +21,70 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !51 {
 entry:
-  %str1 = alloca [13 x i8], align 1
+  %str4 = alloca [13 x i8], align 1
   %"$t" = alloca %"int64_(string[13],int64)__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 32, i1 false)
   %str = alloca [3 x i8], align 1
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [3 x i8] c"hi\00", ptr %str, align 1
-  %4 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %"string[3]_int64__tuple_t", ptr %4, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %str, i64 3, i1 false)
-  %6 = getelementptr %"string[3]_int64__tuple_t", ptr %4, i32 0, i32 1
-  store i64 3, ptr %6, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %"string[3]_int64__tuple_t", ptr %2, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 %str, i64 3, i1 false)
+  %4 = getelementptr %"string[3]_int64__tuple_t", ptr %2, i32 0, i32 1
+  store i64 3, ptr %4, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
-  %7 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 1, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 24, i1 false)
-  %8 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %7, i32 0, i32 0
-  store i64 1, ptr %8, align 8
-  %9 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %7, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %4, i64 16, i1 false)
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %5
+  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %5
+  %6 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 24, i1 false)
+  %7 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %6, i32 0, i32 0
+  store i64 1, ptr %7, align 8
+  %8 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %6, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %2, i64 16, i1 false)
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 32, i1 false)
-  %10 = getelementptr [24 x i8], ptr %7, i64 0, i64 0
-  %11 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %11, ptr align 1 %10, i64 8, i1 false)
-  %12 = getelementptr [24 x i8], ptr %7, i64 0, i64 8
-  %13 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 1
-  %14 = getelementptr [16 x i8], ptr %12, i64 0, i64 0
-  %15 = getelementptr %"string[13]_int64__tuple_t", ptr %13, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %15, ptr align 1 %14, i64 3, i1 false)
-  %16 = getelementptr [16 x i8], ptr %12, i64 0, i64 8
-  %17 = getelementptr %"string[13]_int64__tuple_t", ptr %13, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %17, ptr align 1 %16, i64 8, i1 false)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
-  store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
-  %18 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 2, i64 0
+  %9 = getelementptr [24 x i8], ptr %6, i64 0, i64 0
+  %10 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 8, i1 false)
+  %11 = getelementptr [24 x i8], ptr %6, i64 0, i64 8
+  %12 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 1
+  %13 = getelementptr [16 x i8], ptr %11, i64 0, i64 0
+  %14 = getelementptr %"string[13]_int64__tuple_t", ptr %12, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %14, ptr align 1 %13, i64 3, i1 false)
+  %15 = getelementptr [16 x i8], ptr %11, i64 0, i64 8
+  %16 = getelementptr %"string[13]_int64__tuple_t", ptr %12, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 %15, i64 8, i1 false)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str4)
+  store [13 x i8] c"hellolongstr\00", ptr %str4, align 1
+  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)()
+  %17 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp6 = icmp ule i64 %get_cpu_id5, %17
+  %cpuid.min.select7 = select i1 %cpuid.min.cmp6, i64 %get_cpu_id5, i64 %17
+  %18 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select7, i64 2, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 24, i1 false)
   %19 = getelementptr %"string[13]_int64__tuple_t", ptr %18, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %19, ptr align 1 %str1, i64 13, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %19, ptr align 1 %str4, i64 13, i1 false)
   %20 = getelementptr %"string[13]_int64__tuple_t", ptr %18, i32 0, i32 1
   store i64 4, ptr %20, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
-  %21 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 3, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %21, i8 0, i64 32, i1 false)
-  %22 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %21, i32 0, i32 0
-  store i64 1, ptr %22, align 8
-  %23 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %21, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %23, ptr align 1 %18, i64 24, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %21, i64 32, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str4)
+  %get_cpu_id8 = call i64 inttoptr (i64 8 to ptr)()
+  %21 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp9 = icmp ule i64 %get_cpu_id8, %21
+  %cpuid.min.select10 = select i1 %cpuid.min.cmp9, i64 %get_cpu_id8, i64 %21
+  %22 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select10, i64 3, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %22, i8 0, i64 32, i1 false)
+  %23 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %22, i32 0, i32 0
+  store i64 1, ptr %23, align 8
+  %24 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %22, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %24, ptr align 1 %18, i64 24, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %22, i64 32, i1 false)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -24,10 +24,6 @@ entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 1, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
@@ -36,9 +32,9 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %4 = load i64, ptr %lookup_elem, align 8
-  %5 = add i64 %4, 2
-  store i64 %5, ptr %lookup_elem, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  %2 = add i64 %1, 2
+  store i64 %2, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -99,39 +95,39 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
-  %10 = icmp ule i64 %get_cpu_id, %9
-  %11 = select i1 %10, i64 %get_cpu_id, i64 %9
-  %12 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %11, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %12, i8 0, i64 16, i1 false)
-  %13 = getelementptr %int64_sum_t__tuple_t, ptr %12, i32 0, i32 0
-  store i64 %key, ptr %13, align 8
-  %14 = getelementptr %int64_sum_t__tuple_t, ptr %12, i32 0, i32 1
-  store i64 %8, ptr %14, align 8
-  %15 = getelementptr %int64_sum_t__tuple_t, ptr %12, i32 0, i32 1
-  %16 = load i64, ptr %15, align 8
-  store i64 %16, ptr %"$res", align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
+  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
+  %11 = getelementptr %int64_sum_t__tuple_t, ptr %10, i32 0, i32 0
+  store i64 %key, ptr %11, align 8
+  %12 = getelementptr %int64_sum_t__tuple_t, ptr %10, i32 0, i32 1
+  store i64 %8, ptr %12, align 8
+  %13 = getelementptr %int64_sum_t__tuple_t, ptr %10, i32 0, i32 1
+  %14 = load i64, ptr %13, align 8
+  store i64 %14, ptr %"$res", align 8
   ret i64 0
 
 lookup_success:                                   ; preds = %while_body
-  %17 = load i64, ptr %val_1, align 8
-  %18 = load i64, ptr %lookup_percpu_elem, align 8
-  %19 = add i64 %18, %17
-  store i64 %19, ptr %val_1, align 8
-  %20 = load i32, ptr %i, align 4
-  %21 = add i32 %20, 1
-  store i32 %21, ptr %i, align 4
+  %15 = load i64, ptr %val_1, align 8
+  %16 = load i64, ptr %lookup_percpu_elem, align 8
+  %17 = add i64 %16, %15
+  store i64 %17, ptr %val_1, align 8
+  %18 = load i32, ptr %i, align 4
+  %19 = add i32 %18, 1
+  store i32 %19, ptr %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %22 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %22, 0
+  %20 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %20, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %23 = load i32, ptr %i, align 4
+  %21 = load i32, ptr %i, align 4
   br label %while_end
 }
 

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -21,25 +21,25 @@ entry:
   %key5 = alloca i32, align 4
   %perfdata = alloca i64, align 8
   %key = alloca i32, align 4
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %4 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %4 to i32
-  %5 = zext i32 %pid to i64
-  %6 = icmp ult i64 %5, 10000
-  %7 = zext i1 %6 to i64
-  %true_cond = icmp ne i64 %7, 0
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ult i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
-  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 8, i1 false)
-  %9 = getelementptr %printf_t, ptr %8, i32 0, i32 0
-  store i64 0, ptr %9, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %8, i64 8, i64 0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
+  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
+  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
+  store i64 0, ptr %7, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -64,7 +64,7 @@ counter_merge:                                    ; preds = %lookup_merge, %left
   br label %done
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %8 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -86,7 +86,7 @@ counter_merge3:                                   ; preds = %lookup_merge9, %rig
   ret i64 0
 
 lookup_success7:                                  ; preds = %event_loss_counter2
-  %11 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
+  %9 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter2

--- a/tests/codegen/llvm/tuple.ll
+++ b/tests/codegen/llvm/tuple.ll
@@ -22,24 +22,24 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !63 {
 entry:
   %"@t_key" = alloca i64, align 8
   %str = alloca [4 x i8], align 1
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [4 x i8] c"str\00", ptr %str, align 1
-  %4 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 24, i1 false)
-  %5 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %4, i32 0, i32 0
-  store i64 1, ptr %5, align 8
-  %6 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %4, i32 0, i32 1
-  store i64 2, ptr %6, align 8
-  %7 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %4, i32 0, i32 2
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %str, i64 4, i1 false)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 24, i1 false)
+  %3 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %2, i32 0, i32 0
+  store i64 1, ptr %3, align 8
+  %4 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %2, i32 0, i32 1
+  store i64 2, ptr %4, align 8
+  %5 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %2, i32 0, i32 2
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %str, i64 4, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %4, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@t_key")
   ret i64 0
 }

--- a/tests/codegen/llvm/tuple_array_struct.ll
+++ b/tests/codegen/llvm/tuple_array_struct.ll
@@ -21,24 +21,24 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !65 {
 entry:
   %"@t_key" = alloca i64, align 8
+  %1 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %1, align 8
+  %2 = getelementptr i64, ptr %0, i64 13
+  %arg1 = load volatile i64, ptr %2, align 8
+  %3 = add i64 %arg1, 0
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
-  %4 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %4, align 8
-  %5 = getelementptr i64, ptr %0, i64 13
-  %arg1 = load volatile i64, ptr %5, align 8
-  %6 = add i64 %arg1, 0
-  %7 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 24, i1 false)
-  %8 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %7, i32 0, i32 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %8, i32 8, i64 %arg0)
-  %9 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %7, i32 0, i32 1
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %9, i32 16, i64 %6)
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
+  %5 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 24, i1 false)
+  %6 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %5, i32 0, i32 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %6, i32 8, i64 %arg0)
+  %7 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %5, i32 0, i32 1
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %7, i32 16, i64 %3)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %7, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %5, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@t_key")
   ret i64 0
 }

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -23,33 +23,33 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !63 {
 entry:
   %"@t_key" = alloca i64, align 8
   %usym = alloca %usym_t, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
-  %4 = getelementptr i64, ptr %0, i64 16
-  %reg_ip = load volatile i64, ptr %4, align 8
+  %1 = getelementptr i64, ptr %0, i64 16
+  %reg_ip = load volatile i64, ptr %1, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %5 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %5 to i32
-  %6 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %7 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %8 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 %reg_ip, ptr %6, align 8
-  store i32 %pid, ptr %7, align 4
-  store i32 0, ptr %8, align 4
-  %9 = getelementptr [1 x [1 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 32, i1 false)
-  %10 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %9, i32 0, i32 0
-  store i8 1, ptr %10, align 1
-  %11 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %9, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %11, ptr align 1 %usym, i64 16, i1 false)
-  %12 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %9, i32 0, i32 2
-  store i64 10, ptr %12, align 8
+  %2 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %2 to i32
+  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %5 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 %reg_ip, ptr %3, align 8
+  store i32 %pid, ptr %4, align 4
+  store i32 0, ptr %5, align 4
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %6 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %6
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
+  %7 = getelementptr [1 x [1 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 32, i1 false)
+  %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 0
+  store i8 1, ptr %8, align 1
+  %9 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %usym, i64 16, i1 false)
+  %10 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 2
+  store i64 10, ptr %10, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %9, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %7, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@t_key")
   ret i64 0
 }

--- a/tests/codegen/llvm/tuple_map_val_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_map_val_different_sizes.ll
@@ -21,50 +21,54 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
-  %"@a_key2" = alloca i64, align 8
+  %"@a_key5" = alloca i64, align 8
   %str1 = alloca [13 x i8], align 1
   %"@a_val" = alloca %"int64_string[13]__tuple_t", align 8
   %"@a_key" = alloca i64, align 8
   %str = alloca [3 x i8], align 1
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [3 x i8] c"hi\00", ptr %str, align 1
-  %4 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %"int64_string[3]__tuple_t", ptr %4, i32 0, i32 0
-  store i64 1, ptr %5, align 8
-  %6 = getelementptr %"int64_string[3]__tuple_t", ptr %4, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %str, i64 3, i1 false)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %"int64_string[3]__tuple_t", ptr %2, i32 0, i32 0
+  store i64 1, ptr %3, align 8
+  %4 = getelementptr %"int64_string[3]__tuple_t", ptr %2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %str, i64 3, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
   store i64 0, ptr %"@a_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
   call void @llvm.memset.p0.i64(ptr align 1 %"@a_val", i8 0, i64 24, i1 false)
-  %7 = getelementptr [16 x i8], ptr %4, i64 0, i64 0
-  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %7, i64 8, i1 false)
-  %9 = getelementptr [16 x i8], ptr %4, i64 0, i64 8
-  %10 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 3, i1 false)
+  %5 = getelementptr [16 x i8], ptr %2, i64 0, i64 0
+  %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 8, i1 false)
+  %7 = getelementptr [16 x i8], ptr %2, i64 0, i64 8
+  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %7, i64 3, i1 false)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %"@a_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
   store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
-  %11 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 1, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %11, i8 0, i64 24, i1 false)
-  %12 = getelementptr %"int64_string[13]__tuple_t", ptr %11, i32 0, i32 0
-  store i64 1, ptr %12, align 8
-  %13 = getelementptr %"int64_string[13]__tuple_t", ptr %11, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 %str1, i64 13, i1 false)
+  %get_cpu_id2 = call i64 inttoptr (i64 8 to ptr)()
+  %9 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp3 = icmp ule i64 %get_cpu_id2, %9
+  %cpuid.min.select4 = select i1 %cpuid.min.cmp3, i64 %get_cpu_id2, i64 %9
+  %10 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select4, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 24, i1 false)
+  %11 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 0
+  store i64 1, ptr %11, align 8
+  %12 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %str1, i64 13, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key2")
-  store i64 0, ptr %"@a_key2", align 8
-  %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key2", ptr %11, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key2")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key5")
+  store i64 0, ptr %"@a_key5", align 8
+  %update_elem6 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key5", ptr %10, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key5")
   ret i64 0
 }
 

--- a/tests/codegen/llvm/tuple_variable_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_variable_different_sizes.ll
@@ -24,36 +24,40 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 24, i1 false)
   %str = alloca [3 x i8], align 1
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %2 = icmp ule i64 %get_cpu_id, %1
-  %3 = select i1 %2, i64 %get_cpu_id, i64 %1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [3 x i8] c"hi\00", ptr %str, align 1
-  %4 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %"int64_string[3]__tuple_t", ptr %4, i32 0, i32 0
-  store i64 1, ptr %5, align 8
-  %6 = getelementptr %"int64_string[3]__tuple_t", ptr %4, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %str, i64 3, i1 false)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
+  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
+  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %"int64_string[3]__tuple_t", ptr %2, i32 0, i32 0
+  store i64 1, ptr %3, align 8
+  %4 = getelementptr %"int64_string[3]__tuple_t", ptr %2, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %str, i64 3, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 24, i1 false)
-  %7 = getelementptr [16 x i8], ptr %4, i64 0, i64 0
-  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %7, i64 8, i1 false)
-  %9 = getelementptr [16 x i8], ptr %4, i64 0, i64 8
-  %10 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 3, i1 false)
+  %5 = getelementptr [16 x i8], ptr %2, i64 0, i64 0
+  %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 8, i1 false)
+  %7 = getelementptr [16 x i8], ptr %2, i64 0, i64 8
+  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %7, i64 3, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
   store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
-  %11 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %3, i64 1, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %11, i8 0, i64 24, i1 false)
-  %12 = getelementptr %"int64_string[13]__tuple_t", ptr %11, i32 0, i32 0
-  store i64 1, ptr %12, align 8
-  %13 = getelementptr %"int64_string[13]__tuple_t", ptr %11, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 %str1, i64 13, i1 false)
+  %get_cpu_id2 = call i64 inttoptr (i64 8 to ptr)()
+  %9 = load i64, ptr @max_cpu_id, align 8
+  %cpuid.min.cmp3 = icmp ule i64 %get_cpu_id2, %9
+  %cpuid.min.select4 = select i1 %cpuid.min.cmp3, i64 %get_cpu_id2, i64 %9
+  %10 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select4, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 24, i1 false)
+  %11 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 0
+  store i64 1, ptr %11, align 8
+  %12 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %str1, i64 13, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %11, i64 24, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %10, i64 24, i1 false)
   ret i64 0
 }
 


### PR DESCRIPTION
This reverts commit cd681f142eba7f96dfd8baa97563dd9822d50317.

This is a fix for str_big_read test on master.

On LLVM15, there is a recent regression to dump register values to the stack too aggressively, then read it again later. Thus, the bounded CPU ID value is dumped to the stack. Unfortunately 6.5 BPF verifier doesn't know about how to bound values read from the stack and it blows up. Other more modern kernels do seem to know how to bound this value.

While it is a recent bug in LLVM15 to aggressively dump values to the stack, we should revert this PR because if we have a sufficiently complex program in LLVM18 where it is forced to dump bounded CPU ID to the stack, we will hit the same bug.