### PR TITLE
nix: Remove LLVM 13 nix target

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -161,7 +161,6 @@
             bpftrace-llvm16 = mkBpftrace 16;
             bpftrace-llvm15 = mkBpftrace 15;
             bpftrace-llvm14 = mkBpftrace 14;
-            bpftrace-llvm13 = mkBpftrace 13;
 
             # Self-contained static binary with all dependencies
             appimage = nix-appimage.mkappimage.${system} {
@@ -210,7 +209,6 @@
             bpftrace-llvm16 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm16;
             bpftrace-llvm15 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm15;
             bpftrace-llvm14 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm14;
-            bpftrace-llvm13 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm13;
           };
         });
 }


### PR DESCRIPTION
PR https://github.com/bpftrace/bpftrace/pull/3618 dropped support for LLVM 13. So drop nix target as well.

After this, `nix flake check` will pass.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
