### PR TITLE
Static builds: update Alpine to 3.21

### DIFF
--- a/docker/Dockerfile.static
+++ b/docker/Dockerfile.static
@@ -1,6 +1,6 @@
 # This Dockerfile is used to test STATIC_LINKING=ON builds in the CI
 
-FROM alpine:3.18
+FROM alpine:3.21
 
 RUN apk add --update \
   asciidoctor \
@@ -12,8 +12,9 @@ RUN apk add --update \
   bzip2-static \
   build-base \
   cereal \
-  clang-dev \
-  clang-static \
+  clang18-dev \
+  clang18-extra-tools \
+  clang18-static \
   cmake \
   elfutils-dev \
   flex-dev \
@@ -24,8 +25,9 @@ RUN apk add --update \
   libpcap-dev \
   libc6-compat \
   linux-headers \
-  llvm16-dev \
-  llvm16-static \
+  llvm18-dev \
+  llvm18-gtest \
+  llvm18-static \
   musl-obstack-dev \
   openssl-dev \
   pahole \
@@ -39,6 +41,12 @@ RUN apk add --update \
   zstd-dev \
   zstd-static
 
-# It looks like llvm16 prefers to dynamically link against zstd. Extremely
+# It looks like llvm18 prefers to dynamically link against zstd. Extremely
 # unclear why.  Work around it by modifying LLVMExports.cmake.
-RUN sed -i 's/libzstd_shared/libzstd_static/g' /usr/lib/llvm16/lib/cmake/llvm/LLVMExports.cmake
+RUN sed -i 's/libzstd_shared/libzstd_static/g' /usr/lib/llvm18/lib/cmake/llvm/LLVMExports.cmake
+
+# bcc-static needs clang/llvm 18 instead of the latest 19. As a consequence,
+# CMake reports errors as that it cannot find files in /usr/lib/cmake/clang/ as
+# it's a symlink for /usr/lib/cmake/clangXX/ which is only created when the
+# latest clang is installed. To fix this, create the symlink manually.
+RUN ln -s 'clang18' /usr/lib/cmake/clang

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -33,6 +33,7 @@ if(STATIC_LINKING)
       clangAST
       clangAnalysis
       clangBasic
+      clangCodeGen
       clangDriver
       clangEdit
       clangFormat
@@ -49,9 +50,13 @@ if(STATIC_LINKING)
 
   set(llvm_lib_names
       bpfcodegen
+      coverage
+      frontenddriver
+      frontendhlsl
       frontendopenmp
       ipo
       irreader
+      lto
       mcjit
       option
       orcjit


### PR DESCRIPTION
We now require libbpf 1.5 for fentry probes to work so we need to update `Dockerfile.static` to use Alpine 3.21 which contains libbpf 1.5.

This comes with a couple of problems:

- bcc-static needs LLVM 18, however the latest one in Alpine is LLVM 19. It is not a problem to install Clang/LLVM 18, which we do, however, CMake then reports errors that it cannot find files in `/usr/lib/cmake/clang/`. The reason is that it's a symlink for `/usr/lib/cmake/clangXX/` which is only created when the latest Clang is installed. To fix this, create the symlink manually in Dockerfile.

- bcc in Alpine 3.21 needs an additional Clang library, `libclangCodeGen`. This, in turn, requires a number of additional LLVM libs so add all of them to our CMakeLists.txt.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
