### PR TITLE
test: Add skeleton for additional languages/runtimes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -140,6 +140,9 @@
                   strace
                   unixtools.ping
                   util-linux
+                  # For runtime tests
+                  rustc
+                  go
                 ] ++ pkg.nativeBuildInputs ++ pkg.buildInputs;
 
                 # Some hardening features (like _FORTIFY_SOURCE) requires building with

--- a/tests/runtime/languages
+++ b/tests/runtime/languages
@@ -1,0 +1,16 @@
+# This only tests for the presence of mangled rust probe names. We need to add
+# support for automatically unmangling the names (and include the 'rust'
+# language type).
+NAME uprobes - list rust uprobes (mangled)
+REQUIRES testprogs/hello_rust
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/hello_rust:*'
+EXPECT_REGEX uprobe:./testprogs/hello_rust.*fun1
+
+# This only tests for the presence of the builtin symbol `runtime.schedule`.
+# Argument unpacking and other things will *not* be supported in Go for a
+# while, since the calling convention is different. But useful analysis can
+# still be done with the basics.
+NAME uprobes - list Go uprobes (no arguments)
+REQUIRES testprogs/hello_go
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/hello_go:*'
+EXPECT_REGEX uprobe:./testprogs/hello_go:runtime.schedule

--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -34,6 +34,35 @@ foreach(testprog_source ${testprog_sources})
   endif(HAVE_SYSTEMTAP_SYS_SDT_H)
   list(APPEND testprogtargets ${testprog_name})
 endforeach()
+
+find_program(GO_EXECUTABLE go)
+if(GO_EXECUTABLE)
+  file(GLOB testprog_go_sources *.go)
+  foreach(testprog_source ${testprog_go_sources})
+    get_filename_component(testprog_name ${testprog_source} NAME_WE)
+    add_custom_target(testprog_go_${testprog_name}
+      COMMAND ${GO_EXECUTABLE} build -o ${CMAKE_CURRENT_BINARY_DIR}/${testprog_name} ${testprog_source}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      DEPENDS ${testprog_source}
+    )
+  endforeach()
+  list(APPEND testprogtargets testprog_go_${testprog_name})
+endif()
+
+find_program(RUSTC_EXECUTABLE rustc)
+if(RUSTC_EXECUTABLE)
+  file(GLOB testprog_rust_sources *.rs)
+  foreach(testprog_source ${testprog_rust_sources})
+    get_filename_component(testprog_name ${testprog_source} NAME_WE)
+    add_custom_target(testprog_rust_${testprog_name}
+      COMMAND ${RUSTC_EXECUTABLE} -C symbol_mangling_version=v0 -o ${CMAKE_CURRENT_BINARY_DIR}/${testprog_name} ${testprog_source}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      DEPENDS ${testprog_source}
+    )
+  endforeach()
+  list(APPEND testprogtargets testprog_rust_${testprog_name})
+endif()
+
 add_custom_target(testprogs DEPENDS ${testprogtargets})
 
 target_include_directories(usdt_lib PRIVATE ${CMAKE_SOURCE_DIR}/tests/testlibs/)

--- a/tests/testprogs/hello_go.go
+++ b/tests/testprogs/hello_go.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/tests/testprogs/hello_rust.rs
+++ b/tests/testprogs/hello_rust.rs
@@ -1,0 +1,7 @@
+fn fun1(x: i64) {
+    println!("{}", x)
+}
+
+fn main() {
+    fun1(0)
+}


### PR DESCRIPTION
This provides simple rust and Go programs, that are compiled if the toolchains are available. The toolchains are added to the flake, so these should be built. The runtime tests will be skipped if they are not built.

Updates #3075 

##### Checklist

- ~~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~~
- ~~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~~
- [X] The new behaviour is covered by tests
