### PR TITLE
Allow pointers to evaluate to true/false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- Pointers may now be used in if conditions, tenary conditions and as operands in logical AND and OR expressions
+  - [#3656](https://github.com/bpftrace/bpftrace/pull/3656)
 #### Changed
 #### Deprecated
 #### Removed

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -689,6 +689,11 @@ promoted to the size of the larger one. Sign is preserved in the promotion.
 For example, `(uint32)5 + (uint8)3` is converted to `(uint32)5 + (uint32)3`
 which results in `(uint32)8`.
 
+Pointers may be used with arithmetic operators but only for addition and
+subtraction. For subtraction, the pointer must appear on the left side of the
+operator. Pointers may also be used with logical operators; they are considered
+true when non-null.
+
 ==== Logical Operators
 
 [cols="~,~"]

--- a/tests/codegen/llvm/pointer_if_condition.ll
+++ b/tests/codegen/llvm/pointer_if_condition.ll
@@ -1,0 +1,87 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+entry:
+  %"$v" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
+  store i64 0, ptr %"$v", align 8
+  store i64 1, ptr %"$v", align 8
+  %1 = load i64, ptr %"$v", align 8
+  %true_cond = icmp ne i64 %1, 0
+  br i1 %true_cond, label %if_body, label %if_end
+
+if_body:                                          ; preds = %entry
+  br label %if_end
+
+if_end:                                           ; preds = %if_body, %entry
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/llvm/pointer_logical_and.ll
+++ b/tests/codegen/llvm/pointer_logical_and.ll
@@ -1,0 +1,105 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+entry:
+  %"&&_result" = alloca i64, align 8
+  %"$v" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
+  store i64 0, ptr %"$v", align 8
+  store i64 1, ptr %"$v", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
+  %1 = load i64, ptr %"$v", align 8
+  %lhs_true_cond = icmp ne i64 %1, 0
+  br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
+
+if_body:                                          ; preds = %"&&_merge"
+  br label %if_end
+
+if_end:                                           ; preds = %if_body, %"&&_merge"
+  ret i64 0
+
+"&&_lhs_true":                                    ; preds = %entry
+  br i1 false, label %"&&_true", label %"&&_false"
+
+"&&_true":                                        ; preds = %"&&_lhs_true"
+  store i64 1, ptr %"&&_result", align 8
+  br label %"&&_merge"
+
+"&&_false":                                       ; preds = %"&&_lhs_true", %entry
+  store i64 0, ptr %"&&_result", align 8
+  br label %"&&_merge"
+
+"&&_merge":                                       ; preds = %"&&_false", %"&&_true"
+  %2 = load i64, ptr %"&&_result", align 8
+  %true_cond = icmp ne i64 %2, 0
+  br i1 %true_cond, label %if_body, label %if_end
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/llvm/pointer_logical_or.ll
+++ b/tests/codegen/llvm/pointer_logical_or.ll
@@ -1,0 +1,105 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+entry:
+  %"||_result" = alloca i64, align 8
+  %"$v" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
+  store i64 0, ptr %"$v", align 8
+  store i64 1, ptr %"$v", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
+  %1 = load i64, ptr %"$v", align 8
+  %lhs_true_cond = icmp ne i64 %1, 0
+  br i1 %lhs_true_cond, label %"||_true", label %"||_lhs_false"
+
+if_body:                                          ; preds = %"||_merge"
+  br label %if_end
+
+if_end:                                           ; preds = %if_body, %"||_merge"
+  ret i64 0
+
+"||_lhs_false":                                   ; preds = %entry
+  br i1 false, label %"||_true", label %"||_false"
+
+"||_false":                                       ; preds = %"||_lhs_false"
+  store i64 0, ptr %"||_result", align 8
+  br label %"||_merge"
+
+"||_true":                                        ; preds = %"||_lhs_false", %entry
+  store i64 1, ptr %"||_result", align 8
+  br label %"||_merge"
+
+"||_merge":                                       ; preds = %"||_true", %"||_false"
+  %2 = load i64, ptr %"||_result", align 8
+  %true_cond = icmp ne i64 %2, 0
+  br i1 %true_cond, label %if_body, label %if_end
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/llvm/pointer_tenary_expression.ll
+++ b/tests/codegen/llvm/pointer_tenary_expression.ll
@@ -1,0 +1,95 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+entry:
+  %"$x" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
+  store i64 0, ptr %"$x", align 8
+  %"$v" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
+  store i64 0, ptr %"$v", align 8
+  store i64 1, ptr %"$v", align 8
+  %1 = load i64, ptr %"$v", align 8
+  %true_cond = icmp ne i64 %1, 0
+  br i1 %true_cond, label %left, label %right
+
+left:                                             ; preds = %entry
+  br label %done
+
+right:                                            ; preds = %entry
+  br label %done
+
+done:                                             ; preds = %right, %left
+  %result = phi i64 [ 1, %left ], [ 0, %right ]
+  store i64 %result, ptr %"$x", align 8
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/pointer_truthy.cpp
+++ b/tests/codegen/pointer_truthy.cpp
@@ -1,0 +1,29 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, pointer_if_condition)
+{
+  test("kprobe:f { $v = (int16*)1; if ($v) {} }", NAME);
+}
+
+TEST(codegen, pointer_tenary_expression)
+{
+  test("kprobe:f { $v = (int16*)1; $x = $v ? 1 : 0 }", NAME);
+}
+
+TEST(codegen, pointer_logical_and)
+{
+  test("kprobe:f { $v = (int16*)1; if ($v && 0) {} }", NAME);
+}
+
+TEST(codegen, pointer_logical_or)
+{
+  test("kprobe:f { $v = (int16*)1; if ($v || 0) {} }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/pointers
+++ b/tests/runtime/pointers
@@ -83,3 +83,19 @@ NAME Pointer to pointer arithmetic and dereference
 PROG uprobe:./testprogs/array_access:test_ptr_array { $p = (int32 **)arg0; @x = **($p + 1); exit(); }
 EXPECT @x: 2
 AFTER ./testprogs/array_access
+
+NAME Pointer is truthy for if conditions
+PROG BEGIN { if (curtask) { @ = 1; } exit(); }
+EXPECT @: 1
+
+NAME Pointer is truthy for tenary expressions
+PROG BEGIN { @ = curtask ? 1 : 2; exit(); }
+EXPECT @: 1
+
+NAME Pointer is useable in logical and expressions
+PROG BEGIN { @ = (curtask && 0) ? 1 : 2; exit(); }
+EXPECT @: 2
+
+NAME Pointer is useable in logical or expressions
+PROG BEGIN { @ = (curtask || 0) ? 1 : 2; exit(); }
+EXPECT @: 1

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -482,6 +482,8 @@ TEST(semantic_analyser, if_statements)
   test("kprobe:f { if(1) { 123 } else { 456 } }");
   test("kprobe:f { if(0) { 123 } else if(1) { 456 } else { 789 } }");
   test("kprobe:f { if((int32)pid) { 123 } }");
+  test("kprobe:f { if(curtask) { 123 } }");
+  test("kprobe:f { if(curtask && (int32)pid) { 123 } }");
 }
 
 TEST(semantic_analyser, predicate_expressions)
@@ -509,6 +511,7 @@ TEST(semantic_analyser, ternary_expressions)
   test("kprobe:f { @x = pid < 10000 ? 1 : 2 }");
   test(R"(kprobe:f { @x = pid < 10000 ? "lo" : "high" })");
   test("kprobe:f { pid < 10000 ? printf(\"lo\") : exit() }");
+  test("kprobe:f { curtask ? printf(\"lo\") : exit() }");
   test(R"(kprobe:f { @x = pid < 10000 ? printf("lo") : cat("/proc/uptime") })",
        10);
   // Error location is incorrect: #3063


### PR DESCRIPTION
For if conditions, tenary expressions and logical expressions we can allow pointers to evaluate to true or false. This change updates the codegen to consistently use the null value for the `lhs` and `rhs`, and allows the appropriate conditions in the semantic analyzer. Runtime tests are added to ensure that the given programs evaluate to the expected outcomes.

This fixes #1579, but should only update #1726. The question of broader expanding logical operators to strings and other types is trickier, but the null value for pointers is fairly well-understood and a very common pattern for C programmers (who will often write these probes).

##### Checklist

- [X] Language changes are updated in `man/adoc/bpftrace.adoc`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [X] The new behaviour is covered by tests
