### PR TITLE
Support symbolizing enums

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -17,6 +17,16 @@ aot.call.str_big_printf
 aot.call.buf_map_multikey
 aot.call.cgroup_path
 aot.call.cgroup_path printf
+# Enum metadata is not being serialized
+aot.call.printf_enum_symbolize
+# Enum metadata is not being serialized
+aot.call.printf_enum_symbolize_map
+# Enum metadata is not being serialized
+aot.call.printf_enum_symbolize_var
+# Enum metadata is not being serialized
+aot.call.printf_enum_symbolize_width
+# Enum metadata is not being serialized
+aot.call.printf_enum_symbolize_tracepoint
 aot.call.hist_10g
 aot.call.iter:task
 aot.call.iter:task_file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
   - [#3301](https://github.com/bpftrace/bpftrace/pull/3095)
 - Variable declarations with `let`
   - [#3461](https://github.com/bpftrace/bpftrace/pull/3461)
+- Support symbolizing enum values using `%s` specifier in `printf()`
+  - [#3515](https://github.com/bpftrace/bpftrace/pull/3515)
 #### Changed
 - Merge output into `stdout` when `-lv`
   - [#3383](https://github.com/bpftrace/bpftrace/pull/3383)

--- a/flake.nix
+++ b/flake.nix
@@ -135,6 +135,7 @@
                   procps
                   python3
                   strace
+                  unixtools.ping
                   util-linux
                 ] ++ pkg.nativeBuildInputs ++ pkg.buildInputs;
 

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1949,7 +1949,27 @@ The non-standard ones can be found in the table below:
 
 |===
 
-Supported escape sequences
+`printf()` can also symbolize enums as strings. User defined enums as well as enums
+defined in the kernel are supported. For example:
+
+----
+enum custom {
+  CUSTOM_ENUM = 3,
+};
+
+BEGIN {
+  $r = SKB_DROP_REASON_SOCKET_FILTER;
+  printf("%d, %s, %s\n", $r, $r, CUSTOM_ENUM);
+  exit();
+}
+----
+
+yields:
+
+----
+6, SKB_DROP_REASON_SOCKET_FILTER, CUSTOM_ENUM
+----
+
 
 Colors are supported too, using standard terminal escape sequences:
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -167,7 +167,7 @@ void CodegenLLVM::visit(String &string)
 void CodegenLLVM::visit(Identifier &identifier)
 {
   if (bpftrace_.enums_.count(identifier.ident) != 0) {
-    expr_ = b_.getInt64(bpftrace_.enums_[identifier.ident]);
+    expr_ = b_.getInt64(std::get<0>(bpftrace_.enums_[identifier.ident]));
   } else {
     LOG(BUG) << "unknown identifier \"" << identifier.ident << "\"";
   }

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -213,7 +213,8 @@ void SemanticAnalyser::visit(StackMode &mode)
 void SemanticAnalyser::visit(Identifier &identifier)
 {
   if (bpftrace_.enums_.count(identifier.ident) != 0) {
-    identifier.type = CreateUInt64();
+    const auto &enum_name = std::get<1>(bpftrace_.enums_[identifier.ident]);
+    identifier.type = CreateEnum(64, enum_name);
   } else if (bpftrace_.structs.Has(identifier.ident)) {
     identifier.type = CreateRecord(identifier.ident,
                                    bpftrace_.structs.Lookup(identifier.ident));

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -182,8 +182,8 @@ public:
   BpfBytecode bytecode_;
   StructManager structs;
   std::map<std::string, std::string> macros_;
-  // Map of enum variant_name to variant_value
-  std::map<std::string, uint64_t> enums_;
+  // Map of enum variant_name to (variant_value, enum_name)
+  std::map<std::string, std::tuple<uint64_t, std::string>> enums_;
   // Map of enum_name to map of variant_value to variant_name
   std::map<std::string, std::map<uint64_t, std::string>> enum_defs_;
   std::map<libbpf::bpf_func_id, location> helper_use_loc_;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -182,7 +182,10 @@ public:
   BpfBytecode bytecode_;
   StructManager structs;
   std::map<std::string, std::string> macros_;
+  // Map of enum variant_name to variant_value
   std::map<std::string, uint64_t> enums_;
+  // Map of enum_name to map of variant_value to variant_name
+  std::map<std::string, std::map<uint64_t, std::string>> enum_defs_;
   std::map<libbpf::bpf_func_id, location> helper_use_loc_;
   const FuncsModulesMap &get_traceable_funcs() const;
   KConfig kconfig;

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -186,8 +186,13 @@ static SizedType get_sized_type(CXType clang_type, StructManager &structs)
     case CXType_LongLong:
     case CXType_Int:
       return CreateInt(size);
-    case CXType_Enum:
-      return CreateUInt(size);
+    case CXType_Enum: {
+      // The pretty printed type name contains `enum` prefix. That's not
+      // helpful for us, so remove it. We have our own metadata.
+      static std::regex re("enum ");
+      auto enum_name = std::regex_replace(typestr, re, "");
+      return CreateEnum(size, enum_name);
+    }
     case CXType_Pointer: {
       auto pointee_type = clang_getPointeeType(clang_type);
       return CreatePointer(get_sized_type(pointee_type, structs));

--- a/src/format_string.h
+++ b/src/format_string.h
@@ -2,9 +2,12 @@
 
 #include <ostream>
 #include <regex>
+#include <string>
+#include <tuple>
 #include <vector>
 
 #include "printf.h"
+#include "types.h"
 
 namespace bpftrace {
 
@@ -34,8 +37,12 @@ public:
    */
   FormatString() = default;
 
-  FormatString(const char *s) : fmt_(s){};
-  FormatString(std::string &s) : fmt_(s){};
+  FormatString(const char *s) : fmt_(s)
+  {
+  }
+  FormatString(std::string &s) : fmt_(s)
+  {
+  }
 
   /**
    * format formats the format string with the given args. Its up to the caller
@@ -82,14 +89,15 @@ private:
   std::string fmt_;
   std::vector<std::string> parts_;
   std::vector<ArgumentType> expected_types_;
+  std::vector<std::tuple<std::string, Type>> tokens_;
 
   friend class cereal::access;
 
   template <typename Archive>
   void serialize(Archive &ar)
   {
-    // NOTE: parts_ is not constructed until first use, so no point in
-    // serializing it
+    // NOTE: parts_, expected_types_, and tokens_ are not constructed until
+    // first use, so no point in serializing them
     ar(fmt_);
   }
 };

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -24,6 +24,7 @@ PrintableString::PrintableString(std::string value,
 int PrintableString::print(char *buf,
                            size_t size,
                            const char *fmt,
+                           Type,
                            ArgumentType)
 {
   return snprintf(buf, size, fmt, value_.c_str());
@@ -32,6 +33,7 @@ int PrintableString::print(char *buf,
 int PrintableBuffer::print(char *buf,
                            size_t size,
                            const char *fmt,
+                           Type,
                            ArgumentType)
 {
   return snprintf(
@@ -55,6 +57,7 @@ void PrintableBuffer::escape_hex(bool value)
 int PrintableCString::print(char *buf,
                             size_t size,
                             const char *fmt,
+                            Type,
                             ArgumentType)
 {
   return snprintf(buf, size, fmt, value_);
@@ -63,6 +66,7 @@ int PrintableCString::print(char *buf,
 int PrintableInt::print(char *buf,
                         size_t size,
                         const char *fmt,
+                        Type,
                         ArgumentType expected_type)
 {
   // Since the value is internally always stored as a 64-bit integer, a cast is
@@ -100,6 +104,7 @@ int PrintableInt::print(char *buf,
 int PrintableSInt::print(char *buf,
                          size_t size,
                          const char *fmt,
+                         Type,
                          ArgumentType expected_type)
 {
   switch (expected_type) {

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -1,4 +1,6 @@
 #include "printf.h"
+
+#include "log.h"
 #include "printf_format_types.h"
 #include "struct.h"
 
@@ -132,4 +134,22 @@ int PrintableSInt::print(char *buf,
 
   __builtin_unreachable();
 }
+
+int PrintableEnum::print(char *buf,
+                         size_t size,
+                         const char *fmt,
+                         Type token,
+                         ArgumentType expected_type)
+{
+  switch (token) {
+    case Type::integer:
+      return PrintableInt(value_).print(buf, size, fmt, token, expected_type);
+    case Type::string:
+      return snprintf(buf, size, fmt, name_.c_str());
+    default:
+      LOG(BUG) << "Invalid token type for enum";
+      __builtin_unreachable();
+  }
+}
+
 } // namespace bpftrace

--- a/src/printf.h
+++ b/src/printf.h
@@ -128,4 +128,20 @@ private:
   int64_t value_;
 };
 
+class PrintableEnum : public virtual IPrintable {
+public:
+  PrintableEnum(uint64_t value, std::string name) : name_(name), value_(value)
+  {
+  }
+  int print(char* buf,
+            size_t size,
+            const char* fmt,
+            Type token,
+            ArgumentType expected_type) override;
+
+private:
+  std::string name_;
+  uint64_t value_;
+};
+
 } // namespace bpftrace

--- a/src/printf.h
+++ b/src/printf.h
@@ -44,6 +44,7 @@ public:
   virtual int print(char* buf,
                     size_t size,
                     const char* fmt,
+                    Type token,
                     ArgumentType expected_type = ArgumentType::UNKNOWN) = 0;
 };
 
@@ -52,7 +53,11 @@ public:
   PrintableString(std::string value,
                   std::optional<size_t> buffer_size = std::nullopt,
                   const char* trunc_trailer = nullptr);
-  int print(char* buf, size_t size, const char* fmt, ArgumentType) override;
+  int print(char* buf,
+            size_t size,
+            const char* fmt,
+            Type,
+            ArgumentType) override;
 
 private:
   std::string value_;
@@ -64,7 +69,11 @@ public:
       : value_(std::vector<char>(buffer, buffer + size))
   {
   }
-  int print(char* buf, size_t size, const char* fmt, ArgumentType) override;
+  int print(char* buf,
+            size_t size,
+            const char* fmt,
+            Type,
+            ArgumentType) override;
   void keep_ascii(bool value);
   void escape_hex(bool value);
 
@@ -79,7 +88,11 @@ public:
   PrintableCString(char* value) : value_(value)
   {
   }
-  int print(char* buf, size_t size, const char* fmt, ArgumentType) override;
+  int print(char* buf,
+            size_t size,
+            const char* fmt,
+            Type,
+            ArgumentType) override;
 
 private:
   char* value_;
@@ -93,6 +106,7 @@ public:
   int print(char* buf,
             size_t size,
             const char* fmt,
+            Type token,
             ArgumentType expected_type) override;
 
 private:
@@ -107,6 +121,7 @@ public:
   int print(char* buf,
             size_t size,
             const char* fmt,
+            Type token,
             ArgumentType expected_type) override;
 
 private:

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cassert>
 #include <iostream>
+#include <sstream>
 
 #include "ast/async_event_types.h"
 #include "bpftrace.h"
@@ -102,6 +103,13 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   }
 
   return os;
+}
+
+std::string to_string(Type ty)
+{
+  std::ostringstream ss;
+  ss << ty;
+  return ss.str();
 }
 
 bool SizedType::IsSameType(const SizedType &t) const

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -371,6 +371,13 @@ SizedType CreateUInt64()
   return CreateUInt(64);
 }
 
+SizedType CreateEnum(size_t bits, const std::string &name)
+{
+  auto ty = CreateUInt(bits);
+  ty.name_ = name;
+  return ty;
+}
+
 SizedType CreateString(size_t size)
 {
   return SizedType(Type::string, size);

--- a/src/types.h
+++ b/src/types.h
@@ -150,7 +150,7 @@ private:
   size_t size_bits_ = 0;                    // size in bits
   std::shared_ptr<SizedType> element_type_; // for "container" and pointer
                                             // (like) types
-  std::string name_; // name of this type, for named types like struct
+  std::string name_; // name of this type, for named types like struct and enum
   std::weak_ptr<Struct> inner_struct_; // inner struct for records and tuples
                                        // the actual Struct object is owned by
                                        // StructManager
@@ -302,7 +302,7 @@ public:
 
   const std::string GetName() const
   {
-    assert(IsRecordTy());
+    assert(IsRecordTy() || IsEnumTy());
     return name_;
   }
 
@@ -345,6 +345,10 @@ public:
   {
     return type_ == Type::integer;
   };
+  bool IsEnumTy() const
+  {
+    return IsIntTy() && name_.size();
+  }
   bool IsNoneTy(void) const
   {
     return type_ == Type::none;
@@ -485,6 +489,7 @@ public:
 
   // Factories
 
+  friend SizedType CreateEnum(size_t bits, const std::string &name);
   friend SizedType CreateArray(size_t num_elements,
                                const SizedType &element_type);
 
@@ -511,6 +516,7 @@ SizedType CreateUInt8();
 SizedType CreateUInt16();
 SizedType CreateUInt32();
 SizedType CreateUInt64();
+SizedType CreateEnum(size_t bits, const std::string &name);
 
 SizedType CreateString(size_t size);
 SizedType CreateArray(size_t num_elements, const SizedType &element_type);

--- a/src/types.h
+++ b/src/types.h
@@ -65,6 +65,7 @@ enum class AddrSpace : uint8_t {
 
 std::ostream &operator<<(std::ostream &os, Type type);
 std::ostream &operator<<(std::ostream &os, AddrSpace as);
+std::string to_string(Type ty);
 
 enum class UserSymbolCacheType {
   per_pid,

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -1,10 +1,13 @@
 #include "clang_parser.h"
+
+#include <iostream>
+#include <utility>
+
 #include "ast/passes/field_analyser.h"
 #include "bpftrace.h"
 #include "driver.h"
 #include "struct.h"
 #include "gtest/gtest.h"
-#include <iostream>
 #include <llvm/Config/llvm-config.h>
 
 namespace bpftrace::test::clang_parser {
@@ -89,7 +92,7 @@ TEST(clang_parser, c_union)
 TEST(clang_parser, c_enum)
 {
   BPFtrace bpftrace;
-  parse("enum E {NONE}; struct Foo { enum E e; }", bpftrace);
+  parse("enum E { NONE, SOME = 99, }; struct Foo { enum E e; }", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
   auto foo = bpftrace.structs.Lookup("struct Foo").lock();
@@ -101,6 +104,92 @@ TEST(clang_parser, c_enum)
   EXPECT_TRUE(foo->GetField("e").type.IsIntTy());
   EXPECT_EQ(foo->GetField("e").type.GetSize(), 4U);
   EXPECT_EQ(foo->GetField("e").offset, 0);
+
+  ASSERT_TRUE(bpftrace.enums_.contains("NONE"));
+  EXPECT_EQ(std::get<0>(bpftrace.enums_["NONE"]), 0);
+  EXPECT_EQ(std::get<1>(bpftrace.enums_["NONE"]), "E");
+  ASSERT_TRUE(bpftrace.enums_.contains("SOME"));
+  EXPECT_EQ(std::get<0>(bpftrace.enums_["SOME"]), 99);
+  EXPECT_EQ(std::get<1>(bpftrace.enums_["SOME"]), "E");
+
+  ASSERT_TRUE(bpftrace.enum_defs_.contains("E"));
+  ASSERT_TRUE(bpftrace.enum_defs_["E"].contains(0));
+  EXPECT_EQ(bpftrace.enum_defs_["E"][0], "NONE");
+  ASSERT_TRUE(bpftrace.enum_defs_["E"].contains(99));
+  EXPECT_EQ(bpftrace.enum_defs_["E"][99], "SOME");
+}
+
+TEST(clang_parser, c_enum_anonymous)
+{
+  BPFtrace bpftrace;
+  parse(
+      "enum { ANON_A_VARIANT_1 = 0, ANON_A_VARIANT_2, ANON_A_CONFLICT = 99, }; "
+      "enum { ANON_B_VARIANT_1 = 0, ANON_B_CONFLICT = 99, }; ",
+      bpftrace);
+
+  ASSERT_EQ(bpftrace.enums_.size(), 5);
+  ASSERT_EQ(bpftrace.enum_defs_.size(), 2);
+
+  //
+  // Check enums_ contains first anonymous enum
+  //
+
+  // Check first variant present
+  ASSERT_TRUE(bpftrace.enums_.contains("ANON_A_VARIANT_1"));
+  EXPECT_EQ(std::get<0>(bpftrace.enums_["ANON_A_VARIANT_1"]), 0);
+  auto anon_a_name = std::get<1>(bpftrace.enums_["ANON_A_VARIANT_1"]);
+  ASSERT_FALSE(anon_a_name.empty());
+
+  // Check second variant present
+  ASSERT_TRUE(bpftrace.enums_.contains("ANON_A_VARIANT_2"));
+  EXPECT_EQ(std::get<0>(bpftrace.enums_["ANON_A_VARIANT_2"]), 1);
+  EXPECT_EQ(std::get<1>(bpftrace.enums_["ANON_A_CONFLICT"]), anon_a_name);
+
+  // Check conflict variant present
+  ASSERT_TRUE(bpftrace.enums_.contains("ANON_A_CONFLICT"));
+  EXPECT_EQ(std::get<0>(bpftrace.enums_["ANON_A_CONFLICT"]), 99);
+  EXPECT_EQ(std::get<1>(bpftrace.enums_["ANON_A_CONFLICT"]), anon_a_name);
+
+  //
+  // Check enum_defs_ contains first anonymous enum, with ANON_A_CONFLICT
+  // value resolving correctly to the this enum and not the other.
+  //
+
+  ASSERT_TRUE(bpftrace.enum_defs_.contains(anon_a_name));
+  ASSERT_EQ(bpftrace.enum_defs_[anon_a_name].size(), 3);
+  ASSERT_TRUE(bpftrace.enum_defs_[anon_a_name].contains(0));
+  EXPECT_EQ(bpftrace.enum_defs_[anon_a_name][0], "ANON_A_VARIANT_1");
+  ASSERT_TRUE(bpftrace.enum_defs_[anon_a_name].contains(1));
+  EXPECT_EQ(bpftrace.enum_defs_[anon_a_name][1], "ANON_A_VARIANT_2");
+  ASSERT_TRUE(bpftrace.enum_defs_[anon_a_name].contains(99));
+  EXPECT_EQ(bpftrace.enum_defs_[anon_a_name][99], "ANON_A_CONFLICT");
+
+  //
+  // Check enums_ contains second anonymous enum
+  //
+
+  // Check first variant present
+  ASSERT_TRUE(bpftrace.enums_.contains("ANON_B_VARIANT_1"));
+  EXPECT_EQ(std::get<0>(bpftrace.enums_["ANON_B_VARIANT_1"]), 0);
+  auto anon_b_name = std::get<1>(bpftrace.enums_["ANON_B_VARIANT_1"]);
+  ASSERT_FALSE(anon_b_name.empty());
+
+  // Check conflict variant present
+  ASSERT_TRUE(bpftrace.enums_.contains("ANON_B_CONFLICT"));
+  EXPECT_EQ(std::get<0>(bpftrace.enums_["ANON_B_CONFLICT"]), 99);
+  EXPECT_EQ(std::get<1>(bpftrace.enums_["ANON_B_CONFLICT"]), anon_b_name);
+
+  //
+  // Check enum_defs_ contains second anonymous enum, with ANON_B_CONFLICT
+  // value resolving correctly to the this enum and not the first.
+  //
+
+  ASSERT_TRUE(bpftrace.enum_defs_.contains(anon_b_name));
+  ASSERT_EQ(bpftrace.enum_defs_[anon_b_name].size(), 2);
+  ASSERT_TRUE(bpftrace.enum_defs_[anon_b_name].contains(0));
+  EXPECT_EQ(bpftrace.enum_defs_[anon_b_name][0], "ANON_B_VARIANT_1");
+  ASSERT_TRUE(bpftrace.enum_defs_[anon_b_name].contains(99));
+  EXPECT_EQ(bpftrace.enum_defs_[anon_b_name][99], "ANON_B_CONFLICT");
 }
 
 TEST(clang_parser, integer_ptr)

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -30,6 +30,28 @@ NAME printf_char
 PROG BEGIN { printf("%c%c%c%c\n", 0x41, 0x42, 0x43, 0x44); exit(); }
 EXPECT ABCD
 
+NAME printf_enum_symbolize
+PROG enum Foo { ONE = 1, TWO = 2, OTHER = 99999 }; BEGIN { printf("%d %s %d %s %d %s\n", ONE, ONE, TWO, TWO, OTHER, OTHER); exit() }
+EXPECT 1 ONE 2 TWO 99999 OTHER
+
+NAME printf_enum_symbolize_var
+PROG enum Foo { ONE = 1, TWO = 2, OTHER = 99999 }; BEGIN { $one = ONE; $two = TWO; $other = OTHER; printf("%d %s %d %s %d %s\n", $one, $one, $two, $two, $other, $other); exit() }
+EXPECT 1 ONE 2 TWO 99999 OTHER
+
+NAME printf_enum_symbolize_map
+PROG enum Foo { ONE = 1, TWO = 2, OTHER = 99999 }; BEGIN { @one = ONE; @two = TWO; @other = OTHER; printf("%d %s %d %s %d %s\n", @one, @one, @two, @two, @other, @other); exit() }
+EXPECT 1 ONE 2 TWO 99999 OTHER
+
+NAME printf_enum_symbolize_width
+PROG enum Foo { A, B, C, }; BEGIN { printf("%-5s %5s %s\n", A, B, C); exit() }
+EXPECT A         B C
+
+NAME printf_enum_symbolize_tracepoint
+PROG tracepoint:skb:kfree_skb { $r = args->reason; printf("%d %s\n", args->reason, $r); exit() }
+EXPECT_REGEX ^\d+ [A-Z_]+$
+AFTER ping localhost -c 5
+TIMEOUT 5
+
 NAME time
 PROG i:ms:1 { time("%H:%M:%S\n"); exit();}
 EXPECT_REGEX [0-9]*:[0-9]*:[0-9]*

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -142,9 +142,9 @@ class TestParser(object):
                     expects[-1].expect += '\n' + line
                     continue
 
-            item_split = item.split()
+            item_split = item.strip().split(maxsplit=1)
             item_name = item_split[0]
-            line = ' '.join(item_split[1:])
+            line = item_split[1] if len(item_split) > 1 else ""
             prev_item_name = item_name
 
             if item_name == 'NAME':

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2567,7 +2567,24 @@ TEST(semantic_analyser, macros)
 
 TEST(semantic_analyser, enums)
 {
+  // Anonymous enums have empty string names in libclang <= 15,
+  // so this is an important test
   test("enum { a = 1, b } kprobe:f { printf(\"%d\", a); }");
+  test("enum { a = 1, b } kprobe:f { printf(\"%s\", a); }");
+  test("enum { a = 1, b } kprobe:f { $e = a; printf(\"%s\", $e); }");
+  test("enum { a = 1, b } kprobe:f { printf(\"%15s %-15s\", a, a); }");
+
+  test("enum named { a = 1, b } kprobe:f { printf(\"%d\", a); }");
+  test("enum named { a = 1, b } kprobe:f { printf(\"%s\", a); }");
+  test("enum named { a = 1, b } kprobe:f { $e = a; printf(\"%s\", $e); }");
+  test("enum named { a = 1, b } kprobe:f { printf(\"%15s %-15s\", a, a); }");
+
+  // Cannot symbolize a non-enum
+  test_error("kprobe:f { $x = (uint8)1; printf(\"%s\", $x) }", R"(
+stdin:1:27-43: ERROR: printf: %s specifier expects a value of type string (int supplied)
+kprobe:f { $x = (uint8)1; printf("%s", $x) }
+                          ~~~~~~~~~~~~~~~~
+)");
 }
 
 TEST(semantic_analyser, signed_int_comparison_warnings)


### PR DESCRIPTION
This PR allows the user to symbolize enums in userspace by
using `%s` printf() specifier. This is a fully backwards compatible
change, as trying to use `%s` on an enum was a compile error
before.

Example:
```
# bpftrace -e 'tracepoint:skb:kfree_skb { $r = args->reason; printf("%d, %s\n", $r, $r); exit() }'
Attaching 1 probe...
2, SKB_DROP_REASON_NOT_SPECIFIED
```

Note this PR does not support casting integers to enums. While
this is technically possible (and described in the linked ticket), it's
probably not necessary as users can simply perform arithmetic
operations on an enum and get the same result. There's currently
a limitation but it's being fixed in #3517.

This is easier to review per-commit.

This closes #2772.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
