### PR TITLE
Restrict use some map aggregation types

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -478,8 +478,15 @@ public:
   }
   bool IsMapIterableTy() const
   {
-    return !(type_ == Type::hist_t || type_ == Type::lhist_t ||
-             type_ == Type::stats_t);
+    return !IsMultiOutputMapTy();
+  }
+
+  // These are special map value types that can't be reduced to a single value
+  // and output multiple lines when printed
+  bool IsMultiOutputMapTy() const
+  {
+    return type_ == Type::hist_t || type_ == Type::lhist_t ||
+           type_ == Type::stats_t;
   }
 
   bool NeedsPercpuMap() const;

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1042,6 +1042,11 @@ stdin:1:20-38: ERROR: Single-value (i.e. indexed) map print cannot take addition
 BEGIN { @x[1] = 1; print(@x[1], 3, 5); }
                    ~~~~~~~~~~~~~~~~~~
 )");
+  test_error("BEGIN { @x[1] = hist(10); print(@x[1]); }", R"(
+stdin:1:27-39: ERROR: Map type hist_t cannot print the value of individual keys. You must print the whole map.
+BEGIN { @x[1] = hist(10); print(@x[1]); }
+                          ~~~~~~~~~~~~
+)");
 }
 
 TEST(semantic_analyser, call_print_non_map)
@@ -3412,6 +3417,12 @@ BEGIN { $t = ((uint8)1, (2, 3)); $t = (4, ((int8)5, 6)); }
 
   test(R"_(BEGIN { @t = (1, 2, "hi"); @t = (3, 4, "hellolongstr"); })_");
   test(R"_(BEGIN { $t = (1, ("hi", 2)); $t = (3, ("hellolongstr", 4)); })_");
+
+  test_error("BEGIN { @x[1] = hist(10); $y = (1, @x[1]); }", R"(
+stdin:1:36-41: ERROR: Map type hist_t cannot exist inside a tuple.
+BEGIN { @x[1] = hist(10); $y = (1, @x[1]); }
+                                   ~~~~~
+)");
 }
 
 TEST(semantic_analyser, tuple_indexing)


### PR DESCRIPTION
lhist/hist/stats have some restrictions in that
they cannot be referenced inside tuples and single key values cannot be printed; the entire map must
be printed. This latter restriction could be relaxed; it just requires the development work to support it.

Issue: https://github.com/bpftrace/bpftrace/issues/3540

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
