### PR TITLE
Add checks to prevent assignment of some map types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,8 @@ and this project adheres to
   - [#3308](https://github.com/bpftrace/bpftrace/issues/3308)
 - Fix type back propagation for map keys
   - [#3536](https://github.com/bpftrace/bpftrace/pull/3536)
+- Fix crash by adding checks for bad var/map assignments
+  - [#3542](https://github.com/bpftrace/bpftrace/pull/3542)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4476,4 +4476,43 @@ BEGIN { unroll(1) { $a = 1; } print(($a)); }
 )");
 }
 
+TEST(semantic_analyser, invalid_assignment)
+{
+  test_error("BEGIN { @a = hist(10); let $b = @a; }", R"(
+stdin:1:24-35: ERROR: Map value 'hist_t' cannot be assigned to a scratch variable.
+BEGIN { @a = hist(10); let $b = @a; }
+                       ~~~~~~~~~~~
+)");
+
+  test_error("BEGIN { @a = lhist(123, 0, 123, 1); let $b = @a; }", R"(
+stdin:1:37-48: ERROR: Map value 'lhist_t' cannot be assigned to a scratch variable.
+BEGIN { @a = lhist(123, 0, 123, 1); let $b = @a; }
+                                    ~~~~~~~~~~~
+)");
+
+  test_error("BEGIN { @a = stats(10); let $b = @a; }", R"(
+stdin:1:25-36: ERROR: Map value 'stats_t' cannot be assigned to a scratch variable.
+BEGIN { @a = stats(10); let $b = @a; }
+                        ~~~~~~~~~~~
+)");
+
+  test_error("BEGIN { @a = hist(10); @b = @a; }", R"(
+stdin:1:24-31: ERROR: Map value 'hist_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@a = hist(retval);`.
+BEGIN { @a = hist(10); @b = @a; }
+                       ~~~~~~~
+)");
+
+  test_error("BEGIN { @a = lhist(123, 0, 123, 1); @b = @a; }", R"(
+stdin:1:37-44: ERROR: Map value 'lhist_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@a = lhist(rand %10, 0, 10, 1);`.
+BEGIN { @a = lhist(123, 0, 123, 1); @b = @a; }
+                                    ~~~~~~~
+)");
+
+  test_error("BEGIN { @a = stats(10); @b = @a; }", R"(
+stdin:1:25-32: ERROR: Map value 'stats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@a = stats(arg2);`.
+BEGIN { @a = stats(10); @b = @a; }
+                        ~~~~~~~
+)");
+}
+
 } // namespace bpftrace::test::semantic_analyser


### PR DESCRIPTION
These are special map aggregation types that cannot be assigned to scratch variables or from one map
to another e.g. these are both invalid:
`@a = hist(10); let $b = @a;`
`@a = hist(10); @b = @a;`

https://github.com/bpftrace/bpftrace/issues/3540

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
