### PR TITLE
Remove multi-map delete API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to
 - Return `uint32` instead of `uint64` for `pid` and `tid` builtins
   - [#3441](https://github.com/bpftrace/bpftrace/pull/3441)
   - [Migration guide](docs/migration_guide.md#pid-and-tid-builtins-return-uint32)
+- Remove multi-map `delete` functionality
+  - [#3506](https://github.com/bpftrace/bpftrace/pull/3506)
+  - [Migration guide](docs/migration_guide.md#multi-key-delete-removed)
 #### Added
 - Add `--dry-run` CLI option
   - [#3203](https://github.com/bpftrace/bpftrace/pull/3203)

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -9,6 +9,46 @@ compatibility in some way. Each entry should contain:
 
 ## Versions 0.21.x (or earlier) to 0.22.x (or later)
 
+### multi-key `delete` removed
+
+https://github.com/bpftrace/bpftrace/pull/3506
+
+This map `delete` syntax is no longer valid:
+```
+delete(@b[1], @b[2], @b[3]);
+```
+And will yield this error:
+```
+# bpftrace -e 'BEGIN { @b[1] = 1; delete(@b[1], @b[2], @b[3]); }'
+stdin:1:20-47: ERROR: delete() takes up to 2 arguments (3 provided)
+BEGIN { @b[1] = 1; delete(@b[1], @b[2], @b[3]); }
+                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
+
+You might also see this error:
+```
+# bpftrace -e 'BEGIN { @b[1] = 1; delete(@b[1], @b[2]); }'
+stdin:1:20-32: ERROR: delete() expects a map with no keys for the first argument
+BEGIN { @b[1] = 1; delete(@b[1], @b[2]); }
+                   ~~~~~~~~~~~~
+```
+
+`delete` now expects only two arguments: a map and a key. For example, the above
+delete statement should be rewritten as this:
+```
+delete(@b, 1);
+delete(@b, 2);
+delete(@b, 3);
+```
+
+And for maps with multiple values as keys, which are represented as a tuple,
+the delete call looks like this:
+```
+@c[1, "hello"] = 1;
+
+delete(@c, (1, "hello"));
+```
+
 ### `pid` and `tid` builtins return `uint32`
 
 https://github.com/bpftrace/bpftrace/pull/3441

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2505,7 +2505,7 @@ interval:s:10 {
 
 .variants
 * `delete(map m, mapkey k)`
-* deprecated `delete(mapkey k, ...)`
+* deprecated `delete(mapkey k)`
 
 Delete a single key from a map.
 For scalar maps (e.g. no explicit keys), the key is omitted and is equivalent to calling `clear`.

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -233,10 +233,10 @@ PROG BEGIN { @ = count(); @a[1] = count(); delete(@); delete(@a, 1); exit(); }
 EXPECT @: 0
 TIMEOUT 1
 
-NAME delete multiple-map deprecated
-PROG BEGIN { @ = 1; @a[1] = 1; delete(@, @a[1]); exit(); }
-EXPECT_NONE @: 1
+NAME delete deprecated
+PROG BEGIN { @a[1] = 1; @b[2, "hi"] = 2; delete(@a[1]); delete(@b[2, "hi"]); exit(); }
 EXPECT_NONE @a[1]: 1
+EXPECT_NONE @b[2, hi]: 2
 TIMEOUT 1
 
 NAME increment/decrement map


### PR DESCRIPTION
This is no longer valid:
```
@a = 1;
@b[1] = 2;

delete(@a, @b[1]);
```

This also fixes map key resizing for the `delete` function: this is no longer an error: `@y["hi"] = 5; delete(@y, "longerstr");`

https://github.com/bpftrace/bpftrace/issues/3495
https://github.com/bpftrace/bpftrace/issues/3496

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
