### PR TITLE
Reduce jumps needed from scratch buffer lookup

### DIFF
--- a/src/utils.h
+++ b/src/utils.h
@@ -256,6 +256,8 @@ std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
 std::vector<int> get_pids_for_program(const std::string &program);
 std::vector<int> get_all_running_pids();
 
+uint32_t round_up_to_next_power_of_two(uint32_t n);
+
 std::string sanitise_bpf_program_name(const std::string &name);
 // Generate object file function name for a given probe
 inline std::string get_function_name_for_probe(

--- a/tests/codegen/llvm/avg_cast_loop.ll
+++ b/tests/codegen/llvm/avg_cast_loop.ll
@@ -156,9 +156,8 @@ is_negative_merge_block:                          ; preds = %is_positive, %is_ne
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %31 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %31
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %31
-  %32 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %31
+  %32 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %32, i8 0, i64 16, i1 false)
   %33 = getelementptr %int64_avg_t__tuple_t, ptr %32, i32 0, i32 0
   store i64 %key, ptr %33, align 8

--- a/tests/codegen/llvm/call_cat.ll
+++ b/tests/codegen/llvm/call_cat.ll
@@ -21,9 +21,8 @@ entry:
   %key = alloca i32, align 4
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 8, i1 false)
   %3 = getelementptr %cat_t, ptr %2, i32 0, i32 0
   store i64 20000, ptr %3, align 8

--- a/tests/codegen/llvm/call_cgroup_path.ll
+++ b/tests/codegen/llvm/call_cgroup_path.ll
@@ -29,9 +29,8 @@ entry:
   store i64 %get_cgroup_id, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %3 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %3
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %3
-  %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %3
+  %4 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   %5 = getelementptr %print_cgroup_path_t_16_t, ptr %4, i64 0, i32 0
   store i64 30007, ptr %5, align 8
   %6 = getelementptr %print_cgroup_path_t_16_t, ptr %4, i64 0, i32 1

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -26,9 +26,8 @@ entry:
   store [4 x i8] c"abc\00", ptr %str, align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %"int64_string[4]__tuple_t", ptr %2, i32 0, i32 0
   store i64 1, ptr %3, align 8
@@ -37,9 +36,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %5
-  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %5
-  %6 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select3, i64 0, i64 0
+  %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
+  %6 = getelementptr [1 x [1 x [32 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
   %7 = getelementptr %print_tuple_16_t, ptr %6, i64 0, i32 0
   store i64 30007, ptr %7, align 8
   %8 = getelementptr %print_tuple_16_t, ptr %6, i64 0, i32 1

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -21,9 +21,8 @@ entry:
   %key = alloca i32, align 4
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   %3 = getelementptr %print_int_8_t, ptr %2, i64 0, i32 0
   store i64 30007, ptr %3, align 8
   %4 = getelementptr %print_int_8_t, ptr %2, i64 0, i32 1

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -29,9 +29,8 @@ entry:
   store i64 %arg0, ptr %"$foo", align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %2 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %2
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %2
-  %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %2
+  %3 = getelementptr [1 x [1 x [24 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %3, i8 0, i64 24, i1 false)
   %4 = getelementptr %printf_t, ptr %3, i32 0, i32 0
   store i64 0, ptr %4, align 8

--- a/tests/codegen/llvm/call_system.ll
+++ b/tests/codegen/llvm/call_system.ll
@@ -21,9 +21,8 @@ entry:
   %key = alloca i32, align 4
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %system_t, ptr %2, i32 0, i32 0
   store i64 10000, ptr %3, align 8

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -95,9 +95,8 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
-  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %9
+  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
   %11 = getelementptr %int64_count_t__tuple_t, ptr %10, i32 0, i32 0
   store i64 %key, ptr %11, align 8

--- a/tests/codegen/llvm/for_map_one_key.ll
+++ b/tests/codegen/llvm/for_map_one_key.ll
@@ -47,9 +47,8 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
   %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
   store i64 %key, ptr %7, align 8

--- a/tests/codegen/llvm/for_map_strings.ll
+++ b/tests/codegen/llvm/for_map_strings.ll
@@ -44,9 +44,8 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %"@x_key" = alloca i64, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
   %7 = getelementptr %"string[4]_string[4]__tuple_t", ptr %6, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %1, i64 4, i1 false)

--- a/tests/codegen/llvm/for_map_two_keys.ll
+++ b/tests/codegen/llvm/for_map_two_keys.ll
@@ -26,9 +26,8 @@ entry:
   %"@map_val" = alloca i64, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %int64_int64__tuple_t, ptr %2, i32 0, i32 0
   store i64 16, ptr %3, align 8
@@ -56,9 +55,8 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 1, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 24, i1 false)
   %7 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %6, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %1, i64 16, i1 false)

--- a/tests/codegen/llvm/for_map_variables.ll
+++ b/tests/codegen/llvm/for_map_variables.ll
@@ -92,9 +92,8 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
   %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
   store i64 %key, ptr %7, align 8

--- a/tests/codegen/llvm/for_map_variables_multiple_loops.ll
+++ b/tests/codegen/llvm/for_map_variables_multiple_loops.ll
@@ -65,9 +65,8 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
   %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
   store i64 %key, ptr %7, align 8
@@ -89,9 +88,8 @@ define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section "
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 1, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
   %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
   store i64 %key, ptr %7, align 8

--- a/tests/codegen/llvm/for_map_variables_scope.ll
+++ b/tests/codegen/llvm/for_map_variables_scope.ll
@@ -48,9 +48,8 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
   %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
   store i64 %key, ptr %7, align 8
@@ -71,9 +70,8 @@ define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section "
   %val = load i64, ptr %2, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 1, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
   %7 = getelementptr %int64_int64__tuple_t, ptr %6, i32 0, i32 0
   store i64 %key, ptr %7, align 8

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -45,9 +45,8 @@ if_end:                                           ; preds = %if_end2, %entry
 if_body1:                                         ; preds = %if_body
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %10 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %10
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %10
-  %11 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %10
+  %11 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %11, i8 0, i64 8, i1 false)
   %12 = getelementptr %printf_t, ptr %11, i32 0, i32 0
   store i64 0, ptr %12, align 8

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -31,9 +31,8 @@ entry:
 if_body:                                          ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
   %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
   store i64 0, ptr %7, align 8

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -33,9 +33,8 @@ entry:
   store i64 0, ptr %"$foo", align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [40 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [40 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 40, i1 false)
   %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
   store i64 0, ptr %3, align 8

--- a/tests/codegen/llvm/map_key_int.ll
+++ b/tests/codegen/llvm/map_key_int.ll
@@ -23,9 +23,8 @@ entry:
   %"@x_val" = alloca i64, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 24, i1 false)
   %3 = getelementptr %int64_int64_int64__tuple_t, ptr %2, i32 0, i32 0
   store i64 11, ptr %3, align 8

--- a/tests/codegen/llvm/map_key_string.ll
+++ b/tests/codegen/llvm/map_key_string.ll
@@ -29,9 +29,8 @@ entry:
   store [2 x i8] c"b\00", ptr %str1, align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [4 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [4 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 4, i1 false)
   %3 = getelementptr %"string[2]_string[2]__tuple_t", ptr %2, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 %str, i64 2, i1 false)

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -109,9 +109,8 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
-  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %9
+  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
   %11 = getelementptr %int64_max_t__tuple_t, ptr %10, i32 0, i32 0
   store i64 %key, ptr %11, align 8

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -109,9 +109,8 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
-  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %9
+  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
   %11 = getelementptr %int64_min_t__tuple_t, ptr %10, i32 0, i32 0
   store i64 %key, ptr %11, align 8

--- a/tests/codegen/llvm/nested_tuple_different_sizes.ll
+++ b/tests/codegen/llvm/nested_tuple_different_sizes.ll
@@ -21,7 +21,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !51 {
 entry:
-  %str4 = alloca [13 x i8], align 1
+  %str3 = alloca [13 x i8], align 1
   %"$t" = alloca %"int64_(string[13],int64)__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 32, i1 false)
@@ -30,9 +30,8 @@ entry:
   store [3 x i8] c"hi\00", ptr %str, align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %"string[3]_int64__tuple_t", ptr %2, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 %str, i64 3, i1 false)
@@ -41,9 +40,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp2 = icmp ule i64 %get_cpu_id1, %5
-  %cpuid.min.select3 = select i1 %cpuid.min.cmp2, i64 %get_cpu_id1, i64 %5
-  %6 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select3, i64 1, i64 0
+  %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
+  %6 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 24, i1 false)
   %7 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %6, i32 0, i32 0
   store i64 1, ptr %7, align 8
@@ -61,24 +59,22 @@ entry:
   %15 = getelementptr [16 x i8], ptr %11, i64 0, i64 8
   %16 = getelementptr %"string[13]_int64__tuple_t", ptr %12, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 %15, i64 8, i1 false)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str4)
-  store [13 x i8] c"hellolongstr\00", ptr %str4, align 1
-  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)()
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str3)
+  store [13 x i8] c"hellolongstr\00", ptr %str3, align 1
+  %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
   %17 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp6 = icmp ule i64 %get_cpu_id5, %17
-  %cpuid.min.select7 = select i1 %cpuid.min.cmp6, i64 %get_cpu_id5, i64 %17
-  %18 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select7, i64 2, i64 0
+  %cpu.id.bounded5 = and i64 %get_cpu_id4, %17
+  %18 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded5, i64 2, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %18, i8 0, i64 24, i1 false)
   %19 = getelementptr %"string[13]_int64__tuple_t", ptr %18, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %19, ptr align 1 %str4, i64 13, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %19, ptr align 1 %str3, i64 13, i1 false)
   %20 = getelementptr %"string[13]_int64__tuple_t", ptr %18, i32 0, i32 1
   store i64 4, ptr %20, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str4)
-  %get_cpu_id8 = call i64 inttoptr (i64 8 to ptr)()
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str3)
+  %get_cpu_id6 = call i64 inttoptr (i64 8 to ptr)()
   %21 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp9 = icmp ule i64 %get_cpu_id8, %21
-  %cpuid.min.select10 = select i1 %cpuid.min.cmp9, i64 %get_cpu_id8, i64 %21
-  %22 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select10, i64 3, i64 0
+  %cpu.id.bounded7 = and i64 %get_cpu_id6, %21
+  %22 = getelementptr [1 x [4 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded7, i64 3, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %22, i8 0, i64 32, i1 false)
   %23 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %22, i32 0, i32 0
   store i64 1, ptr %23, align 8

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -95,9 +95,8 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %9
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %9
-  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %9
+  %10 = getelementptr [1 x [1 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 16, i1 false)
   %11 = getelementptr %int64_sum_t__tuple_t, ptr %10, i32 0, i32 0
   store i64 %key, ptr %11, align 8

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -33,9 +33,8 @@ entry:
 left:                                             ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %5
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %5
-  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
   %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
   store i64 0, ptr %7, align 8

--- a/tests/codegen/llvm/tuple.ll
+++ b/tests/codegen/llvm/tuple.ll
@@ -26,9 +26,8 @@ entry:
   store [4 x i8] c"str\00", ptr %str, align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 24, i1 false)
   %3 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %2, i32 0, i32 0
   store i64 1, ptr %3, align 8

--- a/tests/codegen/llvm/tuple_array_struct.ll
+++ b/tests/codegen/llvm/tuple_array_struct.ll
@@ -28,9 +28,8 @@ entry:
   %3 = add i64 %arg1, 0
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %4 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %4
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %4
-  %5 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %4
+  %5 = getelementptr [1 x [1 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 24, i1 false)
   %6 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %5, i32 0, i32 0
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %6, i32 8, i64 %arg0)

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -37,9 +37,8 @@ entry:
   store i32 0, ptr %5, align 4
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %6 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %6
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %6
-  %7 = getelementptr [1 x [1 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %6
+  %7 = getelementptr [1 x [1 x [32 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 32, i1 false)
   %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %7, i32 0, i32 0
   store i8 1, ptr %8, align 1

--- a/tests/codegen/llvm/tuple_map_val_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_map_val_different_sizes.ll
@@ -21,7 +21,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !62 {
 entry:
-  %"@a_key5" = alloca i64, align 8
+  %"@a_key4" = alloca i64, align 8
   %str1 = alloca [13 x i8], align 1
   %"@a_val" = alloca %"int64_string[13]__tuple_t", align 8
   %"@a_key" = alloca i64, align 8
@@ -30,9 +30,8 @@ entry:
   store [3 x i8] c"hi\00", ptr %str, align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %"int64_string[3]__tuple_t", ptr %2, i32 0, i32 0
   store i64 1, ptr %3, align 8
@@ -56,19 +55,18 @@ entry:
   store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
   %get_cpu_id2 = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp3 = icmp ule i64 %get_cpu_id2, %9
-  %cpuid.min.select4 = select i1 %cpuid.min.cmp3, i64 %get_cpu_id2, i64 %9
-  %10 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select4, i64 1, i64 0
+  %cpu.id.bounded3 = and i64 %get_cpu_id2, %9
+  %10 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded3, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 24, i1 false)
   %11 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 0
   store i64 1, ptr %11, align 8
   %12 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %str1, i64 13, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key5")
-  store i64 0, ptr %"@a_key5", align 8
-  %update_elem6 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key5", ptr %10, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key5")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key4")
+  store i64 0, ptr %"@a_key4", align 8
+  %update_elem5 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key4", ptr %10, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key4")
   ret i64 0
 }
 

--- a/tests/codegen/llvm/tuple_variable_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_variable_different_sizes.ll
@@ -28,9 +28,8 @@ entry:
   store [3 x i8] c"hi\00", ptr %str, align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp = icmp ule i64 %get_cpu_id, %1
-  %cpuid.min.select = select i1 %cpuid.min.cmp, i64 %get_cpu_id, i64 %1
-  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select, i64 0, i64 0
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %"int64_string[3]__tuple_t", ptr %2, i32 0, i32 0
   store i64 1, ptr %3, align 8
@@ -48,9 +47,8 @@ entry:
   store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
   %get_cpu_id2 = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
-  %cpuid.min.cmp3 = icmp ule i64 %get_cpu_id2, %9
-  %cpuid.min.select4 = select i1 %cpuid.min.cmp3, i64 %get_cpu_id2, i64 %9
-  %10 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpuid.min.select4, i64 1, i64 0
+  %cpu.id.bounded3 = and i64 %get_cpu_id2, %9
+  %10 = getelementptr [1 x [2 x [24 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded3, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 24, i1 false)
   %11 = getelementptr %"int64_string[13]__tuple_t", ptr %10, i32 0, i32 0
   store i64 1, ptr %11, align 8

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -409,4 +409,18 @@ TEST(utils, get_pids_for_program)
   ASSERT_EQ(pids.size(), 0);
 }
 
+TEST(utils, round_up_to_next_power_of_two)
+{
+  // 2^31 = 2147483648 which is max power of 2 within uint32_t
+  constexpr uint32_t max_power_of_two = 2147483648;
+  ASSERT_EQ(round_up_to_next_power_of_two(0), 0);
+  ASSERT_EQ(round_up_to_next_power_of_two(1), 1);
+  ASSERT_EQ(round_up_to_next_power_of_two(7), 8);
+  ASSERT_EQ(round_up_to_next_power_of_two(55), 64);
+  ASSERT_EQ(round_up_to_next_power_of_two(128), 128);
+  ASSERT_EQ(round_up_to_next_power_of_two(max_power_of_two - 1),
+            max_power_of_two);
+  ASSERT_EQ(round_up_to_next_power_of_two(max_power_of_two), max_power_of_two);
+}
+
 } // namespace bpftrace::test::utils


### PR DESCRIPTION
We currently use global scratch variables to allow for storing big strings. It looks like this in BPF bytecode:
```
ValueType global_var [NUM_CPUS][NUM_SLOTS]

buf = global_var[bpf_get_smp_processor_id()][slot_id]
```

On newer kernels, BPF verifier knows how to bound bpf_get_smp_processor_id. However, on older kernels, the BPF verifier this value is unbounded. Currently, to bound the value of bpf_get_smp_processor_id, we do:
```
bounded_cpu_id = min(bpf_get_smp_processor_id(), NUM_CPUS)
```

However, this min call causes the BPF verifier to do additional jumps and in some complex programs, we hit the kernel complexity limit of 8192 jumps:
```
The sequence of 8193 jumps is too complex.
```

To fix this, we use an AND instruction instead:
```
bounded_cpu_id = bpf_get_smp_processor_id() & (NUM_CPUS - 1)
```

Thus, we need to round up NUM_CPUS to the next largest power of 2 e.g. 55 CPUs will be rounded up to 64 CPUs.

The con is that this allocates more memory than necessary (in the worst case, 2x scratch variable space). But the whole big strings project is about trading off memory increase with better usability.

We previously tried to cache the bounded CPU ID value in a LLVM register. However, LLVM15 started aggressively dumping registers to the stack and the BPF verifier in older kernels (6.5) do not know how to bound values read from the stack.
