### PR TITLE
enums: Do not symbolize enums in json output

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -92,6 +92,10 @@ aot.other.symbolize enum in map key
 # Enum metadata is not being serialized
 aot.other.symbolize enum in map value
 # Enum metadata is not being serialized
+aot.other.symbolize enum in scratch variable
+# Enum metadata is not being serialized
+aot.other.symbolize enum in scratch variable tuple
+# Enum metadata is not being serialized
 aot.other.symbolize enum in tuple map key
 # Enum metadata is not being serialized
 aot.other.symbolize enum in tuple map value

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -168,3 +168,13 @@ TIMEOUT 1
 NAME print_hex_values
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @=(int16*) 0x32; exit(); }'
 EXPECT {"type": "map", "data": {"@": 50}}
+
+# To preserve backwards compat for machines parsing output, we do not symbolize enums in JSON output mode
+NAME enum_not_symbolized
+RUN {{BPFTRACE}} -q -f json -e 'enum { FOO = 333 }; BEGIN { $f = FOO; print($f); exit(); }'
+EXPECT {"type": "value", "data": 333}
+
+# But if user explicitly asks for enum symbolization, we provide it in JSON output
+NAME enum_symbolized_printf
+RUN {{BPFTRACE}} -q -f json -e 'enum Foo { ONE = 1, TWO = 2, OTHER = 99999 }; BEGIN { printf("%d %s %d %s %d %s\n", ONE, ONE, TWO, TWO, OTHER, OTHER); exit() }'
+EXPECT {"type": "printf", "data": "1 ONE 2 TWO 99999 OTHER\n"}

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -306,3 +306,11 @@ NAME no symbolize enum after arithmetic mixed
 PROG enum { ONE = 1, TWO = 2 }; BEGIN { @[ONE+1] = TWO-1; @[ONE] = ONE; exit(); }
 EXPECT @[2]: 1
 EXPECT @[1]: 1
+
+NAME symbolize enum in scratch variable
+PROG enum { FOO = 333 }; BEGIN { $f = FOO; print($f); exit(); }
+EXPECT FOO
+
+NAME symbolize enum in scratch variable tuple
+PROG enum { FOO = 333, BAR }; BEGIN { $t = (FOO, BAR); print($t); exit(); }
+EXPECT (FOO, BAR)


### PR DESCRIPTION
https://github.com/bpftrace/bpftrace/pull/3539 inadvertently supported enum symbolization everywhere. Which is actually fine for text output, as that's what we wanted to do long term. So we add some tests to seal in that behavior there.

But we actually don't want enum symbolization for non-printf use cases in JSON output. So fix that and add tests there as well.


<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
