### PR TITLE
static: Remove gtest from dockerfile

### DIFF
--- a/docker/Dockerfile.static
+++ b/docker/Dockerfile.static
@@ -19,7 +19,6 @@ RUN apk add --update \
   elfutils-dev \
   flex-dev \
   git \
-  gtest-dev \
   libbpf-dev \
   libelf-static \
   libpcap-dev \


### PR DESCRIPTION
Shouldn't be necessary, as we do static builds with BUILD_TESTING=OFF.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
