### PR TITLE
Add config option to control maps printed at exit

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -49,6 +49,10 @@ aot.call.strftime
 aot.call.strftime_as_map_key
 aot.call.strftime_as_map_value
 aot.call.ustack_elf_symtable
+aot.config.maps are printed by default
+aot.config.maps can be disabled
+aot.config.scalar maps are printed by default
+aot.config.scalar maps can be disabled
 aot.dwarf.uprobe inlined function
 # Same problem as #3392
 aot.for.map delete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to
   - [#3461](https://github.com/bpftrace/bpftrace/pull/3461)
 - Support symbolizing enum values using `%s` specifier in `printf()`
   - [#3515](https://github.com/bpftrace/bpftrace/pull/3515)
+- Configuration option to suppress printing maps by default at program exit
+  - [#3547](https://github.com/bpftrace/bpftrace/pull/3547)
 #### Changed
 - Merge output into `stdout` when `-lv`
   - [#3383](https://github.com/bpftrace/bpftrace/pull/3383)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3697,6 +3697,12 @@ Default: `..`
 Trailer to add to strings that were truncated.
 Set to empty string to disable truncation trailers.
 
+=== print_maps_on_exit
+
+Default: 1
+
+Controls whether maps are printed on exit. Set to `0` in order to change the default behavior and not automatically print maps at program exit.
+
 == Environment Variables
 
 These are not available as part of the standard set of <<Config Variables>> and can only be set as environment variables.
@@ -4049,8 +4055,21 @@ Therefore, when you need precise event statistics, it is recommended to use sync
 === Map Printing
 
 By default when a bpftrace program exits it will print all maps to stdout.
-If you don't want this to happen you can specify an `END` probe and `clear` the maps you don't want printed (unfortunately this doesn't work on scalar maps) e.g. this script:
+If you don't want this, you can either override the `print_maps_on_exit` configuration option or you can specify an `END` probe and `clear` the maps you don't want printed (this second method doesn't work for scalar maps).
 
+For example, this script:
+```
+config = {
+  print_maps_on_exit=0
+}
+
+BEGIN {
+  @a = 1;
+  @b[1] = 1;
+}
+```
+
+would print nothing on exit, while this script:
 ```
 BEGIN {
   @a = 1;
@@ -4068,8 +4087,7 @@ will print this on exit:
 @a: 0
 ```
 
-Additionally, if you want to get a snapshot of your maps before script exit, you can send the running bpftrace process a `SIGUSR1` signal. bpftrace will then print all maps to stdout. Example:
-
+If you want to get a snapshot of your maps while the script is running, you can send the running bpftrace process a `SIGUSR1` signal. bpftrace will then print all maps to stdout. Example:
 ```
 # bpftrace -e 'BEGIN { @b[1] = 2; }' & kill -s USR1 $(pidof bpftrace)
 ...

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -14,6 +14,7 @@ Config::Config(bool has_cmd)
     { ConfigKeyBool::cpp_demangle, { .value = true } },
     { ConfigKeyBool::lazy_symbolication, { .value = false } },
     { ConfigKeyBool::probe_inline, { .value = false } },
+    { ConfigKeyBool::print_maps_on_exit, { .value = true } },
     { ConfigKeyInt::log_size, { .value = static_cast<uint64_t>(1000000) } },
     { ConfigKeyInt::max_bpf_progs, { .value = static_cast<uint64_t>(512) } },
     { ConfigKeyInt::max_cat_bytes, { .value = static_cast<uint64_t>(10240) } },

--- a/src/config.h
+++ b/src/config.h
@@ -26,6 +26,7 @@ enum class ConfigKeyBool {
   cpp_demangle,
   lazy_symbolication,
   probe_inline,
+  print_maps_on_exit,
 };
 
 enum class ConfigKeyInt {
@@ -89,6 +90,7 @@ const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
   { "stack_mode", ConfigKeyStackMode::default_ },
   { "str_trunc_trailer", ConfigKeyString::str_trunc_trailer },
   { "missing_probes", ConfigKeyMissingProbes::default_ },
+  { "print_maps_on_exit", ConfigKeyBool::print_maps_on_exit },
 };
 
 // These are not tracked by the config class

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -59,7 +59,9 @@ int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
 
   std::cout << "\n\n";
 
-  err = bpftrace.print_maps();
+  // Print maps if needed (true by default).
+  if (bpftrace.config_.get(ConfigKeyBool::print_maps_on_exit))
+    err = bpftrace.print_maps();
 
   if (bpftrace.child_) {
     auto val = 0;

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -48,6 +48,11 @@ TEST(Config, get_and_set)
   EXPECT_TRUE(config_setter.set(StackMode::bpftrace));
   EXPECT_EQ(config.get(ConfigKeyStackMode::default_), StackMode::bpftrace);
 
+  // Test that this is also true by default, as a requirement.
+  EXPECT_TRUE(config.get(ConfigKeyBool::print_maps_on_exit));
+  EXPECT_TRUE(config_setter.set(ConfigKeyBool::print_maps_on_exit, false));
+  EXPECT_EQ(config.get(ConfigKeyBool::print_maps_on_exit), false);
+
   EXPECT_TRUE(config_setter.set(UserSymbolCacheType::per_program));
   EXPECT_EQ(config.get(ConfigKeyUserSymbolCacheType::default_),
             UserSymbolCacheType::per_program);

--- a/tests/runtime/config
+++ b/tests/runtime/config
@@ -25,3 +25,19 @@ RUN {{BPFTRACE}} -e 'config = { debug_output=1 } uprobe:./testprogs/uprobe_test:
 EXPECT stdin:1:12-25: ERROR: debug_output can only be set as an environment variable
 BEFORE ./testprogs/uprobe_test
 WILL_FAIL
+
+NAME maps are printed by default
+PROG BEGIN { @["test"] = count(); exit(); }
+EXPECT @[test]: 1
+
+NAME maps can be disabled
+PROG config = { print_maps_on_exit=0 } BEGIN { @["test"] = count(); exit(); }
+EXPECT_NONE @[test]: 1
+
+NAME scalar maps are printed by default
+PROG BEGIN { @test = 1; exit(); }
+EXPECT @test: 1
+
+NAME scalar maps can be disabled
+PROG config = { print_maps_on_exit=0 } BEGIN { @test = 1; exit(); }
+EXPECT_NONE @test: 1


### PR DESCRIPTION
Fixes #3545

This change adds a standard configuration option, including relevant environment variables, documentation, to control whether prints are printed.

The default behavior is the current behavior.

##### Checklist

- [X] Language changes are updated in `man/adoc/bpftrace.adoc`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [X] The new behaviour is covered by tests
