### PR TITLE
Add "unstable_attach_to_inline_funcs" to adoc

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3793,6 +3793,15 @@ Available options:
 If the DebugInfo was rewritten by a post-linkage optimisation tool (like BOLT or AutoFDO), it might yield an incorrect address for a probe location.
 This config can force using the Symbol Table, for when the DebugInfo returns invalid addresses.
 
+**NOTE**: the following config variables are experimental (as indicated by their "unstable" prefix) so use these with caution and be aware they may be changed in future releases.
+
+=== unstable_attach_to_inline_funcs
+
+Default: 0
+
+Set to `1` to add the ability to attach uprobes/uretprobes, kprobes/kretprobes, and fentry/fexit to inlined functions.
+This may restrict the use of some builtins.
+
 == Environment Variables
 
 These are not available as part of the standard set of <<Config Variables>> and can only be set as environment variables.

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -485,10 +485,10 @@ void SemanticAnalyser::visit(Builtin &builtin)
     for (auto *attach_point : probe->attach_points) {
       ProbeType type = probetype(attach_point->provider);
       if (type == ProbeType::uprobe &&
-          bpftrace_.config_.get(ConfigKeyBool::probe_inline))
+          bpftrace_.config_.get(ConfigKeyBool::unstable_attach_to_inline_funcs))
         LOG(ERROR, builtin.loc, err_)
             << "The " + builtin.ident + " builtin can only be used when "
-            << "the probe_inline config is disabled.";
+            << "the unstable_attach_to_inline_funcs config is disabled.";
       if (type != ProbeType::kprobe && type != ProbeType::uprobe &&
           type != ProbeType::usdt && type != ProbeType::rawtracepoint)
         LOG(ERROR, builtin.loc, err_)
@@ -516,10 +516,10 @@ void SemanticAnalyser::visit(Builtin &builtin)
             << "The " + builtin.ident
             << " builtin can only be used with 'kprobes' and 'uprobes' probes";
       if (type == ProbeType::uprobe &&
-          bpftrace_.config_.get(ConfigKeyBool::probe_inline))
+          bpftrace_.config_.get(ConfigKeyBool::unstable_attach_to_inline_funcs))
         LOG(ERROR, builtin.loc, err_)
             << "The " + builtin.ident + " builtin can only be used when "
-            << "the probe_inline config is disabled.";
+            << "the unstable_attach_to_inline_funcs config is disabled.";
       if (is_final_pass() &&
           (attach_point->address != 0 || attach_point->func_offset != 0)) {
         // If sargX values are needed when using an offset, they can be stored
@@ -569,10 +569,10 @@ void SemanticAnalyser::visit(Builtin &builtin)
     } else if (type == ProbeType::fentry || type == ProbeType::fexit ||
                type == ProbeType::uprobe) {
       if (type == ProbeType::uprobe &&
-          bpftrace_.config_.get(ConfigKeyBool::probe_inline))
+          bpftrace_.config_.get(ConfigKeyBool::unstable_attach_to_inline_funcs))
         LOG(ERROR, builtin.loc, err_)
             << "The args builtin can only be used when "
-            << "the probe_inline config is disabled.";
+            << "the unstable_attach_to_inline_funcs config is disabled.";
 
       auto type_name = probe->args_typename();
       builtin.type = CreateRecord(type_name,

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -174,7 +174,7 @@ int BPFtrace::add_probe(const ast::AttachPoint &ap,
         // Only use the DWARF information of the Kernel,
         // if the user wants to to probe inlined kprobes.
         // Otherwise, fall back to using the symbol table.
-        if (config_.get(ConfigKeyBool::probe_inline))
+        if (config_.get(ConfigKeyBool::unstable_attach_to_inline_funcs))
           target = find_vmlinux();
       }
     }
@@ -186,7 +186,8 @@ int BPFtrace::add_probe(const ast::AttachPoint &ap,
       // prologue and also returns locations of inlined function calls.
       if (auto *dwarf = get_dwarf(target.value())) {
         const auto locations = dwarf->get_function_locations(
-            probe.attach_point, config_.get(ConfigKeyBool::probe_inline));
+            probe.attach_point,
+            config_.get(ConfigKeyBool::unstable_attach_to_inline_funcs));
         for (const auto loc : locations) {
           // Clear the attach point, so the address will be used instead
           Probe probe_copy = probe;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -13,7 +13,7 @@ Config::Config(bool has_cmd)
   config_map_ = {
     { ConfigKeyBool::cpp_demangle, { .value = true } },
     { ConfigKeyBool::lazy_symbolication, { .value = false } },
-    { ConfigKeyBool::probe_inline, { .value = false } },
+    { ConfigKeyBool::unstable_attach_to_inline_funcs, { .value = false } },
     { ConfigKeyBool::print_maps_on_exit, { .value = true } },
     { ConfigKeyInt::log_size, { .value = static_cast<uint64_t>(1000000) } },
     { ConfigKeyInt::max_bpf_progs, { .value = static_cast<uint64_t>(512) } },

--- a/src/config.h
+++ b/src/config.h
@@ -25,7 +25,7 @@ enum class ConfigSource {
 enum class ConfigKeyBool {
   cpp_demangle,
   lazy_symbolication,
-  probe_inline,
+  unstable_attach_to_inline_funcs,
   print_maps_on_exit,
 };
 
@@ -96,7 +96,8 @@ const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
   { "max_type_res_iterations", ConfigKeyInt::max_type_res_iterations },
   { "on_stack_limit", ConfigKeyInt::on_stack_limit },
   { "perf_rb_pages", ConfigKeyInt::perf_rb_pages },
-  { "probe_inline", ConfigKeyBool::probe_inline },
+  { "unstable_attach_to_inline_funcs",
+    ConfigKeyBool::unstable_attach_to_inline_funcs },
   { "stack_mode", ConfigKeyStackMode::default_ },
   { "str_trunc_trailer", ConfigKeyString::str_trunc_trailer },
   { "symbol_source", ConfigKeySymbolSource::default_ },

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -83,7 +83,7 @@ REQUIRES_FEATURE dwarf
 AFTER ./testprogs/uprobe_test
 
 NAME uprobe inline without dwarf
-PROG config = { symbol_source = "symbol_table"; probe_inline = 1; }
+PROG config = { symbol_source = "symbol_table"; unstable_attach_to_inline_funcs = 1; }
      uprobe:./testprogs/inline_function:square { @count++ }
      uretprobe:./testprogs/inline_function:main { exit() }
 EXPECT @count: 1
@@ -91,7 +91,7 @@ REQUIRES_FEATURE dwarf
 AFTER ./testprogs/inline_function
 
 NAME uprobe skip inlined function
-PROG config = { probe_inline = 0 }
+PROG config = { unstable_attach_to_inline_funcs = 0 }
      uprobe:./testprogs/inline_function:square { @count++ }
      uretprobe:./testprogs/inline_function:main { exit() }
 EXPECT @count: 1
@@ -99,7 +99,7 @@ REQUIRES_FEATURE dwarf
 AFTER ./testprogs/inline_function
 
 NAME uprobe inlined function
-PROG config = { probe_inline = 1 }
+PROG config = { unstable_attach_to_inline_funcs = 1 }
      uprobe:./testprogs/inline_function:square { @count++ }
      uretprobe:./testprogs/inline_function:main { exit() }
 EXPECT @count: 3
@@ -107,7 +107,7 @@ REQUIRES_FEATURE dwarf
 AFTER ./testprogs/inline_function
 
 NAME uprobe inlined function - probe
-PROG config = { probe_inline = 1; cache_user_symbols = "PER_PROGRAM"; }
+PROG config = { unstable_attach_to_inline_funcs = 1; cache_user_symbols = "PER_PROGRAM"; }
      uprobe:./testprogs/inline_function:square {
        printf("%s\n", probe);
        if (++@count == 3) { exit(); }
@@ -119,7 +119,7 @@ REQUIRES_FEATURE dwarf
 AFTER ./testprogs/inline_function
 
 NAME uprobe inlined function - func
-PROG config = { probe_inline = 1; cache_user_symbols = "PER_PROGRAM"; }
+PROG config = { unstable_attach_to_inline_funcs = 1; cache_user_symbols = "PER_PROGRAM"; }
      uprobe:./testprogs/inline_function:square {
        printf("%s\n", func);
        if (++@count == 3) { exit(); }
@@ -131,7 +131,7 @@ REQUIRES_FEATURE dwarf
 AFTER ./testprogs/inline_function
 
 NAME uprobe inlined function - ustack
-PROG config = { probe_inline = 1; cache_user_symbols = "PER_PROGRAM"; }
+PROG config = { unstable_attach_to_inline_funcs = 1; cache_user_symbols = "PER_PROGRAM"; }
      uprobe:./testprogs/inline_function:square {
        printf("%s\n", ustack);
        if (++@count == 3) { exit(); }
@@ -228,7 +228,7 @@ BEFORE ./testprogs/uprobe_test
 # We also check that the offsets bpftrace attaches to are different from 0,
 # since they should be inline instances part of another function/symbol.
 NAME kprobe inlined function
-RUN {{BPFTRACE}} -ve \ 'config = { probe_inline = 1 } BEGIN { exit() } kprobe:str_has_prefix { }'
+RUN {{BPFTRACE}} -ve \ 'config = { unstable_attach_to_inline_funcs = 1 } BEGIN { exit() } kprobe:str_has_prefix { }'
 EXPECT_NONE Attaching 1 probe...
 EXPECT_NONE Attaching 2 probes...
 EXPECT_REGEX_NONE ^bpf_attach_kprobe\(.*, 0, 0\)$

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -281,21 +281,22 @@ TEST(semantic_analyser, builtin_variables_inline)
 {
   auto bpftrace = get_mock_bpftrace();
   ConfigSetter configs{ bpftrace->config_, ConfigSource::script };
-  configs.set(ConfigKeyBool::probe_inline, true);
+  configs.set(ConfigKeyBool::unstable_attach_to_inline_funcs, true);
 
-  // Check argument builtins are rejected when `probe_inline` is enabled.
+  // Check argument builtins are rejected when `unstable_attach_to_inline_funcs`
+  // is enabled.
   test_error(*bpftrace, "uprobe:/bin/sh:f { arg0 }", R"(
-stdin:1:20-24: ERROR: The arg0 builtin can only be used when the probe_inline config is disabled.
+stdin:1:20-24: ERROR: The arg0 builtin can only be used when the unstable_attach_to_inline_funcs config is disabled.
 uprobe:/bin/sh:f { arg0 }
                    ~~~~
 )");
   test_error(*bpftrace, "uprobe:/bin/sh:f { sarg0 }", R"(
-stdin:1:20-25: ERROR: The sarg0 builtin can only be used when the probe_inline config is disabled.
+stdin:1:20-25: ERROR: The sarg0 builtin can only be used when the unstable_attach_to_inline_funcs config is disabled.
 uprobe:/bin/sh:f { sarg0 }
                    ~~~~~
 )");
   test_error(*bpftrace, "uprobe:/bin/sh:f { args }", R"(
-stdin:1:20-24: ERROR: The args builtin can only be used when the probe_inline config is disabled.
+stdin:1:20-24: ERROR: The args builtin can only be used when the unstable_attach_to_inline_funcs config is disabled.
 uprobe:/bin/sh:f { args }
                    ~~~~
 stdin:1:20-24: ERROR: Cannot read function parameters


### PR DESCRIPTION
This also renames the "probe_inline" config to
"unstable_attach_to_inline_funcs" to make it more clear.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
