### PR TITLE
Migrate map keys to scratch buffers

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -45,6 +45,8 @@ aot.call.str_big_tuple
 aot.call.tuple_scratch_buf
 # Same problem as #3392
 aot.call.variable_for_loop_scratch_buf
+# Same problem as #3392
+aot.call.map_key_scratch_buf
 aot.call.str_truncated
 aot.call.str_truncated_custom
 aot.call.strftime

--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -12,6 +12,7 @@ namespace ast {
   DO(bpf_print)                                                                \
   DO(non_map_print)                                                            \
   DO(printf)                                                                   \
+  DO(map_key)                                                                  \
   DO(read_map_value)                                                           \
   DO(skb_output)                                                               \
   DO(strftime)                                                                 \

--- a/src/ast/codegen_helper.cpp
+++ b/src/ast/codegen_helper.cpp
@@ -30,4 +30,17 @@ bool needAssignMapStatementAllocation(const AssignMapStatement &assignment)
   return true;
 }
 
+bool needMapKeyAllocation(const Map &map)
+{
+  return needMapKeyAllocation(map, map.key_expr);
+}
+
+bool needMapKeyAllocation(const Map &map, Expression *key_expr)
+{
+  if (key_expr && inBpfMemory(key_expr->type)) {
+    return !key_expr->type.IsSameSizeRecursive(map.key_type);
+  }
+  return true;
+}
+
 } // namespace bpftrace::ast

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -35,5 +35,8 @@ inline AddrSpace find_addrspace_stack(const SizedType &ty)
 
 bool needAssignMapStatementAllocation(const AssignMapStatement &assignment);
 
+bool needMapKeyAllocation(const Map &map);
+bool needMapKeyAllocation(const Map &map, Expression *key_expr);
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -580,6 +580,19 @@ Value *IRBuilderBPF::CreateVariableAllocationInit(const SizedType &value_type,
   return alloc;
 }
 
+Value *IRBuilderBPF::CreateMapKeyAllocation(const SizedType &value_type,
+                                            const std::string &name,
+                                            const location &loc)
+{
+  return createAllocation(bpftrace::globalvars::GlobalVar::MAP_KEY_BUFFER,
+                          GetType(value_type),
+                          name,
+                          loc,
+                          [](AsyncIds &async_ids) {
+                            return async_ids.map_key();
+                          });
+}
+
 Value *IRBuilderBPF::createAllocation(
     bpftrace::globalvars::GlobalVar globalvar,
     llvm::Type *obj_type,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -178,6 +178,9 @@ public:
   Value *CreateVariableAllocationInit(const SizedType &value_type,
                                       const std::string &name,
                                       const location &loc);
+  Value *CreateMapKeyAllocation(const SizedType &value_type,
+                                const std::string &name,
+                                const location &loc);
   void CreateCheckSetRecursion(const location &loc, int early_exit_ret);
   void CreateUnSetRecursion(const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -76,7 +76,7 @@ public:
   void visit(Program &program) override;
   void visit(Block &block) override;
 
-  AllocaInst *getHistMapKey(Map &map, Value *log2);
+  Value *getHistMapKey(Map &map, Value *log2, const location &loc);
   int getNextIndexForProbe();
   Value *createLogicalAnd(Binop &binop);
   Value *createLogicalOr(Binop &binop);
@@ -189,7 +189,9 @@ private:
   [[nodiscard]] std::tuple<Value *, ScopedExprDeleter> getMapKey(
       Map &map,
       Expression *key_expr);
-  AllocaInst *getMultiMapKey(Map &map, const std::vector<Value *> &extra_keys);
+  Value *getMultiMapKey(Map &map,
+                        const std::vector<Value *> &extra_keys,
+                        const location &loc);
 
   void compareStructure(SizedType &our_type, llvm::Type *llvm_type);
 

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -46,6 +46,8 @@ private:
 
   bool exceeds_stack_limit(size_t size);
 
+  void maybe_allocate_map_key_buffer(const Map &map);
+
   void update_map_info(Map &map);
   void update_variable_info(Variable &var);
 

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -143,6 +143,7 @@ static void update_global_vars_rodata(
       case GlobalVar::READ_MAP_VALUE_BUFFER:
       case GlobalVar::WRITE_MAP_VALUE_BUFFER:
       case GlobalVar::VARIABLE_BUFFER:
+      case GlobalVar::MAP_KEY_BUFFER:
         break;
     }
   }
@@ -293,6 +294,12 @@ SizedType get_type(bpftrace::globalvars::GlobalVar global_var,
       assert(resources.max_variable_size > 0);
       return make_rw_type(resources.variable_buffers,
                           CreateArray(resources.max_variable_size,
+                                      CreateInt8()));
+    case GlobalVar::MAP_KEY_BUFFER:
+      assert(resources.map_key_buffers > 0);
+      assert(resources.max_map_key_size > 0);
+      return make_rw_type(resources.map_key_buffers,
+                          CreateArray(resources.max_map_key_size,
                                       CreateInt8()));
   }
   return {}; // unreachable

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -25,6 +25,7 @@ constexpr std::string_view READ_MAP_VALUE_BUFFER_SECTION_NAME =
 constexpr std::string_view WRITE_MAP_VALUE_BUFFER_SECTION_NAME =
     ".data.write_map_val_buf";
 constexpr std::string_view VARIABLE_BUFFER_SECTION_NAME = ".data.var_buf";
+constexpr std::string_view MAP_KEY_BUFFER_SECTION_NAME = ".data.map_key_buf";
 
 struct GlobalVarConfig {
   std::string name;
@@ -52,6 +53,8 @@ const std::unordered_map<GlobalVar, GlobalVarConfig> GLOBAL_VAR_CONFIGS = {
       false } },
   { GlobalVar::VARIABLE_BUFFER,
     { "var_buf", std::string(VARIABLE_BUFFER_SECTION_NAME), false } },
+  { GlobalVar::MAP_KEY_BUFFER,
+    { "map_key_buf", std::string(MAP_KEY_BUFFER_SECTION_NAME), false } },
 };
 
 void update_global_vars(

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -119,6 +119,10 @@ public:
   size_t variable_buffers = 0;
   size_t max_variable_size = 0;
 
+  // Required for sizing of map key scratch buffers
+  size_t map_key_buffers = 0;
+  size_t max_map_key_size = 0;
+
   // Async argument metadata that codegen creates. Ideally ResourceAnalyser
   // pass should be collecting this, but it's complex to move the logic.
   //

--- a/src/types.h
+++ b/src/types.h
@@ -748,6 +748,7 @@ enum class GlobalVar {
   READ_MAP_VALUE_BUFFER,
   WRITE_MAP_VALUE_BUFFER,
   VARIABLE_BUFFER,
+  MAP_KEY_BUFFER,
 };
 
 } // namespace globalvars

--- a/tests/codegen/llvm/call_map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/call_map_key_scratch_buf.ll
@@ -1,0 +1,263 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !22
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !36
+@map_key_buf = dso_local externally_initialized global [1 x [7 x [8 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !53
+@write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !63
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !67
+@read_map_val_buf = dso_local externally_initialized global [1 x [2 x [8 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !69
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !73
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !78 {
+entry:
+  %initial_value9 = alloca i64, align 8
+  %lookup_elem_val7 = alloca i64, align 8
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [7 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  store i64 1, ptr %2, align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %2)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %3 = load i64, ptr %lookup_elem, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, ptr %lookup_elem, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
+  store i64 1, ptr %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %initial_value, i64 1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
+  %log2 = call i64 @log2(i64 10, i64 0)
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
+  %6 = getelementptr [1 x [7 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
+  store i64 %log2, ptr %6, align 8
+  %lookup_elem3 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_y, ptr %6)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val7)
+  %map_lookup_cond8 = icmp ne ptr %lookup_elem3, null
+  br i1 %map_lookup_cond8, label %lookup_success4, label %lookup_failure5
+
+lookup_success4:                                  ; preds = %lookup_merge
+  %7 = load i64, ptr %lookup_elem3, align 8
+  %8 = add i64 %7, 1
+  store i64 %8, ptr %lookup_elem3, align 8
+  br label %lookup_merge6
+
+lookup_failure5:                                  ; preds = %lookup_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value9)
+  store i64 1, ptr %initial_value9, align 8
+  %update_elem10 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %6, ptr %initial_value9, i64 1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value9)
+  br label %lookup_merge6
+
+lookup_merge6:                                    ; preds = %lookup_failure5, %lookup_success4
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val7)
+  %get_cpu_id11 = call i64 inttoptr (i64 8 to ptr)()
+  %9 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded12 = and i64 %get_cpu_id11, %9
+  %10 = getelementptr [1 x [7 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded12, i64 2, i64 0
+  store i64 1, ptr %10, align 8
+  %lookup_elem13 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %10)
+  %has_key = icmp ne ptr %lookup_elem13, null
+  %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)()
+  %11 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded15 = and i64 %get_cpu_id14, %11
+  %12 = getelementptr [1 x [7 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
+  store i64 1, ptr %12, align 8
+  %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %12)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: alwaysinline
+define internal i64 @log2(i64 %0, i64 %1) #2 section "helpers" {
+entry:
+  %2 = alloca i64, align 8
+  %3 = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %3)
+  store i64 %0, ptr %3, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %2)
+  store i64 %1, ptr %2, align 8
+  %4 = load i64, ptr %3, align 8
+  %5 = icmp slt i64 %4, 0
+  br i1 %5, label %hist.is_less_than_zero, label %hist.is_not_less_than_zero
+
+hist.is_less_than_zero:                           ; preds = %entry
+  ret i64 0
+
+hist.is_not_less_than_zero:                       ; preds = %entry
+  %6 = load i64, ptr %2, align 8
+  %7 = shl i64 1, %6
+  %8 = sub i64 %7, 1
+  %9 = icmp ule i64 %4, %8
+  br i1 %9, label %hist.is_zero, label %hist.is_not_zero
+
+hist.is_zero:                                     ; preds = %hist.is_not_less_than_zero
+  %10 = add i64 %4, 1
+  ret i64 %10
+
+hist.is_not_zero:                                 ; preds = %hist.is_not_less_than_zero
+  %11 = icmp sge i64 %4, 4294967296
+  %12 = zext i1 %11 to i64
+  %13 = shl i64 %12, 5
+  %14 = lshr i64 %4, %13
+  %15 = add i64 0, %13
+  %16 = icmp sge i64 %14, 65536
+  %17 = zext i1 %16 to i64
+  %18 = shl i64 %17, 4
+  %19 = lshr i64 %14, %18
+  %20 = add i64 %15, %18
+  %21 = icmp sge i64 %19, 256
+  %22 = zext i1 %21 to i64
+  %23 = shl i64 %22, 3
+  %24 = lshr i64 %19, %23
+  %25 = add i64 %20, %23
+  %26 = icmp sge i64 %24, 16
+  %27 = zext i1 %26 to i64
+  %28 = shl i64 %27, 2
+  %29 = lshr i64 %24, %28
+  %30 = add i64 %25, %28
+  %31 = icmp sge i64 %29, 4
+  %32 = zext i1 %31 to i64
+  %33 = shl i64 %32, 1
+  %34 = lshr i64 %29, %33
+  %35 = add i64 %30, %33
+  %36 = icmp sge i64 %34, 2
+  %37 = zext i1 %36 to i64
+  %38 = shl i64 %37, 0
+  %39 = lshr i64 %34, %38
+  %40 = add i64 %35, %38
+  %41 = sub i64 %40, %6
+  %42 = load i64, ptr %3, align 8
+  %43 = lshr i64 %42, %41
+  %44 = and i64 %43, %8
+  %45 = add i64 %41, 1
+  %46 = shl i64 %45, %6
+  %47 = add i64 %46, %44
+  %48 = add i64 %47, 1
+  ret i64 %48
+}
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { alwaysinline }
+
+!llvm.dbg.cu = !{!75}
+!llvm.module.flags = !{!77}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 160, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 5, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
+!25 = !{!26, !31}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !29)
+!29 = !{!30}
+!30 = !DISubrange(count: 27, lowerBound: 0)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 262144, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !45, !50, !19}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 2, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !46, size: 64, offset: 64)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !48)
+!48 = !{!49}
+!49 = !DISubrange(count: 1, lowerBound: 0)
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !51, size: 64, offset: 128)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!52 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "map_key_buf", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 448, elements: !48)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 448, elements: !61)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 64, elements: !59)
+!58 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!59 = !{!60}
+!60 = !DISubrange(count: 8, lowerBound: 0)
+!61 = !{!62}
+!62 = !DISubrange(count: 7, lowerBound: 0)
+!63 = !DIGlobalVariableExpression(var: !64, expr: !DIExpression())
+!64 = distinct !DIGlobalVariable(name: "write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !65, isLocal: false, isDefinition: true)
+!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !66, size: 64, elements: !48)
+!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 64, elements: !48)
+!67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
+!68 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!69 = !DIGlobalVariableExpression(var: !70, expr: !DIExpression())
+!70 = distinct !DIGlobalVariable(name: "read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !71, isLocal: false, isDefinition: true)
+!71 = !DICompositeType(tag: DW_TAG_array_type, baseType: !72, size: 128, elements: !48)
+!72 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 128, elements: !43)
+!73 = !DIGlobalVariableExpression(var: !74, expr: !DIExpression())
+!74 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!75 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !76)
+!76 = !{!0, !20, !22, !36, !53, !63, !67, !69, !73}
+!77 = !{i32 2, !"Debug Info Version", i32 3}
+!78 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !79, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !75, retainedNodes: !82)
+!79 = !DISubroutineType(types: !80)
+!80 = !{!18, !81}
+!81 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
+!82 = !{!83}
+!83 = !DILocalVariable(name: "ctx", arg: 1, scope: !78, file: !2, type: !81)

--- a/tests/codegen/llvm/call_map_key_stack.ll
+++ b/tests/codegen/llvm/call_map_key_stack.ll
@@ -1,0 +1,236 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !22
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !36
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !53
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !58 {
+entry:
+  %"@x_key11" = alloca i64, align 8
+  %"@x_key9" = alloca i64, align 8
+  %initial_value7 = alloca i64, align 8
+  %lookup_elem_val5 = alloca i64, align 8
+  %"@y_key" = alloca i64, align 8
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
+  store i64 1, ptr %"@x_key", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %1 = load i64, ptr %lookup_elem, align 8
+  %2 = add i64 %1, 1
+  store i64 %2, ptr %lookup_elem, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
+  store i64 1, ptr %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  %log2 = call i64 @log2(i64 10, i64 0)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
+  store i64 %log2, ptr %"@y_key", align 8
+  %lookup_elem1 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_y, ptr %"@y_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val5)
+  %map_lookup_cond6 = icmp ne ptr %lookup_elem1, null
+  br i1 %map_lookup_cond6, label %lookup_success2, label %lookup_failure3
+
+lookup_success2:                                  ; preds = %lookup_merge
+  %3 = load i64, ptr %lookup_elem1, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, ptr %lookup_elem1, align 8
+  br label %lookup_merge4
+
+lookup_failure3:                                  ; preds = %lookup_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value7)
+  store i64 1, ptr %initial_value7, align 8
+  %update_elem8 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %initial_value7, i64 1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value7)
+  br label %lookup_merge4
+
+lookup_merge4:                                    ; preds = %lookup_failure3, %lookup_success2
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val5)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key9")
+  store i64 1, ptr %"@x_key9", align 8
+  %lookup_elem10 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key9")
+  %has_key = icmp ne ptr %lookup_elem10, null
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key9")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key11")
+  store i64 1, ptr %"@x_key11", align 8
+  %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %"@x_key11")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key11")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: alwaysinline
+define internal i64 @log2(i64 %0, i64 %1) #2 section "helpers" {
+entry:
+  %2 = alloca i64, align 8
+  %3 = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %3)
+  store i64 %0, ptr %3, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %2)
+  store i64 %1, ptr %2, align 8
+  %4 = load i64, ptr %3, align 8
+  %5 = icmp slt i64 %4, 0
+  br i1 %5, label %hist.is_less_than_zero, label %hist.is_not_less_than_zero
+
+hist.is_less_than_zero:                           ; preds = %entry
+  ret i64 0
+
+hist.is_not_less_than_zero:                       ; preds = %entry
+  %6 = load i64, ptr %2, align 8
+  %7 = shl i64 1, %6
+  %8 = sub i64 %7, 1
+  %9 = icmp ule i64 %4, %8
+  br i1 %9, label %hist.is_zero, label %hist.is_not_zero
+
+hist.is_zero:                                     ; preds = %hist.is_not_less_than_zero
+  %10 = add i64 %4, 1
+  ret i64 %10
+
+hist.is_not_zero:                                 ; preds = %hist.is_not_less_than_zero
+  %11 = icmp sge i64 %4, 4294967296
+  %12 = zext i1 %11 to i64
+  %13 = shl i64 %12, 5
+  %14 = lshr i64 %4, %13
+  %15 = add i64 0, %13
+  %16 = icmp sge i64 %14, 65536
+  %17 = zext i1 %16 to i64
+  %18 = shl i64 %17, 4
+  %19 = lshr i64 %14, %18
+  %20 = add i64 %15, %18
+  %21 = icmp sge i64 %19, 256
+  %22 = zext i1 %21 to i64
+  %23 = shl i64 %22, 3
+  %24 = lshr i64 %19, %23
+  %25 = add i64 %20, %23
+  %26 = icmp sge i64 %24, 16
+  %27 = zext i1 %26 to i64
+  %28 = shl i64 %27, 2
+  %29 = lshr i64 %24, %28
+  %30 = add i64 %25, %28
+  %31 = icmp sge i64 %29, 4
+  %32 = zext i1 %31 to i64
+  %33 = shl i64 %32, 1
+  %34 = lshr i64 %29, %33
+  %35 = add i64 %30, %33
+  %36 = icmp sge i64 %34, 2
+  %37 = zext i1 %36 to i64
+  %38 = shl i64 %37, 0
+  %39 = lshr i64 %34, %38
+  %40 = add i64 %35, %38
+  %41 = sub i64 %40, %6
+  %42 = load i64, ptr %3, align 8
+  %43 = lshr i64 %42, %41
+  %44 = and i64 %43, %8
+  %45 = add i64 %41, 1
+  %46 = shl i64 %45, %6
+  %47 = add i64 %46, %44
+  %48 = add i64 %47, 1
+  ret i64 %48
+}
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { alwaysinline }
+
+!llvm.dbg.cu = !{!55}
+!llvm.module.flags = !{!57}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 160, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 5, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
+!25 = !{!26, !31}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !29)
+!29 = !{!30}
+!30 = !DISubrange(count: 27, lowerBound: 0)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 262144, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !45, !50, !19}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 2, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !46, size: 64, offset: 64)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !48)
+!48 = !{!49}
+!49 = !DISubrange(count: 1, lowerBound: 0)
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !51, size: 64, offset: 128)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!52 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
+!56 = !{!0, !20, !22, !36, !53}
+!57 = !{i32 2, !"Debug Info Version", i32 3}
+!58 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !63)
+!59 = !DISubroutineType(types: !60)
+!60 = !{!18, !61}
+!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !62, size: 64)
+!62 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!63 = !{!64}
+!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)

--- a/tests/codegen/llvm/map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/map_key_scratch_buf.ll
@@ -1,0 +1,162 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !30
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !44
+@map_key_buf = dso_local externally_initialized global [1 x [2 x [8 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !57
+@write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !64
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !68
+@read_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !70
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !75 {
+entry:
+  %str = alloca [5 x i8], align 1
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %1 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [2 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  store i64 1, ptr %2, align 8
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded2 = and i64 %get_cpu_id1, %3
+  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
+  store i64 1, ptr %4, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %4, i64 0)
+  %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded4 = and i64 %get_cpu_id3, %5
+  %6 = getelementptr [1 x [2 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded4, i64 1, i64 0
+  store i64 1, ptr %6, align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %6)
+  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)()
+  %7 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded6 = and i64 %get_cpu_id5, %7
+  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @read_map_val_buf, i64 0, i64 %cpu.id.bounded6, i64 0, i64 0
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %9 = load i64, ptr %lookup_elem, align 8
+  store i64 %9, ptr %8, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  store i64 0, ptr %8, align 8
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %10 = load i64, ptr %8, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
+  store [5 x i8] c"yyyy\00", ptr %str, align 1
+  %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)()
+  %11 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded8 = and i64 %get_cpu_id7, %11
+  %12 = getelementptr [1 x [1 x [8 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded8, i64 0, i64 0
+  store i64 %10, ptr %12, align 8
+  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %str, ptr %12, i64 0)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!72}
+!llvm.module.flags = !{!74}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !23)
+!23 = !{!5, !11, !24, !19}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !25, size: 64, offset: 128)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !27, size: 40, elements: !28)
+!27 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!28 = !{!29}
+!29 = !DISubrange(count: 5, lowerBound: 0)
+!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
+!31 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !33)
+!33 = !{!34, !39}
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !35, size: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 27, lowerBound: 0)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !40, size: 64, offset: 64)
+!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !42)
+!42 = !{!43}
+!43 = !DISubrange(count: 262144, lowerBound: 0)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
+!46 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !47)
+!47 = !{!48, !53, !54, !19}
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !49, size: 64)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 2, lowerBound: 0)
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
+!56 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "map_key_buf", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 128, elements: !9)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !61, size: 128, elements: !51)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !27, size: 64, elements: !62)
+!62 = !{!63}
+!63 = !DISubrange(count: 8, lowerBound: 0)
+!64 = !DIGlobalVariableExpression(var: !65, expr: !DIExpression())
+!65 = distinct !DIGlobalVariable(name: "write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !66, isLocal: false, isDefinition: true)
+!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !67, size: 64, elements: !9)
+!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !61, size: 64, elements: !9)
+!68 = !DIGlobalVariableExpression(var: !69, expr: !DIExpression())
+!69 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!70 = !DIGlobalVariableExpression(var: !71, expr: !DIExpression())
+!71 = distinct !DIGlobalVariable(name: "read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !66, isLocal: false, isDefinition: true)
+!72 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !73)
+!73 = !{!0, !20, !30, !44, !57, !64, !68, !70}
+!74 = !{i32 2, !"Debug Info Version", i32 3}
+!75 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !76, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !72, retainedNodes: !79)
+!76 = !DISubroutineType(types: !77)
+!77 = !{!18, !78}
+!78 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!79 = !{!80}
+!80 = !DILocalVariable(name: "ctx", arg: 1, scope: !75, file: !2, type: !78)

--- a/tests/codegen/llvm/map_key_stack.ll
+++ b/tests/codegen/llvm/map_key_stack.ll
@@ -1,0 +1,141 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !30
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !44
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !60 {
+entry:
+  %"@y_val" = alloca i64, align 8
+  %str = alloca [5 x i8], align 1
+  %lookup_elem_val = alloca i64, align 8
+  %"@x_key1" = alloca i64, align 8
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
+  store i64 1, ptr %"@x_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  store i64 1, ptr %"@x_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
+  store i64 1, ptr %"@x_key1", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %1 = load i64, ptr %lookup_elem, align 8
+  store i64 %1, ptr %lookup_elem_val, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  store i64 0, ptr %lookup_elem_val, align 8
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %2 = load i64, ptr %lookup_elem_val, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
+  store [5 x i8] c"yyyy\00", ptr %str, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
+  store i64 %2, ptr %"@y_val", align 8
+  %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %str, ptr %"@y_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!57}
+!llvm.module.flags = !{!59}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !23)
+!23 = !{!5, !11, !24, !19}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !25, size: 64, offset: 128)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !27, size: 40, elements: !28)
+!27 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!28 = !{!29}
+!29 = !DISubrange(count: 5, lowerBound: 0)
+!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
+!31 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !33)
+!33 = !{!34, !39}
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !35, size: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 27, lowerBound: 0)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !40, size: 64, offset: 64)
+!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !42)
+!42 = !{!43}
+!43 = !DISubrange(count: 262144, lowerBound: 0)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
+!46 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !47)
+!47 = !{!48, !53, !54, !19}
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !49, size: 64)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 2, lowerBound: 0)
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
+!56 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
+!58 = !{!0, !20, !30, !44}
+!59 = !{i32 2, !"Debug Info Version", i32 3}
+!60 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !64)
+!61 = !DISubroutineType(types: !62)
+!62 = !{!18, !63}
+!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!64 = !{!65}
+!65 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !63)

--- a/tests/codegen/llvm/map_value_int_scratch_buf.ll
+++ b/tests/codegen/llvm/map_value_int_scratch_buf.ll
@@ -13,72 +13,69 @@ target triple = "bpf-pc-linux"
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !24
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !38
-@write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !40
-@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !48
-@read_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !50
+@map_key_buf = dso_local externally_initialized global [1 x [3 x [8 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !40
+@write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !50
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !54
+@read_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !56
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !55 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !61 {
 entry:
-  %"@y_key" = alloca i64, align 8
-  %"@x_key1" = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 0, ptr %"@x_key", align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  store i64 1, ptr %2, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %2, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 0, ptr %"@x_key1", align 8
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
-  %get_cpu_id2 = call i64 inttoptr (i64 8 to ptr)()
+  %2 = getelementptr [1 x [3 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  store i64 0, ptr %2, align 8
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %3 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded3 = and i64 %get_cpu_id2, %3
-  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @read_map_val_buf, i64 0, i64 %cpu.id.bounded3, i64 0, i64 0
+  %cpu.id.bounded2 = and i64 %get_cpu_id1, %3
+  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
+  store i64 1, ptr %4, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %4, i64 0)
+  %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)()
+  %5 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded4 = and i64 %get_cpu_id3, %5
+  %6 = getelementptr [1 x [3 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded4, i64 1, i64 0
+  store i64 0, ptr %6, align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %6)
+  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)()
+  %7 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded6 = and i64 %get_cpu_id5, %7
+  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @read_map_val_buf, i64 0, i64 %cpu.id.bounded6, i64 0, i64 0
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, ptr %lookup_elem, align 8
-  store i64 %5, ptr %4, align 8
+  %9 = load i64, ptr %lookup_elem, align 8
+  store i64 %9, ptr %8, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, ptr %4, align 8
+  store i64 0, ptr %8, align 8
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %6 = load i64, ptr %4, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
-  store i64 0, ptr %"@y_key", align 8
-  %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
-  %7 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded5 = and i64 %get_cpu_id4, %7
-  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded5, i64 0, i64 0
-  store i64 %6, ptr %8, align 8
-  %update_elem6 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %8, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
+  %10 = load i64, ptr %8, align 8
+  %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)()
+  %11 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded8 = and i64 %get_cpu_id7, %11
+  %12 = getelementptr [1 x [3 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded8, i64 2, i64 0
+  store i64 0, ptr %12, align 8
+  %get_cpu_id9 = call i64 inttoptr (i64 8 to ptr)()
+  %13 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded10 = and i64 %get_cpu_id9, %13
+  %14 = getelementptr [1 x [1 x [8 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded10, i64 0, i64 0
+  store i64 %10, ptr %14, align 8
+  %update_elem11 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %12, ptr %14, i64 0)
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
-
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!52}
-!llvm.module.flags = !{!54}
+!llvm.dbg.cu = !{!58}
+!llvm.module.flags = !{!60}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -121,23 +118,29 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
 !39 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
 !40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !14)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !14)
+!41 = distinct !DIGlobalVariable(name: "map_key_buf", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 192, elements: !14)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 192, elements: !48)
 !44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 64, elements: !46)
 !45 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !46 = !{!47}
 !47 = !DISubrange(count: 8, lowerBound: 0)
-!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!48 = !{!49}
+!49 = !DISubrange(count: 3, lowerBound: 0)
 !50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
-!51 = distinct !DIGlobalVariable(name: "read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!52 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !53)
-!53 = !{!0, !22, !24, !38, !40, !48, !50}
-!54 = !{i32 2, !"Debug Info Version", i32 3}
-!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !59)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!21, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!59 = !{!60}
-!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
+!51 = distinct !DIGlobalVariable(name: "write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 64, elements: !14)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !14)
+!54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
+!55 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!56 = !DIGlobalVariableExpression(var: !57, expr: !DIExpression())
+!57 = distinct !DIGlobalVariable(name: "read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
+!58 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !59)
+!59 = !{!0, !22, !24, !38, !40, !50, !54, !56}
+!60 = !{i32 2, !"Debug Info Version", i32 3}
+!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !58, retainedNodes: !65)
+!62 = !DISubroutineType(types: !63)
+!63 = !{!21, !64}
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!65 = !{!66}
+!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)

--- a/tests/codegen/llvm/map_value_tuple_scratch_buf.ll
+++ b/tests/codegen/llvm/map_value_tuple_scratch_buf.ll
@@ -15,21 +15,18 @@ target triple = "bpf-pc-linux"
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !30
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !32
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !46
-@write_map_val_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !52
-@read_map_val_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !59
-@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !61
-@tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !63
+@map_key_buf = dso_local externally_initialized global [1 x [4 x [8 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !52
+@write_map_val_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !58
+@read_map_val_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !65
+@max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !67
+@tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !69
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !70 {
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !76 {
 entry:
-  %"@y_key" = alloca i64, align 8
-  %"@x_key8" = alloca i64, align 8
-  %"@x_key6" = alloca i64, align 8
-  %str3 = alloca [8 x i8], align 1
-  %"@x_key" = alloca i64, align 8
+  %str5 = alloca [8 x i8], align 1
   %str = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   store [4 x i8] c"xxx\00", ptr %str, align 1
@@ -43,61 +40,69 @@ entry:
   %4 = getelementptr %"string[4]_int64__tuple_t", ptr %2, i32 0, i32 1
   store i64 1, ptr %4, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 0, ptr %"@x_key", align 8
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
-  %6 = getelementptr [1 x [1 x [16 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 16, i1 false)
-  %7 = getelementptr [16 x i8], ptr %2, i64 0, i64 0
-  %8 = getelementptr %"string[8]_int64__tuple_t", ptr %6, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %7, i64 4, i1 false)
-  %9 = getelementptr [16 x i8], ptr %2, i64 0, i64 8
-  %10 = getelementptr %"string[8]_int64__tuple_t", ptr %6, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 8, i1 false)
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %6, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str3)
-  store [8 x i8] c"xxxxxxx\00", ptr %str3, align 1
-  %get_cpu_id4 = call i64 inttoptr (i64 8 to ptr)()
-  %11 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded5 = and i64 %get_cpu_id4, %11
-  %12 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded5, i64 1, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %12, i8 0, i64 16, i1 false)
-  %13 = getelementptr %"string[8]_int64__tuple_t", ptr %12, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 %str3, i64 8, i1 false)
-  %14 = getelementptr %"string[8]_int64__tuple_t", ptr %12, i32 0, i32 1
-  store i64 1, ptr %14, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str3)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key6")
-  store i64 0, ptr %"@x_key6", align 8
-  %update_elem7 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key6", ptr %12, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key6")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key8")
-  store i64 0, ptr %"@x_key8", align 8
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key8")
-  %get_cpu_id9 = call i64 inttoptr (i64 8 to ptr)()
-  %15 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded10 = and i64 %get_cpu_id9, %15
-  %16 = getelementptr [1 x [1 x [16 x i8]]], ptr @read_map_val_buf, i64 0, i64 %cpu.id.bounded10, i64 0, i64 0
+  %6 = getelementptr [1 x [4 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
+  store i64 0, ptr %6, align 8
+  %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)()
+  %7 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded4 = and i64 %get_cpu_id3, %7
+  %8 = getelementptr [1 x [1 x [16 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded4, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
+  %9 = getelementptr [16 x i8], ptr %2, i64 0, i64 0
+  %10 = getelementptr %"string[8]_int64__tuple_t", ptr %8, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 4, i1 false)
+  %11 = getelementptr [16 x i8], ptr %2, i64 0, i64 8
+  %12 = getelementptr %"string[8]_int64__tuple_t", ptr %8, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %11, i64 8, i1 false)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %6, ptr %8, i64 0)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %str5)
+  store [8 x i8] c"xxxxxxx\00", ptr %str5, align 1
+  %get_cpu_id6 = call i64 inttoptr (i64 8 to ptr)()
+  %13 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded7 = and i64 %get_cpu_id6, %13
+  %14 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded7, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %14, i8 0, i64 16, i1 false)
+  %15 = getelementptr %"string[8]_int64__tuple_t", ptr %14, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %15, ptr align 1 %str5, i64 8, i1 false)
+  %16 = getelementptr %"string[8]_int64__tuple_t", ptr %14, i32 0, i32 1
+  store i64 1, ptr %16, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %str5)
+  %get_cpu_id8 = call i64 inttoptr (i64 8 to ptr)()
+  %17 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded9 = and i64 %get_cpu_id8, %17
+  %18 = getelementptr [1 x [4 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded9, i64 1, i64 0
+  store i64 0, ptr %18, align 8
+  %update_elem10 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %18, ptr %14, i64 0)
+  %get_cpu_id11 = call i64 inttoptr (i64 8 to ptr)()
+  %19 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded12 = and i64 %get_cpu_id11, %19
+  %20 = getelementptr [1 x [4 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded12, i64 2, i64 0
+  store i64 0, ptr %20, align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %20)
+  %get_cpu_id13 = call i64 inttoptr (i64 8 to ptr)()
+  %21 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded14 = and i64 %get_cpu_id13, %21
+  %22 = getelementptr [1 x [1 x [16 x i8]]], ptr @read_map_val_buf, i64 0, i64 %cpu.id.bounded14, i64 0, i64 0
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 %lookup_elem, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %22, ptr align 1 %lookup_elem, i64 16, i1 false)
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %16, i8 0, i64 16, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %22, i8 0, i64 16, i1 false)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key8")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
-  store i64 0, ptr %"@y_key", align 8
-  %update_elem11 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %16, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
+  %get_cpu_id15 = call i64 inttoptr (i64 8 to ptr)()
+  %23 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded16 = and i64 %get_cpu_id15, %23
+  %24 = getelementptr [1 x [4 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded16, i64 3, i64 0
+  store i64 0, ptr %24, align 8
+  %update_elem17 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %24, ptr %22, i64 0)
   ret i64 0
 }
 
@@ -118,8 +123,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!67}
-!llvm.module.flags = !{!69}
+!llvm.dbg.cu = !{!73}
+!llvm.module.flags = !{!75}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -174,26 +179,32 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !50 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !51, size: 64, offset: 192)
 !51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
 !52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
-!53 = distinct !DIGlobalVariable(name: "write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !54, isLocal: false, isDefinition: true)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 128, elements: !14)
-!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 128, elements: !14)
-!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 128, elements: !57)
-!57 = !{!58}
-!58 = !DISubrange(count: 16, lowerBound: 0)
-!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
-!60 = distinct !DIGlobalVariable(name: "read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !54, isLocal: false, isDefinition: true)
-!61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
-!62 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
-!63 = !DIGlobalVariableExpression(var: !64, expr: !DIExpression())
-!64 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !65, isLocal: false, isDefinition: true)
-!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !66, size: 256, elements: !14)
-!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 256, elements: !9)
-!67 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !68)
-!68 = !{!0, !30, !32, !46, !52, !59, !61, !63}
-!69 = !{i32 2, !"Debug Info Version", i32 3}
-!70 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !71, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !67, retainedNodes: !74)
-!71 = !DISubroutineType(types: !72)
-!72 = !{!29, !73}
-!73 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
-!74 = !{!75}
-!75 = !DILocalVariable(name: "ctx", arg: 1, scope: !70, file: !2, type: !73)
+!53 = distinct !DIGlobalVariable(name: "map_key_buf", linkageName: "global", scope: !2, file: !2, type: !54, isLocal: false, isDefinition: true)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 256, elements: !14)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 256, elements: !56)
+!56 = !{!57}
+!57 = !DISubrange(count: 4, lowerBound: 0)
+!58 = !DIGlobalVariableExpression(var: !59, expr: !DIExpression())
+!59 = distinct !DIGlobalVariable(name: "write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !60, isLocal: false, isDefinition: true)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !61, size: 128, elements: !14)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 128, elements: !14)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 128, elements: !63)
+!63 = !{!64}
+!64 = !DISubrange(count: 16, lowerBound: 0)
+!65 = !DIGlobalVariableExpression(var: !66, expr: !DIExpression())
+!66 = distinct !DIGlobalVariable(name: "read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !60, isLocal: false, isDefinition: true)
+!67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
+!68 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!69 = !DIGlobalVariableExpression(var: !70, expr: !DIExpression())
+!70 = distinct !DIGlobalVariable(name: "tuple_buf", linkageName: "global", scope: !2, file: !2, type: !71, isLocal: false, isDefinition: true)
+!71 = !DICompositeType(tag: DW_TAG_array_type, baseType: !72, size: 256, elements: !14)
+!72 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 256, elements: !9)
+!73 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !74)
+!74 = !{!0, !30, !32, !46, !52, !58, !65, !67, !69}
+!75 = !{i32 2, !"Debug Info Version", i32 3}
+!76 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !77, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !73, retainedNodes: !80)
+!77 = !DISubroutineType(types: !78)
+!78 = !{!29, !79}
+!79 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!80 = !{!81}
+!81 = !DILocalVariable(name: "ctx", arg: 1, scope: !76, file: !2, type: !79)

--- a/tests/codegen/scratch_buffer.cpp
+++ b/tests/codegen/scratch_buffer.cpp
@@ -115,6 +115,37 @@ TEST(codegen, variable_stack)
       LARGE_ON_STACK_LIMIT);
 }
 
+TEST(codegen, map_key_scratch_buf)
+{
+  test_stack_or_scratch_buffer("kprobe:f { @x[1] = 1; @y[\"yyyy\"] = @x[1]; }",
+                               NAME,
+                               SMALL_ON_STACK_LIMIT);
+}
+
+TEST(codegen, map_key_stack)
+{
+  test_stack_or_scratch_buffer("kprobe:f { @x[1] = 1; @y[\"yyyy\"] = @x[1]; }",
+                               NAME,
+                               LARGE_ON_STACK_LIMIT);
+}
+
+// Test map keys with aggregation and map-related functions
+TEST(codegen, call_map_key_scratch_buf)
+{
+  test_stack_or_scratch_buffer("kprobe:f { @x[1] = count(); @y = hist(10); "
+                               "has_key(@x, 1); delete(@x, 1); }",
+                               NAME,
+                               SMALL_ON_STACK_LIMIT);
+}
+
+TEST(codegen, call_map_key_stack)
+{
+  test_stack_or_scratch_buffer("kprobe:f { @x[1] = count(); @y = hist(10); "
+                               "has_key(@x, 1); delete(@x, 1); }",
+                               NAME,
+                               LARGE_ON_STACK_LIMIT);
+}
+
 } // namespace codegen
 } // namespace test
 } // namespace bpftrace

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -142,26 +142,50 @@ REQUIRES_FEATURE probe_read_kernel
 TIMEOUT 1
 
 NAME fmt_str_args_scratch_buf
-PROG config = { on_stack_limit = 0 } BEGIN { printf("%s %d\n", "XXXX", 1) }
+PROG config = { on_stack_limit = 0 } BEGIN { printf("%s %d\n", "XXXX", 1); exit() }
 EXPECT XXXX 1
 
 NAME map_val_scratch_buf
-PROG config = { on_stack_limit = 0 } BEGIN { @x = 1; @y = @x; print(@y) }
+PROG config = { on_stack_limit = 0 } BEGIN { @x = 1; @y = @x; print(@y); exit() }
 EXPECT @y: 1
 
 NAME variable_scratch_buf
-PROG config = { on_stack_limit = 0 } BEGIN { $x = "XXXX"; $y = $x; print($y) }
+PROG config = { on_stack_limit = 0 } BEGIN { $x = "XXXX"; $y = $x; print($y); exit() }
 EXPECT XXXX
 
 # Verify enough buffer space is allocated for same variable name in multiple scopes
 NAME variable_for_loop_scratch_buf
-PROG config = { on_stack_limit = 0 } BEGIN { @[1] = 1; for ($kv : @) { $y = $kv } for ($kv : @) { $y = $kv; print($y) } }
+PROG config = { on_stack_limit = 0 } BEGIN { @[1] = 1; for ($kv : @) { $y = $kv } for ($kv : @) { $y = $kv; print($y) } exit() }
 EXPECT (1, 1)
 
 # Verify enough buffer space is allocated for same variable name in multiple subprograms
 NAME variable_probe_subprog_scratch_buf
 PROG config = { on_stack_limit = 0 } BEGIN { $x = "XXXX" } i:ms:100 { $x = "YYYY"; exit(); }END { $x = "ZZZZ"; print($x) }
 EXPECT ZZZZ
+
+NAME scalar_map_scratch_buf
+PROG config = { on_stack_limit = 0 } BEGIN { @x = "xxxx"; print(@x); exit() }
+EXPECT @x: xxxx
+
+NAME map_key_scratch_buf
+PROG config = { on_stack_limit = 0 } BEGIN { @x[1, 2] = 1; @[1, 1] = 3; @x[2, 1] = 2; delete(@x[1, 2]); delete(@x, (1, 1)); print(@x); exit() }
+EXPECT @x[2, 1]: 2
+
+NAME hist_map_key_scratch_buf
+PROG config = { on_stack_limit = 0 } BEGIN { @["ok_key"] = hist(1); exit() }
+EXPECT @[ok_key]:
+
+NAME hist_scalar_map_key_scratch_buf
+PROG config = { on_stack_limit = 0 } BEGIN { @ = hist(1); exit() }
+EXPECT @:
+
+NAME lhist_map_key_scratch_buf
+PROG config = { on_stack_limit = 0 } BEGIN { @["ok_key"] = lhist(2,0,10,2); exit() }
+EXPECT @[ok_key]:
+
+NAME lhist_scalar_map_key_scratch_buf
+PROG config = { on_stack_limit = 0 } BEGIN { @ = lhist(2,0,10,2); exit() }
+EXPECT @:
 
 NAME str_big_for
 PROG t:syscalls:sys_enter_execve { @map[str(args.filename)] = str(args.filename); for ($kv : @map) { print($kv); } }


### PR DESCRIPTION
This completes the migration of script-dependent allocations to scratch buffers by migrating map keys > 32 bytes (on_stack_limit). Once this PR is merged, all script-dependent allocations can dynamically determine to use the stack vs. scratch buffer meaning we can support large strings across all data structures.
