### PR TITLE
Logging: Add HINT log level

### DIFF
--- a/docs/coding_guidelines.md
+++ b/docs/coding_guidelines.md
@@ -97,6 +97,9 @@ and line number)
 - `V1`: log info only if verbose logging is enabled (-v); use this (among
   others) for printing warnings which may occur on every bpftrace execution
   (like BTF is not available)
+- `HINT`: log info that could give tips on how the user can resolve a problem
+they have encountered. This would normally be used immediately after a
+LOG(WARNING) or LOG(ERROR).
 - `WARNING`: log info that might affect bpftrace behavior or output but allows
 the run to continue; like using stderr
 - `ERROR`: log info to indicate that the user did something invalid, which will

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2715,13 +2715,11 @@ void SemanticAnalyser::visit(Cast &cast)
         !cast.type.GetElementTy()->IsRecordTy()) &&
       // we support casting integers to int arrays
       !(cast.type.IsArrayTy() && cast.type.GetElementTy()->IsIntTy())) {
-    std::string hint;
+    LOG(ERROR, cast.loc, err_) << "Cannot cast to \"" << cast.type << "\"";
     if (auto it = KNOWN_TYPE_ALIASES.find(cast.type.GetName());
         it != KNOWN_TYPE_ALIASES.end()) {
-      hint = ", did you mean \"" + std::string(it->second) + "\"?";
+      LOG(HINT, cast.loc, err_) << "Did you mean \"" << it->second << "\"?";
     }
-    LOG(ERROR, cast.loc, err_)
-        << "Cannot cast to \"" << cast.type << "\"" << hint;
   }
 
   if (cast.type.IsArrayTy()) {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -8,6 +8,7 @@ std::string logtype_str(LogType t)
     // clang-format off
     case LogType::DEBUG   : return "";
     case LogType::V1      : return "";
+    case LogType::HINT    : return "HINT: ";
     case LogType::WARNING : return "WARNING: ";
     case LogType::ERROR   : return "ERROR: ";
     case LogType::BUG     : return "BUG: ";
@@ -19,10 +20,11 @@ std::string logtype_str(LogType t)
 
 Log::Log()
 {
-  enabled_map_[LogType::ERROR] = true;
-  enabled_map_[LogType::WARNING] = true;
-  enabled_map_[LogType::V1] = false;
   enabled_map_[LogType::DEBUG] = true;
+  enabled_map_[LogType::V1] = false;
+  enabled_map_[LogType::HINT] = true;
+  enabled_map_[LogType::WARNING] = true;
+  enabled_map_[LogType::ERROR] = true;
   enabled_map_[LogType::BUG] = true;
 }
 

--- a/src/log.h
+++ b/src/log.h
@@ -15,6 +15,7 @@ enum class LogType
 {
   DEBUG,
   V1,
+  HINT,
   WARNING,
   ERROR,
   BUG,
@@ -127,6 +128,7 @@ public:
 #define LOGSTREAM_COMMON(...) bpftrace::LogStream(__FILE__, __LINE__, __VA_ARGS__)
 #define LOGSTREAM_DEBUG(...) LOGSTREAM_COMMON(__VA_ARGS__)
 #define LOGSTREAM_V1(...) LOGSTREAM_COMMON(__VA_ARGS__)
+#define LOGSTREAM_HINT(...) LOGSTREAM_COMMON(__VA_ARGS__)
 #define LOGSTREAM_WARNING(...) LOGSTREAM_COMMON(__VA_ARGS__)
 #define LOGSTREAM_ERROR(...) LOGSTREAM_COMMON(__VA_ARGS__)
 #define LOGSTREAM_BUG(...) bpftrace::LogStreamBug(__FILE__, __LINE__, __VA_ARGS__)


### PR DESCRIPTION
This can be used to provide suggestions to the user when an error is encountered. For example:
```
ERROR: No match for function: myfunc(int64)
HINT: Candidates:
        myfunc(string)
```