### PR TITLE
Fix map type back propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ and this project adheres to
   - [#3517](https://github.com/bpftrace/bpftrace/pull/3517)
 - Fix verifier error when comparing result of len()
   - [#3308](https://github.com/bpftrace/bpftrace/issues/3308)
+- Fix type back propagation for map keys
+  - [#3536](https://github.com/bpftrace/bpftrace/pull/3536)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -409,6 +409,8 @@ TEST(semantic_analyser, consistent_map_keys)
 {
   test("BEGIN { @x = 0; @x; }");
   test("BEGIN { @x[1] = 0; @x[2]; }");
+  test("BEGIN { @x[@y] = 5; @y = 1;}");
+  test("BEGIN { @x[@y[@z]] = 5; @y[2] = 1; @z = @x[0]; }");
 
   test_error("BEGIN { @x = 0; @x[1]; }", R"(
 stdin:1:17-22: ERROR: Argument mismatch for @x: trying to access with arguments: 'int64' when map expects no arguments
@@ -3872,6 +3874,8 @@ TEST(semantic_analyser, for_loop_map)
   test("BEGIN { @map[0] = 1; for ($kv : @map) { print($kv); } }");
   test("BEGIN { @map[0] = 1; for ($kv : @map) { print($kv.0); } }");
   test("BEGIN { @map[0] = 1; for ($kv : @map) { print($kv.1); } }");
+  test("BEGIN { @map1[@map2] = 1; @map2 = 1; for ($kv : @map1) { print($kv); } "
+       "}");
 }
 
 TEST(semantic_analyser, for_loop_map_declared_after)


### PR DESCRIPTION
Issue: https://github.com/bpftrace/bpftrace/issues/3448

Both of these should be valid:
```
BEGIN
{
  @stacks[@integer] = kstack;
  @integer = 1;
}
```
And
```
BEGIN
{
  @map1[@map2] = 1;
  @map2 = 1;

  for ($kv : @map1) {
  }
}
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
