### PR TITLE
cmake: Use stricter include paths for src/ast

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ flex_target(flex_lexer src/lexer.l ${CMAKE_BINARY_DIR}/lex.yy.cc)
 add_flex_bison_dependency(flex_lexer bison_parser)
 add_library(parser STATIC ${BISON_bison_parser_OUTPUTS} ${FLEX_flex_lexer_OUTPUTS})
 target_compile_options(parser PRIVATE "-w")
-target_include_directories(parser PUBLIC src src/ast ${CMAKE_BINARY_DIR})
+target_include_directories(parser PRIVATE src src/ast ${CMAKE_BINARY_DIR})
 
 include(CheckSymbolExists)
 set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -3,8 +3,8 @@
 #include <algorithm>
 
 #include "ast/async_event_types.h"
+#include "ast/codegen_helper.h"
 #include "bpftrace.h"
-#include "codegen_helper.h"
 #include "globalvars.h"
 #include "log.h"
 #include "struct.h"

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -1,8 +1,8 @@
 #include "bpfbytecode.h"
+#include "ast/passes/codegen_llvm.h"
+#include "ast/passes/semantic_analyser.h"
 #include "driver.h"
 #include "mocks.h"
-#include "passes/codegen_llvm.h"
-#include "passes/semantic_analyser.h"
 
 #include "gtest/gtest.h"
 


### PR DESCRIPTION
The target_include_directories() on parser target was leaking into other cmake targets. Making include paths stricter keeps the code more uniform. It also matters for stricter build systems like buck.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
