### PR TITLE
Fix: for loops with per-cpu aggregations

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -68,6 +68,7 @@ aot.for.map strings
 # Same problem as #3392
 aot.for.map two key elements
 aot.for.map two keys
+aot.for.map two keys with a per cpu aggregation
 aot.for.variable context multiple
 aot.json-output.complex
 aot.json-output.histogram

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -4568,11 +4568,8 @@ Function *CodegenLLVM::createForEachMapCallback(const For &f, llvm::Type *ctx_t)
 
   const auto &map_val_type = map_info->second.value_type;
   if (canAggPerCpuMapElems(map_val_type, map_info->second.key_type)) {
-    AllocaInst *key_ptr = b_.CreateAllocaBPF(b_.GetType(key_type),
-                                             "lookup_key");
-    b_.CreateStore(key, key_ptr);
-
-    val = b_.CreatePerCpuMapAggElems(ctx_, map, key_ptr, map_val_type, map.loc);
+    val = b_.CreatePerCpuMapAggElems(
+        ctx_, map, callback->getArg(1), map_val_type, map.loc);
   } else if (!inBpfMemory(val_type)) {
     val = b_.CreateLoad(b_.GetType(val_type), val, "val");
   }

--- a/tests/codegen/llvm/avg_cast_loop.ll
+++ b/tests/codegen/llvm/avg_cast_loop.ll
@@ -72,10 +72,7 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
-  store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
@@ -92,7 +89,7 @@ while_cond:                                       ; preds = %lookup_success, %4
 
 while_body:                                       ; preds = %while_cond
   %7 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %lookup_key, i32 %7)
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %1, i32 %7)
   %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -63,10 +63,7 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
-  store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
@@ -83,7 +80,7 @@ while_cond:                                       ; preds = %lookup_success, %4
 
 while_body:                                       ; preds = %while_cond
   %7 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %lookup_key, i32 %7)
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %1, i32 %7)
   %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 

--- a/tests/codegen/llvm/count_cast_loop_multi_key.ll
+++ b/tests/codegen/llvm/count_cast_loop_multi_key.ll
@@ -1,0 +1,218 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%int64_int64__tuple_t = type { i64, i64 }
+%"(int64,int64)_count_t__tuple_t" = type { %int64_int64__tuple_t, i64 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !39
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !56
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !61 {
+entry:
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %tuple = alloca %int64_int64__tuple_t, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
+  %1 = getelementptr %int64_int64__tuple_t, ptr %tuple, i32 0, i32 0
+  store i64 1, ptr %1, align 8
+  %2 = getelementptr %int64_int64__tuple_t, ptr %tuple, i32 0, i32 1
+  store i64 2, ptr %2, align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %tuple)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %3 = load i64, ptr %lookup_elem, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, ptr %lookup_elem, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
+  store i64 1, ptr %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %tuple, ptr %initial_value, i64 1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
+  %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_x, ptr @map_for_each_cb, ptr null, i64 0)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !68 {
+  %"$res" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$res")
+  store i64 0, ptr %"$res", align 8
+  %"$kv" = alloca %"(int64,int64)_count_t__tuple_t", align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
+  %i = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
+  store i32 0, ptr %i, align 4
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
+  br label %while_cond
+
+while_cond:                                       ; preds = %lookup_success, %4
+  %5 = load i32, ptr @num_cpus, align 4
+  %6 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %6, %5
+  br i1 %num_cpu.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %7 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %1, i32 %7)
+  %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+while_end:                                        ; preds = %error_failure, %error_success, %while_cond
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
+  %8 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 24, i1 false)
+  %9 = getelementptr %"(int64,int64)_count_t__tuple_t", ptr %"$kv", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %1, i64 16, i1 false)
+  %10 = getelementptr %"(int64,int64)_count_t__tuple_t", ptr %"$kv", i32 0, i32 1
+  store i64 %8, ptr %10, align 8
+  %11 = getelementptr %"(int64,int64)_count_t__tuple_t", ptr %"$kv", i32 0, i32 1
+  %12 = load i64, ptr %11, align 8
+  store i64 %12, ptr %"$res", align 8
+  ret i64 0
+
+lookup_success:                                   ; preds = %while_body
+  %13 = load i64, ptr %val_1, align 8
+  %14 = load i64, ptr %lookup_percpu_elem, align 8
+  %15 = add i64 %14, %13
+  store i64 %15, ptr %val_1, align 8
+  %16 = load i32, ptr %i, align 4
+  %17 = add i32 %16, 1
+  store i32 %17, ptr %i, align 4
+  br label %while_cond
+
+lookup_failure:                                   ; preds = %while_body
+  %18 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %18, 0
+  br i1 %error_lookup_cond, label %error_success, label %error_failure
+
+error_success:                                    ; preds = %lookup_failure
+  br label %while_end
+
+error_failure:                                    ; preds = %lookup_failure
+  %19 = load i32, ptr %i, align 4
+  br label %while_end
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!58}
+!llvm.module.flags = !{!60}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !23}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 160, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 5, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !19)
+!19 = !{!20, !22}
+!20 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!22 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !21, size: 64, offset: 64)
+!23 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !24, size: 64, offset: 192)
+!24 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !42)
+!42 = !{!43, !48, !53, !23}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 2, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !49, size: 64, offset: 64)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 1, lowerBound: 0)
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !54, size: 64, offset: 128)
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
+!55 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!56 = !DIGlobalVariableExpression(var: !57, expr: !DIExpression())
+!57 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!58 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !59)
+!59 = !{!0, !25, !39, !56}
+!60 = !{i32 2, !"Debug Info Version", i32 3}
+!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !58, retainedNodes: !66)
+!62 = !DISubroutineType(types: !63)
+!63 = !{!21, !64}
+!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !65, size: 64)
+!65 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!66 = !{!67}
+!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)
+!68 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !69, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !58, retainedNodes: !71)
+!69 = !DISubroutineType(types: !70)
+!70 = !{!21, !64, !64, !64, !64}
+!71 = !{!72, !73, !74, !75}
+!72 = !DILocalVariable(name: "map", arg: 1, scope: !68, file: !2, type: !64)
+!73 = !DILocalVariable(name: "key", arg: 2, scope: !68, file: !2, type: !64)
+!74 = !DILocalVariable(name: "value", arg: 3, scope: !68, file: !2, type: !64)
+!75 = !DILocalVariable(name: "ctx", arg: 4, scope: !68, file: !2, type: !64)

--- a/tests/codegen/llvm/count_cast_loop_stack_key.ll
+++ b/tests/codegen/llvm/count_cast_loop_stack_key.ll
@@ -1,0 +1,361 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr }
+%"struct map_t.3" = type { ptr, ptr, ptr, ptr }
+%stack_key = type { i64, i32 }
+%kstack_count_t__tuple_t = type { [12 x i8], i64 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@stack_raw_127 = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !25
+@stack_scratch = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !44
+@ringbuf = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !61
+@event_loss_counter = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !75
+@num_cpus = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !84
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !89 {
+entry:
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %lookup_stack_scratch_key = alloca i32, align 4
+  %stack_key = alloca %stack_key, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
+  %1 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  store i64 0, ptr %1, align 8
+  %2 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  store i32 0, ptr %2, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
+  store i32 0, ptr %lookup_stack_scratch_key, align 4
+  %lookup_stack_scratch_map = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_stack_scratch_key)
+  %lookup_stack_scratch_cond = icmp ne ptr %lookup_stack_scratch_map, null
+  br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
+
+stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
+  br label %merge_block
+
+merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %stack_key)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_stack_scratch_failure:                     ; preds = %entry
+  br label %stack_scratch_failure
+
+lookup_stack_scratch_merge:                       ; preds = %entry
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
+  %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 0)
+  %3 = icmp sge i32 %get_stack, 0
+  br i1 %3, label %get_stack_success, label %get_stack_fail
+
+get_stack_success:                                ; preds = %lookup_stack_scratch_merge
+  %4 = udiv i32 %get_stack, 8
+  %5 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %4, ptr %5, align 4
+  %6 = trunc i32 %4 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %6, i64 1)
+  %7 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %7, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_raw_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
+  br label %merge_block
+
+get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
+  br label %merge_block
+
+lookup_success:                                   ; preds = %merge_block
+  %8 = load i64, ptr %lookup_elem, align 8
+  %9 = add i64 %8, 1
+  store i64 %9, ptr %lookup_elem, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %merge_block
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
+  store i64 1, ptr %initial_value, align 8
+  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %stack_key, ptr %initial_value, i64 1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
+  %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_x, ptr @map_for_each_cb, ptr null, i64 0)
+  ret i64 0
+}
+
+; Function Attrs: alwaysinline
+define internal i64 @murmur_hash_2(ptr %0, i8 %1, i64 %2) #1 section "helpers" {
+entry:
+  %k = alloca i64, align 8
+  %i = alloca i8, align 1
+  %id = alloca i64, align 8
+  %seed_addr = alloca i64, align 8
+  %nr_stack_frames_addr = alloca i8, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %nr_stack_frames_addr)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %seed_addr)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %id)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %k)
+  store i8 %1, ptr %nr_stack_frames_addr, align 1
+  store i64 %2, ptr %seed_addr, align 8
+  %3 = load i8, ptr %nr_stack_frames_addr, align 1
+  %4 = zext i8 %3 to i64
+  %5 = mul i64 %4, -4132994306676758123
+  %6 = load i64, ptr %seed_addr, align 8
+  %7 = xor i64 %6, %5
+  store i64 %7, ptr %id, align 8
+  store i8 0, ptr %i, align 1
+  br label %while_cond
+
+while_cond:                                       ; preds = %while_body, %entry
+  %8 = load i8, ptr %nr_stack_frames_addr, align 1
+  %9 = load i8, ptr %i, align 1
+  %length.cmp = icmp ult i8 %9, %8
+  br i1 %length.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %10 = load i8, ptr %i, align 1
+  %11 = getelementptr i64, ptr %0, i8 %10
+  %12 = load i64, ptr %11, align 8
+  store i64 %12, ptr %k, align 8
+  %13 = load i64, ptr %k, align 8
+  %14 = mul i64 %13, -4132994306676758123
+  store i64 %14, ptr %k, align 8
+  %15 = load i64, ptr %k, align 8
+  %16 = lshr i64 %15, 47
+  %17 = load i64, ptr %k, align 8
+  %18 = xor i64 %17, %16
+  store i64 %18, ptr %k, align 8
+  %19 = load i64, ptr %k, align 8
+  %20 = mul i64 %19, -4132994306676758123
+  store i64 %20, ptr %k, align 8
+  %21 = load i64, ptr %k, align 8
+  %22 = load i64, ptr %id, align 8
+  %23 = xor i64 %22, %21
+  store i64 %23, ptr %id, align 8
+  %24 = load i64, ptr %id, align 8
+  %25 = mul i64 %24, -4132994306676758123
+  store i64 %25, ptr %id, align 8
+  %26 = load i8, ptr %i, align 1
+  %27 = add i8 %26, 1
+  store i8 %27, ptr %i, align 1
+  br label %while_cond
+
+while_end:                                        ; preds = %while_cond
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %nr_stack_frames_addr)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %seed_addr)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %k)
+  %28 = load i64, ptr %id, align 8
+  %zero_cond = icmp eq i64 %28, 0
+  br i1 %zero_cond, label %if_zero, label %if_end
+
+if_zero:                                          ; preds = %while_end
+  store i64 1, ptr %id, align 8
+  br label %if_end
+
+if_end:                                           ; preds = %if_zero, %while_end
+  %29 = load i64, ptr %id, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %id)
+  ret i64 %29
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !95 {
+  %"$res" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$res")
+  store i64 0, ptr %"$res", align 8
+  %"$kv" = alloca %kstack_count_t__tuple_t, align 8
+  %val_2 = alloca i64, align 8
+  %val_1 = alloca i64, align 8
+  %i = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
+  store i32 0, ptr %i, align 4
+  store i64 0, ptr %val_1, align 8
+  store i64 0, ptr %val_2, align 8
+  br label %while_cond
+
+while_cond:                                       ; preds = %lookup_success, %4
+  %5 = load i32, ptr @num_cpus, align 4
+  %6 = load i32, ptr %i, align 4
+  %num_cpu.cmp = icmp ult i32 %6, %5
+  br i1 %num_cpu.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %7 = load i32, ptr %i, align 4
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %1, i32 %7)
+  %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+while_end:                                        ; preds = %error_failure, %error_success, %while_cond
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
+  %8 = load i64, ptr %val_1, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 24, i1 false)
+  %9 = getelementptr %kstack_count_t__tuple_t, ptr %"$kv", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 %1, i64 12, i1 false)
+  %10 = getelementptr %kstack_count_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  store i64 %8, ptr %10, align 8
+  %11 = getelementptr %kstack_count_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  %12 = load i64, ptr %11, align 8
+  store i64 %12, ptr %"$res", align 8
+  ret i64 0
+
+lookup_success:                                   ; preds = %while_body
+  %13 = load i64, ptr %val_1, align 8
+  %14 = load i64, ptr %lookup_percpu_elem, align 8
+  %15 = add i64 %14, %13
+  store i64 %15, ptr %val_1, align 8
+  %16 = load i32, ptr %i, align 4
+  %17 = add i32 %16, 1
+  store i32 %17, ptr %i, align 4
+  br label %while_cond
+
+lookup_failure:                                   ; preds = %while_body
+  %18 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %18, 0
+  br i1 %error_lookup_cond, label %error_success, label %error_failure
+
+error_success:                                    ; preds = %lookup_failure
+  br label %while_end
+
+error_failure:                                    ; preds = %lookup_failure
+  %19 = load i32, ptr %i, align 4
+  br label %while_end
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #4
+
+attributes #0 = { nounwind }
+attributes #1 = { alwaysinline }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #4 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!86}
+!llvm.module.flags = !{!88}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !22}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 160, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 5, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 131072, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 4096, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, size: 96, elements: !20)
+!19 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!20 = !{!21}
+!21 = !DISubrange(count: 12, lowerBound: 0)
+!22 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "stack_raw_127", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !28)
+!28 = !{!29, !34, !16, !39}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 9, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 131072, lowerBound: 0)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !40, size: 64, offset: 192)
+!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 8128, elements: !42)
+!42 = !{!43}
+!43 = !DISubrange(count: 127, lowerBound: 0)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
+!46 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !47)
+!47 = !{!48, !53, !58, !39}
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !49, size: 64)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 6, lowerBound: 0)
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !54, size: 64, offset: 64)
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !56)
+!56 = !{!57}
+!57 = !DISubrange(count: 1, lowerBound: 0)
+!58 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !59, size: 64, offset: 128)
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
+!60 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
+!62 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !63, isLocal: false, isDefinition: true)
+!63 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !64)
+!64 = !{!65, !70}
+!65 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !66, size: 64)
+!66 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !67, size: 64)
+!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !68)
+!68 = !{!69}
+!69 = !DISubrange(count: 27, lowerBound: 0)
+!70 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !71, size: 64, offset: 64)
+!71 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !72, size: 64)
+!72 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !73)
+!73 = !{!74}
+!74 = !DISubrange(count: 262144, lowerBound: 0)
+!75 = !DIGlobalVariableExpression(var: !76, expr: !DIExpression())
+!76 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !77, isLocal: false, isDefinition: true)
+!77 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !78)
+!78 = !{!79, !53, !58, !22}
+!79 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !80, size: 64)
+!80 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !81, size: 64)
+!81 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !82)
+!82 = !{!83}
+!83 = !DISubrange(count: 2, lowerBound: 0)
+!84 = !DIGlobalVariableExpression(var: !85, expr: !DIExpression())
+!85 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!86 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !87)
+!87 = !{!0, !25, !44, !61, !75, !84}
+!88 = !{i32 2, !"Debug Info Version", i32 3}
+!89 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !90, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !86, retainedNodes: !93)
+!90 = !DISubroutineType(types: !91)
+!91 = !{!24, !92}
+!92 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!93 = !{!94}
+!94 = !DILocalVariable(name: "ctx", arg: 1, scope: !89, file: !2, type: !92)
+!95 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !96, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !86, retainedNodes: !98)
+!96 = !DISubroutineType(types: !97)
+!97 = !{!24, !92, !92, !92, !92}
+!98 = !{!99, !100, !101, !102}
+!99 = !DILocalVariable(name: "map", arg: 1, scope: !95, file: !2, type: !92)
+!100 = !DILocalVariable(name: "key", arg: 2, scope: !95, file: !2, type: !92)
+!101 = !DILocalVariable(name: "value", arg: 3, scope: !95, file: !2, type: !92)
+!102 = !DILocalVariable(name: "ctx", arg: 4, scope: !95, file: !2, type: !92)

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -77,10 +77,7 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
-  store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
@@ -97,7 +94,7 @@ while_cond:                                       ; preds = %min_max_merge, %4
 
 while_body:                                       ; preds = %while_cond
   %7 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %lookup_key, i32 %7)
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %1, i32 %7)
   %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -77,10 +77,7 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
-  store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
@@ -97,7 +94,7 @@ while_cond:                                       ; preds = %min_max_merge, %4
 
 while_body:                                       ; preds = %while_cond
   %7 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %lookup_key, i32 %7)
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %1, i32 %7)
   %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -63,10 +63,7 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %lookup_key = alloca i64, align 8
   %key = load i64, ptr %1, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
-  store i64 %key, ptr %lookup_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
@@ -83,7 +80,7 @@ while_cond:                                       ; preds = %lookup_success, %4
 
 while_body:                                       ; preds = %while_cond
   %7 = load i32, ptr %i, align 4
-  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %lookup_key, i32 %7)
+  %lookup_percpu_elem = call ptr inttoptr (i64 195 to ptr)(ptr @AT_x, ptr %1, i32 %7)
   %map_lookup_cond = icmp ne ptr %lookup_percpu_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 

--- a/tests/codegen/per_cpu_map_cast.cpp
+++ b/tests/codegen/per_cpu_map_cast.cpp
@@ -59,6 +59,19 @@ TEST(codegen, count_no_cast_for_print)
   test("BEGIN { @ = count(); print(@) }", NAME);
 }
 
+TEST(codegen, count_cast_loop_multi_key)
+{
+  test("kprobe:f { @x[1, 2] = count(); for ($kv : @x) { $res = $kv.1; } }",
+       NAME);
+}
+
+TEST(codegen, count_cast_loop_stack_key)
+{
+  test("kprobe:f { @x[kstack(raw)] = count(); for ($kv : @x) { $res = $kv.1; } "
+       "}",
+       NAME);
+}
+
 } // namespace codegen
 } // namespace test
 } // namespace bpftrace

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -72,3 +72,12 @@ EXPECT_REGEX ^abc\ndef\ndef$
 NAME variable context multiple
 PROG BEGIN { @map[0] = 0; $var1 = 123; $var2 = "abc"; for ($kv : @map) { print(($var1, $var2)); } exit(); }
 EXPECT (123, abc)
+
+NAME map two keys with a per cpu aggregation
+PROG BEGIN { @map[16,17] = count(); @map[16,17] = count(); @map[1,2] = count(); for ($kv : @map) { print($kv); } exit(); }
+EXPECT ((16, 17), 2)
+EXPECT ((1, 2), 1)
+
+NAME map stack key with a per cpu aggregation
+PROG BEGIN { @map[kstack(raw)] = count(); for ($kv : @map) { print($kv.1); } exit(); }
+EXPECT 1


### PR DESCRIPTION
For a map that had multiple keys or a single key
that was `inBpfMemory` and contained a per-cpu
aggregation as a value (e.g. `count` or `sum`)
then retrieving the value from the `$kv` tuple was broken e.g.
```
@map[1, 2] = count();
for ($kv : @map) {
  print($kv.1); // this would always be 0
}
```

The fix is to just use the callback arg ptr
instead of allocating a new value (as the key)
and trying to store something in it.

Previously, for values inBpfMemory (like tuples) the
key in the line `b_.CreateStore(key, key_ptr);` was
populated with a pointer instead of the actual value
so key_ptr was storing a pointer and then we were
taking a pointer to a pointer for the map lookup,
which was wrong.
##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
