### PR TITLE
tests: fix flaky predicate test

### DIFF
--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -41,7 +41,7 @@ AFTER ./testprogs/syscall openat
 
 NAME tracepoint arg casts in predicates
 RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_wait4 /args.ru/ { @ru[tid] = args.ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru
-EXPECT @: 1
+EXPECT_REGEX @: [1-9][0-9]*
 
 NAME variable string type resize
 PROG BEGIN { $x = "hello"; $x = "hi"; printf("%s\n", $x); exit(); }


### PR DESCRIPTION
Per #3316, there were some conditions wherein the tracepoint could be triggered multiple times. While a unit test could be added separately for the predicate casts, the integration test can be kept simply by ensuring that it tolerates additional invocations.

Fixes #3316