### PR TITLE
nix: Fix bcc SHA

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
                   owner = "iovisor";
                   repo = "bcc";
                   rev = "v${bccVersion}";
-                  sha256 = "sha256-ngGLGfLv2prnjhgaRPf8ea3oyy4129zGodR0Yz1QtCw=";
+                  sha256 = "sha256-6dT3seLuEVQNKWiYGLK1ajXzW7pb62S/GQ0Lp4JdGjc=";
                 };
                 # Seems like these extra tools are needed to build bcc
                 nativeBuildInputs = old.nativeBuildInputs ++ [ pkgs.python310Packages.setuptools pkgs.zip ];


### PR DESCRIPTION
72f6642e ("nix: Bump bcc version to contain FD close bug fix") bumped the rev but didn't update the hash. Fix that, or else CI will build a totally different version.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
