### PR TITLE
Add support for rust demangling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -131,7 +131,7 @@ endif(STATIC_LINKING)
 
 
 target_link_libraries(runtime ${LIBBPF_LIBRARIES} ${ZLIB_LIBRARIES})
-target_link_libraries(libbpftrace parser resources runtime aot ast arch cxxdemangler_llvm)
+target_link_libraries(libbpftrace parser resources runtime aot ast arch cxxdemangler_llvm rustdemangler_llvm)
 
 if(LLDB_FOUND)
   target_link_libraries(runtime LLDB)
@@ -241,3 +241,4 @@ add_subdirectory(arch)
 add_subdirectory(ast)
 add_subdirectory(cxxdemangler)
 add_subdirectory(resources)
+add_subdirectory(rustdemangler)

--- a/src/aot/CMakeLists.txt
+++ b/src/aot/CMakeLists.txt
@@ -16,7 +16,7 @@ if(NOT LIBBCC_BPF_CONTAINS_RUNTIME)
 endif()
 
 add_executable(bpftrace-aotrt aot_main.cpp)
-target_link_libraries(bpftrace-aotrt aot runtime arch ast ast_defs cxxdemangler_stdlib)
+target_link_libraries(bpftrace-aotrt aot runtime arch ast ast_defs cxxdemangler_stdlib rustdemangler_stdlib)
 install(TARGETS bpftrace-aotrt DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 if(LIBPCAP_FOUND)

--- a/src/cxxdemangler/cxxdemangler.h
+++ b/src/cxxdemangler/cxxdemangler.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include <string>
+
 namespace bpftrace {
 
-// Demangle a mangled C++ symbol name
-//
-// Note: callee `free()`ed
-char* cxxdemangle(const char* mangled);
+// Demangle a mangled C++ symbol name.
+std::string cxxdemangle(const char* mangled);
 
 } // namespace bpftrace

--- a/src/cxxdemangler/cxxdemangler_llvm.cpp
+++ b/src/cxxdemangler/cxxdemangler_llvm.cpp
@@ -5,13 +5,20 @@
 
 namespace bpftrace {
 
-char* cxxdemangle(const char* mangled)
+std::string cxxdemangle(const char *mangled)
 {
+  std::string s;
 #if LLVM_VERSION_MAJOR <= 16
-  return llvm::itaniumDemangle(mangled, nullptr, nullptr, nullptr);
+  char *d = llvm::itaniumDemangle(mangled, nullptr, nullptr, nullptr);
 #else
-  return llvm::itaniumDemangle(mangled);
+  char *d = llvm::itaniumDemangle(mangled);
 #endif
+  if (!d) {
+    return s;
+  }
+  s = std::string(d);
+  free(d);
+  return s;
 }
 
 } // namespace bpftrace

--- a/src/cxxdemangler/cxxdemangler_stdlib.cpp
+++ b/src/cxxdemangler/cxxdemangler_stdlib.cpp
@@ -4,9 +4,15 @@
 
 namespace bpftrace {
 
-char* cxxdemangle(const char* mangled)
+std::string cxxdemangle(const char *mangled)
 {
-  return abi::__cxa_demangle(mangled, nullptr, nullptr, nullptr);
+  std::string s;
+  char *d = abi::__cxa_demangle(mangled, nullptr, nullptr, nullptr);
+  if (!d)
+    return s;
+  s = std::string(d);
+  free(d);
+  return s;
 }
 
 } // namespace bpftrace

--- a/src/rustdemangler/CMakeLists.txt
+++ b/src/rustdemangler/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(rustdemangler_stdlib STATIC rustdemangler_stdlib.cpp)
+add_library(rustdemangler_llvm STATIC rustdemangler_llvm.cpp)

--- a/src/rustdemangler/rustdemangler.h
+++ b/src/rustdemangler/rustdemangler.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+namespace bpftrace {
+
+// Demangle a mangled rust symbol name.
+std::string rustdemangle(const char* mangled);
+
+} // namespace bpftrace

--- a/src/rustdemangler/rustdemangler_llvm.cpp
+++ b/src/rustdemangler/rustdemangler_llvm.cpp
@@ -1,0 +1,19 @@
+#include "rustdemangler.h"
+
+#include <llvm/Config/llvm-config.h>
+#include <llvm/Demangle/Demangle.h>
+
+namespace bpftrace {
+
+std::string rustdemangle(const char *mangled)
+{
+  std::string s;
+  char *d = llvm::rustDemangle(mangled);
+  if (!d)
+    return s;
+  s = std::string(d);
+  free(d);
+  return s;
+}
+
+} // namespace bpftrace

--- a/src/rustdemangler/rustdemangler_stdlib.cpp
+++ b/src/rustdemangler/rustdemangler_stdlib.cpp
@@ -1,0 +1,17 @@
+#include "rustdemangler.h"
+
+#include "log.h"
+
+namespace bpftrace {
+
+// We may choose to parse the v0 mangled symbols defined by:
+// https://rust-lang.github.io/rfcs/2603-rust-symbol-name-mangling-v0.html
+//
+// Or may vendor/link an alternate library to do so.
+std::string rustdemangle([[maybe_unused]] const char* mangled)
+{
+  LOG(WARNING) << "Rust demangling is not available.";
+  return std::string();
+}
+
+} // namespace bpftrace

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1237,6 +1237,14 @@ bool symbol_has_cpp_mangled_signature(const std::string &sym_name)
     return false;
 }
 
+bool symbol_has_rust_mangled_signature(const std::string &sym_name)
+{
+  if (!sym_name.rfind("_R", 0))
+    return true;
+  else
+    return false;
+}
+
 static std::string get_invalid_pid_message(const std::string &pid,
                                            const std::string &msg)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -158,7 +158,7 @@ static std::vector<std::string> UNSAFE_BUILTIN_FUNCS = {
 
 static std::vector<std::string> COMPILE_TIME_FUNCS = { "cgroupid" };
 
-static std::vector<std::string> UPROBE_LANGS = { "cpp" };
+static std::vector<std::string> UPROBE_LANGS = { "cpp", "rust" };
 
 static const std::set<std::string> RECURSIVE_KERNEL_FUNCS = {
   "vmlinux:_raw_spin_lock",
@@ -230,6 +230,7 @@ std::string str_join(const std::vector<std::string> &list,
 std::optional<std::variant<int64_t, uint64_t>> get_int_from_str(
     const std::string &s);
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
+bool symbol_has_rust_mangled_signature(const std::string &sym_name);
 std::optional<pid_t> parse_pid(const std::string &str, std::string &err);
 std::string hex_format_buffer(const char *buf,
                               size_t size,

--- a/tests/runtime/languages
+++ b/tests/runtime/languages
@@ -6,6 +6,12 @@ REQUIRES testprogs/hello_rust
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/hello_rust:*'
 EXPECT_REGEX uprobe:./testprogs/hello_rust.*fun1
 
+# This test adds support for mangled names.
+NAME uprobes - list rust uprobes (demangled)
+REQUIRES testprogs/extern/rust/debug/test
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/extern/rust/debug/test:rust:*'
+EXPECT_REGEX uprobe:./testprogs/extern/rust/debug/test:rust:"test::fun1"
+
 # This only tests for the presence of the builtin symbol `runtime.schedule`.
 # Argument unpacking and other things will *not* be supported in Go for a
 # while, since the calling convention is different. But useful analysis can


### PR DESCRIPTION
Adds basic support for rust demangling, similar to existing C++ demangling. Note that unlike C++, there is no good stdlib fallback for the V0 mangling scheme, so this is not generally supported.

Updates #3687 #3075 

##### Checklist

- ~~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~~
- ~~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~~
- [X] The new behaviour is covered by tests
