### PR TITLE
Do not generate functions for empty attach points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,13 @@ and this project adheres to
   - [#3704](https://github.com/bpftrace/bpftrace/pull/3704)
 - Fix `pid`, `tid` and `ustack` when running bpftrace in containers with PID namespacing
   - [#3428](https://github.com/bpftrace/bpftrace/pull/3428)
+- Do not generate functions for empty attach points
+  - [#3715](https://github.com/bpftrace/bpftrace/pull/3715)
 #### Security
 #### Docs
 #### Tools
+- Fix dcsnoop.bt on newer kernels
+  - [#3715](https://github.com/bpftrace/bpftrace/pull/3715)
 
 ## [0.22.0] 2025-01-07
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2823,6 +2823,12 @@ void CodegenLLVM::add_probe(AttachPoint &ap,
 {
   current_attach_point_ = &ap;
   probefull_ = ap.name();
+  if (ap.expansion == ExpansionType::MULTI) {
+    // For non-full expansion (currently only multi), we need to avoid
+    // generating the code as the BPF program would fail to load.
+    if (bpftrace_.probe_matcher_->get_matches_for_ap(ap).empty())
+      return;
+  }
   if (probetype(ap.provider) == ProbeType::usdt) {
     auto usdt = usdt_helper_->find(bpftrace_.pid(), ap.target, ap.ns, ap.func);
     if (!usdt.has_value()) {

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -268,7 +268,7 @@ TEST(bpftrace, add_probes_wildcard_kprobe_multi)
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_symbols_from_traceable_funcs(false))
-      .Times(1);
+      .Times(2);
 
   parse_probe("kprobe:sys_read,kprobe:my_*,kprobe:sys_write{}", *bpftrace);
 
@@ -472,7 +472,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_uprobe_multi)
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_func_symbols_from_file(0, "/bin/sh"))
-      .Times(1);
+      .Times(2);
 
   parse_probe("uprobe:/bin/sh:*open {}", *bpftrace);
 
@@ -524,7 +524,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file_uprobe_multi)
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_func_symbols_from_file(0, "/bin/*sh"))
-      .Times(1);
+      .Times(2);
 
   parse_probe("uprobe:/bin/*sh:*open {}", *bpftrace);
 

--- a/tests/codegen/builtin_func_wild.cpp
+++ b/tests/codegen/builtin_func_wild.cpp
@@ -9,7 +9,7 @@ using ::testing::Return;
 
 TEST(codegen, builtin_func_wild)
 {
-  test("kprobe:do_execve* { @x = func }", NAME);
+  test("kprobe:sys_* { @x = func }", NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/llvm/builtin_func_wild.ll
+++ b/tests/codegen/llvm/builtin_func_wild.ll
@@ -15,7 +15,7 @@ target triple = "bpf-pc-linux"
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @kprobe_do_execve__1(ptr %0) section "s_kprobe_do_execve__1" !dbg !45 {
+define i64 @kprobe_sys___1(ptr %0) section "s_kprobe_sys___1" !dbg !45 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
@@ -93,7 +93,7 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
 !43 = !{!0, !16, !30}
 !44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = distinct !DISubprogram(name: "kprobe_do_execve__1", linkageName: "kprobe_do_execve__1", scope: !2, file: !2, type: !46, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
+!45 = distinct !DISubprogram(name: "kprobe_sys___1", linkageName: "kprobe_sys___1", scope: !2, file: !2, type: !46, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
 !46 = !DISubroutineType(types: !47)
 !47 = !{!14, !48}
 !48 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !49, size: 64)

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -178,6 +178,12 @@ RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { @ = probe; printf("progs: "); syst
 EXPECT_REGEX progs: [1-9][0-9]+
 REQUIRES bpftool
 
+NAME kprobe_multi_mixed_attachpoint
+PROG kprobe:vfs_read,kprobe:nonsense* { printf("SUCCESS\n"); exit(); }
+EXPECT SUCCESS
+REQUIRES_FEATURE kprobe_multi
+AFTER ./testprogs/syscall read
+
 NAME kprobe_offset_module
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x5 { printf("hit\n"); exit(); }'
 AFTER nft add table bpftrace


### PR DESCRIPTION
When a probe contains a mix of wildcarded and non-wildcarded attach points which are not fully expanded (e.g. `kprobe:fun,kprobe:vfs*` as the latter is multi-expanded) and some wildcarded attach point has no matches, we must avoid generating an LLVM function for that attach point as libbpf would turn it into a BPF program for which we wouldn't have a corresponding Probe object and loading of such program would fail.

This fixes the dcsnoop.bt tool as it contains:

    kprobe:lookup_fast,
    kprobe:lookup_fast.constprop.*

and on some kernels, the second probe expands to nothing if `lookup_fast` is not affected by compiler's constant propagation. Without this fix, the tool would fail to load.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
