### PR TITLE
Accept ASTContext& for Visitors and pass manager entries

### DIFF
--- a/src/ast/pass_manager.h
+++ b/src/ast/pass_manager.h
@@ -13,7 +13,7 @@ class BPFtrace;
 namespace ast {
 
 class ASTContext;
-class Node;
+class Program;
 class SemanticAnalyser;
 class Pass;
 
@@ -25,7 +25,7 @@ public:
   static PassResult Error(const std::string &pass);
   static PassResult Error(const std::string &pass, int code);
   static PassResult Error(const std::string &pass, const std::string &msg);
-  static PassResult Success(Node *root = nullptr);
+  static PassResult Success();
 
   // Ok returns whether the pass was successful or not
   bool Ok() const
@@ -51,11 +51,6 @@ public:
     return errpass_;
   }
 
-  Node *Root() const
-  {
-    return root_;
-  };
-
 private:
   PassResult(const std::string &pass) : success_(false), errpass_(pass)
   {
@@ -76,7 +71,7 @@ private:
   {
   }
 
-  PassResult(Node *root) : success_(true), root_(root)
+  PassResult() : success_(true)
   {
   }
 
@@ -84,7 +79,6 @@ private:
   std::optional<std::string> errpass_;
   std::optional<int> errcode_;
   std::optional<std::string> errmsg_;
-  Node *root_ = nullptr;
 };
 
 /**
@@ -100,7 +94,7 @@ public:
   ASTContext &ast_ctx;
 };
 
-using PassFPtr = std::function<PassResult(Node &, PassContext &)>;
+using PassFPtr = std::function<PassResult(PassContext &)>;
 
 /*
   Base pass
@@ -112,9 +106,9 @@ public:
 
   virtual ~Pass() = default;
 
-  PassResult Run(Node &root, PassContext &ctx)
+  PassResult Run(PassContext &ctx)
   {
-    return fn_(root, ctx);
+    return fn_(ctx);
   };
 
 private:
@@ -129,7 +123,7 @@ public:
   PassManager() = default;
 
   void AddPass(Pass p);
-  [[nodiscard]] PassResult Run(Node *n, PassContext &ctx);
+  [[nodiscard]] PassResult Run(PassContext &ctx);
 
 private:
   std::vector<Pass> passes_;

--- a/src/ast/passes/callback_visitor.h
+++ b/src/ast/passes/callback_visitor.h
@@ -11,7 +11,8 @@ using callback = std::function<void(Node *)>;
 
 class CallbackVisitor : public Visitor {
 public:
-  explicit CallbackVisitor(callback func) : func_(func)
+  explicit CallbackVisitor(ASTContext &ctx, callback func)
+      : Visitor(ctx), func_(func)
   {
   }
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -49,15 +49,15 @@
 
 namespace bpftrace::ast {
 
-CodegenLLVM::CodegenLLVM(Node *root, BPFtrace &bpftrace)
-    : CodegenLLVM(root, bpftrace, std::make_unique<USDTHelper>())
+CodegenLLVM::CodegenLLVM(ASTContext &ctx, BPFtrace &bpftrace)
+    : CodegenLLVM(ctx, bpftrace, std::make_unique<USDTHelper>())
 {
 }
 
-CodegenLLVM::CodegenLLVM(Node *root,
+CodegenLLVM::CodegenLLVM(ASTContext &ctx,
                          BPFtrace &bpftrace,
                          std::unique_ptr<USDTHelper> usdt_helper)
-    : root_(root),
+    : Visitor(ctx),
       bpftrace_(bpftrace),
       usdt_helper_(std::move(usdt_helper)),
       context_(std::make_unique<LLVMContext>()),
@@ -3755,13 +3755,13 @@ void CodegenLLVM::generate_ir()
 {
   assert(state_ == State::INIT);
 
-  auto analyser = CodegenResourceAnalyser(root_, bpftrace_.config_);
+  auto analyser = CodegenResourceAnalyser(Visitor::ctx_, bpftrace_.config_);
   auto codegen_resources = analyser.analyse();
 
   generate_maps(bpftrace_.resources, codegen_resources);
   generate_global_vars(bpftrace_.resources, bpftrace_.config_);
 
-  auto scoped_del = accept(root_);
+  auto scoped_del = accept(Visitor::ctx_.root);
   debug_.finalize();
   state_ = State::IR;
 }

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -37,8 +37,8 @@ struct VariableLLVM {
 
 class CodegenLLVM : public Visitor {
 public:
-  explicit CodegenLLVM(Node *root, BPFtrace &bpftrace);
-  explicit CodegenLLVM(Node *root,
+  explicit CodegenLLVM(ASTContext &ctx, BPFtrace &bpftrace);
+  explicit CodegenLLVM(ASTContext &ctx,
                        BPFtrace &bpftrace,
                        std::unique_ptr<USDTHelper> usdt_helper);
 
@@ -279,8 +279,6 @@ private:
                                  const Twine &name);
 
   GlobalVariable *DeclareKernelVar(const std::string &name);
-
-  Node *root_ = nullptr;
 
   BPFtrace &bpftrace_;
   std::unique_ptr<USDTHelper> usdt_helper_;

--- a/src/ast/passes/codegen_resources.cpp
+++ b/src/ast/passes/codegen_resources.cpp
@@ -7,15 +7,15 @@
 namespace bpftrace::ast {
 
 CodegenResourceAnalyser::CodegenResourceAnalyser(
-    Node *root,
+    ASTContext &ctx,
     const ::bpftrace::Config &config)
-    : config_(config), root_(root)
+    : Visitor(ctx), config_(config)
 {
 }
 
 CodegenResources CodegenResourceAnalyser::analyse()
 {
-  Visit(*root_);
+  Visit(*ctx_.root);
   return std::move(resources_);
 }
 

--- a/src/ast/passes/codegen_resources.h
+++ b/src/ast/passes/codegen_resources.h
@@ -22,16 +22,16 @@ struct CodegenResources {
 // logic makes things easier to understand and maintain.
 class CodegenResourceAnalyser : public Visitor {
 public:
-  CodegenResourceAnalyser(Node *root, const ::bpftrace::Config &config);
+  CodegenResourceAnalyser(ASTContext &ctx, const ::bpftrace::Config &config);
   CodegenResources analyse();
 
 private:
   void visit(Builtin &map) override;
   void visit(Call &call) override;
 
+private:
   const ::bpftrace::Config &config_;
   CodegenResources resources_;
-  Node *root_;
 };
 
 } // namespace ast

--- a/src/ast/passes/collect_nodes.h
+++ b/src/ast/passes/collect_nodes.h
@@ -16,6 +16,10 @@ namespace bpftrace::ast {
 template <typename NodeT>
 class CollectNodes : public Visitor {
 public:
+  explicit CollectNodes(ASTContext &ctx) : Visitor(ctx)
+  {
+  }
+
   void run(
       Node &node,
       std::function<bool(const NodeT &)> pred = [](const auto &) {

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -190,7 +190,7 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
 
 bool ConfigAnalyser::analyse()
 {
-  Visit(*root_);
+  Visit(*ctx_.root);
   std::string errors = err_.str();
   if (!errors.empty()) {
     out_ << errors;
@@ -201,8 +201,8 @@ bool ConfigAnalyser::analyse()
 
 Pass CreateConfigPass()
 {
-  auto fn = [](Node &n, PassContext &ctx) {
-    auto configs = ConfigAnalyser(&n, ctx.b);
+  auto fn = [](PassContext &ctx) {
+    auto configs = ConfigAnalyser(ctx.ast_ctx, ctx.b);
     if (!configs.analyse())
       return PassResult::Error("Config");
     return PassResult::Success();

--- a/src/ast/passes/config_analyser.h
+++ b/src/ast/passes/config_analyser.h
@@ -16,10 +16,10 @@ namespace ast {
 
 class ConfigAnalyser : public Visitor {
 public:
-  explicit ConfigAnalyser(Node *root,
+  explicit ConfigAnalyser(ASTContext &ctx,
                           BPFtrace &bpftrace,
                           std::ostream &out = std::cerr)
-      : root_(root),
+      : Visitor(ctx),
         bpftrace_(bpftrace),
         config_setter_(ConfigSetter(bpftrace.config_, ConfigSource::script)),
         out_(out)
@@ -34,7 +34,6 @@ public:
   bool analyse();
 
 private:
-  Node *root_ = nullptr;
   BPFtrace &bpftrace_;
   ConfigSetter config_setter_;
   std::ostream &out_;

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -329,7 +329,7 @@ void FieldAnalyser::visit(Subprog &subprog)
 
 int FieldAnalyser::analyse()
 {
-  Visit(*root_);
+  Visit(*ctx_.root);
 
   std::string errors = err_.str();
   if (!errors.empty()) {

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -16,10 +16,10 @@ namespace ast {
 
 class FieldAnalyser : public Visitor {
 public:
-  explicit FieldAnalyser(Node *root,
+  explicit FieldAnalyser(ASTContext &ctx,
                          BPFtrace &bpftrace,
                          std::ostream &out = std::cerr)
-      : root_(root),
+      : Visitor(ctx),
         bpftrace_(bpftrace),
         prog_type_(libbpf::BPF_PROG_TYPE_UNSPEC),
         out_(out)
@@ -48,7 +48,6 @@ private:
   void resolve_fields(SizedType &type);
   void resolve_type(SizedType &type);
 
-  Node *root_;
   ProbeType probe_type_;
   std::string attach_func_;
   SizedType sized_type_;

--- a/src/ast/passes/node_counter.h
+++ b/src/ast/passes/node_counter.h
@@ -11,6 +11,10 @@ namespace ast {
 
 class NodeCounter : public Visitor {
 public:
+  explicit NodeCounter(ASTContext &ctx) : Visitor(ctx)
+  {
+  }
+
   void Visit(Node &node) override
   {
     count_++;
@@ -28,9 +32,9 @@ private:
 
 inline Pass CreateCounterPass()
 {
-  auto fn = [](Node &n, PassContext &ctx) {
-    NodeCounter c;
-    c.Visit(n);
+  auto fn = [](PassContext &ctx) {
+    NodeCounter c(ctx.ast_ctx);
+    c.Visit(*ctx.ast_ctx.root);
     auto node_count = c.get_count();
     auto max = ctx.b.max_ast_nodes_;
     LOG(V1) << "AST node count: " << node_count;

--- a/src/ast/passes/portability_analyser.cpp
+++ b/src/ast/passes/portability_analyser.cpp
@@ -7,14 +7,14 @@
 
 namespace bpftrace::ast {
 
-PortabilityAnalyser::PortabilityAnalyser(Node *root, std::ostream &out)
-    : root_(root), out_(out)
+PortabilityAnalyser::PortabilityAnalyser(ASTContext &ctx, std::ostream &out)
+    : Visitor(ctx), out_(out)
 {
 }
 
 int PortabilityAnalyser::analyse()
 {
-  Visit(*root_);
+  Visit(*ctx_.root);
 
   std::string errors = err_.str();
   if (!errors.empty()) {
@@ -109,8 +109,8 @@ void PortabilityAnalyser::visit(AttachPoint &ap)
 
 Pass CreatePortabilityPass()
 {
-  auto fn = [](Node &n, PassContext &__attribute__((unused))) {
-    PortabilityAnalyser analyser{ &n };
+  auto fn = [](PassContext &ctx) {
+    PortabilityAnalyser analyser(ctx.ast_ctx);
     if (analyser.analyse()) {
       // Used by runtime test framework to know when to skip an AOT test
       if (std::getenv("__BPFTRACE_NOTIFY_AOT_PORTABILITY_DISABLED"))

--- a/src/ast/passes/portability_analyser.h
+++ b/src/ast/passes/portability_analyser.h
@@ -16,7 +16,7 @@ namespace ast {
 // features.
 class PortabilityAnalyser : public Visitor {
 public:
-  PortabilityAnalyser(Node *root, std::ostream &out = std::cerr);
+  PortabilityAnalyser(ASTContext &ctx, std::ostream &out = std::cerr);
   int analyse();
 
 private:
@@ -26,7 +26,7 @@ private:
   void visit(Cast &cast) override;
   void visit(AttachPoint &ap) override;
 
-  Node *root_;
+private:
   std::ostream &out_;
   std::ostringstream err_;
 };

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -10,10 +10,10 @@
 
 namespace bpftrace::ast {
 
-void Printer::print(Node *root)
+void Printer::print(Node *node)
 {
   ++depth_;
-  Visit(*root);
+  Visit(*node);
   --depth_;
 }
 

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -9,11 +9,11 @@ namespace ast {
 
 class Printer : public Visitor {
 public:
-  explicit Printer(std::ostream &out) : out_(out)
+  explicit Printer(ASTContext &ctx, std::ostream &out) : Visitor(ctx), out_(out)
   {
   }
 
-  void print(Node *root);
+  void print(Node *node);
 
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -33,16 +33,16 @@ std::string get_literal_string(Expression &expr)
 
 } // namespace
 
-ResourceAnalyser::ResourceAnalyser(Node *root,
+ResourceAnalyser::ResourceAnalyser(ASTContext &ctx,
                                    BPFtrace &bpftrace,
                                    std::ostream &out)
-    : root_(root), bpftrace_(bpftrace), out_(out), probe_(nullptr)
+    : Visitor(ctx), bpftrace_(bpftrace), out_(out), probe_(nullptr)
 {
 }
 
 std::optional<RequiredResources> ResourceAnalyser::analyse()
 {
-  Visit(*root_);
+  Visit(*ctx_.root);
 
   if (!err_.str().empty()) {
     out_ << err_.str();
@@ -507,8 +507,8 @@ void ResourceAnalyser::maybe_allocate_map_key_buffer(const Map &map)
 
 Pass CreateResourcePass()
 {
-  auto fn = [](Node &n, PassContext &ctx) {
-    ResourceAnalyser analyser{ &n, ctx.b };
+  auto fn = [](PassContext &ctx) {
+    ResourceAnalyser analyser(ctx.ast_ctx, ctx.b);
     auto pass_result = analyser.analyse();
 
     if (!pass_result.has_value())

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -21,7 +21,7 @@ namespace ast {
 // example the helper error metadata is still being collected during codegen.
 class ResourceAnalyser : public Visitor {
 public:
-  ResourceAnalyser(Node *root,
+  ResourceAnalyser(ASTContext &ctx,
                    BPFtrace &bpftrace,
                    std::ostream &out = std::cerr);
 
@@ -52,7 +52,6 @@ private:
   void update_variable_info(Variable &var);
 
   RequiredResources resources_;
-  Node *root_;
   BPFtrace &bpftrace_;
   std::ostream &out_;
   std::ostringstream err_;

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -3,8 +3,8 @@
 
 namespace bpftrace::ast {
 
-ReturnPathAnalyser::ReturnPathAnalyser(Node *root, std::ostream &out)
-    : root_(root), out_(out)
+ReturnPathAnalyser::ReturnPathAnalyser(ASTContext &ctx, std::ostream &out)
+    : ctx_(ctx), out_(out)
 {
 }
 
@@ -65,7 +65,7 @@ bool ReturnPathAnalyser::default_visitor(__attribute__((unused)) Node &node)
 
 int ReturnPathAnalyser::analyse()
 {
-  int result = Visit(*root_) ? 0 : 1;
+  int result = Visit(*ctx_.root) ? 0 : 1;
   if (result)
     out_ << err_.str();
   return result;
@@ -73,8 +73,8 @@ int ReturnPathAnalyser::analyse()
 
 Pass CreateReturnPathPass()
 {
-  auto fn = [](Node &n, __attribute__((unused)) PassContext &ctx) {
-    auto return_path = ReturnPathAnalyser(&n);
+  auto fn = [](PassContext &ctx) {
+    auto return_path = ReturnPathAnalyser(ctx.ast_ctx);
     int err = return_path.analyse();
     if (err)
       return PassResult::Error("ReturnPath");

--- a/src/ast/passes/return_path_analyser.h
+++ b/src/ast/passes/return_path_analyser.h
@@ -8,7 +8,7 @@ namespace ast {
 
 class ReturnPathAnalyser : public Dispatcher<bool> {
 public:
-  explicit ReturnPathAnalyser(Node *root, std::ostream &out = std::cerr);
+  explicit ReturnPathAnalyser(ASTContext &ctx, std::ostream &out = std::cerr);
 
   // visit methods return true iff all return paths of the analyzed code
   // (represented by the given node) return a value
@@ -26,7 +26,7 @@ public:
   int analyse();
 
 private:
-  Node *root_;
+  ASTContext &ctx_;
   std::ostream &out_;
   std::ostringstream err_;
 };

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -28,7 +28,7 @@ public:
                             std::ostream &out = std::cerr,
                             bool has_child = true,
                             bool listing = false)
-      : ctx_(ctx),
+      : Visitor(ctx),
         bpftrace_(bpftrace),
         out_(out),
         listing_(listing),
@@ -105,7 +105,6 @@ public:
   int analyse();
 
 private:
-  ASTContext &ctx_;
   BPFtrace &bpftrace_;
   std::ostream &out_;
   std::ostringstream err_;

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -62,7 +62,9 @@ public:
 */
 class Visitor : public VisitorBase {
 public:
-  explicit Visitor() = default;
+  explicit Visitor(ASTContext &ctx) : ctx_(ctx)
+  {
+  }
   ~Visitor() = default;
 
   Visitor(const Visitor &) = delete;
@@ -120,6 +122,9 @@ public:
   void visit(Subprog &subprog) override;
   void visit(Program &program) override;
   void visit(Block &block) override;
+
+protected:
+  ASTContext &ctx_;
 };
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -357,12 +357,12 @@ static void parse_env(BPFtrace& bpftrace)
 
   bpftrace.parse_btf(driver.list_modules());
 
-  ast::FieldAnalyser fields(driver.ctx.root, bpftrace);
+  ast::FieldAnalyser fields(driver.ctx, bpftrace);
   err = fields.analyse();
   if (err)
     return {};
 
-  if (TracepointFormatParser::parse(driver.ctx.root, bpftrace) == false)
+  if (TracepointFormatParser::parse(driver.ctx, bpftrace) == false)
     return {};
 
   // NOTE(mmarchini): if there are no C definitions, clang parser won't run to
@@ -890,13 +890,11 @@ int main(int argc, char* argv[])
 
   bpftrace.fentry_recursion_check(ast_ctx->root);
 
-  auto pmresult = pm.Run(ast_ctx->root, ctx);
+  auto pmresult = pm.Run(ctx);
   if (!pmresult.Ok())
     return 1;
 
-  auto* ast_root = pmresult.Root();
-
-  ast::CodegenLLVM llvm(ast_root, bpftrace);
+  ast::CodegenLLVM llvm(ctx.ast_ctx, bpftrace);
   BpfBytecode bytecode;
   try {
     llvm.generate_ir();

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -14,8 +14,10 @@ namespace bpftrace {
 
 std::set<std::string> TracepointFormatParser::struct_list;
 
-bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
+bool TracepointFormatParser::parse(ast::ASTContext &ctx, BPFtrace &bpftrace)
 {
+  ast::Program *program = ctx.root;
+
   std::vector<ast::Probe *> probes_with_tracepoint;
   for (ast::Probe *probe : program->probes) {
     if (probe->has_ap_of_probetype(ProbeType::tracepoint))
@@ -25,7 +27,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
   if (probes_with_tracepoint.empty())
     return true;
 
-  ast::TracepointArgsVisitor n{};
+  ast::TracepointArgsVisitor n(ctx);
   if (!bpftrace.has_btf_data())
     program->c_definitions += "#include <linux/types.h>\n";
   for (ast::Probe *probe : probes_with_tracepoint) {

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -12,6 +12,10 @@ namespace ast {
 
 class TracepointArgsVisitor : public Visitor {
 public:
+  explicit TracepointArgsVisitor(ASTContext &ctx) : Visitor(ctx)
+  {
+  }
+
   void visit(Builtin &builtin) override
   {
     Visitor::visit(builtin);
@@ -39,7 +43,7 @@ private:
 
 class TracepointFormatParser {
 public:
-  static bool parse(ast::Program *program, BPFtrace &bpftrace);
+  static bool parse(ast::ASTContext &ctx, BPFtrace &bpftrace);
   static std::string get_struct_name(const std::string &category,
                                      const std::string &event_name);
   static std::string get_struct_name(const std::string &probe_id);

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -18,7 +18,7 @@ BpfBytecode codegen(std::string_view input)
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   EXPECT_EQ(semantics.analyse(), 0);
 
-  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
   return codegen.compile();
 }
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -39,7 +39,7 @@ static auto parse_probe(const std::string &str,
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(str), 0);
 
-  ast::FieldAnalyser fields(driver.ctx.root, bpftrace);
+  ast::FieldAnalyser fields(driver.ctx, bpftrace);
   ASSERT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
@@ -50,7 +50,7 @@ static auto parse_probe(const std::string &str,
 
   auto usdt_helper = get_mock_usdt_helper(usdt_num_locations);
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.ctx.root, bpftrace, std::move(usdt_helper));
+  ast::CodegenLLVM codegen(driver.ctx, bpftrace, std::move(usdt_helper));
   codegen.generate_ir();
 }
 

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -23,7 +23,7 @@ static void parse(const std::string &input,
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(extended_input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx.root, bpftrace);
+  ast::FieldAnalyser fields(driver.ctx, bpftrace);
   EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -30,12 +30,12 @@ TEST(codegen, call_kstack_mapids)
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 8);
@@ -66,12 +66,12 @@ TEST(codegen, call_kstack_modes_mapids)
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 10);

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -30,12 +30,12 @@ TEST(codegen, call_ustack_mapids)
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 8);
@@ -66,12 +66,12 @@ TEST(codegen, call_ustack_modes_mapids)
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 10);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -53,7 +53,7 @@ static void test(BPFtrace &bpftrace,
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx.root, bpftrace);
+  ast::FieldAnalyser fields(driver.ctx, bpftrace);
   ASSERT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
@@ -64,13 +64,13 @@ static void test(BPFtrace &bpftrace,
   ast::SemanticAnalyser semantics(driver.ctx, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx.root, bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx, bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace.resources = resources_optional.value();
 
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.ctx.root, bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx, bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
   // Test that generated code compiles cleanly

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -68,12 +68,12 @@ TEST(codegen, printf_offsets)
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
   codegen.generate_ir();
 
   EXPECT_EQ(bpftrace->resources.printf_args.size(), 1U);
@@ -115,7 +115,7 @@ TEST(codegen, probe_count)
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.ctx, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ast::CodegenLLVM codegen(driver.ctx.root, bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx, bpftrace);
   codegen.generate_ir();
 }
 } // namespace codegen

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -19,12 +19,12 @@ TEST(codegen, regression_957)
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
   codegen.compile();
 }
 

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -31,7 +31,7 @@ void test(BPFtrace &bpftrace,
   ast::SemanticAnalyser semantics(driver.ctx, bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::ConfigAnalyser config_analyser(driver.ctx.root, bpftrace, out);
+  ast::ConfigAnalyser config_analyser(driver.ctx, bpftrace, out);
   EXPECT_EQ(config_analyser.analyse(), expected_result)
       << msg.str() << out.str();
   if (expected_error.data()) {

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -18,7 +18,7 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
   Driver driver(bpftrace);
   EXPECT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx.root, bpftrace, out);
+  ast::FieldAnalyser fields(driver.ctx, bpftrace, out);
   EXPECT_EQ(fields.analyse(), expected_result) << msg.str() + out.str();
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -39,7 +39,7 @@ void test(BPFtrace &bpftrace, std::string_view input, std::string_view expected)
     expected.remove_prefix(1); // Remove initial '\n'
 
   std::ostringstream out;
-  Printer printer(out);
+  Printer printer(driver.ctx, out);
   printer.print(driver.ctx.root);
   EXPECT_EQ(expected, out.str());
 }

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -23,7 +23,7 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx.root, bpftrace, out);
+  ast::FieldAnalyser fields(driver.ctx, bpftrace, out);
   ASSERT_EQ(fields.analyse(), 0) << msg.str() << out.str();
 
   ClangParser clang;
@@ -34,7 +34,7 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
   ast::SemanticAnalyser semantics(driver.ctx, bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::PortabilityAnalyser portability(driver.ctx.root, out);
+  ast::PortabilityAnalyser portability(driver.ctx, out);
   EXPECT_EQ(portability.analyse(), expected_result) << msg.str() << out.str();
 }
 

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -26,7 +26,7 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx.root, *bpftrace);
+  ast::FieldAnalyser fields(driver.ctx, *bpftrace);
   EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
@@ -37,14 +37,14 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx.root, *bpftrace);
+  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
   auto resources_optional = resource_analyser.analyse();
   ASSERT_TRUE(resources_optional.has_value());
   // clang-tidy doesn't recognize ASSERT_*() as execution terminating
   // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
   bpftrace->resources = resources_optional.value();
 
-  ast::CodegenLLVM codegen(driver.ctx.root, *bpftrace);
+  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
 }

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -24,7 +24,7 @@ void test(BPFtrace &bpftrace,
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx.root, bpftrace, out);
+  ast::FieldAnalyser fields(driver.ctx, bpftrace, out);
   ASSERT_EQ(fields.analyse(), 0) << msg.str() << out.str();
 
   ClangParser clang;
@@ -35,7 +35,7 @@ void test(BPFtrace &bpftrace,
   ast::SemanticAnalyser semantics(driver.ctx, bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx.root, bpftrace, out);
+  ast::ResourceAnalyser resource_analyser(driver.ctx, bpftrace, out);
   auto resources_optional = resource_analyser.analyse();
   EXPECT_EQ(resources_optional.has_value(), expected_result)
       << msg.str() << out.str();

--- a/tests/return_path_analyser.cpp
+++ b/tests/return_path_analyser.cpp
@@ -21,7 +21,7 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx.root, bpftrace, out);
+  ast::FieldAnalyser fields(driver.ctx, bpftrace, out);
   ASSERT_EQ(fields.analyse(), 0) << msg.str() << out.str();
 
   ClangParser clang;
@@ -32,7 +32,7 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
   ast::SemanticAnalyser semantics(driver.ctx, bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::ReturnPathAnalyser return_path(driver.ctx.root, out);
+  ast::ReturnPathAnalyser return_path(driver.ctx, out);
   EXPECT_EQ(return_path.analyse(), expected_result) << msg.str() << out.str();
 }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -69,7 +69,7 @@ void test(BPFtrace &bpftrace,
   bpftrace.safe_mode_ = safe_mode;
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx.root, bpftrace, out);
+  ast::FieldAnalyser fields(driver.ctx, bpftrace, out);
   ASSERT_EQ(fields.analyse(), 0) << msg.str() + out.str();
 
   ClangParser clang;
@@ -200,7 +200,7 @@ void test(BPFtrace &bpftrace,
     expected_ast.remove_prefix(1); // Remove initial '\n'
 
   std::ostringstream out;
-  ast::Printer printer(out);
+  ast::Printer printer(driver.ctx, out);
   printer.print(driver.ctx.root);
 
   if (expected_ast[0] == '*' && expected_ast[expected_ast.size() - 1] == '*') {

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -261,7 +261,7 @@ TEST(tracepoint_format_parser, args_field_access)
   // Test computing the level of nested structs accessed from tracepoint args
   BPFtrace bpftrace;
   Driver driver(bpftrace);
-  ast::TracepointArgsVisitor visitor;
+  ast::TracepointArgsVisitor visitor(driver.ctx);
 
   EXPECT_EQ(driver.parse_str("BEGIN { args.f1->f2->f3 }"), 0);
   visitor.visit(*driver.ctx.root->probes.at(0));


### PR DESCRIPTION
In the future, it will be useful to allow the `Visitor` to rewrite parts of the AST in a consistent way. This requires access to the `ASTContext` in order to allocate new nodes. Standardize this as required to instantiate new passes.

This is plumbed through the pass, and allows us to generally remove the use of `Program` since it is already specified in the `ASTContext`. This is a minor cleanup in preparation for restructuring drafted in #3636.

##### Checklist

- ~~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~~
- ~~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~~
- ~~[ ] The new behaviour is covered by tests~~
