### PR TITLE
Fix variable scoping issues:

### DIFF
--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -30,6 +30,11 @@ using namespace llvm;
 
 using CallArgs = std::vector<std::tuple<FormatString, std::vector<Field>>>;
 
+struct VariableLLVM {
+  llvm::Value *value;
+  llvm::Type *type;
+};
+
 class CodegenLLVM : public Visitor {
 public:
   explicit CodegenLLVM(Node *root, BPFtrace &bpftrace);
@@ -261,6 +266,8 @@ private:
 
   void maybeAllocVariable(const std::string &var_ident,
                           const SizedType &var_type);
+  VariableLLVM *maybeGetVariable(const std::string &);
+  VariableLLVM &getVariable(const std::string &);
 
   Function *DeclareKernelFunc(Kfunc kfunc);
 
@@ -299,11 +306,8 @@ private:
   int current_usdt_location_index_{ 0 };
   bool inside_subprog_ = false;
 
-  struct VariableLLVM {
-    llvm::Value *value;
-    llvm::Type *type;
-  };
-  std::unordered_map<std::string, VariableLLVM> variables_;
+  std::vector<Node *> scope_stack_;
+  std::unordered_map<Node *, std::map<std::string, VariableLLVM>> variables_;
 
   std::unordered_map<std::string, libbpf::bpf_map_type> map_types_;
 

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -8,6 +8,7 @@
 #include "ast/visitors.h"
 #include "bpffeature.h"
 #include "bpftrace.h"
+#include "collect_nodes.h"
 #include "config.h"
 #include "types.h"
 
@@ -181,6 +182,7 @@ private:
 
   std::map<Node *, std::map<std::string, variable>> variables_;
   std::map<Node *, std::map<std::string, location>> variable_decls_;
+  std::map<Node *, CollectNodes<Variable>> for_vars_referenced_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, SizedType> map_key_;
 

--- a/tests/codegen/late_variable_decl.cpp
+++ b/tests/codegen/late_variable_decl.cpp
@@ -1,0 +1,37 @@
+#include "common.h"
+
+namespace bpftrace::test::codegen {
+
+TEST(codegen, late_variable_decl)
+{
+  // This test is to ensure that late variable declarations in an outer scope
+  // don't bleed into inner scopes earlier in the script.
+  // All the $x variables below should get their own allocation
+  test(R"(
+    BEGIN
+    {
+      if (1) {
+				$x = 1;
+			}
+			
+			unroll(1) {
+				$x = 2;
+			}
+			
+			$i = 1;
+      while($i) {
+        --$i;
+        $x = 3;
+      }
+			
+			@map[16] = 32;
+      for ($kv : @map) {
+        $x = 4;
+      }
+			
+      let $x = 5;
+    })",
+       NAME);
+}
+
+} // namespace bpftrace::test::codegen

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -15,6 +15,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
 entry:
+  %"$s1" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s1")
+  store i64 0, ptr %"$s1", align 8
   %"$s" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
@@ -28,7 +31,7 @@ if_end:                                           ; preds = %else_body, %if_body
   ret i64 0
 
 else_body:                                        ; preds = %entry
-  store i64 20, ptr %"$s", align 8
+  store i64 20, ptr %"$s1", align 8
   br label %if_end
 }
 

--- a/tests/codegen/llvm/late_variable_decl.ll
+++ b/tests/codegen/llvm/late_variable_decl.ll
@@ -1,0 +1,173 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%int64_int64__tuple_t = type { i64, i64 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_map = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !50 {
+entry:
+  %"$x3" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x3")
+  store i64 0, ptr %"$x3", align 8
+  %"@map_val" = alloca i64, align 8
+  %"@map_key" = alloca i64, align 8
+  %"$x2" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x2")
+  store i64 0, ptr %"$x2", align 8
+  %"$i" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$i")
+  store i64 0, ptr %"$i", align 8
+  %"$x1" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x1")
+  store i64 0, ptr %"$x1", align 8
+  %"$x" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
+  store i64 0, ptr %"$x", align 8
+  br i1 true, label %if_body, label %if_end
+
+if_body:                                          ; preds = %entry
+  store i64 1, ptr %"$x", align 8
+  br label %if_end
+
+if_end:                                           ; preds = %if_body, %entry
+  store i64 2, ptr %"$x1", align 8
+  store i64 1, ptr %"$i", align 8
+  br label %while_cond
+
+while_cond:                                       ; preds = %while_body, %if_end
+  %1 = load i64, ptr %"$i", align 8
+  %true_cond = icmp ne i64 %1, 0
+  br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !57
+
+while_body:                                       ; preds = %while_cond
+  %2 = load i64, ptr %"$i", align 8
+  %3 = sub i64 %2, 1
+  store i64 %3, ptr %"$i", align 8
+  store i64 3, ptr %"$x2", align 8
+  br label %while_cond
+
+while_end:                                        ; preds = %while_cond
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
+  store i64 16, ptr %"@map_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
+  store i64 32, ptr %"@map_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %"@map_key", ptr %"@map_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_key")
+  %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_map, ptr @map_for_each_cb, ptr null, i64 0)
+  store i64 5, ptr %"$x3", align 8
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !59 {
+  %"$x" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
+  store i64 0, ptr %"$x", align 8
+  %"$kv" = alloca %int64_int64__tuple_t, align 8
+  %key = load i64, ptr %1, align 8
+  %val = load i64, ptr %2, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
+  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i64 %key, ptr %5, align 8
+  %6 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
+  store i64 %val, ptr %6, align 8
+  store i64 4, ptr %"$x", align 8
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
+!23 = !{!24, !29}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
+!27 = !{!28}
+!28 = !DISubrange(count: 27, lowerBound: 0)
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 262144, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
+!37 = !{!38, !43, !44, !19}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 2, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !45, size: 64, offset: 128)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !20, !34}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !55)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!18, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!54 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!57 = distinct !{!57, !58}
+!58 = !{!"llvm.loop.unroll.disable"}
+!59 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !60, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !47, retainedNodes: !62)
+!60 = !DISubroutineType(types: !61)
+!61 = !{!18, !53, !53, !53, !53}
+!62 = !{!63, !64, !65, !66}
+!63 = !DILocalVariable(name: "map", arg: 1, scope: !59, file: !2, type: !53)
+!64 = !DILocalVariable(name: "key", arg: 2, scope: !59, file: !2, type: !53)
+!65 = !DILocalVariable(name: "value", arg: 3, scope: !59, file: !2, type: !53)
+!66 = !DILocalVariable(name: "ctx", arg: 4, scope: !59, file: !2, type: !53)

--- a/tests/runtime/scripts/variable_scope.bt
+++ b/tests/runtime/scripts/variable_scope.bt
@@ -1,0 +1,14 @@
+BEGIN {
+	if (1) {
+		$x = 1;
+	}
+	
+	if (1) { 
+		let $x; 
+		if (0) {
+			$x = 5;
+		}
+		print($x);
+	} 
+	exit(); 
+}

--- a/tests/runtime/scripts/variable_scope_late_decl.bt
+++ b/tests/runtime/scripts/variable_scope_late_decl.bt
@@ -1,0 +1,20 @@
+BEGIN {
+	@a[1] = 1;
+	if (1) {
+		$x = 1;
+		print(("a", $x));
+	}
+	
+	for ($kv : @a) {
+		$x = 2;
+		print(("b", $x));
+	}
+	
+	let $x;
+	if (0) {
+		$x = 3;
+	}
+	print(("c", $x));
+
+	exit(); 
+}

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -121,3 +121,17 @@ EXPECT Attaching 1 probe...
 NAME variable declaration not initialized
 PROG BEGIN { let $a; if (false) { $a = 1; } @b = $a; exit();}
 EXPECT @b: 0
+
+NAME variable doesn't escape scope
+RUN {{BPFTRACE}} runtime/scripts/variable_scope.bt
+EXPECT 0
+
+NAME late variable declaration
+RUN {{BPFTRACE}} runtime/scripts/variable_scope_late_decl.bt
+EXPECT (a, 1)
+EXPECT (b, 2)
+EXPECT (c, 0)
+
+NAME late map evaluation with ctx capture
+RUN {{BPFTRACE}} -e 'interval:ms:100 { $x = 1; for ($kv : @a) { print(($x, $kv.0, $kv.1)); exit(); } @a[1] = 1; }'
+EXPECT (1, 1, 1)


### PR DESCRIPTION
Issue 1:
Don't save variables to the for loop context
that were declared AFTER the loop in the script.
For example:
```
@map[16] = 32;
for ($kv : @map) {
  $x = 4;
}

let $x = 5;
```

Issue 2:
Add a scope_stack similar to the one in semantic
analyser, which is needed to make sure variables
are truly isolated.

For example:
```
BEGIN {
	if (1) {
		$x = 1;
	}

	if (1) {
		let $x;
		if (0) {
			$x = 5;
		}
		print($x)
	}
}
```
On trunk this will print "1" because the `$x` variable in the first `if` is re-used in the lower scope when it shouldn't be.

##### Checklist

- ~~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~~
- ~~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~~
- [x] The new behaviour is covered by tests
