### PR TITLE
Types: Disallow calling GetNumElements() on string types

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2099,7 +2099,7 @@ void SemanticAnalyser::visit(Binop &binop)
     auto *lit = binop.left->is_literal ? binop.left : binop.right;
     auto *str = lit == binop.left ? binop.right : binop.left;
     auto lit_len = bpftrace_.get_string_literal(lit).size();
-    auto str_len = str->type.GetNumElements();
+    auto str_len = str->type.GetSize();
     if (lit_len > str_len) {
       LOG(WARNING, binop.left->loc + binop.loc + binop.right->loc, out_)
           << "The literal is longer than the variable string (size=" << str_len

--- a/src/types.h
+++ b/src/types.h
@@ -298,12 +298,12 @@ public:
 
   size_t GetNumElements() const
   {
-    assert(IsArrayTy() || IsStringTy());
-    // For array's we can't just do size_bits_ / element_type.GetSize()
+    assert(IsArrayTy());
+    // For arrays we can't just do size_bits_ / element_type.GetSize()
     // because we might not know the size of the element type (it may be 0)
     // if it's being resolved in a later AST pass e.g. for an imported type:
     // `let $x: struct Foo[10];`
-    return IsStringTy() ? size_bits_ : num_elements_;
+    return num_elements_;
   };
 
   const std::string GetName() const


### PR DESCRIPTION
The number of characters in a string can be determined by using `GetSize()`.

The implementation of `GetNumElements()` for strings was also incorrect - it returned number of bits, not number of bytes.