### PR TITLE
Store Block through pointers

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -247,29 +247,18 @@ Block::Block(StatementList &&stmts) : stmts(std::move(stmts))
 {
 }
 
-If::If(Expression *cond, StatementList &&stmts)
-    : cond(cond), if_block(Block(std::move(stmts))), else_block(Block({}))
+If::If(Expression *cond, Block *if_block, Block *else_block)
+    : cond(cond), if_block(if_block), else_block(else_block)
 {
 }
 
-If::If(Expression *cond, StatementList &&stmts, StatementList &&else_stmts)
-    : cond(cond),
-      if_block(Block(std::move(stmts))),
-      else_block(Block(std::move(else_stmts)))
+Unroll::Unroll(Expression *expr, Block *block, location loc)
+    : Statement(loc), expr(expr), block(block)
 {
 }
 
-Unroll::Unroll(Expression *expr, StatementList &&stmts, location loc)
-    : Statement(loc), expr(expr), block(std::move(stmts))
-{
-}
-
-Probe::Probe(AttachPointList &&attach_points,
-             Predicate *pred,
-             StatementList &&stmts)
-    : attach_points(std::move(attach_points)),
-      pred(pred),
-      block(std::move(stmts))
+Probe::Probe(AttachPointList &&attach_points, Predicate *pred, Block *block)
+    : attach_points(std::move(attach_points)), pred(pred), block(block)
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -446,12 +446,11 @@ class If : public Statement {
 public:
   DEFINE_ACCEPT
 
-  If(Expression *cond, StatementList &&stmts);
-  If(Expression *cond, StatementList &&stmts, StatementList &&else_stmts);
+  If(Expression *cond, Block *if_block, Block *else_block);
 
   Expression *cond = nullptr;
-  Block if_block;
-  Block else_block;
+  Block *if_block = nullptr;
+  Block *else_block = nullptr;
 
 private:
   If(const If &other) = default;
@@ -461,11 +460,11 @@ class Unroll : public Statement {
 public:
   DEFINE_ACCEPT
 
-  Unroll(Expression *expr, StatementList &&stmts, location loc);
+  Unroll(Expression *expr, Block *block, location loc);
 
   long int var = 0;
   Expression *expr = nullptr;
-  Block block;
+  Block *block = nullptr;
 
 private:
   Unroll(const Unroll &other) = default;
@@ -518,13 +517,13 @@ class While : public Statement {
 public:
   DEFINE_ACCEPT
 
-  While(Expression *cond, StatementList &&stmts, location loc)
-      : Statement(loc), cond(cond), block(std::move(stmts))
+  While(Expression *cond, Block *block, location loc)
+      : Statement(loc), cond(cond), block(block)
   {
   }
 
   Expression *cond = nullptr;
-  Block block;
+  Block *block = nullptr;
 
 private:
   While(const While &other) = default;
@@ -613,13 +612,11 @@ class Probe : public Node {
 public:
   DEFINE_ACCEPT
 
-  Probe(AttachPointList &&attach_points,
-        Predicate *pred,
-        StatementList &&stmts);
+  Probe(AttachPointList &&attach_points, Predicate *pred, Block *block);
 
   AttachPointList attach_points;
   Predicate *pred = nullptr;
-  Block block;
+  Block *block = nullptr;
 
   std::string name() const;
   std::string args_typename() const;

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2555,7 +2555,7 @@ void CodegenLLVM::visit(If &if_node)
   // if condition is false, with else
   //   parent -> if_else -> if_end
   //
-  if (!if_node.else_block.stmts.empty()) {
+  if (!if_node.else_block->stmts.empty()) {
     // LLVM doesn't accept empty basic block, only create when needed
     if_else = BasicBlock::Create(module_->getContext(), "else_body", parent);
     b_.CreateCondBr(cond, if_true, if_else);
@@ -2564,15 +2564,15 @@ void CodegenLLVM::visit(If &if_node)
   }
 
   b_.SetInsertPoint(if_true);
-  auto scoped_del_if_block = accept(&if_node.if_block);
+  auto scoped_del_if_block = accept(if_node.if_block);
 
   b_.CreateBr(if_end);
 
   b_.SetInsertPoint(if_end);
 
-  if (!if_node.else_block.stmts.empty()) {
+  if (!if_node.else_block->stmts.empty()) {
     b_.SetInsertPoint(if_else);
-    auto scoped_del_else_block = accept(&if_node.else_block);
+    auto scoped_del_else_block = accept(if_node.else_block);
 
     b_.CreateBr(if_end);
     b_.SetInsertPoint(if_end);
@@ -2586,7 +2586,7 @@ void CodegenLLVM::visit(Unroll &unroll)
     // the same async calls multiple times.
     auto reset_ids = async_ids_.create_reset_ids();
 
-    auto scoped_del = accept(&unroll.block);
+    auto scoped_del = accept(unroll.block);
 
     if (i != unroll.var - 1)
       reset_ids();
@@ -2667,7 +2667,7 @@ void CodegenLLVM::visit(While &while_block)
   loop_hdr->setMetadata(LLVMContext::MD_loop, loop_metadata_);
 
   b_.SetInsertPoint(while_body);
-  auto scoped_del_block = accept(&while_block.block);
+  auto scoped_del_block = accept(while_block.block);
   b_.CreateBr(while_cond);
 
   b_.SetInsertPoint(while_end);
@@ -2794,7 +2794,7 @@ void CodegenLLVM::generateProbe(Probe &probe,
     auto scoped_del = accept(probe.pred);
   }
   variables_.clear();
-  auto scoped_del = accept(&probe.block);
+  auto scoped_del = accept(probe.block);
 
   createRet();
 

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -315,7 +315,7 @@ void FieldAnalyser::visit(Probe &probe)
   if (probe.pred) {
     Visit(*probe.pred);
   }
-  Visit(probe.block);
+  Visit(*probe.block);
 }
 
 void FieldAnalyser::visit(Subprog &subprog)

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -311,11 +311,11 @@ void Printer::visit(If &if_node)
   ++depth_;
   out_ << indent << " then" << std::endl;
 
-  if_node.if_block.accept(*this);
+  if_node.if_block->accept(*this);
 
-  if (!if_node.else_block.stmts.empty()) {
+  if (!if_node.else_block->stmts.empty()) {
     out_ << indent << " else" << std::endl;
-    if_node.else_block.accept(*this);
+    if_node.else_block->accept(*this);
   }
   depth_ -= 2;
 }
@@ -330,7 +330,7 @@ void Printer::visit(Unroll &unroll)
   out_ << indent << " block" << std::endl;
 
   ++depth_;
-  unroll.block.accept(*this);
+  unroll.block->accept(*this);
   depth_ -= 2;
 }
 
@@ -346,7 +346,7 @@ void Printer::visit(While &while_block)
   ++depth_;
   out_ << indent << " )" << std::endl;
 
-  while_block.block.accept(*this);
+  while_block.block->accept(*this);
 }
 
 void Printer::visit(For &for_loop)
@@ -433,7 +433,7 @@ void Printer::visit(Probe &probe)
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  probe.block.accept(*this);
+  probe.block->accept(*this);
   --depth_;
 }
 

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -38,7 +38,7 @@ bool ReturnPathAnalyser::visit(Jump &jump)
 bool ReturnPathAnalyser::visit(If &if_node)
 {
   bool result = false;
-  for (Statement *stmt : if_node.if_block.stmts) {
+  for (Statement *stmt : if_node.if_block->stmts) {
     if (Visit(*stmt))
       result = true;
   }
@@ -47,7 +47,7 @@ bool ReturnPathAnalyser::visit(If &if_node)
     return false;
   }
 
-  for (Statement *stmt : if_node.else_block.stmts) {
+  for (Statement *stmt : if_node.else_block->stmts) {
     if (Visit(*stmt)) {
       // both blocks have a return
       return true;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2236,8 +2236,8 @@ void SemanticAnalyser::visit(If &if_node)
       LOG(ERROR, if_node.loc, err_) << "Invalid condition in if(): " << cond;
   }
 
-  Visit(&if_node.if_block);
-  Visit(&if_node.else_block);
+  Visit(if_node.if_block);
+  Visit(if_node.else_block);
 }
 
 void SemanticAnalyser::visit(Unroll &unroll)
@@ -2258,7 +2258,7 @@ void SemanticAnalyser::visit(Unroll &unroll)
     LOG(ERROR, unroll.loc, err_) << "unroll minimum value is 1";
   }
 
-  Visit(&unroll.block);
+  Visit(unroll.block);
 }
 
 void SemanticAnalyser::visit(Jump &jump)
@@ -2301,7 +2301,7 @@ void SemanticAnalyser::visit(While &while_block)
   Visit(while_block.cond);
 
   loop_depth_++;
-  Visit(&while_block.block);
+  Visit(while_block.block);
   loop_depth_--;
 }
 
@@ -3416,7 +3416,7 @@ void SemanticAnalyser::visit(Probe &probe)
   if (probe.pred) {
     Visit(probe.pred);
   }
-  Visit(&probe.block);
+  Visit(probe.block);
 }
 
 void SemanticAnalyser::visit(Config &config)

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -127,20 +127,20 @@ void Visitor::visit(VarDeclStatement &decl)
 void Visitor::visit(If &if_node)
 {
   Visit(*if_node.cond);
-  Visit(if_node.if_block);
-  Visit(if_node.else_block);
+  Visit(*if_node.if_block);
+  Visit(*if_node.else_block);
 }
 
 void Visitor::visit(Unroll &unroll)
 {
   Visit(*unroll.expr);
-  Visit(unroll.block);
+  Visit(*unroll.block);
 }
 
 void Visitor::visit(While &while_block)
 {
   Visit(*while_block.cond);
-  Visit(while_block.block);
+  Visit(*while_block.block);
 }
 
 void Visitor::visit(For &for_loop)
@@ -177,7 +177,7 @@ void Visitor::visit(Probe &probe)
   if (probe.pred) {
     Visit(*probe.pred);
   }
-  Visit(probe.block);
+  Visit(*probe.block);
 }
 
 void Visitor::visit(Config &config)

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -320,7 +320,7 @@ probe:
                 attach_points pred block
                 {
                   if (!driver.listing_)
-                    $$ = driver.ctx.make_node<ast::Probe>(std::move($1), $2, std::move($3));
+                    $$ = driver.ctx.make_node<ast::Probe>(std::move($1), $2, driver.ctx.make_node<ast::Block>(std::move($3)));
                   else
                   {
                     error(@$, "unexpected listing query format");
@@ -330,7 +330,7 @@ probe:
         |       attach_points END
                 {
                   if (driver.listing_)
-                    $$ = driver.ctx.make_node<ast::Probe>(std::move($1), nullptr, ast::StatementList());
+                    $$ = driver.ctx.make_node<ast::Probe>(std::move($1), nullptr, driver.ctx.make_node<ast::Block>(ast::StatementList()));
                   else
                   {
                     error(@$, "unexpected end of file, expected {");
@@ -437,9 +437,9 @@ jump_stmt:
                 ;
 
 loop_stmt:
-                UNROLL "(" int ")" block             { $$ = driver.ctx.make_node<ast::Unroll>($3, std::move($5), @1 + @4); }
-        |       UNROLL "(" param ")" block           { $$ = driver.ctx.make_node<ast::Unroll>($3, std::move($5), @1 + @4); }
-        |       WHILE  "(" expr ")" block            { $$ = driver.ctx.make_node<ast::While>($3, std::move($5), @1); }
+                UNROLL "(" int ")" block             { $$ = driver.ctx.make_node<ast::Unroll>($3, driver.ctx.make_node<ast::Block>(std::move($5)), @1 + @4); }
+        |       UNROLL "(" param ")" block           { $$ = driver.ctx.make_node<ast::Unroll>($3, driver.ctx.make_node<ast::Block>(std::move($5)), @1 + @4); }
+        |       WHILE  "(" expr ")" block            { $$ = driver.ctx.make_node<ast::While>($3, driver.ctx.make_node<ast::Block>(std::move($5)), @1); }
                 ;
 
 for_stmt:
@@ -447,8 +447,8 @@ for_stmt:
                 ;
 
 if_stmt:
-                IF "(" expr ")" block                  { $$ = driver.ctx.make_node<ast::If>($3, std::move($5)); }
-        |       IF "(" expr ")" block ELSE block_or_if { $$ = driver.ctx.make_node<ast::If>($3, std::move($5), std::move($7)); }
+                IF "(" expr ")" block                  { $$ = driver.ctx.make_node<ast::If>($3, driver.ctx.make_node<ast::Block>(std::move($5)), driver.ctx.make_node<ast::Block>(ast::StatementList())); }
+        |       IF "(" expr ")" block ELSE block_or_if { $$ = driver.ctx.make_node<ast::If>($3, driver.ctx.make_node<ast::Block>(std::move($5)), driver.ctx.make_node<ast::Block>(std::move($7))); }
                 ;
 
 block_or_if:
@@ -476,7 +476,7 @@ assign_stmt:
                   $$ = driver.ctx.make_node<ast::AssignVarStatement>($1, b, @$);
                 }
         ;
-        
+
 var_decl_stmt:
                  LET var {  $$ = driver.ctx.make_node<ast::VarDeclStatement>($2, @$); }
         |        LET var COLON type {  $$ = driver.ctx.make_node<ast::VarDeclStatement>($2, $4, @$); }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1241,7 +1241,7 @@ TEST(semantic_analyser, call_str_2_lit)
   test(driver, "kprobe:f { $x = str(arg0, 3); }");
 
   auto x = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(0));
+      driver.ctx.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateString(3), x->var->type);
 }
 
@@ -1405,7 +1405,7 @@ TEST(semantic_analyser, call_uaddr)
 
   for (size_t i = 0; i < sizes.size(); i++) {
     auto v = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes.at(0)->block.stmts.at(i));
+        driver.ctx.root->probes.at(0)->block->stmts.at(i));
     EXPECT_TRUE(v->var->type.IsPtrTy());
     EXPECT_TRUE(v->var->type.GetPointeeTy()->IsIntTy());
     EXPECT_EQ((unsigned long int)sizes.at(i),
@@ -1686,26 +1686,26 @@ TEST(semantic_analyser, array_access)
        "struct MyStruct { int y[4]; } kprobe:f { $s = (struct MyStruct *) "
        "arg0; @x = $s->y[0];}");
   auto assignment = static_cast<ast::AssignMapStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(1));
+      driver.ctx.root->probes.at(0)->block->stmts.at(1));
   EXPECT_EQ(CreateInt64(), assignment->map->type);
 
   test(driver,
        "struct MyStruct { int y[4]; } kprobe:f { $s = ((struct MyStruct *) "
        "arg0)->y; @x = $s[0];}");
   auto array_var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(0));
+      driver.ctx.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateArray(4, CreateInt32()), array_var_assignment->var->type);
 
   test(driver,
        "struct MyStruct { int y[4]; } kprobe:f { @a[0] = ((struct MyStruct *) "
        "arg0)->y; @x = @a[0][0];}");
   auto array_map_assignment = static_cast<ast::AssignMapStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(0));
+      driver.ctx.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateArray(4, CreateInt32()), array_map_assignment->map->type);
 
   test(driver, "kprobe:f { $s = (int32 *) arg0; $x = $s[0]; }");
   auto var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(1));
+      driver.ctx.root->probes.at(0)->block->stmts.at(1));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
 
   // Positional parameter as index
@@ -1810,7 +1810,7 @@ TEST(semantic_analyser, variable_type)
   test(driver, "kprobe:f { $x = 1 }");
   auto st = CreateInt64();
   auto assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(0));
+      driver.ctx.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(st, assignment->var->type);
 }
 
@@ -1842,9 +1842,9 @@ TEST(semantic_analyser, map_integer_sizes)
   test(driver, "kprobe:f { $x = (int32) -1; @x = $x; }");
 
   auto var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(0));
+      driver.ctx.root->probes.at(0)->block->stmts.at(0));
   auto map_assignment = static_cast<ast::AssignMapStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(1));
+      driver.ctx.root->probes.at(0)->block->stmts.at(1));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
   EXPECT_EQ(CreateInt64(), map_assignment->map->type);
 }
@@ -1856,7 +1856,7 @@ TEST(semantic_analyser, binop_integer_promotion)
   test(driver, "kprobe:f { $x = (int32)5 + (int16)6 }");
 
   auto var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(0));
+      driver.ctx.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
 }
 
@@ -1867,7 +1867,7 @@ TEST(semantic_analyser, binop_integer_no_promotion)
   test(driver, "kprobe:f { $x = (int8)5 + (int8)6 }");
 
   auto var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(0));
+      driver.ctx.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateInt8(), var_assignment->var->type);
 }
 
@@ -2524,7 +2524,7 @@ TEST(semantic_analyser, field_access_is_internal)
 
   {
     test(driver, structs + "kprobe:f { $x = (*(struct type1*)0).x }");
-    auto stmts = driver.ctx.root->probes.at(0)->block.stmts;
+    auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
     auto var_assignment1 = static_cast<ast::AssignVarStatement *>(stmts.at(0));
     EXPECT_FALSE(var_assignment1->var->type.is_internal);
   }
@@ -2532,7 +2532,7 @@ TEST(semantic_analyser, field_access_is_internal)
   {
     test(driver,
          structs + "kprobe:f { @type1 = *(struct type1*)0; $x = @type1.x }");
-    auto stmts = driver.ctx.root->probes.at(0)->block.stmts;
+    auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
     auto map_assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
     auto var_assignment2 = static_cast<ast::AssignVarStatement *>(stmts.at(1));
     EXPECT_TRUE(map_assignment->map->type.is_internal);
@@ -2640,7 +2640,7 @@ TEST(semantic_analyser, positional_parameters)
   Driver driver(bpftrace);
   test(driver, "k:f { $1 }");
   auto stmt = static_cast<ast::ExprStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(0));
+      driver.ctx.root->probes.at(0)->block->stmts.at(0));
   auto pp = static_cast<ast::PositionalParameter *>(stmt->expr);
   EXPECT_EQ(CreateUInt64(), pp->type);
   EXPECT_TRUE(pp->is_literal);
@@ -2784,13 +2784,13 @@ TEST(semantic_analyser, cast_sign)
   test(driver, prog);
 
   auto s = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(1));
+      driver.ctx.root->probes.at(0)->block->stmts.at(1));
   auto us = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(2));
+      driver.ctx.root->probes.at(0)->block->stmts.at(2));
   auto l = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(3));
+      driver.ctx.root->probes.at(0)->block->stmts.at(3));
   auto ul = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block.stmts.at(4));
+      driver.ctx.root->probes.at(0)->block->stmts.at(4));
   EXPECT_EQ(CreateInt32(), s->var->type);
   EXPECT_EQ(CreateUInt32(), us->var->type);
   EXPECT_EQ(CreateInt64(), l->var->type);
@@ -2821,13 +2821,13 @@ TEST(semantic_analyser, binop_sign)
 
     test(driver, prog);
     auto varA = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes.at(0)->block.stmts.at(1));
+        driver.ctx.root->probes.at(0)->block->stmts.at(1));
     EXPECT_EQ(CreateInt64(), varA->var->type);
     auto varB = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes.at(0)->block.stmts.at(2));
+        driver.ctx.root->probes.at(0)->block->stmts.at(2));
     EXPECT_EQ(CreateUInt64(), varB->var->type);
     auto varC = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes.at(0)->block.stmts.at(3));
+        driver.ctx.root->probes.at(0)->block->stmts.at(3));
     EXPECT_EQ(CreateUInt64(), varC->var->type);
   }
 }
@@ -3206,7 +3206,7 @@ TEST(semantic_analyser, type_ctx)
   test(driver,
        structs + "kprobe:f { $x = (struct x*)ctx; $a = $x->a; $b = $x->b[0]; "
                  "$c = $x->c.c; $d = $x->d->c;}");
-  auto &stmts = driver.ctx.root->probes.at(0)->block.stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
 
   // $x = (struct x*)ctx;
   auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
@@ -3285,7 +3285,7 @@ TEST(semantic_analyser, double_pointer_int)
   BPFtrace bpftrace;
   Driver driver(bpftrace);
   test(driver, "kprobe:f { $pp = (int8 **)1; $p = *$pp; $val = *$p; }");
-  auto &stmts = driver.ctx.root->probes.at(0)->block.stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
 
   // $pp = (int8 **)1;
   auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
@@ -3315,7 +3315,7 @@ TEST(semantic_analyser, double_pointer_struct)
   test(driver,
        "struct Foo { char x; long y; }"
        "kprobe:f { $pp = (struct Foo **)1; $p = *$pp; $val = $p->x; }");
-  auto &stmts = driver.ctx.root->probes.at(0)->block.stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
 
   // $pp = (struct Foo **)1;
   auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
@@ -3501,7 +3501,7 @@ TEST(semantic_analyser, tuple_assign_var)
        R"_(BEGIN { $t = (1, "str"); $t = (4, "other"); })_",
        0);
 
-  auto &stmts = driver.ctx.root->probes.at(0)->block.stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
 
   // $t = (1, "str");
   auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
@@ -3524,7 +3524,7 @@ TEST(semantic_analyser, tuple_assign_map)
        R"_(BEGIN { @ = (1, 3, 3, 7); @ = (0, 0, 0, 0); })_",
        0);
 
-  auto &stmts = driver.ctx.root->probes.at(0)->block.stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
 
   // $t = (1, 3, 3, 7);
   auto assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
@@ -3550,7 +3550,7 @@ TEST(semantic_analyser, tuple_nested)
       bpftrace.structs.AddTuple({ CreateInt64(), ty_inner }));
   test(bpftrace, true, driver, R"_(BEGIN { $t = (1,(1,2)); })_", 0);
 
-  auto &stmts = driver.ctx.root->probes.at(0)->block.stmts;
+  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
 
   // $t = (1, "str");
   auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
@@ -3658,13 +3658,13 @@ TEST(semantic_analyser, string_size)
   BPFtrace bpftrace;
   Driver driver(bpftrace);
   test(bpftrace, true, driver, R"_(BEGIN { $x = "hi"; $x = "hello"; })_", 0);
-  auto stmt = driver.ctx.root->probes.at(0)->block.stmts.at(0);
+  auto stmt = driver.ctx.root->probes.at(0)->block->stmts.at(0);
   auto var_assign = dynamic_cast<ast::AssignVarStatement *>(stmt);
   ASSERT_TRUE(var_assign->var->type.IsStringTy());
   ASSERT_EQ(var_assign->var->type.GetSize(), 6UL);
 
   test(bpftrace, true, driver, R"_(k:f1 {@ = "hi";} k:f2 {@ = "hello";})_", 0);
-  stmt = driver.ctx.root->probes.at(0)->block.stmts.at(0);
+  stmt = driver.ctx.root->probes.at(0)->block->stmts.at(0);
   auto map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
   ASSERT_TRUE(map_assign->map->type.IsStringTy());
   ASSERT_EQ(map_assign->map->type.GetSize(), 6UL);
@@ -3674,7 +3674,7 @@ TEST(semantic_analyser, string_size)
        driver,
        R"_(k:f1 {@["hi"] = 0;} k:f2 {@["hello"] = 1;})_",
        0);
-  stmt = driver.ctx.root->probes.at(0)->block.stmts.at(0);
+  stmt = driver.ctx.root->probes.at(0)->block->stmts.at(0);
   map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
   ASSERT_TRUE(map_assign->map->key_expr->type.IsStringTy());
   ASSERT_EQ(map_assign->map->key_expr->type.GetSize(), 3UL);
@@ -3685,7 +3685,7 @@ TEST(semantic_analyser, string_size)
        driver,
        R"_(k:f1 {@["hi", 0] = 0;} k:f2 {@["hello", 1] = 1;})_",
        0);
-  stmt = driver.ctx.root->probes.at(0)->block.stmts.at(0);
+  stmt = driver.ctx.root->probes.at(0)->block->stmts.at(0);
   map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
   ASSERT_TRUE(map_assign->map->key_expr->type.IsTupleTy());
   ASSERT_TRUE(map_assign->map->key_expr->type.GetField(0).type.IsStringTy());
@@ -3699,7 +3699,7 @@ TEST(semantic_analyser, string_size)
        driver,
        R"_(k:f1 {$x = ("hello", 0);} k:f2 {$x = ("hi", 0); })_",
        0);
-  stmt = driver.ctx.root->probes.at(0)->block.stmts.at(0);
+  stmt = driver.ctx.root->probes.at(0)->block->stmts.at(0);
   var_assign = dynamic_cast<ast::AssignVarStatement *>(stmt);
   ASSERT_TRUE(var_assign->var->type.IsTupleTy());
   ASSERT_TRUE(var_assign->var->type.GetField(0).type.IsStringTy());


### PR DESCRIPTION
AST Nodes typically store references between themselves using pointers.
However, the newly introduced `Block` node was stored as part of the following nodes: `If`, `Unroll`, `While` and `Probe`.

Since the `Block` class has its copy constructor kept `private`, the nodes above could not copy their `Block`s and thus had their own copy constructor deleted. This didn't lead to any issue in bpftrace, but generates lots of warnings when compiling with `clang`.

This PR fixes the issue by storing reference to `Block`s using pointers. The `Block`s are then created like any other AST node by the parser.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
