### PR TITLE
Require libbpf 1.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,10 +88,8 @@ include_directories(SYSTEM ${LIBBCC_INCLUDE_DIRS})
 
 find_package(LibBpf REQUIRED)
 include_directories(SYSTEM ${LIBBPF_INCLUDE_DIRS})
-# TODO: update to 1.5 once [1] is released.
-# [1] https://github.com/libbpf/libbpf/commit/dd589c3b31c13164bdc61ed174fbae6fe76c8308
-if(LIBBPF_VERSION_MAJOR VERSION_LESS 1)
-  message(SEND_ERROR "bpftrace requires libbpf 1.0 or greater")
+if("${LIBBPF_VERSION_MAJOR}.${LIBBPF_VERSION_MINOR}" VERSION_LESS 1.5)
+  message(SEND_ERROR "bpftrace requires libbpf 1.5 or greater")
 endif()
 
 find_package(LibElf REQUIRED)

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           defaultLlvmVersion = 18;
 
           # Overlay to specify build should use the specific libbpf we want
-          libbpfVersion = "1.4.2";
+          libbpfVersion = "1.5.0";
           libbpfOverlay =
             (self: super: {
               libbpf = super.libbpf.overrideAttrs (old: {
@@ -33,18 +33,14 @@
                 src = super.fetchFromGitHub {
                   owner = "libbpf";
                   repo = "libbpf";
-                  # We need libbpf support for "module:function" syntax for
-                  # fentry/fexit probes. This is not released, yet, hence we pin
-                  # to a specific commit for now. Once the next release is out,
-                  # we should move to the corresponding version (likely 1.5.0).
-                  rev = "dd589c3b31c13164bdc61ed174fbae6fe76c8308";
+                  rev = "v${libbpfVersion}";
                   # If you don't know the hash the first time, set:
                   # hash = "";
                   # then nix will fail the build with such an error message:
                   # hash mismatch in fixed-output derivation '/nix/store/m1ga09c0z1a6n7rj8ky3s31dpgalsn0n-source':
                   # specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
                   # got:    sha256-173gxk0ymiw94glyjzjizp8bv8g72gwkjhacigd1an09jshdrjb4
-                  sha256 = "sha256-zreQ18XLzk65w1TxCbL7RUdmzABYSSlfsGBKq2CvvXE=";
+                  sha256 = "sha256-+L/rbp0a3p4PHq1yTJmuMcNj0gT5sqAPeaNRo3Sh6U8=";
                 };
               });
             });


### PR DESCRIPTION
libbpf 1.5.0 has been released [1] and it contains support for "module:function" syntax for fentry/fexit probes which is required by bpftrace.

Update libbpf requirement in CMakeLists.txt and Nix flake to 1.5.0.

[1] https://github.com/libbpf/libbpf/releases/tag/v1.5.0

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
