### PR TITLE
cleanup: remove `find_empty_key`

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -270,7 +270,6 @@ private:
   void handle_event_loss();
   int print_map_hist(const BpfMap &map, uint32_t top, uint32_t div);
   static uint64_t read_address_from_output(std::string output);
-  std::optional<std::vector<uint8_t>> find_empty_key(const BpfMap &map) const;
   struct bcc_symbol_option &get_symbol_opts();
   Probe generate_probe(const ast::AttachPoint &ap,
                        const ast::Probe &p,


### PR DESCRIPTION
The oldest LTS kernel in service is 4.19, so we are free to remove `find_empty_key` as 4.12 and above kernels support passing `NULL` to `BPF_MAP_GET_NEXT_KEY` to get the first element.

https://github.com/torvalds/linux/commit/8fe45924387be6b5c1be59a7eb330790c61d5d10
