### PR TITLE
docs: add example for output parameters

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1044,6 +1044,24 @@ kretprobe:do_nanosleep /has_key(@start, tid)/ {
  */
 ----
 
+This style of map may also be useful for capturing output parameters, or other context, between two different probes. For example:
+
+----
+tracepoint:syscalls:sys_enter_wait4
+{
+  @out[tid] = args.ru;
+}
+
+tracepoint:syscalls:sys_exit_wait4
+{
+  $ru = @out[tid];
+  delete(@out, tid);
+  if ($ru != 0) {
+    printf("got usage ...", ...);
+  }
+}
+----
+
 == Builtins
 
 Builtins are special variables built into the language.


### PR DESCRIPTION
The `tests/runtime/variable` happens to provide a good example of capturing output parameters. Incorporate this as an example into the documentation in a suitable spot.

Fixes #233

##### Checklist

- [X] Language changes are updated in `man/adoc/bpftrace.adoc`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md` (not CHANGELOG relevant)
- [X] The new behaviour is covered by tests (already covered in tests)
