### PR TITLE
Use std::max<uint64_t>() to fix 32-bit build

### DIFF
--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -240,9 +240,9 @@ void ResourceAnalyser::visit(Call &call)
     if (!arg.is_map) {
       resources_.non_map_print_args.push_back(arg.type);
 
-      const auto fmtstring_args_size = nonmap_headroom + arg.type.GetSize();
+      const size_t fmtstring_args_size = nonmap_headroom + arg.type.GetSize();
       if (exceeds_stack_limit(fmtstring_args_size)) {
-        resources_.max_fmtstring_args_size = std::max(
+        resources_.max_fmtstring_args_size = std::max<uint64_t>(
             resources_.max_fmtstring_args_size, fmtstring_args_size);
       }
     } else {
@@ -250,9 +250,9 @@ void ResourceAnalyser::visit(Call &call)
       if (map.key_expr) {
         resources_.non_map_print_args.push_back(map.type);
 
-        const auto fmtstring_args_size = nonmap_headroom + map.type.GetSize();
+        const size_t fmtstring_args_size = nonmap_headroom + map.type.GetSize();
         if (exceeds_stack_limit(fmtstring_args_size)) {
-          resources_.max_fmtstring_args_size = std::max(
+          resources_.max_fmtstring_args_size = std::max<uint64_t>(
               resources_.max_fmtstring_args_size, fmtstring_args_size);
         }
       }


### PR DESCRIPTION
There's an implicit assumption that size_t and uint64_t are the same type, resulting in a compile error on 32-bit systems:

```
  resource_analyser.cpp:245:46: error: no matching function for call to 'max'
          resources_.max_fmtstring_args_size = std::max(
                                               ^~~~~~~~
```
