### PR TITLE
child.cpp: Add missing include of sched.h

### DIFF
--- a/src/child.cpp
+++ b/src/child.cpp
@@ -2,6 +2,7 @@
 #include <cerrno>
 #include <fcntl.h>
 
+#include <sched.h>
 #include <stdexcept>
 #include <string>
 #include <sys/eventfd.h>


### PR DESCRIPTION
An build failure was reported with Google's internal toolchain. I don't know how to reproduce that build failure here, but it seems legit to me, this file calls clone() but doesn't include sched.h.

So, include it.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

(All N/A)

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` 
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
