### PR TITLE
bpffeature: Delete map test for BPF_MAP_TYPE_PERCPU_HASH

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3795,8 +3795,7 @@ libbpf::bpf_map_type CodegenLLVM::get_map_type(const SizedType &val_type,
 {
   if (val_type.IsCountTy() && key_type.IsNoneTy()) {
     return libbpf::BPF_MAP_TYPE_PERCPU_ARRAY;
-  } else if (bpftrace_.feature_->has_map_percpu_hash() &&
-             val_type.NeedsPercpuMap()) {
+  } else if (val_type.NeedsPercpuMap()) {
     return libbpf::BPF_MAP_TYPE_PERCPU_HASH;
   } else if (!val_type.NeedsPercpuMap() && key_type.IsNoneTy()) {
     return libbpf::BPF_MAP_TYPE_ARRAY;

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -603,7 +603,6 @@ std::string BPFfeature::report()
 
   buf << "Map types" << std::endl
       << "  hash: " << to_str(has_map_hash())
-      << "  percpu hash: " << to_str(has_map_percpu_hash())
       << "  array: " << to_str(has_map_array())
       << "  percpu array: " << to_str(has_map_percpu_array())
       << "  stack_trace: " << to_str(has_map_stack_trace())

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -111,7 +111,6 @@ public:
   DEFINE_MAP_TEST(array, libbpf::BPF_MAP_TYPE_ARRAY);
   DEFINE_MAP_TEST(hash, libbpf::BPF_MAP_TYPE_HASH);
   DEFINE_MAP_TEST(percpu_array, libbpf::BPF_MAP_TYPE_PERCPU_ARRAY);
-  DEFINE_MAP_TEST(percpu_hash, libbpf::BPF_MAP_TYPE_PERCPU_HASH);
   DEFINE_MAP_TEST(stack_trace, libbpf::BPF_MAP_TYPE_STACK_TRACE);
   DEFINE_MAP_TEST(perf_event_array, libbpf::BPF_MAP_TYPE_PERF_EVENT_ARRAY);
   DEFINE_MAP_TEST(ringbuf, libbpf::BPF_MAP_TYPE_RINGBUF);

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -104,7 +104,6 @@ public:
     has_uprobe_multi_ = std::make_optional<bool>(has_features);
     has_skb_output_ = std::make_optional<bool>(has_features);
     map_ringbuf_ = std::make_optional<bool>(has_features);
-    map_percpu_hash_ = std::make_optional<bool>(has_features);
     has_ktime_get_tai_ns_ = std::make_optional<bool>(has_features);
     has_get_func_ip_ = std::make_optional<bool>(has_features);
     has_jiffies64_ = std::make_optional<bool>(has_features);


### PR DESCRIPTION
It has been around since at least 4.8 kernel. The oldest active LTS release at time of writing is 4.19. So we are free to assume it always exists.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
