### PR TITLE
Refactor symbolization logic

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(runtime STATIC
   utils.cpp
   pcap_writer.cpp
   ksyms.cpp
+  usyms.cpp
   ${BFD_DISASM_SRC}
 )
 # Ensure flex+bison outputs are built first

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(runtime STATIC
   usdt.cpp
   utils.cpp
   pcap_writer.cpp
+  ksyms.cpp
   ${BFD_DISASM_SRC}
 )
 # Ensure flex+bison outputs are built first

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -67,9 +67,6 @@ BPFtrace::~BPFtrace()
     if (pair.second)
       bcc_free_symcache(pair.second, pair.first);
   }
-
-  if (ksyms_)
-    bcc_free_symcache(ksyms_, -1);
 }
 
 Probe BPFtrace::generateWatchpointSetupProbe(const ast::AttachPoint &ap,
@@ -1664,21 +1661,7 @@ std::string BPFtrace::resolve_buf(const char *buf, size_t size)
 
 std::string BPFtrace::resolve_ksym(uint64_t addr, bool show_offset)
 {
-  struct bcc_symbol ksym;
-  std::ostringstream symbol;
-
-  if (!ksyms_)
-    ksyms_ = bcc_symcache_new(-1, nullptr);
-
-  if (bcc_symcache_resolve(ksyms_, addr, &ksym) == 0) {
-    symbol << ksym.name;
-    if (show_offset)
-      symbol << "+" << ksym.offset;
-  } else {
-    symbol << reinterpret_cast<void *>(addr);
-  }
-
-  return symbol.str();
+  return ksyms_.resolve(addr, show_offset);
 }
 
 uint64_t BPFtrace::resolve_kname(const std::string &name) const

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -33,6 +33,7 @@
 #include "required_resources.h"
 #include "struct.h"
 #include "types.h"
+#include "usyms.h"
 #include "utils.h"
 
 #include <bcc/bcc_syms.h>
@@ -99,7 +100,8 @@ public:
         probe_matcher_(std::make_unique<ProbeMatcher>(this)),
         ncpus_(get_possible_cpus().size()),
         max_cpu_id_(get_max_cpu_id()),
-        config_(config)
+        config_(config),
+        usyms_(config_)
   {
   }
   virtual ~BPFtrace();
@@ -236,11 +238,7 @@ public:
 
 private:
   Ksyms ksyms_;
-  // note: exe_sym_ is used when layout is same for all instances of program
-  std::map<std::string, std::pair<int, void *>> exe_sym_; // exe -> (pid, cache)
-  std::map<int, void *> pid_sym_;                         // pid -> cache
-  std::map<std::string, std::map<uintptr_t, elf_symbol, std::greater<>>>
-      symbol_table_cache_;
+  Usyms usyms_;
   std::vector<std::string> params_;
 
   std::vector<std::unique_ptr<void, void (*)(void *)>> open_perf_buffers_;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -24,6 +24,7 @@
 #include "config.h"
 #include "dwarf_parser.h"
 #include "functions.h"
+#include "ksyms.h"
 #include "output.h"
 #include "pcap_writer.h"
 #include "printf.h"
@@ -234,7 +235,7 @@ public:
   Config config_;
 
 private:
-  void *ksyms_{ nullptr };
+  Ksyms ksyms_;
   // note: exe_sym_ is used when layout is same for all instances of program
   std::map<std::string, std::pair<int, void *>> exe_sym_; // exe -> (pid, cache)
   std::map<int, void *> pid_sym_;                         // pid -> cache

--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -1,0 +1,30 @@
+#include <sstream>
+
+#include <bcc/bcc_syms.h>
+
+#include "ksyms.h"
+
+std::string Ksyms::resolve(uint64_t addr, bool show_offset)
+{
+  struct bcc_symbol ksym;
+  std::ostringstream symbol;
+
+  if (!ksyms_)
+    ksyms_ = bcc_symcache_new(-1, nullptr);
+
+  if (bcc_symcache_resolve(ksyms_, addr, &ksym) == 0) {
+    symbol << ksym.name;
+    if (show_offset)
+      symbol << "+" << ksym.offset;
+  } else {
+    symbol << reinterpret_cast<void *>(addr);
+  }
+
+  return symbol.str();
+}
+
+Ksyms::~Ksyms()
+{
+  if (ksyms_)
+    bcc_free_symcache(ksyms_, -1);
+}

--- a/src/ksyms.h
+++ b/src/ksyms.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+class Ksyms {
+public:
+  Ksyms() = default;
+  ~Ksyms();
+
+  Ksyms(Ksyms &) = delete;
+  Ksyms &operator=(const Ksyms &) = delete;
+
+  std::string resolve(uint64_t addr, bool show_offset);
+
+private:
+  void *ksyms_{ nullptr };
+};

--- a/src/usyms.cpp
+++ b/src/usyms.cpp
@@ -1,0 +1,133 @@
+#include <bcc/bcc_syms.h>
+
+#include "usyms.h"
+
+namespace bpftrace {
+
+Usyms::Usyms(const Config &config) : config_(config)
+{
+}
+
+Usyms::~Usyms()
+{
+  for (const auto &pair : exe_sym_) {
+    if (pair.second.second)
+      bcc_free_symcache(pair.second.second, pair.second.first);
+  }
+
+  for (const auto &pair : pid_sym_) {
+    if (pair.second)
+      bcc_free_symcache(pair.second, pair.first);
+  }
+}
+
+void Usyms::cache(const std::string &elf_file)
+{
+  auto cache_type = config_.get(ConfigKeyUserSymbolCacheType::default_);
+  // preload symbol table for executable to make it available even if the
+  // binary is not present at symbol resolution time
+  // note: this only makes sense with ASLR disabled, since with ASLR offsets
+  // might be different
+  if (cache_type == UserSymbolCacheType::per_program &&
+      symbol_table_cache_.find(elf_file) == symbol_table_cache_.end())
+    symbol_table_cache_[elf_file] = get_symbol_table_for_elf(elf_file);
+
+  if (cache_type == UserSymbolCacheType::per_pid)
+    // preload symbol tables from running processes
+    // this allows symbol resolution for processes that are running at probe
+    // attach time, but not at symbol resolution time, even with ASLR
+    // enabled, since BCC symcache records the offsets
+    for (int pid : get_pids_for_program(elf_file))
+      pid_sym_[pid] = bcc_symcache_new(pid, &get_symbol_opts());
+}
+
+std::string Usyms::resolve(uint64_t addr,
+                           int32_t pid,
+                           const std::string &pid_exe,
+                           bool show_offset,
+                           bool show_module)
+{
+  auto cache_type = config_.get(ConfigKeyUserSymbolCacheType::default_);
+  struct bcc_symbol usym;
+  std::ostringstream symbol;
+  void *psyms = nullptr;
+
+  if (cache_type == UserSymbolCacheType::per_program) {
+    if (!pid_exe.empty()) {
+      // try to resolve symbol directly from program file
+      // this might work when the process does not exist anymore, but cannot
+      // resolve all symbols, e.g. those in a dynamically linked library
+      std::map<uintptr_t, elf_symbol, std::greater<>> &symbol_table =
+          symbol_table_cache_.find(pid_exe) != symbol_table_cache_.end()
+              ? symbol_table_cache_[pid_exe]
+              : (symbol_table_cache_[pid_exe] = get_symbol_table_for_elf(
+                     pid_exe));
+      auto sym = symbol_table.lower_bound(addr);
+      // address has to be either the start of the symbol (for symbols of
+      // length 0) or in [start, end)
+      if (sym != symbol_table.end() &&
+          (addr == sym->second.start ||
+           (addr >= sym->second.start && addr < sym->second.end))) {
+        symbol << sym->second.name;
+        if (show_offset)
+          symbol << "+" << addr - sym->second.start;
+        if (show_module)
+          symbol << " (" << pid_exe << ")";
+        return symbol.str();
+      }
+    }
+    if (exe_sym_.find(pid_exe) == exe_sym_.end()) {
+      // not cached, create new ProcSyms cache
+      psyms = bcc_symcache_new(pid, &get_symbol_opts());
+      exe_sym_[pid_exe] = std::make_pair(pid, psyms);
+    } else {
+      psyms = exe_sym_[pid_exe].second;
+    }
+  } else if (cache_type == UserSymbolCacheType::per_pid) {
+    // cache user symbols per pid
+    if (pid_sym_.find(pid) == pid_sym_.end()) {
+      // not cached, create new ProcSyms cache
+      psyms = bcc_symcache_new(pid, &get_symbol_opts());
+      pid_sym_[pid] = psyms;
+    } else {
+      psyms = pid_sym_[pid];
+    }
+  } else {
+    // no user symbol caching, create new bcc cache
+    psyms = bcc_symcache_new(pid, &get_symbol_opts());
+  }
+
+  if (psyms && bcc_symcache_resolve(psyms, addr, &usym) == 0) {
+    if (config_.get(ConfigKeyBool::cpp_demangle))
+      symbol << usym.demangle_name;
+    else
+      symbol << usym.name;
+    if (show_offset)
+      symbol << "+" << usym.offset;
+    if (show_module)
+      symbol << " (" << usym.module << ")";
+  } else {
+    symbol << reinterpret_cast<void *>(addr);
+    if (show_module)
+      symbol << " ([unknown])";
+  }
+
+  if (cache_type == UserSymbolCacheType::none)
+    bcc_free_symcache(psyms, pid);
+
+  return symbol.str();
+}
+
+struct bcc_symbol_option &Usyms::get_symbol_opts()
+{
+  static struct bcc_symbol_option symopts = {
+    .use_debug_file = 1,
+    .check_debug_file_crc = 1,
+    .lazy_symbolize = config_.get(ConfigKeyBool::lazy_symbolication) ? 1 : 0,
+    .use_symbol_type = BCC_SYM_ALL_TYPES,
+  };
+
+  return symopts;
+}
+
+} // namespace bpftrace

--- a/src/usyms.h
+++ b/src/usyms.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+
+#include "config.h"
+#include "types.h"
+#include "utils.h"
+
+#include <bcc/bcc_syms.h>
+
+namespace bpftrace {
+
+class Usyms {
+public:
+  Usyms(const Config& config);
+  ~Usyms();
+
+  Usyms(Usyms&) = delete;
+  Usyms& operator=(const Usyms&) = delete;
+
+  void cache(const std::string& elf_file);
+  std::string resolve(uint64_t addr,
+                      int32_t pid,
+                      const std::string& pid_exe,
+                      bool show_offset,
+                      bool show_module);
+
+private:
+  const Config& config_;
+  // note: exe_sym_ is used when layout is same for all instances of program
+  std::map<std::string, std::pair<int, void*>> exe_sym_; // exe -> (pid, cache)
+  std::map<int, void*> pid_sym_;                         // pid -> cache
+  std::map<std::string, std::map<uintptr_t, elf_symbol, std::greater<>>>
+      symbol_table_cache_;
+
+  struct bcc_symbol_option& get_symbol_opts();
+};
+} // namespace bpftrace


### PR DESCRIPTION
Refactor the symbolization logic a bit, by moving relevant bits into different files. Please see individual commits for descriptions. Changes are intended to be semantic preserving.

This work is loosely related to https://github.com/bpftrace/bpftrace/pull/3474, but can entirely stand as an improvement on its own.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
