### PR TITLE
Use global scratch buffers for variables

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -43,6 +43,8 @@ aot.call.str_big_for
 aot.call.str_big_tuple
 # Same problem as #3392
 aot.call.tuple_scratch_buf
+# Same problem as #3392
+aot.call.variable_for_loop_scratch_buf
 aot.call.str_truncated
 aot.call.str_truncated_custom
 aot.call.strftime

--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -19,6 +19,7 @@ namespace ast {
   DO(system)                                                                   \
   DO(time)                                                                     \
   DO(tuple)                                                                    \
+  DO(variable)                                                                 \
   DO(watchpoint)
 
 #define DEFINE_MEMBER_VAR(id, ...) int _##id = 0;

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -175,6 +175,9 @@ public:
   Value *CreateWriteMapValueAllocation(const SizedType &value_type,
                                        const std::string &name,
                                        const location &loc);
+  Value *CreateVariableAllocationInit(const SizedType &value_type,
+                                      const std::string &name,
+                                      const location &loc);
   void CreateCheckSetRecursion(const location &loc, int early_exit_ret);
   void CreateUnSetRecursion(const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
@@ -314,6 +317,7 @@ private:
                           const location &loc,
                           std::optional<std::function<size_t(AsyncIds &)>>
                               gen_async_id_cb = std::nullopt);
+  void CreateAllocationInit(const SizedType &stype, Value *alloc);
   Value *createScratchBuffer(globalvars::GlobalVar globalvar,
                              const location &loc,
                              size_t key);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -265,7 +265,8 @@ private:
                             const SizedType &key_type);
 
   void maybeAllocVariable(const std::string &var_ident,
-                          const SizedType &var_type);
+                          const SizedType &var_type,
+                          const location &loc);
   VariableLLVM *maybeGetVariable(const std::string &);
   VariableLLVM &getVariable(const std::string &);
 

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -37,12 +37,17 @@ private:
   void visit(For &f) override;
   void visit(Ternary &ternary) override;
   void visit(AssignMapStatement &assignment) override;
+  void visit(AssignVarStatement &assignment) override;
+  void visit(VarDeclStatement &decl) override;
 
   // Determines whether the given function uses userspace symbol resolution.
   // This is used later for loading the symbol table into memory.
   bool uses_usym_table(const std::string &fun);
 
+  bool exceeds_stack_limit(size_t size);
+
   void update_map_info(Map &map);
+  void update_variable_info(Variable &var);
 
   RequiredResources resources_;
   Node *root_;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3004,22 +3004,6 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
     if (storedTy.IsNoneTy())
       LOG(ERROR, assignment.expr->loc, err_)
           << "Invalid expression for assignment: " << storedTy;
-
-    // Scratch variables are on the BPF stack, which is only 512 bytes at time
-    // of writing, so large values do not fit on there. 200 is a ballpark of
-    // what probably won't work.
-    auto expr_size = storedTy.GetSize();
-    if (expr_size > 200) {
-      LOG(ERROR, assignment.loc, err_)
-          << "Value is too big "
-          << "(" << expr_size << " bytes) for the stack. "
-          << "Try reducing its size, storing it in a map, or creating it in "
-             "argument position to a helper call.\n\n"
-          << "Examples:\n"
-          << "    `$s = str(..);` => `$s = str(.., 32);`\n"
-          << "    `$s = str(..);` => `@s = str(..);`\n"
-          << "    `$s = str(..); print($s);` => `print(str(..));`\n\n";
-    }
   }
 }
 

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -142,6 +142,7 @@ static void update_global_vars_rodata(
       case GlobalVar::GET_STR_BUFFER:
       case GlobalVar::READ_MAP_VALUE_BUFFER:
       case GlobalVar::WRITE_MAP_VALUE_BUFFER:
+      case GlobalVar::VARIABLE_BUFFER:
         break;
     }
   }
@@ -287,6 +288,12 @@ SizedType get_type(bpftrace::globalvars::GlobalVar global_var,
       assert(resources.max_write_map_value_size > 0);
       return make_rw_type(
           1, CreateArray(resources.max_write_map_value_size, CreateInt8()));
+    case GlobalVar::VARIABLE_BUFFER:
+      assert(resources.variable_buffers > 0);
+      assert(resources.max_variable_size > 0);
+      return make_rw_type(resources.variable_buffers,
+                          CreateArray(resources.max_variable_size,
+                                      CreateInt8()));
   }
   return {}; // unreachable
 }

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -24,6 +24,7 @@ constexpr std::string_view READ_MAP_VALUE_BUFFER_SECTION_NAME =
     ".data.read_map_val_buf";
 constexpr std::string_view WRITE_MAP_VALUE_BUFFER_SECTION_NAME =
     ".data.write_map_val_buf";
+constexpr std::string_view VARIABLE_BUFFER_SECTION_NAME = ".data.var_buf";
 
 struct GlobalVarConfig {
   std::string name;
@@ -49,6 +50,8 @@ const std::unordered_map<GlobalVar, GlobalVarConfig> GLOBAL_VAR_CONFIGS = {
     { "write_map_val_buf",
       std::string(WRITE_MAP_VALUE_BUFFER_SECTION_NAME),
       false } },
+  { GlobalVar::VARIABLE_BUFFER,
+    { "var_buf", std::string(VARIABLE_BUFFER_SECTION_NAME), false } },
 };
 
 void update_global_vars(

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -115,6 +115,10 @@ public:
   size_t max_read_map_value_size = 0;
   size_t max_write_map_value_size = 0;
 
+  // Required for sizing of variable scratch buffers
+  size_t variable_buffers = 0;
+  size_t max_variable_size = 0;
+
   // Async argument metadata that codegen creates. Ideally ResourceAnalyser
   // pass should be collecting this, but it's complex to move the logic.
   //

--- a/src/types.h
+++ b/src/types.h
@@ -739,6 +739,7 @@ enum class GlobalVar {
   GET_STR_BUFFER,
   READ_MAP_VALUE_BUFFER,
   WRITE_MAP_VALUE_BUFFER,
+  VARIABLE_BUFFER,
 };
 
 } // namespace globalvars

--- a/tests/codegen/llvm/variable_scratch_buf.ll
+++ b/tests/codegen/llvm/variable_scratch_buf.ll
@@ -1,0 +1,107 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
+@var_buf = dso_local externally_initialized global [1 x [2 x [8 x i8]]] zeroinitializer, section ".data.var_buf", !dbg !38
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
+entry:
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded2 = and i64 %get_cpu_id1, %1
+  %2 = getelementptr [1 x [2 x [8 x i8]]], ptr @var_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
+  store i64 0, ptr %2, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %3
+  %4 = getelementptr [1 x [2 x [8 x i8]]], ptr @var_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  store i64 0, ptr %4, align 8
+  %5 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %5, align 8
+  %6 = icmp ugt i64 %arg0, 0
+  %true_cond = icmp ne i1 %6, false
+  br i1 %true_cond, label %if_body, label %else_body
+
+if_body:                                          ; preds = %entry
+  store i64 1, ptr %4, align 8
+  br label %if_end
+
+if_end:                                           ; preds = %else_body, %if_body
+  ret i64 0
+
+else_body:                                        ; preds = %entry
+  store i64 2, ptr %2, align 8
+  br label %if_end
+}
+
+attributes #0 = { nounwind }
+
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "var_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 128, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 128, elements: !23)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !44)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DISubrange(count: 8, lowerBound: 0)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !16, !36, !38}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!35, !52}
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !52)

--- a/tests/codegen/llvm/variable_stack.ll
+++ b/tests/codegen/llvm/variable_stack.ll
@@ -1,0 +1,96 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+entry:
+  %"$x1" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x1")
+  store i64 0, ptr %"$x1", align 8
+  %"$x" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
+  store i64 0, ptr %"$x", align 8
+  %1 = getelementptr i64, ptr %0, i64 14
+  %arg0 = load volatile i64, ptr %1, align 8
+  %2 = icmp ugt i64 %arg0, 0
+  %true_cond = icmp ne i1 %2, false
+  br i1 %true_cond, label %if_body, label %else_body
+
+if_body:                                          ; preds = %entry
+  store i64 1, ptr %"$x", align 8
+  br label %if_end
+
+if_end:                                           ; preds = %else_body, %if_body
+  ret i64 0
+
+else_body:                                        ; preds = %entry
+  store i64 2, ptr %"$x1", align 8
+  br label %if_end
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/scratch_buffer.cpp
+++ b/tests/codegen/scratch_buffer.cpp
@@ -97,6 +97,24 @@ TEST(codegen, map_value_tuple_stack)
       LARGE_ON_STACK_LIMIT);
 }
 
+// Use an if statement with same variable name with two scopes to ensure
+// initialization happens prior to both scopes
+TEST(codegen, variable_scratch_buf)
+{
+  test_stack_or_scratch_buffer(
+      "kprobe:f { if (arg0 > 0) { $x = 1; } else { $x = 2 } }",
+      NAME,
+      SMALL_ON_STACK_LIMIT);
+}
+
+TEST(codegen, variable_stack)
+{
+  test_stack_or_scratch_buffer(
+      "kprobe:f { if (arg0 > 0) { $x = 1; } else { $x = 2 } }",
+      NAME,
+      LARGE_ON_STACK_LIMIT);
+}
+
 } // namespace codegen
 } // namespace test
 } // namespace bpftrace

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -149,6 +149,20 @@ NAME map_val_scratch_buf
 PROG config = { on_stack_limit = 0 } BEGIN { @x = 1; @y = @x; print(@y) }
 EXPECT @y: 1
 
+NAME variable_scratch_buf
+PROG config = { on_stack_limit = 0 } BEGIN { $x = "XXXX"; $y = $x; print($y) }
+EXPECT XXXX
+
+# Verify enough buffer space is allocated for same variable name in multiple scopes
+NAME variable_for_loop_scratch_buf
+PROG config = { on_stack_limit = 0 } BEGIN { @[1] = 1; for ($kv : @) { $y = $kv } for ($kv : @) { $y = $kv; print($y) } }
+EXPECT (1, 1)
+
+# Verify enough buffer space is allocated for same variable name in multiple subprograms
+NAME variable_probe_subprog_scratch_buf
+PROG config = { on_stack_limit = 0 } BEGIN { $x = "XXXX" } i:ms:100 { $x = "YYYY"; exit(); }END { $x = "ZZZZ"; print($x) }
+EXPECT ZZZZ
+
 NAME str_big_for
 PROG t:syscalls:sys_enter_execve { @map[str(args.filename)] = str(args.filename); for ($kv : @map) { print($kv); } }
 ENV BPFTRACE_MAX_STRLEN=9999

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4222,65 +4222,6 @@ uprobe:/bin/sh:f { buf(arg0) }
 )");
 }
 
-TEST(semantic_analyser, large_scratch_variables)
-{
-  auto bpftrace = get_mock_bpftrace();
-  ConfigSetter configs{ bpftrace->config_, ConfigSource::script };
-  configs.set(ConfigKeyInt::max_strlen, 1024);
-
-  test_error(*bpftrace, "BEGIN { $s = str(0, 999) }", R"(
-stdin:1:9-25: ERROR: Value is too big (999 bytes) for the stack. Try reducing its size, storing it in a map, or creating it in argument position to a helper call.
-
-Examples:
-    `$s = str(..);` => `$s = str(.., 32);`
-    `$s = str(..);` => `@s = str(..);`
-    `$s = str(..); print($s);` => `print(str(..));`
-
-BEGIN { $s = str(0, 999) }
-        ~~~~~~~~~~~~~~~~
-)");
-
-  test_error(*bpftrace, "BEGIN { $s = str(0) }", R"(
-stdin:1:9-20: ERROR: Value is too big (1024 bytes) for the stack. Try reducing its size, storing it in a map, or creating it in argument position to a helper call.
-
-Examples:
-    `$s = str(..);` => `$s = str(.., 32);`
-    `$s = str(..);` => `@s = str(..);`
-    `$s = str(..); print($s);` => `print(str(..));`
-
-BEGIN { $s = str(0) }
-        ~~~~~~~~~~~
-)");
-
-  test_error(*bpftrace, "BEGIN { $l = 1; $b = buf(0, $l) }", R"(
-stdin:1:17-32: ERROR: Value is too big (1024 bytes) for the stack. Try reducing its size, storing it in a map, or creating it in argument position to a helper call.
-
-Examples:
-    `$s = str(..);` => `$s = str(.., 32);`
-    `$s = str(..);` => `@s = str(..);`
-    `$s = str(..); print($s);` => `print(str(..));`
-
-BEGIN { $l = 1; $b = buf(0, $l) }
-                ~~~~~~~~~~~~~~~
-)");
-
-  test_error(*bpftrace, "fentry:foo { $p = path((uint8 *)0) }", R"(
-stdin:1:14-35: ERROR: Value is too big (1024 bytes) for the stack. Try reducing its size, storing it in a map, or creating it in argument position to a helper call.
-
-Examples:
-    `$s = str(..);` => `$s = str(.., 32);`
-    `$s = str(..);` => `@s = str(..);`
-    `$s = str(..); print($s);` => `print(str(..));`
-
-fentry:foo { $p = path((uint8 *)0) }
-             ~~~~~~~~~~~~~~~~~~~~~
-)");
-
-  // Values clamped small enough should fit
-  test("BEGIN { $s = str(0, 10) }");
-  test("BEGIN { $b = buf(0, 10) }");
-}
-
 TEST(semantic_analyser, variable_declarations)
 {
   test("BEGIN { let $a; $a = 1; }");
@@ -4377,7 +4318,7 @@ TEST(semantic_analyser, block_scoping)
   // if/else
   test("BEGIN { $a = 1; if (1) { $b = 2; print(($a, $b)); } }");
   test(R"(
-      BEGIN { 
+      BEGIN {
         $a = 1;
         if (1) {
           print(($a));


### PR DESCRIPTION
This PR migrates variables to use global scratch variables if size > on_stack_limit. This will allow users to store large strings/tuples/objects in local variables.