### PR TITLE
tests: runtime: Set explicit TMPDIR for exact path matches

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -500,19 +500,19 @@ NAME path
 RUN {{BPFTRACE}} -ve 'fentry:security_file_open { if (!strncmp(path(args.file->f_path), "/tmp/bpftrace_runtime_test_syscall_gen_open_temp", 49)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath fentry
-AFTER ./testprogs/syscall open
+AFTER TMPDIR=/tmp ./testprogs/syscall open
 
 NAME path_with_optional_size
 RUN {{BPFTRACE}} -ve 'fentry:security_file_open { $p = path(args.file->f_path, 48);  if ( sizeof($p) == 48 && !strncmp($p, "tmp/bpftrace_runtime_test_syscall_gen_open_temp", 48)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath fentry
-AFTER ./testprogs/syscall open
+AFTER TMPDIR=/tmp ./testprogs/syscall open
 
 NAME strcontains
 RUN {{BPFTRACE}} -ve 'fentry:security_file_open { if (strcontains(path(args.file->f_path), "tmp")) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath fentry
-AFTER ./testprogs/syscall open
+AFTER TMPDIR=/tmp ./testprogs/syscall open
 
 NAME strcontains literals
 RUN {{BPFTRACE}} -e 'BEGIN { if (strcontains("abc", "a")) { printf("OK\n"); exit(); } }'


### PR DESCRIPTION
The test cases explicilty test for /tmp prefix. So we need to set that for testprogs/syscall, otherwise any path could be used. Nix shell, for example, sets a custom TMPDIR prefix.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
