### PR TITLE
docs: Clarify -c COMMAND implicit filtering

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -68,8 +68,11 @@ When the child terminates bpftrace will also terminate, as if 'exit()' had been 
 If bpftrace terminates before the child process does the child process will be terminated with a SIGTERM.
 If used, 'USDT' probes will only be attached to the child process.
 To avoid a race condition when using 'USDTs', the child is stopped after 'execve' using 'ptrace(2)' and continued when all 'USDT' probes are attached.
-The child PID is available to programs as the 'cpid' builtin.
 The child process runs with the same privileges as bpftrace itself (usually root).
+
+Unless otherwise specified, bpftrace does not perform any implicit filtering. Therefore, if you are only interested in
+events in _COMMAND_, you may want to filter based on the child PID. The child PID is available to programs as the 'cpid' builtin.
+For example, you could add the predicate `/pid == cpid/` to probes with userspace context.
 
 === *-d STAGE*
 


### PR DESCRIPTION
Also came up during hands-on-lab. It was unclear if `-c COMMAND` does any implicit filtering. Make this clear in the documentation.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
