### PR TITLE
semantic: NFC: Delete duplicated branch for fentry/fexit

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3270,15 +3270,6 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     }
 
     if (ap.func == "")
-      LOG(ERROR, ap.loc, err_) << "fentry should specify a function";
-  } else if (ap.provider == "fentry" || ap.provider == "fexit") {
-    if (!bpftrace_.feature_->has_fentry()) {
-      LOG(ERROR, ap.loc, err_)
-          << "fentry/fexit not available for your kernel version.";
-      return;
-    }
-
-    if (ap.func == "")
       LOG(ERROR, ap.loc, err_) << "fentry/fexit should specify a function";
   } else if (ap.provider == "iter") {
     if (!listing_ && bpftrace_.btf_->get_all_iters().count(ap.func) <= 0) {


### PR DESCRIPTION
https://github.com/bpftrace/bpftrace/pull/3524 removed references to kfunc/kretfunc using search & replace. But it accidentally created a duplicated branch.

Also add a regression test to ensure kfunc/kretfunc alias still applies

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
