### PR TITLE
Add `FunctionRegistry` for keeping track of functions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,12 @@ endif()
 add_library(required_resources required_resources.cpp)
 add_dependencies(required_resources parser)
 
+add_library(compiler_core STATIC
+  functions.cpp
+  struct.cpp
+  types.cpp
+)
+
 add_library(runtime STATIC
   attached_probe.cpp
   bpffeature.cpp
@@ -37,10 +43,8 @@ add_library(runtime STATIC
   printf.cpp
   resolve_cgroupid.cpp
   run_bpftrace.cpp
-  struct.cpp
   tracefs.cpp
   debugfs.cpp
-  types.cpp
   usdt.cpp
   utils.cpp
   pcap_writer.cpp

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library(ast STATIC
 )
 
 target_compile_definitions(ast PRIVATE ${BPFTRACE_FLAGS})
-target_link_libraries(ast PUBLIC ast_defs arch parser)
+target_link_libraries(ast PUBLIC ast_defs arch compiler_core parser)
 
 if(STATIC_LINKING)
   include(Util)

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -11,6 +11,7 @@
 #include "utils.h"
 
 namespace bpftrace {
+
 namespace ast {
 
 class VisitorBase;

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -16,7 +16,7 @@ DIBuilderBPF::DIBuilderBPF(Module &module) : DIBuilder(module)
   file = createFile("bpftrace.bpf.o", ".");
 }
 
-void DIBuilderBPF::createFunctionDebugInfo(Function &func,
+void DIBuilderBPF::createFunctionDebugInfo(llvm::Function &func,
                                            const SizedType &ret_type,
                                            const Struct &args,
                                            bool is_declaration)
@@ -61,7 +61,7 @@ void DIBuilderBPF::createFunctionDebugInfo(Function &func,
   func.setSubprogram(subprog);
 }
 
-void DIBuilderBPF::createProbeDebugInfo(Function &probe_func)
+void DIBuilderBPF::createProbeDebugInfo(llvm::Function &probe_func)
 {
   // BPF probe function has:
   // - int return type

--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "functions.h"
 #include "types.h"
 
 #include <linux/bpf.h>
@@ -19,11 +20,11 @@ class DIBuilderBPF : public DIBuilder {
 public:
   DIBuilderBPF(Module &module);
 
-  void createFunctionDebugInfo(Function &func,
+  void createFunctionDebugInfo(llvm::Function &func,
                                const SizedType &ret_type,
                                const Struct &args,
                                bool is_declaration = false);
-  void createProbeDebugInfo(Function &probe_func);
+  void createProbeDebugInfo(llvm::Function &probe_func);
 
   DIType *getInt8Ty();
   DIType *getInt16Ty();

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -173,15 +173,15 @@ IRBuilderBPF::IRBuilderBPF(LLVMContext &context,
   // Declare external LLVM function
   FunctionType *pseudo_func_type = FunctionType::get(
       getInt64Ty(), { getInt64Ty(), getInt64Ty() }, false);
-  Function::Create(pseudo_func_type,
-                   GlobalValue::ExternalLinkage,
-                   "llvm.bpf.pseudo",
-                   &module_);
+  llvm::Function::Create(pseudo_func_type,
+                         GlobalValue::ExternalLinkage,
+                         "llvm.bpf.pseudo",
+                         &module_);
 }
 
 void IRBuilderBPF::hoist(const std::function<void()> &functor)
 {
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock &entry_block = parent->getEntryBlock();
 
   auto ip = saveIP();
@@ -701,7 +701,7 @@ CallInst *IRBuilderBPF::createGetScratchMap(const std::string &map_name,
       map_name, keyAlloc, val_ptr_ty, "lookup_" + name + "_map");
   CreateLifetimeEnd(keyAlloc);
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *lookup_failure_block = BasicBlock::Create(
       module_.getContext(), "lookup_" + name + "_failure", parent);
   BasicBlock *lookup_merge_block = BasicBlock::Create(
@@ -754,7 +754,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
   CallInst *call = createMapLookup(map_name, key);
 
   // Check if result == 0
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *lookup_success_block = BasicBlock::Create(module_.getContext(),
                                                         "lookup_success",
                                                         parent);
@@ -840,7 +840,7 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
   CreateStore(getInt64(0), val_1);
   CreateStore(getInt64(0), val_2);
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *while_cond = BasicBlock::Create(module_.getContext(),
                                               "while_cond",
                                               parent);
@@ -868,7 +868,7 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
                                          key,
                                          CreateLoad(getInt32Ty(), i));
 
-  Function *lookup_parent = GetInsertBlock()->getParent();
+  llvm::Function *lookup_parent = GetInsertBlock()->getParent();
   BasicBlock *lookup_success_block = BasicBlock::Create(module_.getContext(),
                                                         "lookup_success",
                                                         lookup_parent);
@@ -898,7 +898,7 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
   CreateBr(while_cond);
   SetInsertPoint(lookup_failure_block);
 
-  Function *error_parent = GetInsertBlock()->getParent();
+  llvm::Function *error_parent = GetInsertBlock()->getParent();
   BasicBlock *error_success_block = BasicBlock::Create(module_.getContext(),
                                                        "error_success",
                                                        error_parent);
@@ -939,7 +939,7 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
     // the value is negative, flip it, do an unsigned division, and then
     // flip it back
     if (type.IsSigned()) {
-      Function *avg_parent = GetInsertBlock()->getParent();
+      llvm::Function *avg_parent = GetInsertBlock()->getParent();
       BasicBlock *is_negative_block = BasicBlock::Create(module_.getContext(),
                                                          "is_negative",
                                                          avg_parent);
@@ -1028,7 +1028,7 @@ void IRBuilderBPF::createPerCpuMinMax(AllocaInst *ret,
    * }
    */
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *val_set_success = BasicBlock::Create(module_.getContext(),
                                                    "val_set_success",
                                                    parent);
@@ -1212,7 +1212,7 @@ void IRBuilderBPF::CreateCheckSetRecursion(const location &loc,
 
   CallInst *call = createMapLookup(map_ident, key);
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *lookup_success_block = BasicBlock::Create(module_.getContext(),
                                                         "lookup_success",
                                                         parent);
@@ -1244,7 +1244,7 @@ void IRBuilderBPF::CreateCheckSetRecursion(const location &loc,
                                         8,
                                         AtomicOrdering::SequentiallyConsistent);
 
-  Function *set_parent = GetInsertBlock()->getParent();
+  llvm::Function *set_parent = GetInsertBlock()->getParent();
   BasicBlock *value_is_set_block = BasicBlock::Create(module_.getContext(),
                                                       "value_is_set",
                                                       set_parent);
@@ -1284,7 +1284,7 @@ void IRBuilderBPF::CreateUnSetRecursion(const location &loc)
 
   CallInst *call = createMapLookup(map_ident, key);
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *lookup_success_block = BasicBlock::Create(module_.getContext(),
                                                         "lookup_success",
                                                         parent);
@@ -1585,7 +1585,7 @@ Value *IRBuilderBPF::CreateStrncmp(Value *str1,
   std::optional<std::string> literal1 = ValToString(str1);
   std::optional<std::string> literal2 = ValToString(str2);
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   AllocaInst *store = CreateAllocaBPF(getInt1Ty(), "strcmp.result");
   BasicBlock *str_ne = BasicBlock::Create(module_.getContext(),
                                           "strcmp.false",
@@ -1703,7 +1703,7 @@ Value *IRBuilderBPF::CreateStrcontains(Value *val1,
     }
   }
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   AllocaInst *store = CreateAllocaBPF(getInt1Ty(), "strcontains.result");
   BasicBlock *done_true = BasicBlock::Create(module_.getContext(),
                                              "strcontains.true",
@@ -1859,7 +1859,7 @@ Value *IRBuilderBPF::CreateIntegerArrayCmpUnrolled(Value *ctx,
   AllocaInst *v1 = CreateAllocaBPF(elem_type, "v1");
   AllocaInst *v2 = CreateAllocaBPF(elem_type, "v2");
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   AllocaInst *store = CreateAllocaBPF(getInt1Ty(), "arraycmp.result");
   CreateStore(getInt1(inverse), store);
   BasicBlock *arr_ne = BasicBlock::Create(module_.getContext(),
@@ -1958,7 +1958,7 @@ Value *IRBuilderBPF::CreateIntegerArrayCmp(Value *ctx,
   AllocaInst *store = CreateAllocaBPF(getInt1Ty(), "arraycmp.result");
   CreateStore(getInt1(inverse), store);
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *while_cond = BasicBlock::Create(module_.getContext(),
                                               "while_cond",
                                               parent);
@@ -2301,7 +2301,7 @@ void IRBuilderBPF::CreateRingbufOutput(Value *data,
                                 "ringbuf_output",
                                 loc);
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *loss_block = BasicBlock::Create(module_.getContext(),
                                               "event_loss_counter",
                                               parent);
@@ -2326,7 +2326,7 @@ void IRBuilderBPF::CreateAtomicIncCounter(const std::string &map_name,
   CreateStore(getInt32(idx), key);
 
   CallInst *call = createMapLookup(map_name, key);
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *lookup_success_block = BasicBlock::Create(module_.getContext(),
                                                         "lookup_success",
                                                         parent);
@@ -2381,7 +2381,7 @@ void IRBuilderBPF::CreateMapElemAdd(Value *ctx,
   CallInst *call = CreateMapLookup(map, key);
   SizedType &type = map.type;
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *lookup_success_block = BasicBlock::Create(module_.getContext(),
                                                         "lookup_success",
                                                         parent);
@@ -2723,7 +2723,7 @@ void IRBuilderBPF::CreateHelperErrorCond(Value *ctx,
       (bpftrace_.helper_check_level_ == 1 && return_zero_if_err(func_id)))
     return;
 
-  Function *parent = GetInsertBlock()->getParent();
+  llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *helper_failure_block = BasicBlock::Create(module_.getContext(),
                                                         "helper_failure",
                                                         parent);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -374,7 +374,7 @@ private:
                        const SizedType &type);
 
   std::map<std::string, StructType *> structs_;
-  Function *preserve_static_offset_ = nullptr;
+  llvm::Function *preserve_static_offset_ = nullptr;
 };
 
 } // namespace ast

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -196,7 +196,7 @@ void CodegenLLVM::kstack_ustack(const std::string &ident,
                               stack_key,
                               { b_.getInt64(0), b_.getInt32(1) }));
 
-  Function *parent = b_.GetInsertBlock()->getParent();
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
   BasicBlock *stack_scratch_failure = BasicBlock::Create(
       module_->getContext(), "stack_scratch_failure", parent);
   BasicBlock *merge_block = BasicBlock::Create(module_->getContext(),
@@ -523,7 +523,7 @@ void CodegenLLVM::visit(Call &call)
 
     llvm::Type *mm_struct_ty = b_.GetMapValueType(map.type);
 
-    Function *parent = b_.GetInsertBlock()->getParent();
+    llvm::Function *parent = b_.GetInsertBlock()->getParent();
     BasicBlock *lookup_success_block = BasicBlock::Create(module_->getContext(),
                                                           "lookup_success",
                                                           parent);
@@ -631,7 +631,7 @@ void CodegenLLVM::visit(Call &call)
 
     llvm::Type *avg_struct_ty = b_.GetMapValueType(map.type);
 
-    Function *parent = b_.GetInsertBlock()->getParent();
+    llvm::Function *parent = b_.GetInsertBlock()->getParent();
     BasicBlock *lookup_success_block = BasicBlock::Create(module_->getContext(),
                                                           "lookup_success",
                                                           parent);
@@ -959,7 +959,7 @@ void CodegenLLVM::visit(Call &call)
     auto scoped_del = accept(arg0);
     auto addrspace = arg0->type.GetAS();
 
-    Function *parent = b_.GetInsertBlock()->getParent();
+    llvm::Function *parent = b_.GetInsertBlock()->getParent();
     BasicBlock *failure_callback = BasicBlock::Create(module_->getContext(),
                                                       "failure_callback",
                                                       parent);
@@ -1462,9 +1462,9 @@ void CodegenLLVM::visit(Call &call)
     assert(arg->type.IsIntegerTy());
     if (arg->type.GetSize() > 1) {
       llvm::Type *arg_type = b_.GetType(arg->type);
-      Function *swap_fun = Intrinsic::getDeclaration(module_.get(),
-                                                     Intrinsic::bswap,
-                                                     { arg_type });
+      llvm::Function *swap_fun = Intrinsic::getDeclaration(module_.get(),
+                                                           Intrinsic::bswap,
+                                                           { arg_type });
 
       expr_ = b_.CreateCall(swap_fun, { expr_ });
     }
@@ -1975,7 +1975,7 @@ void CodegenLLVM::visit(Unop &unop)
 
 void CodegenLLVM::visit(Ternary &ternary)
 {
-  Function *parent = b_.GetInsertBlock()->getParent();
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
   BasicBlock *left_block = BasicBlock::Create(module_->getContext(),
                                               "left",
                                               parent);
@@ -2537,7 +2537,7 @@ void CodegenLLVM::visit(VarDeclStatement &decl)
 
 void CodegenLLVM::visit(If &if_node)
 {
-  Function *parent = b_.GetInsertBlock()->getParent();
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
   BasicBlock *if_true = BasicBlock::Create(module_->getContext(),
                                            "if_body",
                                            parent);
@@ -2638,7 +2638,7 @@ void CodegenLLVM::visit(Jump &jump)
   //   br label %while_cond
   //
 
-  Function *parent = b_.GetInsertBlock()->getParent();
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
   BasicBlock *unreach = BasicBlock::Create(module_->getContext(),
                                            "unreach",
                                            parent);
@@ -2650,7 +2650,7 @@ void CodegenLLVM::visit(While &while_block)
   if (!loop_metadata_)
     loop_metadata_ = createLoopMetadata();
 
-  Function *parent = b_.GetInsertBlock()->getParent();
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
   BasicBlock *while_cond = BasicBlock::Create(module_->getContext(),
                                               "while_cond",
                                               parent);
@@ -2726,7 +2726,7 @@ void CodegenLLVM::visit(For &f)
 
 void CodegenLLVM::visit(Predicate &pred)
 {
-  Function *parent = b_.GetInsertBlock()->getParent();
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
   BasicBlock *pred_false_block = BasicBlock::Create(module_->getContext(),
                                                     "pred_false",
                                                     parent);
@@ -2780,8 +2780,8 @@ void CodegenLLVM::generateProbe(Probe &probe,
   auto func_name = get_function_name_for_probe(name,
                                                index,
                                                usdt_location_index);
-  Function *func = Function::Create(
-      func_type, Function::ExternalLinkage, func_name, module_.get());
+  auto *func = llvm::Function::Create(
+      func_type, llvm::Function::ExternalLinkage, func_name, module_.get());
   func->setSection(get_section_name(func_name));
   debug_.createProbeDebugInfo(*func);
 
@@ -2869,8 +2869,10 @@ void CodegenLLVM::visit(Subprog &subprog)
                                               arg_types,
                                               0);
 
-  Function *func = Function::Create(
-      func_type, Function::InternalLinkage, subprog.name(), module_.get());
+  auto *func = llvm::Function::Create(func_type,
+                                      llvm::Function::InternalLinkage,
+                                      subprog.name(),
+                                      module_.get());
   BasicBlock *entry = BasicBlock::Create(module_->getContext(), "entry", func);
   b_.SetInsertPoint(entry);
 
@@ -3197,7 +3199,7 @@ Value *CodegenLLVM::createLogicalAnd(Binop &binop)
   assert(binop.left->type.IsIntTy() || binop.left->type.IsPtrTy());
   assert(binop.right->type.IsIntTy() || binop.right->type.IsPtrTy());
 
-  Function *parent = b_.GetInsertBlock()->getParent();
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
   BasicBlock *lhs_true_block = BasicBlock::Create(module_->getContext(),
                                                   "&&_lhs_true",
                                                   parent);
@@ -3246,7 +3248,7 @@ Value *CodegenLLVM::createLogicalOr(Binop &binop)
   assert(binop.left->type.IsIntTy() || binop.left->type.IsPtrTy());
   assert(binop.right->type.IsIntTy() || binop.right->type.IsPtrTy());
 
-  Function *parent = b_.GetInsertBlock()->getParent();
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
   BasicBlock *lhs_false_block = BasicBlock::Create(module_->getContext(),
                                                    "||_lhs_false",
                                                    parent);
@@ -3290,7 +3292,7 @@ Value *CodegenLLVM::createLogicalOr(Binop &binop)
   return b_.CreateLoad(b_.getInt64Ty(), result);
 }
 
-Function *CodegenLLVM::createLog2Function()
+llvm::Function *CodegenLLVM::createLog2Function()
 {
   auto ip = b_.saveIP();
   // Arguments: VAL (int64), K (0..5)
@@ -3332,8 +3334,8 @@ Function *CodegenLLVM::createLog2Function()
 
   FunctionType *log2_func_type = FunctionType::get(
       b_.getInt64Ty(), { b_.getInt64Ty(), b_.getInt64Ty() }, false);
-  Function *log2_func = Function::Create(
-      log2_func_type, Function::InternalLinkage, "log2", module_.get());
+  auto *log2_func = llvm::Function::Create(
+      log2_func_type, llvm::Function::InternalLinkage, "log2", module_.get());
   log2_func->addFnAttr(Attribute::AlwaysInline);
   log2_func->setSection("helpers");
   BasicBlock *entry = BasicBlock::Create(module_->getContext(),
@@ -3412,7 +3414,7 @@ Function *CodegenLLVM::createLog2Function()
   return module_->getFunction("log2");
 }
 
-Function *CodegenLLVM::createLinearFunction()
+llvm::Function *CodegenLLVM::createLinearFunction()
 {
   auto ip = b_.saveIP();
   // lhist() returns a bucket index for the given value. The first and last
@@ -3438,8 +3440,10 @@ Function *CodegenLLVM::createLinearFunction()
       b_.getInt64Ty(),
       { b_.getInt64Ty(), b_.getInt64Ty(), b_.getInt64Ty(), b_.getInt64Ty() },
       false);
-  Function *linear_func = Function::Create(
-      linear_func_type, Function::InternalLinkage, "linear", module_.get());
+  auto *linear_func = llvm::Function::Create(linear_func_type,
+                                             llvm::Function::InternalLinkage,
+                                             "linear",
+                                             module_.get());
   linear_func->addFnAttr(Attribute::AlwaysInline);
   linear_func->setSection("helpers");
   BasicBlock *entry = BasicBlock::Create(module_->getContext(),
@@ -3609,8 +3613,8 @@ void CodegenLLVM::generateWatchpointSetupProbe(
 {
   auto func_name = get_function_name_for_watchpoint_setup(expanded_probe_name,
                                                           index);
-  Function *func = Function::Create(
-      func_type, Function::ExternalLinkage, func_name, module_.get());
+  auto *func = llvm::Function::Create(
+      func_type, llvm::Function::ExternalLinkage, func_name, module_.get());
   func->setSection(get_section_name(func_name));
   debug_.createProbeDebugInfo(*func);
 
@@ -4237,7 +4241,7 @@ void CodegenLLVM::probereadDatastructElem(Value *src_data,
       // check context access for iter probes (required by kernel)
       if (data_type.IsCtxAccess() &&
           probetype(current_attach_point_->provider) == ProbeType::iter) {
-        Function *parent = b_.GetInsertBlock()->getParent();
+        llvm::Function *parent = b_.GetInsertBlock()->getParent();
         BasicBlock *pred_false_block = BasicBlock::Create(module_->getContext(),
                                                           "pred_false",
                                                           parent);
@@ -4308,7 +4312,7 @@ void CodegenLLVM::createIncDec(Unop &unop)
   }
 }
 
-Function *CodegenLLVM::createMurmurHash2Func()
+llvm::Function *CodegenLLVM::createMurmurHash2Func()
 {
   // The goal is to produce the following code:
   //
@@ -4339,10 +4343,11 @@ Function *CodegenLLVM::createMurmurHash2Func()
                                        b_.getInt64Ty() };
   FunctionType *callback_type = FunctionType::get(b_.getInt64Ty(), args, false);
 
-  Function *callback = Function::Create(callback_type,
-                                        Function::LinkageTypes::InternalLinkage,
-                                        "murmur_hash_2",
-                                        module_.get());
+  auto *callback = llvm::Function::Create(
+      callback_type,
+      llvm::Function::LinkageTypes::InternalLinkage,
+      "murmur_hash_2",
+      module_.get());
   callback->addFnAttr(Attribute::AlwaysInline);
   callback->setSection("helpers");
 
@@ -4379,7 +4384,7 @@ Function *CodegenLLVM::createMurmurHash2Func()
   // int i = 0;
   b_.CreateStore(b_.getInt8(0), i);
 
-  Function *parent = b_.GetInsertBlock()->getParent();
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
   BasicBlock *while_cond = BasicBlock::Create(module_->getContext(),
                                               "while_cond",
                                               parent);
@@ -4469,7 +4474,7 @@ Function *CodegenLLVM::createMurmurHash2Func()
   return callback;
 }
 
-Function *CodegenLLVM::createMapLenCallback()
+llvm::Function *CodegenLLVM::createMapLenCallback()
 {
   // The goal is to produce the following code:
   //
@@ -4485,10 +4490,11 @@ Function *CodegenLLVM::createMapLenCallback()
 
   FunctionType *callback_type = FunctionType::get(b_.getInt64Ty(), args, false);
 
-  Function *callback = Function::Create(callback_type,
-                                        Function::LinkageTypes::InternalLinkage,
-                                        "map_len_cb",
-                                        module_.get());
+  auto *callback = llvm::Function::Create(
+      callback_type,
+      llvm::Function::LinkageTypes::InternalLinkage,
+      "map_len_cb",
+      module_.get());
 
   callback->setDSOLocal(true);
   callback->setVisibility(llvm::GlobalValue::DefaultVisibility);
@@ -4511,7 +4517,8 @@ Function *CodegenLLVM::createMapLenCallback()
   return callback;
 }
 
-Function *CodegenLLVM::createForEachMapCallback(const For &f, llvm::Type *ctx_t)
+llvm::Function *CodegenLLVM::createForEachMapCallback(const For &f,
+                                                      llvm::Type *ctx_t)
 {
   /*
    * Create a callback function suitable for passing to bpf_for_each_map_elem,
@@ -4536,10 +4543,11 @@ Function *CodegenLLVM::createForEachMapCallback(const For &f, llvm::Type *ctx_t)
   };
 
   FunctionType *callback_type = FunctionType::get(b_.getInt64Ty(), args, false);
-  Function *callback = Function::Create(callback_type,
-                                        Function::LinkageTypes::InternalLinkage,
-                                        "map_for_each_cb",
-                                        module_.get());
+  auto *callback = llvm::Function::Create(
+      callback_type,
+      llvm::Function::LinkageTypes::InternalLinkage,
+      "map_for_each_cb",
+      module_.get());
   callback->setDSOLocal(true);
   callback->setVisibility(llvm::GlobalValue::DefaultVisibility);
   callback->setSection(".text");
@@ -4664,7 +4672,7 @@ Value *CodegenLLVM::createFmtString(int print_id)
 ///
 /// If the function declaration is already in the module, just return it.
 ///
-Function *CodegenLLVM::DeclareKernelFunc(Kfunc kfunc)
+llvm::Function *CodegenLLVM::DeclareKernelFunc(Kfunc kfunc)
 {
   const std::string &func_name = kfunc_name(kfunc);
   if (auto *fun = module_->getFunction(func_name))
@@ -4687,10 +4695,10 @@ Function *CodegenLLVM::DeclareKernelFunc(Kfunc kfunc)
       args,
       false);
 
-  Function *fun = Function::Create(func_type,
-                                   llvm::GlobalValue::ExternalWeakLinkage,
-                                   func_name,
-                                   module_.get());
+  auto *fun = llvm::Function::Create(func_type,
+                                     llvm::GlobalValue::ExternalWeakLinkage,
+                                     func_name,
+                                     module_.get());
   fun->setSection(".ksyms");
   fun->setUnnamedAddr(GlobalValue::UnnamedAddr::Local);
 

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -195,8 +195,8 @@ private:
 
   void compareStructure(SizedType &our_type, llvm::Type *llvm_type);
 
-  Function *createLog2Function();
-  Function *createLinearFunction();
+  llvm::Function *createLog2Function();
+  llvm::Function *createLinearFunction();
   MDNode *createLoopMetadata();
 
   std::pair<Value *, uint64_t> getString(Expression *expr);
@@ -257,9 +257,9 @@ private:
 
   void createIncDec(Unop &unop);
 
-  Function *createMapLenCallback();
-  Function *createForEachMapCallback(const For &f, llvm::Type *ctx_t);
-  Function *createMurmurHash2Func();
+  llvm::Function *createMapLenCallback();
+  llvm::Function *createForEachMapCallback(const For &f, llvm::Type *ctx_t);
+  llvm::Function *createMurmurHash2Func();
 
   Value *createFmtString(int print_id);
 
@@ -272,7 +272,7 @@ private:
   VariableLLVM *maybeGetVariable(const std::string &);
   VariableLLVM &getVariable(const std::string &);
 
-  Function *DeclareKernelFunc(Kfunc kfunc);
+  llvm::Function *DeclareKernelFunc(Kfunc kfunc);
 
   CallInst *CreateKernelFuncCall(Kfunc kfunc,
                                  ArrayRef<Value *> args,
@@ -314,10 +314,10 @@ private:
 
   std::unordered_map<std::string, libbpf::bpf_map_type> map_types_;
 
-  Function *linear_func_ = nullptr;
-  Function *log2_func_ = nullptr;
-  Function *murmur_hash_2_func_ = nullptr;
-  Function *map_len_func_ = nullptr;
+  llvm::Function *linear_func_ = nullptr;
+  llvm::Function *log2_func_ = nullptr;
+  llvm::Function *murmur_hash_2_func_ = nullptr;
+  llvm::Function *map_len_func_ = nullptr;
   MDNode *loop_metadata_ = nullptr;
 
   size_t getStructSize(StructType *s)

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -23,6 +23,7 @@
 #include "child.h"
 #include "config.h"
 #include "dwarf_parser.h"
+#include "functions.h"
 #include "output.h"
 #include "pcap_writer.h"
 #include "printf.h"
@@ -182,6 +183,7 @@ public:
   RequiredResources resources;
   BpfBytecode bytecode_;
   StructManager structs;
+  FunctionRegistry functions;
   std::map<std::string, std::string> macros_;
   // Map of enum variant_name to (variant_value, enum_name)
   std::map<std::string, std::tuple<uint64_t, std::string>> enums_;

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,0 +1,165 @@
+#include "functions.h"
+
+#include "log.h"
+
+namespace bpftrace {
+
+namespace {
+std::string arg_types_str(const std::vector<SizedType> &arg_types)
+{
+  std::string str = "(";
+  bool first = true;
+  for (const SizedType &arg_type : arg_types) {
+    if (!first)
+      str += ", ";
+    str += typestr(arg_type);
+    first = false;
+  }
+  str += ")";
+  return str;
+}
+
+std::string param_types_str(const std::vector<Param> &params)
+{
+  std::string str = "(";
+  bool first = true;
+  for (const Param &param : params) {
+    if (!first)
+      str += ", ";
+    str += typestr(param.type());
+    first = false;
+  }
+  str += ")";
+  return str;
+}
+} // namespace
+
+const Function *FunctionRegistry::add(Function::Origin origin,
+                                      std::string_view name,
+                                      const SizedType &return_type,
+                                      const std::vector<Param> &params)
+{
+  return add(origin, {}, name, return_type, params);
+}
+
+const Function *FunctionRegistry::add(Function::Origin origin,
+                                      std::string_view ns,
+                                      std::string_view name,
+                                      const SizedType &return_type,
+                                      const std::vector<Param> &params)
+{
+  FqName fq_name{
+    .ns = std::string{ ns },
+    .name = std::string{ name },
+  };
+
+  // Check for duplicate function definitions
+  // The assumption is that builtin functions are all added to the registry
+  // before any user-defined functions.
+  // Builtin functions can be duplicated. Other functions can not.
+  for (const Function &func : funcs_by_fq_name_[fq_name]) {
+    if (func.origin() != Function::Origin::Builtin) {
+      return nullptr;
+    }
+  }
+
+  all_funcs_.push_back(std::make_unique<Function>(
+      origin, std::string{ name }, return_type, params));
+  Function &new_func = *all_funcs_.back().get();
+
+  funcs_by_fq_name_[fq_name].push_back(new_func);
+  return &new_func;
+}
+
+namespace {
+bool can_implicit_cast(const SizedType &from, const SizedType &to)
+{
+  if (from.FitsInto(to))
+    return true;
+
+  if (from.IsStringTy() && to.IsPtrTy() && to.GetPointeeTy()->IsIntTy() &&
+      to.GetPointeeTy()->GetSize() == 1) {
+    // Allow casting from string to int8* or uint8*
+    return true;
+  }
+
+  // Builtin and script functions do not care about string sizes. External
+  // functions cannot be defined to accept string types (they'd take char*)
+  if (from.IsStringTy() && to.IsStringTy())
+    return true;
+
+  return false;
+}
+} // namespace
+
+/*
+ * Find the best function by name for the given argument types.
+ *
+ * Returns either a single function or nullptr, when no such function exists.
+ *
+ * When there are multiple candidate functions with the same name, prefer the
+ * non-builtin over the builtin function.
+ *
+ * Valid functions have the correct name and all arguments can be implicitly
+ * casted into all parameter types.
+ */
+const Function *FunctionRegistry::get(std::string_view ns,
+                                      std::string_view name,
+                                      const std::vector<SizedType> &arg_types,
+                                      std::ostream &out,
+                                      std::optional<location> loc) const
+{
+  FqName fq_name = {
+    .ns = std::string{ ns },
+    .name = std::string{ name },
+  };
+  auto it = funcs_by_fq_name_.find(fq_name);
+  if (it == funcs_by_fq_name_.end()) {
+    LOG(ERROR, loc, out) << "Function not found: '" << name << "'";
+    return nullptr;
+  }
+
+  const auto &candidates = it->second;
+
+  // We disallow duplicate functions other than for builtins, so expect at most
+  // two exact matches.
+  assert(candidates.size() <= 2);
+
+  // No candidates => no match
+  // 1 candidate   => use it
+  // 2 candidates  => use non-builtin candidate
+  const Function *candidate = nullptr;
+  for (const Function &func : candidates) {
+    candidate = &func;
+    if (candidate->origin() != Function::Origin::Builtin)
+      break;
+  }
+
+  // Validate that the candidate's parameters can take our arguments
+  if (candidate) {
+    bool valid = true;
+    if (candidate->params().size() != arg_types.size()) {
+      valid = false;
+    } else {
+      for (size_t i = 0; i < arg_types.size(); i++) {
+        if (!can_implicit_cast(arg_types[i], candidate->params()[i].type())) {
+          valid = false;
+          break;
+        }
+      }
+    }
+
+    if (valid)
+      return candidate;
+  }
+
+  LOG(ERROR, loc, out) << "Cannot call function '" << name
+                       << "' using argument types: "
+                       << arg_types_str(arg_types);
+  LOG(HINT, out) << "Candidate function:\n  " << candidate->name()
+                 << param_types_str(candidate->params());
+
+  return nullptr;
+}
+
+} // namespace bpftrace

--- a/src/functions.h
+++ b/src/functions.h
@@ -1,0 +1,152 @@
+#pragma once
+
+#include <optional>
+#include <ostream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "location.hh"
+#include "types.h"
+
+namespace bpftrace {
+
+/**
+ * A parameter for a BpfScript function
+ */
+class Param {
+public:
+  Param(std::string name, const SizedType &type)
+      : name_(std::move(name)), type_(type)
+  {
+  }
+
+  const std::string &name() const
+  {
+    return name_;
+  }
+  const SizedType &type() const
+  {
+    return type_;
+  }
+
+private:
+  std::string name_;
+  SizedType type_;
+};
+
+/**
+ * Represents the type of a function which is callable in a BpfScript program.
+ *
+ * The function's implementation is not contained here.
+ */
+class Function {
+public:
+  /**
+   * "Builtin" functions are hardcoded into bpftrace.
+   * "Script" functions are user-defined in BpfScript.
+   * "External" functions are imported from pre-compiled BPF programs.
+   */
+  enum class Origin {
+    Builtin,
+    Script,
+    External,
+  };
+
+  Function(Origin origin,
+           std::string name,
+           const SizedType &return_type,
+           const std::vector<Param> &params)
+      : name_(std::move(name)),
+        return_type_(return_type),
+        params_(params),
+        origin_(origin)
+  {
+  }
+
+  const std::string &name() const
+  {
+    return name_;
+  }
+  const SizedType &return_type() const
+  {
+    return return_type_;
+  }
+  const std::vector<Param> &params() const
+  {
+    return params_;
+  }
+  Origin origin() const
+  {
+    return origin_;
+  }
+
+private:
+  std::string name_;
+  SizedType return_type_;
+  std::vector<Param> params_;
+  Origin origin_;
+};
+
+/**
+ * Registry of callable functions
+ *
+ * Non-builtin functions are not allowed to share the same name. When a builtin
+ * and a non-builtin function share a name, the non-builtin is preferred.
+ */
+class FunctionRegistry {
+public:
+  const Function *add(Function::Origin origin,
+                      std::string_view name,
+                      const SizedType &return_type,
+                      const std::vector<Param> &params);
+  const Function *add(Function::Origin origin,
+                      std::string_view ns,
+                      std::string_view name,
+                      const SizedType &return_type,
+                      const std::vector<Param> &params);
+
+  /**
+   * Returns the best match for the given function name and arguments
+   */
+  const Function *get(std::string_view ns,
+                      std::string_view name,
+                      const std::vector<SizedType> &arg_types,
+                      std::ostream &out = std::cerr,
+                      std::optional<location> loc = {}) const;
+
+private:
+  struct FqName {
+    std::string ns;
+    std::string name;
+
+    std::string str() const
+    {
+      if (ns.empty())
+        return name;
+      return ns + "::" + name;
+    }
+
+    bool operator==(const FqName &other) const
+    {
+      return ns == other.ns && name == other.name;
+    }
+  };
+
+  class HashFqName {
+  public:
+    size_t operator()(const FqName &fq_name) const
+    {
+      return std::hash<std::string>()(fq_name.ns) ^
+             std::hash<std::string>()(fq_name.name);
+    }
+  };
+
+  std::unordered_map<FqName,
+                     std::vector<std::reference_wrapper<const Function>>,
+                     HashFqName>
+      funcs_by_fq_name_;
+  std::vector<std::unique_ptr<Function>> all_funcs_;
+};
+
+} // namespace bpftrace

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -163,7 +163,7 @@ LogStream::LogStream(const std::string& file,
 LogStream::LogStream(const std::string& file,
                      int line,
                      LogType type,
-                     const location& loc,
+                     std::optional<location> loc,
                      std::ostream& out)
     : sink_(Log::get()),
       type_(type),

--- a/src/log.h
+++ b/src/log.h
@@ -79,7 +79,7 @@ public:
   LogStream(const std::string& file,
             int line,
             LogType type,
-            const location& loc,
+            std::optional<location> loc,
             std::ostream& out = std::cerr);
   template <typename T>
   LogStream& operator<<(const T& v)
@@ -108,13 +108,13 @@ public:
                int line,
                __attribute__((unused)) LogType,
                std::ostream& out = std::cerr)
-      : LogStream(file, line, LogType::BUG, out){};
+      : LogStream(file, line, LogType::BUG, out) {};
   LogStreamBug(const std::string& file,
                int line,
                __attribute__((unused)) LogType,
-               const location& loc,
+               std::optional<location> loc,
                std::ostream& out = std::cerr)
-      : LogStream(file, line, LogType::BUG, loc, out){};
+      : LogStream(file, line, LogType::BUG, loc, out) {};
   [[noreturn]] ~LogStreamBug();
 };
 

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -172,14 +172,16 @@ void Struct::ClearFields()
   fields.clear();
 }
 
-void StructManager::Add(const std::string &name,
-                        size_t size,
-                        bool allow_override)
+std::weak_ptr<Struct> StructManager::Add(const std::string &name,
+                                         size_t size,
+                                         bool allow_override)
 {
-  if (struct_map_.find(name) != struct_map_.end())
+  auto [it, inserted] = struct_map_.insert(
+      { name, std::make_unique<Struct>(size, allow_override) });
+  if (!inserted)
     throw FatalUserException("Type redefinition: type with name \'" + name +
                              "\' already exists");
-  struct_map_[name] = std::make_unique<Struct>(size, allow_override);
+  return it->second;
 }
 
 void StructManager::Add(const std::string &name, Struct &&record)

--- a/src/struct.h
+++ b/src/struct.h
@@ -164,7 +164,9 @@ namespace bpftrace {
 class StructManager {
 public:
   // struct map manipulation
-  void Add(const std::string &name, size_t size, bool allow_override = true);
+  std::weak_ptr<Struct> Add(const std::string &name,
+                            size_t size,
+                            bool allow_override = true);
   void Add(const std::string &name, Struct &&record);
   std::weak_ptr<Struct> Lookup(const std::string &name) const;
   std::weak_ptr<Struct> LookupOrAdd(const std::string &name,

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -32,55 +32,51 @@ std::ostream &operator<<(std::ostream &os, ProbeType type)
 
 std::ostream &operator<<(std::ostream &os, const SizedType &type)
 {
+  os << typestr(type);
+  return os;
+}
+
+std::string typestr(const SizedType &type)
+{
   switch (type.GetTy()) {
-    case Type::integer: {
-      os << (type.is_signed_ ? "" : "u") << "int" << 8 * type.GetSize();
-      break;
-    }
+    case Type::integer:
+      return (type.is_signed_ ? "int" : "uint") +
+             std::to_string(8 * type.GetSize());
     case Type::inet:
     case Type::string:
-    case Type::buffer: {
-      os << type.GetTy() << "[" << type.GetSize() << "]";
-      break;
-    }
+    case Type::buffer:
+      return typestr(type.GetTy()) + "[" + std::to_string(type.GetSize()) + "]";
     case Type::pointer: {
+      std::string prefix;
       if (type.IsCtxAccess())
-        os << "(ctx) ";
-      os << *type.GetPointeeTy() << " *";
-      break;
+        prefix = "(ctx) ";
+      return prefix + typestr(*type.GetPointeeTy()) + " *";
     }
-    case Type::array: {
-      os << *type.GetElementTy() << "[" << type.GetNumElements() << "]";
-      break;
-    }
-    case Type::record: {
-      os << type.GetName();
-      break;
-    }
-    case Type::reference: {
-      os << *type.GetDereferencedTy() << " &";
-      break;
-    }
+    case Type::array:
+      return typestr(*type.GetElementTy()) + "[" +
+             std::to_string(type.GetNumElements()) + "]";
+    case Type::record:
+      return type.GetName();
+    case Type::reference:
+      return typestr(*type.GetDereferencedTy()) + " &";
     case Type::tuple: {
-      os << "(";
+      std::string res = "(";
       size_t n = type.GetFieldCount();
       for (size_t i = 0; i < n; ++i) {
-        os << type.GetField(i).type;
+        res += typestr(type.GetField(i).type);
         if (i != n - 1)
-          os << ",";
+          res += ",";
       }
-      os << ")";
-      break;
+      res += ")";
+      return res;
     }
     case Type::max_t:
     case Type::min_t:
     case Type::sum_t:
     case Type::avg_t:
     case Type::count_t:
-    case Type::stats_t: {
-      os << (type.is_signed_ ? "" : "u") << type.GetTy();
-      break;
-    }
+    case Type::stats_t:
+      return (type.is_signed_ ? "" : "u") + typestr(type.GetTy());
     case Type::mac_address:
     case Type::kstack_t:
     case Type::ustack_t:
@@ -95,13 +91,11 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
     case Type::hist_t:
     case Type::lhist_t:
     case Type::none:
-    case Type::voidtype: {
-      os << type.GetTy();
-      break;
-    }
+    case Type::voidtype:
+      return typestr(type.GetTy());
   }
 
-  return os;
+  __builtin_unreachable();
 }
 
 std::string to_string(Type ty)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -644,7 +644,15 @@ bool SizedType::FitsInto(const SizedType &t) const
     return GetSize() <= t.GetSize();
 
   if (IsIntegerTy()) {
-    return (IsSigned() == t.IsSigned()) && (GetSize() <= t.GetSize());
+    if (IsSigned() == t.IsSigned())
+      return GetSize() <= t.GetSize();
+
+    // Unsigned into signed requires the destination to be bigger than the
+    // source, e.g. uint32 -> int64.  uint32 does not fit into int32.
+    if (!IsSigned())
+      return GetSize() < t.GetSize();
+
+    return false; // signed never fits into unsigned
   }
 
   if (IsTupleTy()) {

--- a/src/types.h
+++ b/src/types.h
@@ -486,8 +486,7 @@ public:
 
   bool NeedsPercpuMap() const;
 
-  friend std::ostream &operator<<(std::ostream &, const SizedType &);
-  friend std::ostream &operator<<(std::ostream &, Type);
+  friend std::string typestr(const SizedType &type);
 
   void IntoPointer()
   {
@@ -649,6 +648,7 @@ const std::vector<ProbeItem> PROBE_LIST = {
 ProbeType probetype(const std::string &type);
 std::string addrspacestr(AddrSpace as);
 std::string typestr(Type t);
+std::string typestr(const SizedType &type);
 std::string expand_probe_name(const std::string &orig_name);
 std::string probetypeName(ProbeType t);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(bpftrace_test
   collect_nodes.cpp
   cstring_view.cpp
   field_analyser.cpp
+  function_registry.cpp
   log.cpp
   main.cpp
   mocks.cpp

--- a/tests/function_registry.cpp
+++ b/tests/function_registry.cpp
@@ -1,0 +1,361 @@
+#include "functions.h"
+
+#include <sstream>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "struct.h"
+
+namespace bpftrace::test::function_registry {
+
+using ::testing::Property;
+using ::testing::StrEq;
+using ::testing::Throws;
+
+class TestFunctionRegistryPopulated : public ::testing::Test {
+protected:
+  TestFunctionRegistryPopulated()
+  {
+    unique_no_args_ = reg_.add(
+        Function::Origin::Builtin, "unique_no_args", CreateNone(), {});
+    unique_int8_ = reg_.add(Function::Origin::Builtin,
+                            "unique_int8",
+                            CreateNone(),
+                            {
+                                Param{ "a", CreateInt8() },
+                            });
+    unique_int16_ = reg_.add(Function::Origin::Builtin,
+                             "unique_int16",
+                             CreateNone(),
+                             {
+                                 Param{ "a", CreateInt16() },
+                             });
+    unique_int32_ = reg_.add(Function::Origin::Builtin,
+                             "unique_int32",
+                             CreateNone(),
+                             {
+                                 Param{ "a", CreateInt32() },
+                             });
+    unique_int64_ = reg_.add(Function::Origin::Builtin,
+                             "unique_int64",
+                             CreateNone(),
+                             {
+                                 Param{ "a", CreateInt64() },
+                             });
+    unique_uint8_ = reg_.add(Function::Origin::Builtin,
+                             "unique_uint8",
+                             CreateNone(),
+                             {
+                                 Param{ "a", CreateUInt8() },
+                             });
+    unique_uint16_ = reg_.add(Function::Origin::Builtin,
+                              "unique_uint16",
+                              CreateNone(),
+                              {
+                                  Param{ "a", CreateUInt16() },
+                              });
+    unique_uint32_ = reg_.add(Function::Origin::Builtin,
+                              "unique_uint32",
+                              CreateNone(),
+                              {
+                                  Param{ "a", CreateUInt32() },
+                              });
+    unique_uint64_ = reg_.add(Function::Origin::Builtin,
+                              "unique_uint64",
+                              CreateNone(),
+                              {
+                                  Param{ "a", CreateUInt64() },
+                              });
+    unique_string_ = reg_.add(Function::Origin::Builtin,
+                              "unique_string",
+                              CreateNone(),
+                              {
+                                  Param{ "a", CreateString(32) },
+                              });
+    unique_tuple_ = reg_.add(
+        Function::Origin::Builtin,
+        "unique_tuple",
+        CreateNone(),
+        {
+            Param{ "a",
+                   CreateTuple(structs_.AddTuple(
+                       { CreateInt32(), CreateString(64) })) },
+        });
+
+    auto unique_struct_arg = structs_.Add("unique_struct_arg", 8).lock();
+    unique_struct_arg->AddField("x", CreateInt64(), 0);
+    unique_struct_ = reg_.add(
+        Function::Origin::Builtin,
+        "unique_struct",
+        CreateNone(),
+        {
+            Param{ "a", CreateRecord("unique_struct_arg", unique_struct_arg) },
+        });
+
+    takes_c_string_ = reg_.add(Function::Origin::Builtin,
+                               "takes_c_string",
+                               CreateNone(),
+                               {
+                                   Param{ "a", CreatePointer(CreateInt8()) },
+                               });
+
+    overloaded_origin_b_s_builtin_ = reg_.add(
+        Function::Origin::Builtin, "overloaded_origin_b_s", CreateNone(), {});
+    overloaded_origin_b_s_script_ = reg_.add(
+        Function::Origin::Script, "overloaded_origin_b_s", CreateNone(), {});
+
+    overloaded_origin_b_e_builtin_ = reg_.add(
+        Function::Origin::Builtin, "overloaded_origin_b_e", CreateNone(), {});
+    overloaded_origin_b_e_external_ = reg_.add(
+        Function::Origin::External, "overloaded_origin_b_e", CreateNone(), {});
+  }
+
+  FunctionRegistry reg_;
+  StructManager structs_;
+  const Function *unique_no_args_ = nullptr;
+  const Function *unique_int8_ = nullptr;
+  const Function *unique_int16_ = nullptr;
+  const Function *unique_int32_ = nullptr;
+  const Function *unique_int64_ = nullptr;
+  const Function *unique_uint8_ = nullptr;
+  const Function *unique_uint16_ = nullptr;
+  const Function *unique_uint32_ = nullptr;
+  const Function *unique_uint64_ = nullptr;
+  const Function *unique_string_ = nullptr;
+  const Function *unique_tuple_ = nullptr;
+  const Function *unique_struct_ = nullptr;
+  const Function *takes_c_string_ = nullptr;
+  const Function *overloaded_origin_b_s_builtin_ = nullptr;
+  const Function *overloaded_origin_b_s_script_ = nullptr;
+  const Function *overloaded_origin_b_e_builtin_ = nullptr;
+  const Function *overloaded_origin_b_e_external_ = nullptr;
+
+  void test(const std::string &func_name,
+            const std::vector<SizedType> &arg_types,
+            const Function *expected_result);
+  void test(const std::string &func_name,
+            const std::vector<SizedType> &arg_types,
+            std::string_view expected_error);
+};
+
+void TestFunctionRegistryPopulated::test(
+    const std::string &func_name,
+    const std::vector<SizedType> &arg_types,
+    const Function *expected_result)
+{
+  std::stringstream out;
+  EXPECT_EQ(expected_result, reg_.get("", func_name, arg_types, out));
+  EXPECT_EQ("", out.str());
+}
+
+void TestFunctionRegistryPopulated::test(
+    const std::string &func_name,
+    const std::vector<SizedType> &arg_types,
+    std::string_view expected_error)
+{
+  std::stringstream out;
+  EXPECT_EQ(nullptr, reg_.get("", func_name, arg_types, out));
+
+  if (expected_error[0] == '\n')
+    expected_error.remove_prefix(1);
+  EXPECT_EQ(expected_error, out.str());
+}
+
+TEST_F(TestFunctionRegistryPopulated, does_not_exist)
+{
+  test("does_not_exist", {}, R"(
+ERROR: Function not found: 'does_not_exist'
+)");
+}
+
+TEST_F(TestFunctionRegistryPopulated, unique_wrong_args)
+{
+  test("unique_int32", { CreateString(32) }, R"(
+ERROR: Cannot call function 'unique_int32' using argument types: (string[32])
+HINT: Candidate function:
+  unique_int32(int32)
+)");
+  test("unique_int32", { CreateInt32(), CreateInt32() }, R"(
+ERROR: Cannot call function 'unique_int32' using argument types: (int32, int32)
+HINT: Candidate function:
+  unique_int32(int32)
+)");
+}
+
+TEST_F(TestFunctionRegistryPopulated, unique_exact_args)
+{
+  test("unique_no_args", {}, unique_no_args_);
+}
+
+TEST_F(TestFunctionRegistryPopulated, unique_integers)
+{
+  // This test goes through every combination of [u]intX -> [u]intY
+
+  // Include one hardcoded test so we can see clearly what the full error
+  // messages look like. This acts as a sanity-check for the generated error
+  // messages below.
+  test("unique_int8", { CreateInt16() }, R"(
+ERROR: Cannot call function 'unique_int8' using argument types: (int16)
+HINT: Candidate function:
+  unique_int8(int8)
+)");
+
+  // columns represent the type of the parameter being passed in, in order:
+  // int8, int16, int32, int64,    uint8, uint16, uint32, uint64
+  // clang-format off
+  const std::vector<std::vector<int>> expected = {
+    { 1, 0, 0, 0,    0, 0, 0, 0 }, // to int8
+    { 1, 1, 0, 0,    1, 0, 0, 0 }, // to int16
+    { 1, 1, 1, 0,    1, 1, 0, 0 }, // to int32
+    { 1, 1, 1, 1,    1, 1, 1, 0 }, // to int64
+
+    { 0, 0, 0, 0,    1, 0, 0, 0 }, // to uint8
+    { 0, 0, 0, 0,    1, 1, 0, 0 }, // to uint16
+    { 0, 0, 0, 0,    1, 1, 1, 0 }, // to uint32
+    { 0, 0, 0, 0,    1, 1, 1, 1 }, // to uint64
+  };
+  // clang-format on
+  const std::vector<std::pair<std::string, const Function *>> to = {
+    { "int8", unique_int8_ },     { "int16", unique_int16_ },
+    { "int32", unique_int32_ },   { "int64", unique_int64_ },
+    { "uint8", unique_uint8_ },   { "uint16", unique_uint16_ },
+    { "uint32", unique_uint32_ }, { "uint64", unique_uint64_ },
+  };
+  const std::vector<std::pair<std::string, SizedType>> from = {
+    { "int8", CreateInt8() },     { "int16", CreateInt16() },
+    { "int32", CreateInt32() },   { "int64", CreateInt64() },
+    { "uint8", CreateUInt8() },   { "uint16", CreateUInt16() },
+    { "uint32", CreateUInt32() }, { "uint64", CreateUInt64() },
+  };
+
+  for (size_t i = 0; i < to.size(); i++) {
+    for (size_t j = 0; j < from.size(); j++) {
+      std::string func_name = "unique_" + to[i].first;
+
+      if (expected[i][j]) {
+        // valid
+        test(func_name, { from[j].second }, to[i].second);
+      } else {
+        // invalid
+        std::string expected_error = R"(
+ERROR: Cannot call function ')" + func_name +
+                                     "' using argument types: (" +
+                                     from[j].first + R"()
+HINT: Candidate function:
+  )" + func_name + "(" + to[i].first +
+                                     R"()
+)";
+        test(func_name, { from[j].second }, expected_error);
+      }
+    }
+  }
+}
+
+TEST_F(TestFunctionRegistryPopulated, unique_string)
+{
+  test("unique_string", { CreateString(10) }, unique_string_);
+  test("unique_string", { CreateString(32) }, unique_string_);
+  test("unique_string", { CreateString(64) }, unique_string_);
+}
+
+TEST_F(TestFunctionRegistryPopulated, unique_tuple)
+{
+  auto tuple1 = CreateTuple(
+      structs_.AddTuple({ CreateInt16(), CreateString(64) }));
+  auto tuple2 = CreateTuple(
+      structs_.AddTuple({ CreateInt32(), CreateString(64) }));
+  auto tuple3 = CreateTuple(
+      structs_.AddTuple({ CreateInt64(), CreateString(64) }));
+
+  test("unique_tuple", { tuple1 }, unique_tuple_);
+  test("unique_tuple", { tuple2 }, unique_tuple_);
+
+  test("unique_tuple", { tuple3 }, R"(
+ERROR: Cannot call function 'unique_tuple' using argument types: ((int64,string[64]))
+HINT: Candidate function:
+  unique_tuple((int32,string[64]))
+)");
+
+  // Can't pass deconstructed tuple fields as multiple arguments
+  test("unique_tuple", { CreateInt32(), CreateString(64) }, R"(
+ERROR: Cannot call function 'unique_tuple' using argument types: (int32, string[64])
+HINT: Candidate function:
+  unique_tuple((int32,string[64]))
+)");
+}
+
+TEST_F(TestFunctionRegistryPopulated, unique_struct)
+{
+  auto exact_struct = structs_.Lookup("unique_struct_arg");
+
+  auto compatible_struct =
+      structs_.Add("same_layout_as_unique_struct_arg", 8).lock();
+  compatible_struct->AddField("x", CreateInt64(), 0);
+
+  auto different_struct =
+      structs_.Add("different_layout_to_unique_struct_arg", 2).lock();
+  different_struct->AddField("a", CreateInt8(), 0);
+  different_struct->AddField("b", CreateInt8(), 0);
+
+  test("unique_struct",
+       { CreateRecord("unique_struct_arg", exact_struct) },
+       unique_struct_);
+
+  test("unique_struct",
+       { CreateRecord("same_layout_as_unique_struct_arg", compatible_struct) },
+       R"(
+ERROR: Cannot call function 'unique_struct' using argument types: (same_layout_as_unique_struct_arg)
+HINT: Candidate function:
+  unique_struct(unique_struct_arg)
+)");
+
+  test("unique_struct",
+       { CreateRecord("different_layout_to_unique_struct_arg",
+                      different_struct) },
+       R"(
+ERROR: Cannot call function 'unique_struct' using argument types: (different_layout_to_unique_struct_arg)
+HINT: Candidate function:
+  unique_struct(unique_struct_arg)
+)");
+}
+
+TEST_F(TestFunctionRegistryPopulated, string_to_pointer)
+{
+  test("takes_c_string", { CreateString(64) }, takes_c_string_);
+}
+
+TEST_F(TestFunctionRegistryPopulated, overloaded_origin)
+{
+  test("overloaded_origin_b_s", {}, overloaded_origin_b_s_script_);
+  test("overloaded_origin_b_e", {}, overloaded_origin_b_e_external_);
+}
+
+TEST(TestFunctionRegistry, add_namespaced)
+{
+  std::stringstream out; // To suppress (expected) errors from unit test output
+  FunctionRegistry reg;
+  auto *foo = reg.add(Function::Origin::Script, "ns", "foo", CreateNone(), {});
+  EXPECT_EQ(nullptr, reg.get("", "foo", {}, out));
+  EXPECT_EQ(foo, reg.get("ns", "foo", {}, out));
+}
+
+TEST(TestFunctionRegistry, add_duplicate_of_builtin)
+{
+  FunctionRegistry reg;
+  EXPECT_NE(nullptr,
+            reg.add(Function::Origin::Builtin, "foo", CreateNone(), {}));
+  EXPECT_NE(nullptr,
+            reg.add(Function::Origin::Script, "foo", CreateNone(), {}));
+}
+
+TEST(TestFunctionRegistry, add_duplicate)
+{
+  FunctionRegistry reg;
+  EXPECT_NE(nullptr,
+            reg.add(Function::Origin::Script, "foo", CreateNone(), {}));
+  EXPECT_EQ(nullptr,
+            reg.add(Function::Origin::Script, "foo", CreateNone(), {}));
+}
+
+} // namespace bpftrace::test::function_registry


### PR DESCRIPTION
This will eventually be used by builtin functions, user-defined functions from scripts and those imported from external BPF programs.  It handles duplicate function definitions by preferring non-builtin functions over builtins.

See #3610 for an example of how `FunctionRegistry` can be used. 

##### Checklist

- ~[ ]~ Language changes are updated in `man/adoc/bpftrace.adoc`
- ~[ ]~ User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
