### PR TITLE
Fix alignment for multi-map keys (backport)

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -204,7 +204,9 @@ AllocaInst *IRBuilderBPF::CreateAllocaBPF(const SizedType &stype,
 
 AllocaInst *IRBuilderBPF::CreateAllocaBPF(int bytes, const std::string &name)
 {
-  llvm::Type *ty = ArrayType::get(getInt8Ty(), bytes);
+  // Note that we allocate this as a Int64 array in order to ensure that it has
+  // basic alignment. This is a backport for #3644.
+  llvm::Type *ty = ArrayType::get(getInt64Ty(), (bytes + 7) >> 3);
   return CreateAllocaBPF(ty, name);
 }
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2828,6 +2828,7 @@ AllocaInst *CodegenLLVM::getMultiMapKey(Map &map,
   // as well to take the new lifetime semantics into account.
   AllocaInst *key = b_.CreateAllocaBPF(size, map.ident + "_key");
   auto *key_type = ArrayType::get(b_.getInt8Ty(), size);
+  Value *cast_key = b_.CreatePointerCast(key, key_type->getPointerTo());
 
   int offset = 0;
   bool aligned = true;
@@ -2870,7 +2871,7 @@ AllocaInst *CodegenLLVM::getMultiMapKey(Map &map,
 
   for (auto *extra_key : extra_keys) {
     Value *offset_val = b_.CreateGEP(key_type,
-                                     key,
+                                     cast_key,
                                      { b_.getInt64(0), b_.getInt64(offset) });
     Value *offset_val_cast = b_.CreatePointerCast(
         offset_val, extra_key->getType()->getPointerTo());

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -97,3 +97,10 @@ PROG kfunc:__module_get { print(args.module->trace_events[1]->flags); exit(); }
 AFTER lsmod
 EXPECT Attaching 1 probe...
 TIMEOUT 1
+
+# In the past, codegen would generate misaligned access for multi-key maps in
+# certain conditions. Make sure that this does not happen. See #3644.
+NAME unaligned multi-key map
+PROG profile:hz:1 { @[pid,kstack]=count(); }
+EXPECT Attaching 1 probe...
+TIMEOUT 1


### PR DESCRIPTION
The allocation call for multi-map keys is currently a byte array, which has no alignment restrictions. This is converted to a set of int64 values, which will correctly enforce alignment.

Updates #3644

##### Checklist

- [X] Language changes are updated in `man/adoc/bpftrace.adoc`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [X] The new behaviour is covered by tests
