### PR TITLE
tests: runtime: Use LSM hooks for more reliable path() tests

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -507,22 +507,22 @@ EXPECT_REGEX BEGIN\n@\[1\]:(.*\n)+@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
 TIMEOUT 1
 
 NAME path
-RUN {{BPFTRACE}} -ve 'fentry:filp_close { if (!strncmp(path(args.filp->f_path), "/tmp/bpftrace_runtime_test_syscall_gen_read_temp", 49)) { printf("OK\n"); exit(); } }'
+RUN {{BPFTRACE}} -ve 'fentry:security_file_open { if (!strncmp(path(args.file->f_path), "/tmp/bpftrace_runtime_test_syscall_gen_open_temp", 49)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath fentry
-AFTER ./testprogs/syscall read
+AFTER ./testprogs/syscall open
 
 NAME path_with_optional_size
-RUN {{BPFTRACE}} -ve 'fentry:filp_close { $p = path(args.filp->f_path, 48);  if ( sizeof($p) == 48 && !strncmp($p, "tmp/bpftrace_runtime_test_syscall_gen_read_temp", 48)) { printf("OK\n"); exit(); } }'
+RUN {{BPFTRACE}} -ve 'fentry:security_file_open { $p = path(args.file->f_path, 48);  if ( sizeof($p) == 48 && !strncmp($p, "tmp/bpftrace_runtime_test_syscall_gen_open_temp", 48)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath fentry
-AFTER ./testprogs/syscall read
+AFTER ./testprogs/syscall open
 
 NAME strcontains
-RUN {{BPFTRACE}} -ve 'fentry:filp_close { if (strcontains(path(args.filp->f_path), "tmp")) { printf("OK\n"); exit(); } }'
+RUN {{BPFTRACE}} -ve 'fentry:security_file_open { if (strcontains(path(args.file->f_path), "tmp")) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath fentry
-AFTER ./testprogs/syscall read
+AFTER ./testprogs/syscall open
 
 NAME strcontains literals
 RUN {{BPFTRACE}} -e 'BEGIN { if (strcontains("abc", "a")) { printf("OK\n"); exit(); } }'

--- a/tests/testprogs/syscall.c
+++ b/tests/testprogs/syscall.c
@@ -1,7 +1,6 @@
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
-#include <linux/version.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -117,11 +116,7 @@ int gen_read()
   }
   char buf[10];
   int r = syscall(SYS_read, fd, (void *)buf, 0);
-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 9, 0)
   close(fd);
-#else
-  close_range(fd, fd, 0);
-#endif
   remove(file_path);
   free(file_path);
   if (r < 0) {


### PR DESCRIPTION
Previously, we were jumping through all kinds of hoops to keep kfunc:filp_close probe working. Since it's broken again on newer kernels, just switch to using a more stable API - the LSM hooks. These are way less likely to change in the future.

This also reverts 2455741e ("Fix `call.path*` tests in newer kernel") b/c it's no longer necessary.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
