### PR TITLE
codegen: use preserve_static_offset intrinsic

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -412,7 +412,7 @@ void CodegenLLVM::visit(Builtin &builtin)
     auto probe_type = probetype(current_attach_point_->provider);
 
     if (builtin.type.is_funcarg) {
-      expr_ = b_.CreatKFuncArg(ctx_, builtin.type, builtin.ident);
+      expr_ = b_.CreateKFuncArg(ctx_, builtin.type, builtin.ident);
       return;
     }
 
@@ -473,10 +473,9 @@ void CodegenLLVM::visit(Builtin &builtin)
     // uprobe args record is built on stack
     expr_ = b_.CreateUprobeArgsRecord(ctx_, builtin.type);
   } else if (builtin.ident == "args" || builtin.ident == "ctx") {
-    // ctx is undocumented builtin: for debugging
-    // ctx_ is casted to int for arithmetic operation
-    // it will be casted to a pointer when loading
-    expr_ = b_.CreatePtrToInt(ctx_, b_.getInt64Ty());
+    // ctx is undocumented builtin: for debugging. The context value is left as
+    // a pointer type, and may be cast explicitly if needed.
+    expr_ = ctx_;
   } else if (builtin.ident == "cpid") {
     pid_t cpid = bpftrace_.child_->pid();
     if (cpid < 1) {
@@ -2067,7 +2066,7 @@ void CodegenLLVM::visit(FieldAccess &acc)
   if (type.is_funcarg) {
     auto probe_type = probetype(current_attach_point_->provider);
     if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit)
-      expr_ = b_.CreatKFuncArg(ctx_, acc.type, acc.field);
+      expr_ = b_.CreateKFuncArg(ctx_, acc.type, acc.field);
     else if (probe_type == ProbeType::uprobe) {
       Value *args = expr_;
       llvm::Type *args_type = b_.UprobeArgsType(type);
@@ -2126,17 +2125,20 @@ void CodegenLLVM::visit(FieldAccess &acc)
     // (bitfields and _data_loc)
     if (field.type.IsIntTy() &&
         (field.bitfield.has_value() || field.is_data_loc)) {
-      Value *src = b_.CreateAdd(expr_, b_.getInt64(field.offset));
-
       if (field.bitfield.has_value()) {
         Value *raw;
         auto field_type = b_.GetType(field.type);
-        if (type.IsCtxAccess())
-          raw = b_.CreateLoad(field_type,
-                              b_.CreateIntToPtr(src,
-                                                field_type->getPointerTo()),
-                              true);
-        else {
+        if (type.IsCtxAccess()) {
+          // The offset is specified in absolute terms here; and the load
+          // will implicitly convert to the intended field_type.
+          Value *src = b_.CreateSafeGEP(b_.GET_PTR_TY(),
+                                        expr_,
+                                        b_.getInt64(field.offset));
+          raw = b_.CreateLoad(field_type, src, true);
+        } else {
+          // Since `src` is treated as a offset for a constructed probe read,
+          // we are not constrained in the same way.
+          Value *src = b_.CreateAdd(expr_, b_.getInt64(field.offset));
           AllocaInst *dst = b_.CreateAllocaBPF(field.type,
                                                type.GetName() + "." +
                                                    acc.field);
@@ -2166,22 +2168,23 @@ void CodegenLLVM::visit(FieldAccess &acc)
         // `is_data_loc` should only be set if field access is on `args` which
         // has to be a ctx access
         assert(type.IsCtxAccess());
-        assert(ctx_->getType() == b_.GET_PTR_TY());
         // Parser needs to have rewritten field to be a u64
         assert(field.type.IsIntTy());
         assert(field.type.GetIntBitWidth() == 64);
 
         // Top 2 bytes are length (which we'll ignore). Bottom two bytes are
-        // offset which we add to the start of the tracepoint struct.
-        expr_ = b_.CreateLoad(
-            b_.getInt32Ty(),
-            b_.CreateGEP(b_.getInt32Ty(),
-                         b_.CreatePointerCast(ctx_,
-                                              b_.getInt32Ty()->getPointerTo()),
-                         b_.getInt64(field.offset / 4)));
+        // offset which we add to the start of the tracepoint struct. We need
+        // to wrap the context here in a special way to treat it as the
+        // expected pointer type for all versions.
+        expr_ = b_.CreateLoad(b_.getInt32Ty(),
+                              b_.CreateSafeGEP(b_.getInt32Ty(),
+                                               ctx_,
+                                               b_.getInt64(field.offset / 4)));
         expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false);
         expr_ = b_.CreateAnd(expr_, b_.getInt64(0xFFFF));
-        expr_ = b_.CreateAdd(expr_, b_.CreatePtrToInt(ctx_, b_.getInt64Ty()));
+        expr_ = b_.CreateSafeGEP(b_.getInt32Ty(), ctx_, expr_);
+        expr_ = b_.CreatePointerCast(expr_,
+                                     b_.GetType(field.type)->getPointerTo());
       }
     } else {
       probereadDatastructElem(expr_,
@@ -2701,7 +2704,7 @@ void CodegenLLVM::visit(For &f)
     for (size_t i = 0; i < ctx_fields.size(); i++) {
       const auto &field = ctx_fields[i];
       auto *field_expr = getVariable(field.name).value;
-      auto *ctx_field_ptr = b_.CreateGEP(
+      auto *ctx_field_ptr = b_.CreateSafeGEP(
           ctx_t, ctx, { b_.getInt64(0), b_.getInt32(i) }, "ctx." + field.name);
 #if LLVM_VERSION_MAJOR < 15
       // An extra cast is required for older LLVM versions, pre-opaque-pointers
@@ -4197,9 +4200,13 @@ void CodegenLLVM::probereadDatastructElem(Value *src_data,
                                           location loc,
                                           const std::string &temp_name)
 {
-  Value *src = b_.CreateAdd(src_data, offset);
-
+  // We treat this access as a raw byte offset, but may then subsequently need
+  // to cast the pointer to the expected value.
+  Value *src = b_.CreateSafeGEP(b_.getInt8Ty(), src_data, offset);
   auto dst_type = b_.GetType(elem_type);
+  if (dst_type != b_.getInt8Ty())
+    src = b_.CreatePointerCast(src, dst_type->getPointerTo());
+
   if (elem_type.IsRecordTy() || elem_type.IsArrayTy()) {
     // For nested arrays and structs, just pass the pointer along and
     // dereference it later when necessary. We just need to extend lifetime
@@ -4221,11 +4228,9 @@ void CodegenLLVM::probereadDatastructElem(Value *src_data,
   } else {
     // Read data onto stack
     if (data_type.IsCtxAccess() || data_type.is_btftype) {
+      // Types have already been suitably casted; just do the access.
       expr_ = b_.CreateDatastructElemLoad(
-          elem_type,
-          b_.CreateIntToPtr(src, dst_type->getPointerTo()),
-          true,
-          data_type.GetAS());
+          elem_type, src, true, data_type.GetAS());
       // check context access for iter probes (required by kernel)
       if (data_type.IsCtxAccess() &&
           probetype(current_attach_point_->provider) == ProbeType::iter) {

--- a/tests/codegen/llvm/argN_rawtracepoint.ll
+++ b/tests/codegen/llvm/argN_rawtracepoint.ll
@@ -19,8 +19,9 @@ define i64 @rawtracepoint_sched_switch_1(ptr %0) section "s_rawtracepoint_sched_
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 0
-  %arg0 = load i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 0
+  %arg0 = load i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 %arg0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
@@ -31,14 +32,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!47}
 !llvm.module.flags = !{!49}

--- a/tests/codegen/llvm/args_multiple_tracepoints.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints.ll
@@ -19,12 +19,11 @@ define i64 @tracepoint_sched_sched_one_1(ptr %0) section "s_tracepoint_sched_sch
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = ptrtoint ptr %0 to i64
-  %2 = add i64 %1, 8
-  %3 = inttoptr i64 %2 to ptr
-  %4 = load volatile i64, ptr %3, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i8, ptr %1, i64 8
+  %3 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 %4, ptr %"@_key", align 8
+  store i64 %3, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -33,22 +32,24 @@ entry:
   ret i64 1
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 define i64 @tracepoint_sched_sched_two_2(ptr %0) section "s_tracepoint_sched_sched_two_2" !dbg !57 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = ptrtoint ptr %0 to i64
-  %2 = add i64 %1, 16
-  %3 = inttoptr i64 %2 to ptr
-  %4 = load volatile i64, ptr %3, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i8, ptr %1, i64 16
+  %3 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 %4, ptr %"@_key", align 8
+  store i64 %3, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -58,7 +59,8 @@ entry:
 }
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!47}
 !llvm.module.flags = !{!49}

--- a/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
@@ -19,12 +19,11 @@ define i64 @tracepoint_sched_sched_one_1(ptr %0) section "s_tracepoint_sched_sch
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = ptrtoint ptr %0 to i64
-  %2 = add i64 %1, 8
-  %3 = inttoptr i64 %2 to ptr
-  %4 = load volatile i64, ptr %3, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i8, ptr %1, i64 8
+  %3 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 %4, ptr %"@_key", align 8
+  store i64 %3, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -33,22 +32,24 @@ entry:
   ret i64 1
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 define i64 @tracepoint_sched_sched_two_1(ptr %0) section "s_tracepoint_sched_sched_two_1" !dbg !57 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = ptrtoint ptr %0 to i64
-  %2 = add i64 %1, 16
-  %3 = inttoptr i64 %2 to ptr
-  %4 = load volatile i64, ptr %3, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i8, ptr %1, i64 16
+  %3 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 %4, ptr %"@_key", align 8
+  store i64 %3, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -61,12 +62,11 @@ define i64 @tracepoint_sched_extra_sched_extra_1(ptr %0) section "s_tracepoint_s
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = ptrtoint ptr %0 to i64
-  %2 = add i64 %1, 24
-  %3 = inttoptr i64 %2 to ptr
-  %4 = load volatile i64, ptr %3, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i8, ptr %1, i64 24
+  %3 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 %4, ptr %"@_key", align 8
+  store i64 %3, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -76,7 +76,8 @@ entry:
 }
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!47}
 !llvm.module.flags = !{!49}

--- a/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
@@ -19,12 +19,11 @@ define i64 @tracepoint_sched_sched_one_1(ptr %0) section "s_tracepoint_sched_sch
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = ptrtoint ptr %0 to i64
-  %2 = add i64 %1, 8
-  %3 = inttoptr i64 %2 to ptr
-  %4 = load volatile i64, ptr %3, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i8, ptr %1, i64 8
+  %3 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 %4, ptr %"@_key", align 8
+  store i64 %3, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -33,22 +32,24 @@ entry:
   ret i64 1
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 define i64 @tracepoint_sched_sched_two_1(ptr %0) section "s_tracepoint_sched_sched_two_1" !dbg !57 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = ptrtoint ptr %0 to i64
-  %2 = add i64 %1, 16
-  %3 = inttoptr i64 %2 to ptr
-  %4 = load volatile i64, ptr %3, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i8, ptr %1, i64 16
+  %3 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 %4, ptr %"@_key", align 8
+  store i64 %3, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -58,7 +59,8 @@ entry:
 }
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!47}
 !llvm.module.flags = !{!49}

--- a/tests/codegen/llvm/array_integer_equal_comparison.ll
+++ b/tests/codegen/llvm/array_integer_equal_comparison.ll
@@ -27,37 +27,45 @@ entry:
   %"$a" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
   store i64 0, ptr %"$a", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %2 = add i64 %arg0, 0
-  store i64 %2, ptr %"$a", align 8
-  %3 = getelementptr i64, ptr %0, i64 14
-  %arg01 = load volatile i64, ptr %3, align 8
-  %4 = add i64 %arg01, 0
-  store i64 %4, ptr %"$b", align 8
-  %5 = load i64, ptr %"$a", align 8
-  %6 = load i64, ptr %"$b", align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = call ptr @llvm.preserve.static.offset(ptr %3)
+  %5 = getelementptr i8, ptr %4, i64 0
+  %6 = ptrtoint ptr %5 to i64
+  store i64 %6, ptr %"$a", align 8
+  %7 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %8 = getelementptr i64, ptr %7, i64 14
+  %arg01 = load volatile i64, ptr %8, align 8
+  %9 = inttoptr i64 %arg01 to ptr
+  %10 = call ptr @llvm.preserve.static.offset(ptr %9)
+  %11 = getelementptr i8, ptr %10, i64 0
+  %12 = ptrtoint ptr %11 to i64
+  store i64 %12, ptr %"$b", align 8
+  %13 = load i64, ptr %"$a", align 8
+  %14 = load i64, ptr %"$b", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %v1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %v2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %arraycmp.result)
   store i1 true, ptr %arraycmp.result, align 1
-  %7 = inttoptr i64 %5 to ptr
-  %8 = inttoptr i64 %6 to ptr
-  %9 = getelementptr [4 x i32], ptr %7, i32 0, i32 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %9)
-  %10 = load i32, ptr %v1, align 4
-  %11 = getelementptr [4 x i32], ptr %8, i32 0, i32 0
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %11)
-  %12 = load i32, ptr %v2, align 4
-  %arraycmp.cmp = icmp ne i32 %10, %12
+  %15 = inttoptr i64 %13 to ptr
+  %16 = inttoptr i64 %14 to ptr
+  %17 = getelementptr [4 x i32], ptr %15, i32 0, i32 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %17)
+  %18 = load i32, ptr %v1, align 4
+  %19 = getelementptr [4 x i32], ptr %16, i32 0, i32 0
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %19)
+  %20 = load i32, ptr %v2, align 4
+  %arraycmp.cmp = icmp ne i32 %18, %20
   br i1 %arraycmp.cmp, label %arraycmp.false, label %arraycmp.loop
 
 if_body:                                          ; preds = %arraycmp.done
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
-  %13 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %13, align 8
-  %14 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
-  store i8 0, ptr %14, align 1
+  %21 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
+  store i64 30000, ptr %21, align 8
+  %22 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
+  store i8 0, ptr %22, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -70,42 +78,42 @@ arraycmp.false:                                   ; preds = %arraycmp.loop7, %ar
   br label %arraycmp.done
 
 arraycmp.done:                                    ; preds = %arraycmp.false, %arraycmp.loop11
-  %15 = load i1, ptr %arraycmp.result, align 1
+  %23 = load i1, ptr %arraycmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %arraycmp.result)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %v1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %v2)
-  %16 = zext i1 %15 to i64
-  %true_cond = icmp ne i64 %16, 0
+  %24 = zext i1 %23 to i64
+  %true_cond = icmp ne i64 %24, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 arraycmp.loop:                                    ; preds = %entry
-  %17 = getelementptr [4 x i32], ptr %7, i32 0, i32 1
-  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %17)
-  %18 = load i32, ptr %v1, align 4
-  %19 = getelementptr [4 x i32], ptr %8, i32 0, i32 1
-  %probe_read_kernel5 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %19)
-  %20 = load i32, ptr %v2, align 4
-  %arraycmp.cmp6 = icmp ne i32 %18, %20
+  %25 = getelementptr [4 x i32], ptr %15, i32 0, i32 1
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %25)
+  %26 = load i32, ptr %v1, align 4
+  %27 = getelementptr [4 x i32], ptr %16, i32 0, i32 1
+  %probe_read_kernel5 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %27)
+  %28 = load i32, ptr %v2, align 4
+  %arraycmp.cmp6 = icmp ne i32 %26, %28
   br i1 %arraycmp.cmp6, label %arraycmp.false, label %arraycmp.loop3
 
 arraycmp.loop3:                                   ; preds = %arraycmp.loop
-  %21 = getelementptr [4 x i32], ptr %7, i32 0, i32 2
-  %probe_read_kernel8 = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %21)
-  %22 = load i32, ptr %v1, align 4
-  %23 = getelementptr [4 x i32], ptr %8, i32 0, i32 2
-  %probe_read_kernel9 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %23)
-  %24 = load i32, ptr %v2, align 4
-  %arraycmp.cmp10 = icmp ne i32 %22, %24
+  %29 = getelementptr [4 x i32], ptr %15, i32 0, i32 2
+  %probe_read_kernel8 = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %29)
+  %30 = load i32, ptr %v1, align 4
+  %31 = getelementptr [4 x i32], ptr %16, i32 0, i32 2
+  %probe_read_kernel9 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %31)
+  %32 = load i32, ptr %v2, align 4
+  %arraycmp.cmp10 = icmp ne i32 %30, %32
   br i1 %arraycmp.cmp10, label %arraycmp.false, label %arraycmp.loop7
 
 arraycmp.loop7:                                   ; preds = %arraycmp.loop3
-  %25 = getelementptr [4 x i32], ptr %7, i32 0, i32 3
-  %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %25)
-  %26 = load i32, ptr %v1, align 4
-  %27 = getelementptr [4 x i32], ptr %8, i32 0, i32 3
-  %probe_read_kernel13 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %27)
-  %28 = load i32, ptr %v2, align 4
-  %arraycmp.cmp14 = icmp ne i32 %26, %28
+  %33 = getelementptr [4 x i32], ptr %15, i32 0, i32 3
+  %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %33)
+  %34 = load i32, ptr %v1, align 4
+  %35 = getelementptr [4 x i32], ptr %16, i32 0, i32 3
+  %probe_read_kernel13 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %35)
+  %36 = load i32, ptr %v2, align 4
+  %arraycmp.cmp14 = icmp ne i32 %34, %36
   br i1 %arraycmp.cmp14, label %arraycmp.false, label %arraycmp.loop11
 
 arraycmp.loop11:                                  ; preds = %arraycmp.loop7
@@ -123,7 +131,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %29 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %37 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -137,14 +145,18 @@ deadcode:                                         ; No predecessors!
   br label %if_end
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38}

--- a/tests/codegen/llvm/array_integer_equal_comparison_no_unroll.ll
+++ b/tests/codegen/llvm/array_integer_equal_comparison_no_unroll.ll
@@ -29,22 +29,30 @@ entry:
   %"$a" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
   store i64 0, ptr %"$a", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %2 = add i64 %arg0, 0
-  store i64 %2, ptr %"$a", align 8
-  %3 = getelementptr i64, ptr %0, i64 14
-  %arg01 = load volatile i64, ptr %3, align 8
-  %4 = add i64 %arg01, 0
-  store i64 %4, ptr %"$b", align 8
-  %5 = load i64, ptr %"$a", align 8
-  %6 = load i64, ptr %"$b", align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = call ptr @llvm.preserve.static.offset(ptr %3)
+  %5 = getelementptr i8, ptr %4, i64 0
+  %6 = ptrtoint ptr %5 to i64
+  store i64 %6, ptr %"$a", align 8
+  %7 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %8 = getelementptr i64, ptr %7, i64 14
+  %arg01 = load volatile i64, ptr %8, align 8
+  %9 = inttoptr i64 %arg01 to ptr
+  %10 = call ptr @llvm.preserve.static.offset(ptr %9)
+  %11 = getelementptr i8, ptr %10, i64 0
+  %12 = ptrtoint ptr %11 to i64
+  store i64 %12, ptr %"$b", align 8
+  %13 = load i64, ptr %"$a", align 8
+  %14 = load i64, ptr %"$b", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %v1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %v2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %arraycmp.result)
   store i1 true, ptr %arraycmp.result, align 1
-  %7 = inttoptr i64 %5 to ptr
-  %8 = inttoptr i64 %6 to ptr
+  %15 = inttoptr i64 %13 to ptr
+  %16 = inttoptr i64 %14 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %n)
   store i32 0, ptr %i, align 4
@@ -53,10 +61,10 @@ entry:
 
 if_body:                                          ; preds = %arraycmp.done
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
-  %9 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %9, align 8
-  %10 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
-  store i8 0, ptr %10, align 1
+  %17 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
+  store i64 30000, ptr %17, align 8
+  %18 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
+  store i8 0, ptr %18, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -65,21 +73,21 @@ if_end:                                           ; preds = %deadcode, %arraycmp
   ret i64 0
 
 while_cond:                                       ; preds = %arraycmp.loop, %entry
-  %11 = load i32, ptr %n, align 4
-  %12 = load i32, ptr %i, align 4
-  %size_check = icmp slt i32 %12, %11
+  %19 = load i32, ptr %n, align 4
+  %20 = load i32, ptr %i, align 4
+  %size_check = icmp slt i32 %20, %19
   br i1 %size_check, label %while_body, label %arraycmp.done, !llvm.loop !46
 
 while_body:                                       ; preds = %while_cond
-  %13 = load i32, ptr %i, align 4
-  %14 = getelementptr [4 x i32], ptr %7, i32 0, i32 %13
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %14)
-  %15 = load i32, ptr %v1, align 4
-  %16 = load i32, ptr %i, align 4
-  %17 = getelementptr [4 x i32], ptr %8, i32 0, i32 %16
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %17)
-  %18 = load i32, ptr %v2, align 4
-  %arraycmp.cmp = icmp ne i32 %15, %18
+  %21 = load i32, ptr %i, align 4
+  %22 = getelementptr [4 x i32], ptr %15, i32 0, i32 %21
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %22)
+  %23 = load i32, ptr %v1, align 4
+  %24 = load i32, ptr %i, align 4
+  %25 = getelementptr [4 x i32], ptr %16, i32 0, i32 %24
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %25)
+  %26 = load i32, ptr %v2, align 4
+  %arraycmp.cmp = icmp ne i32 %23, %26
   br i1 %arraycmp.cmp, label %arraycmp.false, label %arraycmp.loop
 
 arraycmp.false:                                   ; preds = %while_body
@@ -87,18 +95,18 @@ arraycmp.false:                                   ; preds = %while_body
   br label %arraycmp.done
 
 arraycmp.done:                                    ; preds = %arraycmp.false, %while_cond
-  %19 = load i1, ptr %arraycmp.result, align 1
+  %27 = load i1, ptr %arraycmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %arraycmp.result)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %v1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %v2)
-  %20 = zext i1 %19 to i64
-  %true_cond = icmp ne i64 %20, 0
+  %28 = zext i1 %27 to i64
+  %true_cond = icmp ne i64 %28, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 arraycmp.loop:                                    ; preds = %while_body
-  %21 = load i32, ptr %i, align 4
-  %22 = add i32 %21, 1
-  store i32 %22, ptr %i, align 4
+  %29 = load i32, ptr %i, align 4
+  %30 = add i32 %29, 1
+  store i32 %30, ptr %i, align 4
   br label %while_cond
 
 event_loss_counter:                               ; preds = %if_body
@@ -113,7 +121,7 @@ counter_merge:                                    ; preds = %lookup_merge, %if_b
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %23 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %31 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -127,14 +135,18 @@ deadcode:                                         ; No predecessors!
   br label %if_end
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38}

--- a/tests/codegen/llvm/builtin_arg.ll
+++ b/tests/codegen/llvm/builtin_arg.ll
@@ -23,8 +23,9 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -32,8 +33,9 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %2 = getelementptr i64, ptr %0, i64 12
-  %arg2 = load volatile i64, ptr %2, align 8
+  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %4 = getelementptr i64, ptr %3, i64 12
+  %arg2 = load volatile i64, ptr %4, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
@@ -44,14 +46,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!44}
 !llvm.module.flags = !{!46}

--- a/tests/codegen/llvm/builtin_ctx.ll
+++ b/tests/codegen/llvm/builtin_ctx.ll
@@ -19,11 +19,11 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !45 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %1 = ptrtoint ptr %0 to i64
+  %cast = zext ptr %0 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %1, ptr %"@x_val", align 8
+  store i64 %cast, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -39,11 +39,11 @@ entry:
   %"$x" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
   store i64 0, ptr %"$x", align 8
-  %1 = ptrtoint ptr %0 to i64
-  store i64 %1, ptr %"$x", align 8
-  %2 = load i64, ptr %"$x", align 8
-  %3 = add i64 %2, 0
-  %4 = inttoptr i64 %3 to ptr
+  store ptr %0, ptr %"$x", align 8
+  %1 = load i64, ptr %"$x", align 8
+  %2 = inttoptr i64 %1 to ptr
+  %3 = call ptr @llvm.preserve.static.offset(ptr %2)
+  %4 = getelementptr i8, ptr %3, i64 0
   %5 = load volatile i64, ptr %4, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
   store i64 0, ptr %"@a_key", align 8
@@ -53,52 +53,63 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
   %6 = load i64, ptr %"$x", align 8
-  %7 = add i64 %6, 8
-  %8 = add i64 %7, 0
-  %9 = inttoptr i64 %8 to ptr
-  %10 = load volatile i16, ptr %9, align 2
+  %7 = inttoptr i64 %6 to ptr
+  %8 = call ptr @llvm.preserve.static.offset(ptr %7)
+  %9 = getelementptr i8, ptr %8, i64 8
+  %10 = ptrtoint ptr %9 to i64
+  %11 = inttoptr i64 %10 to ptr
+  %12 = call ptr @llvm.preserve.static.offset(ptr %11)
+  %13 = getelementptr i8, ptr %12, i64 0
+  %14 = load volatile i16, ptr %13, align 2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_key")
   store i64 0, ptr %"@b_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_val")
-  %11 = sext i16 %10 to i64
-  store i64 %11, ptr %"@b_val", align 8
+  %15 = sext i16 %14 to i64
+  store i64 %15, ptr %"@b_val", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_b, ptr %"@b_key", ptr %"@b_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_key")
-  %12 = load i64, ptr %"$x", align 8
-  %13 = add i64 %12, 16
-  %14 = add i64 %13, 0
-  %15 = inttoptr i64 %14 to ptr
-  %16 = load volatile i8, ptr %15, align 1
+  %16 = load i64, ptr %"$x", align 8
+  %17 = inttoptr i64 %16 to ptr
+  %18 = call ptr @llvm.preserve.static.offset(ptr %17)
+  %19 = getelementptr i8, ptr %18, i64 16
+  %20 = call ptr @llvm.preserve.static.offset(ptr %19)
+  %21 = getelementptr i8, ptr %20, i64 0
+  %22 = load volatile i8, ptr %21, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@c_key")
   store i64 0, ptr %"@c_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@c_val")
-  %17 = sext i8 %16 to i64
-  store i64 %17, ptr %"@c_val", align 8
+  %23 = sext i8 %22 to i64
+  store i64 %23, ptr %"@c_val", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_c, ptr %"@c_key", ptr %"@c_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@c_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@c_key")
-  %18 = load i64, ptr %"$x", align 8
-  %19 = add i64 %18, 24
-  %20 = inttoptr i64 %19 to ptr
-  %21 = load volatile i64, ptr %20, align 8
-  %22 = add i64 %21, 0
+  %24 = load i64, ptr %"$x", align 8
+  %25 = inttoptr i64 %24 to ptr
+  %26 = call ptr @llvm.preserve.static.offset(ptr %25)
+  %27 = getelementptr i8, ptr %26, i64 24
+  %28 = load volatile i64, ptr %27, align 8
+  %29 = inttoptr i64 %28 to ptr
+  %30 = call ptr @llvm.preserve.static.offset(ptr %29)
+  %31 = getelementptr i8, ptr %30, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct c.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct c.c", i32 1, i64 %22)
-  %23 = load i8, ptr %"struct c.c", align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct c.c", i32 1, ptr %31)
+  %32 = load i8, ptr %"struct c.c", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct c.c")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@d_key")
   store i64 0, ptr %"@d_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@d_val")
-  %24 = sext i8 %23 to i64
-  store i64 %24, ptr %"@d_val", align 8
+  %33 = sext i8 %32 to i64
+  store i64 %33, ptr %"@d_val", align 8
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_d, ptr %"@d_key", ptr %"@d_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@d_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@d_key")
-  %25 = load i64, ptr %"$x", align 8
-  %26 = add i64 %25, 32
+  %34 = load i64, ptr %"$x", align 8
+  %35 = inttoptr i64 %34 to ptr
+  %36 = call ptr @llvm.preserve.static.offset(ptr %35)
+  %37 = getelementptr i8, ptr %36, i64 32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct x.e")
-  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct x.e", i32 4, i64 %26)
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct x.e", i32 4, ptr %37)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@e_key")
   store i64 0, ptr %"@e_key", align 8
   %update_elem5 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_e, ptr %"@e_key", ptr %"struct x.e", i64 0)
@@ -110,11 +121,15 @@ entry:
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!58}
 !llvm.module.flags = !{!60}

--- a/tests/codegen/llvm/builtin_func_kprobe.ll
+++ b/tests/codegen/llvm/builtin_func_kprobe.ll
@@ -19,8 +19,9 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !45 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 16
-  %func = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 16
+  %func = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -31,14 +32,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/builtin_func_uprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uprobe.ll
@@ -20,18 +20,19 @@ define i64 @uprobe__bin_sh_f_1(ptr %0) section "s_uprobe__bin_sh_f_1" !dbg !51 {
 entry:
   %"@x_key" = alloca i64, align 8
   %usym = alloca %usym_t, align 8
-  %1 = getelementptr i64, ptr %0, i64 16
-  %func = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 16
+  %func = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %2 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %2 to i32
-  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %5 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 %func, ptr %3, align 8
-  store i32 %pid, ptr %4, align 4
-  store i32 0, ptr %5, align 4
+  %3 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %3 to i32
+  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %5 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %6 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 %func, ptr %4, align 8
+  store i32 %pid, ptr %5, align 4
+  store i32 0, ptr %6, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %usym, i64 0)
@@ -40,14 +41,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50}

--- a/tests/codegen/llvm/builtin_func_wild.ll
+++ b/tests/codegen/llvm/builtin_func_wild.ll
@@ -19,8 +19,9 @@ define i64 @kprobe_do_execve__1(ptr %0) section "s_kprobe_do_execve__1" !dbg !45
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 16
-  %func = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 16
+  %func = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -31,14 +32,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/builtin_retval.ll
+++ b/tests/codegen/llvm/builtin_retval.ll
@@ -19,8 +19,9 @@ define i64 @kretprobe_f_1(ptr %0) section "s_kretprobe_f_1" !dbg !45 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 10
-  %retval = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 10
+  %retval = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -31,14 +32,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/builtin_sarg.ll
+++ b/tests/codegen/llvm/builtin_sarg.ll
@@ -25,45 +25,51 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %sarg0 = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 19
-  %reg_sp = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 19
+  %reg_sp = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %sarg0)
-  %2 = add i64 %reg_sp, 8
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %sarg0, i32 8, i64 %2)
-  %3 = load i64, ptr %sarg0, align 8
+  %3 = add i64 %reg_sp, 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %sarg0, i32 8, i64 %3)
+  %4 = load i64, ptr %sarg0, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %sarg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %3, ptr %"@x_val", align 8
+  store i64 %4, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %4 = getelementptr i64, ptr %0, i64 19
-  %reg_sp1 = load volatile i64, ptr %4, align 8
+  %5 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %6 = getelementptr i64, ptr %5, i64 19
+  %reg_sp1 = load volatile i64, ptr %6, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %sarg2)
-  %5 = add i64 %reg_sp1, 24
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %sarg2, i32 8, i64 %5)
-  %6 = load i64, ptr %sarg2, align 8
+  %7 = add i64 %reg_sp1, 24
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %sarg2, i32 8, i64 %7)
+  %8 = load i64, ptr %sarg2, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %sarg2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  store i64 %6, ptr %"@y_val", align 8
+  store i64 %8, ptr %"@y_val", align 8
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!44}
 !llvm.module.flags = !{!46}

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -34,8 +34,10 @@ entry:
   %4 = getelementptr %buffer_16_t, ptr %2, i32 0, i32 1
   call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
   %5 = load i64, ptr %"$foo", align 8
-  %6 = add i64 %5, 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 16, i64 %6)
+  %6 = inttoptr i64 %5 to ptr
+  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
+  %8 = getelementptr i8, ptr %7, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 16, ptr %8)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %2, i64 0)
@@ -49,12 +51,16 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #3
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!57}
 !llvm.module.flags = !{!59}

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -29,8 +29,9 @@ entry:
   store i32 1, ptr %3, align 4
   %4 = getelementptr %buffer_1_t, ptr %2, i32 0, i32 1
   call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 1, i1 false)
-  %5 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %5, align 8
+  %5 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %6 = getelementptr i64, ptr %5, i64 14
+  %arg0 = load volatile i64, ptr %6, align 8
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 1, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
@@ -42,15 +43,19 @@ entry:
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!57}
 !llvm.module.flags = !{!59}

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -21,41 +21,47 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 13
-  %arg1 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 13
+  %arg1 = load volatile i64, ptr %2, align 8
   %length.cmp = icmp ule i64 %arg1, 60
   %length.select = select i1 %length.cmp, i64 %arg1, i64 60
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %2 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %2
-  %3 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  %4 = getelementptr %buffer_60_t, ptr %3, i32 0, i32 0
-  %5 = trunc i64 %length.select to i32
-  store i32 %5, ptr %4, align 4
-  %6 = getelementptr %buffer_60_t, ptr %3, i32 0, i32 1
-  call void @llvm.memset.p0.i64(ptr align 1 %6, i8 0, i64 60, i1 false)
-  %7 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %7, align 8
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %6, i32 %5, i64 %arg0)
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %3
+  %4 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %5 = getelementptr %buffer_60_t, ptr %4, i32 0, i32 0
+  %6 = trunc i64 %length.select to i32
+  store i32 %6, ptr %5, align 4
+  %7 = getelementptr %buffer_60_t, ptr %4, i32 0, i32 1
+  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 60, i1 false)
+  %8 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %9 = getelementptr i64, ptr %8, i64 14
+  %arg0 = load volatile i64, ptr %9, align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %7, i32 %6, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %3, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %4, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!54}
 !llvm.module.flags = !{!56}

--- a/tests/codegen/llvm/call_join.ll
+++ b/tests/codegen/llvm/call_join.ll
@@ -26,10 +26,12 @@ entry:
   store i64 0, ptr %"$x", align 8
   store i64 0, ptr %"$x", align 8
   %1 = load i64, ptr %"$x", align 8
-  %2 = add i64 %1, 0
+  %2 = inttoptr i64 %1 to ptr
+  %3 = call ptr @llvm.preserve.static.offset(ptr %2)
+  %4 = getelementptr i8, ptr %3, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct arg.argv")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct arg.argv", i32 8, i64 %2)
-  %3 = load i64, ptr %"struct arg.argv", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct arg.argv", i32 8, ptr %4)
+  %5 = load i64, ptr %"struct arg.argv", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct arg.argv")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_join_key)
   store i32 0, ptr %lookup_join_key, align 4
@@ -46,88 +48,88 @@ lookup_join_failure:                              ; preds = %entry
 
 lookup_join_merge:                                ; preds = %entry
   store i64 30005, ptr %lookup_join_map, align 8
-  %4 = getelementptr i8, ptr %lookup_join_map, i64 8
-  store i64 0, ptr %4, align 8
+  %6 = getelementptr i8, ptr %lookup_join_map, i64 8
+  store i64 0, ptr %6, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %join_r0)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %3)
-  %5 = load i64, ptr %join_r0, align 8
-  %6 = getelementptr i8, ptr %lookup_join_map, i64 16
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %6, i32 1024, i64 %5)
-  %7 = add i64 %3, 8
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %7)
-  %8 = load i64, ptr %join_r0, align 8
-  %9 = getelementptr i8, ptr %lookup_join_map, i64 1040
-  %probe_read_kernel_str3 = call i64 inttoptr (i64 115 to ptr)(ptr %9, i32 1024, i64 %8)
-  %10 = add i64 %7, 8
-  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %10)
-  %11 = load i64, ptr %join_r0, align 8
-  %12 = getelementptr i8, ptr %lookup_join_map, i64 2064
-  %probe_read_kernel_str5 = call i64 inttoptr (i64 115 to ptr)(ptr %12, i32 1024, i64 %11)
-  %13 = add i64 %10, 8
-  %probe_read_kernel6 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %13)
-  %14 = load i64, ptr %join_r0, align 8
-  %15 = getelementptr i8, ptr %lookup_join_map, i64 3088
-  %probe_read_kernel_str7 = call i64 inttoptr (i64 115 to ptr)(ptr %15, i32 1024, i64 %14)
-  %16 = add i64 %13, 8
-  %probe_read_kernel8 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %16)
-  %17 = load i64, ptr %join_r0, align 8
-  %18 = getelementptr i8, ptr %lookup_join_map, i64 4112
-  %probe_read_kernel_str9 = call i64 inttoptr (i64 115 to ptr)(ptr %18, i32 1024, i64 %17)
-  %19 = add i64 %16, 8
-  %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %19)
-  %20 = load i64, ptr %join_r0, align 8
-  %21 = getelementptr i8, ptr %lookup_join_map, i64 5136
-  %probe_read_kernel_str11 = call i64 inttoptr (i64 115 to ptr)(ptr %21, i32 1024, i64 %20)
-  %22 = add i64 %19, 8
-  %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %22)
-  %23 = load i64, ptr %join_r0, align 8
-  %24 = getelementptr i8, ptr %lookup_join_map, i64 6160
-  %probe_read_kernel_str13 = call i64 inttoptr (i64 115 to ptr)(ptr %24, i32 1024, i64 %23)
-  %25 = add i64 %22, 8
-  %probe_read_kernel14 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %25)
-  %26 = load i64, ptr %join_r0, align 8
-  %27 = getelementptr i8, ptr %lookup_join_map, i64 7184
-  %probe_read_kernel_str15 = call i64 inttoptr (i64 115 to ptr)(ptr %27, i32 1024, i64 %26)
-  %28 = add i64 %25, 8
-  %probe_read_kernel16 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %28)
-  %29 = load i64, ptr %join_r0, align 8
-  %30 = getelementptr i8, ptr %lookup_join_map, i64 8208
-  %probe_read_kernel_str17 = call i64 inttoptr (i64 115 to ptr)(ptr %30, i32 1024, i64 %29)
-  %31 = add i64 %28, 8
-  %probe_read_kernel18 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %31)
-  %32 = load i64, ptr %join_r0, align 8
-  %33 = getelementptr i8, ptr %lookup_join_map, i64 9232
-  %probe_read_kernel_str19 = call i64 inttoptr (i64 115 to ptr)(ptr %33, i32 1024, i64 %32)
-  %34 = add i64 %31, 8
-  %probe_read_kernel20 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %34)
-  %35 = load i64, ptr %join_r0, align 8
-  %36 = getelementptr i8, ptr %lookup_join_map, i64 10256
-  %probe_read_kernel_str21 = call i64 inttoptr (i64 115 to ptr)(ptr %36, i32 1024, i64 %35)
-  %37 = add i64 %34, 8
-  %probe_read_kernel22 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %37)
-  %38 = load i64, ptr %join_r0, align 8
-  %39 = getelementptr i8, ptr %lookup_join_map, i64 11280
-  %probe_read_kernel_str23 = call i64 inttoptr (i64 115 to ptr)(ptr %39, i32 1024, i64 %38)
-  %40 = add i64 %37, 8
-  %probe_read_kernel24 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %40)
-  %41 = load i64, ptr %join_r0, align 8
-  %42 = getelementptr i8, ptr %lookup_join_map, i64 12304
-  %probe_read_kernel_str25 = call i64 inttoptr (i64 115 to ptr)(ptr %42, i32 1024, i64 %41)
-  %43 = add i64 %40, 8
-  %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %43)
-  %44 = load i64, ptr %join_r0, align 8
-  %45 = getelementptr i8, ptr %lookup_join_map, i64 13328
-  %probe_read_kernel_str27 = call i64 inttoptr (i64 115 to ptr)(ptr %45, i32 1024, i64 %44)
-  %46 = add i64 %43, 8
-  %probe_read_kernel28 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %46)
-  %47 = load i64, ptr %join_r0, align 8
-  %48 = getelementptr i8, ptr %lookup_join_map, i64 14352
-  %probe_read_kernel_str29 = call i64 inttoptr (i64 115 to ptr)(ptr %48, i32 1024, i64 %47)
-  %49 = add i64 %46, 8
-  %probe_read_kernel30 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %49)
-  %50 = load i64, ptr %join_r0, align 8
-  %51 = getelementptr i8, ptr %lookup_join_map, i64 15376
-  %probe_read_kernel_str31 = call i64 inttoptr (i64 115 to ptr)(ptr %51, i32 1024, i64 %50)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %5)
+  %7 = load i64, ptr %join_r0, align 8
+  %8 = getelementptr i8, ptr %lookup_join_map, i64 16
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %8, i32 1024, i64 %7)
+  %9 = add i64 %5, 8
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %9)
+  %10 = load i64, ptr %join_r0, align 8
+  %11 = getelementptr i8, ptr %lookup_join_map, i64 1040
+  %probe_read_kernel_str3 = call i64 inttoptr (i64 115 to ptr)(ptr %11, i32 1024, i64 %10)
+  %12 = add i64 %9, 8
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %12)
+  %13 = load i64, ptr %join_r0, align 8
+  %14 = getelementptr i8, ptr %lookup_join_map, i64 2064
+  %probe_read_kernel_str5 = call i64 inttoptr (i64 115 to ptr)(ptr %14, i32 1024, i64 %13)
+  %15 = add i64 %12, 8
+  %probe_read_kernel6 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %15)
+  %16 = load i64, ptr %join_r0, align 8
+  %17 = getelementptr i8, ptr %lookup_join_map, i64 3088
+  %probe_read_kernel_str7 = call i64 inttoptr (i64 115 to ptr)(ptr %17, i32 1024, i64 %16)
+  %18 = add i64 %15, 8
+  %probe_read_kernel8 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %18)
+  %19 = load i64, ptr %join_r0, align 8
+  %20 = getelementptr i8, ptr %lookup_join_map, i64 4112
+  %probe_read_kernel_str9 = call i64 inttoptr (i64 115 to ptr)(ptr %20, i32 1024, i64 %19)
+  %21 = add i64 %18, 8
+  %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %21)
+  %22 = load i64, ptr %join_r0, align 8
+  %23 = getelementptr i8, ptr %lookup_join_map, i64 5136
+  %probe_read_kernel_str11 = call i64 inttoptr (i64 115 to ptr)(ptr %23, i32 1024, i64 %22)
+  %24 = add i64 %21, 8
+  %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %24)
+  %25 = load i64, ptr %join_r0, align 8
+  %26 = getelementptr i8, ptr %lookup_join_map, i64 6160
+  %probe_read_kernel_str13 = call i64 inttoptr (i64 115 to ptr)(ptr %26, i32 1024, i64 %25)
+  %27 = add i64 %24, 8
+  %probe_read_kernel14 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %27)
+  %28 = load i64, ptr %join_r0, align 8
+  %29 = getelementptr i8, ptr %lookup_join_map, i64 7184
+  %probe_read_kernel_str15 = call i64 inttoptr (i64 115 to ptr)(ptr %29, i32 1024, i64 %28)
+  %30 = add i64 %27, 8
+  %probe_read_kernel16 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %30)
+  %31 = load i64, ptr %join_r0, align 8
+  %32 = getelementptr i8, ptr %lookup_join_map, i64 8208
+  %probe_read_kernel_str17 = call i64 inttoptr (i64 115 to ptr)(ptr %32, i32 1024, i64 %31)
+  %33 = add i64 %30, 8
+  %probe_read_kernel18 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %33)
+  %34 = load i64, ptr %join_r0, align 8
+  %35 = getelementptr i8, ptr %lookup_join_map, i64 9232
+  %probe_read_kernel_str19 = call i64 inttoptr (i64 115 to ptr)(ptr %35, i32 1024, i64 %34)
+  %36 = add i64 %33, 8
+  %probe_read_kernel20 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %36)
+  %37 = load i64, ptr %join_r0, align 8
+  %38 = getelementptr i8, ptr %lookup_join_map, i64 10256
+  %probe_read_kernel_str21 = call i64 inttoptr (i64 115 to ptr)(ptr %38, i32 1024, i64 %37)
+  %39 = add i64 %36, 8
+  %probe_read_kernel22 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %39)
+  %40 = load i64, ptr %join_r0, align 8
+  %41 = getelementptr i8, ptr %lookup_join_map, i64 11280
+  %probe_read_kernel_str23 = call i64 inttoptr (i64 115 to ptr)(ptr %41, i32 1024, i64 %40)
+  %42 = add i64 %39, 8
+  %probe_read_kernel24 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %42)
+  %43 = load i64, ptr %join_r0, align 8
+  %44 = getelementptr i8, ptr %lookup_join_map, i64 12304
+  %probe_read_kernel_str25 = call i64 inttoptr (i64 115 to ptr)(ptr %44, i32 1024, i64 %43)
+  %45 = add i64 %42, 8
+  %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %45)
+  %46 = load i64, ptr %join_r0, align 8
+  %47 = getelementptr i8, ptr %lookup_join_map, i64 13328
+  %probe_read_kernel_str27 = call i64 inttoptr (i64 115 to ptr)(ptr %47, i32 1024, i64 %46)
+  %48 = add i64 %45, 8
+  %probe_read_kernel28 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %48)
+  %49 = load i64, ptr %join_r0, align 8
+  %50 = getelementptr i8, ptr %lookup_join_map, i64 14352
+  %probe_read_kernel_str29 = call i64 inttoptr (i64 115 to ptr)(ptr %50, i32 1024, i64 %49)
+  %51 = add i64 %48, 8
+  %probe_read_kernel30 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %51)
+  %52 = load i64, ptr %join_r0, align 8
+  %53 = getelementptr i8, ptr %lookup_join_map, i64 15376
+  %probe_read_kernel_str31 = call i64 inttoptr (i64 115 to ptr)(ptr %53, i32 1024, i64 %52)
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_join_map, i64 16400, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -143,7 +145,7 @@ counter_merge:                                    ; preds = %lookup_merge, %look
   br label %failure_callback
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %52 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %54 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -157,11 +159,15 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!51}
 !llvm.module.flags = !{!53}

--- a/tests/codegen/llvm/call_join_with_debug.ll
+++ b/tests/codegen/llvm/call_join_with_debug.ll
@@ -27,10 +27,12 @@ entry:
   store i64 0, ptr %"$x", align 8
   store i64 0, ptr %"$x", align 8
   %1 = load i64, ptr %"$x", align 8
-  %2 = add i64 %1, 0
+  %2 = inttoptr i64 %1 to ptr
+  %3 = call ptr @llvm.preserve.static.offset(ptr %2)
+  %4 = getelementptr i8, ptr %3, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct arg.argv")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct arg.argv", i32 8, i64 %2)
-  %3 = load i64, ptr %"struct arg.argv", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct arg.argv", i32 8, ptr %4)
+  %5 = load i64, ptr %"struct arg.argv", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct arg.argv")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_join_key)
   store i32 0, ptr %lookup_join_key, align 4
@@ -51,88 +53,88 @@ lookup_join_failure:                              ; preds = %entry
 
 lookup_join_merge:                                ; preds = %entry
   store i64 30005, ptr %lookup_join_map, align 8
-  %4 = getelementptr i8, ptr %lookup_join_map, i64 8
-  store i64 0, ptr %4, align 8
+  %6 = getelementptr i8, ptr %lookup_join_map, i64 8
+  store i64 0, ptr %6, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %join_r0)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %3)
-  %5 = load i64, ptr %join_r0, align 8
-  %6 = getelementptr i8, ptr %lookup_join_map, i64 16
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %6, i32 1024, i64 %5)
-  %7 = add i64 %3, 8
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %7)
-  %8 = load i64, ptr %join_r0, align 8
-  %9 = getelementptr i8, ptr %lookup_join_map, i64 1040
-  %probe_read_kernel_str3 = call i64 inttoptr (i64 115 to ptr)(ptr %9, i32 1024, i64 %8)
-  %10 = add i64 %7, 8
-  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %10)
-  %11 = load i64, ptr %join_r0, align 8
-  %12 = getelementptr i8, ptr %lookup_join_map, i64 2064
-  %probe_read_kernel_str5 = call i64 inttoptr (i64 115 to ptr)(ptr %12, i32 1024, i64 %11)
-  %13 = add i64 %10, 8
-  %probe_read_kernel6 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %13)
-  %14 = load i64, ptr %join_r0, align 8
-  %15 = getelementptr i8, ptr %lookup_join_map, i64 3088
-  %probe_read_kernel_str7 = call i64 inttoptr (i64 115 to ptr)(ptr %15, i32 1024, i64 %14)
-  %16 = add i64 %13, 8
-  %probe_read_kernel8 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %16)
-  %17 = load i64, ptr %join_r0, align 8
-  %18 = getelementptr i8, ptr %lookup_join_map, i64 4112
-  %probe_read_kernel_str9 = call i64 inttoptr (i64 115 to ptr)(ptr %18, i32 1024, i64 %17)
-  %19 = add i64 %16, 8
-  %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %19)
-  %20 = load i64, ptr %join_r0, align 8
-  %21 = getelementptr i8, ptr %lookup_join_map, i64 5136
-  %probe_read_kernel_str11 = call i64 inttoptr (i64 115 to ptr)(ptr %21, i32 1024, i64 %20)
-  %22 = add i64 %19, 8
-  %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %22)
-  %23 = load i64, ptr %join_r0, align 8
-  %24 = getelementptr i8, ptr %lookup_join_map, i64 6160
-  %probe_read_kernel_str13 = call i64 inttoptr (i64 115 to ptr)(ptr %24, i32 1024, i64 %23)
-  %25 = add i64 %22, 8
-  %probe_read_kernel14 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %25)
-  %26 = load i64, ptr %join_r0, align 8
-  %27 = getelementptr i8, ptr %lookup_join_map, i64 7184
-  %probe_read_kernel_str15 = call i64 inttoptr (i64 115 to ptr)(ptr %27, i32 1024, i64 %26)
-  %28 = add i64 %25, 8
-  %probe_read_kernel16 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %28)
-  %29 = load i64, ptr %join_r0, align 8
-  %30 = getelementptr i8, ptr %lookup_join_map, i64 8208
-  %probe_read_kernel_str17 = call i64 inttoptr (i64 115 to ptr)(ptr %30, i32 1024, i64 %29)
-  %31 = add i64 %28, 8
-  %probe_read_kernel18 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %31)
-  %32 = load i64, ptr %join_r0, align 8
-  %33 = getelementptr i8, ptr %lookup_join_map, i64 9232
-  %probe_read_kernel_str19 = call i64 inttoptr (i64 115 to ptr)(ptr %33, i32 1024, i64 %32)
-  %34 = add i64 %31, 8
-  %probe_read_kernel20 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %34)
-  %35 = load i64, ptr %join_r0, align 8
-  %36 = getelementptr i8, ptr %lookup_join_map, i64 10256
-  %probe_read_kernel_str21 = call i64 inttoptr (i64 115 to ptr)(ptr %36, i32 1024, i64 %35)
-  %37 = add i64 %34, 8
-  %probe_read_kernel22 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %37)
-  %38 = load i64, ptr %join_r0, align 8
-  %39 = getelementptr i8, ptr %lookup_join_map, i64 11280
-  %probe_read_kernel_str23 = call i64 inttoptr (i64 115 to ptr)(ptr %39, i32 1024, i64 %38)
-  %40 = add i64 %37, 8
-  %probe_read_kernel24 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %40)
-  %41 = load i64, ptr %join_r0, align 8
-  %42 = getelementptr i8, ptr %lookup_join_map, i64 12304
-  %probe_read_kernel_str25 = call i64 inttoptr (i64 115 to ptr)(ptr %42, i32 1024, i64 %41)
-  %43 = add i64 %40, 8
-  %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %43)
-  %44 = load i64, ptr %join_r0, align 8
-  %45 = getelementptr i8, ptr %lookup_join_map, i64 13328
-  %probe_read_kernel_str27 = call i64 inttoptr (i64 115 to ptr)(ptr %45, i32 1024, i64 %44)
-  %46 = add i64 %43, 8
-  %probe_read_kernel28 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %46)
-  %47 = load i64, ptr %join_r0, align 8
-  %48 = getelementptr i8, ptr %lookup_join_map, i64 14352
-  %probe_read_kernel_str29 = call i64 inttoptr (i64 115 to ptr)(ptr %48, i32 1024, i64 %47)
-  %49 = add i64 %46, 8
-  %probe_read_kernel30 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %49)
-  %50 = load i64, ptr %join_r0, align 8
-  %51 = getelementptr i8, ptr %lookup_join_map, i64 15376
-  %probe_read_kernel_str31 = call i64 inttoptr (i64 115 to ptr)(ptr %51, i32 1024, i64 %50)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %5)
+  %7 = load i64, ptr %join_r0, align 8
+  %8 = getelementptr i8, ptr %lookup_join_map, i64 16
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %8, i32 1024, i64 %7)
+  %9 = add i64 %5, 8
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %9)
+  %10 = load i64, ptr %join_r0, align 8
+  %11 = getelementptr i8, ptr %lookup_join_map, i64 1040
+  %probe_read_kernel_str3 = call i64 inttoptr (i64 115 to ptr)(ptr %11, i32 1024, i64 %10)
+  %12 = add i64 %9, 8
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %12)
+  %13 = load i64, ptr %join_r0, align 8
+  %14 = getelementptr i8, ptr %lookup_join_map, i64 2064
+  %probe_read_kernel_str5 = call i64 inttoptr (i64 115 to ptr)(ptr %14, i32 1024, i64 %13)
+  %15 = add i64 %12, 8
+  %probe_read_kernel6 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %15)
+  %16 = load i64, ptr %join_r0, align 8
+  %17 = getelementptr i8, ptr %lookup_join_map, i64 3088
+  %probe_read_kernel_str7 = call i64 inttoptr (i64 115 to ptr)(ptr %17, i32 1024, i64 %16)
+  %18 = add i64 %15, 8
+  %probe_read_kernel8 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %18)
+  %19 = load i64, ptr %join_r0, align 8
+  %20 = getelementptr i8, ptr %lookup_join_map, i64 4112
+  %probe_read_kernel_str9 = call i64 inttoptr (i64 115 to ptr)(ptr %20, i32 1024, i64 %19)
+  %21 = add i64 %18, 8
+  %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %21)
+  %22 = load i64, ptr %join_r0, align 8
+  %23 = getelementptr i8, ptr %lookup_join_map, i64 5136
+  %probe_read_kernel_str11 = call i64 inttoptr (i64 115 to ptr)(ptr %23, i32 1024, i64 %22)
+  %24 = add i64 %21, 8
+  %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %24)
+  %25 = load i64, ptr %join_r0, align 8
+  %26 = getelementptr i8, ptr %lookup_join_map, i64 6160
+  %probe_read_kernel_str13 = call i64 inttoptr (i64 115 to ptr)(ptr %26, i32 1024, i64 %25)
+  %27 = add i64 %24, 8
+  %probe_read_kernel14 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %27)
+  %28 = load i64, ptr %join_r0, align 8
+  %29 = getelementptr i8, ptr %lookup_join_map, i64 7184
+  %probe_read_kernel_str15 = call i64 inttoptr (i64 115 to ptr)(ptr %29, i32 1024, i64 %28)
+  %30 = add i64 %27, 8
+  %probe_read_kernel16 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %30)
+  %31 = load i64, ptr %join_r0, align 8
+  %32 = getelementptr i8, ptr %lookup_join_map, i64 8208
+  %probe_read_kernel_str17 = call i64 inttoptr (i64 115 to ptr)(ptr %32, i32 1024, i64 %31)
+  %33 = add i64 %30, 8
+  %probe_read_kernel18 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %33)
+  %34 = load i64, ptr %join_r0, align 8
+  %35 = getelementptr i8, ptr %lookup_join_map, i64 9232
+  %probe_read_kernel_str19 = call i64 inttoptr (i64 115 to ptr)(ptr %35, i32 1024, i64 %34)
+  %36 = add i64 %33, 8
+  %probe_read_kernel20 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %36)
+  %37 = load i64, ptr %join_r0, align 8
+  %38 = getelementptr i8, ptr %lookup_join_map, i64 10256
+  %probe_read_kernel_str21 = call i64 inttoptr (i64 115 to ptr)(ptr %38, i32 1024, i64 %37)
+  %39 = add i64 %36, 8
+  %probe_read_kernel22 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %39)
+  %40 = load i64, ptr %join_r0, align 8
+  %41 = getelementptr i8, ptr %lookup_join_map, i64 11280
+  %probe_read_kernel_str23 = call i64 inttoptr (i64 115 to ptr)(ptr %41, i32 1024, i64 %40)
+  %42 = add i64 %39, 8
+  %probe_read_kernel24 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %42)
+  %43 = load i64, ptr %join_r0, align 8
+  %44 = getelementptr i8, ptr %lookup_join_map, i64 12304
+  %probe_read_kernel_str25 = call i64 inttoptr (i64 115 to ptr)(ptr %44, i32 1024, i64 %43)
+  %45 = add i64 %42, 8
+  %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %45)
+  %46 = load i64, ptr %join_r0, align 8
+  %47 = getelementptr i8, ptr %lookup_join_map, i64 13328
+  %probe_read_kernel_str27 = call i64 inttoptr (i64 115 to ptr)(ptr %47, i32 1024, i64 %46)
+  %48 = add i64 %45, 8
+  %probe_read_kernel28 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %48)
+  %49 = load i64, ptr %join_r0, align 8
+  %50 = getelementptr i8, ptr %lookup_join_map, i64 14352
+  %probe_read_kernel_str29 = call i64 inttoptr (i64 115 to ptr)(ptr %50, i32 1024, i64 %49)
+  %51 = add i64 %48, 8
+  %probe_read_kernel30 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %51)
+  %52 = load i64, ptr %join_r0, align 8
+  %53 = getelementptr i8, ptr %lookup_join_map, i64 15376
+  %probe_read_kernel_str31 = call i64 inttoptr (i64 115 to ptr)(ptr %53, i32 1024, i64 %52)
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_join_map, i64 16400, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -148,7 +150,7 @@ counter_merge:                                    ; preds = %lookup_merge, %look
   br label %failure_callback
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %52 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %54 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -162,15 +164,19 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!51}
 !llvm.module.flags = !{!53}

--- a/tests/codegen/llvm/call_macaddr.ll
+++ b/tests/codegen/llvm/call_macaddr.ll
@@ -21,7 +21,9 @@ entry:
   %macaddr = alloca [6 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %macaddr)
   call void @llvm.memset.p0.i64(ptr align 1 %macaddr, i8 0, i64 6, i1 false)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %macaddr, i32 6, i64 0)
+  %1 = call ptr @llvm.preserve.static.offset(ptr null)
+  %2 = getelementptr i8, ptr %1, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %macaddr, i32 6, ptr %2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %macaddr, i64 0)
@@ -36,12 +38,16 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #3
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50}

--- a/tests/codegen/llvm/call_ntop_char16.ll
+++ b/tests/codegen/llvm/call_ntop_char16.ll
@@ -25,7 +25,9 @@ entry:
   store i64 10, ptr %1, align 8
   %2 = getelementptr %inet, ptr %inet, i32 0, i32 1
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 16, i64 0)
+  %3 = call ptr @llvm.preserve.static.offset(ptr null)
+  %4 = getelementptr i8, ptr %3, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 16, ptr %4)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %inet, i64 0)
@@ -40,12 +42,16 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #3
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50}

--- a/tests/codegen/llvm/call_ntop_char4.ll
+++ b/tests/codegen/llvm/call_ntop_char4.ll
@@ -25,7 +25,9 @@ entry:
   store i64 2, ptr %1, align 8
   %2 = getelementptr %inet, ptr %inet, i32 0, i32 1
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 4, i64 0)
+  %3 = call ptr @llvm.preserve.static.offset(ptr null)
+  %4 = getelementptr i8, ptr %3, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 4, ptr %4)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %inet, i64 0)
@@ -40,12 +42,16 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #3
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50}

--- a/tests/codegen/llvm/call_override.ll
+++ b/tests/codegen/llvm/call_override.ll
@@ -15,13 +15,18 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
 entry:
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   %override = call i64 inttoptr (i64 58 to ptr)(ptr %0, i64 %arg0)
   ret i64 0
 }
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
 attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38}

--- a/tests/codegen/llvm/call_path.ll
+++ b/tests/codegen/llvm/call_path.ll
@@ -22,20 +22,25 @@ entry:
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  %3 = ptrtoint ptr %0 to i64
-  %4 = getelementptr i64, ptr %0, i64 0
+  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %4 = getelementptr i64, ptr %3, i64 0
   %filp = load volatile i64, ptr %4, align 8
-  %5 = add i64 %filp, 152
-  %6 = inttoptr i64 %5 to ptr
-  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %6, ptr %2, i32 64)
+  %5 = inttoptr i64 %filp to ptr
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 152
+  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %7, ptr %2, i32 64)
   ret i64 0
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}

--- a/tests/codegen/llvm/call_path_with_optional_size.ll
+++ b/tests/codegen/llvm/call_path_with_optional_size.ll
@@ -22,20 +22,25 @@ entry:
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  %3 = ptrtoint ptr %0 to i64
-  %4 = getelementptr i64, ptr %0, i64 0
+  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %4 = getelementptr i64, ptr %3, i64 0
   %filp = load volatile i64, ptr %4, align 8
-  %5 = add i64 %filp, 152
-  %6 = inttoptr i64 %5 to ptr
-  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %6, ptr %2, i32 48)
+  %5 = inttoptr i64 %filp to ptr
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 152
+  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %7, ptr %2, i32 48)
   ret i64 0
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}

--- a/tests/codegen/llvm/call_reg.ll
+++ b/tests/codegen/llvm/call_reg.ll
@@ -19,8 +19,9 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !45 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 16
-  %reg_ip = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 16
+  %reg_ip = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -31,14 +32,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/call_signal.ll
+++ b/tests/codegen/llvm/call_signal.ll
@@ -15,14 +15,19 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
 entry:
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %2 = trunc i64 %arg0 to i32
-  %signal = call i64 inttoptr (i64 109 to ptr)(i32 %2)
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
+  %3 = trunc i64 %arg0 to i32
+  %signal = call i64 inttoptr (i64 109 to ptr)(i32 %3)
   ret i64 0
 }
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
 attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38}

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -25,8 +25,9 @@ entry:
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  %3 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %3, align 8
+  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %4 = getelementptr i64, ptr %3, i64 14
+  %arg0 = load volatile i64, ptr %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
@@ -38,15 +39,19 @@ entry:
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!54}
 !llvm.module.flags = !{!56}

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -20,39 +20,45 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 13
-  %arg1 = load volatile i64, ptr %1, align 8
-  %2 = add i64 %arg1, 1
-  %str.min.cmp = icmp ule i64 %2, 64
-  %str.min.select = select i1 %str.min.cmp, i64 %2, i64 64
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 13
+  %arg1 = load volatile i64, ptr %2, align 8
+  %3 = add i64 %arg1, 1
+  %str.min.cmp = icmp ule i64 %3, 64
+  %str.min.select = select i1 %str.min.cmp, i64 %3, i64 64
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %3 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %3
-  %4 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 64, i1 false)
-  %5 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %5, align 8
-  %6 = trunc i64 %str.min.select to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %4, i32 %6, i64 %arg0)
+  %4 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %4
+  %5 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 64, i1 false)
+  %6 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %7 = getelementptr i64, ptr %6, i64 14
+  %arg0 = load volatile i64, ptr %7, align 8
+  %8 = trunc i64 %str.min.select to i32
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %5, i32 %8, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %4, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %5, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!54}
 !llvm.module.flags = !{!56}

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -25,8 +25,9 @@ entry:
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  %3 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %3, align 8
+  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %4 = getelementptr i64, ptr %3, i64 14
+  %arg0 = load volatile i64, ptr %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 7, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
@@ -38,15 +39,19 @@ entry:
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!57}
 !llvm.module.flags = !{!59}

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -20,31 +20,36 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %deref = alloca i16, align 2
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
   %probe_read_user = call i64 inttoptr (i64 112 to ptr)(ptr %deref, i32 2, i64 %arg0)
-  %2 = load i16, ptr %deref, align 2
+  %3 = load i16, ptr %deref, align 2
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %3 = sext i16 %2 to i64
-  store i64 %3, ptr %"@_val", align 8
+  %4 = sext i16 %3 to i64
+  store i64 %4, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -20,31 +20,36 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %deref = alloca i32, align 4
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
   %probe_read_user = call i64 inttoptr (i64 112 to ptr)(ptr %deref, i32 4, i64 %arg0)
-  %2 = load i32, ptr %deref, align 4
+  %3 = load i32, ptr %deref, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %3 = sext i32 %2 to i64
-  store i64 %3, ptr %"@_val", align 8
+  %4 = sext i32 %3 to i64
+  store i64 %4, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/comparison_extend.ll
+++ b/tests/codegen/llvm/comparison_extend.ll
@@ -19,28 +19,33 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !45 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %2 = icmp ult i64 1, %arg0
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
+  %3 = icmp ult i64 1, %arg0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %3 = zext i1 %2 to i64
-  store i64 %3, ptr %"@_val", align 8
+  %4 = zext i1 %3 to i64
+  store i64 %4, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/fentry_dereference.ll
+++ b/tests/codegen/llvm/fentry_dereference.ll
@@ -19,16 +19,18 @@ define i64 @fentry_mock_vmlinux_tcp_sendmsg_1(ptr %0) section "s_fentry_mock_vml
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = ptrtoint ptr %0 to i64
-  %2 = getelementptr i64, ptr %0, i64 0
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 0
   %sk = load volatile i64, ptr %2, align 8
-  %3 = add i64 %sk, 0
-  %4 = add i64 %3, 0
-  %5 = inttoptr i64 %4 to ptr
-  %6 = load volatile i32, ptr %5, align 4
+  %3 = inttoptr i64 %sk to ptr
+  %4 = call ptr @llvm.preserve.static.offset(ptr %3)
+  %5 = getelementptr i8, ptr %4, i64 0
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
+  %8 = load volatile i32, ptr %7, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %7 = zext i32 %6 to i64
-  store i64 %7, ptr %"@_key", align 8
+  %9 = zext i32 %8 to i64
+  store i64 %9, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -37,14 +39,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!47}
 !llvm.module.flags = !{!49}

--- a/tests/codegen/llvm/fexit_dereference.ll
+++ b/tests/codegen/llvm/fexit_dereference.ll
@@ -19,15 +19,18 @@ define i64 @fexit_mock_vmlinux_sk_alloc_1(ptr %0) section "s_fexit_mock_vmlinux_
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 5
-  %retval = load volatile i64, ptr %1, align 8
-  %2 = add i64 %retval, 0
-  %3 = add i64 %2, 0
-  %4 = inttoptr i64 %3 to ptr
-  %5 = load volatile i32, ptr %4, align 4
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 5
+  %retval = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %retval to ptr
+  %4 = call ptr @llvm.preserve.static.offset(ptr %3)
+  %5 = getelementptr i8, ptr %4, i64 0
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
+  %8 = load volatile i32, ptr %7, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %6 = zext i32 %5 to i64
-  store i64 %6, ptr %"@_key", align 8
+  %9 = zext i32 %8 to i64
+  store i64 %9, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -36,14 +39,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!47}
 !llvm.module.flags = !{!49}

--- a/tests/codegen/llvm/for_map_variables.ll
+++ b/tests/codegen/llvm/for_map_variables.ll
@@ -54,16 +54,18 @@ entry:
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var3", ptr align 1 %str1, i64 4, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %ctx)
-  %"ctx.$var1" = getelementptr %ctx_t, ptr %ctx, i64 0, i32 0
+  %1 = call ptr @llvm.preserve.static.offset(ptr %ctx)
+  %"ctx.$var1" = getelementptr %ctx_t, ptr %1, i64 0, i32 0
   store ptr %"$var1", ptr %"ctx.$var1", align 8
-  %"ctx.$var3" = getelementptr %ctx_t, ptr %ctx, i64 0, i32 1
+  %2 = call ptr @llvm.preserve.static.offset(ptr %ctx)
+  %"ctx.$var3" = getelementptr %ctx_t, ptr %2, i64 0, i32 1
   store ptr %"$var3", ptr %"ctx.$var3", align 8
   %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_map, ptr @map_for_each_cb, ptr %ctx, i64 0)
-  %1 = load i64, ptr %"$var1", align 8
+  %3 = load i64, ptr %"$var1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@len_key")
   store i64 0, ptr %"@len_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@len_val")
-  store i64 %1, ptr %"@len_val", align 8
+  store i64 %3, ptr %"@len_val", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_len, ptr %"@len_key", ptr %"@len_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@len_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@len_key")
@@ -81,6 +83,9 @@ declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 i
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #4
 
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !61 {
   %"$can_read" = alloca [4 x i8], align 1
@@ -110,6 +115,7 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #4 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!51}
 !llvm.module.flags = !{!53}

--- a/tests/codegen/llvm/for_map_variables_multiple_loops.ll
+++ b/tests/codegen/llvm/for_map_variables_multiple_loops.ll
@@ -40,13 +40,16 @@ entry:
   store i64 0, ptr %"$var1", align 8
   store i64 0, ptr %"$var2", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %ctx)
-  %"ctx.$var1" = getelementptr %ctx_t, ptr %ctx, i64 0, i32 0
+  %1 = call ptr @llvm.preserve.static.offset(ptr %ctx)
+  %"ctx.$var1" = getelementptr %ctx_t, ptr %1, i64 0, i32 0
   store ptr %"$var1", ptr %"ctx.$var1", align 8
   %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_, ptr @map_for_each_cb, ptr %ctx, i64 0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %ctx1)
-  %"ctx.$var12" = getelementptr %ctx_t.2, ptr %ctx1, i64 0, i32 0
+  %2 = call ptr @llvm.preserve.static.offset(ptr %ctx1)
+  %"ctx.$var12" = getelementptr %ctx_t.2, ptr %2, i64 0, i32 0
   store ptr %"$var1", ptr %"ctx.$var12", align 8
-  %"ctx.$var2" = getelementptr %ctx_t.2, ptr %ctx1, i64 0, i32 1
+  %3 = call ptr @llvm.preserve.static.offset(ptr %ctx1)
+  %"ctx.$var2" = getelementptr %ctx_t.2, ptr %3, i64 0, i32 1
   store ptr %"$var2", ptr %"ctx.$var2", align 8
   %for_each_map_elem3 = call i64 inttoptr (i64 164 to ptr)(ptr @AT_, ptr @map_for_each_cb.1, ptr %ctx1, i64 0)
   ret i64 0
@@ -57,6 +60,9 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
 
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !57 {
   %"$_" = alloca %int64_int64__tuple_t, align 8
@@ -77,7 +83,7 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !65 {
   %"$_" = alloca %int64_int64__tuple_t, align 8
@@ -104,7 +110,8 @@ define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section "
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!47}
 !llvm.module.flags = !{!49}

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -23,24 +23,25 @@ entry:
   %"@_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
-  %1 = getelementptr i64, ptr %0, i64 10
-  %retval = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 10
+  %retval = load volatile i64, ptr %2, align 8
   %cast = trunc i64 %retval to i32
-  %2 = sext i32 %cast to i64
+  %3 = sext i32 %cast to i64
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_, ptr %"@_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %3 = load i64, ptr %lookup_elem, align 8
-  %4 = add i64 %3, %2
-  store i64 %4, ptr %lookup_elem, align 8
+  %4 = load i64, ptr %lookup_elem, align 8
+  %5 = add i64 %4, %3
+  store i64 %5, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
-  store i64 %2, ptr %initial_value, align 8
+  store i64 %3, ptr %initial_value, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %initial_value, i64 1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
@@ -54,11 +55,15 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50}

--- a/tests/codegen/llvm/intcast_retval.ll
+++ b/tests/codegen/llvm/intcast_retval.ll
@@ -19,28 +19,33 @@ define i64 @kretprobe_f_1(ptr %0) section "s_kretprobe_f_1" !dbg !45 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 10
-  %retval = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 10
+  %retval = load volatile i64, ptr %2, align 8
   %cast = trunc i64 %retval to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %2 = sext i32 %cast to i64
-  store i64 %2, ptr %"@_val", align 8
+  %3 = sext i32 %cast to i64
+  store i64 %3, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -20,32 +20,37 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %deref = alloca i8, align 1
-  %1 = getelementptr i64, ptr %0, i64 4
-  %reg_bp = load volatile i64, ptr %1, align 8
-  %2 = sub i64 %reg_bp, 1
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 4
+  %reg_bp = load volatile i64, ptr %2, align 8
+  %3 = sub i64 %reg_bp, 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 1, i64 %2)
-  %3 = load i8, ptr %deref, align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 1, i64 %3)
+  %4 = load i8, ptr %deref, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %4 = sext i8 %3 to i64
-  store i64 %4, ptr %"@_val", align 8
+  %5 = sext i8 %4 to i64
+  store i64 %5, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/iter_dereference.ll
+++ b/tests/codegen/llvm/iter_dereference.ll
@@ -19,19 +19,19 @@ define i64 @iter_task_file_1(ptr %0) section "s_iter_task_file_1" !dbg !50 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %1 = ptrtoint ptr %0 to i64
-  %2 = add i64 %1, 0
-  %3 = inttoptr i64 %2 to ptr
-  %4 = load volatile i64, ptr %3, align 8
-  %predcond = icmp eq i64 %4, 0
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i8, ptr %1, i64 0
+  %3 = load volatile i64, ptr %2, align 8
+  %predcond = icmp eq i64 %3, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 pred_false:                                       ; preds = %entry
   ret i64 0
 
 pred_true:                                        ; preds = %entry
-  %5 = add i64 %4, 8
-  %6 = inttoptr i64 %5 to ptr
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 8
   %7 = load volatile i64, ptr %6, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 %7, ptr %"@_key", align 8
@@ -43,14 +43,18 @@ pred_true:                                        ; preds = %entry
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!47}
 !llvm.module.flags = !{!49}

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -40,12 +40,14 @@ entry:
   store i64 0, ptr %3, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
   %4 = load i64, ptr %"$foo", align 8
-  %5 = add i64 %4, 0
+  %5 = inttoptr i64 %4 to ptr
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m")
-  %probe_read = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m", i32 4, i64 %5)
-  %6 = load i32, ptr %"struct Foo.m", align 4
+  %probe_read = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m", i32 4, ptr %7)
+  %8 = load i32, ptr %"struct Foo.m", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m")
-  %lhs_true_cond = icmp ne i32 %6, 0
+  %lhs_true_cond = icmp ne i32 %8, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
@@ -60,20 +62,22 @@ entry:
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %7 = load i64, ptr %"&&_result", align 8
-  %8 = getelementptr %printf_t, ptr %2, i32 0, i32 1
-  store i64 %7, ptr %8, align 8
+  %9 = load i64, ptr %"&&_result", align 8
+  %10 = getelementptr %printf_t, ptr %2, i32 0, i32 1
+  store i64 %9, ptr %10, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result5")
   br i1 true, label %"&&_lhs_true1", label %"&&_false3"
 
 "&&_lhs_true1":                                   ; preds = %"&&_merge"
-  %9 = load i64, ptr %"$foo", align 8
-  %10 = add i64 %9, 0
+  %11 = load i64, ptr %"$foo", align 8
+  %12 = inttoptr i64 %11 to ptr
+  %13 = call ptr @llvm.preserve.static.offset(ptr %12)
+  %14 = getelementptr i8, ptr %13, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m6")
-  %probe_read7 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m6", i32 4, i64 %10)
-  %11 = load i32, ptr %"struct Foo.m6", align 4
+  %probe_read7 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m6", i32 4, ptr %14)
+  %15 = load i32, ptr %"struct Foo.m6", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m6")
-  %rhs_true_cond = icmp ne i32 %11, 0
+  %rhs_true_cond = icmp ne i32 %15, 0
   br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
 
 "&&_true2":                                       ; preds = %"&&_lhs_true1"
@@ -85,17 +89,19 @@ entry:
   br label %"&&_merge4"
 
 "&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %12 = load i64, ptr %"&&_result5", align 8
-  %13 = getelementptr %printf_t, ptr %2, i32 0, i32 2
-  store i64 %12, ptr %13, align 8
+  %16 = load i64, ptr %"&&_result5", align 8
+  %17 = getelementptr %printf_t, ptr %2, i32 0, i32 2
+  store i64 %16, ptr %17, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
-  %14 = load i64, ptr %"$foo", align 8
-  %15 = add i64 %14, 0
+  %18 = load i64, ptr %"$foo", align 8
+  %19 = inttoptr i64 %18 to ptr
+  %20 = call ptr @llvm.preserve.static.offset(ptr %19)
+  %21 = getelementptr i8, ptr %20, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m8")
-  %probe_read9 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m8", i32 4, i64 %15)
-  %16 = load i32, ptr %"struct Foo.m8", align 4
+  %probe_read9 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m8", i32 4, ptr %21)
+  %22 = load i32, ptr %"struct Foo.m8", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m8")
-  %lhs_true_cond10 = icmp ne i32 %16, 0
+  %lhs_true_cond10 = icmp ne i32 %22, 0
   br i1 %lhs_true_cond10, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %"&&_merge4"
@@ -110,20 +116,22 @@ entry:
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %17 = load i64, ptr %"||_result", align 8
-  %18 = getelementptr %printf_t, ptr %2, i32 0, i32 3
-  store i64 %17, ptr %18, align 8
+  %23 = load i64, ptr %"||_result", align 8
+  %24 = getelementptr %printf_t, ptr %2, i32 0, i32 3
+  store i64 %23, ptr %24, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result15")
   br i1 false, label %"||_true13", label %"||_lhs_false11"
 
 "||_lhs_false11":                                 ; preds = %"||_merge"
-  %19 = load i64, ptr %"$foo", align 8
-  %20 = add i64 %19, 0
+  %25 = load i64, ptr %"$foo", align 8
+  %26 = inttoptr i64 %25 to ptr
+  %27 = call ptr @llvm.preserve.static.offset(ptr %26)
+  %28 = getelementptr i8, ptr %27, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m16")
-  %probe_read17 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m16", i32 4, i64 %20)
-  %21 = load i32, ptr %"struct Foo.m16", align 4
+  %probe_read17 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m16", i32 4, ptr %28)
+  %29 = load i32, ptr %"struct Foo.m16", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m16")
-  %rhs_true_cond18 = icmp ne i32 %21, 0
+  %rhs_true_cond18 = icmp ne i32 %29, 0
   br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
 
 "||_false12":                                     ; preds = %"||_lhs_false11"
@@ -135,9 +143,9 @@ entry:
   br label %"||_merge14"
 
 "||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %22 = load i64, ptr %"||_result15", align 8
-  %23 = getelementptr %printf_t, ptr %2, i32 0, i32 4
-  store i64 %22, ptr %23, align 8
+  %30 = load i64, ptr %"||_result15", align 8
+  %31 = getelementptr %printf_t, ptr %2, i32 0, i32 4
+  store i64 %30, ptr %31, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 40, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -153,7 +161,7 @@ counter_merge:                                    ; preds = %lookup_merge, %"||_
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %24 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  %32 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
@@ -170,12 +178,16 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #3
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}

--- a/tests/codegen/llvm/map_args.ll
+++ b/tests/codegen/llvm/map_args.ll
@@ -21,23 +21,27 @@ entry:
   %"@_key" = alloca i64, align 8
   %args = alloca %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %args)
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %2 = trunc i64 %arg0 to i32
-  %3 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 0
-  store i32 %2, ptr %3, align 4
-  %4 = getelementptr i64, ptr %0, i64 13
-  %arg1 = load volatile i64, ptr %4, align 8
-  %5 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 1
-  store i64 %arg1, ptr %5, align 8
-  %6 = getelementptr i64, ptr %0, i64 12
-  %arg2 = load volatile i64, ptr %6, align 8
-  %7 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 2
-  store i64 %arg2, ptr %7, align 8
-  %8 = getelementptr i64, ptr %0, i64 11
-  %arg3 = load volatile i64, ptr %8, align 8
-  %9 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 3
-  store i64 %arg3, ptr %9, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
+  %3 = trunc i64 %arg0 to i32
+  %4 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 0
+  store i32 %3, ptr %4, align 4
+  %5 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %6 = getelementptr i64, ptr %5, i64 13
+  %arg1 = load volatile i64, ptr %6, align 8
+  %7 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 1
+  store i64 %arg1, ptr %7, align 8
+  %8 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %9 = getelementptr i64, ptr %8, i64 12
+  %arg2 = load volatile i64, ptr %9, align 8
+  %10 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 2
+  store i64 %arg2, ptr %10, align 8
+  %11 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %12 = getelementptr i64, ptr %11, i64 11
+  %arg3 = load volatile i64, ptr %12, align 8
+  %13 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 3
+  store i64 %arg3, ptr %13, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %args, i64 0)
@@ -48,11 +52,15 @@ entry:
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50}

--- a/tests/codegen/llvm/map_key_struct.ll
+++ b/tests/codegen/llvm/map_key_struct.ll
@@ -19,8 +19,9 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !55 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca [4 x i8], align 1
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@x_key", i32 4, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -31,14 +32,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!52}
 !llvm.module.flags = !{!54}

--- a/tests/codegen/llvm/nested_array_struct.ll
+++ b/tests/codegen/llvm/nested_array_struct.ll
@@ -25,13 +25,16 @@ entry:
   %"@bar_key1" = alloca i64, align 8
   %"@bar_val" = alloca [2 x [2 x [4 x i8]]], align 1
   %"@bar_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %2 = add i64 %arg0, 0
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = call ptr @llvm.preserve.static.offset(ptr %3)
+  %5 = getelementptr i8, ptr %4, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@bar_key")
   store i64 42, ptr %"@bar_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@bar_val")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@bar_val", i32 16, i64 %2)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@bar_val", i32 16, ptr %5)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_bar, ptr %"@bar_key", ptr %"@bar_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@bar_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@bar_key")
@@ -52,38 +55,42 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@bar_key1")
-  %3 = getelementptr [2 x [2 x [4 x i8]]], ptr %lookup_elem_val, i32 0, i64 0
-  %4 = getelementptr [2 x [4 x i8]], ptr %3, i32 0, i64 1
-  %5 = getelementptr [4 x i8], ptr %4, i32 0, i64 0
-  %6 = load volatile i32, ptr %5, align 4
+  %6 = getelementptr [2 x [2 x [4 x i8]]], ptr %lookup_elem_val, i32 0, i64 0
+  %7 = getelementptr [2 x [4 x i8]], ptr %6, i32 0, i64 1
+  %8 = getelementptr [4 x i8], ptr %7, i32 0, i64 0
+  %9 = load volatile i32, ptr %8, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %7 = sext i32 %6 to i64
-  store i64 %7, ptr %"@_val", align 8
+  %10 = sext i32 %9 to i64
+  store i64 %10, ptr %"@_val", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #4
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
-attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #4 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!59}
 !llvm.module.flags = !{!61}

--- a/tests/codegen/llvm/str_scratch_buf.ll
+++ b/tests/codegen/llvm/str_scratch_buf.ll
@@ -22,8 +22,9 @@ entry:
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  %3 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %3, align 8
+  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %4 = getelementptr i64, ptr %3, i64 14
+  %arg0 = load volatile i64, ptr %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 %arg0)
   ret i64 0
 }
@@ -31,8 +32,12 @@ entry:
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}

--- a/tests/codegen/llvm/str_stack.ll
+++ b/tests/codegen/llvm/str_stack.ll
@@ -18,8 +18,9 @@ entry:
   %str = alloca [64 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   call void @llvm.memset.p0.i64(ptr align 1 %str, i8 0, i64 64, i1 false)
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %str, i32 64, i64 %arg0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   ret i64 0
@@ -31,12 +32,16 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #3
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38}

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -28,21 +28,20 @@ entry:
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  %3 = ptrtoint ptr %0 to i64
-  %4 = add i64 %3, 8
-  %5 = inttoptr i64 %4 to ptr
-  %6 = load volatile i64, ptr %5, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 %6)
+  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %4 = getelementptr i8, ptr %3, i64 8
+  %5 = load volatile i64, ptr %4, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 %5)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %comm)
   call void @llvm.memset.p0.i64(ptr align 1 %comm, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to ptr)(ptr %comm, i64 16)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %strcmp.result)
   store i1 false, ptr %strcmp.result, align 1
-  %7 = getelementptr i8, ptr %2, i32 0
-  %8 = load i8, ptr %7, align 1
-  %9 = getelementptr i8, ptr %comm, i32 0
-  %10 = load i8, ptr %9, align 1
-  %strcmp.cmp = icmp ne i8 %8, %10
+  %6 = getelementptr i8, ptr %2, i32 0
+  %7 = load i8, ptr %6, align 1
+  %8 = getelementptr i8, ptr %comm, i32 0
+  %9 = load i8, ptr %8, align 1
+  %strcmp.cmp = icmp ne i8 %7, %9
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 pred_false:                                       ; preds = %strcmp.false
@@ -60,10 +59,10 @@ pred_true:                                        ; preds = %strcmp.false
   ret i64 1
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
-  %11 = load i1, ptr %strcmp.result, align 1
+  %10 = load i1, ptr %strcmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
-  %12 = zext i1 %11 to i64
-  %predcond = icmp eq i64 %12, 0
+  %11 = zext i1 %10 to i64
+  %predcond = icmp eq i64 %11, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.done:                                      ; preds = %strcmp.loop57, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp54, %strcmp.loop_null_cmp50, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp42, %strcmp.loop_null_cmp38, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp30, %strcmp.loop_null_cmp26, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp18, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
@@ -71,205 +70,209 @@ strcmp.done:                                      ; preds = %strcmp.loop57, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %13 = getelementptr i8, ptr %2, i32 1
-  %14 = load i8, ptr %13, align 1
-  %15 = getelementptr i8, ptr %comm, i32 1
-  %16 = load i8, ptr %15, align 1
-  %strcmp.cmp3 = icmp ne i8 %14, %16
+  %12 = getelementptr i8, ptr %2, i32 1
+  %13 = load i8, ptr %12, align 1
+  %14 = getelementptr i8, ptr %comm, i32 1
+  %15 = load i8, ptr %14, align 1
+  %strcmp.cmp3 = icmp ne i8 %13, %15
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
-  %strcmp.cmp_null = icmp eq i8 %8, 0
+  %strcmp.cmp_null = icmp eq i8 %7, 0
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %17 = getelementptr i8, ptr %2, i32 2
-  %18 = load i8, ptr %17, align 1
-  %19 = getelementptr i8, ptr %comm, i32 2
-  %20 = load i8, ptr %19, align 1
-  %strcmp.cmp7 = icmp ne i8 %18, %20
+  %16 = getelementptr i8, ptr %2, i32 2
+  %17 = load i8, ptr %16, align 1
+  %18 = getelementptr i8, ptr %comm, i32 2
+  %19 = load i8, ptr %18, align 1
+  %strcmp.cmp7 = icmp ne i8 %17, %19
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %14, 0
+  %strcmp.cmp_null4 = icmp eq i8 %13, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %21 = getelementptr i8, ptr %2, i32 3
-  %22 = load i8, ptr %21, align 1
-  %23 = getelementptr i8, ptr %comm, i32 3
-  %24 = load i8, ptr %23, align 1
-  %strcmp.cmp11 = icmp ne i8 %22, %24
+  %20 = getelementptr i8, ptr %2, i32 3
+  %21 = load i8, ptr %20, align 1
+  %22 = getelementptr i8, ptr %comm, i32 3
+  %23 = load i8, ptr %22, align 1
+  %strcmp.cmp11 = icmp ne i8 %21, %23
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %18, 0
+  %strcmp.cmp_null8 = icmp eq i8 %17, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %25 = getelementptr i8, ptr %2, i32 4
-  %26 = load i8, ptr %25, align 1
-  %27 = getelementptr i8, ptr %comm, i32 4
-  %28 = load i8, ptr %27, align 1
-  %strcmp.cmp15 = icmp ne i8 %26, %28
+  %24 = getelementptr i8, ptr %2, i32 4
+  %25 = load i8, ptr %24, align 1
+  %26 = getelementptr i8, ptr %comm, i32 4
+  %27 = load i8, ptr %26, align 1
+  %strcmp.cmp15 = icmp ne i8 %25, %27
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %22, 0
+  %strcmp.cmp_null12 = icmp eq i8 %21, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
-  %29 = getelementptr i8, ptr %2, i32 5
-  %30 = load i8, ptr %29, align 1
-  %31 = getelementptr i8, ptr %comm, i32 5
-  %32 = load i8, ptr %31, align 1
-  %strcmp.cmp19 = icmp ne i8 %30, %32
+  %28 = getelementptr i8, ptr %2, i32 5
+  %29 = load i8, ptr %28, align 1
+  %30 = getelementptr i8, ptr %comm, i32 5
+  %31 = load i8, ptr %30, align 1
+  %strcmp.cmp19 = icmp ne i8 %29, %31
   br i1 %strcmp.cmp19, label %strcmp.false, label %strcmp.loop_null_cmp18
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %26, 0
+  %strcmp.cmp_null16 = icmp eq i8 %25, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 strcmp.loop17:                                    ; preds = %strcmp.loop_null_cmp18
-  %33 = getelementptr i8, ptr %2, i32 6
-  %34 = load i8, ptr %33, align 1
-  %35 = getelementptr i8, ptr %comm, i32 6
-  %36 = load i8, ptr %35, align 1
-  %strcmp.cmp23 = icmp ne i8 %34, %36
+  %32 = getelementptr i8, ptr %2, i32 6
+  %33 = load i8, ptr %32, align 1
+  %34 = getelementptr i8, ptr %comm, i32 6
+  %35 = load i8, ptr %34, align 1
+  %strcmp.cmp23 = icmp ne i8 %33, %35
   br i1 %strcmp.cmp23, label %strcmp.false, label %strcmp.loop_null_cmp22
 
 strcmp.loop_null_cmp18:                           ; preds = %strcmp.loop13
-  %strcmp.cmp_null20 = icmp eq i8 %30, 0
+  %strcmp.cmp_null20 = icmp eq i8 %29, 0
   br i1 %strcmp.cmp_null20, label %strcmp.done, label %strcmp.loop17
 
 strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
-  %37 = getelementptr i8, ptr %2, i32 7
-  %38 = load i8, ptr %37, align 1
-  %39 = getelementptr i8, ptr %comm, i32 7
-  %40 = load i8, ptr %39, align 1
-  %strcmp.cmp27 = icmp ne i8 %38, %40
+  %36 = getelementptr i8, ptr %2, i32 7
+  %37 = load i8, ptr %36, align 1
+  %38 = getelementptr i8, ptr %comm, i32 7
+  %39 = load i8, ptr %38, align 1
+  %strcmp.cmp27 = icmp ne i8 %37, %39
   br i1 %strcmp.cmp27, label %strcmp.false, label %strcmp.loop_null_cmp26
 
 strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop17
-  %strcmp.cmp_null24 = icmp eq i8 %34, 0
+  %strcmp.cmp_null24 = icmp eq i8 %33, 0
   br i1 %strcmp.cmp_null24, label %strcmp.done, label %strcmp.loop21
 
 strcmp.loop25:                                    ; preds = %strcmp.loop_null_cmp26
-  %41 = getelementptr i8, ptr %2, i32 8
-  %42 = load i8, ptr %41, align 1
-  %43 = getelementptr i8, ptr %comm, i32 8
-  %44 = load i8, ptr %43, align 1
-  %strcmp.cmp31 = icmp ne i8 %42, %44
+  %40 = getelementptr i8, ptr %2, i32 8
+  %41 = load i8, ptr %40, align 1
+  %42 = getelementptr i8, ptr %comm, i32 8
+  %43 = load i8, ptr %42, align 1
+  %strcmp.cmp31 = icmp ne i8 %41, %43
   br i1 %strcmp.cmp31, label %strcmp.false, label %strcmp.loop_null_cmp30
 
 strcmp.loop_null_cmp26:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null28 = icmp eq i8 %38, 0
+  %strcmp.cmp_null28 = icmp eq i8 %37, 0
   br i1 %strcmp.cmp_null28, label %strcmp.done, label %strcmp.loop25
 
 strcmp.loop29:                                    ; preds = %strcmp.loop_null_cmp30
-  %45 = getelementptr i8, ptr %2, i32 9
-  %46 = load i8, ptr %45, align 1
-  %47 = getelementptr i8, ptr %comm, i32 9
-  %48 = load i8, ptr %47, align 1
-  %strcmp.cmp35 = icmp ne i8 %46, %48
+  %44 = getelementptr i8, ptr %2, i32 9
+  %45 = load i8, ptr %44, align 1
+  %46 = getelementptr i8, ptr %comm, i32 9
+  %47 = load i8, ptr %46, align 1
+  %strcmp.cmp35 = icmp ne i8 %45, %47
   br i1 %strcmp.cmp35, label %strcmp.false, label %strcmp.loop_null_cmp34
 
 strcmp.loop_null_cmp30:                           ; preds = %strcmp.loop25
-  %strcmp.cmp_null32 = icmp eq i8 %42, 0
+  %strcmp.cmp_null32 = icmp eq i8 %41, 0
   br i1 %strcmp.cmp_null32, label %strcmp.done, label %strcmp.loop29
 
 strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
-  %49 = getelementptr i8, ptr %2, i32 10
-  %50 = load i8, ptr %49, align 1
-  %51 = getelementptr i8, ptr %comm, i32 10
-  %52 = load i8, ptr %51, align 1
-  %strcmp.cmp39 = icmp ne i8 %50, %52
+  %48 = getelementptr i8, ptr %2, i32 10
+  %49 = load i8, ptr %48, align 1
+  %50 = getelementptr i8, ptr %comm, i32 10
+  %51 = load i8, ptr %50, align 1
+  %strcmp.cmp39 = icmp ne i8 %49, %51
   br i1 %strcmp.cmp39, label %strcmp.false, label %strcmp.loop_null_cmp38
 
 strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop29
-  %strcmp.cmp_null36 = icmp eq i8 %46, 0
+  %strcmp.cmp_null36 = icmp eq i8 %45, 0
   br i1 %strcmp.cmp_null36, label %strcmp.done, label %strcmp.loop33
 
 strcmp.loop37:                                    ; preds = %strcmp.loop_null_cmp38
-  %53 = getelementptr i8, ptr %2, i32 11
-  %54 = load i8, ptr %53, align 1
-  %55 = getelementptr i8, ptr %comm, i32 11
-  %56 = load i8, ptr %55, align 1
-  %strcmp.cmp43 = icmp ne i8 %54, %56
+  %52 = getelementptr i8, ptr %2, i32 11
+  %53 = load i8, ptr %52, align 1
+  %54 = getelementptr i8, ptr %comm, i32 11
+  %55 = load i8, ptr %54, align 1
+  %strcmp.cmp43 = icmp ne i8 %53, %55
   br i1 %strcmp.cmp43, label %strcmp.false, label %strcmp.loop_null_cmp42
 
 strcmp.loop_null_cmp38:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null40 = icmp eq i8 %50, 0
+  %strcmp.cmp_null40 = icmp eq i8 %49, 0
   br i1 %strcmp.cmp_null40, label %strcmp.done, label %strcmp.loop37
 
 strcmp.loop41:                                    ; preds = %strcmp.loop_null_cmp42
-  %57 = getelementptr i8, ptr %2, i32 12
-  %58 = load i8, ptr %57, align 1
-  %59 = getelementptr i8, ptr %comm, i32 12
-  %60 = load i8, ptr %59, align 1
-  %strcmp.cmp47 = icmp ne i8 %58, %60
+  %56 = getelementptr i8, ptr %2, i32 12
+  %57 = load i8, ptr %56, align 1
+  %58 = getelementptr i8, ptr %comm, i32 12
+  %59 = load i8, ptr %58, align 1
+  %strcmp.cmp47 = icmp ne i8 %57, %59
   br i1 %strcmp.cmp47, label %strcmp.false, label %strcmp.loop_null_cmp46
 
 strcmp.loop_null_cmp42:                           ; preds = %strcmp.loop37
-  %strcmp.cmp_null44 = icmp eq i8 %54, 0
+  %strcmp.cmp_null44 = icmp eq i8 %53, 0
   br i1 %strcmp.cmp_null44, label %strcmp.done, label %strcmp.loop41
 
 strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
-  %61 = getelementptr i8, ptr %2, i32 13
-  %62 = load i8, ptr %61, align 1
-  %63 = getelementptr i8, ptr %comm, i32 13
-  %64 = load i8, ptr %63, align 1
-  %strcmp.cmp51 = icmp ne i8 %62, %64
+  %60 = getelementptr i8, ptr %2, i32 13
+  %61 = load i8, ptr %60, align 1
+  %62 = getelementptr i8, ptr %comm, i32 13
+  %63 = load i8, ptr %62, align 1
+  %strcmp.cmp51 = icmp ne i8 %61, %63
   br i1 %strcmp.cmp51, label %strcmp.false, label %strcmp.loop_null_cmp50
 
 strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop41
-  %strcmp.cmp_null48 = icmp eq i8 %58, 0
+  %strcmp.cmp_null48 = icmp eq i8 %57, 0
   br i1 %strcmp.cmp_null48, label %strcmp.done, label %strcmp.loop45
 
 strcmp.loop49:                                    ; preds = %strcmp.loop_null_cmp50
-  %65 = getelementptr i8, ptr %2, i32 14
-  %66 = load i8, ptr %65, align 1
-  %67 = getelementptr i8, ptr %comm, i32 14
-  %68 = load i8, ptr %67, align 1
-  %strcmp.cmp55 = icmp ne i8 %66, %68
+  %64 = getelementptr i8, ptr %2, i32 14
+  %65 = load i8, ptr %64, align 1
+  %66 = getelementptr i8, ptr %comm, i32 14
+  %67 = load i8, ptr %66, align 1
+  %strcmp.cmp55 = icmp ne i8 %65, %67
   br i1 %strcmp.cmp55, label %strcmp.false, label %strcmp.loop_null_cmp54
 
 strcmp.loop_null_cmp50:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null52 = icmp eq i8 %62, 0
+  %strcmp.cmp_null52 = icmp eq i8 %61, 0
   br i1 %strcmp.cmp_null52, label %strcmp.done, label %strcmp.loop49
 
 strcmp.loop53:                                    ; preds = %strcmp.loop_null_cmp54
-  %69 = getelementptr i8, ptr %2, i32 15
-  %70 = load i8, ptr %69, align 1
-  %71 = getelementptr i8, ptr %comm, i32 15
-  %72 = load i8, ptr %71, align 1
-  %strcmp.cmp59 = icmp ne i8 %70, %72
+  %68 = getelementptr i8, ptr %2, i32 15
+  %69 = load i8, ptr %68, align 1
+  %70 = getelementptr i8, ptr %comm, i32 15
+  %71 = load i8, ptr %70, align 1
+  %strcmp.cmp59 = icmp ne i8 %69, %71
   br i1 %strcmp.cmp59, label %strcmp.false, label %strcmp.loop_null_cmp58
 
 strcmp.loop_null_cmp54:                           ; preds = %strcmp.loop49
-  %strcmp.cmp_null56 = icmp eq i8 %66, 0
+  %strcmp.cmp_null56 = icmp eq i8 %65, 0
   br i1 %strcmp.cmp_null56, label %strcmp.done, label %strcmp.loop53
 
 strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
   br label %strcmp.done
 
 strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop53
-  %strcmp.cmp_null60 = icmp eq i8 %70, 0
+  %strcmp.cmp_null60 = icmp eq i8 %69, 0
   br i1 %strcmp.cmp_null60, label %strcmp.done, label %strcmp.loop57
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!52}
 !llvm.module.flags = !{!54}

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -23,34 +23,41 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 1, i64 %3)
-  %4 = load i8, ptr %"struct Foo.x", align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 1, ptr %6)
+  %7 = load i8, ptr %"struct Foo.x", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %5 = sext i8 %4 to i64
-  store i64 %5, ptr %"@x_val", align 8
+  %8 = sext i8 %7 to i64
+  store i64 %8, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -23,34 +23,41 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 1, i64 %3)
-  %4 = load i8, ptr %"struct Foo.x", align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 1, ptr %6)
+  %7 = load i8, ptr %"struct Foo.x", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %5 = sext i8 %4 to i64
-  store i64 %5, ptr %"@x_val", align 8
+  %8 = sext i8 %7 to i64
+  store i64 %8, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -24,38 +24,45 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, i64 %3)
-  %4 = load i64, ptr %"struct Foo.x", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, ptr %6)
+  %7 = load i64, ptr %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 4, i64 %4)
-  %5 = load i32, ptr %deref, align 4
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 4, i64 %7)
+  %8 = load i32, ptr %deref, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %6 = sext i32 %5 to i64
-  store i64 %6, ptr %"@x_val", align 8
+  %9 = sext i32 %8 to i64
+  store i64 %9, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -24,38 +24,45 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, i64 %3)
-  %4 = load i64, ptr %"struct Foo.x", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, ptr %6)
+  %7 = load i64, ptr %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 4, i64 %4)
-  %5 = load i32, ptr %deref, align 4
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 4, i64 %7)
+  %8 = load i32, ptr %deref, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %6 = sext i32 %5 to i64
-  store i64 %6, ptr %"@x_val", align 8
+  %9 = sext i32 %8 to i64
+  store i64 %9, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -23,34 +23,41 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 4, i64 %3)
-  %4 = load i32, ptr %"struct Foo.x", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 4, ptr %6)
+  %7 = load i32, ptr %"struct Foo.x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %5 = sext i32 %4 to i64
-  store i64 %5, ptr %"@x_val", align 8
+  %8 = sext i32 %7 to i64
+  store i64 %8, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -23,34 +23,41 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 4, i64 %3)
-  %4 = load i32, ptr %"struct Foo.x", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 4, ptr %6)
+  %7 = load i32, ptr %"struct Foo.x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %5 = sext i32 %4 to i64
-  store i64 %5, ptr %"@x_val", align 8
+  %8 = sext i32 %7 to i64
+  store i64 %8, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_long_1.ll
+++ b/tests/codegen/llvm/struct_long_1.ll
@@ -23,33 +23,40 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, i64 %3)
-  %4 = load i64, ptr %"struct Foo.x", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, ptr %6)
+  %7 = load i64, ptr %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %4, ptr %"@x_val", align 8
+  store i64 %7, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_long_2.ll
+++ b/tests/codegen/llvm/struct_long_2.ll
@@ -23,33 +23,40 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, i64 %3)
-  %4 = load i64, ptr %"struct Foo.x", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, ptr %6)
+  %7 = load i64, ptr %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %4, ptr %"@x_val", align 8
+  store i64 %7, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -23,35 +23,43 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
-  %4 = add i64 %3, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
+  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
+  %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo::(unnamed at definitions.h:2:14).x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo::(unnamed at definitions.h:2:14).x", i32 4, i64 %4)
-  %5 = load i32, ptr %"struct Foo::(unnamed at definitions.h:2:14).x", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo::(unnamed at definitions.h:2:14).x", i32 4, ptr %8)
+  %9 = load i32, ptr %"struct Foo::(unnamed at definitions.h:2:14).x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo::(unnamed at definitions.h:2:14).x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %6 = sext i32 %5 to i64
-  store i64 %6, ptr %"@x_val", align 8
+  %10 = sext i32 %9 to i64
+  store i64 %10, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -23,35 +23,43 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
-  %4 = add i64 %3, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
+  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
+  %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo::(unnamed at definitions.h:2:14).x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo::(unnamed at definitions.h:2:14).x", i32 4, i64 %4)
-  %5 = load i32, ptr %"struct Foo::(unnamed at definitions.h:2:14).x", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo::(unnamed at definitions.h:2:14).x", i32 4, ptr %8)
+  %9 = load i32, ptr %"struct Foo::(unnamed at definitions.h:2:14).x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo::(unnamed at definitions.h:2:14).x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %6 = sext i32 %5 to i64
-  store i64 %6, ptr %"@x_val", align 8
+  %10 = sext i32 %9 to i64
+  store i64 %10, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -23,35 +23,43 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
-  %4 = add i64 %3, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
+  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
+  %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Bar.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, i64 %4)
-  %5 = load i32, ptr %"struct Bar.x", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, ptr %8)
+  %9 = load i32, ptr %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Bar.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %6 = sext i32 %5 to i64
-  store i64 %6, ptr %"@x_val", align 8
+  %10 = sext i32 %9 to i64
+  store i64 %10, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -23,35 +23,43 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
-  %4 = add i64 %3, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
+  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
+  %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Bar.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, i64 %4)
-  %5 = load i32, ptr %"struct Bar.x", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, ptr %8)
+  %9 = load i32, ptr %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Bar.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %6 = sext i32 %5 to i64
-  store i64 %6, ptr %"@x_val", align 8
+  %10 = sext i32 %9 to i64
+  store i64 %10, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -24,39 +24,48 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.bar")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.bar", i32 8, i64 %3)
-  %4 = load i64, ptr %"struct Foo.bar", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.bar", i32 8, ptr %6)
+  %7 = load i64, ptr %"struct Foo.bar", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.bar")
-  %5 = add i64 %4, 0
+  %8 = inttoptr i64 %7 to ptr
+  %9 = call ptr @llvm.preserve.static.offset(ptr %8)
+  %10 = getelementptr i8, ptr %9, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Bar.x")
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, i64 %5)
-  %6 = load i32, ptr %"struct Bar.x", align 4
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, ptr %10)
+  %11 = load i32, ptr %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Bar.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %7 = sext i32 %6 to i64
-  store i64 %7, ptr %"@x_val", align 8
+  %12 = sext i32 %11 to i64
+  store i64 %12, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -24,39 +24,48 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.bar")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.bar", i32 8, i64 %3)
-  %4 = load i64, ptr %"struct Foo.bar", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.bar", i32 8, ptr %6)
+  %7 = load i64, ptr %"struct Foo.bar", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.bar")
-  %5 = add i64 %4, 0
+  %8 = inttoptr i64 %7 to ptr
+  %9 = call ptr @llvm.preserve.static.offset(ptr %8)
+  %10 = getelementptr i8, ptr %9, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Bar.x")
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, i64 %5)
-  %6 = load i32, ptr %"struct Bar.x", align 4
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, ptr %10)
+  %11 = load i32, ptr %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Bar.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %7 = sext i32 %6 to i64
-  store i64 %7, ptr %"@x_val", align 8
+  %12 = sext i32 %11 to i64
+  store i64 %12, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_save_1.ll
+++ b/tests/codegen/llvm/struct_save_1.ll
@@ -19,8 +19,9 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !51 {
 entry:
   %"@foo_val" = alloca [12 x i8], align 1
   %"@foo_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key")
   store i64 0, ptr %"@foo_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_val")
@@ -31,14 +32,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50}

--- a/tests/codegen/llvm/struct_save_2.ll
+++ b/tests/codegen/llvm/struct_save_2.ll
@@ -19,8 +19,9 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !51 {
 entry:
   %"@foo_val" = alloca [12 x i8], align 1
   %"@foo_key" = alloca i64, align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key")
   store i64 0, ptr %"@foo_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_val")
@@ -31,14 +32,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50}

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -23,34 +23,41 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 2, i64 %3)
-  %4 = load i16, ptr %"struct Foo.x", align 2
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 2, ptr %6)
+  %7 = load i16, ptr %"struct Foo.x", align 2
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %5 = sext i16 %4 to i64
-  store i64 %5, ptr %"@x_val", align 8
+  %8 = sext i16 %7 to i64
+  store i64 %8, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -23,34 +23,41 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %2 = load i64, ptr %"$foo", align 8
-  %3 = add i64 %2, 0
+  %3 = load i64, ptr %"$foo", align 8
+  %4 = inttoptr i64 %3 to ptr
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 2, i64 %3)
-  %4 = load i16, ptr %"struct Foo.x", align 2
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 2, ptr %6)
+  %7 = load i16, ptr %"struct Foo.x", align 2
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %5 = sext i16 %4 to i64
-  store i64 %5, ptr %"@x_val", align 8
+  %8 = sext i16 %7 to i64
+  store i64 %8, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -24,40 +24,47 @@ entry:
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %2 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %2
-  %3 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %3, i8 0, i64 64, i1 false)
-  %4 = load i64, ptr %"$foo", align 8
-  %5 = add i64 %4, 0
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %3
+  %4 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 64, i1 false)
+  %5 = load i64, ptr %"$foo", align 8
+  %6 = inttoptr i64 %5 to ptr
+  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
+  %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.str")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.str", i32 8, i64 %5)
-  %6 = load i64, ptr %"struct Foo.str", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.str", i32 8, ptr %8)
+  %9 = load i64, ptr %"struct Foo.str", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.str")
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %3, i32 64, i64 %6)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %4, i32 64, i64 %9)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@mystr_key")
   store i64 0, ptr %"@mystr_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_mystr, ptr %"@mystr_key", ptr %3, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_mystr, ptr %"@mystr_key", ptr %4, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@mystr_key")
   ret i64 0
 }
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!54}
 !llvm.module.flags = !{!56}

--- a/tests/codegen/llvm/tuple_array_struct.ll
+++ b/tests/codegen/llvm/tuple_array_struct.ll
@@ -20,17 +20,21 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !58 {
 entry:
   %"@t_key" = alloca i64, align 8
   %tuple = alloca %"struct Foo_int32[4]__tuple_t", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %2 = getelementptr i64, ptr %0, i64 13
-  %arg1 = load volatile i64, ptr %2, align 8
-  %3 = add i64 %arg1, 0
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
+  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %4 = getelementptr i64, ptr %3, i64 13
+  %arg1 = load volatile i64, ptr %4, align 8
+  %5 = inttoptr i64 %arg1 to ptr
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 24, i1 false)
-  %4 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %tuple, i32 0, i32 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 8, i64 %arg0)
-  %5 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %tuple, i32 0, i32 1
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %5, i32 16, i64 %3)
+  %8 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %tuple, i32 0, i32 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %8, i32 8, i64 %arg0)
+  %9 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %tuple, i32 0, i32 1
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %9, i32 16, ptr %7)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %tuple, i64 0)
@@ -39,18 +43,22 @@ entry:
   ret i64 0
 }
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!55}
 !llvm.module.flags = !{!57}

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -22,26 +22,27 @@ entry:
   %"@t_key" = alloca i64, align 8
   %tuple = alloca %uint8_usym_t_int64__tuple_t, align 8
   %usym = alloca %usym_t, align 8
-  %1 = getelementptr i64, ptr %0, i64 16
-  %reg_ip = load volatile i64, ptr %1, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 16
+  %reg_ip = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %2 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %2 to i32
-  %3 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
-  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
-  %5 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
-  store i64 %reg_ip, ptr %3, align 8
-  store i32 %pid, ptr %4, align 4
-  store i32 0, ptr %5, align 4
+  %3 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %3 to i32
+  %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
+  %5 = getelementptr %usym_t, ptr %usym, i64 0, i32 1
+  %6 = getelementptr %usym_t, ptr %usym, i64 0, i32 2
+  store i64 %reg_ip, ptr %4, align 8
+  store i32 %pid, ptr %5, align 4
+  store i32 0, ptr %6, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 32, i1 false)
-  %6 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 0
-  store i8 1, ptr %6, align 1
-  %7 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %usym, i64 16, i1 false)
-  %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 2
-  store i64 10, ptr %8, align 8
+  %7 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 0
+  store i8 1, ptr %7, align 1
+  %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %usym, i64 16, i1 false)
+  %9 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 2
+  store i64 10, ptr %9, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %tuple, i64 0)
@@ -50,22 +51,26 @@ entry:
   ret i64 0
 }
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #4
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #4 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!53}
 !llvm.module.flags = !{!55}

--- a/tests/codegen/llvm/variable_assign_array.ll
+++ b/tests/codegen/llvm/variable_assign_array.ll
@@ -23,35 +23,45 @@ entry:
   %"$var" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
   store i64 0, ptr %"$var", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %2 = add i64 %arg0, 0
-  store i64 %2, ptr %"$var", align 8
-  %3 = load i64, ptr %"$var", align 8
-  %4 = add i64 %3, 0
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = call ptr @llvm.preserve.static.offset(ptr %3)
+  %5 = getelementptr i8, ptr %4, i64 0
+  %6 = ptrtoint ptr %5 to i64
+  store i64 %6, ptr %"$var", align 8
+  %7 = load i64, ptr %"$var", align 8
+  %8 = inttoptr i64 %7 to ptr
+  %9 = call ptr @llvm.preserve.static.offset(ptr %8)
+  %10 = getelementptr i8, ptr %9, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %array_access)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %array_access, i32 4, i64 %4)
-  %5 = load i32, ptr %array_access, align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %array_access, i32 4, ptr %10)
+  %11 = load i32, ptr %array_access, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %array_access)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %6 = sext i32 %5 to i64
-  store i64 %6, ptr %"@x_val", align 8
+  %12 = sext i32 %11 to i64
+  store i64 %12, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44}

--- a/tests/codegen/llvm/variable_scratch_buf.ll
+++ b/tests/codegen/llvm/variable_scratch_buf.ll
@@ -27,10 +27,11 @@ entry:
   %cpu.id.bounded = and i64 %get_cpu_id, %3
   %4 = getelementptr [1 x [2 x [8 x i8]]], ptr @var_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   store i64 0, ptr %4, align 8
-  %5 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %5, align 8
-  %6 = icmp ugt i64 %arg0, 0
-  %true_cond = icmp ne i1 %6, false
+  %5 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %6 = getelementptr i64, ptr %5, i64 14
+  %arg0 = load volatile i64, ptr %6, align 8
+  %7 = icmp ugt i64 %arg0, 0
+  %true_cond = icmp ne i1 %7, false
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
@@ -45,7 +46,11 @@ else_body:                                        ; preds = %entry
   br label %if_end
 }
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
 attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}

--- a/tests/codegen/llvm/variable_stack.ll
+++ b/tests/codegen/llvm/variable_stack.ll
@@ -21,10 +21,11 @@ entry:
   %"$x" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
   store i64 0, ptr %"$x", align 8
-  %1 = getelementptr i64, ptr %0, i64 14
-  %arg0 = load volatile i64, ptr %1, align 8
-  %2 = icmp ugt i64 %arg0, 0
-  %true_cond = icmp ne i1 %2, false
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 14
+  %arg0 = load volatile i64, ptr %2, align 8
+  %3 = icmp ugt i64 %arg0, 0
+  %true_cond = icmp ne i1 %3, false
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
@@ -39,11 +40,15 @@ else_body:                                        ; preds = %entry
   br label %if_end
 }
 
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38}

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -108,3 +108,13 @@ NAME unaligned key with aligned value
 PROG BEGIN { @mapA["aaaabbb", 0] = 1; @mapA["ccccdddd", 0] = 1; }
 EXPECT Attaching 1 probe...
 TIMEOUT 1
+
+# In some cases, LLVM can generate code that violates the BPF verifier
+# constraint that the context pointer is not modified prior to access (see
+# #3603). #3629 introduces the use of intrinsics that should ensure that this
+# doesn't happen, but this runtime test exercises a pattern that previously
+# produced code that failed to verify.
+NAME preserve context pointer
+PROG BEGIN { @test[1] = (uint64)1; } tracepoint:syscalls:sys_enter_kill { if (strcontains(comm, "test")) { @test[(uint64)args.pid] = 1; } if (args.pid == @test[1]) { print((1)); } if (args.pid == @test[1]) { print((1)); exit(); } }
+EXPECT Attaching 2 probes...
+TIMEOUT 1


### PR DESCRIPTION
Currently argument access uses pointer conversions with manual integer
arithmetic. This means that using the same values will often result in
LLVM choosing to save these intermediate values, which violates the
rules imposed by the verified if these are based on the context.

This situation is increasingly likely to happen as programs get larger.

Instead, we change to use proper pointer arithmetic and protect context
accesses using the `preserve_static_offsets` instrinsic, which was
introduced for Clang to prevent the same set of optimizations.

This results in optimized IR being generated that no longer uses manual
pointer casts and integer arithmetic, and ends up being converted to the
`llvm.bpf.getelementptr.and.load` intrinsic:

```
-  %14 = ptrtoint ptr %0 to i64
-  %15 = add i64 %14, 16
-  %16 = inttoptr i64 %15 to ptr
-  %17 = load volatile i64, ptr %16, align 8
+  %14 = call i64 (ptr, i1, i8, i8, i8, i1, ...) @llvm.bpf.getelementptr.and.load.i64(ptr elementtype(i8) %0, i1 true, i8 0, i8 1, i8 3, i1 false, i64 immarg 16)
```

The types used during IR generation are still very confusing, because
pointers are often treated as integer types. This could be significant
improved in the future, and types coerced only at the point where it is
needed.

##### Checklist

- [X] Language changes are updated in `man/adoc/bpftrace.adoc`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests