### PR TITLE
dibuilder: Use string_view for constexpr string

### DIFF
--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -1,11 +1,13 @@
 #include "dibuilderbpf.h"
 
+#include <string_view>
+
+#include <llvm/IR/Function.h>
+
 #include "libbpf/bpf.h"
 #include "log.h"
 #include "struct.h"
 #include "utils.h"
-
-#include <llvm/IR/Function.h>
 
 namespace bpftrace::ast {
 
@@ -213,8 +215,8 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype, bool emit_codegen_types)
 {
   if (!emit_codegen_types && stype.IsRecordTy()) {
     std::string name = stype.GetName();
-    static constexpr std::string struct_prefix = "struct ";
-    static constexpr std::string union_prefix = "union ";
+    static constexpr std::string_view struct_prefix = "struct ";
+    static constexpr std::string_view union_prefix = "union ";
     if (name.find(struct_prefix) == 0)
       name = name.substr(struct_prefix.length());
     else if (name.find(union_prefix) == 0)


### PR DESCRIPTION
std::string is not very const. The build fails with the following on clang17:

```
src/ast/dibuilderbpf.cpp:216:34: error: constexpr variable cannot have non-literal type 'const std::string' (aka 'const basic_string<char>')
  216 |     static constexpr std::string struct_prefix = "struct ";
      |                                  ^
libgcc/include/c++/trunk/bits/basic_string.h:85:11: note: 'basic_string<char>' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
   85 |     class basic_string
      |           ^
src/ast/dibuilderbpf.cpp:217:34: error: constexpr variable cannot have non-literal type 'const std::string' (aka 'const basic_string<char>')
  217 |     static constexpr std::string union_prefix = "union ";
      |                                  ^
libgcc/include/c++/trunk/bits/basic_string.h:85:11: note: 'basic_string<char>' is not literal because it is not an aggregate and has no constexpr constructors other than copy or move constructors
   85 |     class basic_string
      |           ^
2 errors generated.
```

Fix by using string_view which accomplishes the same thing.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
