### PR TITLE
tests: Make call.skboutput more reliable

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,7 @@
                   gawk
                   git
                   gnugrep
+                  iproute2
                   kmod
                   # For git-clang-format
                   libclang.python

--- a/tests/README.md
+++ b/tests/README.md
@@ -75,10 +75,13 @@ Each runtime testcase consists of multiple directives. In no particular order:
    converting the output and the file to a dict (thus ignoring field order).
 * `TIMEOUT`: The timeout for the testcase (in seconds). This field is required.
 * `BEFORE`: Run the command in a shell before running bpftrace. The command
-  will be terminated after testcase is over. Can be used multiple times,
-  commands will run in parallel.
+  will run while bpftrace is running and be terminated after the test case
+  finishes. Can be used multiple times, commands will run in parallel.
 * `AFTER`: Run the command in a shell after running bpftrace (after the probes
   are attached). The command will be terminated after the testcase is over.
+* `SETUP`: Run the command in a shell before the test is run. This differs from
+  the `BEFORE` directive in that setup commands are expected to exit before
+  bpftrace is executed.
 * `CLEANUP`: Run the command in a shell after test is over. This holds any
   cleanup command to free resources after test completes.
 * `MIN_KERNEL`: Skip the test unless the host's kernel version is >= the

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -620,9 +620,11 @@ EXPECT 1234
 TIMEOUT 1
 
 NAME skboutput
-RUN {{BPFTRACE}} -e 'fentry:__dev_queue_xmit { $ret = skboutput("skb.pcap", args.skb, args.skb->len, 14); if ($ret == 0) { printf("OK\n"); exit(); } }'
-AFTER ./testprogs/syscall connect 127.0.0.1 80
-EXPECT OK
+RUN {{BPFTRACE}} -e 'fentry:__dev_queue_xmit { $ret = skboutput("skb.pcap", args.skb, args.skb->len, 14); printf("ret: %d\n", $ret); exit(); }'
+SETUP ip netns add bpftrace-test && ip -netns bpftrace-test link set lo up
+AFTER ip netns exec bpftrace-test ./testprogs/syscall connect 127.0.0.1 80
+CLEANUP ip netns delete bpftrace-test
+EXPECT ret: 0
 REQUIRES_FEATURE fentry
 REQUIRES_FEATURE skboutput
 MIN_KERNEL 5.5

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -33,6 +33,7 @@ TestStruct = namedtuple(
         'timeout',
         'befores',
         'after',
+        'setup',
         'cleanup',
         'suite',
         'kernel_min',
@@ -114,6 +115,7 @@ class TestParser(object):
         timeout = ''
         befores = []
         after = ''
+        setup = ''
         cleanup = ''
         kernel_min = ''
         kernel_max = ''
@@ -173,6 +175,8 @@ class TestParser(object):
                 befores.append(line)
             elif item_name == 'AFTER':
                 after = line
+            elif item_name == 'SETUP':
+                setup = line
             elif item_name == 'CLEANUP':
                 cleanup = line
             elif item_name == 'MIN_KERNEL':
@@ -256,6 +260,7 @@ class TestParser(object):
             timeout,
             befores,
             after,
+            setup,
             cleanup,
             test_suite,
             kernel_min,

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -177,6 +177,28 @@ class Runner(object):
 
 
     @staticmethod
+    def __setup_cleanup(test, setup=True):
+        test_ident = f"{test.suite}.{test.name}"
+        if setup:
+            cmd = test.setup
+            name = "SETUP"
+        else:
+            cmd = test.cleanup
+            name = "CLEANUP"
+
+        try:
+            process = subprocess.run(cmd, shell=True, stderr=subprocess.STDOUT,
+                                     stdout=subprocess.PIPE, universal_newlines=True)
+            process.check_returncode()
+        except subprocess.CalledProcessError as e:
+            print(fail(f"[  FAILED  ] {test_ident}"))
+            print(f"\t{name} error: %s" % e.stdout)
+            return Runner.FAIL
+
+        return None
+
+
+    @staticmethod
     def run_test(test):
         current_kernel = LooseVersion(os.uname()[2])
         if test.kernel_min and LooseVersion(test.kernel_min) > current_kernel:
@@ -301,6 +323,11 @@ class Runner(object):
 
             if test.new_pidns and not test.befores:
                 raise ValueError("`NEW_PIDNS` requires at least one `BEFORE` directive as something needs to run in the new pid namespace")
+
+            if test.setup:
+                setup = Runner.__setup_cleanup(test, setup=True)
+                if setup:
+                    return setup
 
             if test.befores:
                 if test.new_pidns:
@@ -459,14 +486,9 @@ class Runner(object):
                     after_output = after.communicate()[0]
 
         if test.cleanup:
-            try:
-                cleanup = subprocess.run(test.cleanup, shell=True, stderr=subprocess.PIPE,
-                                         stdout=subprocess.PIPE, universal_newlines=True)
-                cleanup.check_returncode()
-            except subprocess.CalledProcessError as e:
-                print(fail("[  FAILED  ] ") + "%s.%s" % (test.suite, test.name))
-                print('\tCLEANUP error: %s' % e.stderr)
-                return Runner.FAIL
+                cleanup = Runner.__setup_cleanup(test, setup=False)
+                if cleanup:
+                    return cleanup
 
         def to_utf8(s):
             return s.encode("unicode_escape").decode("utf-8")


### PR DESCRIPTION
Loopback device may not always be up. On most systems it's there, but in
a minimal VM, it could not be.  Make this test more reliable by setting
up a loopback device in a new netns.

The choice was made to not add NEW_NETNS (like with NEW_PIDNS), as netns
stuff is unlikely to be reused in the future.

Also make the test case easier to debug by always printing the return
value.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
