### PR TITLE
Nix: update nixpkgs to 24.11

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -126,6 +126,7 @@ def shell(
             # play nice with root or writing temporary files. So that
             # requires further investigation.
             "--preserve-env=PATH",
+            "--preserve-env=PYTHONPATH",
             # Also preserve any caller specified env vars
             f"--preserve-env={to_preserve}",
         ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,6 @@ jobs:
     strategy:
       matrix:
         env:
-        - NAME: LLVM 13
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm13
-          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 14
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm14

--- a/flake.lock
+++ b/flake.lock
@@ -79,16 +79,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1718290262,
-        "narHash": "sha256-C1OvC8At5IvvYHKf278Zq+wfnUXhO8vd2yNgbzZzArc=",
+        "lastModified": 1733135940,
+        "narHash": "sha256-YGc18lXzjnk0DZUIkgUOsr7Y9Z+VcVqsbjcJyh8mK40=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aeb13d0815848e88980ee5164f949f7238e728ee",
+        "rev": "c2a32c702844e7a82a6b08fc15b512344872d86a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.05",
+        "ref": "release-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,7 @@
                   nftables
                   procps
                   python3
+                  python3Packages.looseversion
                   strace
                   unixtools.ping
                   util-linux

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "High-level tracing language for Linux";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
     flake-utils.url = "github:numtide/flake-utils";
     nix-appimage = {
       # Use fork until following PRs are in:

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -513,7 +513,7 @@ bool BPFfeature::has_uprobe_multi()
 #else
   has_uprobe_multi_ = false;
 #endif // HAVE_LIBBPF_UPROBE_MULTI
-  return *has_uprobe_multi_;
+  return *has_uprobe_multi_; // NOLINT(bugprone-unchecked-optional-access)
 }
 
 bool BPFfeature::has_skb_output()

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -556,9 +556,13 @@ void Output::map_hist_contents(
     auto key_str = map_key_to_str(bpftrace, map, key);
     std::string val_str;
     if (map_type.IsHistTy()) {
+      if (!map_info.hist_bits_arg.has_value())
+        LOG(BUG) << "call to hist with missing \"bits\" argument";
       val_str = hist_to_str(value, div, *map_info.hist_bits_arg);
     } else {
       auto &args = map_info.lhist_args;
+      if (!args.has_value())
+        LOG(BUG) << "call to lhist with missing arguments";
       val_str = lhist_to_str(value, args->min, args->max, args->step);
     }
     map_key_val(map_type, key_str, val_str);

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -6,7 +6,7 @@ import signal
 import sys
 import os
 import time
-from distutils.version import LooseVersion
+from looseversion import LooseVersion
 import re
 from functools import lru_cache
 


### PR DESCRIPTION
The 24.11 release contains LLVM 19 so we can finally merge #3433.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
