### PR TITLE
cleanup: update explicit C++20 TODOs

### DIFF
--- a/src/ast/passes/config_analyser.h
+++ b/src/ast/passes/config_analyser.h
@@ -39,15 +39,16 @@ private:
   std::ostream &out_;
   std::ostringstream err_;
 
-  void set_uint64_config(AssignConfigVarStatement &assignment,
-                         ConfigKeyInt key);
-  void set_bool_config(AssignConfigVarStatement &assignment, ConfigKeyBool key);
-  void set_string_config(AssignConfigVarStatement &assignment,
-                         ConfigKeyString key);
-  void set_stack_mode_config(AssignConfigVarStatement &assignment);
-  void set_user_symbol_cache_type_config(AssignConfigVarStatement &assignment);
-  void set_symbol_source_config(AssignConfigVarStatement &assignment);
-  void set_missing_probes_config(AssignConfigVarStatement &assignment);
+  void set_config(AssignConfigVarStatement &assignment, ConfigKeyInt key);
+  void set_config(AssignConfigVarStatement &assignment, ConfigKeyBool key);
+  void set_config(AssignConfigVarStatement &assignment, ConfigKeyString key);
+  void set_config(AssignConfigVarStatement &assignment,
+                  ConfigKeyUserSymbolCacheType key);
+  void set_config(AssignConfigVarStatement &assignment,
+                  ConfigKeySymbolSource key);
+  void set_config(AssignConfigVarStatement &assignment, ConfigKeyStackMode key);
+  void set_config(AssignConfigVarStatement &assignment,
+                  ConfigKeyMissingProbes key);
 
   void log_type_error(SizedType &type,
                       Type expected_type,

--- a/src/container/cstring_view.h
+++ b/src/container/cstring_view.h
@@ -22,11 +22,10 @@ public:
   constexpr cstring_view(const char *str) noexcept : std::string_view{ str }
   {
   }
-  // This ctor can be made constexpt in C++20:
-  cstring_view(const std::string &str) noexcept : std::string_view{ str }
+  constexpr cstring_view(const std::string &str) noexcept
+      : std::string_view{ str }
   {
   }
-
   constexpr const char *c_str() const noexcept
   {
     return data();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -775,7 +775,7 @@ std::vector<std::pair<std::string, std::string>> get_cgroup_paths(
   auto paths_v1 = filtered_v1 | get_path_func;
   auto paths_v2 = filtered_v2 | get_path_func;
 
-  // Return paths with v2 first, then v2 sorted lexically by name.
+  // Return paths with v2 first, then v1 sorted lexically by name.
   std::vector<std::pair<std::string, std::string>> sorted(paths_v2.begin(),
                                                           paths_v2.end());
   std::vector<std::pair<std::string, std::string>> sorted_v1(paths_v1.begin(),

--- a/src/utils.h
+++ b/src/utils.h
@@ -205,7 +205,7 @@ std::vector<std::string> get_kernel_cflags(const char *uname_machine,
                                            const KConfig &kconfig);
 std::string get_cgroup_path_in_hierarchy(uint64_t cgroupid,
                                          std::string base_path);
-std::vector<std::pair<std::string, std::string>> get_cgroup_hierarchy_roots();
+std::array<std::vector<std::string>, 2> get_cgroup_hierarchy_roots();
 std::vector<std::pair<std::string, std::string>> get_cgroup_paths(
     uint64_t cgroupid,
     std::string filter);

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -220,10 +220,14 @@ TEST(utils, get_cgroup_hierarchy_roots)
 {
   auto roots = get_cgroup_hierarchy_roots();
 
-  // Check that each entry is a proper cgroup filesystem
-  for (auto root : roots) {
-    EXPECT_TRUE(root.first == "cgroup" || root.first == "cgroup2");
-    std::filesystem::path root_path(root.second);
+  // Check that each entry is a proper cgroup filesystem. The first set are
+  // cgroupv1 results, and the second set are cgroupv2 results.
+  for (auto root : roots[0]) {
+    std::filesystem::path root_path(root);
+    EXPECT_TRUE(std::filesystem::exists(root_path / "cgroup.procs"));
+  }
+  for (auto root : roots[1]) {
+    std::filesystem::path root_path(root);
     EXPECT_TRUE(std::filesystem::exists(root_path / "cgroup.procs"));
   }
 }


### PR DESCRIPTION
This change updates C++20 TODOs with a reasonable implementation. There may be other code that could be updated, but this at least removes the explicit cases that are marked for improvement with C++20.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
