### PR TITLE
Fix build on clang 17

### DIFF
--- a/src/struct.h
+++ b/src/struct.h
@@ -12,7 +12,7 @@
 
 namespace bpftrace {
 
-static constexpr std::string RETVAL_FIELD_NAME = "$retval";
+static constexpr auto RETVAL_FIELD_NAME = "$retval";
 
 struct Bitfield {
   Bitfield(size_t byte_offset, size_t bit_width);


### PR DESCRIPTION
We're seeing a clang 17 build failure:

```
... struct.h:15:30: error: constexpr variable cannot have non-literal type 'const std::string' (aka 'const basic_string<char>')
   15 | static constexpr std::string RETVAL_FIELD_NAME = "$retval";
      |                              ^
... bits/basic_string.h:85:11: note: 'basic_string<char>' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
   85 |     class basic_string
      |           ^
1 error generated.
```

Seems correct - std::string is not very const. Fix by changing it to raw string which should construct temporary std::string& correctly.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
