### PR TITLE
Fix crash using some per-cpu maps as map keys

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -91,6 +91,7 @@ aot.other.no symbolize enum after arithmetic
 aot.other.no symbolize enum after arithmetic mixed
 aot.other.per_cpu_map_arithmetic
 aot.other.per_cpu_map_avg_if
+aot.other.per_cpu_map_as_map_key
 # Enum metadata is not being serialized
 aot.other.symbolize enum in map key
 # Enum metadata is not being serialized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ and this project adheres to
   - [#3542](https://github.com/bpftrace/bpftrace/pull/3542)
 - Fix field access and offsetof for strings that are builtin types
   - [#3565](https://github.com/bpftrace/bpftrace/pull/3565)
+- Fix crash when using castable per-cpu map types as map keys
+  - [#3594](https://github.com/bpftrace/bpftrace/pull/3594)
 #### Security
 #### Docs
 - Remove mention of unsupported character literals

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1672,6 +1672,10 @@ void SemanticAnalyser::validate_map_key(const SizedType &key,
     LOG(ERROR, loc, err_) << "context cannot be used as a map key";
   }
 
+  if (key.IsHistTy() || key.IsLhistTy() || key.IsStatsTy()) {
+    LOG(ERROR, loc, err_) << key << " cannot be used as a map key";
+  }
+
   if (is_final_pass() && key.IsNoneTy()) {
     LOG(ERROR, loc, err_) << "Invalid expression for assignment: ";
   }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -452,6 +452,11 @@ std::string Output::map_key_str(BPFtrace &bpftrace,
     case Type::array:
     case Type::mac_address:
     case Type::record:
+    case Type::count_t:
+    case Type::avg_t:
+    case Type::max_t:
+    case Type::min_t:
+    case Type::sum_t:
       return value_to_str(bpftrace, arg, data, false, 1, true);
     case Type::tuple: {
       std::vector<std::string> elems;
@@ -466,17 +471,12 @@ std::string Output::map_key_str(BPFtrace &bpftrace,
     }
     case Type::cgroup_path_t:
     case Type::strerror_t:
-    case Type::avg_t:
-    case Type::count_t:
     case Type::hist_t:
     case Type::lhist_t:
-    case Type::max_t:
-    case Type::min_t:
     case Type::none:
     case Type::reference:
     case Type::stack_mode:
     case Type::stats_t:
-    case Type::sum_t:
     case Type::timestamp_mode:
     case Type::voidtype:
       LOG(BUG) << "Invalid mapkey argument type: " << arg;

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -275,6 +275,10 @@ NAME per_cpu_map_cast
 PROG BEGIN { @a = count(); @b = sum(10); printf("%d-%d\n", (uint64)@a, (int64)@b); exit();}
 EXPECT 1-10
 
+NAME per_cpu_map_as_map_key
+PROG BEGIN {@a = count(); @b = sum(5); @c = min(1); @d = max(10); @e = avg(7); @[@a, @b, @c, @d, @e] = 1; exit(); }
+EXPECT @[1, 5, 1, 10, 7]: 1
+
 NAME dry run empty output
 RUN {{BPFTRACE}} --dry-run -e 'BEGIN { printf("hello\n"); @ = 0; }'
 EXPECT_NONE hello


### PR DESCRIPTION
'count', 'sum', 'avg', 'min', 'max' are all castable per-cpu map aggregation types so they should be valid as map keys when printing.

Issue: https://github.com/bpftrace/bpftrace/issues/3591

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
