### PR TITLE
ints: Support subword binary operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ and this project adheres to
   - [#3453](https://github.com/bpftrace/bpftrace/pull/3453)
 - Fix json formatting for hex values
   - [#3475](https://github.com/bpftrace/bpftrace/pull/3475)
+- Fix binary operations on integers always returning 64 bit values
+  - [#3517](https://github.com/bpftrace/bpftrace/pull/3517)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -675,7 +675,15 @@ The following operators are available for integer arithmetic:
 
 |===
 
-// TODO: Words about integer conversion when types mismatch
+Operations between a signed and an unsigned integer are allowed providing
+bpftrace can statically prove a safe conversion is possible. If safe conversion
+is not guaranteed, the operation is undefined behavior and a corresponding
+warning will be emitted.
+
+If the two operands are different size, the smaller integer is implicitly
+promoted to the size of the larger one. Sign is preserved in the promotion.
+For example, `(uint32)5 + (uint8)3` is converted to `(uint32)5 + (uint32)3`
+which results in `(uint32)8`.
 
 ==== Logical Operators
 
@@ -2553,7 +2561,7 @@ kprobe:dummy {
   if (has_key(@scalar)) { // error
     print(("hello"));
   }
-  
+
   $a = has_key(@associative, (1,2)); // ok
   @b[has_key(@associative, (1,2))] = has_key(@associative, (1,2)); // ok
 }

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1656,9 +1656,11 @@ void CodegenLLVM::binop_int(Binop &binop)
   bool lsign = binop.left->type.IsSigned();
   bool rsign = binop.right->type.IsSigned();
   bool do_signed = lsign && rsign;
-  // promote int to 64-bit
-  lhs = b_.CreateIntCast(lhs, b_.getInt64Ty(), lsign);
-  rhs = b_.CreateIntCast(rhs, b_.getInt64Ty(), rsign);
+
+  // Promote operands if necessary
+  auto size = binop.type.GetSize();
+  lhs = b_.CreateIntCast(lhs, b_.getIntNTy(size * 8), lsign);
+  rhs = b_.CreateIntCast(rhs, b_.getIntNTy(size * 8), rsign);
 
   switch (binop.op) {
     case Operator::EQ:

--- a/tests/codegen/binop_int_promotion.cpp
+++ b/tests/codegen/binop_int_promotion.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, binop_int_promotion)
+{
+  test("kretprobe:f { $x = (uint32)5; $x += (uint16)1 }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/basic_while_loop.ll
+++ b/tests/codegen/llvm/basic_while_loop.ll
@@ -28,18 +28,17 @@ entry:
 while_cond:                                       ; preds = %while_body, %entry
   %1 = load i64, ptr %"$a", align 8
   %2 = icmp sle i64 %1, 150
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !48
 
 while_body:                                       ; preds = %while_cond
-  %4 = load i64, ptr %"$a", align 8
-  %5 = add i64 %4, 1
-  store i64 %5, ptr %"$a", align 8
+  %3 = load i64, ptr %"$a", align 8
+  %4 = add i64 %3, 1
+  store i64 %4, ptr %"$a", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 %4, ptr %"@_val", align 8
+  store i64 %3, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")

--- a/tests/codegen/llvm/binop_int_promotion.ll
+++ b/tests/codegen/llvm/binop_int_promotion.ll
@@ -1,0 +1,82 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kretprobe_f_1(ptr %0) section "s_kretprobe_f_1" !dbg !39 {
+entry:
+  %"$x" = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
+  store i32 0, ptr %"$x", align 4
+  store i32 5, ptr %"$x", align 4
+  %1 = load i32, ptr %"$x", align 4
+  %2 = add i32 %1, 1
+  store i32 %2, ptr %"$x", align 4
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kretprobe_f_1", linkageName: "kretprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/llvm/comparison_extend.ll
+++ b/tests/codegen/llvm/comparison_extend.ll
@@ -22,9 +22,9 @@ entry:
   %1 = getelementptr i64, ptr %0, i64 14
   %arg0 = load volatile i64, ptr %1, align 8
   %2 = icmp ult i64 1, %arg0
-  %3 = zext i1 %2 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
+  %3 = zext i1 %2 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 %3, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -26,19 +26,18 @@ entry:
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
   %3 = icmp ugt i64 %2, 10
-  %4 = zext i1 %3 to i64
-  %true_cond = icmp ne i64 %4, 0
+  %true_cond = icmp ne i1 %3, false
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %5 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %5
-  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
-  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
-  store i64 0, ptr %7, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 8, i64 0)
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %4
+  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
+  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
+  store i64 0, ptr %6, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -47,13 +46,13 @@ if_end:                                           ; preds = %counter_merge5, %co
 
 else_body:                                        ; preds = %entry
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
-  %8 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded2 = and i64 %get_cpu_id1, %8
-  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
-  %10 = getelementptr %printf_t.1, ptr %9, i32 0, i32 0
-  store i64 1, ptr %10, align 8
-  %ringbuf_output3 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %9, i64 8, i64 0)
+  %7 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded2 = and i64 %get_cpu_id1, %7
+  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 8, i1 false)
+  %9 = getelementptr %printf_t.1, ptr %8, i32 0, i32 0
+  store i64 1, ptr %9, align 8
+  %ringbuf_output3 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %8, i64 8, i64 0)
   %ringbuf_loss6 = icmp slt i64 %ringbuf_output3, 0
   br i1 %ringbuf_loss6, label %event_loss_counter4, label %counter_merge5
 
@@ -68,7 +67,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %11 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -89,7 +88,7 @@ counter_merge5:                                   ; preds = %lookup_merge11, %el
   br label %if_end
 
 lookup_success9:                                  ; preds = %event_loss_counter4
-  %12 = atomicrmw add ptr %lookup_elem8, i64 1 seq_cst, align 8
+  %11 = atomicrmw add ptr %lookup_elem8, i64 1 seq_cst, align 8
   br label %lookup_merge11
 
 lookup_failure10:                                 ; preds = %event_loss_counter4

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -24,19 +24,17 @@ entry:
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
   %3 = icmp ugt i64 %2, 10000
-  %4 = zext i1 %3 to i64
-  %true_cond = icmp ne i64 %4, 0
+  %true_cond = icmp ne i1 %3, false
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
   %get_pid_tgid3 = call i64 inttoptr (i64 14 to ptr)()
-  %5 = lshr i64 %get_pid_tgid3, 32
-  %pid4 = trunc i64 %5 to i32
-  %6 = zext i32 %pid4 to i64
-  %7 = urem i64 %6, 2
-  %8 = icmp eq i64 %7, 0
-  %9 = zext i1 %8 to i64
-  %true_cond5 = icmp ne i64 %9, 0
+  %4 = lshr i64 %get_pid_tgid3, 32
+  %pid4 = trunc i64 %4 to i32
+  %5 = zext i32 %pid4 to i64
+  %6 = urem i64 %5, 2
+  %7 = icmp eq i64 %6, 0
+  %true_cond5 = icmp ne i1 %7, false
   br i1 %true_cond5, label %if_body1, label %if_end2
 
 if_end:                                           ; preds = %if_end2, %entry
@@ -44,13 +42,13 @@ if_end:                                           ; preds = %if_end2, %entry
 
 if_body1:                                         ; preds = %if_body
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %10 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %10
-  %11 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %11, i8 0, i64 8, i1 false)
-  %12 = getelementptr %printf_t, ptr %11, i32 0, i32 0
-  store i64 0, ptr %12, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %11, i64 8, i64 0)
+  %8 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %8
+  %9 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %9, i8 0, i64 8, i1 false)
+  %10 = getelementptr %printf_t, ptr %9, i32 0, i32 0
+  store i64 0, ptr %10, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %9, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -68,7 +66,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end2
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %13 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %11 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -24,25 +24,24 @@ entry:
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
   %3 = icmp ugt i64 %2, 10000
-  %4 = zext i1 %3 to i64
-  %true_cond = icmp ne i64 %4, 0
+  %true_cond = icmp ne i1 %3, false
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %5 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %5
-  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
-  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
-  store i64 0, ptr %7, align 8
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %4
+  %5 = getelementptr [1 x [1 x [16 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
+  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
+  store i64 0, ptr %6, align 8
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %8 = lshr i64 %get_pid_tgid1, 32
-  %pid2 = trunc i64 %8 to i32
-  %9 = getelementptr %printf_t, ptr %6, i32 0, i32 1
-  %10 = zext i32 %pid2 to i64
-  store i64 %10, ptr %9, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 16, i64 0)
+  %7 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %7 to i32
+  %8 = getelementptr %printf_t, ptr %5, i32 0, i32 1
+  %9 = zext i32 %pid2 to i64
+  store i64 %9, ptr %8, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -60,7 +59,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   br label %if_end
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %11 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter

--- a/tests/codegen/llvm/logical_and.ll
+++ b/tests/codegen/llvm/logical_and.ll
@@ -26,18 +26,16 @@ entry:
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
   %3 = icmp ne i64 %2, 1234
-  %4 = zext i1 %3 to i64
-  %lhs_true_cond = icmp ne i64 %4, 0
+  %lhs_true_cond = icmp ne i1 %3, false
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %5 = lshr i64 %get_pid_tgid1, 32
-  %pid2 = trunc i64 %5 to i32
-  %6 = zext i32 %pid2 to i64
-  %7 = icmp ne i64 %6, 1235
-  %8 = zext i1 %7 to i64
-  %rhs_true_cond = icmp ne i64 %8, 0
+  %4 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %4 to i32
+  %5 = zext i32 %pid2 to i64
+  %6 = icmp ne i64 %5, 1235
+  %rhs_true_cond = icmp ne i1 %6, false
   br i1 %rhs_true_cond, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
@@ -49,11 +47,11 @@ entry:
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %9 = load i64, ptr %"&&_result", align 8
+  %7 = load i64, ptr %"&&_result", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %9, ptr %"@x_val", align 8
+  store i64 %7, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/logical_or.ll
+++ b/tests/codegen/llvm/logical_or.ll
@@ -26,18 +26,16 @@ entry:
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
   %3 = icmp eq i64 %2, 1234
-  %4 = zext i1 %3 to i64
-  %lhs_true_cond = icmp ne i64 %4, 0
+  %lhs_true_cond = icmp ne i1 %3, false
   br i1 %lhs_true_cond, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %entry
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
-  %5 = lshr i64 %get_pid_tgid1, 32
-  %pid2 = trunc i64 %5 to i32
-  %6 = zext i32 %pid2 to i64
-  %7 = icmp eq i64 %6, 1235
-  %8 = zext i1 %7 to i64
-  %rhs_true_cond = icmp ne i64 %8, 0
+  %4 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %4 to i32
+  %5 = zext i32 %pid2 to i64
+  %6 = icmp eq i64 %5, 1235
+  %rhs_true_cond = icmp ne i1 %6, false
   br i1 %rhs_true_cond, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
@@ -49,11 +47,11 @@ entry:
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %9 = load i64, ptr %"||_result", align 8
+  %7 = load i64, ptr %"||_result", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %9, ptr %"@x_val", align 8
+  store i64 %7, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/nested_while_loop.ll
+++ b/tests/codegen/llvm/nested_while_loop.ll
@@ -32,25 +32,23 @@ entry:
 while_cond:                                       ; preds = %while_end3, %entry
   %1 = load i64, ptr %"$i", align 8
   %2 = icmp sle i64 %1, 100
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !48
 
 while_body:                                       ; preds = %while_cond
   store i64 0, ptr %"$j", align 8
-  %4 = load i64, ptr %"$i", align 8
-  %5 = add i64 %4, 1
-  store i64 %5, ptr %"$i", align 8
+  %3 = load i64, ptr %"$i", align 8
+  %4 = add i64 %3, 1
+  store i64 %4, ptr %"$i", align 8
   br label %while_cond1
 
 while_end:                                        ; preds = %while_cond
   ret i64 0
 
 while_cond1:                                      ; preds = %lookup_merge, %while_body
-  %6 = load i64, ptr %"$j", align 8
-  %7 = icmp sle i64 %6, 100
-  %8 = zext i1 %7 to i64
-  %true_cond4 = icmp ne i64 %8, 0
+  %5 = load i64, ptr %"$j", align 8
+  %6 = icmp sle i64 %5, 100
+  %true_cond4 = icmp ne i1 %6, false
   br i1 %true_cond4, label %while_body2, label %while_end3, !llvm.loop !48
 
 while_body2:                                      ; preds = %while_cond1
@@ -65,8 +63,8 @@ while_end3:                                       ; preds = %while_cond1
   br label %while_cond
 
 lookup_success:                                   ; preds = %while_body2
-  %9 = load i64, ptr %lookup_elem, align 8
-  store i64 %9, ptr %lookup_elem_val, align 8
+  %7 = load i64, ptr %lookup_elem, align 8
+  store i64 %7, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %while_body2
@@ -74,17 +72,17 @@ lookup_failure:                                   ; preds = %while_body2
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %10 = load i64, ptr %lookup_elem_val, align 8
+  %8 = load i64, ptr %lookup_elem_val, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_newval")
-  %11 = add i64 %10, 1
-  store i64 %11, ptr %"@_newval", align 8
+  %9 = add i64 %8, 1
+  store i64 %9, ptr %"@_newval", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_newval", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_newval")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
-  %12 = load i64, ptr %"$j", align 8
-  %13 = add i64 %12, 1
-  store i64 %13, ptr %"$j", align 8
+  %10 = load i64, ptr %"$j", align 8
+  %11 = add i64 %10, 1
+  store i64 %11, ptr %"$j", align 8
   br label %while_cond1
 }
 

--- a/tests/codegen/llvm/ternary_int.ll
+++ b/tests/codegen/llvm/ternary_int.ll
@@ -24,8 +24,7 @@ entry:
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
   %3 = icmp ult i64 %2, 10000
-  %4 = zext i1 %3 to i64
-  %true_cond = icmp ne i64 %4, 0
+  %true_cond = icmp ne i1 %3, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -27,28 +27,27 @@ entry:
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
   %3 = icmp ult i64 %2, 10000
-  %4 = zext i1 %3 to i64
-  %true_cond = icmp ne i64 %4, 0
+  %true_cond = icmp ne i1 %3, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %5 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %5
-  %6 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 8, i1 false)
-  %7 = getelementptr %printf_t, ptr %6, i32 0, i32 0
-  store i64 0, ptr %7, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %6, i64 8, i64 0)
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %4
+  %5 = getelementptr [1 x [1 x [8 x i8]]], ptr @fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 8, i1 false)
+  %6 = getelementptr %printf_t, ptr %5, i32 0, i32 0
+  store i64 0, ptr %6, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %5, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 right:                                            ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
-  %8 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %8, align 8
-  %9 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
-  store i8 0, ptr %9, align 1
+  %7 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
+  store i64 30000, ptr %7, align 8
+  %8 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
+  store i8 0, ptr %8, align 1
   %ringbuf_output1 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)
   %ringbuf_loss4 = icmp slt i64 %ringbuf_output1, 0
   br i1 %ringbuf_loss4, label %event_loss_counter2, label %counter_merge3
@@ -67,7 +66,7 @@ counter_merge:                                    ; preds = %lookup_merge, %left
   br label %done
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %10 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %9 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -89,7 +88,7 @@ counter_merge3:                                   ; preds = %lookup_merge9, %rig
   ret i64 0
 
 lookup_success7:                                  ; preds = %event_loss_counter2
-  %11 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
+  %10 = atomicrmw add ptr %lookup_elem6, i64 1 seq_cst, align 8
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %event_loss_counter2

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -61,8 +61,7 @@ lookup_str_merge:                                 ; preds = %entry
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
   %3 = icmp ult i64 %2, 10000
-  %4 = zext i1 %3 to i64
-  %true_cond = icmp ne i64 %4, 0
+  %true_cond = icmp ne i1 %3, false
   br i1 %true_cond, label %left, label %right
 }
 

--- a/tests/codegen/llvm/while_loop_no_unroll.ll
+++ b/tests/codegen/llvm/while_loop_no_unroll.ll
@@ -28,18 +28,17 @@ entry:
 while_cond:                                       ; preds = %while_body, %entry
   %1 = load i64, ptr %"$a", align 8
   %2 = icmp sle i64 %1, 10
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !48
 
 while_body:                                       ; preds = %while_cond
-  %4 = load i64, ptr %"$a", align 8
-  %5 = add i64 %4, 1
-  store i64 %5, ptr %"$a", align 8
+  %3 = load i64, ptr %"$a", align 8
+  %4 = add i64 %3, 1
+  store i64 %4, ptr %"$a", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 %4, ptr %"@_val", align 8
+  store i64 %3, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")

--- a/tests/runtime/intcast
+++ b/tests/runtime/intcast
@@ -15,3 +15,19 @@ EXPECT Values: 246 15
 NAME Implicit truncation of ints
 PROG BEGIN{ $a = (int16)0; $a = 2; $b = (int8)3; $b = -100; print(($a, $b)); exit(); }
 EXPECT (2, -100)
+
+NAME Binop on 32bit int
+PROG BEGIN { $x = (uint32)5; $x += (uint32)1; print($x); exit() }
+EXPECT 6
+
+NAME Binop on 16bit int
+PROG BEGIN { $x = (uint16)0xFF; $x &= (uint16)0xF; print($x); exit() }
+EXPECT 15
+
+NAME Binop on 8bit int
+PROG BEGIN { $x = (uint8)0xF; $x |= (uint8)0xF0; print($x); exit() }
+EXPECT 255
+
+NAME Binop promotion
+PROG BEGIN { $x = (uint32)0; $x = (uint32)5 + (uint16)1; print($x); exit() }
+EXPECT 6


### PR DESCRIPTION
Previously, all binary operations result in a 64 bit signed integer.
This causes issues when you try to do things like:

    $x = (uint32)5; $x |= 1;

Even explicitly casting the literal does not help:

    $x = (uint32)5; $x |= (uint32)1;

Both result in the error:

    Integer size mismatch. Assignment type 'uint64' is larger than the
    variable type 'uint32'.

This commit teaches semantic analyser and codegen to promote to only the
necessary size and not always 64 bits.

This closes https://github.com/bpftrace/bpftrace/issues/3516.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
