### PR TITLE
bpffeature: Fix alignment in output table

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -571,7 +571,7 @@ static void tabulate(std::stringstream& buf,
   constexpr int width = 35;
   for (size_t i = 0; i < len; i += 2) {
     buf << std::setw(width) << std::left
-        << " " + data[i].first + ": " + data[i].second << std::setw(width);
+        << "  " + data[i].first + ": " + data[i].second << std::setw(width);
     if (i + 1 < len) {
       buf << data[i + 1].first + ": " + data[i + 1].second << std::endl;
     } else {


### PR DESCRIPTION
System and Build sections have leading 2 spaces. 72920bda ("feat(report): bpftrace --info made more compact (#3616)") made later sections lead with a single space.

Fix the above commit.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
