### PR TITLE
codegen: Disable bpf_map_sum_elem_count() on LLVM < 17

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1308,7 +1308,8 @@ void CodegenLLVM::visit(Call &call)
     // it, otherwise fall back to bpf_for_each_map_elem with a custom callback.
     if (map_has_single_elem(map.type, map.key_type)) {
       expr_ = b_.getInt64(1);
-    } else if (bpftrace_.feature_->has_kernel_func(
+    } else if (LLVM_VERSION_MAJOR >= 17 &&
+               bpftrace_.feature_->has_kernel_func(
                    Kfunc::bpf_map_sum_elem_count) &&
                !is_array_map(map.type, map.key_type)) {
       expr_ = CreateKernelFuncCall(Kfunc::bpf_map_sum_elem_count,


### PR DESCRIPTION
On LLVM 14/15/16 we see the following runtime test failures:

```
[  FAILED  ] basic.map strings are memset
[  FAILED  ] basic.variable strings are memset
[  FAILED  ] call.map len
[  FAILED  ] call.map len keyless
[  FAILED  ] call.map lencmp
```

They all have the same failure:

```
 [  FAILED  ] call.map len (498 ms)
	Command: /home/runner/work/bpftrace/bpftrace/build-ci/src/bpftrace  -e 'BEGIN { @[0] = 0; @[1] = 1; printf("map len: %d\n", len(@)); exit(); }'
	Unclean exit code: 1
	Output: Expected no forward declarations!\n!63 = <temporary!> !{}\n\nERROR: Verification of generated LLVM IR failed\n
```

Examining the IR reveals:

```
!69 = !DISubprogram(name: "bpf_map_sum_elem_count", linkageName: "bpf_map_sum_elem_count", scope: !2, file: !2, type: !70, flags: DIFlagPrototyped, spFlags: 0, retainedNodes: !75)

[..]

!75 = <temporary!> !{}
Call parameter type does not match function signature!
%"struct map_t"* @AT_
 i8*  %len = call i64 @bpf_map_sum_elem_count(%"struct map_t"* @AT_)
Expected no forward declarations!
!75 = <temporary!> !{}
```

So two things are happening:

1. We're passing a `map_t *` type into the kfunc when it should be `i8 *`
2. There's an temporary retainedNodes field for the DI entry

Both of these issues do not cause validation errors on LLVM >= 17. Since (1) seems harmless but (2) was too difficult to debug, just disable the optimization on LLVM < 17.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
