### PR TITLE
Unambiguously adopt zero value semantics

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -822,7 +822,8 @@ $b = --$a; // a = 9; b = 9
 ----
 
 Note that maps will be implicitly declared and initialized to 0 if not already declared or defined.
-Scratch variables must be initialized before using these operators.
+
+Scratch variables must be declared or initialized before using these operators.
 
 Note `{plus}{plus}`/`--` on a shared global variable can lose updates. See <<map-functions-count, `count()`>> for more details.
 

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -18,7 +18,6 @@ namespace ast {
 struct variable {
   SizedType type;
   bool can_resize;
-  bool was_assigned;
 };
 
 class SemanticAnalyser : public Visitor {

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2980,7 +2980,7 @@ TEST(semantic_analyser, mixed_int_var_assignments)
   // test("kprobe:f { $x = (uint32)5; $x += 1; }");
 
   test_error("kprobe:f { $x = (uint8)1; $x = -1; }", R"(
-stdin:1:27-34: ERROR: Type mismatch for $x: trying to assign value of type 'int64' when variable already contains a value of type 'uint8'
+stdin:1:27-34: ERROR: Type mismatch for $x: trying to assign value of type 'int64' when variable has type 'uint8'
 kprobe:f { $x = (uint8)1; $x = -1; }
                           ~~~~~~~
 )");
@@ -2995,7 +2995,7 @@ kprobe:f { $a = (uint16)5; $x = (uint8)0; $x = $a; }
                                           ~~~~~~~
 )");
   test_error("kprobe:f { $a = (int8)-1; $x = (uint8)0; $x = $a; }", R"(
-stdin:1:42-49: ERROR: Type mismatch for $x: trying to assign value of type 'int8' when variable already contains a value of type 'uint8'
+stdin:1:42-49: ERROR: Type mismatch for $x: trying to assign value of type 'int8' when variable has type 'uint8'
 kprobe:f { $a = (int8)-1; $x = (uint8)0; $x = $a; }
                                          ~~~~~~~
 )");
@@ -3005,7 +3005,7 @@ kprobe:f { $x = -1; $x = 10223372036854775807; }
                     ~~~~~~~~~~~~~~~~~~~~~~~~~
 )");
   test_error("kprobe:f { $x = (0, (uint32)123); $x = (0, (int32)-123); }", R"(
-stdin:1:35-56: ERROR: Type mismatch for $x: trying to assign value of type '(int64,int32)' when variable already contains a value of type '(int64,uint32)'
+stdin:1:35-56: ERROR: Type mismatch for $x: trying to assign value of type '(int64,int32)' when variable has type '(int64,uint32)'
 kprobe:f { $x = (0, (uint32)123); $x = (0, (int32)-123); }
                                   ~~~~~~~~~~~~~~~~~~~~~
 )");
@@ -3469,7 +3469,7 @@ TEST(semantic_analyser, tuple)
   test(R"_(BEGIN { $t = (1, (int64)2); $t = (2, (int32)3); })_");
 
   test_error(R"_(BEGIN { $t = (1, (int32)2); $t = (2, (int64)3); })_", R"(
-stdin:1:29-47: ERROR: Type mismatch for $t: trying to assign value of type '(int64,int64)' when variable already contains a value of type '(int64,int32)'
+stdin:1:29-47: ERROR: Type mismatch for $t: trying to assign value of type '(int64,int64)' when variable has type '(int64,int32)'
 BEGIN { $t = (1, (int32)2); $t = (2, (int64)3); }
                             ~~~~~~~~~~~~~~~~~~
 )");
@@ -3489,14 +3489,14 @@ BEGIN { $t = (1, (int32)2); $t = (2, (int64)3); }
 
   test_error(R"_(BEGIN { $t = (1, ((int8)2, 3)); $t = (4, (5, 6)); })_",
              R"(
-stdin:1:33-49: ERROR: Type mismatch for $t: trying to assign value of type '(int64,(int64,int64))' when variable already contains a value of type '(int64,(int8,int64))'
+stdin:1:33-49: ERROR: Type mismatch for $t: trying to assign value of type '(int64,(int64,int64))' when variable has type '(int64,(int8,int64))'
 BEGIN { $t = (1, ((int8)2, 3)); $t = (4, (5, 6)); }
                                 ~~~~~~~~~~~~~~~~
 )");
 
   test_error(R"_(BEGIN { $t = ((uint8)1, (2, 3)); $t = (4, ((int8)5, 6)); })_",
              R"(
-stdin:1:34-56: ERROR: Type mismatch for $t: trying to assign value of type '(int64,(int8,int64))' when variable already contains a value of type '(uint8,(int64,int64))'
+stdin:1:34-56: ERROR: Type mismatch for $t: trying to assign value of type '(int64,(int8,int64))' when variable has type '(uint8,(int64,int64))'
 BEGIN { $t = ((uint8)1, (2, 3)); $t = (4, ((int8)5, 6)); }
                                  ~~~~~~~~~~~~~~~~~~~~~~
 )");
@@ -4373,13 +4373,13 @@ BEGIN { let $a; let $a; }
 )");
 
   test_error("BEGIN { let $a: uint16; $a = -1; }", R"(
-stdin:1:26-33: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable already has a type 'uint16'
+stdin:1:26-33: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable has type 'uint16'
 BEGIN { let $a: uint16; $a = -1; }
                          ~~~~~~~
 )");
 
   test_error("BEGIN { let $a; $a = (uint8)1; $a = -1; }", R"(
-stdin:1:32-39: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable already contains a value of type 'uint8'
+stdin:1:32-39: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable has type 'uint8'
 BEGIN { let $a; $a = (uint8)1; $a = -1; }
                                ~~~~~~~
 )");
@@ -4397,21 +4397,15 @@ BEGIN { $a = -1; let $a; }
 )");
 
   test_error("BEGIN { let $a: uint16 = -1; }", R"(
-stdin:1:9-29: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable already has a type 'uint16'
+stdin:1:9-29: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable has type 'uint16'
 BEGIN { let $a: uint16 = -1; }
         ~~~~~~~~~~~~~~~~~~~~
 )");
 
   test_error(R"(BEGIN { let $a: string[5] = "hiya"; $a = "longerstr"; })", R"(
-stdin:1:38-54: ERROR: Type mismatch for $a: trying to assign value of type 'string[10]' when variable already contains a value of type 'string[5]'
+stdin:1:38-54: ERROR: Type mismatch for $a: trying to assign value of type 'string[10]' when variable has type 'string[5]'
 BEGIN { let $a: string[5] = "hiya"; $a = "longerstr"; }
                                      ~~~~~~~~~~~~~~~~
-)");
-
-  test_error(R"(BEGIN { let $a; print(($a)); $a = 1; })", R"(
-stdin:1:17-26: ERROR: Variable used before it was assigned: $a
-BEGIN { let $a; print(($a)); $a = 1; }
-                ~~~~~~~~~
 )");
 
   test_error(R"(BEGIN { let $a: sum_t; })", R"(
@@ -4421,7 +4415,7 @@ BEGIN { let $a: sum_t; }
 )");
 
   test_error(R"(BEGIN { let $a: struct bad_task; $a = *curtask; })", R"(
-stdin:1:34-47: ERROR: Type mismatch for $a: trying to assign value of type 'struct task_struct' when variable already has a type 'struct bad_task'
+stdin:1:34-47: ERROR: Type mismatch for $a: trying to assign value of type 'struct task_struct' when variable has type 'struct bad_task'
 BEGIN { let $a: struct bad_task; $a = *curtask; }
                                  ~~~~~~~~~~~~~
 )");


### PR DESCRIPTION
Rather than relying on semantic analysis to detect cases where variables are unassigned, we can simplify the code by simply specifying that variables are always initialized with their respect "zero values", that is the value specified by an in-memory representation of all zero.

In fact, this is already the case today, both for implementation and documentation.

For the implementation, during code generation variables of all sizes are zeroed. We do not make any attempt to optimize for the case where there is a different initializer, and the generated bytecode often looks like `store 0`, followed by `store <x>`. This is perfectly reasonable, and we can defer such analysis and optimization to LLVM. Doing a complete analysis for whether a variable is assigned can become arbitrarily complex, and in all likelihood we would need to generate this pattern to avoid undefined behavior (which I suspect the BPF verified would reject anyways).

Just to provide an example of this analysis being complex, it is already trivial to escape the existing analysis by simply having the variable defined in the first branch of an `if` statement:
```
BEGIN {
   let $x: int32;
   let $y: int32;
   $y = 1;
   if ($y == 0) {
     $x = 1;
   } else {
     if ($x == 0) {
        print("x is 0");
     } else {
        print("x is 1");
     }
   }
   exit();
}
```

For the documentation, the man page already states:
```
If no assignment is specified variables will initialize to 0.
```

This change merely drops the associated semantic analyzer checks and metadata, as well as the test against that specific error.

##### Checklist

- [X] Language changes are updated in `man/adoc/bpftrace.adoc`
- [-] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [-] The new behaviour is covered by tests
