### PR TITLE
Make strftime more reliable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 #### Fixed
 - Fix json output for none type
   - [#3692](https://github.com/bpftrace/bpftrace/pull/3692)
+- Fix bug where strftime() %f specifier could be off by up to 1s
+  - [#3704](https://github.com/bpftrace/bpftrace/pull/3704)
 #### Security
 #### Docs
 #### Tools

--- a/flake.nix
+++ b/flake.nix
@@ -120,11 +120,11 @@
               with pkgs;
               pkgs.mkShell {
                 buildInputs = [
+                  bc
                   binutils
                   coreutils
                   # Needed for the nix-aware "wrapped" clang-tidy
                   clang-tools
-                  findutils
                   gawk
                   git
                   gnugrep

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -463,17 +463,15 @@ PROG BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}
 EXPECT_REGEX @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 
 # Output two microsecond timestamps, 123000 nsecs apart. Use python to evaluate and verify there's a 123us delta
-#
-# Note we add a `1` before the timestamp b/c leading zeros (eg `0123`) is invalid integer in python.
 NAME strftime_microsecond_extension
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000123000), strftime("1%f", 0)); exit(); }' | tail -n +3 | xargs -I{} python3 -c "print({})"
-EXPECT 123
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("%s.%f", 123000), strftime("%s.%f", 0)); exit(); }' | tail -n +3 | bc
+EXPECT .000123
 TIMEOUT 1
 
 # Similar to above test but test that rolling over past 1s works as expected
 NAME strftime_microsecond_extension_rollover
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000000123000), strftime("1%f", 0)); exit(); }' | tail -n +3 | xargs -I{} python3 -c "print({})"
-EXPECT 123
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("%s.%f", 1000123000), strftime("%s.%f", 0)); exit(); }' | tail -n +3 | bc
+EXPECT 1.000123
 TIMEOUT 1
 
 NAME print_avg_map_args


### PR DESCRIPTION
See individual commits for more details.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
