### PR TITLE
test: make config_analyzer test more robust

### DIFF
--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -126,11 +126,21 @@ TEST(config_analyser, config_setting)
             UserSymbolCacheType::per_program);
   EXPECT_EQ(bpftrace->config_.get(ConfigKeyInt::log_size), 150);
 
+  // When liblldb is present, the default config for symbol_source is "dwarf",
+  // otherwise the default is "symbol_table".
+#ifdef HAVE_LIBLLDB
   EXPECT_EQ(bpftrace->config_.get(ConfigKeySymbolSource::default_),
             ConfigSymbolSource::dwarf);
   test(*bpftrace, "config = { symbol_source = \"symbol_table\" } BEGIN { }");
   EXPECT_EQ(bpftrace->config_.get(ConfigKeySymbolSource::default_),
             ConfigSymbolSource::symbol_table);
+#else
+  EXPECT_EQ(bpftrace->config_.get(ConfigKeySymbolSource::default_),
+            ConfigSymbolSource::symbol_table);
+  test(*bpftrace, "config = { symbol_source = \"dwarf\" } BEGIN { }");
+  EXPECT_EQ(bpftrace->config_.get(ConfigKeySymbolSource::default_),
+            ConfigSymbolSource::dwarf);
+#endif
 }
 
 } // namespace bpftrace::test::config_analyser


### PR DESCRIPTION
This test currently assumes that `HAVE_LLDB` is a specific setting. Make this robust against the default in the simplest possible way, by using the same `#ifdef` to change the default value probed.

##### Checklist

- [X] Language changes are updated in `man/adoc/bpftrace.adoc` (not needed)
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md` (not needed)
- [X] The new behaviour is covered by tests (not needed)
