### PR TITLE
Add feature check for map_lookup_percpu_elem

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -831,6 +831,18 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
 
   const std::string &map_name = map.ident;
 
+  if (!bpftrace_.feature_->has_helper_map_lookup_percpu_elem()) {
+    /*
+     * Unfortunately detecting this in semantic_analyser would be very ugly &
+     * complicated for all implicit casting, so error here until we drop
+     * support for kernel 5.19
+     */
+    throw FatalUserException("Missing required kernel feature "
+                             "(map_lookup_percpu_elem) to read map: " +
+                             map_name);
+    exit(-1);
+  }
+
   AllocaInst *i = CreateAllocaBPF(getInt32Ty(), "i");
   AllocaInst *val_1 = CreateAllocaBPF(getInt64Ty(), "val_1");
   // used for min/max/avg

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2468,6 +2468,12 @@ void SemanticAnalyser::visit(For &f)
   map.skip_key_validation = true;
   Visit(&map);
 
+  if (map.type.IsCastableMapTy() &&
+      !bpftrace_.feature_->has_helper_map_lookup_percpu_elem()) {
+    LOG(ERROR, f.expr->loc, err_)
+        << "Missing required kernel feature: map_lookup_percpu_elem";
+  }
+
   if (has_error())
     return;
 

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -604,6 +604,7 @@ std::string BPFfeature::report()
     { "jiffies64", to_str(has_helper_jiffies64()) },
     { "for_each_map_elem", to_str(has_helper_for_each_map_elem()) },
     { "get_ns_current_pid_tgid", to_str(has_helper_get_ns_current_pid_tgid()) },
+    { "lookup_percpu_elem", to_str(has_helper_map_lookup_percpu_elem()) },
   };
 
   std::vector<std::pair<std::string, std::string>> features = {

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -129,6 +129,7 @@ public:
   DEFINE_HELPER_TEST(jiffies64, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(for_each_map_elem, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(get_ns_current_pid_tgid, libbpf::BPF_PROG_TYPE_KPROBE);
+  DEFINE_HELPER_TEST(map_lookup_percpu_elem, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(kprobe, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(tracepoint, libbpf::BPF_PROG_TYPE_TRACEPOINT);
   DEFINE_PROG_TEST(perf_event, libbpf::BPF_PROG_TYPE_PERF_EVENT);

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -128,6 +128,7 @@ public:
     has_jiffies64_ = std::make_optional<bool>(has_features);
     has_for_each_map_elem_ = std::make_optional<bool>(has_features);
     has_get_ns_current_pid_tgid_ = std::make_optional<bool>(has_features);
+    has_map_lookup_percpu_elem_ = std::make_optional<bool>(has_features);
   };
 
   void has_loop(bool has)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4371,6 +4371,20 @@ BEGIN { @map[0] = 1; for ($kv : @map) { print($kv); } }
              false);
 }
 
+TEST(semantic_analyser, for_loop_castable_map_missing_feature)
+{
+  test_error("BEGIN { @map = count(); for ($kv : @map) { print($kv); } }",
+             R"(
+stdin:1:25-28: ERROR: Missing required kernel feature: for_each_map_elem
+BEGIN { @map = count(); for ($kv : @map) { print($kv); } }
+                        ~~~
+stdin:1:36-41: ERROR: Missing required kernel feature: map_lookup_percpu_elem
+BEGIN { @map = count(); for ($kv : @map) { print($kv); } }
+                                   ~~~~~
+)",
+             false);
+}
+
 TEST(semantic_analyser, for_loop_no_ctx_access)
 {
   test_error("kprobe:f { @map[0] = 1; for ($kv : @map) { arg0 } }",


### PR DESCRIPTION
This feature wasn't added till 5.19
so we need to check if it's available.

https://github.com/bpftrace/bpftrace/issues/3732

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
