### PR TITLE
Fix tracepoint_order test

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -163,8 +163,8 @@ TIMEOUT 2
 NAME it lists probes in a given file
 RUN {{BPFTRACE}} -l runtime/scripts/interval_order.bt
 EXPECT interval:ms:
-EXPECT interval:ms:
-EXPECT interval:ms:
+EXPECT interval:s:
+EXPECT interval:us:
 
 NAME warning on non existent file
 RUN {{BPFTRACE}} -l non_existent_file.bt

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -107,7 +107,7 @@ AFTER ./testprogs/syscall read
 NAME kprobe_order
 RUN {{BPFTRACE}} runtime/scripts/kprobe_order.bt
 EXPECT first second
-AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
+AFTER /bin/bash -c "./testprogs/syscall nanosleep 1001";
 
 NAME kprobe_offset
 PROG kprobe:vfs_read+0 { printf("SUCCESS %d\n", pid); exit(); }
@@ -243,7 +243,7 @@ AFTER ./testprogs/syscall read
 NAME kretprobe_order
 RUN {{BPFTRACE}} runtime/scripts/kretprobe_order.bt
 EXPECT first second
-AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
+AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000";
 
 NAME kretprobe_wildcard
 PROG kretprobe:vmlinux:vfs_rea* { printf("SUCCESS %d\n", pid); exit(); }
@@ -310,7 +310,7 @@ REQUIRES_FEATURE libpath_resolv
 NAME uprobe_order
 RUN {{BPFTRACE}} runtime/scripts/uprobe_order.bt
 EXPECT first second
-AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
+AFTER /bin/bash -c "echo lala";
 
 NAME uprobe_zero_size
 PROG uprobe:./testprogs/uprobe_test:_init { printf("arg0: %d\n", arg0); exit();}
@@ -347,7 +347,7 @@ AFTER /bin/bash -c "echo lala"
 NAME uretprobe_order
 RUN {{BPFTRACE}} runtime/scripts/uretprobe_order.bt
 EXPECT first second
-AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
+AFTER /bin/bash -c "echo lala";
 
 NAME tracepoint
 PROG tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS %d\n", gid); exit(); }

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -362,7 +362,7 @@ AFTER ./testprogs/syscall nanosleep 1e8
 NAME tracepoint_order
 RUN {{BPFTRACE}} runtime/scripts/tracepoint_order.bt
 EXPECT first second
-AFTER ./testprogs/syscall nanosleep 1e8; ./testprogs/syscall nanosleep 1e8
+AFTER ./testprogs/syscall nanosleep 100000001;
 
 NAME tracepoint_expansion
 RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit\n"); }' -c "./testprogs/syscall nanosleep 1e8"

--- a/tests/runtime/scripts/interval_order.bt
+++ b/tests/runtime/scripts/interval_order.bt
@@ -1,25 +1,5 @@
-interval:ms:1
-{
-  @probe1_ready = 1;
-  if (@go == 1) {
-    printf("first");
-  }
-}
+interval:ms:1000 {}
 
-interval:ms:1
-{
-  @probe2_ready = 1;
-  if (@go == 1) {
-    printf(" second\n");
-    exit();
-  }
-}
+interval:s:1 {}
 
-interval:ms:1
-{
-  // Make sure all probes are attached before letting them print anything
-  // so that the output we get is all from the same event.
-  if (@probe1_ready == 1 && @probe2_ready == 1) {
-    @go = 1;
-  }
-}
+interval:us:100000 {}

--- a/tests/runtime/scripts/kprobe_order.bt
+++ b/tests/runtime/scripts/kprobe_order.bt
@@ -1,25 +1,16 @@
+// Check arg0 to make sure these are the nanosleeps we issued
+
 kprobe:hrtimer_nanosleep
 {
-  @probe1_ready = 1;
-  if (@go == 1) {
-    printf("first");
+  if (arg0 == 1001) {
+     printf("first");
   }
 }
 
 kprobe:hrtimer_nanosleep
 {
-  @probe2_ready = 1;
-  if (@go == 1) {
+  if (arg0 == 1001) {
     printf(" second\n");
     exit();
-  }
-}
-
-kprobe:hrtimer_nanosleep
-{
-  // Make sure all probes are attached before letting them print anything
-  // so that the output we get is all from the same event.
-  if (@probe1_ready == 1 && @probe2_ready == 1) {
-    @go = 1;
   }
 }

--- a/tests/runtime/scripts/kretprobe_order.bt
+++ b/tests/runtime/scripts/kretprobe_order.bt
@@ -1,25 +1,10 @@
 kretprobe:hrtimer_nanosleep
 {
-  @probe1_ready = 1;
-  if (@go == 1) {
-    printf("first");
-  }
+  printf("first");
 }
 
 kretprobe:hrtimer_nanosleep
 {
-  @probe2_ready = 1;
-  if (@go == 1) {
-    printf(" second\n");
-    exit();
-  }
-}
-
-kretprobe:hrtimer_nanosleep
-{
-  // Make sure all probes are attached before letting them print anything
-  // so that the output we get is all from the same event.
-  if (@probe1_ready == 1 && @probe2_ready == 1) {
-    @go = 1;
-  }
+  printf(" second\n");
+  exit();
 }

--- a/tests/runtime/scripts/tracepoint_order.bt
+++ b/tests/runtime/scripts/tracepoint_order.bt
@@ -1,25 +1,18 @@
-tracepoint:syscalls:sys_exit_nanosleep
+// Check tv_nsec to make sure these are the nanosleeps we issued
+
+tracepoint:syscalls:sys_enter_nanosleep
 {
-  @probe1_ready = 1;
-  if (@go == 1) {
+  $tv_nsecs = (*args.rqtp).tv_nsec;
+  if ($tv_nsecs == 100000001) {
     printf("first");
   }
 }
 
-tracepoint:syscalls:sys_exit_nanosleep
+tracepoint:syscalls:sys_enter_nanosleep
 {
-  @probe2_ready = 1;
-  if (@go == 1) {
+  $tv_nsecs = (*args.rqtp).tv_nsec;
+  if ($tv_nsecs == 100000001) {
     printf(" second\n");
     exit();
-  }
-}
-
-tracepoint:syscalls:sys_exit_nanosleep
-{
-  // Make sure all probes are attached before letting them print anything
-  // so that the output we get is all from the same event.
-  if (@probe1_ready == 1 && @probe2_ready == 1) {
-    @go = 1;
   }
 }

--- a/tests/runtime/scripts/uprobe_order.bt
+++ b/tests/runtime/scripts/uprobe_order.bt
@@ -1,25 +1,10 @@
 uprobe:/bin/bash:echo_builtin
 {
-  @probe1_ready = 1;
-  if (@go == 1) {
-    printf("first");
-  }
+  printf("first");
 }
 
 uprobe:/bin/bash:echo_builtin
 {
-  @probe2_ready = 1;
-  if (@go == 1) {
-    printf(" second\n");
-    exit();
-  }
-}
-
-uprobe:/bin/bash:echo_builtin
-{
-  // Make sure all probes are attached before letting them print anything
-  // so that the output we get is all from the same event.
-  if (@probe1_ready == 1 && @probe2_ready == 1) {
-    @go = 1;
-  }
+  printf(" second\n");
+  exit();
 }

--- a/tests/runtime/scripts/uretprobe_order.bt
+++ b/tests/runtime/scripts/uretprobe_order.bt
@@ -1,25 +1,10 @@
 uretprobe:/bin/bash:echo_builtin
 {
-  @probe1_ready = 1;
-  if (@go == 1) {
-    printf("first");
-  }
+  printf("first");
 }
 
 uretprobe:/bin/bash:echo_builtin
 {
-  @probe2_ready = 1;
-  if (@go == 1) {
-    printf(" second\n");
-    exit();
-  }
-}
-
-uretprobe:/bin/bash:echo_builtin
-{
-  // Make sure all probes are attached before letting them print anything
-  // so that the output we get is all from the same event.
-  if (@probe1_ready == 1 && @probe2_ready == 1) {
-    @go = 1;
-  }
+  printf(" second\n");
+  exit();
 }


### PR DESCRIPTION
This test was flaky and would sometimes see this
output: firstfirst second.

Seems like there might be a race condition with
the @go hashmap. So let's check the tv_nsecs arg
to make sure it's the events we fired in the test
runner (as other nanosleeps may be happening on
the system).

Also fix up the other *_order runtime tests
as they don't require maps and multiple events.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
