### PR TITLE
tests: runtime: Avoid /usr/sbin paths

### DIFF
--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -31,38 +31,38 @@ WILL_FAIL
 
 NAME kernel_module_attach
 RUN {{BPFTRACE}} -e 'fentry:nft_trans_alloc_gfp { printf("hit\n"); exit(); }'
-AFTER /usr/sbin/nft add table bpftrace
+AFTER nft add table bpftrace
 EXPECT hit
 REQUIRES_FEATURE fentry
 REQUIRES lsmod | grep '^nf_tables'
-REQUIRES /usr/sbin/nft --help
+REQUIRES nft --help
 CLEANUP nft delete table bpftrace
 
 NAME kernel_module_attach_wildcard
 RUN {{BPFTRACE}} -e 'fentry:nf_table*:nft_trans_alloc_gfp { printf("hit\n"); exit(); }'
-AFTER /usr/sbin/nft add table bpftrace
+AFTER nft add table bpftrace
 EXPECT hit
 REQUIRES_FEATURE fentry
 REQUIRES lsmod | grep '^nf_tables'
-REQUIRES /usr/sbin/nft --help
+REQUIRES nft --help
 CLEANUP nft delete table bpftrace
 
 NAME kernel_module_args
 RUN {{BPFTRACE}} -e 'fentry:nft_trans_alloc_gfp { printf("size: %d\n", args.size); exit(); }'
-AFTER /usr/sbin/nft add table bpftrace
+AFTER nft add table bpftrace
 EXPECT_REGEX size: [0-9]+
 REQUIRES_FEATURE fentry
 REQUIRES lsmod | grep '^nf_tables'
-REQUIRES /usr/sbin/nft --help
+REQUIRES nft --help
 CLEANUP nft delete table bpftrace
 
 NAME kernel_module_types
 RUN {{BPFTRACE}} -e 'fentry:nft_trans_alloc_gfp { printf("portid: %d\n", args.ctx->portid); exit(); }'
-AFTER /usr/sbin/nft add table bpftrace
+AFTER nft add table bpftrace
 EXPECT_REGEX portid: [0-9]+
 REQUIRES_FEATURE fentry
 REQUIRES lsmod | grep '^nf_tables'
-REQUIRES /usr/sbin/nft --help
+REQUIRES nft --help
 CLEANUP nft delete table bpftrace
 
 NAME kernel_module_tracepoint

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -120,9 +120,9 @@ EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall read
 
 NAME kprobe_wildcard_multi
-RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { printf("progs: "); system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { printf("progs: "); system("bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
 EXPECT progs: 1
-REQUIRES /usr/sbin/bpftool
+REQUIRES bpftool
 REQUIRES_FEATURE kprobe_multi
 
 NAME kprobe_module
@@ -161,22 +161,22 @@ EXPECT ERROR: Error attaching probe: kprobe:vmlinux:nonsense
 WILL_FAIL
 
 NAME kprobe_multi_wildcard
-RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { printf("link: "); system("/usr/sbin/bpftool link | grep kprobe_multi | wc -l"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { printf("link: "); system("bpftool link | grep kprobe_multi | wc -l"); exit(); }'
 EXPECT link: 1
-REQUIRES /usr/sbin/bpftool
+REQUIRES bpftool
 REQUIRES_FEATURE kprobe_multi
 
 NAME uprobe_multi_wildcard
-RUN {{BPFTRACE}} --unsafe -e 'uprobe:./testprogs/uprobe_test:uprobeFunction* { printf("link: "); system("/usr/sbin/bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -e 'uprobe:./testprogs/uprobe_test:uprobeFunction* { printf("link: "); system("bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }'
 EXPECT link: 1
-REQUIRES /usr/sbin/bpftool
+REQUIRES bpftool
 REQUIRES_FEATURE uprobe_multi
 AFTER ./testprogs/uprobe_test
 
 NAME kprobe_wildcard probe builtin
-RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { @ = probe; printf("progs: "); system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { @ = probe; printf("progs: "); system("bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
 EXPECT_REGEX progs: [1-9][0-9]+
-REQUIRES /usr/sbin/bpftool
+REQUIRES bpftool
 
 # Note: this test may fail if you've installed a new kernel but not rebooted
 # yet. Reason is b/c bpftrace will look for a vmlinux based on the running kernel's
@@ -190,22 +190,22 @@ SKIP_IF_ENV_HAS CI=true
 
 NAME kprobe_offset_module
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x5 { printf("hit\n"); exit(); }'
-AFTER /usr/sbin/nft add table bpftrace
+AFTER nft add table bpftrace
 EXPECT hit
 ARCH x86_64
 REQUIRES lsmod | grep '^nf_tables'
-REQUIRES /usr/sbin/nft --help
-CLEANUP /usr/sbin/nft delete table bpftrace
+REQUIRES nft --help
+CLEANUP nft delete table bpftrace
 
 # Local entry point to nft_trans_alloc_gfp is located at offset of 8 bytes in ppc64 and aarch64.
 NAME kprobe_offset_module
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x8 { printf("hit\n"); exit(); }'
-AFTER /usr/sbin/nft add table bpftrace
+AFTER nft add table bpftrace
 EXPECT hit
 ARCH ppc64|ppc64le|aarch64
 REQUIRES lsmod | grep '^nf_tables'
-REQUIRES /usr/sbin/nft --help
-CLEANUP /usr/sbin/nft delete table bpftrace
+REQUIRES nft --help
+CLEANUP nft delete table bpftrace
 
 NAME kprobe_offset_module_error
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
@@ -255,28 +255,28 @@ EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall read
 
 NAME kretprobe_wildcard_multi
-RUN {{BPFTRACE}} --unsafe -e 'kretprobe:ksys_* { system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -e 'kretprobe:ksys_* { system("bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
 EXPECT 1
-REQUIRES /usr/sbin/bpftool
+REQUIRES bpftool
 REQUIRES_FEATURE kprobe_multi
 
 NAME kretprobe_wildcard_multi_link
-RUN {{BPFTRACE}} --unsafe -e 'kretprobe:ksys_* { printf("link: "); system("/usr/sbin/bpftool link | grep kprobe_multi | wc -l"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -e 'kretprobe:ksys_* { printf("link: "); system("bpftool link | grep kprobe_multi | wc -l"); exit(); }'
 EXPECT link: 1
-REQUIRES /usr/sbin/bpftool
+REQUIRES bpftool
 REQUIRES_FEATURE kprobe_multi
 
 NAME uretprobe_multi_wildcard
-RUN {{BPFTRACE}} --unsafe -e 'uretprobe:./testprogs/uprobe_test:uprobeFunction* { printf("link: "); system("/usr/sbin/bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -e 'uretprobe:./testprogs/uprobe_test:uprobeFunction* { printf("link: "); system("bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }'
 EXPECT link: 1
-REQUIRES /usr/sbin/bpftool
+REQUIRES bpftool
 REQUIRES_FEATURE uprobe_multi
 AFTER ./testprogs/uprobe_test
 
 NAME uprobe_multi_wildcard_target_wildcard
-RUN {{BPFTRACE}} --unsafe -e 'uretprobe:*:uprobeFunction* { printf("link: "); system("/usr/sbin/bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} --unsafe -e 'uretprobe:*:uprobeFunction* { printf("link: "); system("bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }' -p {{BEFORE_PID}}
 EXPECT link: 1
-REQUIRES /usr/sbin/bpftool
+REQUIRES bpftool
 REQUIRES_FEATURE uprobe_multi
 BEFORE ./testprogs/uprobe_test
 


### PR DESCRIPTION
Avoid using absolute paths in runtime tests, as in CI under nix nothing will be reliably be present there. Instead rely on PATH search.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
