### PR TITLE
tests: cmake: Remove static linking conditional

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ add_executable(bpftrace_test
 
   ${CODEGEN_SRC}
 )
+add_test(NAME bpftrace_test COMMAND bpftrace_test)
 
 add_subdirectory(data)
 if(${LLDB_FOUND})
@@ -94,11 +95,8 @@ find_package(GMock REQUIRED)
 include_directories(SYSTEM ${GTEST_INCLUDE_DIRS} ${GMOCK_INCLUDE_DIRS})
 target_link_libraries(bpftrace_test ${GTEST_BOTH_LIBRARIES} ${GMOCK_LIBRARIES})
 
-add_test(NAME bpftrace_test COMMAND bpftrace_test)
-if(NOT STATIC_LINKING)
-  find_package(Threads REQUIRED)
-  target_link_libraries(bpftrace_test ${CMAKE_THREAD_LIBS_INIT})
-endif(NOT STATIC_LINKING)
+find_package(Threads REQUIRED)
+target_link_libraries(bpftrace_test ${CMAKE_THREAD_LIBS_INIT})
 
 add_subdirectory(testprogs)
 add_subdirectory(testlibs)


### PR DESCRIPTION
We probably used to support statically linking the test binary. That seems overkill, as static linking the main binary is hard enough.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
