### PR TITLE
ci: nix: Install bpftool

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,7 @@
               pkgs.mkShell {
                 buildInputs = [
                   binutils
+                  bpftools
                   coreutils
                   # Needed for the nix-aware "wrapped" clang-tidy
                   clang-tools


### PR DESCRIPTION
Needed for multi probe runtime tests. The tests are currently being skipped in CI due to missing bpftool.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
