### PR TITLE
feat(report): bpftrace --info made more compact

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -564,87 +564,91 @@ bool BPFfeature::has_skb_output()
   return *has_skb_output_;
 }
 
+void tabulate(std::stringstream& buf,
+              std::vector<std::pair<std::string, std::string>>& data)
+{
+  size_t len = data.size();
+  constexpr int width = 35;
+  for (size_t i = 0; i < len; i += 2) {
+    buf << std::setw(width) << std::left
+        << " " + data[i].first + ": " + data[i].second << std::setw(width);
+    if (i + 1 < len) {
+      buf << data[i + 1].first + ": " + data[i + 1].second << std::endl;
+    } else {
+      buf << std::endl;
+    }
+  }
+}
+
 std::string BPFfeature::report()
 {
   std::stringstream buf;
 
-  auto to_str = [](bool f) -> std::string { return f ? " yes" : " no"; };
+  auto to_str = [](bool f) -> std::string { return f ? "yes" : "no"; };
 
-  constexpr int width = 35;
+  std::vector<std::pair<std::string, std::string>> helpers = {
+    { "probe_read", to_str(has_helper_probe_read()) },
+    { "probe_read_str", to_str(has_helper_probe_read_str()) },
+    { "probe_read_user", to_str(has_helper_probe_read_user()) },
+    { "probe_read_user_str", to_str(has_helper_probe_read_user_str()) },
+    { "probe_read_kernel", to_str(has_helper_probe_read_kernel()) },
+    { "probe_read_kernel_str", to_str(has_helper_probe_read_kernel_str()) },
+    { "get_current_cgroup_id", to_str(has_helper_get_current_cgroup_id()) },
+    { "send_signal", to_str(has_helper_send_signal()) },
+    { "override_return", to_str(has_helper_override_return()) },
+    { "get_boot_ns", to_str(has_helper_ktime_get_boot_ns()) },
+    { "dpath", to_str(has_d_path()) },
+    { "skboutput", to_str(has_skb_output()) },
+    { "get_tai_ns", to_str(has_helper_ktime_get_tai_ns()) },
+    { "get_func_ip", to_str(has_helper_get_func_ip()) },
+    { "jiffies64", to_str(has_helper_jiffies64()) },
+    { "for_each_map_elem", to_str(has_helper_for_each_map_elem()) }
+  };
 
-  buf << "Kernel helpers" << std::endl
-      << std::setw(width) << std::left
-      << "  probe_read:" + to_str(has_helper_probe_read()) << std::setw(width)
-      << "probe_read_str:" + to_str(has_helper_probe_read_str()) << std::endl
-      << std::setw(width) << std::left << std::left
-      << "  probe_read_user:" + to_str(has_helper_probe_read_user())
-      << std::setw(width)
-      << "probe_read_user_str:" + to_str(has_helper_probe_read_user_str())
-      << std::endl
-      << std::setw(width) << std::left
-      << "  probe_read_kernel:" + to_str(has_helper_probe_read_kernel())
-      << std::setw(width)
-      << "probe_read_kernel_str:" + to_str(has_helper_probe_read_kernel_str())
-      << std::endl
-      << std::setw(width) << std::left
-      << "  get_current_cgroup_id:" + to_str(has_helper_get_current_cgroup_id())
-      << std::setw(width) << "send_signal:" + to_str(has_helper_send_signal())
-      << std::endl
-      << std::setw(width) << std::left
-      << "  override_return:" + to_str(has_helper_override_return())
-      << std::setw(width)
-      << "get_boot_ns:" + to_str(has_helper_ktime_get_boot_ns()) << std::endl
-      << std::setw(width) << std::left << "  dpath:" + to_str(has_d_path())
-      << std::setw(width) << "skboutput:" + to_str(has_skb_output())
-      << std::endl
-      << std::setw(width) << std::left
-      << "  get_tai_ns:" + to_str(has_helper_ktime_get_tai_ns())
-      << std::setw(width) << "get_func_ip:" + to_str(has_helper_get_func_ip())
-      << std::endl
-      << std::setw(width) << std::left
-      << "  jiffies64:" + to_str(has_helper_jiffies64()) << std::setw(width)
-      << "for_each_map_elem:" + to_str(has_helper_for_each_map_elem())
-      << std::endl;
+  std::vector<std::pair<std::string, std::string>> features = {
+    { "Instruction limit", std::to_string(instruction_limit()) },
+    { "Loop support", to_str(has_loop()) },
+    { "btf", to_str(has_btf()) },
+    { "module btf", to_str(has_module_btf()) },
+    { "Kernel DWARF", to_str(has_kernel_dwarf()) },
+    { "map batch", to_str(has_map_batch()) },
+    { "uprobe refcount", to_str(has_uprobe_refcnt()) }
+  };
 
-  buf << std::endl
-      << "Kernel features" << std::endl
-      << std::setw(width) << std::left
-      << "  Instruction limit: " + std::to_string(instruction_limit())
-      << std::setw(width) << "Loop support:" + to_str(has_loop()) << std::endl
-      << std::setw(width) << std::left << "  btf:" + to_str(has_btf())
-      << std::setw(width) << std::left
-      << "module btf:" + to_str(has_module_btf()) << std::endl
-      << std::setw(width) << std::left
-      << "  Kernel DWARF:" + to_str(has_kernel_dwarf()) << std::setw(width)
-      << "map batch:" + to_str(has_map_batch()) << std::endl
-      << std::setw(width) << std::left
-      << "  uprobe refcount:" + to_str(has_uprobe_refcnt()) << std::endl;
+  std::vector<std::pair<std::string, std::string>> map_types = {
+    { "hash", to_str(has_map_hash()) },
+    { "array", to_str(has_map_array()) },
+    { "percpu array", to_str(has_map_percpu_array()) },
+    { "stack_trace", to_str(has_map_stack_trace()) },
+    { "perf_event_array", to_str(has_map_perf_event_array()) },
+    { "ringbuf", to_str(has_map_ringbuf()) }
+  };
 
-  buf << std::endl
-      << "Map types" << std::endl
-      << std::setw(width) << std::left << "  hash:" + to_str(has_map_hash())
-      << std::setw(width) << "array:" + to_str(has_map_array()) << std::endl
-      << std::setw(width) << std::left
-      << "  percpu array:" + to_str(has_map_percpu_array()) << std::setw(width)
-      << "stack_trace:" + to_str(has_map_stack_trace()) << std::endl
-      << std::setw(width) << std::left
-      << "  perf_event_array:" + to_str(has_map_perf_event_array())
-      << std::setw(width) << "ringbuf:" + to_str(has_map_ringbuf())
-      << std::endl;
+  std::vector<std::pair<std::string, std::string>> probe_types = {
+    { "kprobe", to_str(has_prog_kprobe()) },
+    { "tracepoint", to_str(has_prog_tracepoint()) },
+    { "perf_event", to_str(has_prog_perf_event()) },
+    { "fentry", to_str(has_fentry()) },
+    { "kprobe_multi", to_str(has_kprobe_multi()) },
+    { "uprobe_multi", to_str(has_uprobe_multi()) },
+    { "iter", to_str(has_iter("task")) }
+  };
 
-  buf << std::endl
-      << "Probe types" << std::endl
-      << std::setw(width) << std::left
-      << "  kprobe:" + to_str(has_prog_kprobe()) << std::setw(width)
-      << "tracepoint:" + to_str(has_prog_tracepoint()) << std::endl
-      << std::setw(width) << std::left
-      << "  perf_event:" + to_str(has_prog_perf_event()) << std::setw(width)
-      << "fentry:" + to_str(has_fentry()) << std::endl
-      << std::setw(width) << std::left
-      << "  kprobe_multi:" + to_str(has_kprobe_multi()) << std::setw(width)
-      << "uprobe_multi:" + to_str(has_uprobe_multi()) << std::endl
-      << std::setw(width) << std::left << "  iter:" + to_str(has_iter("task"))
-      << std::endl;
+  buf << "Kernel helpers" << std::endl;
+  tabulate(buf, helpers);
+  buf << std::endl;
+
+  buf << "Kernel features" << std::endl;
+  tabulate(buf, features);
+  buf << std::endl;
+
+  buf << "Map types" << std::endl;
+  tabulate(buf, map_types);
+  buf << std::endl;
+
+  buf << "Probe types" << std::endl;
+  tabulate(buf, probe_types);
+  buf << std::endl;
 
   return buf.str();
 }

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -612,7 +612,8 @@ std::string BPFfeature::report()
     { "module btf", to_str(has_module_btf()) },
     { "Kernel DWARF", to_str(has_kernel_dwarf()) },
     { "map batch", to_str(has_map_batch()) },
-    { "uprobe refcount", to_str(has_uprobe_refcnt()) } //depends on Build:bcc bpf_attach_uprobe refcount:
+    // Depends on BCC's bpf_attach_uprobe refcount feature
+    { "uprobe refcount", to_str(has_uprobe_refcnt()) } 
   };
 
   std::vector<std::pair<std::string, std::string>> map_types = {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -567,60 +567,92 @@ bool BPFfeature::has_skb_output()
 std::string BPFfeature::report()
 {
   std::stringstream buf;
-  auto to_str = [](bool f) -> auto { return f ? "yes" : "no"; };
+  auto to_str = [](bool f) -> auto
+  {
+    return f ? "yes" : "no";
+  };
   constexpr int width = 30;
   constexpr int sep = 10;
 
   buf << "Kernel helpers" << std::endl
-      << std::left << std::setw(width) << "  probe_read:" << std::setw(sep) << to_str(has_helper_probe_read())
-      << std::setw(width) << "probe_read_str:" << std::setw(sep) << to_str(has_helper_probe_read_str()) << std::endl
-      << std::setw(width) << "  probe_read_user:" << std::setw(sep) << to_str(has_helper_probe_read_user())
-      << std::setw(width) << "probe_read_user_str:" << std::setw(sep) << to_str(has_helper_probe_read_user_str()) << std::endl
-      << std::setw(width) << "  probe_read_kernel:" << std::setw(sep) << to_str(has_helper_probe_read_kernel())
-      << std::setw(width) << "probe_read_kernel_str:" << std::setw(sep) << to_str(has_helper_probe_read_kernel_str()) << std::endl
-      << std::setw(width) << "  get_current_cgroup_id:" << std::setw(sep) << to_str(has_helper_get_current_cgroup_id())
-      << std::setw(width) << "send_signal:" << std::setw(sep) << to_str(has_helper_send_signal()) << std::endl
-      << std::setw(width) << "  override_return:" << std::setw(sep) << to_str(has_helper_override_return())
-      << std::setw(width) << "get_boot_ns:" << std::setw(sep) << to_str(has_helper_ktime_get_boot_ns()) << std::endl
-      << std::setw(width) << "  dpath:" << std::setw(sep) << to_str(has_d_path())
-      << std::setw(width) << "skboutput:" << std::setw(sep) << to_str(has_skb_output()) << std::endl
-      << std::setw(width) << "  get_tai_ns:" << std::setw(sep) << to_str(has_helper_ktime_get_tai_ns())
-      << std::setw(width) << "get_func_ip:" << std::setw(sep) << to_str(has_helper_get_func_ip()) << std::endl
-      << std::setw(width) << "  jiffies64:" << std::setw(sep) << to_str(has_helper_jiffies64())
-      << std::setw(width) << "for_each_map_elem:" << std::setw(sep) << to_str(has_helper_for_each_map_elem()) << std::endl;
+      << std::left << std::setw(width) << "  probe_read:" << std::setw(sep)
+      << to_str(has_helper_probe_read()) << std::setw(width)
+      << "probe_read_str:" << std::setw(sep)
+      << to_str(has_helper_probe_read_str()) << std::endl
+      << std::setw(width) << "  probe_read_user:" << std::setw(sep)
+      << to_str(has_helper_probe_read_user()) << std::setw(width)
+      << "probe_read_user_str:" << std::setw(sep)
+      << to_str(has_helper_probe_read_user_str()) << std::endl
+      << std::setw(width) << "  probe_read_kernel:" << std::setw(sep)
+      << to_str(has_helper_probe_read_kernel()) << std::setw(width)
+      << "probe_read_kernel_str:" << std::setw(sep)
+      << to_str(has_helper_probe_read_kernel_str()) << std::endl
+      << std::setw(width) << "  get_current_cgroup_id:" << std::setw(sep)
+      << to_str(has_helper_get_current_cgroup_id()) << std::setw(width)
+      << "send_signal:" << std::setw(sep) << to_str(has_helper_send_signal())
+      << std::endl
+      << std::setw(width) << "  override_return:" << std::setw(sep)
+      << to_str(has_helper_override_return()) << std::setw(width)
+      << "get_boot_ns:" << std::setw(sep)
+      << to_str(has_helper_ktime_get_boot_ns()) << std::endl
+      << std::setw(width) << "  dpath:" << std::setw(sep)
+      << to_str(has_d_path()) << std::setw(width)
+      << "skboutput:" << std::setw(sep) << to_str(has_skb_output()) << std::endl
+      << std::setw(width) << "  get_tai_ns:" << std::setw(sep)
+      << to_str(has_helper_ktime_get_tai_ns()) << std::setw(width)
+      << "get_func_ip:" << std::setw(sep) << to_str(has_helper_get_func_ip())
+      << std::endl
+      << std::setw(width) << "  jiffies64:" << std::setw(sep)
+      << to_str(has_helper_jiffies64()) << std::setw(width)
+      << "for_each_map_elem:" << std::setw(sep)
+      << to_str(has_helper_for_each_map_elem()) << std::endl;
 
   buf << std::endl
       << "Kernel features" << std::endl
-      << std::setw(width) << "  Instruction limit:" << std::setw(sep) << instruction_limit()
-      << std::setw(width) << "Loop support:" << std::setw(sep) << to_str(has_loop()) << std::endl
+      << std::setw(width) << "  Instruction limit:" << std::setw(sep)
+      << instruction_limit() << std::setw(width)
+      << "Loop support:" << std::setw(sep) << to_str(has_loop()) << std::endl
       << std::setw(width) << "  btf:" << std::setw(sep) << to_str(has_btf())
-      << std::setw(width) << "module btf:" << std::setw(sep) << to_str(has_module_btf()) << std::endl
-      << std::setw(width) << "  Kernel DWARF:" << std::setw(sep) << to_str(has_kernel_dwarf())
-      << std::setw(width) << "map batch:" << std::setw(sep) << to_str(has_map_batch()) << std::endl
-      << std::setw(width) << "  uprobe refcount:" << std::setw(sep) << to_str(has_uprobe_refcnt()) << std::endl;
+      << std::setw(width) << "module btf:" << std::setw(sep)
+      << to_str(has_module_btf()) << std::endl
+      << std::setw(width) << "  Kernel DWARF:" << std::setw(sep)
+      << to_str(has_kernel_dwarf()) << std::setw(width)
+      << "map batch:" << std::setw(sep) << to_str(has_map_batch()) << std::endl
+      << std::setw(width) << "  uprobe refcount:" << std::setw(sep)
+      << to_str(has_uprobe_refcnt()) << std::endl;
 
   buf << std::endl
       << "Map types" << std::endl
-      << std::setw(width) << "  hash:" << std::setw(sep) << to_str(has_map_hash())
-      << std::setw(width) << "  array:" << std::setw(sep) << to_str(has_map_array()) << std::endl
-      << std::setw(width) << "  percpu array:" << std::setw(sep) << to_str(has_map_percpu_array()) 
-      << std::setw(width) << "  stack_trace:" << std::setw(sep) << to_str(has_map_stack_trace()) << std::endl
-      << std::setw(width) << "  perf_event_array:" << std::setw(sep) << to_str(has_map_perf_event_array())
-      << std::setw(width) << "  ringbuf:" << std::setw(sep) << to_str(has_map_ringbuf()) << std::endl;
+      << std::setw(width) << "  hash:" << std::setw(sep)
+      << to_str(has_map_hash()) << std::setw(width)
+      << "  array:" << std::setw(sep) << to_str(has_map_array()) << std::endl
+      << std::setw(width) << "  percpu array:" << std::setw(sep)
+      << to_str(has_map_percpu_array()) << std::setw(width)
+      << "  stack_trace:" << std::setw(sep) << to_str(has_map_stack_trace())
+      << std::endl
+      << std::setw(width) << "  perf_event_array:" << std::setw(sep)
+      << to_str(has_map_perf_event_array()) << std::setw(width)
+      << "  ringbuf:" << std::setw(sep) << to_str(has_map_ringbuf())
+      << std::endl;
 
   buf << std::endl
       << "Probe types" << std::endl
-      << std::setw(width) << "  kprobe:" << std::setw(sep) << to_str(has_prog_kprobe())
-      << std::setw(width) << "tracepoint:" << std::setw(sep) << to_str(has_prog_tracepoint()) << std::endl
-      << std::setw(width) << "  perf_event:" << std::setw(sep) << to_str(has_prog_perf_event())
-      << std::setw(width) << "fentry:" << std::setw(sep) << to_str(has_fentry()) << std::endl
-      << std::setw(width) << "  kprobe_multi:" << std::setw(sep) << to_str(has_kprobe_multi())
-      << std::setw(width) << "uprobe_multi:" << std::setw(sep) << to_str(has_uprobe_multi()) << std::endl
-      << std::setw(width) << "  iter:" << std::setw(sep) << to_str(has_iter("task")) << std::endl;
+      << std::setw(width) << "  kprobe:" << std::setw(sep)
+      << to_str(has_prog_kprobe()) << std::setw(width)
+      << "tracepoint:" << std::setw(sep) << to_str(has_prog_tracepoint())
+      << std::endl
+      << std::setw(width) << "  perf_event:" << std::setw(sep)
+      << to_str(has_prog_perf_event()) << std::setw(width)
+      << "fentry:" << std::setw(sep) << to_str(has_fentry()) << std::endl
+      << std::setw(width) << "  kprobe_multi:" << std::setw(sep)
+      << to_str(has_kprobe_multi()) << std::setw(width)
+      << "uprobe_multi:" << std::setw(sep) << to_str(has_uprobe_multi())
+      << std::endl
+      << std::setw(width) << "  iter:" << std::setw(sep)
+      << to_str(has_iter("task")) << std::endl;
 
   return buf.str();
 }
-
 
 bool BPFfeature::has_prog_fentry()
 {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -568,65 +568,83 @@ std::string BPFfeature::report()
 {
   std::stringstream buf;
 
-  auto to_str = [](bool f) -> std::string {
-    return f ? "yes" : "no";
-  };
+  auto to_str = [](bool f) -> std::string { return f ? "yes" : "no"; };
 
   constexpr int width = 35;
-  
-    buf << "Kernel helpers" << std::endl
-      <<std::setw(width) << std::left << std::left << "  probe_read:" + to_str(has_helper_probe_read()) << std::setw(width)
-      << "probe_read_str:" + to_str(has_helper_probe_read_str()) << std::endl
-      << std::setw(width) << std::left << std::left << "  probe_read_user:" + to_str(has_helper_probe_read_user()) << std::setw(width)
-      << "probe_read_user_str:" + to_str(has_helper_probe_read_user_str()) << std::endl
-      << std::setw(width) << std::left << "  probe_read_kernel:" + to_str(has_helper_probe_read_kernel()) << std::setw(width)
-      << "probe_read_kernel_str:" + to_str(has_helper_probe_read_kernel_str()) << std::endl
-      << std::setw(width) << std::left << "  get_current_cgroup_id:" + to_str(has_helper_get_current_cgroup_id()) << std::setw(width)
-      << "send_signal:" + to_str(has_helper_send_signal())
-      << std::endl
-      << std::setw(width) << std::left << "  override_return:" + to_str(has_helper_override_return()) << std::setw(width)
-      << "get_boot_ns:" + to_str(has_helper_ktime_get_boot_ns()) << std::endl
-      << std::setw(width) << std::left << "  dpath:" + to_str(has_d_path()) << std::setw(width)
-      << "skboutput:" + to_str(has_skb_output()) << std::endl
-      << std::setw(width) << std::left << "  get_tai_ns:" + to_str(has_helper_ktime_get_tai_ns()) << std::setw(width)
-      << "get_func_ip:" + to_str(has_helper_get_func_ip())
-      << std::endl
-      << std::setw(width) << std::left << "  jiffies64:" + to_str(has_helper_jiffies64()) << std::setw(width)
-      << "for_each_map_elem:" + to_str(has_helper_for_each_map_elem()) << std::endl;
 
+  buf << "Kernel helpers" << std::endl
+      << std::setw(width) << std::left << std::left
+      << "  probe_read:" + to_str(has_helper_probe_read()) << std::setw(width)
+      << "probe_read_str:" + to_str(has_helper_probe_read_str()) << std::endl
+      << std::setw(width) << std::left << std::left
+      << "  probe_read_user:" + to_str(has_helper_probe_read_user())
+      << std::setw(width)
+      << "probe_read_user_str:" + to_str(has_helper_probe_read_user_str())
+      << std::endl
+      << std::setw(width) << std::left
+      << "  probe_read_kernel:" + to_str(has_helper_probe_read_kernel())
+      << std::setw(width)
+      << "probe_read_kernel_str:" + to_str(has_helper_probe_read_kernel_str())
+      << std::endl
+      << std::setw(width) << std::left
+      << "  get_current_cgroup_id:" + to_str(has_helper_get_current_cgroup_id())
+      << std::setw(width) << "send_signal:" + to_str(has_helper_send_signal())
+      << std::endl
+      << std::setw(width) << std::left
+      << "  override_return:" + to_str(has_helper_override_return())
+      << std::setw(width)
+      << "get_boot_ns:" + to_str(has_helper_ktime_get_boot_ns()) << std::endl
+      << std::setw(width) << std::left << "  dpath:" + to_str(has_d_path())
+      << std::setw(width) << "skboutput:" + to_str(has_skb_output())
+      << std::endl
+      << std::setw(width) << std::left
+      << "  get_tai_ns:" + to_str(has_helper_ktime_get_tai_ns())
+      << std::setw(width) << "get_func_ip:" + to_str(has_helper_get_func_ip())
+      << std::endl
+      << std::setw(width) << std::left
+      << "  jiffies64:" + to_str(has_helper_jiffies64()) << std::setw(width)
+      << "for_each_map_elem:" + to_str(has_helper_for_each_map_elem())
+      << std::endl;
 
   buf << std::endl
       << "Kernel features" << std::endl
-      << std::setw(width) << std::left << "  Instruction limit:" + std::to_string(instruction_limit()) << std::setw(width)
-      << "Loop support:" + to_str(has_loop()) << std::endl
+      << std::setw(width) << std::left
+      << "  Instruction limit:" + std::to_string(instruction_limit())
+      << std::setw(width) << "Loop support:" + to_str(has_loop()) << std::endl
       << std::setw(width) << std::left << "  btf:" + to_str(has_btf())
-      << std::setw(width) << std::left << "module btf:" +  to_str(has_module_btf()) << std::endl
-      << std::setw(width) << std::left << "  Kernel DWARF:" + to_str(has_kernel_dwarf()) << std::setw(width)
+      << std::setw(width) << std::left
+      << "module btf:" + to_str(has_module_btf()) << std::endl
+      << std::setw(width) << std::left
+      << "  Kernel DWARF:" + to_str(has_kernel_dwarf()) << std::setw(width)
       << "map batch:" + to_str(has_map_batch()) << std::endl
-      << std::setw(width) << std::left << "  uprobe refcount:" + to_str(has_uprobe_refcnt()) << std::endl;
+      << std::setw(width) << std::left
+      << "  uprobe refcount:" + to_str(has_uprobe_refcnt()) << std::endl;
 
   buf << std::endl
       << "Map types" << std::endl
-      << std::setw(width) << std::left << "  hash:" + to_str(has_map_hash()) << std::setw(width)
-      << "  array:" + to_str(has_map_array()) << std::endl
-      << std::setw(width) << std::left << "  percpu array:" + to_str(has_map_percpu_array()) << std::setw(width)
-      << "  stack_trace:" + to_str(has_map_stack_trace())
-      << std::endl
-      << std::setw(width) << std::left << "  perf_event_array:" + to_str(has_map_perf_event_array()) << std::setw(width)
-      << "  ringbuf:" + to_str(has_map_ringbuf())
+      << std::setw(width) << std::left << "  hash:" + to_str(has_map_hash())
+      << std::setw(width) << "  array:" + to_str(has_map_array()) << std::endl
+      << std::setw(width) << std::left
+      << "  percpu array:" + to_str(has_map_percpu_array()) << std::setw(width)
+      << "  stack_trace:" + to_str(has_map_stack_trace()) << std::endl
+      << std::setw(width) << std::left
+      << "  perf_event_array:" + to_str(has_map_perf_event_array())
+      << std::setw(width) << "  ringbuf:" + to_str(has_map_ringbuf())
       << std::endl;
 
   buf << std::endl
       << "Probe types" << std::endl
-      << std::setw(width) << std::left << "  kprobe:" + to_str(has_prog_kprobe()) << std::setw(width)
-      << "tracepoint:" + to_str(has_prog_tracepoint())
-      << std::endl
-      << std::setw(width) << std::left << "  perf_event:" + to_str(has_prog_perf_event()) << std::setw(width)
+      << std::setw(width) << std::left
+      << "  kprobe:" + to_str(has_prog_kprobe()) << std::setw(width)
+      << "tracepoint:" + to_str(has_prog_tracepoint()) << std::endl
+      << std::setw(width) << std::left
+      << "  perf_event:" + to_str(has_prog_perf_event()) << std::setw(width)
       << "fentry:" + to_str(has_fentry()) << std::endl
-      << std::setw(width) << std::left << "  kprobe_multi:" + to_str(has_kprobe_multi()) << std::setw(width)
-      << "uprobe_multi:" + to_str(has_uprobe_multi())
-      << std::endl
-      << std::setw(width) << std::left << "  iter:" + to_str(has_iter("task")) << std::endl;
+      << std::setw(width) << std::left
+      << "  kprobe_multi:" + to_str(has_kprobe_multi()) << std::setw(width)
+      << "uprobe_multi:" + to_str(has_uprobe_multi()) << std::endl
+      << std::setw(width) << std::left << "  iter:" + to_str(has_iter("task"))
+      << std::endl;
 
   return buf.str();
 }

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -567,89 +567,66 @@ bool BPFfeature::has_skb_output()
 std::string BPFfeature::report()
 {
   std::stringstream buf;
-  auto to_str = [](bool f) -> auto
-  {
+
+  auto to_str = [](bool f) -> std::string {
     return f ? "yes" : "no";
   };
-  constexpr int width = 30;
-  constexpr int sep = 10;
 
-  buf << "Kernel helpers" << std::endl
-      << std::left << std::setw(width) << "  probe_read:" << std::setw(sep)
-      << to_str(has_helper_probe_read()) << std::setw(width)
-      << "probe_read_str:" << std::setw(sep)
-      << to_str(has_helper_probe_read_str()) << std::endl
-      << std::setw(width) << "  probe_read_user:" << std::setw(sep)
-      << to_str(has_helper_probe_read_user()) << std::setw(width)
-      << "probe_read_user_str:" << std::setw(sep)
-      << to_str(has_helper_probe_read_user_str()) << std::endl
-      << std::setw(width) << "  probe_read_kernel:" << std::setw(sep)
-      << to_str(has_helper_probe_read_kernel()) << std::setw(width)
-      << "probe_read_kernel_str:" << std::setw(sep)
-      << to_str(has_helper_probe_read_kernel_str()) << std::endl
-      << std::setw(width) << "  get_current_cgroup_id:" << std::setw(sep)
-      << to_str(has_helper_get_current_cgroup_id()) << std::setw(width)
-      << "send_signal:" << std::setw(sep) << to_str(has_helper_send_signal())
+  constexpr int width = 35;
+  
+    buf << "Kernel helpers" << std::endl
+      <<std::setw(width) << std::left << std::left << "  probe_read:" + to_str(has_helper_probe_read()) << std::setw(width)
+      << "probe_read_str:" + to_str(has_helper_probe_read_str()) << std::endl
+      << std::setw(width) << std::left << std::left << "  probe_read_user:" + to_str(has_helper_probe_read_user()) << std::setw(width)
+      << "probe_read_user_str:" + to_str(has_helper_probe_read_user_str()) << std::endl
+      << std::setw(width) << std::left << "  probe_read_kernel:" + to_str(has_helper_probe_read_kernel()) << std::setw(width)
+      << "probe_read_kernel_str:" + to_str(has_helper_probe_read_kernel_str()) << std::endl
+      << std::setw(width) << std::left << "  get_current_cgroup_id:" + to_str(has_helper_get_current_cgroup_id()) << std::setw(width)
+      << "send_signal:" + to_str(has_helper_send_signal())
       << std::endl
-      << std::setw(width) << "  override_return:" << std::setw(sep)
-      << to_str(has_helper_override_return()) << std::setw(width)
-      << "get_boot_ns:" << std::setw(sep)
-      << to_str(has_helper_ktime_get_boot_ns()) << std::endl
-      << std::setw(width) << "  dpath:" << std::setw(sep)
-      << to_str(has_d_path()) << std::setw(width)
-      << "skboutput:" << std::setw(sep) << to_str(has_skb_output()) << std::endl
-      << std::setw(width) << "  get_tai_ns:" << std::setw(sep)
-      << to_str(has_helper_ktime_get_tai_ns()) << std::setw(width)
-      << "get_func_ip:" << std::setw(sep) << to_str(has_helper_get_func_ip())
+      << std::setw(width) << std::left << "  override_return:" + to_str(has_helper_override_return()) << std::setw(width)
+      << "get_boot_ns:" + to_str(has_helper_ktime_get_boot_ns()) << std::endl
+      << std::setw(width) << std::left << "  dpath:" + to_str(has_d_path()) << std::setw(width)
+      << "skboutput:" + to_str(has_skb_output()) << std::endl
+      << std::setw(width) << std::left << "  get_tai_ns:" + to_str(has_helper_ktime_get_tai_ns()) << std::setw(width)
+      << "get_func_ip:" + to_str(has_helper_get_func_ip())
       << std::endl
-      << std::setw(width) << "  jiffies64:" << std::setw(sep)
-      << to_str(has_helper_jiffies64()) << std::setw(width)
-      << "for_each_map_elem:" << std::setw(sep)
-      << to_str(has_helper_for_each_map_elem()) << std::endl;
+      << std::setw(width) << std::left << "  jiffies64:" + to_str(has_helper_jiffies64()) << std::setw(width)
+      << "for_each_map_elem:" + to_str(has_helper_for_each_map_elem()) << std::endl;
+
 
   buf << std::endl
       << "Kernel features" << std::endl
-      << std::setw(width) << "  Instruction limit:" << std::setw(sep)
-      << instruction_limit() << std::setw(width)
-      << "Loop support:" << std::setw(sep) << to_str(has_loop()) << std::endl
-      << std::setw(width) << "  btf:" << std::setw(sep) << to_str(has_btf())
-      << std::setw(width) << "module btf:" << std::setw(sep)
-      << to_str(has_module_btf()) << std::endl
-      << std::setw(width) << "  Kernel DWARF:" << std::setw(sep)
-      << to_str(has_kernel_dwarf()) << std::setw(width)
-      << "map batch:" << std::setw(sep) << to_str(has_map_batch()) << std::endl
-      << std::setw(width) << "  uprobe refcount:" << std::setw(sep)
-      << to_str(has_uprobe_refcnt()) << std::endl;
+      << std::setw(width) << std::left << "  Instruction limit:" + std::to_string(instruction_limit()) << std::setw(width)
+      << "Loop support:" + to_str(has_loop()) << std::endl
+      << std::setw(width) << std::left << "  btf:" + to_str(has_btf())
+      << std::setw(width) << std::left << "module btf:" +  to_str(has_module_btf()) << std::endl
+      << std::setw(width) << std::left << "  Kernel DWARF:" + to_str(has_kernel_dwarf()) << std::setw(width)
+      << "map batch:" + to_str(has_map_batch()) << std::endl
+      << std::setw(width) << std::left << "  uprobe refcount:" + to_str(has_uprobe_refcnt()) << std::endl;
 
   buf << std::endl
       << "Map types" << std::endl
-      << std::setw(width) << "  hash:" << std::setw(sep)
-      << to_str(has_map_hash()) << std::setw(width)
-      << "  array:" << std::setw(sep) << to_str(has_map_array()) << std::endl
-      << std::setw(width) << "  percpu array:" << std::setw(sep)
-      << to_str(has_map_percpu_array()) << std::setw(width)
-      << "  stack_trace:" << std::setw(sep) << to_str(has_map_stack_trace())
+      << std::setw(width) << std::left << "  hash:" + to_str(has_map_hash()) << std::setw(width)
+      << "  array:" + to_str(has_map_array()) << std::endl
+      << std::setw(width) << std::left << "  percpu array:" + to_str(has_map_percpu_array()) << std::setw(width)
+      << "  stack_trace:" + to_str(has_map_stack_trace())
       << std::endl
-      << std::setw(width) << "  perf_event_array:" << std::setw(sep)
-      << to_str(has_map_perf_event_array()) << std::setw(width)
-      << "  ringbuf:" << std::setw(sep) << to_str(has_map_ringbuf())
+      << std::setw(width) << std::left << "  perf_event_array:" + to_str(has_map_perf_event_array()) << std::setw(width)
+      << "  ringbuf:" + to_str(has_map_ringbuf())
       << std::endl;
 
   buf << std::endl
       << "Probe types" << std::endl
-      << std::setw(width) << "  kprobe:" << std::setw(sep)
-      << to_str(has_prog_kprobe()) << std::setw(width)
-      << "tracepoint:" << std::setw(sep) << to_str(has_prog_tracepoint())
+      << std::setw(width) << std::left << "  kprobe:" + to_str(has_prog_kprobe()) << std::setw(width)
+      << "tracepoint:" + to_str(has_prog_tracepoint())
       << std::endl
-      << std::setw(width) << "  perf_event:" << std::setw(sep)
-      << to_str(has_prog_perf_event()) << std::setw(width)
-      << "fentry:" << std::setw(sep) << to_str(has_fentry()) << std::endl
-      << std::setw(width) << "  kprobe_multi:" << std::setw(sep)
-      << to_str(has_kprobe_multi()) << std::setw(width)
-      << "uprobe_multi:" << std::setw(sep) << to_str(has_uprobe_multi())
+      << std::setw(width) << std::left << "  perf_event:" + to_str(has_prog_perf_event()) << std::setw(width)
+      << "fentry:" + to_str(has_fentry()) << std::endl
+      << std::setw(width) << std::left << "  kprobe_multi:" + to_str(has_kprobe_multi()) << std::setw(width)
+      << "uprobe_multi:" + to_str(has_uprobe_multi())
       << std::endl
-      << std::setw(width) << "  iter:" << std::setw(sep)
-      << to_str(has_iter("task")) << std::endl;
+      << std::setw(width) << std::left << "  iter:" + to_str(has_iter("task")) << std::endl;
 
   return buf.str();
 }

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -565,7 +565,7 @@ bool BPFfeature::has_skb_output()
 }
 
 static void tabulate(std::stringstream& buf,
-              std::vector<std::pair<std::string, std::string>>& data)
+                     std::vector<std::pair<std::string, std::string>>& data)
 {
   size_t len = data.size();
   constexpr int width = 35;
@@ -613,7 +613,7 @@ std::string BPFfeature::report()
     { "Kernel DWARF", to_str(has_kernel_dwarf()) },
     { "map batch", to_str(has_map_batch()) },
     // Depends on BCC's bpf_attach_uprobe refcount feature
-    { "uprobe refcount", to_str(has_uprobe_refcnt()) } 
+    { "uprobe refcount", to_str(has_uprobe_refcnt()) }
   };
 
   std::vector<std::pair<std::string, std::string>> map_types = {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -564,7 +564,7 @@ bool BPFfeature::has_skb_output()
   return *has_skb_output_;
 }
 
-void tabulate(std::stringstream& buf,
+static void tabulate(std::stringstream& buf,
               std::vector<std::pair<std::string, std::string>>& data)
 {
   size_t len = data.size();
@@ -612,7 +612,7 @@ std::string BPFfeature::report()
     { "module btf", to_str(has_module_btf()) },
     { "Kernel DWARF", to_str(has_kernel_dwarf()) },
     { "map batch", to_str(has_map_batch()) },
-    { "uprobe refcount", to_str(has_uprobe_refcnt()) }
+    { "uprobe refcount", to_str(has_uprobe_refcnt()) } //depends on Build:bcc bpf_attach_uprobe refcount:
   };
 
   std::vector<std::pair<std::string, std::string>> map_types = {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -568,12 +568,12 @@ std::string BPFfeature::report()
 {
   std::stringstream buf;
 
-  auto to_str = [](bool f) -> std::string { return f ? "yes" : "no"; };
+  auto to_str = [](bool f) -> std::string { return f ? " yes" : " no"; };
 
   constexpr int width = 35;
 
   buf << "Kernel helpers" << std::endl
-      << std::setw(width) << std::left << std::left
+      << std::setw(width) << std::left
       << "  probe_read:" + to_str(has_helper_probe_read()) << std::setw(width)
       << "probe_read_str:" + to_str(has_helper_probe_read_str()) << std::endl
       << std::setw(width) << std::left << std::left
@@ -609,7 +609,7 @@ std::string BPFfeature::report()
   buf << std::endl
       << "Kernel features" << std::endl
       << std::setw(width) << std::left
-      << "  Instruction limit:" + std::to_string(instruction_limit())
+      << "  Instruction limit: " + std::to_string(instruction_limit())
       << std::setw(width) << "Loop support:" + to_str(has_loop()) << std::endl
       << std::setw(width) << std::left << "  btf:" + to_str(has_btf())
       << std::setw(width) << std::left
@@ -623,13 +623,13 @@ std::string BPFfeature::report()
   buf << std::endl
       << "Map types" << std::endl
       << std::setw(width) << std::left << "  hash:" + to_str(has_map_hash())
-      << std::setw(width) << "  array:" + to_str(has_map_array()) << std::endl
+      << std::setw(width) << "array:" + to_str(has_map_array()) << std::endl
       << std::setw(width) << std::left
       << "  percpu array:" + to_str(has_map_percpu_array()) << std::setw(width)
-      << "  stack_trace:" + to_str(has_map_stack_trace()) << std::endl
+      << "stack_trace:" + to_str(has_map_stack_trace()) << std::endl
       << std::setw(width) << std::left
       << "  perf_event_array:" + to_str(has_map_perf_event_array())
-      << std::setw(width) << "  ringbuf:" + to_str(has_map_ringbuf())
+      << std::setw(width) << "ringbuf:" + to_str(has_map_ringbuf())
       << std::endl;
 
   buf << std::endl

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -567,59 +567,60 @@ bool BPFfeature::has_skb_output()
 std::string BPFfeature::report()
 {
   std::stringstream buf;
-  auto to_str = [](bool f) -> auto { return f ? "yes\n" : "no\n"; };
+  auto to_str = [](bool f) -> auto { return f ? "yes" : "no"; };
+  constexpr int width = 30;
+  constexpr int sep = 10;
 
   buf << "Kernel helpers" << std::endl
-      << "  probe_read: " << to_str(has_helper_probe_read())
-      << "  probe_read_str: " << to_str(has_helper_probe_read_str())
-      << "  probe_read_user: " << to_str(has_helper_probe_read_user())
-      << "  probe_read_user_str: " << to_str(has_helper_probe_read_user_str())
-      << "  probe_read_kernel: " << to_str(has_helper_probe_read_kernel())
-      << "  probe_read_kernel_str: "
-      << to_str(has_helper_probe_read_kernel_str())
-      << "  get_current_cgroup_id: "
-      << to_str(has_helper_get_current_cgroup_id())
-      << "  send_signal: " << to_str(has_helper_send_signal())
-      << "  override_return: " << to_str(has_helper_override_return())
-      << "  get_boot_ns: " << to_str(has_helper_ktime_get_boot_ns())
-      << "  dpath: " << to_str(has_d_path())
-      << "  skboutput: " << to_str(has_skb_output())
-      << "  get_tai_ns: " << to_str(has_helper_ktime_get_tai_ns())
-      << "  get_func_ip: " << to_str(has_helper_get_func_ip())
-      << "  jiffies64: " << to_str(has_helper_jiffies64())
-      << "  for_each_map_elem: " << to_str(has_helper_for_each_map_elem())
+      << std::left << std::setw(width) << "  probe_read:" << std::setw(sep) << to_str(has_helper_probe_read())
+      << std::setw(width) << "probe_read_str:" << std::setw(sep) << to_str(has_helper_probe_read_str()) << std::endl
+      << std::setw(width) << "  probe_read_user:" << std::setw(sep) << to_str(has_helper_probe_read_user())
+      << std::setw(width) << "probe_read_user_str:" << std::setw(sep) << to_str(has_helper_probe_read_user_str()) << std::endl
+      << std::setw(width) << "  probe_read_kernel:" << std::setw(sep) << to_str(has_helper_probe_read_kernel())
+      << std::setw(width) << "probe_read_kernel_str:" << std::setw(sep) << to_str(has_helper_probe_read_kernel_str()) << std::endl
+      << std::setw(width) << "  get_current_cgroup_id:" << std::setw(sep) << to_str(has_helper_get_current_cgroup_id())
+      << std::setw(width) << "send_signal:" << std::setw(sep) << to_str(has_helper_send_signal()) << std::endl
+      << std::setw(width) << "  override_return:" << std::setw(sep) << to_str(has_helper_override_return())
+      << std::setw(width) << "get_boot_ns:" << std::setw(sep) << to_str(has_helper_ktime_get_boot_ns()) << std::endl
+      << std::setw(width) << "  dpath:" << std::setw(sep) << to_str(has_d_path())
+      << std::setw(width) << "skboutput:" << std::setw(sep) << to_str(has_skb_output()) << std::endl
+      << std::setw(width) << "  get_tai_ns:" << std::setw(sep) << to_str(has_helper_ktime_get_tai_ns())
+      << std::setw(width) << "get_func_ip:" << std::setw(sep) << to_str(has_helper_get_func_ip()) << std::endl
+      << std::setw(width) << "  jiffies64:" << std::setw(sep) << to_str(has_helper_jiffies64())
+      << std::setw(width) << "for_each_map_elem:" << std::setw(sep) << to_str(has_helper_for_each_map_elem()) << std::endl;
 
-      << std::endl;
+  buf << std::endl
+      << "Kernel features" << std::endl
+      << std::setw(width) << "  Instruction limit:" << std::setw(sep) << instruction_limit()
+      << std::setw(width) << "Loop support:" << std::setw(sep) << to_str(has_loop()) << std::endl
+      << std::setw(width) << "  btf:" << std::setw(sep) << to_str(has_btf())
+      << std::setw(width) << "module btf:" << std::setw(sep) << to_str(has_module_btf()) << std::endl
+      << std::setw(width) << "  Kernel DWARF:" << std::setw(sep) << to_str(has_kernel_dwarf())
+      << std::setw(width) << "map batch:" << std::setw(sep) << to_str(has_map_batch()) << std::endl
+      << std::setw(width) << "  uprobe refcount:" << std::setw(sep) << to_str(has_uprobe_refcnt()) << std::endl;
 
-  buf << "Kernel features" << std::endl
-      << "  Instruction limit: " << instruction_limit() << std::endl
-      << "  Loop support: " << to_str(has_loop())
-      << "  btf: " << to_str(has_btf())
-      << "  module btf: " << to_str(has_module_btf())
-      << "  Kernel DWARF: " << to_str(has_kernel_dwarf())
-      << "  map batch: " << to_str(has_map_batch())
-      << "  uprobe refcount (depends on Build:bcc bpf_attach_uprobe refcount): "
-      << to_str(has_uprobe_refcnt()) << std::endl;
+  buf << std::endl
+      << "Map types" << std::endl
+      << std::setw(width) << "  hash:" << std::setw(sep) << to_str(has_map_hash())
+      << std::setw(width) << "  array:" << std::setw(sep) << to_str(has_map_array()) << std::endl
+      << std::setw(width) << "  percpu array:" << std::setw(sep) << to_str(has_map_percpu_array()) 
+      << std::setw(width) << "  stack_trace:" << std::setw(sep) << to_str(has_map_stack_trace()) << std::endl
+      << std::setw(width) << "  perf_event_array:" << std::setw(sep) << to_str(has_map_perf_event_array())
+      << std::setw(width) << "  ringbuf:" << std::setw(sep) << to_str(has_map_ringbuf()) << std::endl;
 
-  buf << "Map types" << std::endl
-      << "  hash: " << to_str(has_map_hash())
-      << "  array: " << to_str(has_map_array())
-      << "  percpu array: " << to_str(has_map_percpu_array())
-      << "  stack_trace: " << to_str(has_map_stack_trace())
-      << "  perf_event_array: " << to_str(has_map_perf_event_array())
-      << "  ringbuf: " << to_str(has_map_ringbuf()) << std::endl;
-
-  buf << "Probe types" << std::endl
-      << "  kprobe: " << to_str(has_prog_kprobe())
-      << "  tracepoint: " << to_str(has_prog_tracepoint())
-      << "  perf_event: " << to_str(has_prog_perf_event())
-      << "  fentry: " << to_str(has_fentry())
-      << "  kprobe_multi: " << to_str(has_kprobe_multi())
-      << "  uprobe_multi: " << to_str(has_uprobe_multi())
-      << "  iter: " << to_str(has_iter("task")) << std::endl;
+  buf << std::endl
+      << "Probe types" << std::endl
+      << std::setw(width) << "  kprobe:" << std::setw(sep) << to_str(has_prog_kprobe())
+      << std::setw(width) << "tracepoint:" << std::setw(sep) << to_str(has_prog_tracepoint()) << std::endl
+      << std::setw(width) << "  perf_event:" << std::setw(sep) << to_str(has_prog_perf_event())
+      << std::setw(width) << "fentry:" << std::setw(sep) << to_str(has_fentry()) << std::endl
+      << std::setw(width) << "  kprobe_multi:" << std::setw(sep) << to_str(has_kprobe_multi())
+      << std::setw(width) << "uprobe_multi:" << std::setw(sep) << to_str(has_uprobe_multi()) << std::endl
+      << std::setw(width) << "  iter:" << std::setw(sep) << to_str(has_iter("task")) << std::endl;
 
   return buf.str();
 }
+
 
 bool BPFfeature::has_prog_fentry()
 {

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -261,7 +261,7 @@ TIMEOUT 3
 
 NAME info flag
 RUN {{BPFTRACE}} --info
-EXPECT perf_event_array: yes
+EXPECT_REGEX perf_event_array: yes
 TIMEOUT 1
 
 NAME basic while loop

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -138,8 +138,7 @@ class Runner(object):
         bpffeature["btf"] = output.find("btf: yes") != -1
         bpffeature["fentry"] = output.find("fentry: yes") != -1
         bpffeature["dpath"] = output.find("dpath: yes") != -1
-        bpffeature["uprobe_refcount"] = \
-            output.find("uprobe refcount") != -1
+        bpffeature["uprobe_refcount"] = output.find("uprobe refcount") != -1
         bpffeature["signal"] = output.find("send_signal: yes") != -1
         bpffeature["iter"] = output.find("iter: yes") != -1
         bpffeature["libpath_resolv"] = output.find("bcc library path resolution: yes") != -1

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -139,7 +139,7 @@ class Runner(object):
         bpffeature["fentry"] = output.find("fentry: yes") != -1
         bpffeature["dpath"] = output.find("dpath: yes") != -1
         bpffeature["uprobe_refcount"] = \
-            output.find("uprobe refcount (depends on Build:bcc bpf_attach_uprobe refcount): yes") != -1
+            output.find("uprobe refcount") != -1
         bpffeature["signal"] = output.find("send_signal: yes") != -1
         bpffeature["iter"] = output.find("iter: yes") != -1
         bpffeature["libpath_resolv"] = output.find("bcc library path resolution: yes") != -1


### PR DESCRIPTION
- Added a separator width to ensure consistent alignment of key-value pairs in the report function

This PR addresses issue #3554 by making the output of bpftrace --info more compact. Key-value pairs are now displayed two per line, utilizing horizontal space efficiently and maintaining readability. Column widths and separator widths were used to ensure proper alignment.

Screenshot of the output:
![image](https://github.com/user-attachments/assets/5c3dfd8f-5691-4d76-b951-3e67050db247)


##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
