### PR TITLE
docs: Document that path() will truncate at the front

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1853,6 +1853,8 @@ Error attaching probe: 'kprobe:vfs_read'
 Return full path referenced by struct path pointer in argument. If `size` is set,
 the path will be clamped by `size` otherwise `BPFTRACE_MAX_STRLEN` is used.
 
+If `size` is smaller than the resolved path, the resulting string will be truncated at the front rather than at the end.
+
 This function can only be used by functions that are allowed to, these functions are contained in the `btf_allowlist_d_path` set in the kernel.
 
 [#functions-percpu-kaddr]


### PR DESCRIPTION
This is confirmed expected behavior of bpf_d_path() helper. It's non-obvious, so document it.

This closes https://github.com/bpftrace/bpftrace/issues/3663.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
