### PR TITLE
test: Ensure bpftrace_test runs in `nix develop` environment

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3249,7 +3249,11 @@ void SemanticAnalyser::visit(AttachPoint &ap)
                                  << "' does not exist or is not executable";
         break;
       case 1:
-        ap.target = paths.front();
+        // Replace the glob at this stage only if this is *not* a wildcard,
+        // otherwise we rely on the probe matcher. This is not going through
+        // any interfaces that can be properly mocked.
+        if (ap.target.find("*") == std::string::npos)
+          ap.target = paths.front();
         break;
       default:
         // If we are doing a PATH lookup (ie not glob), we follow shell
@@ -3277,12 +3281,12 @@ void SemanticAnalyser::visit(AttachPoint &ap)
                                    << "' does not exist or is not executable";
           break;
         case 1:
-          ap.target = paths.front();
+          // See uprobe, above.
+          if (ap.target.find("*") == std::string::npos)
+            ap.target = paths.front();
           break;
         default:
-          // If we are doing a PATH lookup (ie not glob), we follow shell
-          // behavior and take the first match.
-          // Otherwise we keep the target with glob, it will be expanded later
+          // See uprobe, above.
           if (ap.target.find("*") == std::string::npos) {
             LOG(WARNING, ap.loc, out_)
                 << "attaching to usdt target file '" << paths.front()

--- a/tests/procmon.cpp
+++ b/tests/procmon.cpp
@@ -26,7 +26,12 @@ TEST(procmon, no_such_proc)
 
 TEST(procmon, child_terminates)
 {
-  auto child = getChild("/bin/ls");
+  std::error_code ec;
+  auto self = std::filesystem::read_symlink("/proc/self/exe", ec);
+  ASSERT_FALSE(ec);
+  auto parent_dir = self.parent_path();
+  auto out = parent_dir / std::filesystem::path("testprogs/true");
+  auto child = getChild(out.c_str());
   auto procmon = std::make_unique<ProcMon>(child->pid());
   EXPECT_TRUE(procmon->is_alive());
   child->run();

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -70,19 +70,19 @@ EXPECT _A_
 
 NAME str
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
-AFTER ./testprogs/syscall execve /bin/ls
+AFTER ./testprogs/syscall execve ./testprogs/true
 EXPECT_REGEX P: /*.
 
 NAME str_truncated
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
 ENV BPFTRACE_MAX_STRLEN=5
-AFTER ./testprogs/syscall execve /bin/ls &>/dev/null
+AFTER ./testprogs/syscall execve ./testprogs/true &>/dev/null
 EXPECT_REGEX P: /...\.\.
 
 NAME str_truncated_custom
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
 ENV BPFTRACE_MAX_STRLEN=5 BPFTRACE_STR_TRUNC_TRAILER=_xxx
-AFTER ./testprogs/syscall execve /bin/ls &>/dev/null
+AFTER ./testprogs/syscall execve ./testprogs/true &>/dev/null
 EXPECT_REGEX P: /..._xxx
 
 NAME str_big

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -355,7 +355,7 @@ TEST(semantic_analyser, builtin_functions)
   test("kprobe:f { kstack(1) }");
   test("kprobe:f { ustack(1) }");
   test("kprobe:f { cat(\"/proc/uptime\") }");
-  test("uprobe:/bin/bash:main { uaddr(\"glob_asciirange\") }");
+  test("uprobe:/bin/sh:main { uaddr(\"glob_asciirange\") }");
   test("kprobe:f { cgroupid(\"/sys/fs/cgroup/unified/mycg\"); }");
   test("kprobe:f { macaddr(0xffff) }");
   test("kprobe:f { nsecs() }");
@@ -1365,15 +1365,15 @@ TEST(semantic_analyser, call_kaddr)
 
 TEST(semantic_analyser, call_uaddr)
 {
-  test("u:/bin/bash:main { uaddr(\"github.com/golang/glog.severityName\"); }");
-  test("uprobe:/bin/bash:main { uaddr(\"glob_asciirange\"); }");
-  test("u:/bin/bash:main,u:/bin/bash:readline { uaddr(\"glob_asciirange\"); }");
-  test("uprobe:/bin/bash:main { @x = uaddr(\"glob_asciirange\"); }");
-  test("uprobe:/bin/bash:main { uaddr(); }", 1);
-  test("uprobe:/bin/bash:main { uaddr(123); }", 1);
-  test("uprobe:/bin/bash:main { uaddr(\"?\"); }", 1);
-  test("uprobe:/bin/bash:main { $str = \"glob_asciirange\"; uaddr($str); }", 1);
-  test("uprobe:/bin/bash:main { @str = \"glob_asciirange\"; uaddr(@str); }", 1);
+  test("u:/bin/sh:main { uaddr(\"github.com/golang/glog.severityName\"); }");
+  test("uprobe:/bin/sh:main { uaddr(\"glob_asciirange\"); }");
+  test("u:/bin/sh:main,u:/bin/sh:readline { uaddr(\"glob_asciirange\"); }");
+  test("uprobe:/bin/sh:main { @x = uaddr(\"glob_asciirange\"); }");
+  test("uprobe:/bin/sh:main { uaddr(); }", 1);
+  test("uprobe:/bin/sh:main { uaddr(123); }", 1);
+  test("uprobe:/bin/sh:main { uaddr(\"?\"); }", 1);
+  test("uprobe:/bin/sh:main { $str = \"glob_asciirange\"; uaddr($str); }", 1);
+  test("uprobe:/bin/sh:main { @str = \"glob_asciirange\"; uaddr(@str); }", 1);
 
   test("k:f { uaddr(\"A\"); }", 1);
   test("i:s:1 { uaddr(\"A\"); }", 1);
@@ -1381,7 +1381,7 @@ TEST(semantic_analyser, call_uaddr)
   // The C struct parser should set the is_signed flag on signed types
   BPFtrace bpftrace;
   Driver driver(bpftrace);
-  std::string prog = "uprobe:/bin/bash:main {"
+  std::string prog = "uprobe:/bin/sh:main {"
                      "$a = uaddr(\"12345_1\");"
                      "$b = uaddr(\"12345_2\");"
                      "$c = uaddr(\"12345_4\");"
@@ -3705,7 +3705,7 @@ TEST(semantic_analyser, call_path)
   test("kprobe:f { $k = path( arg0 ) }", 1);
   test("kretprobe:f{ $k = path( \"abc\" ) }", 1);
   test("tracepoint:category:event { $k = path( -100 ) }", 1);
-  test("uprobe:/bin/bash:f { $k = path( arg0 ) }", 1);
+  test("uprobe:/bin/sh:f { $k = path( arg0 ) }", 1);
   test("BEGIN { $k = path( 1 ) }", 1);
   test("END { $k = path( 1 ) }", 1);
 }

--- a/tests/testprogs/false.c
+++ b/tests/testprogs/false.c
@@ -1,0 +1,4 @@
+int main(void)
+{
+  return 1;
+}

--- a/tests/testprogs/true.c
+++ b/tests/testprogs/true.c
@@ -1,0 +1,4 @@
+int main(void)
+{
+  return 0;
+}

--- a/tests/testprogs/wait10.c
+++ b/tests/testprogs/wait10.c
@@ -1,0 +1,7 @@
+#include <unistd.h>
+
+int main(void)
+{
+  sleep(10);
+  return 0;
+}


### PR DESCRIPTION
This change cleans up minor issues with testing. One is that the probe expansion `/bin/*sh` implicitly depends on multiple paths matching in order to call the mocks. A small code change prevents inline expansion until later on when this will follow the correct code path.

Another introduces local testprogs to replace the use of `/bin/ls` and `/bin/sleep` (which are not guaranteed to be available). These are used in the child and procmon tests, as well as the runtime tests.

##### Checklist

- [-] Language changes are updated in `man/adoc/bpftrace.adoc`
- [-] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [X] The new behaviour is covered by tests
