### PR TITLE
runtime: engine: Prevent hangs after sending SIGTERM

### DIFF
--- a/tests/runtime/selftest
+++ b/tests/runtime/selftest
@@ -1,0 +1,7 @@
+# This file contains selftests for runtime engine
+
+NAME command doesn't respond to SIGTERM
+# The __BPFTRACE_NOTIFY_PROBES_ATTACHED is needed to disable attach timeout
+RUN trap '' TERM; echo __BPFTRACE_NOTIFY_PROBES_ATTACHED && sleep 999 && echo "shouldn't echo"
+TIMEOUT 1
+EXPECT_NONE shouldn't echo


### PR DESCRIPTION
SIGTERM only sets BPFtrace::exitsig_recv which the event loop reads. If bpftrace is not in the event loop (for example computing wildcarded probes), SIGTERM will not be immediately respected and will instead hang until the blocking work is done.

To better respect TIMEOUT directive, we must limit the amount of time the engine actually waits.

Also fix up other subprocess.communicate() calls to retry after a timeout. The python docs say this is required for reliable output fetching.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
