### PR TITLE
Allow builtin types to be used for field access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,8 @@ and this project adheres to
   - [#3536](https://github.com/bpftrace/bpftrace/pull/3536)
 - Fix crash by adding checks for bad var/map assignments
   - [#3542](https://github.com/bpftrace/bpftrace/pull/3542)
+- Fix field access and offsetof for strings that are builtin types
+  - [#3565](https://github.com/bpftrace/bpftrace/pull/3565)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -655,6 +655,7 @@ keyword:
 ident:
                 IDENT         { $$ = $1; }
         |       BUILTIN       { $$ = $1; }
+        |       BUILTIN_TYPE  { $$ = $1; }
         |       CALL          { $$ = $1; }
         |       CALL_BUILTIN  { $$ = $1; }
         |       STACK_MODE    { $$ = $1; }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1983,6 +1983,18 @@ TEST(Parser, offsetof_expression)
        "   x\n");
 }
 
+TEST(Parser, offsetof_builtin_type)
+{
+  test("struct Foo { timestamp x; } BEGIN { offsetof(struct Foo, timestamp); }",
+       "struct Foo { timestamp x; };\n"
+       "\n"
+       "Program\n"
+       " BEGIN\n"
+       "  offsetof: \n"
+       "   struct Foo\n"
+       "   timestamp\n");
+}
+
 TEST(Parser, dereference_precedence)
 {
   test("kprobe:sys_read { *@x+1 }",
@@ -2053,6 +2065,24 @@ TEST(Parser, field_access_builtin)
        "   dereference\n"
        "    map: @x\n"
        "   count\n");
+}
+
+TEST(Parser, field_access_builtin_type)
+{
+  test("kprobe:sys_read { @x.timestamp; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  .\n"
+       "   map: @x\n"
+       "   timestamp\n");
+
+  test("kprobe:sys_read { @x->timestamp; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  .\n"
+       "   dereference\n"
+       "    map: @x\n"
+       "   timestamp\n");
 }
 
 TEST(Parser, array_access)


### PR DESCRIPTION
This was previously an error because "timestamp"
is a builtin_type.
```
bpftrace -e 'kfunc:perf_event_update_time { print(args->event->ctx->timestamp); }'a
stdin:1:32-65: ERROR: syntax error, unexpected builtin type
kfunc:perf_event_update_time { print(args->event->ctx->timestamp); }a
                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This will all go away when we finally pull the hardcoded types out of the lexer and make them all idents.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
