### PR TITLE
ci: Move color configuration into ci.py

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -41,9 +41,7 @@ RUN_MEMLEAK_TEST = os.environ.get("RUN_MEMLEAK_TEST", "0")
 RUN_AOT_TESTS = os.environ.get("RUN_AOT_TESTS", "0")
 CC = os.environ.get("CC", "cc")
 CXX = os.environ.get("CXX", "c++")
-GTEST_COLOR = os.environ.get("GTEST_COLOR", "auto")
 CI = os.environ.get("CI", "false")
-RUNTIME_TEST_COLOR = os.environ.get("RUNTIME_TEST_COLOR", "auto")
 TOOLS_TEST_OLDVERSION = os.environ.get("TOOLS_TEST_OLDVERSION", "")
 TOOLS_TEST_DISABLE = os.environ.get("TOOLS_TEST_DISABLE", "")
 AOT_SKIPLIST_FILE = os.environ.get("AOT_SKIPLIST_FILE", "")
@@ -240,7 +238,7 @@ def test():
             lambda: shell(
                 ["./tests/bpftrace_test"],
                 cwd=Path(BUILD_DIR),
-                env={"GTEST_COLOR": GTEST_COLOR},
+                env={"GTEST_COLOR": "yes"},
             ),
         )
     )
@@ -254,7 +252,7 @@ def test():
                 cwd=Path(BUILD_DIR),
                 env={
                     "CI": CI,
-                    "RUNTIME_TEST_COLOR": RUNTIME_TEST_COLOR,
+                    "RUNTIME_TEST_COLOR": "yes",
                 },
             ),
         )
@@ -299,7 +297,7 @@ def test():
                 cwd=Path(BUILD_DIR),
                 env={
                     "CI": CI,
-                    "RUNTIME_TEST_COLOR": RUNTIME_TEST_COLOR,
+                    "RUNTIME_TEST_COLOR": "yes",
                 },
             ),
         )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ jobs:
   build_test:
     runs-on: ubuntu-latest
     continue-on-error: true
-    env:
-      GTEST_COLOR: yes
-      RUNTIME_TEST_COLOR: yes
     strategy:
       matrix:
         env:


### PR DESCRIPTION
There's no need for the configuration to be wired through the YAML. We always want the CI in GHA to be as similar to local execution as possible. So move the configuration directly into ci.py.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
