### PR TITLE
bpftrace: Support bash-completion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,9 @@ if (ENABLE_MAN)
   add_subdirectory(man)
 endif(ENABLE_MAN)
 
+set(BASH_COMPLETION_PATH ${CMAKE_CURRENT_SOURCE_DIR}/scripts/bash-completion/bpftrace)
+install(FILES ${BASH_COMPLETION_PATH} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/bash-completion/completions)
+
 if(NOT TARGET uninstall)
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/CmakeUninstall.cmake.in"

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ bpftrace has several plugins/definitions, integrating the syntax into your edito
 - [Emacs](https://gitlab.com/jgkamat/bpftrace-mode)
 - [Vim](https://github.com/mmarchini/bpftrace.vim)
 - [VS Code](https://github.com/bolinfest/bpftrace-vscode)
+- [Bash Completion](https://github.com/scop/bash-completion)
 
 ## License
 

--- a/scripts/bash-completion/bpftrace
+++ b/scripts/bash-completion/bpftrace
@@ -1,0 +1,67 @@
+# bash completion of bpftrace(8)
+
+_bpftrace_filedir()
+{
+  # bash-completion 2.11-1091-g6e8a1546bde2 rename _filedir to _comp_compgen_filedir
+  if [[ ${BASH_COMPLETION_VERSINFO[0]} == 2 ]] && \
+     [[ ${BASH_COMPLETION_VERSINFO[1]} > 11 ]]; then
+    _comp_compgen_filedir "${@}"
+  else
+    _filedir "${@}"
+  fi
+}
+
+_bpftrace()
+{
+  local cur prev words
+
+  _init_completion -- "$@" || return
+
+  local all_args='-B -f -o -e -h --help -I --include -l -p -c
+                  --usdt-file-activation --unsafe -q --info -k -kk
+                  -V --version --no-warnings -v --dry-run -d
+                  --emit-elf --emit-llvm'
+
+  case ${prev} in
+  -B)
+    COMPREPLY=( $(compgen -W "line full none" -- ${cur}) )
+    return 0
+    ;;
+  -f)
+    COMPREPLY=( $(compgen -W "text json" -- ${cur}) )
+    return 0
+    ;;
+  -c)
+    COMPREPLY=( $(compgen -c -- ${cur}) )
+    return 0
+    ;;
+  -o | --include | --emit-elf | --emit-llvm)
+    _bpftrace_filedir
+    return 0
+    ;;
+  -I)
+    _bpftrace_filedir -d
+    return 0
+    ;;
+  -p)
+    local PIDS=$(cd /proc && echo [0-9]*)
+    COMPREPLY=( $(compgen -W "$PIDS" -- ${cur}) )
+    return 0
+    ;;
+  -d)
+    COMPREPLY=( $(compgen -W "all ast codegen codegen-opt dis libbpf verifier" -- ${cur}) )
+    return 0
+    ;;
+  -h | --help | -V | --version | --info)
+    return
+    ;;
+  esac
+
+  # Just drop -e content completion, because it's very complex.
+  if ([[ ${cur} == -* ]] || [[ -z ${cur} ]]) && [[ ${prev} != -e ]]; then
+    COMPREPLY=( $(compgen -W "${all_args}" -- ${cur}) )
+    return
+  fi
+}
+
+complete -F _bpftrace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,7 +92,7 @@ void usage(std::ostream& out)
   out << "    bpftrace [options] -e 'program'" << std::endl;
   out << std::endl;
   out << "OPTIONS:" << std::endl;
-  out << "    -B MODE        output buffering mode ('full', 'none')" << std::endl;
+  out << "    -B MODE        output buffering mode ('line', 'full', 'none')" << std::endl;
   out << "    -f FORMAT      output format ('text', 'json')" << std::endl;
   out << "    -o file        redirect bpftrace output to file" << std::endl;
   out << "    -e 'program'   execute this program" << std::endl;


### PR DESCRIPTION
Based on bash-completion [1], this commit enables bpftrace to support command autocompletion.

Also modified INSTALL.md and add '-B line' to 'bpftrace --help'.

Link: https://github.com/scop/bash-completion [1]
