### PR TITLE
config: Change default max_strlen to 1024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#3638](https://github.com/bpftrace/bpftrace/pull/3638)
 - Change bpftrace help flag output from stderr to stdout
   - [#3678](https://github.com/bpftrace/bpftrace/pull/3678)
+- Change max_strlen default from 64 to 1024
+  - [#3713](https://github.com/bpftrace/bpftrace/pull/3713)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3715,7 +3715,7 @@ system.
 
 === max_strlen
 
-Default: 64
+Default: 1024
 
 The maximum length (in bytes) for values created by `str()`, `buf()` and `path()`.
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -20,7 +20,7 @@ Config::Config(bool has_cmd)
     { ConfigKeyInt::max_cat_bytes, { .value = static_cast<uint64_t>(10240) } },
     { ConfigKeyInt::max_map_keys, { .value = static_cast<uint64_t>(4096) } },
     { ConfigKeyInt::max_probes, { .value = static_cast<uint64_t>(512) } },
-    { ConfigKeyInt::max_strlen, { .value = static_cast<uint64_t>(64) } },
+    { ConfigKeyInt::max_strlen, { .value = static_cast<uint64_t>(1024) } },
     { ConfigKeyInt::max_type_res_iterations,
       { .value = static_cast<uint64_t>(0) } },
     { ConfigKeyInt::on_stack_limit, { .value = static_cast<uint64_t>(32) } },

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,7 +134,7 @@ void usage(std::ostream& out)
   out << "    BPFTRACE_MAX_CAT_BYTES            [default: 10k] maximum bytes read by cat builtin" << std::endl;
   out << "    BPFTRACE_MAX_MAP_KEYS             [default: 4096] max keys in a map" << std::endl;
   out << "    BPFTRACE_MAX_PROBES               [default: 512] max number of probes" << std::endl;
-  out << "    BPFTRACE_MAX_STRLEN               [default: 64] bytes on BPF stack per str()" << std::endl;
+  out << "    BPFTRACE_MAX_STRLEN               [default: 1024] bytes on BPF stack per str()" << std::endl;
   out << "    BPFTRACE_MAX_TYPE_RES_ITERATIONS  [default: 0] number of levels of nested field accesses for tracepoint args" << std::endl;
   out << "    BPFTRACE_PERF_RB_PAGES            [default: 64] pages per CPU to allocate for ring buffer" << std::endl;
   out << "    BPFTRACE_STACK_MODE               [default: bpftrace] Output format for ustack and kstack builtins" << std::endl;

--- a/tests/codegen/call_path.cpp
+++ b/tests/codegen/call_path.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, call_path)
 {
-  test("fentry:filp_close { path(args->filp->f_path); }", NAME);
+  test("fentry:filp_close { path((uint8 *)0); }", NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/call_path_with_optional_size.cpp
+++ b/tests/codegen/call_path_with_optional_size.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, call_path_with_optional_size)
 {
-  test("fentry:filp_close { path(args->filp->f_path, 48); }", NAME);
+  test("fentry:filp_close { path((uint8 *)0, 48); }", NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -13,7 +13,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !48
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -28,7 +28,7 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   %3 = getelementptr %buffer_16_t, ptr %2, i32 0, i32 0
   store i32 16, ptr %3, align 4
   %4 = getelementptr %buffer_16_t, ptr %2, i32 0, i32 1
@@ -117,11 +117,11 @@ attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !49 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
 !50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
 !51 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 512, elements: !9)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 512, elements: !9)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 512, elements: !55)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 8192, elements: !9)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 8192, elements: !9)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8192, elements: !55)
 !55 = !{!56}
-!56 = !DISubrange(count: 64, lowerBound: 0)
+!56 = !DISubrange(count: 1024, lowerBound: 0)
 !57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
 !58 = !{!0, !21, !35, !48, !50}
 !59 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -13,7 +13,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !48
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -24,7 +24,7 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   %3 = getelementptr %buffer_1_t, ptr %2, i32 0, i32 0
   store i32 1, ptr %3, align 4
   %4 = getelementptr %buffer_1_t, ptr %2, i32 0, i32 1
@@ -112,11 +112,11 @@ attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !49 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
 !50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
 !51 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 512, elements: !9)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 512, elements: !9)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 512, elements: !55)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 8192, elements: !9)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 8192, elements: !9)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8192, elements: !55)
 !55 = !{!56}
-!56 = !DISubrange(count: 64, lowerBound: 0)
+!56 = !DISubrange(count: 1024, lowerBound: 0)
 !57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
 !58 = !{!0, !21, !35, !48, !50}
 !59 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -6,14 +6,14 @@ target triple = "bpf-pc-linux"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
-%buffer_60_t = type <{ i32, [60 x i8] }>
+%buffer_1020_t = type <{ i32, [1020 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !48
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -24,21 +24,21 @@ entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i64, ptr %1, i64 13
   %arg1 = load volatile i64, ptr %2, align 8
-  %length.cmp = icmp ule i64 %arg1, 60
-  %length.select = select i1 %length.cmp, i64 %arg1, i64 60
+  %length.cmp = icmp ule i64 %arg1, 1020
+  %length.select = select i1 %length.cmp, i64 %arg1, i64 1020
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %3 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %3
-  %4 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  %5 = getelementptr %buffer_60_t, ptr %4, i32 0, i32 0
+  %4 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %5 = getelementptr %buffer_1020_t, ptr %4, i32 0, i32 0
   %6 = trunc i64 %length.select to i32
   store i32 %6, ptr %5, align 4
-  %7 = getelementptr %buffer_60_t, ptr %4, i32 0, i32 1
-  call void @llvm.memset.p0.i64(ptr align 1 %7, i8 0, i64 60, i1 false)
+  %7 = getelementptr %buffer_1020_t, ptr %4, i32 0, i32 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %7, i32 1020, ptr null)
   %8 = call ptr @llvm.preserve.static.offset(ptr %0)
   %9 = getelementptr i64, ptr %8, i64 14
   %arg0 = load volatile i64, ptr %9, align 8
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %7, i32 %6, i64 %arg0)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %7, i32 %6, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %4, i64 0)
@@ -49,19 +49,15 @@ entry:
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!54}
 !llvm.module.flags = !{!56}
@@ -83,10 +79,10 @@ attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !14 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !15 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !16, size: 64, offset: 192)
 !16 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !17, size: 64)
-!17 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 512, elements: !19)
+!17 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8192, elements: !19)
 !18 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !19 = !{!20}
-!20 = !DISubrange(count: 64, lowerBound: 0)
+!20 = !DISubrange(count: 1024, lowerBound: 0)
 !21 = !DIGlobalVariableExpression(var: !22, expr: !DIExpression())
 !22 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !23, isLocal: false, isDefinition: true)
 !23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !24)
@@ -118,8 +114,8 @@ attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !49 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
 !50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
 !51 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 512, elements: !9)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 512, elements: !9)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 8192, elements: !9)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 8192, elements: !9)
 !54 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !55)
 !55 = !{!0, !21, !35, !48, !50}
 !56 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/call_path.ll
+++ b/tests/codegen/llvm/call_path.ll
@@ -10,7 +10,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !38
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -20,17 +20,13 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr null, ptr %2, i32 64)
+  %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
+  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr null, ptr %2, i32 1024)
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
-
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}
@@ -75,12 +71,12 @@ attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
 !38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
 !39 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 512, elements: !28)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 512, elements: !28)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 512, elements: !44)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 8192, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 8192, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 8192, elements: !44)
 !43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !44 = !{!45}
-!45 = !DISubrange(count: 64, lowerBound: 0)
+!45 = !DISubrange(count: 1024, lowerBound: 0)
 !46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
 !47 = !{!0, !16, !36, !38}
 !48 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/call_path.ll
+++ b/tests/codegen/llvm/call_path.ll
@@ -22,25 +22,15 @@ entry:
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %4 = getelementptr i64, ptr %3, i64 0
-  %filp = load volatile i64, ptr %4, align 8
-  %5 = inttoptr i64 %filp to ptr
-  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
-  %7 = getelementptr i8, ptr %6, i64 152
-  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %7, ptr %2, i32 64)
+  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr null, ptr %2, i32 64)
   ret i64 0
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
-
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}

--- a/tests/codegen/llvm/call_path_with_optional_size.ll
+++ b/tests/codegen/llvm/call_path_with_optional_size.ll
@@ -22,25 +22,15 @@ entry:
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %4 = getelementptr i64, ptr %3, i64 0
-  %filp = load volatile i64, ptr %4, align 8
-  %5 = inttoptr i64 %filp to ptr
-  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
-  %7 = getelementptr i8, ptr %6, i64 152
-  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr %7, ptr %2, i32 48)
+  %d_path = call i64 inttoptr (i64 147 to ptr)(ptr null, ptr %2, i32 48)
   ret i64 0
 }
 
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
-; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
-
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}

--- a/tests/codegen/llvm/call_path_with_optional_size.ll
+++ b/tests/codegen/llvm/call_path_with_optional_size.ll
@@ -10,7 +10,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
 @event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !36
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !38
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !38
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -20,17 +20,13 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
+  %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
   %d_path = call i64 inttoptr (i64 147 to ptr)(ptr null, ptr %2, i32 48)
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
-
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48}
@@ -75,12 +71,12 @@ attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !37 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
 !38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
 !39 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 512, elements: !28)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 512, elements: !28)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 512, elements: !44)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 8192, elements: !28)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 8192, elements: !28)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 8192, elements: !44)
 !43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !44 = !{!45}
-!45 = !DISubrange(count: 64, lowerBound: 0)
+!45 = !DISubrange(count: 1024, lowerBound: 0)
 !46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
 !47 = !{!0, !16, !36, !38}
 !48 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !48
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -23,12 +23,12 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
+  %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
   %4 = getelementptr i64, ptr %3, i64 14
   %arg0 = load volatile i64, ptr %4, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 %arg0)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 1024, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %2, i64 0)
@@ -36,22 +36,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
-
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
-attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!54}
 !llvm.module.flags = !{!56}
@@ -73,10 +69,10 @@ attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !14 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !15 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !16, size: 64, offset: 192)
 !16 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !17, size: 64)
-!17 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 512, elements: !19)
+!17 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8192, elements: !19)
 !18 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !19 = !{!20}
-!20 = !DISubrange(count: 64, lowerBound: 0)
+!20 = !DISubrange(count: 1024, lowerBound: 0)
 !21 = !DIGlobalVariableExpression(var: !22, expr: !DIExpression())
 !22 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !23, isLocal: false, isDefinition: true)
 !23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !24)
@@ -108,8 +104,8 @@ attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !49 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
 !50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
 !51 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 512, elements: !9)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 512, elements: !9)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 8192, elements: !9)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 8192, elements: !9)
 !54 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !55)
 !55 = !{!0, !21, !35, !48, !50}
 !56 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !48
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -24,13 +24,13 @@ entry:
   %2 = getelementptr i64, ptr %1, i64 13
   %arg1 = load volatile i64, ptr %2, align 8
   %3 = add i64 %arg1, 1
-  %str.min.cmp = icmp ule i64 %3, 64
-  %str.min.select = select i1 %str.min.cmp, i64 %3, i64 64
+  %str.min.cmp = icmp ule i64 %3, 1024
+  %str.min.select = select i1 %str.min.cmp, i64 %3, i64 1024
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %4 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %4
-  %5 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 64, i1 false)
+  %5 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %5, i32 1024, ptr null)
   %6 = call ptr @llvm.preserve.static.offset(ptr %0)
   %7 = getelementptr i64, ptr %6, i64 14
   %arg0 = load volatile i64, ptr %7, align 8
@@ -46,19 +46,15 @@ entry:
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
-
-; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!54}
 !llvm.module.flags = !{!56}
@@ -80,10 +76,10 @@ attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !14 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !15 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !16, size: 64, offset: 192)
 !16 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !17, size: 64)
-!17 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 512, elements: !19)
+!17 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8192, elements: !19)
 !18 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !19 = !{!20}
-!20 = !DISubrange(count: 64, lowerBound: 0)
+!20 = !DISubrange(count: 1024, lowerBound: 0)
 !21 = !DIGlobalVariableExpression(var: !22, expr: !DIExpression())
 !22 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !23, isLocal: false, isDefinition: true)
 !23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !24)
@@ -115,8 +111,8 @@ attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !49 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
 !50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
 !51 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 512, elements: !9)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 512, elements: !9)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 8192, elements: !9)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 8192, elements: !9)
 !54 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !55)
 !55 = !{!0, !21, !35, !48, !50}
 !56 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !48
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -23,8 +23,8 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
+  %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
   %4 = getelementptr i64, ptr %3, i64 14
   %arg0 = load volatile i64, ptr %4, align 8
@@ -36,22 +36,18 @@ entry:
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
-
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
-attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!57}
 !llvm.module.flags = !{!59}
@@ -108,11 +104,11 @@ attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !49 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
 !50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
 !51 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 512, elements: !9)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 512, elements: !9)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 512, elements: !55)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 8192, elements: !9)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 8192, elements: !9)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8192, elements: !55)
 !55 = !{!56}
-!56 = !DISubrange(count: 64, lowerBound: 0)
+!56 = !DISubrange(count: 1024, lowerBound: 0)
 !57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
 !58 = !{!0, !21, !35, !48, !50}
 !59 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -14,7 +14,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !26
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !40
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !52
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !54
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !54
 @0 = global [1 x i8] zeroinitializer
 
 ; Function Attrs: nounwind
@@ -35,9 +35,9 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 ptrtoint (ptr @0 to i64))
+  %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 1024, i64 ptrtoint (ptr @0 to i64))
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %2, i64 0)
@@ -51,12 +51,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!58}
 !llvm.module.flags = !{!60}
@@ -83,10 +79,10 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !19 = !{!5, !11, !12, !20}
 !20 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !21, size: 64, offset: 192)
 !21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
-!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !23, size: 512, elements: !24)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !23, size: 8192, elements: !24)
 !23 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !24 = !{!25}
-!25 = !DISubrange(count: 64, lowerBound: 0)
+!25 = !DISubrange(count: 1024, lowerBound: 0)
 !26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
 !27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
 !28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
@@ -117,8 +113,8 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !53 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
 !54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
 !55 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !56, isLocal: false, isDefinition: true)
-!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 512, elements: !9)
-!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 512, elements: !9)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 8192, elements: !9)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 8192, elements: !9)
 !58 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !59)
 !59 = !{!0, !16, !26, !40, !52, !54}
 !60 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !30
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !42
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !44
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -26,12 +26,12 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
+  %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
   %4 = getelementptr i8, ptr %3, i64 8
   %5 = load volatile i64, ptr %4, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 %5)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 1024, i64 %5)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %comm)
   call void @llvm.memset.p0.i64(ptr align 1 %comm, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to ptr)(ptr %comm, i64 16)
@@ -257,22 +257,22 @@ strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop53
   br i1 %strcmp.cmp_null60, label %strcmp.done, label %strcmp.loop57
 }
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
-
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
-declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
-attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!52}
 !llvm.module.flags = !{!54}
@@ -323,12 +323,12 @@ attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !43 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
 !44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
 !45 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !47, size: 512, elements: !9)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 512, elements: !9)
-!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !49, size: 512, elements: !50)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !47, size: 8192, elements: !9)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 8192, elements: !9)
+!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !49, size: 8192, elements: !50)
 !49 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !50 = !{!51}
-!51 = !DISubrange(count: 64, lowerBound: 0)
+!51 = !DISubrange(count: 1024, lowerBound: 0)
 !52 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !53)
 !53 = !{!0, !16, !30, !42, !44}
 !54 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !48
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -31,17 +31,17 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %3 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %3
-  %4 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 64, i1 false)
+  %4 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 1024, ptr null)
   %5 = load i64, ptr %"$foo", align 8
   %6 = inttoptr i64 %5 to ptr
   %7 = call ptr @llvm.preserve.static.offset(ptr %6)
   %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.str")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.str", i32 8, ptr %8)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.str", i32 8, ptr %8)
   %9 = load i64, ptr %"struct Foo.str", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.str")
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %4, i32 64, i64 %9)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %4, i32 1024, i64 %9)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@mystr_key")
   store i64 0, ptr %"@mystr_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_mystr, ptr %"@mystr_key", ptr %4, i64 0)
@@ -55,16 +55,12 @@ declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!54}
 !llvm.module.flags = !{!56}
@@ -86,10 +82,10 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !14 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !15 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !16, size: 64, offset: 192)
 !16 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !17, size: 64)
-!17 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 512, elements: !19)
+!17 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8192, elements: !19)
 !18 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
 !19 = !{!20}
-!20 = !DISubrange(count: 64, lowerBound: 0)
+!20 = !DISubrange(count: 1024, lowerBound: 0)
 !21 = !DIGlobalVariableExpression(var: !22, expr: !DIExpression())
 !22 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !23, isLocal: false, isDefinition: true)
 !23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !24)
@@ -121,8 +117,8 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !49 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
 !50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
 !51 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 512, elements: !9)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 512, elements: !9)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 8192, elements: !9)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !17, size: 8192, elements: !9)
 !54 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !55)
 !55 = !{!0, !21, !35, !48, !50}
 !56 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 @ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !21
 @event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !35
 @max_cpu_id = dso_local externally_initialized constant i64 zeroinitializer, section ".rodata", !dbg !48
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [64 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
+@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !50
 @lo = global [3 x i8] c"lo\00"
 @hi = global [3 x i8] c"hi\00"
 
@@ -25,8 +25,8 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
+  %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
   %3 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %3 to i32
@@ -51,22 +51,18 @@ done:                                             ; preds = %right, %left
   ret i64 0
 }
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
-
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #2
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #3
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
-declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #3
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
 attributes #0 = { nounwind }
-attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
-attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
-attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
 !llvm.dbg.cu = !{!57}
 !llvm.module.flags = !{!59}
@@ -123,11 +119,11 @@ attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !49 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
 !50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
 !51 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 512, elements: !9)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 512, elements: !9)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 512, elements: !55)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !53, size: 8192, elements: !9)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 8192, elements: !9)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !18, size: 8192, elements: !55)
 !55 = !{!56}
-!56 = !DISubrange(count: 64, lowerBound: 0)
+!56 = !DISubrange(count: 1024, lowerBound: 0)
 !57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
 !58 = !{!0, !21, !35, !48, !50}
 !59 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -507,7 +507,7 @@ REQUIRES_FEATURE dpath fentry
 AFTER TMPDIR=/tmp ./testprogs/syscall open
 
 NAME strcontains
-RUN {{BPFTRACE}} -ve 'fentry:security_file_open { if (strcontains(path(args.file->f_path), "tmp")) { printf("OK\n"); exit(); } }'
+RUN {{BPFTRACE}} -e 'fentry:security_file_open { if (strcontains(path(args.file->f_path), "tmp")) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath fentry
 AFTER TMPDIR=/tmp ./testprogs/syscall open

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -56,6 +56,6 @@ REQUIRES_FEATURE signal
 
 NAME unique_probe_bodies
 RUN {{BPFTRACE}} -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
-EXPECT_REGEX .*increment_0:4:w..!
+EXPECT_REGEX .*increment_0:4:w!
 ARCH aarch64|x86_64
 REQUIRES_FEATURE signal


### PR DESCRIPTION
Now that bpftrace v0.22 has landed and it's a new release cycle, bump the default string size up from 64 to 1024. 1024 is chosen arbitrarily - it's a nice power of 2. It should also be big enough where users don't bump against truncated strings very often.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
