### PR TITLE
Hint the correct integer type for casts

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2634,6 +2634,16 @@ void SemanticAnalyser::visit(FieldAccess &acc)
   }
 }
 
+// We can't hint for unsigned types. It is a syntax error,
+// because the word "unsigned" is not allowed in a type name.
+static std::unordered_map<std::string_view, std::string_view>
+    KNOWN_TYPE_ALIASES{
+      { "char", "int8" },   /* { "unsigned char", "uint8" }, */
+      { "short", "int16" }, /* { "unsigned short", "uint16" }, */
+      { "int", "int32" },   /* { "unsigned int", "uint32" }, */
+      { "long", "int64" },  /* { "unsigned long", "uint64" }, */
+    };
+
 void SemanticAnalyser::visit(Cast &cast)
 {
   Visit(cast.expr);
@@ -2655,7 +2665,13 @@ void SemanticAnalyser::visit(Cast &cast)
         !cast.type.GetElementTy()->IsRecordTy()) &&
       // we support casting integers to int arrays
       !(cast.type.IsArrayTy() && cast.type.GetElementTy()->IsIntTy())) {
-    LOG(ERROR, cast.loc, err_) << "Cannot cast to \"" << cast.type << "\"";
+    std::string hint;
+    if (auto it = KNOWN_TYPE_ALIASES.find(cast.type.GetName());
+        it != KNOWN_TYPE_ALIASES.end()) {
+      hint = ", did you mean \"" + std::string(it->second) + "\"?";
+    }
+    LOG(ERROR, cast.loc, err_)
+        << "Cannot cast to \"" << cast.type << "\"" << hint;
   }
 
   if (cast.type.IsArrayTy()) {

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2372,6 +2372,43 @@ TEST(semantic_analyser, cast_unknown_type)
   test("kprobe:f { (struct faketype *)cpu }", 1);
 }
 
+TEST(semantic_analyser, cast_c_integers)
+{
+  // Casting to a C integer type gives a hint with the correct name
+  test_error("BEGIN { (char)cpu }", R"(
+stdin:1:9-15: ERROR: Cannot resolve unknown type "char"
+BEGIN { (char)cpu }
+        ~~~~~~
+stdin:1:9-15: ERROR: Cannot cast to "char", did you mean "int8"?
+BEGIN { (char)cpu }
+        ~~~~~~
+)");
+  test_error("BEGIN { (short)cpu }", R"(
+stdin:1:9-16: ERROR: Cannot resolve unknown type "short"
+BEGIN { (short)cpu }
+        ~~~~~~~
+stdin:1:9-16: ERROR: Cannot cast to "short", did you mean "int16"?
+BEGIN { (short)cpu }
+        ~~~~~~~
+)");
+  test_error("BEGIN { (int)cpu }", R"(
+stdin:1:9-14: ERROR: Cannot resolve unknown type "int"
+BEGIN { (int)cpu }
+        ~~~~~
+stdin:1:9-14: ERROR: Cannot cast to "int", did you mean "int32"?
+BEGIN { (int)cpu }
+        ~~~~~
+)");
+  test_error("BEGIN { (long)cpu }", R"(
+stdin:1:9-15: ERROR: Cannot resolve unknown type "long"
+BEGIN { (long)cpu }
+        ~~~~~~
+stdin:1:9-15: ERROR: Cannot cast to "long", did you mean "int64"?
+BEGIN { (long)cpu }
+        ~~~~~~
+)");
+}
+
 TEST(semantic_analyser, cast_struct)
 {
   // Casting struct by value is forbidden


### PR DESCRIPTION
The naming scheme for integers in `bpftrace` is different from `C`: `int` becomes `int32`, `unsigned char` becomes `uint8`. It might cause confusion for first time users to not have these basic types. They would not be able to pretty print the value of a `counter()`, if they can't cast it to an integer.

This PR adds a hint for type casts, suggesting the name of the `bpftrace` integer type matching the `C` type.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
