### PR TITLE
fix verifier Error / Incorrect comparisons against result of len() function

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1076,7 +1076,7 @@ void IRBuilderBPF::CreateForEachMapElem(Value *ctx,
                                 CreateBitCast(callback_ctx, int8_ptr),
                                 /*flags=*/getInt64(0) },
                               "for_each_map_elem");
-  if(return_ctx && return_ctx->getType() == GET_PTR_TY())
+  if (return_ctx && return_ctx->getType() == GET_PTR_TY())
     CreateStore(call, return_ctx);
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_for_each_map_elem, loc);
 }

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1044,6 +1044,7 @@ void IRBuilderBPF::CreateForEachMapElem(Value *ctx,
                                         Map &map,
                                         Value *callback,
                                         Value *callback_ctx,
+                                        Value *return_ctx,
                                         const location &loc)
 {
   Value *map_ptr = GetMapVar(map.ident);
@@ -1075,6 +1076,8 @@ void IRBuilderBPF::CreateForEachMapElem(Value *ctx,
                                 CreateBitCast(callback_ctx, int8_ptr),
                                 /*flags=*/getInt64(0) },
                               "for_each_map_elem");
+  if(return_ctx && return_ctx->getType() == GET_PTR_TY())
+    CreateStore(call, return_ctx);
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_for_each_map_elem, loc);
 }
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1040,12 +1040,11 @@ void IRBuilderBPF::CreateMapDeleteElem(Value *ctx,
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_map_delete_elem, loc);
 }
 
-void IRBuilderBPF::CreateForEachMapElem(Value *ctx,
-                                        Map &map,
-                                        Value *callback,
-                                        Value *callback_ctx,
-                                        Value *return_ctx,
-                                        const location &loc)
+Value *IRBuilderBPF::CreateForEachMapElem(Value *ctx,
+                                          Map &map,
+                                          Value *callback,
+                                          Value *callback_ctx,
+                                          const location &loc)
 {
   Value *map_ptr = GetMapVar(map.ident);
 
@@ -1069,16 +1068,16 @@ void IRBuilderBPF::CreateForEachMapElem(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_for_each_map_elem),
       for_each_map_ptr_type);
-  CallInst *call = createCall(for_each_map_type,
-                              for_each_map_func,
-                              { map_ptr,
-                                callback,
-                                CreateBitCast(callback_ctx, int8_ptr),
-                                /*flags=*/getInt64(0) },
-                              "for_each_map_elem");
-  if (return_ctx)
-    CreateStore(call, return_ctx);
+  CallInst *call = createCall(
+      for_each_map_type,
+      for_each_map_func,
+      { map_ptr,
+        callback,
+        callback_ctx ? CreateBitCast(callback_ctx, int8_ptr) : GetNull(),
+        /*flags=*/getInt64(0) },
+      "for_each_map_elem");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_for_each_map_elem, loc);
+  return call;
 }
 
 void IRBuilderBPF::CreateCheckSetRecursion(const location &loc,

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1076,7 +1076,7 @@ void IRBuilderBPF::CreateForEachMapElem(Value *ctx,
                                 CreateBitCast(callback_ctx, int8_ptr),
                                 /*flags=*/getInt64(0) },
                               "for_each_map_elem");
-  if (return_ctx && return_ctx->getType() == GET_PTR_TY())
+  if (return_ctx)
     CreateStore(call, return_ctx);
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_for_each_map_elem, loc);
 }

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -74,12 +74,11 @@ public:
                            Map &map,
                            Value *key,
                            const location &loc);
-  void CreateForEachMapElem(Value *ctx,
-                            Map &map,
-                            Value *callback,
-                            Value *callback_ctx,
-                            Value *return_ctx,
-                            const location &loc);
+  Value *CreateForEachMapElem(Value *ctx,
+                              Map &map,
+                              Value *callback,
+                              Value *callback_ctx,
+                              const location &loc);
   void CreateProbeRead(Value *ctx,
                        Value *dst,
                        llvm::Value *size,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -78,6 +78,7 @@ public:
                             Map &map,
                             Value *callback,
                             Value *callback_ctx,
+                            Value *return_ctx,
                             const location &loc);
   void CreateProbeRead(Value *ctx,
                        Value *dst,

--- a/tests/codegen/llvm/call_len.ll
+++ b/tests/codegen/llvm/call_len.ll
@@ -44,6 +44,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %len)
   store i64 0, ptr %len, align 8
   %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_x, ptr @map_len_cb, ptr %len, i64 0)
+  store i64 %for_each_map_elem, ptr %len, align 8
   %1 = load i64, ptr %len, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %len)
   store i64 %1, ptr %"$s", align 8
@@ -51,9 +52,6 @@ entry:
 }
 
 define internal i64 @map_len_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !60 {
-  %5 = load i64, ptr %3, align 8
-  %6 = add i64 %5, 1
-  store i64 %6, ptr %3, align 8
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_len.ll
+++ b/tests/codegen/llvm/call_len.ll
@@ -40,14 +40,8 @@ entry:
   %"$s" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
-  %len = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %len)
-  store i64 0, ptr %len, align 8
-  %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_x, ptr @map_len_cb, ptr %len, i64 0)
-  store i64 %for_each_map_elem, ptr %len, align 8
-  %1 = load i64, ptr %len, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %len)
-  store i64 %1, ptr %"$s", align 8
+  %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_x, ptr @map_len_cb, ptr null, i64 0)
+  store i64 %for_each_map_elem, ptr %"$s", align 8
   ret i64 0
 }
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -607,6 +607,6 @@ EXPECT map len: 2
 TIMEOUT 3
 
 NAME map lencmp
-PROG BEGIN { @[1] = 1; @[2] = 2; $count = len(@); if ($count > 1) { print("true"); } else { print("false"); } exit(); }
+PROG BEGIN { @[1] = 1; @[2] = 2; $count = len(@); if ($count > 1) { print("true"); } exit(); }
 EXPECT true
 TIMEOUT 3

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -605,3 +605,8 @@ NAME map len
 PROG BEGIN { @[0] = 0; @[1] = 1; printf("map len: %d\n", len(@)); exit(); }
 EXPECT map len: 2
 TIMEOUT 3
+
+NAME map lencmp
+PROG BEGIN { @[1] = 1; @[2] = 2; $count = len(@); if ($count > 1) { print("true"); } else { print("false"); } exit(); }
+EXPECT true
+TIMEOUT 3


### PR DESCRIPTION
Use the return value of `bpf_for_each_map_elem` as `len()` function result 
since it means the number of traversed map elements for success. 
Modify the `map_len_cb` to a dummy function and only return 0.

That will close [#3308](https://github.com/bpftrace/bpftrace/issues/3308)
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->