### PR TITLE
docs: correct the retval type in bpftrace.adoc

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1192,10 +1192,10 @@ For string arguments use the `str()` call to retrieve the value.
 | The return keyword is used to exit the current probe. This differs from exit() in that it doesn't exit bpftrace.
 
 | retval
-| int64
+| uint64
 | n/a
 | n/a
-| Value returned by the function being traced (kretprobe, uretprobe, fexit)
+| Value returned by the function being traced (kretprobe, uretprobe, fexit). For kretprobe and uretprobe, its type is `uint64`, but for fexit it depends. You can look up the type using `bpftrace -lv`
 
 | tid
 | uint32


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

According to the [code](https://github.com/bpftrace/bpftrace/blob/master/src/ast/passes/semantic_analyser.cpp#L418), the `retval` type is uint64, not int64. This PR corrects the document.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
