### PR TITLE
Fix fentry probes wrt. missing_probes config

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -107,10 +107,13 @@ aot.other.symbolize enum in tuple map value
 aot.probe.fentry
 aot.probe.fentry args
 aot.probe.fentry args as a pointer
+aot.probe.fentry_error_missing_probes
 aot.probe.fentry func builtin
+aot.probe.fentry_ignore_missing_probes
 aot.probe.fentry_module
 aot.probe.fentry_module_wildcard
 aot.probe.fentry_multiple_attach_point_multiple_functions
+aot.probe.fentry_warn_missing_probes
 aot.probe.fentry_wildcard
 aot.probe.fexit
 aot.probe.kfunc

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -95,6 +95,9 @@ std::string progtypeName(libbpf::bpf_prog_type t)
 
 void AttachedProbe::attach_fentry()
 {
+  if (progfd_ < 0)
+    return;
+
   tracing_fd_ = bpf_raw_tracepoint_open(nullptr, progfd_);
   if (tracing_fd_ < 0) {
     throw FatalUserException("Error attaching probe: " + probe_.name);

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -68,6 +68,19 @@ REQUIRES_FEATURE fentry
 REQUIRES_FEATURE btf
 AFTER ./testprogs/fentry_args 1111 2222
 
+NAME fentry_warn_missing_probes
+PROG fentry:vfs_read,fentry:nonsense { exit(); }
+EXPECT WARNING: No BTF found for nonsense, skipping.
+
+NAME fentry_ignore_missing_probes
+PROG config = { missing_probes = "ignore" } fentry:vfs_read,fentry:nonsense { exit(); }
+EXPECT_NONE WARNING: No BTF found for nonsense, skipping.
+
+NAME fentry_error_missing_probes
+PROG config = { missing_probes = "error" } fentry:vfs_read,fentry:nonsense { exit(); }
+EXPECT ERROR: No BTF found for nonsense
+WILL_FAIL
+
 # Sanity check for kfunc/kretfunc alias
 NAME kfunc
 PROG kfunc:vfs_read { printf("SUCCESS %d\n", pid); exit(); }


### PR DESCRIPTION
Currently, fentry/fexit probes do not correctly respect the `missing_probes` config, especially for the "ignore" and "warn" settings. The reason is that while a warning is correctly displayed (or not for "ignore"), the probe is still attempted to be loaded which causes the loading of the entire BPF object fail as libbpf fails on not finding the symbol in BTF.

Fix this issue by disabling auto-load for missing probes. Note that this means that the code for the missing probes is still generated into the BPF object. This is a bit inefficient but will be necessary for AOT as we will not know which symbols exist on the target machine in advance.

Also fix the error/warning message a bit to show `symbol` instead of `:symbol` in case when module name is not given.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
