### PR TITLE
cleanup: run include-what-you-use on existing headers

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -113,6 +113,34 @@ can be used to easily format commits, e.g. `git clang-format upstream/master`
 We want to avoid `fix formatting` commits. Instead every commit should be
 formatted correctly.
 
+### Using 'include-what-you-use'
+
+Occasionally, it may be helpful to run 'include-what-you-use' to ensure that
+headers reflect dependencies accurately, and that you don't have a) many
+transitive dependencies that can break unexpectedly, or b) many unused headers.
+
+The 'include-what-you-use' tool can automatically analyze what is used during
+the build and provide recommendations. This is done by configuring the `cmake`
+build. In an existing build directory, you can run:
+
+```
+CC=clang CXX=clang++ cmake -DCMAKE_CXX_INCLUDE_WHAT_YOU_USE="include-what-you-use;-Xiwyu;--no_comments;-Xiwyu;--quoted_includes_first;-Xiwyu;--no_fwd_decls" --fresh .
+make clean
+make 2>/tmp/iwyu.out
+```
+
+In order to apply the recommendations, you can use the `fix_includes.py` tool
+that also comes with 'include-what-you-use':
+
+```
+fix_includes.py < /tmp/iwyu.out
+```
+
+Note that these recommendations should be checked and not applied blindly.
+Occasionally recommendations might be to include implementation-specific
+headers, e.g. `__stddef_size_t.h` instead of `stddef.h`. However, they
+generally get you 95% of the way there.
+
 ## Merging pull requests
 
 Please squash + rebase all pull requests (with no merge commit). In other words,

--- a/flake.nix
+++ b/flake.nix
@@ -140,6 +140,7 @@
                   strace
                   unixtools.ping
                   util-linux
+                  include-what-you-use
                   # For runtime tests
                   rustc
                   go

--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -1,7 +1,16 @@
+#include <bpf/libbpf.h>
+#include <cstring>
+#include <errno.h>
 #include <filesystem>
 #include <fstream>
 #include <getopt.h>
 #include <iostream>
+#include <memory>
+#include <set>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+#include <utility>
 
 #include "aot.h"
 #include "bpftrace.h"

--- a/src/arch/x86_64.cpp
+++ b/src/arch/x86_64.cpp
@@ -1,7 +1,10 @@
-#include "arch.h"
-
 #include <algorithm>
 #include <array>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "arch.h"
 
 // SP + 8 points to the first argument that is passed on the stack
 #define ARG0_STACK 8

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1,9 +1,11 @@
 #include "ast/ast.h"
 
 #include <algorithm>
+#include <iterator>
 
 #include "ast/visitors.h"
 #include "log.h"
+#include "utils.h"
 
 namespace bpftrace::ast {
 

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -1,8 +1,16 @@
 #include "dibuilderbpf.h"
 
-#include <string_view>
-
+#include <assert.h>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/BitmaskEnum.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/BinaryFormat/Dwarf.h>
 #include <llvm/IR/Function.h>
+#include <llvm/IR/Metadata.h>
+#include <stddef.h>
+#include <string_view>
+#include <vector>
 
 #include "libbpf/bpf.h"
 #include "log.h"

--- a/src/ast/passes/collect_nodes.h
+++ b/src/ast/passes/collect_nodes.h
@@ -3,6 +3,7 @@
 #include <functional>
 #include <vector>
 
+#include "ast/ast.h"
 #include "ast/visitors.h"
 
 namespace bpftrace::ast {

--- a/src/ast/passes/portability_analyser.cpp
+++ b/src/ast/passes/portability_analyser.cpp
@@ -1,7 +1,11 @@
 #include "portability_analyser.h"
 
 #include <cstdlib>
+#include <optional>
+#include <string>
+#include <vector>
 
+#include "location.hh"
 #include "log.h"
 #include "types.h"
 

--- a/src/ast/passes/portability_analyser.h
+++ b/src/ast/passes/portability_analyser.h
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <sstream>
 
+#include "ast/ast.h"
 #include "ast/pass_manager.h"
 #include "ast/visitors.h"
 

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <ostream>
+#include <string>
 
+#include "ast/ast.h"
 #include "ast/visitors.h"
+#include "types.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -1,8 +1,12 @@
 #pragma once
 
 #include <iostream>
+#include <optional>
 #include <sstream>
+#include <stddef.h>
+#include <string>
 
+#include "ast/ast.h"
 #include "ast/pass_manager.h"
 #include "ast/visitors.h"
 #include "required_resources.h"

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -1,5 +1,12 @@
 #include "return_path_analyser.h"
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "location.hh"
 #include "log.h"
+#include "types.h"
 
 namespace bpftrace::ast {
 

--- a/src/ast/passes/return_path_analyser.h
+++ b/src/ast/passes/return_path_analyser.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <iostream>
+#include <sstream>
+
+#include "ast/ast.h"
 #include "ast/pass_manager.h"
 #include "ast/visitors.h"
 

--- a/src/ast/signal.cpp
+++ b/src/ast/signal.cpp
@@ -1,7 +1,11 @@
-#include "ast/signal_bt.h"
-
 #include <algorithm>
+#include <ctype.h>
 #include <map>
+#include <signal.h>
+#include <string>
+#include <utility>
+
+#include "ast/signal_bt.h"
 
 namespace bpftrace {
 

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -1,5 +1,7 @@
 #include "ast/visitors.h"
 
+#include <vector>
+
 #include "ast/ast.h"
 
 namespace bpftrace::ast {

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <stdexcept>
 #include <string>
+#include <typeinfo>
 
 #include "ast/ast.h"
 #include "ast/vtable.h"

--- a/src/bfd-disasm.h
+++ b/src/bfd-disasm.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stdint.h>
+#include <string>
+
 #include "disasm.h"
 
 namespace bpftrace {

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -1,8 +1,8 @@
 #include <llvm/Config/llvm-config.h>
 #include <sstream>
+#include <string_view>
 
 #include "build_info.h"
-
 #include "version.h"
 
 namespace bpftrace {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,6 +1,9 @@
 #include <algorithm>
+#include <cctype>
 #include <cstring>
+#include <errno.h>
 #include <fstream>
+#include <iostream>
 
 #include "config.h"
 #include "log.h"

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -1,12 +1,17 @@
 #pragma once
 
-#include "struct.h"
-#include "types.h"
-
+#include <atomic>
+#include <lldb/API/SBType.h>
+#include <lldb/API/SBValueList.h>
 #include <memory>
 #include <optional>
+#include <stddef.h>
+#include <stdint.h>
 #include <string>
 #include <vector>
+
+#include "struct.h"
+#include "types.h"
 
 #ifdef HAVE_LIBLLDB
 #include <lldb/API/SBDebugger.h>

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -1,5 +1,8 @@
 #include "functions.h"
 
+#include <assert.h>
+#include <ostream>
+
 #include "log.h"
 
 namespace bpftrace {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,5 +1,8 @@
 #include "log.h"
 
+#include <stdlib.h>
+#include <utility>
+
 namespace bpftrace {
 
 std::string logtype_str(LogType t)

--- a/src/log.h
+++ b/src/log.h
@@ -4,6 +4,8 @@
 #include <iostream>
 #include <optional>
 #include <sstream>
+#include <string>
+#include <string_view>
 #include <unordered_map>
 
 #include "location.hh"

--- a/src/pcap_writer.cpp
+++ b/src/pcap_writer.cpp
@@ -1,5 +1,8 @@
 #include "pcap_writer.h"
 
+#include <pcap/dlt.h>
+#include <sys/types.h>
+
 #ifdef HAVE_LIBPCAP
 #include <pcap/pcap.h>
 

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -1,5 +1,14 @@
 #include <csignal>
+#include <iostream>
+#include <memory>
+#include <set>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <utility>
 
+#include "child.h"
+#include "config.h"
 #include "log.h"
 #include "run_bpftrace.h"
 

--- a/src/run_bpftrace.h
+++ b/src/run_bpftrace.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <bpf/libbpf.h>
+#include <stdarg.h>
+
+#include "bpfbytecode.h"
 #include "bpftrace.h"
 
 int libbpf_print(enum libbpf_print_level level, const char *msg, va_list ap);

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -1,7 +1,12 @@
 #include "struct.h"
 
+#include <algorithm>
+#include <assert.h>
 #include <iomanip>
 #include <limits>
+#include <ostream>
+#include <stddef.h>
+#include <utility>
 
 #include "log.h"
 #include "utils.h"

--- a/src/struct.h
+++ b/src/struct.h
@@ -1,10 +1,19 @@
 #pragma once
 
+#include <cereal/access.hpp>
+#include <cstddef>
+#include <functional>
+#include <iosfwd>
 #include <map>
 #include <memory>
 #include <optional>
-
-#include <cereal/access.hpp>
+#include <stdint.h>
+#include <string>
+#include <string_view>
+#include <sys/types.h>
+#include <unordered_set>
+#include <variant>
+#include <vector>
 
 #include "ast/ast.h"
 #include "types.h"

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -2,7 +2,9 @@
 
 #include <istream>
 #include <set>
+#include <string>
 
+#include "ast/ast.h"
 #include "ast/visitors.h"
 #include "bpftrace.h"
 

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -1,9 +1,11 @@
 #include "bpfbytecode.h"
+
+#include <string_view>
+
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/semantic_analyser.h"
 #include "driver.h"
 #include "mocks.h"
-
 #include "gtest/gtest.h"
 
 namespace bpftrace::test::bpfbytecode {

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1,14 +1,32 @@
 #include <cstdint>
 #include <cstring>
+#include <initializer_list>
+#include <memory>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <stddef.h>
+#include <string>
+#include <time.h>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
+#include "ast/ast.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/semantic_analyser.h"
+#include "bpffeature.h"
 #include "bpftrace.h"
 #include "clang_parser.h"
+#include "config.h"
 #include "driver.h"
 #include "mocks.h"
+#include "required_resources.h"
+#include "struct.h"
 #include "tracefs.h"
+#include "types.h"
+#include "usdt.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/tests/collect_nodes.cpp
+++ b/tests/collect_nodes.cpp
@@ -1,8 +1,11 @@
 #include "ast/passes/collect_nodes.h"
-#include "gtest/gtest.h"
 
 #include <functional>
+#include <stddef.h>
 #include <vector>
+
+#include "location.hh"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::collect_nodes {
 

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -1,11 +1,20 @@
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include <memory>
+#include <sstream>
+#include <string>
+#include <string_view>
 
+#include "ast/ast.h"
 #include "ast/passes/config_analyser.h"
 #include "ast/passes/semantic_analyser.h"
+#include "bpffeature.h"
+#include "bpftrace.h"
 #include "clang_parser.h"
+#include "config.h"
 #include "driver.h"
 #include "mocks.h"
+#include "types.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::config_analyser {
 

--- a/tests/cstring_view.cpp
+++ b/tests/cstring_view.cpp
@@ -1,7 +1,9 @@
 #include "container/cstring_view.h"
-#include "gtest/gtest.h"
 
+#include <string.h>
 #include <type_traits>
+
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::cstring_view {
 

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -1,6 +1,16 @@
 #include "ast/passes/field_analyser.h"
+
+#include <algorithm>
+#include <compare>
+#include <memory>
+#include <optional>
+#include <set>
+#include <stdint.h>
+
 #include "driver.h"
 #include "mocks.h"
+#include "struct.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace bpftrace::test::field_analyser {

--- a/tests/function_registry.cpp
+++ b/tests/function_registry.cpp
@@ -1,11 +1,16 @@
-#include "functions.h"
-
+#include <memory>
 #include <sstream>
+#include <stddef.h>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
 
+#include "functions.h"
+#include "struct.h"
+#include "types.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-
-#include "struct.h"
 
 namespace bpftrace::test::function_registry {
 

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -1,4 +1,10 @@
 #include "mocks.h"
+
+#include <set>
+#include <sstream>
+#include <time.h>
+
+#include "struct.h"
 #include "tracefs.h"
 
 namespace bpftrace::test {

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -1,12 +1,28 @@
 #pragma once
 
-#include "gmock/gmock.h"
+#include <iosfwd>
+#include <memory>
+#include <optional>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 #include "bpffeature.h"
 #include "bpftrace.h"
 #include "child.h"
+#include "kfuncs.h"
 #include "probe_matcher.h"
 #include "procmon.h"
+#include "required_resources.h"
+#include "types.h"
+#include "usdt.h"
+#include "utils.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace {
 namespace test {

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -1,11 +1,11 @@
 #include "output.h"
 
-#include <gtest/gtest.h>
 #include <sstream>
 
 #include "bpfmap.h"
 #include "bpftrace.h"
 #include "mocks.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::output {
 
@@ -84,7 +84,7 @@ TEST(TextOutput, lhist_suffix)
 
   output.map_hist(bpftrace, map, 0, 0, values_by_key, total_counts_by_key);
 
-  EXPECT_EQ(R"(@mymap: 
+  EXPECT_EQ(R"(@mymap:
 [0, 1K)                1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
 [1K, 2K)               1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
 [2K, 3K)               1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1,7 +1,14 @@
 #include <climits>
+#include <limits>
 #include <sstream>
+#include <stdio.h>
+#include <string>
+#include <string_view>
+#include <vector>
 
+#include "ast/ast.h"
 #include "ast/passes/printer.h"
+#include "bpftrace.h"
 #include "driver.h"
 #include "gtest/gtest.h"
 

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -1,12 +1,19 @@
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include <memory>
+#include <sstream>
+#include <string>
 
+#include "ast/ast.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/portability_analyser.h"
 #include "ast/passes/semantic_analyser.h"
+#include "bpffeature.h"
+#include "bpftrace.h"
 #include "clang_parser.h"
 #include "driver.h"
 #include "mocks.h"
+#include "procmon.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::portability_analyser {
 

--- a/tests/required_resources.cpp
+++ b/tests/required_resources.cpp
@@ -3,11 +3,10 @@
 #include <iostream>
 #include <sstream>
 
-#include <gtest/gtest.h>
-
 #include "format_string.h"
 #include "struct.h"
 #include "types.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test {
 

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -1,12 +1,22 @@
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <stdint.h>
+#include <string>
 
+#include "ast/ast.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/semantic_analyser.h"
+#include "bpffeature.h"
+#include "bpftrace.h"
 #include "clang_parser.h"
+#include "config.h"
 #include "driver.h"
 #include "mocks.h"
+#include "required_resources.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::resource_analyser {
 

--- a/tests/return_path_analyser.cpp
+++ b/tests/return_path_analyser.cpp
@@ -1,12 +1,18 @@
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include <memory>
+#include <sstream>
+#include <string>
 
+#include "ast/ast.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/return_path_analyser.h"
 #include "ast/passes/semantic_analyser.h"
+#include "bpffeature.h"
+#include "bpftrace.h"
 #include "clang_parser.h"
 #include "driver.h"
 #include "mocks.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::return_path_analyser {
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1,11 +1,19 @@
 #include "ast/passes/semantic_analyser.h"
+
+#include <assert.h>
+#include <memory>
+#include <string_view>
+
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/printer.h"
 #include "bpffeature.h"
 #include "bpftrace.h"
 #include "clang_parser.h"
+#include "config.h"
 #include "driver.h"
 #include "mocks.h"
+#include "procmon.h"
+#include "struct.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -1,7 +1,11 @@
 #include "tracepoint_format_parser.h"
+
+#include <sstream>
+
+#include "driver.h"
 #include "mocks.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include <driver.h>
 
 using namespace testing;
 


### PR DESCRIPTION
This removes a few headers and mostly reflects that there are no implicit transitive dependencies. Developer documentation is added for how to run this in the future. It is not necessarily intended to be a continuous process (as it requires some degree of human judgement).

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
