### PR TITLE
cleanup: use standardized architecture macros

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,18 +69,6 @@ target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(bpftrace_test PRIVATE TEST_CODEGEN_LOCATION="${CMAKE_SOURCE_DIR}/tests/codegen/llvm/")
 target_link_libraries(bpftrace_test libbpftrace)
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-  target_compile_definitions(bpftrace_test PRIVATE ARCH_AARCH64)
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64" OR
-       CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
-  target_compile_definitions(bpftrace_test PRIVATE ARCH_PPC64)
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "s390" OR
-       CMAKE_SYSTEM_PROCESSOR STREQUAL "s390x")
-  target_compile_definitions(bpftrace_test PRIVATE ARCH_S390)
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  target_compile_definitions(bpftrace_test PRIVATE ARCH_X86_64)
-endif()
-
 target_compile_definitions(bpftrace_test PRIVATE ${BPFTRACE_FLAGS})
 
 if(BUILD_ASAN)

--- a/tests/codegen/call_reg.cpp
+++ b/tests/codegen/call_reg.cpp
@@ -4,7 +4,7 @@ namespace bpftrace {
 namespace test {
 namespace codegen {
 
-#ifdef ARCH_X86_64
+#ifdef __x86_64__
 TEST(codegen, call_reg) // Identical to builtin_func apart from variable names
 {
   test("kprobe:f { @x = reg(\"ip\") }",

--- a/tests/codegen/intptrcast_assign_var.cpp
+++ b/tests/codegen/intptrcast_assign_var.cpp
@@ -4,7 +4,7 @@ namespace bpftrace {
 namespace test {
 namespace codegen {
 
-#ifdef ARCH_X86_64
+#ifdef __x86_64__
 TEST(codegen, intptrcast_assign_var)
 {
   test("kretprobe:f { @=*(int8*)(reg(\"bp\")-1) }", NAME);

--- a/tests/codegen/intptrcast_call.cpp
+++ b/tests/codegen/intptrcast_call.cpp
@@ -4,7 +4,7 @@ namespace bpftrace {
 namespace test {
 namespace codegen {
 
-#ifdef ARCH_X86_64
+#ifdef __x86_64__
 TEST(codegen, intptrcast_call)
 {
   // Casting should work inside a call

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -349,7 +349,7 @@ TEST(semantic_analyser, builtin_functions)
   test("kprobe:f { pton(\"127.0.0.1\") }");
   test("kprobe:f { pton(\"::1\") }");
   test("kprobe:f { pton(\"0000:0000:0000:0000:0000:0000:0000:0001\") }");
-#ifdef ARCH_X86_64
+#ifdef __x86_64__
   test("kprobe:f { reg(\"ip\") }");
 #endif
   test("kprobe:f { kstack(1) }");
@@ -1415,7 +1415,7 @@ TEST(semantic_analyser, call_cgroupid)
 
 TEST(semantic_analyser, call_reg)
 {
-#ifdef ARCH_X86_64
+#ifdef __x86_64__
   test("kprobe:f { reg(\"ip\"); }");
   test("kprobe:f { @x = reg(\"ip\"); }");
 #endif
@@ -2226,15 +2226,15 @@ TEST(semantic_analyser, rawtracepoint)
   test("rawtracepoint:event { args }", 1);
 }
 
-#if defined(ARCH_X86_64) || defined(ARCH_AARCH64)
+#if defined(__x86_64__) || defined(__aarch64__)
 TEST(semantic_analyser, watchpoint_invalid_modes)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->procmon_ = std::make_unique<MockProcMon>(123);
 
-#ifdef ARCH_X86_64
+#if defined(__x86_64__)
   test(*bpftrace, "watchpoint:0x1234:8:r { 1 }", 1);
-#elif ARCH_AARCH64
+#elif defined(__aarch64__)
   test(*bpftrace, "watchpoint:0x1234:8:r { 1 }");
 #endif
   test(*bpftrace, "watchpoint:0x1234:8:rx { 1 }", 1);
@@ -2285,7 +2285,7 @@ TEST(semantic_analyser, asyncwatchpoint)
   bpftrace->procmon_ = std::make_unique<MockProcMon>(0);
   test(*bpftrace, "watchpoint:func1+arg2:8:rw { 1 }", 1);
 }
-#endif // if defined(ARCH_X86_64) || defined(ARCH_AARCH64)
+#endif // if defined(__x86_64__) || defined(__aarch64__)
 
 TEST(semantic_analyser, args_builtin_wrong_use)
 {
@@ -3341,7 +3341,7 @@ TEST(semantic_analyser, type_ctx)
   var = static_cast<ast::Variable *>(unop->expr);
   EXPECT_TRUE(var->type.IsPtrTy());
 
-#ifdef ARCH_X86_64
+#ifdef __x86_64__
   auto chartype = CreateInt8();
 #else
   auto chartype = CreateUInt8();
@@ -3914,7 +3914,7 @@ fexit:func_1 { $x = args.foo; }
   test("fentry:func_1 { @ = args; }");
   test("fentry:func_1 { @[args] = 1; }");
   // reg() is not available in fentry
-#ifdef ARCH_X86_64
+#ifdef __x86_64__
   test_error("fentry:func_1 { reg(\"ip\") }", R"(
 stdin:1:17-26: ERROR: reg can not be used with "fentry" probes
 fentry:func_1 { reg("ip") }
@@ -4042,7 +4042,7 @@ kretfunc:func_1 { $x = args.foo; }
   test("kfunc:func_1 { @ = args; }");
   test("kfunc:func_1 { @[args] = 1; }");
   // reg() is not available in kfunc
-#ifdef ARCH_X86_64
+#ifdef __x86_64__
   test_error("kfunc:func_1 { reg(\"ip\") }", R"(
 stdin:1:16-25: ERROR: reg can not be used with "fentry" probes
 kfunc:func_1 { reg("ip") }


### PR DESCRIPTION
There is no need to define custom architecture macros. Although the standard macros were originally defined as GNU C extensions, they are generally portable and implemented by clang and others (e.g. [1], [2]).

[1] https://github.com/llvm/llvm-project/blob/cccb55491223cd410cb2f83973377dd75757cb60/clang/lib/Basic/Targets/X86.cpp#L551
[2] https://github.com/llvm/llvm-project/blob/cccb55491223cd410cb2f83973377dd75757cb60/clang/lib/Basic/Targets/AArch64.cpp#L405

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
