### PR TITLE
RFC: Add ability to cast probe builtin as a string

### DIFF
--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -359,6 +359,17 @@ void ResourceAnalyser::visit(Call &call)
   }
 }
 
+void ResourceAnalyser::visit(Cast &cast)
+{
+  Visitor::visit(cast);
+  if (cast.type.IsStringTy() && cast.expr->type.IsProbeTy()) {
+    const auto max_strlen = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
+    if (exceeds_stack_limit(max_strlen)) {
+      resources_.str_buffers++;
+    }
+  }
+}
+
 void ResourceAnalyser::visit(Map &map)
 {
   Visitor::visit(map);

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -32,6 +32,7 @@ private:
   void visit(Subprog &subprog) override;
   void visit(Builtin &map) override;
   void visit(Call &call) override;
+  void visit(Cast &cast) override;
   void visit(Map &map) override;
   void visit(Tuple &tuple) override;
   void visit(For &f) override;

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -452,6 +452,10 @@ REQUIRES ls /sys/devices/cpu/events/cache-misses
 PROG hardware:cache-misses:10 { print(probe); exit();}
 EXPECT hardware:cache-misses:10
 
+NAME probe_builtin_cast_to_string
+RUN {{BPFTRACE}} -e 'uprobe:testprogs/uprobe_test:uprobeFunction* { if ((string)probe == "uprobe:testprogs/uprobe_test:uprobeFunction2") { print(((string)probe)); } }' -c ./testprogs/uprobe_test
+EXPECT uprobe:testprogs/uprobe_test:uprobeFunction2
+
 NAME BEGIN
 PROG BEGIN { printf("Hello\n"); exit();}
 EXPECT Hello


### PR DESCRIPTION
This allows string comparison in BPF space which is useful if there is a glob matching against multiple probes e.g. `kprobe:vfs_*`. Utilizing the `probe` builtin enforces probe expansion so we get all the probe names in codegen.

Sytnax: `(string)probe`

Issue: https://github.com/bpftrace/bpftrace/issues/3598

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
