### PR TITLE
BTF: Print textual error as opposed to mere error number

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -78,7 +78,7 @@ void BTF::load_kernel_btfs(const std::set<std::string> &modules)
 {
   vmlinux_btf = btf__load_vmlinux_btf();
   if (libbpf_get_error(vmlinux_btf)) {
-    LOG(V1) << "BTF: failed to find BTF data for vmlinux, errno " << errno;
+    LOG(V1) << "BTF: failed to find BTF data for vmlinux: " << strerror(errno);
     return;
   }
   btf_objects.push_back(
@@ -94,7 +94,8 @@ void BTF::load_kernel_btfs(const std::set<std::string> &modules)
     int err = bpf_btf_get_next_id(id, &id);
     if (err) {
       if (errno != ENOENT)
-        LOG(V1) << "BTF: failed to iterate modules BTF objects";
+        LOG(V1) << "BTF: failed to iterate modules BTF objects: "
+                << strerror(errno);
       break;
     }
 


### PR DESCRIPTION
Print a textual representation of the error as opposed to a mere number that the user has to decode when logging an error in the BTF logic.