### PR TITLE
tests: runtime: Remove races with uprobe_test

### DIFF
--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -199,25 +199,25 @@ NAME args in uprobe print
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { print(args); exit(); }
 EXPECT_REGEX { .n = 0x[0-9a-f]+, .c = 120 }
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME args in uprobe store in map
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = args; exit(); }
 EXPECT_REGEX @: { .n = 0x[0-9a-f]+, .c = 120 }
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME args in uprobe store in map and access field
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = args; print(@.c); exit(); }
 EXPECT 120
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME args in uprobe as a map key
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @[args] = 1; exit(); }
 EXPECT_REGEX @[{ .n = 0x[0-9a-f]+, .c = 120 }]: 1
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME jiffies
 PROG i:ms:1 { printf("SUCCESS %llu\n", jiffies); exit(); }
@@ -226,9 +226,9 @@ REQUIRES_FEATURE jiffies64
 MIN_KERNEL 5.9
 
 NAME ustack builtin with stack_mode config
-RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { @c[ustack] = 1; exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { @c[ustack] = 1; exit(); }'
 EXPECT_REGEX ^@c\[\n[0-9a-f]+$
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME kstack builtin with stack_mode config
 RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } k:do_nanosleep { @c[kstack] = 1; exit(); }'

--- a/tests/runtime/config
+++ b/tests/runtime/config
@@ -1,29 +1,27 @@
 NAME config as env var
-RUN {{BPFTRACE}} -e 'config = { BPFTRACE_STACK_MODE=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'config = { BPFTRACE_STACK_MODE=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }'
 EXPECT_REGEX ^\s+[0-9a-f]+$
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME config short name
-RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }'
 EXPECT_REGEX ^\s+[0-9a-f]+$
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME env var takes precedence
-RUN {{BPFTRACE}} -e 'config = { BPFTRACE_STACK_MODE=perf } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'config = { BPFTRACE_STACK_MODE=perf } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }'
 ENV BPFTRACE_STACK_MODE=raw
 EXPECT_REGEX ^\s+[0-9a-f]+$
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME bad config
-RUN {{BPFTRACE}} -e 'config = { bad_config=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'config = { bad_config=raw } BEGIN {}'
 EXPECT stdin:1:12-23: ERROR: Unrecognized config variable: bad_config
-BEFORE ./testprogs/uprobe_test
 WILL_FAIL
 
 NAME env only config
-RUN {{BPFTRACE}} -e 'config = { debug_output=1 } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'config = { debug_output=1 } BEGIN {}'
 EXPECT stdin:1:12-25: ERROR: debug_output can only be set as an environment variable
-BEFORE ./testprogs/uprobe_test
 WILL_FAIL
 
 NAME maps are printed by default

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -36,19 +36,19 @@ NAME uprobe arg by name - char
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("c = %c\n", args.c); exit(); }
 EXPECT c = x
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME uprobe arg by name - pointer
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("n = %d\n", *(args.n)); exit(); }
 EXPECT n = 13
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME uprobe arg by name - struct
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->a = %d\n", args.foo1->a); exit(); }
 EXPECT foo1->a = 123
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 # NAME uprobe arg by index - 128-bits integer
 # PROG uprobe:./testprogs/uprobe_test:uprobeFunctionUint128 { printf("x = %x\ny = %x\nz = %x\nw = %x\n", arg0, arg1, arg2, arg3); exit(); }
@@ -57,7 +57,7 @@ BEFORE ./testprogs/uprobe_test
 #        z = cdcdcdcd
 #        w = abababab
 # REQUIRES_FEATURE dwarf
-# BEFORE ./testprogs/uprobe_test
+# AFTER ./testprogs/uprobe_test
 
 # NAME uprobe arg by name - 128-bits integer
 # PROG uprobe:./testprogs/uprobe_test:uprobeFunctionUint128 { printf("x = %x\ny = %x\nz = %x\nw = %x\n", args.x, args.y, args.z, args.w); exit(); }
@@ -66,13 +66,13 @@ BEFORE ./testprogs/uprobe_test
 #        z = cdcdcdcd
 #        w = abababab
 # REQUIRES_FEATURE dwarf
-# BEFORE ./testprogs/uprobe_test
+# AFTER ./testprogs/uprobe_test
 
 NAME uprobe arg by name - struct with 128-bits integer
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->d = %x\n", args.foo1->d); exit(); }
 EXPECT foo1->d = 9abcdef0
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME uprobe without dwarf
 PROG config = { symbol_source = "symbol_table"; cache_user_symbols = "PER_PROGRAM"; }
@@ -196,31 +196,31 @@ NAME uprobe args as pointer
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("c = %c\n", args->c); exit(); }
 EXPECT c = x
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME struct field string
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->b = %s\n", args.foo1->b); exit(); }
 EXPECT foo1->b = hello
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME struct field array
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { print(args.foo1->c); exit(); }
 EXPECT [1,2,3]
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME cast to struct
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->a = %d\n", ((struct Foo *)arg0)->a); exit(); }
 EXPECT foo1->a = 123
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 NAME struct override
 PROG struct Foo { int b; } uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->b = %d\n", ((struct Foo *)arg0)->b); exit(); }
 EXPECT foo1->b = 123
 REQUIRES_FEATURE dwarf
-BEFORE ./testprogs/uprobe_test
+AFTER ./testprogs/uprobe_test
 
 # The function `str_has_prefix` is marked to be always inlined, so we'll get
 # more than one occurrence for it.

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -104,12 +104,12 @@ EXPECT_REGEX ^@: \(\d+, \d+:\d+\)$
 
 NAME bytearray in tuple
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = ((int8)1, usym(reg("ip")), 10); exit(); }
-EXPECT_REGEX ^@: \(1, 0x[0-9a-f]+, 10\)$
+EXPECT_REGEX ^@: \(1, uprobeFunction1, 10\)$
 ARCH x86_64
 AFTER ./testprogs/uprobe_test
 
 NAME bytearray in tuple
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = ((int8)1, usym(reg("nip")), 10); exit(); }
-EXPECT_REGEX ^@: \(1, 0x[0-9a-f]+, 10\)$
+EXPECT_REGEX ^@: \(1, uprobeFunction1, 10\)$
 ARCH ppc64|ppc64le
 AFTER ./testprogs/uprobe_test

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -42,13 +42,9 @@ RUN {{BPFTRACE}} -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:uprob
 EXPECT Attaching 1 probe...
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
-# Note that we don't expect the exact uprobeFunction1 name because CI runs in a docker
-# container and symbols don't currently get resolved correctly in this scenario
-# as the event received by bpftrace contains the pid of the process in the root
-# pid namespace, not that of the docker container's namespace.
 NAME uprobes - attach to probe for executable in a pivot_root'd mount namespace
 RUN {{BPFTRACE}} -e 'uprobe:/proc/{{BEFORE_PID}}/root/uprobe_test:uprobeFunction1 { printf("func %s\n", func); exit(); }'
-EXPECT_REGEX ^func (0x[0-9a-f]+|function1)$
+EXPECT func uprobeFunction1
 BEFORE ./testprogs/mountns_pivot_wrapper uprobe_test
 
 NAME uprobes - attach to probe by pid with only wildcard

--- a/tests/testprogs/uprobe_test.c
+++ b/tests/testprogs/uprobe_test.c
@@ -61,25 +61,27 @@ __uint128_t uprobeFunctionUint128(__uint128_t x,
 
 int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
 {
-  usleep(1000000);
+  while (1) {
+    int n = 13;
+    char c = 'x';
+    uprobeFunction1(&n, c);
 
-  int n = 13;
-  char c = 'x';
-  uprobeFunction1(&n, c);
+    struct Foo foo1 = {
+      .a = 123, .b = "hello", .c = { 1, 2, 3 }, .d = 0x123456789ABCDEF0
+    };
+    struct Foo foo2 = {
+      .a = 456, .b = "world", .c = { 4, 5, 6 }, .d = 0xFEDCBA9876543210
+    };
+    uprobeFunction2(&foo1, &foo2);
 
-  struct Foo foo1 = {
-    .a = 123, .b = "hello", .c = { 1, 2, 3 }, .d = 0x123456789ABCDEF0
-  };
-  struct Foo foo2 = {
-    .a = 456, .b = "world", .c = { 4, 5, 6 }, .d = 0xFEDCBA9876543210
-  };
-  uprobeFunction2(&foo1, &foo2);
+    __uint128_t x = 0x123456789ABCDEF0;
+    __uint128_t y = 0xEFEFEFEFEFEFEFEF;
+    __uint128_t z = 0xCDCDCDCDCDCDCDCD;
+    __uint128_t w = 0xABABABABABABABAB;
+    uprobeFunctionUint128(x, y, z, w);
 
-  __uint128_t x = 0x123456789ABCDEF0;
-  __uint128_t y = 0xEFEFEFEFEFEFEFEF;
-  __uint128_t z = 0xCDCDCDCDCDCDCDCD;
-  __uint128_t w = 0xABABABABABABABAB;
-  uprobeFunctionUint128(x, y, z, w);
+    usleep(100000);
+  }
 
   return 0;
 }


### PR DESCRIPTION
There was a `sleep(1)` in the beginning of uprobe_test. This was a racey
way to synchronize between `BEFORE` clause and bpftrace execution.

Not only was it racey, but it introduces unnecessary delay in the event
that bpftrace runs fast. We can shave off some CI time by doing more
precise synchronization.

See individual commits for more details.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
