### PR TITLE
Add basic benchmark for parsing and passes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
                   asciidoctor
                   cereal
                   elfutils
+                  gbenchmark
                   gtest
                   libbfd
                   libelf

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -109,9 +109,6 @@ public:
 
   int64_t n;
   bool is_negative;
-
-private:
-  Integer(const Integer &other) = default;
 };
 
 class PositionalParameter : public Expression {
@@ -125,9 +122,6 @@ public:
   PositionalParameterType ptype;
   long n;
   bool is_in_str = false;
-
-private:
-  PositionalParameter(const PositionalParameter &other) = default;
 };
 
 class String : public Expression {
@@ -137,9 +131,6 @@ public:
   explicit String(const std::string &str, location loc);
 
   std::string str;
-
-private:
-  String(const String &other) = default;
 };
 
 class StackMode : public Expression {
@@ -149,9 +140,6 @@ public:
   explicit StackMode(const std::string &mode, location loc);
 
   std::string mode;
-
-private:
-  StackMode(const StackMode &other) = default;
 };
 
 class Identifier : public Expression {
@@ -161,9 +149,6 @@ public:
   explicit Identifier(const std::string &ident, location loc);
 
   std::string ident;
-
-private:
-  Identifier(const Identifier &other) = default;
 };
 
 class Builtin : public Expression {
@@ -181,9 +166,6 @@ public:
     return !ident.compare(0, 3, "arg") && ident.size() == 4 &&
            ident.at(3) >= '0' && ident.at(3) <= '9';
   }
-
-private:
-  Builtin(const Builtin &other) = default;
 };
 
 class Call : public Expression {
@@ -195,9 +177,6 @@ public:
 
   std::string func;
   ExpressionList vargs;
-
-private:
-  Call(const Call &other) = default;
 };
 
 class Sizeof : public Expression {
@@ -209,9 +188,6 @@ public:
 
   Expression *expr = nullptr;
   SizedType argtype;
-
-private:
-  Sizeof(const Sizeof &other) = default;
 };
 
 class Offsetof : public Expression {
@@ -224,9 +200,6 @@ public:
   SizedType record;
   Expression *expr = nullptr;
   std::string field;
-
-private:
-  Offsetof(const Offsetof &other) = default;
 };
 
 class Map : public Expression {
@@ -240,9 +213,6 @@ public:
   Expression *key_expr = nullptr;
   SizedType key_type;
   bool skip_key_validation = false;
-
-private:
-  Map(const Map &other) = default;
 };
 
 class Variable : public Expression {
@@ -252,9 +222,6 @@ public:
   explicit Variable(const std::string &ident, location loc);
 
   std::string ident;
-
-private:
-  Variable(const Variable &other) = default;
 };
 
 class Binop : public Expression {
@@ -266,9 +233,6 @@ public:
   Expression *left = nullptr;
   Expression *right = nullptr;
   Operator op;
-
-private:
-  Binop(const Binop &other) = default;
 };
 
 class Unop : public Expression {
@@ -284,9 +248,6 @@ public:
   Expression *expr = nullptr;
   Operator op;
   bool is_post_op;
-
-private:
-  Unop(const Unop &other) = default;
 };
 
 class FieldAccess : public Expression {
@@ -300,9 +261,6 @@ public:
   Expression *expr = nullptr;
   std::string field;
   ssize_t index = -1;
-
-private:
-  FieldAccess(const FieldAccess &other) = default;
 };
 
 class ArrayAccess : public Expression {
@@ -314,9 +272,6 @@ public:
 
   Expression *expr = nullptr;
   Expression *indexpr = nullptr;
-
-private:
-  ArrayAccess(const ArrayAccess &other) = default;
 };
 
 class Cast : public Expression {
@@ -326,9 +281,6 @@ public:
   Cast(SizedType type, Expression *expr, location loc);
 
   Expression *expr = nullptr;
-
-private:
-  Cast(const Cast &other) = default;
 };
 
 class Tuple : public Expression {
@@ -338,9 +290,6 @@ public:
   Tuple(ExpressionList &&elems, location loc);
 
   ExpressionList elems;
-
-private:
-  Tuple(const Tuple &other) = default;
 };
 
 class Statement : public Node {
@@ -364,9 +313,6 @@ public:
   explicit ExprStatement(Expression *expr, location loc);
 
   Expression *expr = nullptr;
-
-private:
-  ExprStatement(const ExprStatement &other) = default;
 };
 
 class VarDeclStatement : public Statement {
@@ -378,9 +324,6 @@ public:
 
   Variable *var = nullptr;
   bool set_type = false;
-
-private:
-  VarDeclStatement(const VarDeclStatement &other) = default;
 };
 
 class AssignMapStatement : public Statement {
@@ -391,9 +334,6 @@ public:
 
   Map *map = nullptr;
   Expression *expr = nullptr;
-
-private:
-  AssignMapStatement(const AssignMapStatement &other) = default;
 };
 
 class AssignVarStatement : public Statement {
@@ -410,9 +350,6 @@ public:
   VarDeclStatement *var_decl_stmt = nullptr;
   Variable *var = nullptr;
   Expression *expr = nullptr;
-
-private:
-  AssignVarStatement(const AssignVarStatement &other) = default;
 };
 
 class AssignConfigVarStatement : public Statement {
@@ -425,9 +362,6 @@ public:
 
   std::string config_var;
   Expression *expr = nullptr;
-
-private:
-  AssignConfigVarStatement(const AssignConfigVarStatement &other) = default;
 };
 
 class Block : public Statement {
@@ -437,9 +371,6 @@ public:
   Block(StatementList &&stmts);
 
   StatementList stmts;
-
-private:
-  Block(const Block &other) = default;
 };
 
 class If : public Statement {
@@ -451,9 +382,6 @@ public:
   Expression *cond = nullptr;
   Block *if_block = nullptr;
   Block *else_block = nullptr;
-
-private:
-  If(const If &other) = default;
 };
 
 class Unroll : public Statement {
@@ -465,9 +393,6 @@ public:
   long int var = 0;
   Expression *expr = nullptr;
   Block *block = nullptr;
-
-private:
-  Unroll(const Unroll &other) = default;
 };
 
 class Jump : public Statement {
@@ -485,9 +410,6 @@ public:
 
   JumpType ident = JumpType::INVALID;
   Expression *return_value;
-
-private:
-  Jump(const Jump &other) = default;
 };
 
 class Predicate : public Node {
@@ -497,9 +419,6 @@ public:
   explicit Predicate(Expression *expr, location loc);
 
   Expression *expr = nullptr;
-
-private:
-  Predicate(const Predicate &other) = default;
 };
 
 class Ternary : public Expression {
@@ -524,9 +443,6 @@ public:
 
   Expression *cond = nullptr;
   Block *block = nullptr;
-
-private:
-  While(const While &other) = default;
 };
 
 class For : public Statement {
@@ -542,9 +458,6 @@ public:
   Expression *expr = nullptr;
   StatementList stmts;
   SizedType ctx_type;
-
-private:
-  For(const For &other) = default;
 };
 
 class Config : public Statement {
@@ -556,9 +469,6 @@ public:
   }
 
   StatementList stmts;
-
-private:
-  Config(const Config &other) = default;
 };
 
 class AttachPoint : public Node {
@@ -602,8 +512,6 @@ public:
   void set_index(int index);
 
 private:
-  AttachPoint(const AttachPoint &other) = default;
-
   int index_ = 0;
 };
 using AttachPointList = std::vector<AttachPoint *>;
@@ -630,7 +538,6 @@ public:
   bool has_ap_of_probetype(ProbeType probe_type);
 
 private:
-  Probe(const Probe &other) = default;
   int index_ = 0;
 };
 using ProbeList = std::vector<Probe *>;
@@ -645,7 +552,6 @@ public:
   SizedType type;
 
 private:
-  SubprogArg(const SubprogArg &other) = default;
   std::string name_;
 };
 using SubprogArgList = std::vector<SubprogArg *>;
@@ -666,7 +572,6 @@ public:
   std::string name() const;
 
 private:
-  Subprog(const Subprog &other) = default;
   std::string name_;
 };
 using SubprogList = std::vector<Subprog *>;
@@ -684,9 +589,6 @@ public:
   Config *config = nullptr;
   SubprogList functions;
   ProbeList probes;
-
-private:
-  Program(const Program &other) = default;
 };
 
 std::string opstr(const Binop &binop);

--- a/src/ast/passes/clone.h
+++ b/src/ast/passes/clone.h
@@ -1,0 +1,343 @@
+#pragma once
+
+#include <ostream>
+
+#include "ast/visitors.h"
+
+namespace bpftrace {
+namespace ast {
+
+class Clone : public Visitor {
+private:
+  // CopyNode uses dynamic dispatch to make a copy of the given type. All
+  // the internal values will point to the same external values, and will
+  // need to be rewritten.
+  class CopyNode : public VisitorBase {
+  public:
+    CopyNode(ASTContext &ctx) : ctx_(ctx)
+    {
+    }
+    virtual void visit(Integer &integer) override
+    {
+      result_ = ctx_.make_node<Integer>(integer);
+    }
+    virtual void visit(PositionalParameter &integer) override
+    {
+      result_ = ctx_.make_node<PositionalParameter>(integer);
+    }
+    virtual void visit(String &string) override
+    {
+      result_ = ctx_.make_node<String>(string);
+    }
+    virtual void visit(Builtin &builtin) override
+    {
+      result_ = ctx_.make_node<Builtin>(builtin);
+    }
+    virtual void visit(Identifier &identifier) override
+    {
+      result_ = ctx_.make_node<Identifier>(identifier);
+    }
+    virtual void visit(StackMode &mode) override
+    {
+      result_ = ctx_.make_node<StackMode>(mode);
+    }
+    virtual void visit(Call &call) override
+    {
+      result_ = ctx_.make_node<Call>(call);
+    }
+    virtual void visit(Sizeof &szof) override
+    {
+      result_ = ctx_.make_node<Sizeof>(szof);
+    }
+    virtual void visit(Offsetof &ofof) override
+    {
+      result_ = ctx_.make_node<Offsetof>(ofof);
+    }
+    virtual void visit(Map &map) override
+    {
+      result_ = ctx_.make_node<Map>(map);
+    }
+    virtual void visit(Variable &var) override
+    {
+      result_ = ctx_.make_node<Variable>(var);
+    }
+    virtual void visit(Binop &binop) override
+    {
+      result_ = ctx_.make_node<Binop>(binop);
+    }
+    virtual void visit(Unop &unop) override
+    {
+      result_ = ctx_.make_node<Unop>(unop);
+    }
+    virtual void visit(Ternary &ternary) override
+    {
+      result_ = ctx_.make_node<Ternary>(ternary);
+    }
+    virtual void visit(FieldAccess &acc) override
+    {
+      result_ = ctx_.make_node<FieldAccess>(acc);
+    }
+    virtual void visit(ArrayAccess &arr) override
+    {
+      result_ = ctx_.make_node<ArrayAccess>(arr);
+    }
+    virtual void visit(Cast &cast) override
+    {
+      result_ = ctx_.make_node<Cast>(cast);
+    }
+    virtual void visit(Tuple &tuple) override
+    {
+      result_ = ctx_.make_node<Tuple>(tuple);
+    }
+    virtual void visit(ExprStatement &expr) override
+    {
+      result_ = ctx_.make_node<ExprStatement>(expr);
+    }
+    virtual void visit(AssignMapStatement &assignment) override
+    {
+      result_ = ctx_.make_node<AssignMapStatement>(assignment);
+    }
+    virtual void visit(AssignVarStatement &assignment) override
+    {
+      result_ = ctx_.make_node<AssignVarStatement>(assignment);
+    }
+    virtual void visit(AssignConfigVarStatement &assignment) override
+    {
+      result_ = ctx_.make_node<AssignConfigVarStatement>(assignment);
+    }
+    virtual void visit(VarDeclStatement &decl) override
+    {
+      result_ = ctx_.make_node<VarDeclStatement>(decl);
+    }
+    virtual void visit(If &if_node) override
+    {
+      result_ = ctx_.make_node<If>(if_node);
+    }
+    virtual void visit(Jump &jump) override
+    {
+      result_ = ctx_.make_node<Jump>(jump);
+    }
+    virtual void visit(Unroll &unroll) override
+    {
+      result_ = ctx_.make_node<Unroll>(unroll);
+    }
+    virtual void visit(While &while_block) override
+    {
+      result_ = ctx_.make_node<While>(while_block);
+    }
+    virtual void visit(For &for_loop) override
+    {
+      result_ = ctx_.make_node<For>(for_loop);
+    }
+    virtual void visit(Predicate &pred) override
+    {
+      result_ = ctx_.make_node<Predicate>(pred);
+    }
+    virtual void visit(AttachPoint &ap) override
+    {
+      result_ = ctx_.make_node<AttachPoint>(ap);
+    }
+    virtual void visit(Probe &probe) override
+    {
+      result_ = ctx_.make_node<Probe>(probe);
+    }
+    virtual void visit(Config &config) override
+    {
+      result_ = ctx_.make_node<Config>(config);
+    }
+    virtual void visit(Block &block) override
+    {
+      result_ = ctx_.make_node<Block>(block);
+    }
+    virtual void visit(SubprogArg &subprog_arg) override
+    {
+      result_ = ctx_.make_node<SubprogArg>(subprog_arg);
+    }
+    virtual void visit(Subprog &subprog) override
+    {
+      result_ = ctx_.make_node<Subprog>(subprog);
+    }
+    virtual void visit(Program &program) override
+    {
+      result_ = ctx_.make_node<Program>(program);
+    }
+    ASTContext &ctx_;
+    Node *result_;
+  };
+
+public:
+  explicit Clone(ASTContext &dst) : dst_(dst)
+  {
+  }
+
+  template <typename T>
+  void clone(T **t)
+  {
+    // Lookup the casted expression in our remapped database, and if it already
+    // exists then return a reference to it.
+    auto key = static_cast<Node *>(*t);
+    if (key == nullptr)
+      return;
+    auto it = remapped_.find(key);
+    if (it != remapped_.end()) {
+      *t = static_cast<T *>(it->second);
+      return;
+    }
+    // Otherwise, instantiate and copy the object, and push it to the stack. We
+    // then visit the copy to recursively clone its parts.
+    CopyNode copier(dst_);
+    (*t)->accept(copier);
+    Node *copy = copier.result_;
+    remapped_[key] = copy;
+    copy->accept(*this);
+    *t = static_cast<T *>(copy);
+    // Rewrite the expression bits.
+    if constexpr (std::is_base_of_v<Expression, T>) {
+      clone(&((*t)->key_for_map));
+      clone(&((*t)->map));
+      clone(&((*t)->var));
+    }
+    return;
+  }
+  template <typename T>
+  void clone(std::vector<T *> *in)
+  {
+    for (auto &val : *in) {
+      clone(&val);
+    }
+  }
+
+  virtual void visit(Call &call) override
+  {
+    clone(&call.vargs);
+  }
+  virtual void visit(Sizeof &szof) override
+  {
+    clone(&szof.expr);
+  }
+  virtual void visit(Offsetof &ofof) override
+  {
+    clone(&ofof.expr);
+  }
+  virtual void visit(Map &map) override
+  {
+    clone(&map.key_expr);
+  }
+  virtual void visit(Binop &binop) override
+  {
+    clone(&binop.left);
+    clone(&binop.right);
+  }
+  virtual void visit(Unop &unop) override
+  {
+    clone(&unop.expr);
+  }
+  virtual void visit(Ternary &ternary) override
+  {
+    clone(&ternary.cond);
+    clone(&ternary.left);
+    clone(&ternary.right);
+  }
+  virtual void visit(FieldAccess &acc) override
+  {
+    clone(&acc.expr);
+  }
+  virtual void visit(ArrayAccess &arr) override
+  {
+    clone(&arr.expr);
+    clone(&arr.indexpr);
+  }
+  virtual void visit(Cast &cast) override
+  {
+    clone(&cast.expr);
+  }
+  virtual void visit(Tuple &tuple) override
+  {
+    clone(&tuple.elems);
+  }
+  virtual void visit(ExprStatement &expr) override
+  {
+    clone(&expr.expr);
+  }
+  virtual void visit(AssignMapStatement &assignment) override
+  {
+    clone(&assignment.map);
+    clone(&assignment.expr);
+  }
+  virtual void visit(AssignVarStatement &assignment) override
+  {
+    clone(&assignment.var_decl_stmt);
+    clone(&assignment.var);
+    clone(&assignment.expr);
+  }
+  virtual void visit(AssignConfigVarStatement &assignment) override
+  {
+    clone(&assignment.expr);
+  }
+  virtual void visit(VarDeclStatement &decl) override
+  {
+    clone(&decl.var);
+  }
+  virtual void visit(If &if_node) override
+  {
+    clone(&if_node.cond);
+    clone(&if_node.if_block);
+    clone(&if_node.else_block);
+  }
+  virtual void visit(Jump &jump) override
+  {
+    clone(&jump.return_value);
+  }
+  virtual void visit(Unroll &unroll) override
+  {
+    clone(&unroll.expr);
+    clone(&unroll.block);
+  }
+  virtual void visit(While &while_block) override
+  {
+    clone(&while_block.cond);
+    clone(&while_block.block);
+  }
+  virtual void visit(For &for_loop) override
+  {
+    clone(&for_loop.decl);
+    clone(&for_loop.expr);
+    clone(&for_loop.stmts);
+  }
+  virtual void visit(Predicate &pred) override
+  {
+    clone(&pred.expr);
+  }
+  virtual void visit(Probe &probe) override
+  {
+    clone(&probe.attach_points);
+    clone(&probe.pred);
+    clone(&probe.block);
+  }
+  virtual void visit(Config &config) override
+  {
+    clone(&config.stmts);
+  }
+  virtual void visit(Block &block) override
+  {
+    clone(&block.stmts);
+  }
+  virtual void visit(Subprog &subprog) override
+  {
+    clone(&subprog.args);
+    clone(&subprog.stmts);
+  }
+  virtual void visit(Program &program) override
+  {
+    clone(&program.config);
+    clone(&program.functions);
+    clone(&program.probes);
+  }
+
+private:
+  ASTContext &dst_;
+  std::unordered_map<Node *, Node *> remapped_;
+};
+
+} // namespace ast
+} // namespace bpftrace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,6 +56,12 @@ add_executable(bpftrace_test
 )
 add_test(NAME bpftrace_test COMMAND bpftrace_test)
 
+add_executable(bpftrace_benchmark
+  benchmarks.cpp
+  mocks.cpp
+  tracepoint_format_parser.cpp
+)
+
 add_subdirectory(data)
 if(${LLDB_FOUND})
   add_dependencies(bpftrace_test debuginfo_dwarf_data)
@@ -64,9 +70,12 @@ endif()
 add_dependencies(bpftrace_test debuginfo_btf_data)
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(bpftrace_benchmark PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(bpftrace_benchmark PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
 target_compile_definitions(bpftrace_test PRIVATE TEST_CODEGEN_LOCATION="${CMAKE_SOURCE_DIR}/tests/codegen/llvm/")
 target_link_libraries(bpftrace_test libbpftrace)
+target_link_libraries(bpftrace_benchmark libbpftrace)
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   target_compile_definitions(bpftrace_test PRIVATE ARCH_AARCH64)
@@ -92,11 +101,15 @@ endif()
 # modules don't respect minimum requested version.
 find_package(GTest REQUIRED)
 find_package(GMock REQUIRED)
+find_package(benchmark REQUIRED)
 include_directories(SYSTEM ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS})
 target_link_libraries(bpftrace_test ${GTEST_BOTH_LIBRARIES} ${GMOCK_LIBRARIES})
+target_link_libraries(bpftrace_benchmark ${GTEST_BOTH_LIBRARIES} ${GMOCK_LIBRARIES})
+target_link_libraries(bpftrace_benchmark benchmark::benchmark)
 
 find_package(Threads REQUIRED)
 target_link_libraries(bpftrace_test ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(bpftrace_benchmark ${CMAKE_THREAD_LIBS_INIT})
 
 add_subdirectory(testprogs)
 add_subdirectory(testlibs)

--- a/tests/README.md
+++ b/tests/README.md
@@ -173,3 +173,11 @@ test suite
 - `TOOLS_TEST_DISABLE`: comma separated list of tools to skip, e.g.
   `vfscount.bt,swapin.bt`
 - `TOOLS_TEST_OLDVERSION`: tests the tools/old version of these tools instead.
+
+## Benchmarks
+
+Some basic benchmarks are available in `tests/benchmarks.cpp`. These can be run
+by building and executing the tool `tests/bpftrace_benchmark`. All benchmarks
+are self-contained.
+
+For more detailed information about how to run specific benchmarks, see the [Google benchmarks user manual](https://github.com/google/benchmark/blob/main/docs/user_guide.md#command-line).

--- a/tests/benchmarks.cpp
+++ b/tests/benchmarks.cpp
@@ -1,0 +1,147 @@
+#include "benchmark/benchmark.h"
+#include "gmock/gmock.h"
+
+#include "mocks.h"
+
+#include "ast/passes/clone.h"
+#include "ast/passes/codegen_llvm.h"
+#include "ast/passes/field_analyser.h"
+#include "ast/passes/resource_analyser.h"
+#include "ast/passes/semantic_analyser.h"
+
+#include "bpffeature.h"
+#include "bpftrace.h"
+#include "clang_parser.h"
+#include "driver.h"
+
+namespace bpftrace::test {
+
+// We break the benchmarks into several phases, in order to track issues
+// separately. Note that currently each meaningful pass has its own phase, but
+// these could be logically merged as "optimizations" or some other passes with
+// some minor code restructuring.
+enum class Phase {
+  Parse,
+  FieldAnalyser,
+  ClangParser,
+  SemanticAnalyser,
+  ResourceAnalyser,
+  Codegen,
+};
+
+template <Phase P, Phase Is, typename Func>
+void measure(benchmark::State &state, Driver &driver, Func fn)
+{
+  // Run once only if we are not in the benchmark.
+  if constexpr (P != Is) {
+    fn();
+    return;
+  }
+
+  auto orig = std::move(driver.ctx);
+  for (auto _ : state) {
+    {
+      // Clone the AST in its current exact form. This should be relatively
+      // inexpensive (at least on the order of the pass itself), but we need to
+      // exclude this time.
+      state.PauseTiming();
+      if (orig.root != nullptr) {
+        bpftrace::ast::ASTContext newctx;
+        bpftrace::ast::Clone cloner(newctx);
+        newctx.root = orig.root;
+        cloner.clone(&newctx.root);
+        driver.ctx = std::move(newctx);
+      }
+      state.ResumeTiming();
+    }
+
+    // Run the function.
+    fn();
+  }
+}
+
+template <Phase P>
+void BM_compile(benchmark::State &state, const std::string &input)
+{
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  Driver driver(*bpftrace);
+
+  measure<Phase::Parse, P>(state, driver, [&] {
+    ASSERT_EQ(driver.parse_str(input), 0);
+  });
+
+  std::unique_ptr<ast::FieldAnalyser> fields;
+  measure<Phase::FieldAnalyser, P>(state, driver, [&] {
+    fields = std::make_unique<ast::FieldAnalyser>(driver.ctx.root, *bpftrace);
+    ASSERT_EQ(fields->analyse(), 0);
+  });
+
+  std::unique_ptr<ClangParser> clang;
+  measure<Phase::ClangParser, P>(state, driver, [&] {
+    clang = std::make_unique<ClangParser>();
+    clang->parse(driver.ctx.root, *bpftrace);
+  });
+
+  std::unique_ptr<ast::SemanticAnalyser> semantics;
+  measure<Phase::SemanticAnalyser, P>(state, driver, [&] {
+    semantics = std::make_unique<ast::SemanticAnalyser>(driver.ctx, *bpftrace);
+    ASSERT_EQ(semantics->analyse(), 0);
+  });
+
+  std::unique_ptr<ast::ResourceAnalyser> resources;
+  std::optional<RequiredResources> required_resources;
+  measure<Phase::ResourceAnalyser, P>(state, driver, [&] {
+    resources = std::make_unique<ast::ResourceAnalyser>(driver.ctx.root,
+                                                        *bpftrace);
+    required_resources = resources->analyse();
+    ASSERT_TRUE(required_resources.has_value());
+  });
+
+  std::unique_ptr<ast::CodegenLLVM> codegen;
+  measure<Phase::Codegen, P>(state, driver, [&] {
+    bpftrace->resources = required_resources.value();
+    codegen = std::make_unique<ast::CodegenLLVM>(driver.ctx.root, *bpftrace);
+    codegen->generate_ir();
+    codegen->optimize();
+    codegen->emit(false);
+  });
+}
+
+} // namespace bpftrace::test
+
+#define COMPILE_BENCHMARK_DEFINE(name, phase_name, phase)                      \
+  BENCHMARK_F(name, phase_name)(benchmark::State & st)                         \
+  {                                                                            \
+    bpftrace::test::BM_compile<phase>(st, input);                              \
+  }
+
+#define COMPILE_BENCHMARK(name, prog)                                          \
+  class name : public benchmark::Fixture {                                     \
+  public:                                                                      \
+    const std::string input = prog;                                            \
+  };                                                                           \
+  COMPILE_BENCHMARK_DEFINE(name, parser, bpftrace::test::Phase::Parse);        \
+  COMPILE_BENCHMARK_DEFINE(name,                                               \
+                           field_analyser,                                     \
+                           bpftrace::test::Phase::FieldAnalyser);              \
+  COMPILE_BENCHMARK_DEFINE(name,                                               \
+                           clang_parser,                                       \
+                           bpftrace::test::Phase::ClangParser);                \
+  COMPILE_BENCHMARK_DEFINE(name,                                               \
+                           semantic_analyser,                                  \
+                           bpftrace::test::Phase::SemanticAnalyser);           \
+  COMPILE_BENCHMARK_DEFINE(name,                                               \
+                           resource_analyser,                                  \
+                           bpftrace::test::Phase::ResourceAnalyser);           \
+  COMPILE_BENCHMARK_DEFINE(name, codegen, bpftrace::test::Phase::Codegen);
+
+COMPILE_BENCHMARK(hello_world, R"(
+BEGIN
+{
+    printf("hello world!\n");
+    exit();
+}
+)");
+
+BENCHMARK_MAIN();


### PR DESCRIPTION
This is a standalone executable for now, not wired into any tests. In
the future we may want to expand the set of benchmarks and add more
structure, to ensure that we can track parse times, compile times, etc.
and catch any massive regressions. For now however, this is a simple
tool that can be used to manually find regressions during refactors.

Here is an example of the `hello_world` benchmark:

```
------------------------------------------------------------------------
Benchmark                              Time             CPU   Iterations
------------------------------------------------------------------------
hello_world/parser                 45554 ns        45543 ns        15300
hello_world/field_analyser           970 ns          961 ns       768297
hello_world/clang_parser        18220105 ns      4284873 ns          125
hello_world/semantic_analyser      23912 ns        23898 ns        29148
hello_world/resource_analyser       4006 ns         4004 ns       171757
hello_world/codegen               846969 ns       845485 ns          790
```

Interestingly, for trivial programs the `clang_parser` is completely dominant.
However, this will need to be built out a bit further before making any hard
conclusions.


##### Checklist

- [-] Language changes are updated in `man/adoc/bpftrace.adoc`
- [-] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [-] The new behaviour is covered by tests
