### PR TITLE
Hide pcap writer lifecycle

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -157,8 +157,6 @@ public:
   virtual bool is_traceable_func(const std::string &func_name) const;
   virtual std::unordered_set<std::string> get_func_modules(
       const std::string &func_name) const;
-  int create_pcaps(void);
-  void close_pcaps(void);
   bool write_pcaps(uint64_t id, uint64_t ns, uint8_t *pkt, unsigned int size);
 
   void parse_btf(const std::set<std::string> &modules);
@@ -191,8 +189,6 @@ public:
   KConfig kconfig;
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
   std::optional<int> sigusr1_prog_fd_;
-
-  std::map<std::string, std::unique_ptr<PCAPwriter>> pcap_writers;
 
   unsigned int join_argnum_ = 16;
   unsigned int join_argsize_ = 1024;
@@ -242,12 +238,15 @@ private:
   std::vector<std::string> params_;
 
   std::vector<std::unique_ptr<void, void (*)(void *)>> open_perf_buffers_;
+  std::map<std::string, std::unique_ptr<PCAPwriter>> pcap_writers_;
 
   std::vector<std::unique_ptr<AttachedProbe>> attach_usdt_probe(
       Probe &probe,
       const BpfProgram &program,
       int pid,
       bool file_activation);
+  int create_pcaps();
+  void close_pcaps();
   int setup_output();
   int setup_perf_events();
   void setup_ringbuf();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -694,8 +694,6 @@ Args parse_args(int argc, char* argv[])
 
 int main(int argc, char* argv[])
 {
-  int err;
-
   const Args args = parse_args(argc, argv);
 
   std::ostream* os = &std::cout;
@@ -897,12 +895,6 @@ int main(int argc, char* argv[])
     return 1;
 
   auto* ast_root = pmresult.Root();
-
-  err = bpftrace.create_pcaps();
-  if (err) {
-    LOG(ERROR) << "Failed to create pcap file";
-    return err;
-  }
 
   ast::CodegenLLVM llvm(ast_root, bpftrace);
   BpfBytecode bytecode;

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -71,8 +71,6 @@ int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
       LOG(V1) << "Child exited with code: " << val;
   }
 
-  bpftrace.close_pcaps();
-
   if (err)
     return err;
 


### PR DESCRIPTION
Right now class BPFTrace owns the pcap writers but the lifecycle is
managed outside of the class in two different places. Simplify the logic
by privatizing the members and moving all management into class BPFTrace.

This also makes skboutput() helper work for AOT. All create_pcaps()
needs is the skboutput async args. And those are stored in
RequiredResources, which AOT shim will load back up.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
