### PR TITLE
Turn known string allocations into globals

### DIFF
--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -11,6 +11,7 @@ target triple = "bpf-pc-linux"
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@abc = global [4 x i8] c"abc\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -20,16 +21,12 @@ entry:
   %key = alloca i32, align 4
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %tuple = alloca %"int64_string[4]__tuple_t", align 8
-  %str = alloca [4 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [4 x i8] c"abc\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
   %1 = getelementptr %"int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 0
   store i64 1, ptr %1, align 8
   %2 = getelementptr %"int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 4, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @abc, i64 4, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %print_tuple_16_t)
   %3 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 0
   store i64 30007, ptr %3, align 8

--- a/tests/codegen/llvm/fmt_str_args_scratch_buf.ll
+++ b/tests/codegen/llvm/fmt_str_args_scratch_buf.ll
@@ -12,6 +12,7 @@ target triple = "bpf-pc-linux"
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
 @fmt_str_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !38
+@xxxx = global [5 x i8] c"xxxx\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -19,7 +20,6 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
   %key = alloca i32, align 4
-  %str = alloca [5 x i8], align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
@@ -27,11 +27,8 @@ entry:
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 24, i1 false)
   %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
   store i64 0, ptr %3, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [5 x i8] c"xxxx\00", ptr %str, align 1
   %4 = getelementptr %printf_t, ptr %2, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %str, i64 5, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 @xxxx, i64 5, i1 false)
   %5 = getelementptr %printf_t, ptr %2, i32 0, i32 2
   store i64 1, ptr %5, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 24, i64 0)
@@ -63,19 +60,19 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}

--- a/tests/codegen/llvm/fmt_str_args_stack.ll
+++ b/tests/codegen/llvm/fmt_str_args_stack.ll
@@ -10,6 +10,7 @@ target triple = "bpf-pc-linux"
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@xxxx = global [5 x i8] c"xxxx\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -17,17 +18,13 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
 entry:
   %key = alloca i32, align 4
-  %str = alloca [5 x i8], align 1
   %printf_args = alloca %printf_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 24, i1 false)
   %1 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
   store i64 0, ptr %1, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [5 x i8] c"xxxx\00", ptr %str, align 1
   %2 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 5, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @xxxx, i64 5, i1 false)
   %3 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 2
   store i64 1, ptr %3, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 24, i64 0)

--- a/tests/codegen/llvm/for_map_strings.ll
+++ b/tests/codegen/llvm/for_map_strings.ll
@@ -14,29 +14,18 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !23
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !37
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !51
+@xyz = global [4 x i8] c"xyz\00"
+@abc = global [4 x i8] c"abc\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !67 {
 entry:
-  %str1 = alloca [4 x i8], align 1
-  %str = alloca [4 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [4 x i8] c"xyz\00", ptr %str, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
-  store [4 x i8] c"abc\00", ptr %str1, align 1
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %str1, ptr %str, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr @abc, ptr @xyz, i64 0)
   %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_map, ptr @map_for_each_cb, ptr null, i64 0)
   ret i64 0
 }
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !73 {
   %"@x_key" = alloca i64, align 8
@@ -54,11 +43,17 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   ret i64 0
 }
 
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }

--- a/tests/codegen/llvm/for_map_variables.ll
+++ b/tests/codegen/llvm/for_map_variables.ll
@@ -15,6 +15,8 @@ target triple = "bpf-pc-linux"
 @AT_map = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !25
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !39
+@abc = global [4 x i8] c"abc\00"
+@def = global [4 x i8] c"def\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -27,11 +29,9 @@ entry:
   %"$var3" = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var3")
   call void @llvm.memset.p0.i64(ptr align 1 %"$var3", i8 0, i64 4, i1 false)
-  %str1 = alloca [4 x i8], align 1
   %"$var2" = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var2")
   call void @llvm.memset.p0.i64(ptr align 1 %"$var2", i8 0, i64 4, i1 false)
-  %str = alloca [4 x i8], align 1
   %"$var1" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var1")
   store i64 0, ptr %"$var1", align 8
@@ -45,14 +45,8 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_key")
   store i64 123, ptr %"$var1", align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [4 x i8] c"abc\00", ptr %str, align 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var2", ptr align 1 %str, i64 4, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
-  store [4 x i8] c"def\00", ptr %str1, align 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var3", ptr align 1 %str1, i64 4, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var2", ptr align 1 @abc, i64 4, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var3", ptr align 1 @def, i64 4, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %ctx)
   %1 = call ptr @llvm.preserve.static.offset(ptr %ctx)
   %"ctx.$var1" = getelementptr %ctx_t, ptr %1, i64 0, i32 0
@@ -66,7 +60,7 @@ entry:
   store i64 0, ptr %"@len_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@len_val")
   store i64 %3, ptr %"@len_val", align 8
-  %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_len, ptr %"@len_key", ptr %"@len_val", i64 0)
+  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_len, ptr %"@len_key", ptr %"@len_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@len_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@len_key")
   ret i64 0

--- a/tests/codegen/llvm/map_assign_string.ll
+++ b/tests/codegen/llvm/map_assign_string.ll
@@ -11,6 +11,7 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
+@blah = global [5 x i8] c"blah\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -18,14 +19,10 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !51 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %str = alloca [5 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [5 x i8] c"blah\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr @blah, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/map_assign_string_shorter.ll
+++ b/tests/codegen/llvm/map_assign_string_shorter.ll
@@ -11,6 +11,8 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
+@xxxxx = global [6 x i8] c"xxxxx\00"
+@a = global [2 x i8] c"a\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -18,28 +20,20 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !51 {
 entry:
   %"@x_val" = alloca [6 x i8], align 1
-  %"@x_key2" = alloca i64, align 8
-  %str1 = alloca [2 x i8], align 1
+  %"@x_key1" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %str = alloca [6 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [6 x i8] c"xxxxx\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr @xxxxx, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
-  store [2 x i8] c"a\00", ptr %str1, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key2")
-  store i64 0, ptr %"@x_key2", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
+  store i64 0, ptr %"@x_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   call void @llvm.memset.p0.i64(ptr align 1 %"@x_val", i8 0, i64 6, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"@x_val", ptr align 1 %str1, i64 2, i1 false)
-  %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key2", ptr %"@x_val", i64 0)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"@x_val", ptr align 1 @a, i64 2, i1 false)
+  %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key1", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key2")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   ret i64 0
 }
 

--- a/tests/codegen/llvm/map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/map_key_scratch_buf.ll
@@ -17,13 +17,13 @@ target triple = "bpf-pc-linux"
 @write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !64
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !68
 @read_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !70
+@yyyy = global [5 x i8] c"yyyy\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !75 {
 entry:
-  %str = alloca [5 x i8], align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
@@ -59,22 +59,16 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %10 = load i64, ptr %8, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [5 x i8] c"yyyy\00", ptr %str, align 1
   %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)()
   %11 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded8 = and i64 %get_cpu_id7, %11
   %12 = getelementptr [1 x [1 x [8 x i8]]], ptr @write_map_val_buf, i64 0, i64 %cpu.id.bounded8, i64 0, i64 0
   store i64 %10, ptr %12, align 8
-  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %str, ptr %12, i64 0)
+  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr @yyyy, ptr %12, i64 0)
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!72}
 !llvm.module.flags = !{!74}

--- a/tests/codegen/llvm/map_key_stack.ll
+++ b/tests/codegen/llvm/map_key_stack.ll
@@ -13,6 +13,7 @@ target triple = "bpf-pc-linux"
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !30
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !44
+@yyyy = global [5 x i8] c"yyyy\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -20,7 +21,6 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !60 {
 entry:
   %"@y_val" = alloca i64, align 8
-  %str = alloca [5 x i8], align 1
   %lookup_elem_val = alloca i64, align 8
   %"@x_key1" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
@@ -52,11 +52,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %2 = load i64, ptr %lookup_elem_val, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [5 x i8] c"yyyy\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
   store i64 %2, ptr %"@y_val", align 8
-  %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %str, ptr %"@y_val", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr @yyyy, ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   ret i64 0
 }

--- a/tests/codegen/llvm/map_key_string.ll
+++ b/tests/codegen/llvm/map_key_string.ll
@@ -12,6 +12,8 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !29
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !43
+@a = global [2 x i8] c"a\00"
+@b = global [2 x i8] c"b\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -20,20 +22,12 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %"@x_val" = alloca i64, align 8
   %tuple = alloca %"string[2]_string[2]__tuple_t", align 8
-  %str1 = alloca [2 x i8], align 1
-  %str = alloca [2 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [2 x i8] c"a\00", ptr %str, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
-  store [2 x i8] c"b\00", ptr %str1, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 4, i1 false)
   %1 = getelementptr %"string[2]_string[2]__tuple_t", ptr %tuple, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 %str, i64 2, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 @a, i64 2, i1 false)
   %2 = getelementptr %"string[2]_string[2]__tuple_t", ptr %tuple, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str1, i64 2, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @b, i64 2, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   store i64 44, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %tuple, ptr %"@x_val", i64 0)

--- a/tests/codegen/llvm/map_value_tuple_scratch_buf.ll
+++ b/tests/codegen/llvm/map_value_tuple_scratch_buf.ll
@@ -20,26 +20,23 @@ target triple = "bpf-pc-linux"
 @read_map_val_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !67
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !69
 @tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !71
+@xxx = global [4 x i8] c"xxx\00"
+@xxxxxxx = global [8 x i8] c"xxxxxxx\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !78 {
 entry:
-  %str5 = alloca [8 x i8], align 1
-  %str = alloca [4 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [4 x i8] c"xxx\00", ptr %str, align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %"string[4]_int64__tuple_t", ptr %2, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 %str, i64 4, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 @xxx, i64 4, i1 false)
   %4 = getelementptr %"string[4]_int64__tuple_t", ptr %2, i32 0, i32 1
   store i64 1, ptr %4, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
@@ -57,34 +54,31 @@ entry:
   %12 = getelementptr %"string[8]_int64__tuple_t", ptr %8, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %11, i64 8, i1 false)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %6, ptr %8, i64 0)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str5)
-  store [8 x i8] c"xxxxxxx\00", ptr %str5, align 1
-  %get_cpu_id6 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)()
   %13 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded7 = and i64 %get_cpu_id6, %13
-  %14 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded7, i64 1, i64 0
+  %cpu.id.bounded6 = and i64 %get_cpu_id5, %13
+  %14 = getelementptr [1 x [2 x [16 x i8]]], ptr @tuple_buf, i64 0, i64 %cpu.id.bounded6, i64 1, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %14, i8 0, i64 16, i1 false)
   %15 = getelementptr %"string[8]_int64__tuple_t", ptr %14, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %15, ptr align 1 %str5, i64 8, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %15, ptr align 1 @xxxxxxx, i64 8, i1 false)
   %16 = getelementptr %"string[8]_int64__tuple_t", ptr %14, i32 0, i32 1
   store i64 1, ptr %16, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str5)
-  %get_cpu_id8 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)()
   %17 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded9 = and i64 %get_cpu_id8, %17
-  %18 = getelementptr [1 x [4 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded9, i64 1, i64 0
+  %cpu.id.bounded8 = and i64 %get_cpu_id7, %17
+  %18 = getelementptr [1 x [4 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded8, i64 1, i64 0
   store i64 0, ptr %18, align 8
-  %update_elem10 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %18, ptr %14, i64 0)
-  %get_cpu_id11 = call i64 inttoptr (i64 8 to ptr)()
+  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %18, ptr %14, i64 0)
+  %get_cpu_id10 = call i64 inttoptr (i64 8 to ptr)()
   %19 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded12 = and i64 %get_cpu_id11, %19
-  %20 = getelementptr [1 x [4 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded12, i64 2, i64 0
+  %cpu.id.bounded11 = and i64 %get_cpu_id10, %19
+  %20 = getelementptr [1 x [4 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded11, i64 2, i64 0
   store i64 0, ptr %20, align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %20)
-  %get_cpu_id13 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id12 = call i64 inttoptr (i64 8 to ptr)()
   %21 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded14 = and i64 %get_cpu_id13, %21
-  %22 = getelementptr [1 x [1 x [16 x i8]]], ptr @read_map_val_buf, i64 0, i64 %cpu.id.bounded14, i64 0, i64 0
+  %cpu.id.bounded13 = and i64 %get_cpu_id12, %21
+  %22 = getelementptr [1 x [1 x [16 x i8]]], ptr @read_map_val_buf, i64 0, i64 %cpu.id.bounded13, i64 0, i64 0
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
@@ -97,31 +91,24 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %get_cpu_id15 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)()
   %23 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded16 = and i64 %get_cpu_id15, %23
-  %24 = getelementptr [1 x [4 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded16, i64 3, i64 0
+  %cpu.id.bounded15 = and i64 %get_cpu_id14, %23
+  %24 = getelementptr [1 x [4 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
   store i64 0, ptr %24, align 8
-  %update_elem17 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %24, ptr %22, i64 0)
+  %update_elem16 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %24, ptr %22, i64 0)
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!75}
 !llvm.module.flags = !{!77}

--- a/tests/codegen/llvm/map_value_tuple_stack.ll
+++ b/tests/codegen/llvm/map_value_tuple_stack.ll
@@ -15,6 +15,8 @@ target triple = "bpf-pc-linux"
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !27
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !41
+@xxx = global [4 x i8] c"xxx\00"
+@xxxxxxx = global [8 x i8] c"xxxxxxx\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -23,23 +25,18 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !57 {
 entry:
   %"@y_key" = alloca i64, align 8
   %lookup_elem_val = alloca %"string[8]_int64__tuple_t", align 8
-  %"@x_key5" = alloca i64, align 8
-  %"@x_key3" = alloca i64, align 8
-  %tuple2 = alloca %"string[8]_int64__tuple_t", align 8
-  %str1 = alloca [8 x i8], align 1
+  %"@x_key4" = alloca i64, align 8
+  %"@x_key2" = alloca i64, align 8
+  %tuple1 = alloca %"string[8]_int64__tuple_t", align 8
   %"@x_val" = alloca %"string[8]_int64__tuple_t", align 8
   %"@x_key" = alloca i64, align 8
   %tuple = alloca %"string[4]_int64__tuple_t", align 8
-  %str = alloca [4 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [4 x i8] c"xxx\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
   %1 = getelementptr %"string[4]_int64__tuple_t", ptr %tuple, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 %str, i64 4, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 @xxx, i64 4, i1 false)
   %2 = getelementptr %"string[4]_int64__tuple_t", ptr %tuple, i32 0, i32 1
   store i64 1, ptr %2, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -54,23 +51,20 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
-  store [8 x i8] c"xxxxxxx\00", ptr %str1, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple2)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 16, i1 false)
-  %7 = getelementptr %"string[8]_int64__tuple_t", ptr %tuple2, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %str1, i64 8, i1 false)
-  %8 = getelementptr %"string[8]_int64__tuple_t", ptr %tuple2, i32 0, i32 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 16, i1 false)
+  %7 = getelementptr %"string[8]_int64__tuple_t", ptr %tuple1, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 @xxxxxxx, i64 8, i1 false)
+  %8 = getelementptr %"string[8]_int64__tuple_t", ptr %tuple1, i32 0, i32 1
   store i64 1, ptr %8, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key3")
-  store i64 0, ptr %"@x_key3", align 8
-  %update_elem4 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key3", ptr %tuple2, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key3")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple2)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key5")
-  store i64 0, ptr %"@x_key5", align 8
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key5")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key2")
+  store i64 0, ptr %"@x_key2", align 8
+  %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key2", ptr %tuple1, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key2")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key4")
+  store i64 0, ptr %"@x_key4", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key4")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
@@ -84,10 +78,10 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key5")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key4")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
-  %update_elem6 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %lookup_elem_val, i64 0)
+  %update_elem5 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %lookup_elem_val, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   ret i64 0

--- a/tests/codegen/llvm/nested_tuple_different_sizes.ll
+++ b/tests/codegen/llvm/nested_tuple_different_sizes.ll
@@ -13,30 +13,27 @@ target triple = "bpf-pc-linux"
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@hi = global [3 x i8] c"hi\00"
+@hellolongstr = global [13 x i8] c"hellolongstr\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
 entry:
-  %tuple4 = alloca %"int64_(string[13],int64)__tuple_t", align 8
-  %tuple3 = alloca %"string[13]_int64__tuple_t", align 8
-  %str2 = alloca [13 x i8], align 1
+  %tuple3 = alloca %"int64_(string[13],int64)__tuple_t", align 8
+  %tuple2 = alloca %"string[13]_int64__tuple_t", align 8
   %"$t" = alloca %"int64_(string[13],int64)__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 32, i1 false)
   %tuple1 = alloca %"int64_(string[3],int64)__tuple_t", align 8
   %tuple = alloca %"string[3]_int64__tuple_t", align 8
-  %str = alloca [3 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [3 x i8] c"hi\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
   %1 = getelementptr %"string[3]_int64__tuple_t", ptr %tuple, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 %str, i64 3, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 @hi, i64 3, i1 false)
   %2 = getelementptr %"string[3]_int64__tuple_t", ptr %tuple, i32 0, i32 1
   store i64 3, ptr %2, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 24, i1 false)
   %3 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %tuple1, i32 0, i32 0
@@ -57,24 +54,21 @@ entry:
   %12 = getelementptr %"string[13]_int64__tuple_t", ptr %8, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %11, i64 8, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple1)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str2)
-  store [13 x i8] c"hellolongstr\00", ptr %str2, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple3)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple3, i8 0, i64 24, i1 false)
-  %13 = getelementptr %"string[13]_int64__tuple_t", ptr %tuple3, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 %str2, i64 13, i1 false)
-  %14 = getelementptr %"string[13]_int64__tuple_t", ptr %tuple3, i32 0, i32 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple2)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 24, i1 false)
+  %13 = getelementptr %"string[13]_int64__tuple_t", ptr %tuple2, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 @hellolongstr, i64 13, i1 false)
+  %14 = getelementptr %"string[13]_int64__tuple_t", ptr %tuple2, i32 0, i32 1
   store i64 4, ptr %14, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str2)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple4)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple4, i8 0, i64 32, i1 false)
-  %15 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %tuple4, i32 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple3)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple3, i8 0, i64 32, i1 false)
+  %15 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %tuple3, i32 0, i32 0
   store i64 1, ptr %15, align 8
-  %16 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %tuple4, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 %tuple3, i64 24, i1 false)
+  %16 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %tuple3, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 %tuple2, i64 24, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple2)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple3, i64 32, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple3)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple4, i64 32, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple4)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -15,6 +15,7 @@ target triple = "bpf-pc-linux"
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !40
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !52
 @get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !54
+@0 = global [1 x i8] zeroinitializer
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -22,7 +23,6 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !61 {
 entry:
   %"@y_key" = alloca i64, align 8
-  %str = alloca [1 x i8], align 1
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -37,12 +37,7 @@ entry:
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  call void @llvm.memset.p0.i64(ptr align 1 %str, i8 0, i64 1, i1 false)
-  store [1 x i8] zeroinitializer, ptr %str, align 1
-  %3 = ptrtoint ptr %str to i64
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 %3)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 ptrtoint (ptr @0 to i64))
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %2, i64 0)

--- a/tests/codegen/llvm/string_propagation.ll
+++ b/tests/codegen/llvm/string_propagation.ll
@@ -13,6 +13,7 @@ target triple = "bpf-pc-linux"
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !23
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !37
+@asdf = global [5 x i8] c"asdf\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -23,14 +24,10 @@ entry:
   %lookup_elem_val = alloca [5 x i8], align 1
   %"@x_key1" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %str = alloca [5 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [5 x i8] c"asdf\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr @asdf, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 0, ptr %"@x_key1", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")

--- a/tests/codegen/llvm/tuple.ll
+++ b/tests/codegen/llvm/tuple.ll
@@ -12,6 +12,7 @@ target triple = "bpf-pc-linux"
 @AT_t = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
+@str = global [4 x i8] c"str\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -20,9 +21,6 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !56 {
 entry:
   %"@t_key" = alloca i64, align 8
   %tuple = alloca %"int64_int64_string[4]__tuple_t", align 8
-  %str = alloca [4 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [4 x i8] c"str\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 24, i1 false)
   %1 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 0
@@ -30,8 +28,7 @@ entry:
   %2 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 1
   store i64 2, ptr %2, align 8
   %3 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 2
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 %str, i64 4, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 @str, i64 4, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %tuple, i64 0)

--- a/tests/codegen/llvm/tuple_map_val_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_map_val_different_sizes.ll
@@ -13,28 +13,25 @@ target triple = "bpf-pc-linux"
 @AT_a = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@hi = global [3 x i8] c"hi\00"
+@hellolongstr = global [13 x i8] c"hellolongstr\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !55 {
 entry:
-  %"@a_key3" = alloca i64, align 8
-  %tuple2 = alloca %"int64_string[13]__tuple_t", align 8
-  %str1 = alloca [13 x i8], align 1
+  %"@a_key2" = alloca i64, align 8
+  %tuple1 = alloca %"int64_string[13]__tuple_t", align 8
   %"@a_val" = alloca %"int64_string[13]__tuple_t", align 8
   %"@a_key" = alloca i64, align 8
   %tuple = alloca %"int64_string[3]__tuple_t", align 8
-  %str = alloca [3 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [3 x i8] c"hi\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
   %1 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 0
   store i64 1, ptr %1, align 8
   %2 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 3, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @hi, i64 3, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
   store i64 0, ptr %"@a_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
@@ -49,20 +46,17 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
-  store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple2)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 24, i1 false)
-  %7 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 24, i1 false)
+  %7 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple1, i32 0, i32 0
   store i64 1, ptr %7, align 8
-  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %str1, i64 13, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key3")
-  store i64 0, ptr %"@a_key3", align 8
-  %update_elem4 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key3", ptr %tuple2, i64 0)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key3")
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple2)
+  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple1, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 @hellolongstr, i64 13, i1 false)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key2")
+  store i64 0, ptr %"@a_key2", align 8
+  %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key2", ptr %tuple1, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key2")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple1)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/tuple_scratch_buf.ll
+++ b/tests/codegen/llvm/tuple_scratch_buf.ll
@@ -12,15 +12,13 @@ target triple = "bpf-pc-linux"
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
 @tuple_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !38
+@xxxx = global [5 x i8] c"xxxx\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !49 {
 entry:
-  %str = alloca [5 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [5 x i8] c"xxxx\00", ptr %str, align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
@@ -29,27 +27,19 @@ entry:
   %3 = getelementptr %"int64_string[5]__tuple_t", ptr %2, i32 0, i32 0
   store i64 1, ptr %3, align 8
   %4 = getelementptr %"int64_string[5]__tuple_t", ptr %2, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %str, i64 5, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 @xxxx, i64 5, i1 false)
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}

--- a/tests/codegen/llvm/tuple_stack.ll
+++ b/tests/codegen/llvm/tuple_stack.ll
@@ -10,6 +10,7 @@ target triple = "bpf-pc-linux"
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@xxxx = global [5 x i8] c"xxxx\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -17,16 +18,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
 entry:
   %tuple = alloca %"int64_string[5]__tuple_t", align 8
-  %str = alloca [5 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [5 x i8] c"xxxx\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
   %1 = getelementptr %"int64_string[5]__tuple_t", ptr %tuple, i32 0, i32 0
   store i64 1, ptr %1, align 8
   %2 = getelementptr %"int64_string[5]__tuple_t", ptr %tuple, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 5, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @xxxx, i64 5, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 }

--- a/tests/codegen/llvm/tuple_variable_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_variable_different_sizes.ll
@@ -11,28 +11,25 @@ target triple = "bpf-pc-linux"
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@hi = global [3 x i8] c"hi\00"
+@hellolongstr = global [13 x i8] c"hellolongstr\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
 entry:
-  %tuple2 = alloca %"int64_string[13]__tuple_t", align 8
-  %str1 = alloca [13 x i8], align 1
+  %tuple1 = alloca %"int64_string[13]__tuple_t", align 8
   %"$t" = alloca %"int64_string[13]__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 24, i1 false)
   %tuple = alloca %"int64_string[3]__tuple_t", align 8
-  %str = alloca [3 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [3 x i8] c"hi\00", ptr %str, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
   %1 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 0
   store i64 1, ptr %1, align 8
   %2 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 %str, i64 3, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @hi, i64 3, i1 false)
   call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 24, i1 false)
   %3 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 0
   %4 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 0
@@ -41,17 +38,14 @@ entry:
   %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 3, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
-  store [13 x i8] c"hellolongstr\00", ptr %str1, align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple2)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 24, i1 false)
-  %7 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 24, i1 false)
+  %7 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple1, i32 0, i32 0
   store i64 1, ptr %7, align 8
-  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple2, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %str1, i64 13, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple2, i64 24, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple2)
+  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple1, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 @hellolongstr, i64 13, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple1, i64 24, i1 false)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple1)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/variable_assign_string.ll
+++ b/tests/codegen/llvm/variable_assign_string.ll
@@ -11,6 +11,7 @@ target triple = "bpf-pc-linux"
 @AT_map = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
+@blah = global [5 x i8] c"blah\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -21,11 +22,7 @@ entry:
   %"$var" = alloca [5 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
   call void @llvm.memset.p0.i64(ptr align 1 %"$var", i8 0, i64 5, i1 false)
-  %str = alloca [5 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [5 x i8] c"blah\00", ptr %str, align 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var", ptr align 1 %str, i64 5, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var", ptr align 1 @blah, i64 5, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
   store i64 0, ptr %"@map_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %"@map_key", ptr %"$var", i64 0)

--- a/tests/codegen/llvm/variable_assign_string_shorter.ll
+++ b/tests/codegen/llvm/variable_assign_string_shorter.ll
@@ -11,6 +11,8 @@ target triple = "bpf-pc-linux"
 @AT_map = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
+@xxxxx = global [6 x i8] c"xxxxx\00"
+@a = global [2 x i8] c"a\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -18,20 +20,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !51 {
 entry:
   %"@map_key" = alloca i64, align 8
-  %str1 = alloca [2 x i8], align 1
   %"$var" = alloca [6 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
   call void @llvm.memset.p0.i64(ptr align 1 %"$var", i8 0, i64 6, i1 false)
-  %str = alloca [6 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [6 x i8] c"xxxxx\00", ptr %str, align 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var", ptr align 1 %str, i64 6, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str1)
-  store [2 x i8] c"a\00", ptr %str1, align 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var", ptr align 1 @xxxxx, i64 6, i1 false)
   call void @llvm.memset.p0.i64(ptr align 1 %"$var", i8 0, i64 6, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var", ptr align 1 %str1, i64 2, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str1)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$var", ptr align 1 @a, i64 2, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
   store i64 0, ptr %"@map_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %"@map_key", ptr %"$var", i64 0)

--- a/tests/codegen/llvm/variable_map_key_lifetime.ll
+++ b/tests/codegen/llvm/variable_map_key_lifetime.ll
@@ -11,6 +11,7 @@ target triple = "bpf-pc-linux"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@abc = global [4 x i8] c"abc\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -22,11 +23,7 @@ entry:
   %"$myvar" = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$myvar")
   call void @llvm.memset.p0.i64(ptr align 1 %"$myvar", i8 0, i64 4, i1 false)
-  %str = alloca [4 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
-  store [4 x i8] c"abc\00", ptr %str, align 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$myvar", ptr align 1 %str, i64 4, i1 false)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %str)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$myvar", ptr align 1 @abc, i64 4, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   store i64 1, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"$myvar", ptr %"@x_val", i64 0)


### PR DESCRIPTION
This saves us from doing a stack allocation (using up valuable BPF stack space) and saves some instructions.

This applies to AST strings and positional params that are converted to strings.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- [x] The new behaviour is covered by tests
