### PR TITLE
cmake: fix the LLVM linking logic

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library(ast STATIC
 )
 
 target_compile_definitions(ast PRIVATE ${BPFTRACE_FLAGS})
-target_link_libraries(ast ast_defs arch parser)
+target_link_libraries(ast PUBLIC ast_defs arch parser)
 
 if(STATIC_LINKING)
   include(Util)
@@ -66,23 +66,19 @@ if(STATIC_LINKING)
   unlink_transitive_dependency("${CLANG_EXPORTED_TARGETS}" "$<LINK_ONLY:clang-cpp>")
 
   if(TARGET libclang_static)
-    target_link_libraries(ast libclang_static)
+    target_link_libraries(ast PUBLIC libclang_static)
   else()
     # old LLVM versions don't export libclang_static in ClangTargets.cmake; fall back to
     # libclang.a in that case
-    target_link_libraries(ast libclang.a)
+    target_link_libraries(ast PUBLIC libclang.a)
   endif()
 
-  target_link_libraries(ast ${clang_libs})
-  target_link_libraries(ast ${llvm_libs})
+  target_link_libraries(ast PUBLIC ${clang_libs})
+  target_link_libraries(ast PUBLIC ${llvm_libs})
 else()
-  find_library(found_LLVM LLVM HINTS ${LLVM_LIBRARY_DIRS})
-  if(found_LLVM)
-    target_link_libraries(ast LLVM)
-  else()
-    llvm_map_components_to_libnames(_llvm_libs bpfcodegen ipo irreader mcjit orcjit)
-    llvm_expand_dependencies(llvm_libs ${_llvm_libs})
-    target_link_libraries(ast ${llvm_libs})
-  endif()
-  target_link_libraries(ast libclang)
+  # llvm_config macro comes from the LLVM toolchain and will auto-resolve component
+  # names to library names. USE_SHARED option will tell llvm_config macro to prefer
+  # shared library / DLL on the system over the static libraries
+  llvm_config(ast USE_SHARED bpfcodegen ipo irreader mcjit orcjit)
+  target_link_libraries(ast PUBLIC libclang)
 endif()


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

This pull request fixes the LLVM linking logic when the system contains both shared and static libraries. Currently, even if shared libraries are preferred over static ones, the build system will still link static libraries.

Should fix #1855.

##### Checklist

- [X] Language changes are updated in `man/adoc/bpftrace.adoc`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [X] The new behaviour is covered by tests
