### PR TITLE
NFC: Delete duplicated child creation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -739,9 +739,6 @@ int main(int argc, char* argv[])
   Config config = Config(!args.cmd_str.empty());
   BPFtrace bpftrace(std::move(output), args.no_feature, config);
 
-  if (!args.cmd_str.empty())
-    bpftrace.cmd_ = args.cmd_str;
-
   parse_env(bpftrace);
 
   bpftrace.usdt_file_activation_ = args.usdt_file_activation;
@@ -900,15 +897,6 @@ int main(int argc, char* argv[])
     return 1;
 
   auto* ast_root = pmresult.Root();
-
-  if (!bpftrace.cmd_.empty()) {
-    try {
-      bpftrace.child_ = std::make_unique<ChildProc>(args.cmd_str);
-    } catch (const std::runtime_error& e) {
-      LOG(ERROR) << "Failed to fork child: " << e.what();
-      exit(1);
-    }
-  }
 
   err = bpftrace.create_pcaps();
   if (err) {


### PR DESCRIPTION
Remove pointlessly duplicated code. Note this was not actually running child twice, it was just forking and blocking on the eventfd to exec. Still, unnecessary overhead.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
