### PR TITLE
Fix typo in FindLibPcap.cmake

### DIFF
--- a/cmake/FindLibPcap.cmake
+++ b/cmake/FindLibPcap.cmake
@@ -32,7 +32,7 @@ find_library(LIBPCAP_LIBRARIES
 include (FindPackageHandleStandardArgs)
 
 # handle the QUIETLY and REQUIRED arguments and set LIBPCAP_FOUND to TRUE if all listed variables are TRUE
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibPcap "Please install the libcap development package"
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibPcap "Please install the libpcap development package"
   LIBPCAP_LIBRARIES
   LIBPCAP_INCLUDE_DIRS)
 


### PR DESCRIPTION
libcap and libpcap are different libraries:

libcap: Library for getting and setting POSIX.1e capabilities
libpcap: A system-independent interface for user-level packet capture

The one needed by bpftrace is libpcap.