### PR TITLE
Fix binop type check

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1987,6 +1987,12 @@ void SemanticAnalyser::binop_ptr(Binop &binop)
     else
       invalid_op();
   }
+  // Might need an additional pass to resolve the type
+  else if (other.IsNoneTy()) {
+    if (is_final_pass()) {
+      invalid_op();
+    }
+  }
   // Binop on a pointer and something else
   else {
     invalid_op();

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4265,6 +4265,11 @@ fentry:func_1,tracepoint:sched:sched_one { args }
 )");
 }
 
+TEST_F(semantic_analyser_btf, binop_late_ptr_resolution)
+{
+  test(R"(fentry:func_1 { if (@a[1] == args.foo1) { } @a[1] = args.foo1; })");
+}
+
 TEST(semantic_analyser, buf_strlen_too_large)
 {
   auto bpftrace = get_mock_bpftrace();


### PR DESCRIPTION
If either the left or the right is a none type
then wait till the final pass before throwing
a mismatch error.

Issue: https://github.com/bpftrace/bpftrace/issues/3592

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
