### PR TITLE
Call `bpf_map_sum_elem_count` in test/data main

### DIFF
--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -128,16 +128,20 @@ long bpf_map_sum_elem_count(const struct bpf_map *map)
   return 0;
 }
 
+// Make sure all new mocked kernel functions are called in this main (below)
+// so they don't get optimzed away
 int main(void)
 {
   struct bpf_iter__task iter_task;
   struct bpf_iter__task_file iter_task_file;
   struct bpf_iter__task_vma iter_task_vma;
+  struct bpf_map bpf_map;
 
   func_1(0, 0, 0, 0);
 
   bpf_iter_task();
   bpf_iter_task_file();
   bpf_iter_task_vma();
+  bpf_map_sum_elem_count(&bpf_map);
   return 0;
 }


### PR DESCRIPTION
This is so this function doesn't get optimized away and will be used in tests.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
