### PR TITLE
Don't print out scalar maps if clear()ed in END

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ and this project adheres to
   - [#3542](https://github.com/bpftrace/bpftrace/pull/3542)
 - Fix field access and offsetof for strings that are builtin types
   - [#3565](https://github.com/bpftrace/bpftrace/pull/3565)
+- Fix printing of cleared scalar maps as 0 value even if cleared in END probe
+  - [#3578](https://github.com/bpftrace/bpftrace/pull/3578)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -4090,9 +4090,9 @@ Therefore, when you need precise event statistics, it is recommended to use sync
 === Map Printing
 
 By default when a bpftrace program exits it will print all maps to stdout.
-If you don't want this, you can either override the `print_maps_on_exit` configuration option or you can specify an `END` probe and `clear` the maps you don't want printed (this second method doesn't work for scalar maps).
+If you don't want this, you can either override the `print_maps_on_exit` configuration option or you can specify an `END` probe and `clear` the maps you don't want printed.
 
-For example, this script:
+For example, these two scripts are equivalent and will print nothing on exit:
 ```
 config = {
   print_maps_on_exit=0
@@ -4104,7 +4104,6 @@ BEGIN {
 }
 ```
 
-would print nothing on exit, while this script:
 ```
 BEGIN {
   @a = 1;
@@ -4115,11 +4114,6 @@ END {
   clear(@a);
   clear(@b);
 }
-```
-
-will print this on exit:
-```
-@a: 0
 ```
 
 === Systemd support

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -286,6 +286,13 @@ private:
   mutable FuncsModulesMap traceable_funcs_;
 
   std::unordered_map<std::string, std::unique_ptr<Dwarf>> dwarves_;
+
+  // Used to keep track of which maps are cleared in END probe. This is
+  // necessary for scalar maps, as they are backed by an arraymap and
+  // thus cannot have its entries deleted - only zeroed. So to avoid
+  // printing out zero entries, keep track of which maps are semantically
+  // cleared.
+  std::unordered_set<int> cleared_map_fds_;
 };
 
 } // namespace bpftrace

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -650,6 +650,15 @@ PROG BEGIN { @[1] = 1; @[2] = 2; $count = len(@); if ($count > 1) { print("true"
 EXPECT true
 TIMEOUT 3
 
-NAME map len keyless
+NAME scalar map len
 PROG BEGIN { @ = 0; printf("map len: %d\n", len(@)); exit(); }
 EXPECT map len: 1
+
+NAME scalar map clear
+PROG BEGIN { @ = 5; @s = 6; exit(); } END { clear(@s) }
+EXPECT @: 5
+EXPECT_NONE @s: 6
+
+NAME scalar map clear in non-end then set in end
+PROG BEGIN { @ = 5; clear(@); exit(); } END { @ = 5 }
+EXPECT @: 5


### PR DESCRIPTION
Since b4a70de7 ("Keyless maps default to BPF_MAP_TYPE_ARRAY for some types (#3300)"), scalar maps are backed by BPF_MAP_TYPE_ARRAY. Which means their entries cannot be cleared. This has started causing confusing issues where scalar map entries are printed out with value 0.

This commit closes the hole somewhat by teaching the runtime to reliably keep track of which maps are cleared in the END probe.

Note that we technically still do the right thing even given something like this:

    BEGIN { @s = 5 } END { clear(@s); @s = 1 }

That is b/c clear() is defined as an async helper. Which means that the user is racing with clear() and we are free to choose either outcome. So we happen to choose the cleared outcome.

However, it does not solve the case where scalar maps are cleared in non-END probes like this:

    BEGIN { @s = 5; clear(@s) }

But at least it doesn't make the problem worse.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
