### PR TITLE
Fix alignment issues for multiple map keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to
 #### Docs
 #### Tools
 
+## [0.21.3] 2024-12-16
+
+- Fix alignment issue for multi-key maps
+  - [#3646](https://github.com/bpftrace/bpftrace/pull/3646)
+
 ## [0.21.2] 2024-07-17
 
 - Fix min/max map functions

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_policy(SET CMP0057 NEW)
 # bpftrace version number components.
 set(bpftrace_VERSION_MAJOR 0)
 set(bpftrace_VERSION_MINOR 21)
-set(bpftrace_VERSION_PATCH 2)
+set(bpftrace_VERSION_PATCH 3)
 
 include(GNUInstallDirs)
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -309,7 +309,7 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
   else if (type.IsIntTy()) {
     auto sign = type.IsSigned();
     switch (type.GetIntBitWidth()) {
-      // clang-format off
+        // clang-format off
       case 64:
         if (sign)
           return std::to_string(reduce_value<int64_t>(value, nvalues) / (int64_t)div);

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -300,3 +300,18 @@ NAME print_per_cpu_map_vals
 PROG BEGIN { @c = count(); @s = sum(5); @mn = min(1); @mx = max(-1); print((@c, @s, @mn, @mx)); exit(); }
 EXPECT (1, 5, 1, -1)
 TIMEOUT 3
+
+NAME multi map keys need alignment strings last
+PROG BEGIN { @[0, "asdfasdf"] = 1; }
+EXPECT Attaching 1 probe...
+TIMEOUT 3
+
+NAME multi map keys need alignment different size strings
+PROG BEGIN { @mapA["aaaabbb", 0] = 1; @mapA["ccccdddd", 0] = 1; }
+EXPECT Attaching 1 probe...
+TIMEOUT 3
+
+NAME multi map keys need alignment kstack
+PROG BEGIN { @[0, kstack] = 1; }
+EXPECT Attaching 1 probe...
+TIMEOUT 3


### PR DESCRIPTION
This is caused by not aligning all the keys
when one of them has a size that is not a multiple of 8 bytes.

Issue: https://github.com/bpftrace/bpftrace/issues/3644

Partial fix on master: https://github.com/bpftrace/bpftrace/pull/3295

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
