### PR TITLE
tools/bashreadline: fix probe for dynamically linked readline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,8 @@ and this project adheres to
 - Remove mention of unsupported character literals
   - [#3283](https://github.com/bpftrace/bpftrace/pull/3283)
 #### Tools
+- Fix bashreadline tool probe for dynamically linked readline
+  - [#3564](https://github.com/bpftrace/bpftrace/pull/3564)
 
 ## [0.21.0] 2024-06-21
 

--- a/tools/bashreadline.bt
+++ b/tools/bashreadline.bt
@@ -15,13 +15,17 @@
  * 06-Sep-2018	Brendan Gregg	Created this.
  */
 
+config = { missing_probes = "ignore" }
+
 BEGIN
 {
 	printf("Tracing bash commands... Hit Ctrl-C to end.\n");
 	printf("%-9s %-6s %s\n", "TIME", "PID", "COMMAND");
 }
 
-uretprobe:/bin/bash:readline
+uretprobe:/bin/bash:readline,
+uretprobe:libreadline:readline
+/comm == "bash"/
 {
 	time("%H:%M:%S  ");
 	printf("%-6d %s\n", pid, str(retval));


### PR DESCRIPTION
When bash links against libreadline dynamically, the probe fails as the readline symbol is undefined until runtime. Fix this issue by adding a fallback probe that hooks directly into libreadline.