### PR TITLE
ci: binary: Upgrade upload-artifact to v4

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -25,7 +25,7 @@ jobs:
         cp ./result bpftrace
 
     - name: Upload appimage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: bpftrace
         path: ./bpftrace


### PR DESCRIPTION
I got an email saying v3 is being deprecated this month. Looks like it's upgrade time!

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
