### PR TITLE
Migrate strings from scratch maps to global scratch variables

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -475,16 +475,11 @@ CallInst *IRBuilderBPF::CreateGetStackScratchMap(StackType stack_type,
                              failure_callback);
 }
 
-CallInst *IRBuilderBPF::CreateGetStrScratchMap(int idx,
-                                               BasicBlock *failure_callback,
-                                               const location &loc)
+Value *IRBuilderBPF::CreateGetStrScratchBuffer(const location &loc, int key)
 {
-  return createGetScratchMap(to_string(MapType::StrBuffer),
-                             "str",
-                             GET_PTR_TY(),
+  return createScratchBuffer(bpftrace::globalvars::GlobalVar::GET_STR_BUFFER,
                              loc,
-                             failure_callback,
-                             idx);
+                             key);
 }
 
 Value *IRBuilderBPF::CreateGetFmtStringArgsScratchBuffer(const location &loc)
@@ -507,7 +502,9 @@ Value *IRBuilderBPF::createScratchBuffer(
 {
   auto config = globalvars::get_config(globalvar);
   // ValueType var[MAX_CPU_ID + 1][num_elements]
-  auto type = globalvars::get_type(globalvar, bpftrace_.resources);
+  auto type = globalvars::get_type(globalvar,
+                                   bpftrace_.resources,
+                                   bpftrace_.config_);
 
   // Get CPU ID
   auto cpu_id = CreateGetCpuId(loc);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -165,9 +165,7 @@ public:
   CallInst *CreateGetStackScratchMap(StackType stack_type,
                                      BasicBlock *failure_callback,
                                      const location &loc);
-  CallInst *CreateGetStrScratchMap(int idx,
-                                   BasicBlock *failure_callback,
-                                   const location &loc);
+  Value *CreateGetStrScratchBuffer(const location &loc, int key);
   Value *CreateGetFmtStringArgsScratchBuffer(const location &loc);
   Value *CreateTupleScratchBuffer(const location &loc, int key);
   void CreateCheckSetRecursion(const location &loc, int early_exit_ret);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -104,7 +104,8 @@ public:
   libbpf::bpf_map_type get_map_type(const SizedType &val_type,
                                     const SizedType &key_type);
   void generate_maps(const RequiredResources &rr, const CodegenResources &cr);
-  void generate_global_vars(const RequiredResources &resources);
+  void generate_global_vars(const RequiredResources &resources,
+                            const ::bpftrace::Config &bpftrace_config);
   void optimize(void);
   bool verify(void);
   BpfBytecode emit(bool disassemble);

--- a/src/ast/passes/codegen_resources.cpp
+++ b/src/ast/passes/codegen_resources.cpp
@@ -35,23 +35,9 @@ void CodegenResourceAnalyser::visit(Call &call)
 
   if (call.func == "join") {
     resources_.needs_join_map = true;
-  } else if (call.func == "str" || call.func == "buf" || call.func == "path") {
-    resources_.str_buffers++;
   } else if (call.func == "kstack" || call.func == "ustack") {
     resources_.stackid_maps.insert(call.type.stack_type);
   }
-}
-
-void CodegenResourceAnalyser::visit(Ternary &ternary)
-{
-  Visitor::visit(ternary);
-
-  // Codegen cannot use a phi node for ternary string b/c strings can be of
-  // differing lengths and phi node wants identical types. So we have to
-  // allocate a result temporary, but not on the stack b/c a big string would
-  // blow it up. So we need a scratch buffer for it.
-  if (ternary.type.IsStringTy())
-    resources_.str_buffers++;
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/codegen_resources.h
+++ b/src/ast/passes/codegen_resources.h
@@ -12,7 +12,6 @@ namespace ast {
 struct CodegenResources {
   bool needs_elapsed_map = false;
   bool needs_join_map = false;
-  uint32_t str_buffers = 0;
   std::unordered_set<StackType> stackid_maps;
 };
 
@@ -29,7 +28,6 @@ public:
 private:
   void visit(Builtin &map) override;
   void visit(Call &call) override;
-  void visit(Ternary &ternary) override;
 
   const ::bpftrace::Config &config_;
   CodegenResources resources_;

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -35,6 +35,7 @@ private:
   void visit(Map &map) override;
   void visit(Tuple &tuple) override;
   void visit(For &f) override;
+  void visit(Ternary &ternary) override;
 
   // Determines whether the given function uses userspace symbol resolution.
   // This is used later for loading the symbol table into memory.

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -70,8 +70,6 @@ std::string to_string(MapType t)
       return "elapsed";
     case MapType::Ringbuf:
       return "ringbuf";
-    case MapType::StrBuffer:
-      return "str_buffer";
     case MapType::EventLossCounter:
       return "event_loss_counter";
     case MapType::RecursionPrevention:

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -71,7 +71,6 @@ enum class MapType {
   Join,
   Elapsed,
   Ringbuf,
-  StrBuffer,
   EventLossCounter,
   RecursionPrevention,
 };

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -19,6 +19,7 @@ constexpr std::string_view RO_SECTION_NAME = ".rodata";
 constexpr std::string_view FMT_STRINGS_BUFFER_SECTION_NAME =
     ".data.fmt_str_buf";
 constexpr std::string_view TUPLE_BUFFER_SECTION_NAME = ".data.tuple_buf";
+constexpr std::string_view GET_STR_BUFFER_SECTION_NAME = ".data.get_str_buf";
 
 struct GlobalVarConfig {
   std::string name;
@@ -34,6 +35,8 @@ const std::unordered_map<GlobalVar, GlobalVarConfig> GLOBAL_VAR_CONFIGS = {
     { "fmt_str_buf", std::string(FMT_STRINGS_BUFFER_SECTION_NAME), false } },
   { GlobalVar::TUPLE_BUFFER,
     { "tuple_buf", std::string(TUPLE_BUFFER_SECTION_NAME), false } },
+  { GlobalVar::GET_STR_BUFFER,
+    { "get_str_buf", std::string(GET_STR_BUFFER_SECTION_NAME), false } },
 };
 
 void update_global_vars(
@@ -42,7 +45,9 @@ void update_global_vars(
     const BPFtrace &bpftrace);
 
 const GlobalVarConfig &get_config(GlobalVar global_var);
-SizedType get_type(GlobalVar global_var, const RequiredResources &resources);
+SizedType get_type(GlobalVar global_var,
+                   const RequiredResources &resources,
+                   const Config &bpftrace_config);
 std::unordered_set<std::string> get_section_names();
 
 } // namespace globalvars

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -107,6 +107,9 @@ public:
   size_t tuple_buffers = 0;
   size_t max_tuple_size = 0;
 
+  // Required for sizing of string scratch buffer
+  size_t str_buffers = 0;
+
   // Async argument metadata that codegen creates. Ideally ResourceAnalyser
   // pass should be collecting this, but it's complex to move the logic.
   //

--- a/src/types.h
+++ b/src/types.h
@@ -719,6 +719,7 @@ enum class GlobalVar {
   // Scratch buffers used to avoid BPF stack allocation limits
   FMT_STRINGS_BUFFER,
   TUPLE_BUFFER,
+  GET_STR_BUFFER,
 };
 
 } // namespace globalvars

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -6,47 +6,39 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %buffer_16_t = type <{ i32, [16 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
-@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !53
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !46
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !48
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !63 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !58 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %lookup_str_key = alloca i32, align 4
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   store i64 0, ptr %"$foo", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
-  store i32 0, ptr %lookup_str_key, align 4
-  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
-  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
-  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
-
-lookup_str_failure:                               ; preds = %entry
-  ret i64 0
-
-lookup_str_merge:                                 ; preds = %entry
-  %1 = getelementptr %buffer_16_t, ptr %lookup_str_map, i32 0, i32 0
-  store i32 16, ptr %1, align 4
-  %2 = getelementptr %buffer_16_t, ptr %lookup_str_map, i32 0, i32 1
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = add i64 %3, 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 16, i64 %4)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %3 = getelementptr %buffer_16_t, ptr %2, i32 0, i32 0
+  store i32 16, ptr %3, align 4
+  %4 = getelementptr %buffer_16_t, ptr %2, i32 0, i32 1
+  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
+  %5 = load i64, ptr %"$foo", align 8
+  %6 = add i64 %5, 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 16, i64 %6)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %lookup_str_map, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
@@ -54,18 +46,18 @@ lookup_str_merge:                                 ; preds = %entry
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!60}
-!llvm.module.flags = !{!62}
+!llvm.dbg.cu = !{!55}
+!llvm.module.flags = !{!57}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -107,32 +99,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !37 = !{!38}
 !38 = !DISubrange(count: 262144, lowerBound: 0)
 !39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
 !41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !11, !16, !48}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!42 = !{!5, !11, !16, !43}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !44, size: 64, offset: 192)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 6, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !49, size: 64, offset: 192)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !51)
-!51 = !{!52}
-!52 = !DISubrange(count: 64, lowerBound: 0)
-!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
-!54 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
-!55 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !56)
-!56 = !{!5, !11, !16, !57}
-!57 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !58, size: 64, offset: 192)
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!60 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !61)
-!61 = !{!0, !25, !39, !53}
-!62 = !{i32 2, !"Debug Info Version", i32 3}
-!63 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !64, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !60, retainedNodes: !67)
-!64 = !DISubroutineType(types: !65)
-!65 = !{!59, !66}
-!66 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!67 = !{!68}
-!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !63, file: !2, type: !66)
+!45 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
+!49 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 512, elements: !14)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !52, size: 512, elements: !14)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !53)
+!53 = !{!54}
+!54 = !DISubrange(count: 64, lowerBound: 0)
+!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
+!56 = !{!0, !25, !39, !46, !48}
+!57 = !{i32 2, !"Debug Info Version", i32 3}
+!58 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
+!59 = !DISubroutineType(types: !60)
+!60 = !{!45, !61}
+!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -6,62 +6,54 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %buffer_1_t = type <{ i32, [1 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
-@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !53
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !46
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !48
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !63 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !58 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %lookup_str_key = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
-  store i32 0, ptr %lookup_str_key, align 4
-  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
-  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
-  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
-
-lookup_str_failure:                               ; preds = %entry
-  ret i64 0
-
-lookup_str_merge:                                 ; preds = %entry
-  %1 = getelementptr %buffer_1_t, ptr %lookup_str_map, i32 0, i32 0
-  store i32 1, ptr %1, align 4
-  %2 = getelementptr %buffer_1_t, ptr %lookup_str_map, i32 0, i32 1
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 1, i1 false)
-  %3 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %3, align 8
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1, i64 %arg0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %3 = getelementptr %buffer_1_t, ptr %2, i32 0, i32 0
+  store i32 1, ptr %3, align 4
+  %4 = getelementptr %buffer_1_t, ptr %2, i32 0, i32 1
+  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 1, i1 false)
+  %5 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %5, align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 1, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %lookup_str_map, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!60}
-!llvm.module.flags = !{!62}
+!llvm.dbg.cu = !{!55}
+!llvm.module.flags = !{!57}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -103,32 +95,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !37 = !{!38}
 !38 = !DISubrange(count: 262144, lowerBound: 0)
 !39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
 !41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !11, !16, !48}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!42 = !{!5, !11, !16, !43}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !44, size: 64, offset: 192)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 6, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !49, size: 64, offset: 192)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !51)
-!51 = !{!52}
-!52 = !DISubrange(count: 64, lowerBound: 0)
-!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
-!54 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
-!55 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !56)
-!56 = !{!5, !11, !16, !57}
-!57 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !58, size: 64, offset: 192)
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!60 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !61)
-!61 = !{!0, !25, !39, !53}
-!62 = !{i32 2, !"Debug Info Version", i32 3}
-!63 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !64, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !60, retainedNodes: !67)
-!64 = !DISubroutineType(types: !65)
-!65 = !{!59, !66}
-!66 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!67 = !{!68}
-!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !63, file: !2, type: !66)
+!45 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
+!49 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 512, elements: !14)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !52, size: 512, elements: !14)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !53)
+!53 = !{!54}
+!54 = !DISubrange(count: 64, lowerBound: 0)
+!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
+!56 = !{!0, !25, !39, !46, !48}
+!57 = !{i32 2, !"Debug Info Version", i32 3}
+!58 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
+!59 = !DISubroutineType(types: !60)
+!60 = !{!45, !61}
+!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -6,67 +6,59 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %buffer_60_t = type <{ i32, [60 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
-@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !48
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !46
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !48
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !58 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !55 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %lookup_str_key = alloca i32, align 4
   %1 = getelementptr i64, ptr %0, i64 13
   %arg1 = load volatile i64, ptr %1, align 8
   %length.cmp = icmp ule i64 %arg1, 60
   %length.select = select i1 %length.cmp, i64 %arg1, i64 60
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
-  store i32 0, ptr %lookup_str_key, align 4
-  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
-  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
-  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
-
-lookup_str_failure:                               ; preds = %entry
-  ret i64 0
-
-lookup_str_merge:                                 ; preds = %entry
-  %2 = getelementptr %buffer_60_t, ptr %lookup_str_map, i32 0, i32 0
-  %3 = trunc i64 %length.select to i32
-  store i32 %3, ptr %2, align 4
-  %4 = getelementptr %buffer_60_t, ptr %lookup_str_map, i32 0, i32 1
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 60, i1 false)
-  %5 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %5, align 8
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 %3, i64 %arg0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %2 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %2
+  %3 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %4 = getelementptr %buffer_60_t, ptr %3, i32 0, i32 0
+  %5 = trunc i64 %length.select to i32
+  store i32 %5, ptr %4, align 4
+  %6 = getelementptr %buffer_60_t, ptr %3, i32 0, i32 1
+  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 60, i1 false)
+  %7 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %7, align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %6, i32 %5, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %lookup_str_map, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %3, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!55}
-!llvm.module.flags = !{!57}
+!llvm.dbg.cu = !{!52}
+!llvm.module.flags = !{!54}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -108,27 +100,24 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !37 = !{!38}
 !38 = !DISubrange(count: 262144, lowerBound: 0)
 !39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
 !41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !11, !16, !19}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!42 = !{!5, !11, !16, !43}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !44, size: 64, offset: 192)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
 !48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
-!50 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !51)
-!51 = !{!5, !11, !16, !52}
-!52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !53, size: 64, offset: 192)
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
-!54 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
-!56 = !{!0, !25, !39, !48}
-!57 = !{i32 2, !"Debug Info Version", i32 3}
-!58 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
-!59 = !DISubroutineType(types: !60)
-!60 = !{!54, !61}
-!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!62 = !{!63}
-!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)
+!49 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 512, elements: !14)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !21, size: 512, elements: !14)
+!52 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !53)
+!53 = !{!0, !25, !39, !46, !48}
+!54 = !{i32 2, !"Debug Info Version", i32 3}
+!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !59)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!45, !58}
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!59 = !{!60}
+!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)

--- a/tests/codegen/llvm/call_path.ll
+++ b/tests/codegen/llvm/call_path.ll
@@ -5,55 +5,40 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@str_buffer = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kfunc_mock_vmlinux_filp_close_1(ptr %0) section "s_kfunc_mock_vmlinux_filp_close_1" !dbg !54 {
+define i64 @kfunc_mock_vmlinux_filp_close_1(ptr %0) section "s_kfunc_mock_vmlinux_filp_close_1" !dbg !49 {
 entry:
-  %lookup_str_key = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
-  store i32 0, ptr %lookup_str_key, align 4
-  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
-  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
-  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
-
-lookup_str_failure:                               ; preds = %entry
-  ret i64 0
-
-lookup_str_merge:                                 ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %1 = ptrtoint ptr %0 to i64
-  %2 = getelementptr i64, ptr %0, i64 0
-  %filp = load volatile i64, ptr %2, align 8
-  %3 = add i64 %filp, 152
-  %4 = inttoptr i64 %3 to ptr
-  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %4, ptr %lookup_str_map, i32 64)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
+  %3 = ptrtoint ptr %0 to i64
+  %4 = getelementptr i64, ptr %0, i64 0
+  %filp = load volatile i64, ptr %4, align 8
+  %5 = add i64 %filp, 152
+  %6 = inttoptr i64 %5 to ptr
+  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %6, ptr %2, i32 64)
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -72,14 +57,14 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !14 = !{!15}
 !15 = !DISubrange(count: 262144, lowerBound: 0)
 !16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
-!17 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
 !18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
 !19 = !{!20, !25, !30, !33}
 !20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
 !21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !23)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
 !23 = !{!24}
-!24 = !DISubrange(count: 6, lowerBound: 0)
+!24 = !DISubrange(count: 2, lowerBound: 0)
 !25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
 !26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
 !27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
@@ -90,28 +75,23 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !36, size: 512, elements: !37)
-!36 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!37 = !{!38}
-!38 = !DISubrange(count: 64, lowerBound: 0)
-!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
-!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !25, !30, !48}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 2, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !49, size: 64, offset: 192)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !39}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kfunc_mock_vmlinux_filp_close_1", linkageName: "kfunc_mock_vmlinux_filp_close_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!50, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 512, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 512, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 512, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 64, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kfunc_mock_vmlinux_filp_close_1", linkageName: "kfunc_mock_vmlinux_filp_close_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/call_path_with_optional_size.ll
+++ b/tests/codegen/llvm/call_path_with_optional_size.ll
@@ -5,55 +5,40 @@ target triple = "bpf-pc-linux"
 
 %"struct map_t" = type { ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
-@str_buffer = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kfunc_mock_vmlinux_filp_close_1(ptr %0) section "s_kfunc_mock_vmlinux_filp_close_1" !dbg !54 {
+define i64 @kfunc_mock_vmlinux_filp_close_1(ptr %0) section "s_kfunc_mock_vmlinux_filp_close_1" !dbg !49 {
 entry:
-  %lookup_str_key = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
-  store i32 0, ptr %lookup_str_key, align 4
-  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
-  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
-  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
-
-lookup_str_failure:                               ; preds = %entry
-  ret i64 0
-
-lookup_str_merge:                                 ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %1 = ptrtoint ptr %0 to i64
-  %2 = getelementptr i64, ptr %0, i64 0
-  %filp = load volatile i64, ptr %2, align 8
-  %3 = add i64 %filp, 152
-  %4 = inttoptr i64 %3 to ptr
-  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %4, ptr %lookup_str_map, i32 48)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
+  %3 = ptrtoint ptr %0 to i64
+  %4 = getelementptr i64, ptr %0, i64 0
+  %filp = load volatile i64, ptr %4, align 8
+  %5 = add i64 %filp, 152
+  %6 = inttoptr i64 %5 to ptr
+  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %6, ptr %2, i32 48)
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -72,14 +57,14 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !14 = !{!15}
 !15 = !DISubrange(count: 262144, lowerBound: 0)
 !16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
-!17 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
 !18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
 !19 = !{!20, !25, !30, !33}
 !20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
 !21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !23)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
 !23 = !{!24}
-!24 = !DISubrange(count: 6, lowerBound: 0)
+!24 = !DISubrange(count: 2, lowerBound: 0)
 !25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
 !26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
 !27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
@@ -90,28 +75,23 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
 !34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !36, size: 512, elements: !37)
-!36 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!37 = !{!38}
-!38 = !DISubrange(count: 64, lowerBound: 0)
-!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
-!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !25, !30, !48}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 2, lowerBound: 0)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !49, size: 64, offset: 192)
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
-!50 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !16, !39}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = distinct !DISubprogram(name: "kfunc_mock_vmlinux_filp_close_1", linkageName: "kfunc_mock_vmlinux_filp_close_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!50, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 512, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 512, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 512, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 64, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kfunc_mock_vmlinux_filp_close_1", linkageName: "kfunc_mock_vmlinux_filp_close_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -6,58 +6,50 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
-@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !48
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !46
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !48
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !58 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !55 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %lookup_str_key = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
-  store i32 0, ptr %lookup_str_key, align 4
-  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
-  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
-  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
-
-lookup_str_failure:                               ; preds = %entry
-  ret i64 0
-
-lookup_str_merge:                                 ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %lookup_str_map, i32 64, i64 %arg0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
+  %3 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %3, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %lookup_str_map, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!55}
-!llvm.module.flags = !{!57}
+!llvm.dbg.cu = !{!52}
+!llvm.module.flags = !{!54}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -99,27 +91,24 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !37 = !{!38}
 !38 = !DISubrange(count: 262144, lowerBound: 0)
 !39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
 !41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !11, !16, !19}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!42 = !{!5, !11, !16, !43}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !44, size: 64, offset: 192)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
 !48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
-!50 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !51)
-!51 = !{!5, !11, !16, !52}
-!52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !53, size: 64, offset: 192)
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
-!54 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
-!56 = !{!0, !25, !39, !48}
-!57 = !{i32 2, !"Debug Info Version", i32 3}
-!58 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
-!59 = !DISubroutineType(types: !60)
-!60 = !{!54, !61}
-!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!62 = !{!63}
-!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)
+!49 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 512, elements: !14)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !21, size: 512, elements: !14)
+!52 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !53)
+!53 = !{!0, !25, !39, !46, !48}
+!54 = !{i32 2, !"Debug Info Version", i32 3}
+!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !59)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!45, !58}
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!59 = !{!60}
+!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -6,64 +6,56 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
-@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !48
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !46
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !48
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !58 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !55 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %lookup_str_key = alloca i32, align 4
   %1 = getelementptr i64, ptr %0, i64 13
   %arg1 = load volatile i64, ptr %1, align 8
   %2 = add i64 %arg1, 1
   %str.min.cmp = icmp ule i64 %2, 64
   %str.min.select = select i1 %str.min.cmp, i64 %2, i64 64
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
-  store i32 0, ptr %lookup_str_key, align 4
-  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
-  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
-  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
-
-lookup_str_failure:                               ; preds = %entry
-  ret i64 0
-
-lookup_str_merge:                                 ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %3 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %3, align 8
-  %4 = trunc i64 %str.min.select to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %lookup_str_map, i32 %4, i64 %arg0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %3
+  %4 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 64, i1 false)
+  %5 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %5, align 8
+  %6 = trunc i64 %str.min.select to i32
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %4, i32 %6, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %lookup_str_map, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %4, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!55}
-!llvm.module.flags = !{!57}
+!llvm.dbg.cu = !{!52}
+!llvm.module.flags = !{!54}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -105,27 +97,24 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !37 = !{!38}
 !38 = !DISubrange(count: 262144, lowerBound: 0)
 !39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
 !41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !11, !16, !19}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!42 = !{!5, !11, !16, !43}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !44, size: 64, offset: 192)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 6, lowerBound: 0)
+!45 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
 !48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
-!50 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !51)
-!51 = !{!5, !11, !16, !52}
-!52 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !53, size: 64, offset: 192)
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
-!54 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
-!56 = !{!0, !25, !39, !48}
-!57 = !{i32 2, !"Debug Info Version", i32 3}
-!58 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
-!59 = !DISubroutineType(types: !60)
-!60 = !{!54, !61}
-!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!62 = !{!63}
-!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)
+!49 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 512, elements: !14)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !21, size: 512, elements: !14)
+!52 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !53)
+!53 = !{!0, !25, !39, !46, !48}
+!54 = !{i32 2, !"Debug Info Version", i32 3}
+!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !59)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!45, !58}
+!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!59 = !{!60}
+!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -6,58 +6,50 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
-@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
-@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !51
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !46
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !48
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !61 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !58 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %lookup_str_key = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
-  store i32 0, ptr %lookup_str_key, align 4
-  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
-  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
-  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
-
-lookup_str_failure:                               ; preds = %entry
-  ret i64 0
-
-lookup_str_merge:                                 ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %lookup_str_map, i32 7, i64 %arg0)
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
+  %3 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %3, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 7, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %lookup_str_map, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!58}
-!llvm.module.flags = !{!60}
+!llvm.dbg.cu = !{!55}
+!llvm.module.flags = !{!57}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -99,30 +91,27 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !37 = !{!38}
 !38 = !DISubrange(count: 262144, lowerBound: 0)
 !39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
-!40 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
 !41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
-!42 = !{!43, !11, !16, !46}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!42 = !{!5, !11, !16, !43}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !44, size: 64, offset: 192)
 !44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !23)
-!46 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !47, size: 64, offset: 192)
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !49)
-!49 = !{!50}
-!50 = !DISubrange(count: 64, lowerBound: 0)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !54)
-!54 = !{!5, !11, !16, !55}
-!55 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !56, size: 64, offset: 192)
-!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !57, size: 64)
-!57 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!58 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !59)
-!59 = !{!0, !25, !39, !51}
-!60 = !{i32 2, !"Debug Info Version", i32 3}
-!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !58, retainedNodes: !65)
-!62 = !DISubroutineType(types: !63)
-!63 = !{!57, !64}
-!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!65 = !{!66}
-!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)
+!45 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
+!49 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 512, elements: !14)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !52, size: 512, elements: !14)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !53)
+!53 = !{!54}
+!54 = !DISubrange(count: 64, lowerBound: 0)
+!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
+!56 = !{!0, !25, !39, !46, !48}
+!57 = !{i32 2, !"Debug Info Version", i32 3}
+!58 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
+!59 = !DISubroutineType(types: !60)
+!60 = !{!45, !61}
+!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -6,30 +6,44 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
-@str_buffer = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
-@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !51
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !38
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !40
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @tracepoint_file_filename_1(ptr %0) section "s_tracepoint_file_filename_1" !dbg !56 {
+define i64 @tracepoint_file_filename_1(ptr %0) section "s_tracepoint_file_filename_1" !dbg !51 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %strcmp.result = alloca i1, align 1
   %comm = alloca [16 x i8], align 1
-  %lookup_str_key = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_str_key)
-  store i32 0, ptr %lookup_str_key, align 4
-  %lookup_str_map = call ptr inttoptr (i64 1 to ptr)(ptr @str_buffer, ptr %lookup_str_key)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_str_key)
-  %lookup_str_cond = icmp ne ptr %lookup_str_map, null
-  br i1 %lookup_str_cond, label %lookup_str_merge, label %lookup_str_failure
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
+  %3 = ptrtoint ptr %0 to i64
+  %4 = add i64 %3, 8
+  %5 = inttoptr i64 %4 to ptr
+  %6 = load volatile i64, ptr %5, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 %6)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %comm)
+  call void @llvm.memset.p0.i64(ptr align 1 %comm, i8 0, i64 16, i1 false)
+  %get_comm = call i64 inttoptr (i64 16 to ptr)(ptr %comm, i64 16)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %strcmp.result)
+  store i1 false, ptr %strcmp.result, align 1
+  %7 = getelementptr i8, ptr %2, i32 0
+  %8 = load i8, ptr %7, align 1
+  %9 = getelementptr i8, ptr %comm, i32 0
+  %10 = load i8, ptr %9, align 1
+  %strcmp.cmp = icmp ne i8 %8, %10
+  br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 pred_false:                                       ; preds = %strcmp.false
   ret i64 1
@@ -45,33 +59,11 @@ pred_true:                                        ; preds = %strcmp.false
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
   ret i64 1
 
-lookup_str_failure:                               ; preds = %entry
-  ret i64 0
-
-lookup_str_merge:                                 ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_str_map, i8 0, i64 64, i1 false)
-  %1 = ptrtoint ptr %0 to i64
-  %2 = add i64 %1, 8
-  %3 = inttoptr i64 %2 to ptr
-  %4 = load volatile i64, ptr %3, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %lookup_str_map, i32 64, i64 %4)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %comm)
-  call void @llvm.memset.p0.i64(ptr align 1 %comm, i8 0, i64 16, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to ptr)(ptr %comm, i64 16)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %strcmp.result)
-  store i1 false, ptr %strcmp.result, align 1
-  %5 = getelementptr i8, ptr %lookup_str_map, i32 0
-  %6 = load i8, ptr %5, align 1
-  %7 = getelementptr i8, ptr %comm, i32 0
-  %8 = load i8, ptr %7, align 1
-  %strcmp.cmp = icmp ne i8 %6, %8
-  br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
-
-strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %lookup_str_merge
-  %9 = load i1, ptr %strcmp.result, align 1
+strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
+  %11 = load i1, ptr %strcmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
-  %10 = zext i1 %9 to i64
-  %predcond = icmp eq i64 %10, 0
+  %12 = zext i1 %11 to i64
+  %predcond = icmp eq i64 %12, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.done:                                      ; preds = %strcmp.loop57, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp54, %strcmp.loop_null_cmp50, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp42, %strcmp.loop_null_cmp38, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp30, %strcmp.loop_null_cmp26, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp18, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
@@ -79,208 +71,208 @@ strcmp.done:                                      ; preds = %strcmp.loop57, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %11 = getelementptr i8, ptr %lookup_str_map, i32 1
-  %12 = load i8, ptr %11, align 1
-  %13 = getelementptr i8, ptr %comm, i32 1
+  %13 = getelementptr i8, ptr %2, i32 1
   %14 = load i8, ptr %13, align 1
-  %strcmp.cmp3 = icmp ne i8 %12, %14
+  %15 = getelementptr i8, ptr %comm, i32 1
+  %16 = load i8, ptr %15, align 1
+  %strcmp.cmp3 = icmp ne i8 %14, %16
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
-strcmp.loop_null_cmp:                             ; preds = %lookup_str_merge
-  %strcmp.cmp_null = icmp eq i8 %6, 0
+strcmp.loop_null_cmp:                             ; preds = %entry
+  %strcmp.cmp_null = icmp eq i8 %8, 0
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %15 = getelementptr i8, ptr %lookup_str_map, i32 2
-  %16 = load i8, ptr %15, align 1
-  %17 = getelementptr i8, ptr %comm, i32 2
+  %17 = getelementptr i8, ptr %2, i32 2
   %18 = load i8, ptr %17, align 1
-  %strcmp.cmp7 = icmp ne i8 %16, %18
+  %19 = getelementptr i8, ptr %comm, i32 2
+  %20 = load i8, ptr %19, align 1
+  %strcmp.cmp7 = icmp ne i8 %18, %20
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %12, 0
+  %strcmp.cmp_null4 = icmp eq i8 %14, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %19 = getelementptr i8, ptr %lookup_str_map, i32 3
-  %20 = load i8, ptr %19, align 1
-  %21 = getelementptr i8, ptr %comm, i32 3
+  %21 = getelementptr i8, ptr %2, i32 3
   %22 = load i8, ptr %21, align 1
-  %strcmp.cmp11 = icmp ne i8 %20, %22
+  %23 = getelementptr i8, ptr %comm, i32 3
+  %24 = load i8, ptr %23, align 1
+  %strcmp.cmp11 = icmp ne i8 %22, %24
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %16, 0
+  %strcmp.cmp_null8 = icmp eq i8 %18, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %23 = getelementptr i8, ptr %lookup_str_map, i32 4
-  %24 = load i8, ptr %23, align 1
-  %25 = getelementptr i8, ptr %comm, i32 4
+  %25 = getelementptr i8, ptr %2, i32 4
   %26 = load i8, ptr %25, align 1
-  %strcmp.cmp15 = icmp ne i8 %24, %26
+  %27 = getelementptr i8, ptr %comm, i32 4
+  %28 = load i8, ptr %27, align 1
+  %strcmp.cmp15 = icmp ne i8 %26, %28
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %20, 0
+  %strcmp.cmp_null12 = icmp eq i8 %22, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
-  %27 = getelementptr i8, ptr %lookup_str_map, i32 5
-  %28 = load i8, ptr %27, align 1
-  %29 = getelementptr i8, ptr %comm, i32 5
+  %29 = getelementptr i8, ptr %2, i32 5
   %30 = load i8, ptr %29, align 1
-  %strcmp.cmp19 = icmp ne i8 %28, %30
+  %31 = getelementptr i8, ptr %comm, i32 5
+  %32 = load i8, ptr %31, align 1
+  %strcmp.cmp19 = icmp ne i8 %30, %32
   br i1 %strcmp.cmp19, label %strcmp.false, label %strcmp.loop_null_cmp18
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %24, 0
+  %strcmp.cmp_null16 = icmp eq i8 %26, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 strcmp.loop17:                                    ; preds = %strcmp.loop_null_cmp18
-  %31 = getelementptr i8, ptr %lookup_str_map, i32 6
-  %32 = load i8, ptr %31, align 1
-  %33 = getelementptr i8, ptr %comm, i32 6
+  %33 = getelementptr i8, ptr %2, i32 6
   %34 = load i8, ptr %33, align 1
-  %strcmp.cmp23 = icmp ne i8 %32, %34
+  %35 = getelementptr i8, ptr %comm, i32 6
+  %36 = load i8, ptr %35, align 1
+  %strcmp.cmp23 = icmp ne i8 %34, %36
   br i1 %strcmp.cmp23, label %strcmp.false, label %strcmp.loop_null_cmp22
 
 strcmp.loop_null_cmp18:                           ; preds = %strcmp.loop13
-  %strcmp.cmp_null20 = icmp eq i8 %28, 0
+  %strcmp.cmp_null20 = icmp eq i8 %30, 0
   br i1 %strcmp.cmp_null20, label %strcmp.done, label %strcmp.loop17
 
 strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
-  %35 = getelementptr i8, ptr %lookup_str_map, i32 7
-  %36 = load i8, ptr %35, align 1
-  %37 = getelementptr i8, ptr %comm, i32 7
+  %37 = getelementptr i8, ptr %2, i32 7
   %38 = load i8, ptr %37, align 1
-  %strcmp.cmp27 = icmp ne i8 %36, %38
+  %39 = getelementptr i8, ptr %comm, i32 7
+  %40 = load i8, ptr %39, align 1
+  %strcmp.cmp27 = icmp ne i8 %38, %40
   br i1 %strcmp.cmp27, label %strcmp.false, label %strcmp.loop_null_cmp26
 
 strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop17
-  %strcmp.cmp_null24 = icmp eq i8 %32, 0
+  %strcmp.cmp_null24 = icmp eq i8 %34, 0
   br i1 %strcmp.cmp_null24, label %strcmp.done, label %strcmp.loop21
 
 strcmp.loop25:                                    ; preds = %strcmp.loop_null_cmp26
-  %39 = getelementptr i8, ptr %lookup_str_map, i32 8
-  %40 = load i8, ptr %39, align 1
-  %41 = getelementptr i8, ptr %comm, i32 8
+  %41 = getelementptr i8, ptr %2, i32 8
   %42 = load i8, ptr %41, align 1
-  %strcmp.cmp31 = icmp ne i8 %40, %42
+  %43 = getelementptr i8, ptr %comm, i32 8
+  %44 = load i8, ptr %43, align 1
+  %strcmp.cmp31 = icmp ne i8 %42, %44
   br i1 %strcmp.cmp31, label %strcmp.false, label %strcmp.loop_null_cmp30
 
 strcmp.loop_null_cmp26:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null28 = icmp eq i8 %36, 0
+  %strcmp.cmp_null28 = icmp eq i8 %38, 0
   br i1 %strcmp.cmp_null28, label %strcmp.done, label %strcmp.loop25
 
 strcmp.loop29:                                    ; preds = %strcmp.loop_null_cmp30
-  %43 = getelementptr i8, ptr %lookup_str_map, i32 9
-  %44 = load i8, ptr %43, align 1
-  %45 = getelementptr i8, ptr %comm, i32 9
+  %45 = getelementptr i8, ptr %2, i32 9
   %46 = load i8, ptr %45, align 1
-  %strcmp.cmp35 = icmp ne i8 %44, %46
+  %47 = getelementptr i8, ptr %comm, i32 9
+  %48 = load i8, ptr %47, align 1
+  %strcmp.cmp35 = icmp ne i8 %46, %48
   br i1 %strcmp.cmp35, label %strcmp.false, label %strcmp.loop_null_cmp34
 
 strcmp.loop_null_cmp30:                           ; preds = %strcmp.loop25
-  %strcmp.cmp_null32 = icmp eq i8 %40, 0
+  %strcmp.cmp_null32 = icmp eq i8 %42, 0
   br i1 %strcmp.cmp_null32, label %strcmp.done, label %strcmp.loop29
 
 strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
-  %47 = getelementptr i8, ptr %lookup_str_map, i32 10
-  %48 = load i8, ptr %47, align 1
-  %49 = getelementptr i8, ptr %comm, i32 10
+  %49 = getelementptr i8, ptr %2, i32 10
   %50 = load i8, ptr %49, align 1
-  %strcmp.cmp39 = icmp ne i8 %48, %50
+  %51 = getelementptr i8, ptr %comm, i32 10
+  %52 = load i8, ptr %51, align 1
+  %strcmp.cmp39 = icmp ne i8 %50, %52
   br i1 %strcmp.cmp39, label %strcmp.false, label %strcmp.loop_null_cmp38
 
 strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop29
-  %strcmp.cmp_null36 = icmp eq i8 %44, 0
+  %strcmp.cmp_null36 = icmp eq i8 %46, 0
   br i1 %strcmp.cmp_null36, label %strcmp.done, label %strcmp.loop33
 
 strcmp.loop37:                                    ; preds = %strcmp.loop_null_cmp38
-  %51 = getelementptr i8, ptr %lookup_str_map, i32 11
-  %52 = load i8, ptr %51, align 1
-  %53 = getelementptr i8, ptr %comm, i32 11
+  %53 = getelementptr i8, ptr %2, i32 11
   %54 = load i8, ptr %53, align 1
-  %strcmp.cmp43 = icmp ne i8 %52, %54
+  %55 = getelementptr i8, ptr %comm, i32 11
+  %56 = load i8, ptr %55, align 1
+  %strcmp.cmp43 = icmp ne i8 %54, %56
   br i1 %strcmp.cmp43, label %strcmp.false, label %strcmp.loop_null_cmp42
 
 strcmp.loop_null_cmp38:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null40 = icmp eq i8 %48, 0
+  %strcmp.cmp_null40 = icmp eq i8 %50, 0
   br i1 %strcmp.cmp_null40, label %strcmp.done, label %strcmp.loop37
 
 strcmp.loop41:                                    ; preds = %strcmp.loop_null_cmp42
-  %55 = getelementptr i8, ptr %lookup_str_map, i32 12
-  %56 = load i8, ptr %55, align 1
-  %57 = getelementptr i8, ptr %comm, i32 12
+  %57 = getelementptr i8, ptr %2, i32 12
   %58 = load i8, ptr %57, align 1
-  %strcmp.cmp47 = icmp ne i8 %56, %58
+  %59 = getelementptr i8, ptr %comm, i32 12
+  %60 = load i8, ptr %59, align 1
+  %strcmp.cmp47 = icmp ne i8 %58, %60
   br i1 %strcmp.cmp47, label %strcmp.false, label %strcmp.loop_null_cmp46
 
 strcmp.loop_null_cmp42:                           ; preds = %strcmp.loop37
-  %strcmp.cmp_null44 = icmp eq i8 %52, 0
+  %strcmp.cmp_null44 = icmp eq i8 %54, 0
   br i1 %strcmp.cmp_null44, label %strcmp.done, label %strcmp.loop41
 
 strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
-  %59 = getelementptr i8, ptr %lookup_str_map, i32 13
-  %60 = load i8, ptr %59, align 1
-  %61 = getelementptr i8, ptr %comm, i32 13
+  %61 = getelementptr i8, ptr %2, i32 13
   %62 = load i8, ptr %61, align 1
-  %strcmp.cmp51 = icmp ne i8 %60, %62
+  %63 = getelementptr i8, ptr %comm, i32 13
+  %64 = load i8, ptr %63, align 1
+  %strcmp.cmp51 = icmp ne i8 %62, %64
   br i1 %strcmp.cmp51, label %strcmp.false, label %strcmp.loop_null_cmp50
 
 strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop41
-  %strcmp.cmp_null48 = icmp eq i8 %56, 0
+  %strcmp.cmp_null48 = icmp eq i8 %58, 0
   br i1 %strcmp.cmp_null48, label %strcmp.done, label %strcmp.loop45
 
 strcmp.loop49:                                    ; preds = %strcmp.loop_null_cmp50
-  %63 = getelementptr i8, ptr %lookup_str_map, i32 14
-  %64 = load i8, ptr %63, align 1
-  %65 = getelementptr i8, ptr %comm, i32 14
+  %65 = getelementptr i8, ptr %2, i32 14
   %66 = load i8, ptr %65, align 1
-  %strcmp.cmp55 = icmp ne i8 %64, %66
+  %67 = getelementptr i8, ptr %comm, i32 14
+  %68 = load i8, ptr %67, align 1
+  %strcmp.cmp55 = icmp ne i8 %66, %68
   br i1 %strcmp.cmp55, label %strcmp.false, label %strcmp.loop_null_cmp54
 
 strcmp.loop_null_cmp50:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null52 = icmp eq i8 %60, 0
+  %strcmp.cmp_null52 = icmp eq i8 %62, 0
   br i1 %strcmp.cmp_null52, label %strcmp.done, label %strcmp.loop49
 
 strcmp.loop53:                                    ; preds = %strcmp.loop_null_cmp54
-  %67 = getelementptr i8, ptr %lookup_str_map, i32 15
-  %68 = load i8, ptr %67, align 1
-  %69 = getelementptr i8, ptr %comm, i32 15
+  %69 = getelementptr i8, ptr %2, i32 15
   %70 = load i8, ptr %69, align 1
-  %strcmp.cmp59 = icmp ne i8 %68, %70
+  %71 = getelementptr i8, ptr %comm, i32 15
+  %72 = load i8, ptr %71, align 1
+  %strcmp.cmp59 = icmp ne i8 %70, %72
   br i1 %strcmp.cmp59, label %strcmp.false, label %strcmp.loop_null_cmp58
 
 strcmp.loop_null_cmp54:                           ; preds = %strcmp.loop49
-  %strcmp.cmp_null56 = icmp eq i8 %64, 0
+  %strcmp.cmp_null56 = icmp eq i8 %66, 0
   br i1 %strcmp.cmp_null56, label %strcmp.done, label %strcmp.loop53
 
 strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
   br label %strcmp.done
 
 strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop53
-  %strcmp.cmp_null60 = icmp eq i8 %68, 0
+  %strcmp.cmp_null60 = icmp eq i8 %70, 0
   br i1 %strcmp.cmp_null60, label %strcmp.done, label %strcmp.loop57
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!53}
-!llvm.module.flags = !{!55}
+!llvm.dbg.cu = !{!48}
+!llvm.module.flags = !{!50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -319,28 +311,23 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !34 = !{!35}
 !35 = !DISubrange(count: 262144, lowerBound: 0)
 !36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "str_buffer", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !11, !16, !45}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 6, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !46, size: 64, offset: 192)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 512, elements: !49)
-!48 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
-!49 = !{!50}
-!50 = !DISubrange(count: 64, lowerBound: 0)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
-!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
-!54 = !{!0, !22, !36, !51}
-!55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "tracepoint_file_filename_1", linkageName: "tracepoint_file_filename_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!21, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 512, elements: !14)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 512, elements: !14)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 512, elements: !46)
+!45 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!46 = !{!47}
+!47 = !DISubrange(count: 64, lowerBound: 0)
+!48 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !49)
+!49 = !{!0, !22, !36, !38, !40}
+!50 = !{i32 2, !"Debug Info Version", i32 3}
+!51 = distinct !DISubprogram(name: "tracepoint_file_filename_1", linkageName: "tracepoint_file_filename_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !48, retainedNodes: !55)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!21, !54}
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)


### PR DESCRIPTION
Continuing to iterate on https://github.com/bpftrace/bpftrace/issues/3431

Global scratch maps allows users to use large strings in bpftrace. However, we've seen they can cause many jumps/branches in large programs. Global scratch variables allow both large strings and support complex programs via read-write global variables.

This PR is in preparation for adding a scratch buffer vs. stack threshold as described in https://github.com/bpftrace/bpftrace/pull/3483#issuecomment-2407858401