### PR TITLE
doc: add reference to JSON Lines in addition to NDJSON

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -97,7 +97,7 @@ Valid values are::
 *json* +
 *text*
 
-Note: the json output is ndjson, meaning each line of the streamed output is a single blob of valid json.
+The JSON output is compatible with NDJSON and JSON Lines, meaning each line of the streamed output is a single blob of valid JSON.
 
 === *-h, --help*
 


### PR DESCRIPTION
This issue has been fixed already, but given this format is commonly known as JSON Lines as well. Add to this the documentation and use this hook to close the original issue.

Fixes #2902

##### Checklist

- [X] Language changes are updated in `man/adoc/bpftrace.adoc`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [X] The new behaviour is covered by tests
