### PR TITLE
Introduce builtin to access percpu kernel data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to
   - [#3547](https://github.com/bpftrace/bpftrace/pull/3547)
 - Add `symbol_source` config to source uprobe locations from either DWARF or the Symbol Table
   - [#3504](https://github.com/bpftrace/bpftrace/pull/3504/)
+- Introduce builtin to access percpu kernel data
+  - [#3596](https://github.com/bpftrace/bpftrace/pull/3596/)
 #### Changed
 - Merge output into `stdout` when `-lv`
   - [#3383](https://github.com/bpftrace/bpftrace/pull/3383)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1364,6 +1364,10 @@ Tracing block I/O sizes > 0 bytes
 | Return full path
 | Sync
 
+| <<functions-percpu-kaddr, `percpu_kaddr(const string name [, int cpu])`>>
+| Resolve percpu kernel symbol name
+| Sync
+
 | <<functions-print, `print(...)`>>
 | Print a non-map value with default formatting
 | Async
@@ -1845,6 +1849,39 @@ Return full path referenced by struct path pointer in argument. If `size` is set
 the path will be clamped by `size` otherwise `BPFTRACE_MAX_STRLEN` is used.
 
 This function can only be used by functions that are allowed to, these functions are contained in the `btf_allowlist_d_path` set in the kernel.
+
+[#functions-percpu-kaddr]
+=== percpu_kaddr
+
+.variants
+* `void *percpu_kaddr(const string name)`
+* `void *percpu_kaddr(const string name, int cpu)`
+
+*sync*
+
+Get the address of the percpu kernel symbol `name` for CPU `cpu`. When `cpu` is
+omitted, the current CPU is used.
+
+----
+interval:s:1 {
+  $proc_cnt = percpu_kaddr("process_counts");
+  printf("% processes are running on CPU %d\n", *$proc_cnt, cpu);
+}
+----
+
+The second variant may return NULL if `cpu` is higher than the number of
+available CPUs. Therefore, it is necessary to perform a NULL-check on the result
+when accessing fields of the pointed structure, otherwise the BPF program will
+be rejected.
+
+----
+interval:s:1 {
+  $runqueues = (struct rq *)percpu_kaddr("runqueues", 0);
+  if ($runqueues != 0) {         // The check is mandatory here
+    print($runqueues->nr_running);
+  }
+}
+----
 
 [#functions-print]
 === print

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -213,10 +213,12 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype, bool emit_codegen_types)
 {
   if (!emit_codegen_types && stype.IsRecordTy()) {
     std::string name = stype.GetName();
-    if (name.find("struct ") == 0)
-      name = name.substr(std::string("struct ").length());
-    else if (name.find("union ") == 0)
-      name = name.substr(std::string("union ").length());
+    static constexpr std::string struct_prefix = "struct ";
+    static constexpr std::string union_prefix = "union ";
+    if (name.find(struct_prefix) == 0)
+      name = name.substr(struct_prefix.length());
+    else if (name.find(union_prefix) == 0)
+      name = name.substr(union_prefix.length());
 
     return createStructType(file,
                             name,

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -212,8 +212,14 @@ DIType *DIBuilderBPF::CreateByteArrayType(uint64_t num_bytes)
 DIType *DIBuilderBPF::GetType(const SizedType &stype, bool emit_codegen_types)
 {
   if (!emit_codegen_types && stype.IsRecordTy()) {
+    std::string name = stype.GetName();
+    if (name.find("struct ") == 0)
+      name = name.substr(std::string("struct ").length());
+    else if (name.find("union ") == 0)
+      name = name.substr(std::string("union ").length());
+
     return createStructType(file,
-                            stype.GetName(),
+                            name,
                             file,
                             0,
                             stype.GetSize() * 8,

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -347,7 +347,7 @@ DIGlobalVariableExpression *DIBuilderBPF::createGlobalVariable(
     const SizedType &stype)
 {
   return createGlobalVariableExpression(
-      file, name, "global", file, 0, GetType(stype), false);
+      file, name, "global", file, 0, GetType(stype, false), false);
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -2141,6 +2141,39 @@ CallInst *IRBuilderBPF::CreateGetFuncIp(Value *ctx, const location &loc)
                           &loc);
 }
 
+CallInst *IRBuilderBPF::CreatePerCpuPtr(Value *var,
+                                        Value *cpu,
+                                        const location &loc)
+{
+  // void *bpf_per_cpu_ptr(const void *percpu_ptr, u32 cpu)
+  // Return:
+  //    A pointer pointing to the kernel percpu variable on
+  //    cpu, or NULL, if cpu is invalid.
+  FunctionType *percpuptr_func_type = FunctionType::get(
+      GET_PTR_TY(), { GET_PTR_TY(), getInt64Ty() }, false);
+  return CreateHelperCall(libbpf::BPF_FUNC_per_cpu_ptr,
+                          percpuptr_func_type,
+                          { var, cpu },
+                          "per_cpu_ptr",
+                          &loc);
+}
+
+CallInst *IRBuilderBPF::CreateThisCpuPtr(Value *var, const location &loc)
+{
+  // void *bpf_per_cpu_ptr(const void *percpu_ptr)
+  // Return:
+  //    A pointer pointing to the kernel percpu variable on
+  //    this cpu. May never be NULL.
+  FunctionType *percpuptr_func_type = FunctionType::get(GET_PTR_TY(),
+                                                        { GET_PTR_TY() },
+                                                        false);
+  return CreateHelperCall(libbpf::BPF_FUNC_this_cpu_ptr,
+                          percpuptr_func_type,
+                          { var },
+                          "this_cpu_ptr",
+                          &loc);
+}
+
 void IRBuilderBPF::CreateGetCurrentComm(Value *ctx,
                                         AllocaInst *buf,
                                         size_t size,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -161,6 +161,8 @@ public:
                            StackType stack_type,
                            const location &loc);
   CallInst *CreateGetFuncIp(Value *ctx, const location &loc);
+  CallInst *CreatePerCpuPtr(Value *var, Value *cpu, const location &loc);
+  CallInst *CreateThisCpuPtr(Value *var, const location &loc);
   CallInst *CreateGetJoinMap(BasicBlock *failure_callback, const location &loc);
   CallInst *CreateGetStackScratchMap(StackType stack_type,
                                      BasicBlock *failure_callback,

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -278,6 +278,8 @@ private:
                                  ArrayRef<Value *> args,
                                  const Twine &name);
 
+  GlobalVariable *DeclareKernelVar(const std::string &name);
+
   Node *root_ = nullptr;
 
   BPFtrace &bpftrace_;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1102,6 +1102,20 @@ void SemanticAnalyser::visit(Call &call)
     }
     call.type = CreateUInt64();
     call.type.SetAS(AddrSpace::kernel);
+  } else if (call.func == "percpu_kaddr") {
+    if (check_varargs(call, 1, 2)) {
+      check_arg(call, Type::string, 0, true);
+      if (call.vargs.size() == 2)
+        check_arg(call, Type::integer, 1, false);
+
+      auto symbol = bpftrace_.get_string_literal(call.vargs.at(0));
+      if (bpftrace_.btf_->get_var_type(symbol).IsNoneTy()) {
+        LOG(ERROR, call.loc, err_)
+            << "Could not resolve variable \"" << symbol << "\" from BTF";
+      }
+    }
+    call.type = CreateUInt64();
+    call.type.SetAS(AddrSpace::kernel);
   } else if (call.func == "uaddr") {
     auto probe = get_probe(call.loc, call.func);
     if (probe == nullptr)

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -220,11 +220,15 @@ void BpfBytecode::load_progs(const RequiredResources &resources,
     // failures when the verifier log is non-empty.
     std::string_view log(log_bufs[name].data());
     if (!log.empty()) {
-      // This should be the only error that may occur here and does not imply
+      // These should be the only errors that may occur here which do not imply
       // a bpftrace bug so throw immediately with a proper error message.
       maybe_throw_helper_verifier_error(log,
                                         "helper call is not allowed in probe",
                                         " not allowed in probe");
+      maybe_throw_helper_verifier_error(
+          log,
+          "pointer arithmetic on ptr_or_null_ prohibited, null-check it first",
+          ": result needs to be null-checked before accessing fields");
 
       std::stringstream errmsg;
       errmsg << "Error loading BPF program for " << name << ".";

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -875,4 +875,17 @@ SizedType BTF::get_stype(const std::string &type_name)
   return CreateNone();
 }
 
+SizedType BTF::get_var_type(const std::string &var_name)
+{
+  auto var_id = find_id(var_name, BTF_KIND_VAR);
+  if (!var_id.btf)
+    return CreateNone();
+
+  const struct btf_type *t = btf__type_by_id(var_id.btf, var_id.id);
+  if (!t)
+    return CreateNone();
+
+  return get_stype(BTFId{ .btf = var_id.btf, .id = t->type });
+}
+
 } // namespace bpftrace

--- a/src/btf.h
+++ b/src/btf.h
@@ -67,6 +67,7 @@ public:
   std::string type_of(const std::string& name, const std::string& field);
   std::string type_of(const BTFId& type_id, const std::string& field);
   SizedType get_stype(const std::string& type_name);
+  SizedType get_var_type(const std::string& var_name);
 
   std::set<std::string> get_all_structs() const;
   std::unique_ptr<std::istream> get_all_funcs() const;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#+\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|len|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf|has_key
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|len|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf|has_key|percpu_kaddr
 
 int_type        bool|(u)?int(8|16|32|64)
 builtin_type    void|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|strerror_t|kstack_t|ustack_t

--- a/tests/codegen/call_percpu_kaddr.cpp
+++ b/tests/codegen/call_percpu_kaddr.cpp
@@ -1,0 +1,19 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_percpu_kaddr)
+{
+  test("BEGIN { percpu_kaddr(\"process_counts\", 0); }", NAME);
+}
+
+TEST(codegen, call_percpu_kaddr_this_cpu)
+{
+  test("BEGIN { percpu_kaddr(\"process_counts\"); }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_len_map_sum_elem_count.ll
+++ b/tests/codegen/llvm/call_len_map_sum_elem_count.ll
@@ -117,5 +117,5 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !61 = !DISubroutineType(types: !62)
 !62 = !{!18, !63}
 !63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !64, size: 64)
-!64 = !DICompositeType(tag: DW_TAG_structure_type, name: "struct bpf_map", scope: !2, file: !2, elements: !65)
+!64 = !DICompositeType(tag: DW_TAG_structure_type, name: "bpf_map", scope: !2, file: !2, elements: !65)
 !65 = !{}

--- a/tests/codegen/llvm/call_percpu_kaddr.ll
+++ b/tests/codegen/llvm/call_percpu_kaddr.ll
@@ -1,0 +1,76 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@process_counts = external global i64, section ".ksyms", !dbg !36
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !41 {
+entry:
+  %per_cpu_ptr = call ptr inttoptr (i64 153 to ptr)(ptr @process_counts, i64 0)
+  %1 = ptrtoint ptr %per_cpu_ptr to i64
+  ret i64 0
+}
+
+attributes #0 = { nounwind }
+
+!llvm.dbg.cu = !{!38}
+!llvm.module.flags = !{!40}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "process_counts", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !39)
+!39 = !{!0, !16, !36}
+!40 = !{i32 2, !"Debug Info Version", i32 3}
+!41 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !42, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !38, retainedNodes: !46)
+!42 = !DISubroutineType(types: !43)
+!43 = !{!35, !44}
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!46 = !{!47}
+!47 = !DILocalVariable(name: "ctx", arg: 1, scope: !41, file: !2, type: !44)

--- a/tests/codegen/llvm/call_percpu_kaddr_this_cpu.ll
+++ b/tests/codegen/llvm/call_percpu_kaddr_this_cpu.ll
@@ -1,0 +1,76 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@process_counts = external global i64, section ".ksyms", !dbg !36
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !41 {
+entry:
+  %this_cpu_ptr = call ptr inttoptr (i64 154 to ptr)(ptr @process_counts)
+  %1 = ptrtoint ptr %this_cpu_ptr to i64
+  ret i64 0
+}
+
+attributes #0 = { nounwind }
+
+!llvm.dbg.cu = !{!38}
+!llvm.module.flags = !{!40}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "process_counts", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!38 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !39)
+!39 = !{!0, !16, !36}
+!40 = !{i32 2, !"Debug Info Version", i32 3}
+!41 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !42, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !38, retainedNodes: !46)
+!42 = !DISubroutineType(types: !43)
+!43 = !{!35, !44}
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!46 = !{!47}
+!47 = !DILocalVariable(name: "ctx", arg: 1, scope: !41, file: !2, type: !44)

--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -13,9 +13,10 @@ find_program(STRIP strip REQUIRED)
 # Build data_source.o and inject BTF into it
 set(DATA_SOURCE_C ${CMAKE_CURRENT_SOURCE_DIR}/data_source.c)
 set(DATA_SOURCE_O ${CMAKE_CURRENT_BINARY_DIR}/data_source.o)
+set(DATA_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/data_source)
 add_custom_command(
   OUTPUT ${DATA_SOURCE_O}
-  COMMAND gcc -g -o ${DATA_SOURCE_O} ${DATA_SOURCE_C}
+  COMMAND gcc -g -c -o ${DATA_SOURCE_O} ${DATA_SOURCE_C}
   # pahole uses LLVM_OBJCOPY env var.
   # We must hack it like this b/c cmake does not support setting env vars at build time
   COMMAND bash -c "LLVM_OBJCOPY=${LLVM_OBJCOPY} pahole -J ${DATA_SOURCE_O}"
@@ -49,7 +50,8 @@ if(${LLDB_FOUND})
   set(DWARF_DATA_FILE ${CMAKE_CURRENT_BINARY_DIR}/dwarf_data)
   add_custom_command(
     OUTPUT ${DWARF_DATA_FILE}
-    COMMAND strip --only-keep-debug -o ${DWARF_DATA_FILE} ${DATA_SOURCE_O}
+    COMMAND gcc ${DATA_SOURCE_O} -o ${DATA_SOURCE}
+    COMMAND strip --only-keep-debug -o ${DWARF_DATA_FILE} ${DATA_SOURCE}
     DEPENDS data_source_o)
 
   # Generate dwarf_data.hex from dwarf_data

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -128,6 +128,9 @@ long bpf_map_sum_elem_count(const struct bpf_map *map)
   return 0;
 }
 
+// kernel percpu variables
+__attribute__((section(".data..percpu"))) unsigned long process_counts;
+
 // Make sure all new mocked kernel functions are called in this main (below)
 // so they don't get optimzed away
 int main(void)

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -677,3 +677,22 @@ TIMEOUT 3
 NAME map len keyless
 PROG BEGIN { @ = 0; printf("map len: %d\n", len(@)); exit(); }
 EXPECT map len: 1
+
+NAME percpu_kaddr
+PROG BEGIN { printf("processes: %d\n", *percpu_kaddr("process_counts", 0)); exit(); }
+EXPECT_REGEX processes: -?[0-9]+
+
+NAME percpu_kaddr this cpu
+PROG BEGIN { if (*percpu_kaddr("process_counts") == *percpu_kaddr("process_counts", cpu)) { printf("SUCCESS\n") } exit(); }
+EXPECT SUCCESS
+
+NAME percpu_kaddr field access
+PROG BEGIN { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); if ($runq != 0) { printf("nr_running: %d\n", $runq->nr_running) } exit() }
+EXPECT_REGEX nr_running: [0-9]+
+
+NAME percpu_kaddr field access no NULL check
+PROG BEGIN { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); printf("nr_running: %d\n", $runq->nr_running); exit() }
+EXPECT stdin:1:17-60: ERROR: helper bpf_per_cpu_ptr: result needs to be null-checked before accessing fields
+       BEGIN { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); printf("nr_running: %d\n", $runq->nr_running); exit() }
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+WILL_FAIL

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3838,6 +3838,24 @@ fentry:func_1 { skboutput("one.pcap", args.foo1, 1500, 0); }
 )");
 }
 
+TEST_F(semantic_analyser_btf, call_percpu_kaddr)
+{
+  test("kprobe:f { percpu_kaddr(\"process_counts\"); }");
+  test("kprobe:f { percpu_kaddr(\"process_counts\", 0); }");
+  test("kprobe:f { @x = percpu_kaddr(\"process_counts\"); }");
+  test("kprobe:f { @x = percpu_kaddr(\"process_counts\", 0); }");
+  test("kprobe:f { percpu_kaddr(); }", 1);
+  test("kprobe:f { percpu_kaddr(0); }", 1);
+
+  test_error("kprobe:f { percpu_kaddr(\"nonsense\"); }",
+             R"(
+stdin:1:12-36: ERROR: Could not resolve variable "nonsense" from BTF
+kprobe:f { percpu_kaddr("nonsense"); }
+           ~~~~~~~~~~~~~~~~~~~~~~~~
+)",
+             false);
+}
+
 TEST_F(semantic_analyser_btf, iter)
 {
   test("iter:task { 1 }");


### PR DESCRIPTION
Introduce new builtin `percpu_kaddr` to access kernel percpu variables. It leverages the `bpf_per_cpu_ptr` helper which accepts a pointer to a percpu ksym and a CPU number. The ksym is an extern variable with a BTF entry matching the BTF of the corresponding kernel variable. Since we now use libbpf to do the loading, it is sufficient to emit a global variable declaration with a proper BTF (debug info) and libbpf will take care of the rest.

The helper has two forms:

    percpu_kaddr("symbol_name")
    percpu_kaddr("symbol_name", N)

where N is the CPU number. The former variant retrieves the value for the current CPU.

For instance, this allows to access the `process_counts` percpu variable:
```
$ bpftrace -e 'BEGIN { printf("%d processes running on CPU %d\n", *percpu_kaddr("process_counts"), cpu); exit() }'
Attaching 1 probe...
88 processes running on CPU 1
```

 A tricky part is that `bpf_per_cpu_ptr` may return NULL if the supplied CPU number is higher than the number of the CPUs. The BPF program should perform a NULL-check on the returned value, otherwise it is rejected by the verifier. In practice, this only happens if pointer arithmetics is used (i.e. a struct field is accessed). Since it is quite complex to detect a missing NULL-check in bpftrace, we instead let verifier do it and just display the potential verifier error in a nicer manner:

```
$ bpftrace -e 'BEGIN { printf("%d\n", ((struct rq *)percpu_kaddr("runqueues"))->nr_running); exit() }'
Attaching 1 probe...
stdin:1:24-64: ERROR: helper bpf_per_cpu_ptr: result needs to be null-checked before accessing fields
BEGIN { printf("%d\n", ((struct rq *)percpu_kaddr("runqueues"))->nr_running); exit() }
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Resolves #1837.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
