### PR TITLE
ci: Remove magic-nix-cache-action usage

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -17,7 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: DeterminateSystems/nix-installer-action@v11
-    - uses: DeterminateSystems/magic-nix-cache-action@v6
 
     - name: Build appimage
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       with:
         fetch-depth: 0
     - uses: DeterminateSystems/nix-installer-action@v11
-    - uses: DeterminateSystems/magic-nix-cache-action@v6
     - name: clang-format
       run: nix develop --command git clang-format --diff origin/master
 
@@ -74,7 +73,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: DeterminateSystems/nix-installer-action@v11
-    - uses: DeterminateSystems/magic-nix-cache-action@v6
     - uses: ./.github/actions/configure_kvm
     - name: Load kernel modules
       # nf_tables and xfs are necessary for testing kernel modules BTF support

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,6 @@ jobs:
           submodules: recursive
 
       - uses: DeterminateSystems/nix-installer-action@v11
-      - uses: DeterminateSystems/magic-nix-cache-action@v6
 
       - name: Configure (cpp)
         if: ${{ matrix.language == 'cpp' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: DeterminateSystems/nix-installer-action@v11
-    - uses: DeterminateSystems/magic-nix-cache-action@v6
 
     - name: Build artifacts
       run: nix develop --command bash -c "OUT=./assets ./scripts/create-assets.sh"

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -21,6 +21,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: DeterminateSystems/nix-installer-action@v4
-      - uses: DeterminateSystems/magic-nix-cache-action@v2
       - name: Run clang-tidy
         run: ./scripts/clang_tidy.sh


### PR DESCRIPTION

On Feb 1st this will start breaking [0]. Long term we still want a
cache, as some experiements show it results in a 20% regression in CI
wall time.

But in case we haven't figure it by the deadline, we'll land this to
unbreak CI.

[0]: https://determinate.systems/posts/magic-nix-cache-free-tier-eol/

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
