### PR TITLE
tests: runtime: engine: Get rid of attachment timeout

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -28,22 +28,18 @@ TIMEOUT 1
 NAME it lists kprobes
 RUN {{BPFTRACE}} -l | grep kprobes
 EXPECT_REGEX kprobe:.*
-TIMEOUT 1
 
 NAME it lists tracepoints
 RUN {{BPFTRACE}} -l | grep tracepoint
 EXPECT_REGEX tracepoint:.*
-TIMEOUT 1
 
 NAME it lists software events
 RUN {{BPFTRACE}} -l | grep software
 EXPECT_REGEX software:.*
-TIMEOUT 1
 
 NAME it lists hardware events
 RUN {{BPFTRACE}} -l | grep hardware
 EXPECT_REGEX hardware:.*
-TIMEOUT 1
 
 NAME it lists fentry
 RUN {{BPFTRACE}} -l | grep fentry
@@ -55,14 +51,12 @@ TIMEOUT 1
 NAME it lists rawtracepoints
 RUN {{BPFTRACE}} -l | grep rawtracepoint
 EXPECT_REGEX rawtracepoint:.*
-TIMEOUT 1
 
 NAME it lists fentry params
 RUN {{BPFTRACE}} -lv "fentry:*"
 EXPECT_REGEX [ ]+[a-zA-Z_\*\s]+
 REQUIRES_FEATURE btf
 REQUIRES_FEATURE fentry
-TIMEOUT 1
 
 NAME it lists kprobes with regex filter
 RUN {{BPFTRACE}} -l "kprobe:*"

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -15,7 +15,6 @@ import cmake_vars
 
 BPFTRACE_BIN = os.environ["BPFTRACE_RUNTIME_TEST_EXECUTABLE"]
 COLOR_SETTING = os.environ.get("RUNTIME_TEST_COLOR", "auto")
-ATTACH_TIMEOUT = 10
 
 
 OK_COLOR = '\033[92m'
@@ -384,7 +383,7 @@ class Runner(object):
             bpftrace = p
 
             attached = False
-            signal.alarm(ATTACH_TIMEOUT)
+            signal.alarm(test.timeout)
 
             while p.poll() is None:
                 nextline = p.stdout.readline()
@@ -393,7 +392,6 @@ class Runner(object):
                     attached = True
                     if test.has_exact_expect:
                         output = ""  # ignore earlier ouput
-                    signal.alarm(test.timeout)
                     if test.after:
                         after_cmd = get_pid_ns_cmd(test.after) if test.new_pidns else test.after
                         after = subprocess.Popen(after_cmd, shell=True,

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import json
+import math
 import subprocess
 import signal
 import sys
@@ -193,6 +194,7 @@ class Runner(object):
 
         signal.signal(signal.SIGALRM, Runner.__handler)
 
+        start_time = time.time()
         p = None
         befores = []
         befores_output = []
@@ -478,12 +480,15 @@ class Runner(object):
             if after_output is not None:
                 print(f"\tAfter cmd output: {to_utf8(after_output)}")
 
+        elapsed = math.ceil((time.time() - start_time) * 1000)
+        label = f"{test.suite}.{test.name} ({elapsed} ms)"
+
         if '__BPFTRACE_NOTIFY_AOT_PORTABILITY_DISABLED' in to_utf8(output):
-            print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
+            print(warn("[   SKIP   ] ") + label)
             return Runner.SKIP_AOT_NOT_SUPPORTED
 
         if p and p.returncode != test.return_code and not test.will_fail and not timeout:
-            print(fail("[  FAILED  ] ") + "%s.%s" % (test.suite, test.name))
+            print(fail("[  FAILED  ] ") + label)
             print('\tCommand: ' + bpf_call)
             print('\tUnclean exit code: ' + str(p.returncode))
             print('\tOutput: ' + to_utf8(output))
@@ -491,10 +496,10 @@ class Runner(object):
             return Runner.FAIL
 
         if result:
-            print(ok("[       OK ] ") + "%s.%s" % (test.suite, test.name))
+            print(ok("[       OK ] ") + label)
             return Runner.PASS
         else:
-            print(fail("[  FAILED  ] ") + "%s.%s" % (test.suite, test.name))
+            print(fail("[  FAILED  ] ") + label)
             print('\tCommand: ' + bpf_call)
             for failed_expect in failed_expects:
                 if failed_expect.mode == "text":


### PR DESCRIPTION
Runtime tests have the explicit TIMEOUT directive in each test case. But there is also a hidden timeout for attachment. Previously it was 10s for waiting to attach that did not count towards TIMEOUT directive.

IMO that's confusing - better to just have a single timeout that does what it suggests. If any tests are relying on that additional 10s, just increase their timeout.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
