### PR TITLE
Automatically cast map function when assigning to int map

### DIFF
--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -136,6 +136,7 @@ private:
 
   Probe *get_probe(const location &loc, std::string name = "");
 
+  bool is_valid_assignment(const Expression *target, const Expression *expr);
   SizedType *get_map_type(const Map &map);
   SizedType *get_map_key_type(const Map &map);
   void assign_map_type(const Map &map, const SizedType &type);


### PR DESCRIPTION
Assigning a map containing a castable map function (like `count()`) to another map containing integers is allowed, but requires a cast. However, the cast is not required for other operations, like comparison. This is inconsistent and particularly confusing for new users.

This PR removes this requirement for assignments.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
