### PR TITLE
cmake: Fix version.h build rule

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -13,7 +13,7 @@
 # Try and get a version string from Git tags
 execute_process(
   COMMAND git describe --abbrev=4 --dirty --tags
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  WORKING_DIRECTORY ${bpftrace_SOURCE_DIR}
   OUTPUT_VARIABLE BPFTRACE_VERSION
   ERROR_VARIABLE GIT_DESCRIBE_ERROR
   OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ add_custom_target(version_h
     -Dbpftrace_VERSION_MAJOR=${bpftrace_VERSION_MAJOR}
     -Dbpftrace_VERSION_MINOR=${bpftrace_VERSION_MINOR}
     -Dbpftrace_VERSION_PATCH=${bpftrace_VERSION_PATCH}
+    -Dbpftrace_SOURCE_DIR=${CMAKE_SOURCE_DIR}
     -P ${CMAKE_SOURCE_DIR}/cmake/Version.cmake
 )
 add_dependencies(${BPFTRACE} version_h)


### PR DESCRIPTION
If cmake is invoked from a separate directory, running "git describe" to get the version info fails:

```
  $ cd /tmp/build && cmake [...] ~/bpftrace && make version_h
  -- Could not obtain version string from Git. Falling back to CMake version string.
```

That's because `cmake -P` sets `CMAKE_CURRENT_SOURCE_DIR` to the current working directory[1], which may be outside of the git repository.

Fix it by explicitly passing `CMAKE_SOURCE_DIR` to `Version.cmake`.

[1] https://cmake.org/cmake/help/latest/variable/CMAKE_CURRENT_SOURCE_DIR.html
