### PR TITLE
has_key: only skip key validation for first arg

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -549,7 +549,7 @@ namespace {
 bool skip_key_validation(const Call &call)
 {
   return call.func == "print" || call.func == "clear" || call.func == "zero" ||
-         call.func == "len" || call.func == "has_key";
+         call.func == "len";
 }
 } // namespace
 
@@ -591,8 +591,8 @@ void SemanticAnalyser::visit(Call &call)
 
       // If the map is indexed, don't skip key validation
       if (map.key_expr == nullptr) {
-        // Delete expects just a map reference for the first argument
-        if (call.func == "delete" && i == 0) {
+        // These calls expect just a map reference for the first argument
+        if ((call.func == "delete" || call.func == "has_key") && i == 0) {
           map.skip_key_validation = true;
         } else if (skip_key_validation(call)) {
           map.skip_key_validation = true;

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1116,6 +1116,7 @@ TEST(semantic_analyser, call_has_key)
       R"(kprobe:f { @x[1, "longerstr"] = 0; if (has_key(@x, (2, "hi"))) {} })");
   test("kprobe:f { @x[1, 2] = 0; $a = (3, 4); if (has_key(@x, $a)) {} }");
   test("kprobe:f { @x[1, 2] = 0; @a = (3, 4); if (has_key(@x, @a)) {} }");
+  test("kprobe:f { @x[1, 2] = 0; @a[1] = (3, 4); if (has_key(@x, @a[1])) {} }");
   test("kprobe:f { @x[1] = 0; @a = has_key(@x, 1); }");
   test("kprobe:f { @x[1] = 0; $a = has_key(@x, 1); }");
   test("kprobe:f { @x[1] = 0; @a[has_key(@x, 1)] = 1; }");
@@ -1160,6 +1161,12 @@ kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, 1))) {} }
 stdin:1:34-45: ERROR: has_key() expects the first argument to be a map
 kprobe:f { @x[1] = 1; $a = 1; if (has_key($a, 1)) {} }
                                  ~~~~~~~~~~~
+)");
+
+  test_error("kprobe:f { @a[1] = 1; has_key(@a, @a); }", R"(
+stdin:1:35-37: ERROR: Argument mismatch for @a: trying to access with no arguments when map expects arguments: 'int64'
+kprobe:f { @a[1] = 1; has_key(@a, @a); }
+                                  ~~
 )");
 }
 


### PR DESCRIPTION
Similar to the new `delete` API, `has_key` expects only a map reference as the first argument but the second arg should be treated normally and have map key validation.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
