### PR TITLE
cleanup: standardize comment style

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -139,6 +139,17 @@ can be used to easily format commits, e.g. `git clang-format upstream/master`
 We want to avoid `fix formatting` commits. Instead every commit should be
 formatted correctly.
 
+### Comment style
+
+Strongly prefer C++-style comments for single line and block comments. C-style
+comments are still useable for nested comments within a single line, e.g. to
+leave an annotation on a specific argument or parameter. In the future, there
+may be considerations for automated documentation based on comments, but this
+is not currently done.
+
+`bpftrace` itself supports both C-style and C++-style comment blocks. There is
+currently no decision on recommended comment style, and both are used freely.
+
 ## Merging pull requests
 
 Please squash + rebase all pull requests (with no merge commit). In other words,

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -62,7 +62,7 @@ enum class ExpansionType {
 class Node {
 public:
   Node() = default;
-  Node(location loc) : loc(loc){};
+  Node(location loc) : loc(loc) {};
   virtual ~Node() = default;
 
   Node(const Node &) = default;
@@ -78,7 +78,7 @@ class Variable;
 class Expression : public Node {
 public:
   Expression() = default;
-  Expression(location loc) : Node(loc){};
+  Expression(location loc) : Node(loc) {};
   virtual ~Expression() = default;
 
   Expression(const Expression &) = default;
@@ -311,7 +311,7 @@ private:
 class Statement : public Node {
 public:
   Statement() = default;
-  Statement(location loc) : Node(loc){};
+  Statement(location loc) : Node(loc) {};
   virtual ~Statement() = default;
 
   Statement(const Statement &) = default;
@@ -625,19 +625,15 @@ SizedType ident_to_record(const std::string &ident, int pointer_level = 0);
 template <typename T>
 concept NodeType = std::derived_from<T, Node>;
 
-/*
- * Manages the lifetime of AST nodes.
- *
- * Nodes allocated by an ASTContext will be kept alive for the duration of the
- * owning ASTContext object.
- */
+// Manages the lifetime of AST nodes.
+//
+// Nodes allocated by an ASTContext will be kept alive for the duration of the
+// owning ASTContext object.
 class ASTContext {
 public:
   Program *root = nullptr;
 
-  /*
-   * Creates and returns a pointer to an AST node.
-   */
+  // Creates and returns a pointer to an AST node.
   template <NodeType T, typename... Args>
   T *make_node(Args &&...args)
   {

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -17,12 +17,10 @@ class IRBuilderBPF;
 } // namespace ast
 } // namespace bpftrace
 
-/*
- * The main goal here is to keep the struct definitions close to each other,
- * making it easier to spot type mismatches.
- *
- * If you update a type, remember to update the .cpp too!
- */
+// The main goal here is to keep the struct definitions close to each other,
+// making it easier to spot type mismatches.
+//
+// If you update a type, remember to update the .cpp too!
 
 namespace bpftrace {
 namespace AsyncEvent {

--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -38,11 +38,9 @@ public:
 
   FOR_LIST_OF_ASYNC_IDS(DEFINE_ACCESS_METHOD)
 
-  /*
-   * For 'create_reset_ids' return a lambda that has captured-by-value
-   * CodegenLLVM's async id state. Running the returned lambda will restore
-   * `CodegenLLVM`s async id state back to when this function was first called.
-   */
+  // For 'create_reset_ids' return a lambda that has captured-by-value
+  // CodegenLLVM's async id state. Running the returned lambda will restore
+  // `CodegenLLVM`s async id state back to when this function was first called.
   std::function<void()> create_reset_ids()
   {
     return [FOR_LIST_OF_ASYNC_IDS(LOCAL_SAVE) this] {

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -24,18 +24,16 @@ private:
   enum State { OK = 0, INVALID, NEW_APS, SKIP };
 
   State parse_attachpoint(AttachPoint &ap);
-  /*
-   * This method splits an attach point definition into arguments,
-   * where arguments are separated by `:`. The exception is `:`s inside
-   * of quoted strings, which we must treat as a literal.
-   *
-   * This method also resolves positional parameters. Positional params
-   * may be escaped with double quotes.
-   *
-   * Note that this function assumes the raw string is generally well
-   * formed. More specifically, that there is no unescaped whitespace
-   * and no unmatched quotes.
-   */
+  // This method splits an attach point definition into arguments,
+  // where arguments are separated by `:`. The exception is `:`s inside
+  // of quoted strings, which we must treat as a literal.
+  //
+  // This method also resolves positional parameters. Positional params
+  // may be escaped with double quotes.
+  //
+  // Note that this function assumes the raw string is generally well
+  // formed. More specifically, that there is no unescaped whitespace
+  // and no unmatched quotes.
   State lex_attachpoint(const AttachPoint &ap);
 
   State special_parser();

--- a/src/ast/codegen_helper.cpp
+++ b/src/ast/codegen_helper.cpp
@@ -2,22 +2,21 @@
 
 namespace bpftrace::ast {
 
-/* needAssignMapStatementAllocation determines if a map assignment requires a
- * new memory allocation. This happens only in a few cases e.g. if there are
- * two map assignments of tuples of different sizes e.g.
- *   @x = ("xxx", 1); @x = ("xxxxxxx", 1);
- * which requires a 0 memsetting and copying of each tuple element into the
- * new allocation before calling bpf_map_update_elem.
- *
- * Another case when we need an allocation is for a external struct e.g.
- *   $v = (struct task_struct *)arg1; @ = *$v;.
- *
- * Most cases we can reuse existing BPF memory and not create a new allocation.
- *
- * Note this function does NOT determine if an allocation should use scratch
- * buffer or the stack, that logic is in
- * IRBuilderBPF::CreateWriteMapValueAllocation
- */
+// needAssignMapStatementAllocation determines if a map assignment requires a
+// new memory allocation. This happens only in a few cases e.g. if there are
+// two map assignments of tuples of different sizes e.g.
+//   @x = ("xxx", 1); @x = ("xxxxxxx", 1);
+// which requires a 0 memsetting and copying of each tuple element into the
+// new allocation before calling bpf_map_update_elem.
+//
+// Another case when we need an allocation is for a external struct e.g.
+//   $v = (struct task_struct *)arg1; @ = *$v;.
+//
+// Most cases we can reuse existing BPF memory and not create a new allocation.
+//
+// Note this function does NOT determine if an allocation should use scratch
+// buffer or the stack, that logic is in
+// IRBuilderBPF::CreateWriteMapValueAllocation
 bool needAssignMapStatementAllocation(const AssignMapStatement &assignment)
 {
   const auto &map = *assignment.map;

--- a/src/ast/int_parser.h
+++ b/src/ast/int_parser.h
@@ -5,17 +5,15 @@ namespace bpftrace {
 namespace ast {
 namespace int_parser {
 
-/*
-  String -> int conversion specific to bpftrace
-
-  - error when trailing characters are found
-  - supports scientific notation, e.g. 1e6
-    - error when out of int range (1e20)
-    - error when base > 9 (12e3)
-  - support underscore as separator, e.g. 1_234_000
-
-  All errors are raised as std::invalid_argument exception
- */
+//   String -> int conversion specific to bpftrace
+//
+//   - error when trailing characters are found
+//   - supports scientific notation, e.g. 1e6
+//    - error when out of int range (1e20)
+//    - error when base > 9 (12e3)
+//   - support underscore as separator, e.g. 1_234_000
+//
+//   All errors are raised as std::invalid_argument exception
 int64_t to_int(const std::string &num, int base);
 uint64_t to_uint(const std::string &num, int base);
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -622,10 +622,10 @@ Value *IRBuilderBPF::CreateVariableAllocationInit(const SizedType &value_type,
                                                   const std::string &name,
                                                   const location &loc)
 {
-  /* Hoist variable declaration and initialization to entry point of
-   * probe/subprogram. While we technically do not need this as variables
-   * are properly scoped, it eases debugging and is consistent with previous
-   * stack-only variable implementation. */
+  // Hoist variable declaration and initialization to entry point of
+  // probe/subprogram. While we technically do not need this as variables
+  // are properly scoped, it eases debugging and is consistent with previous
+  // stack-only variable implementation.
   Value *alloc;
   hoist([this, &value_type, &name, &loc, &alloc] {
     alloc = createAllocation(bpftrace::globalvars::GlobalVar::VARIABLE_BUFFER,
@@ -705,14 +705,12 @@ Value *IRBuilderBPF::createScratchBuffer(
                    { getInt64(0), bounded_cpu_id, getInt64(key), getInt64(0) });
 }
 
-/*
- * Failure to lookup a scratch map will result in a jump to the
- * failure_callback, if non-null.
- *
- * In practice, a properly constructed percpu lookup will never fail. The only
- * way it can fail is if we have a bug in our code. So a null failure_callback
- * simply causes a blind 0 return. See comment in function for why this is ok.
- */
+// Failure to lookup a scratch map will result in a jump to the
+// failure_callback, if non-null.
+//
+// In practice, a properly constructed percpu lookup will never fail. The only
+// way it can fail is if we have a bug in our code. So a null failure_callback
+// simply causes a blind 0 return. See comment in function for why this is ok.
 CallInst *IRBuilderBPF::createGetScratchMap(const std::string &map_name,
                                             const std::string &name,
                                             PointerType *val_ptr_ty,
@@ -745,16 +743,14 @@ CallInst *IRBuilderBPF::createGetScratchMap(const std::string &map_name,
   if (failure_callback) {
     CreateBr(failure_callback);
   } else {
-    /*
-     * Think of this like an assert(). In practice, we cannot fail to lookup a
-     * percpu array map unless we have a coding error. Rather than have some
-     * kind of complicated fallback path where we provide an error string for
-     * our caller, just indicate to verifier we want to terminate execution.
-     *
-     * Note that we blindly return 0 in contrast to the logic inside
-     * CodegenLLVM::createRet(). That's b/c the return value doesn't matter
-     * if it'll never get executed.
-     */
+    // Think of this like an assert(). In practice, we cannot fail to lookup a
+    // percpu array map unless we have a coding error. Rather than have some
+    // kind of complicated fallback path where we provide an error string for
+    // our caller, just indicate to verifier we want to terminate execution.
+    //
+    // Note that we blindly return 0 in contrast to the logic inside
+    // CodegenLLVM::createRet(). That's b/c the return value doesn't matter
+    // if it'll never get executed.
     CreateRet(getInt64(0));
   }
 
@@ -836,23 +832,21 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
                                              const SizedType &type,
                                              const location &loc)
 {
-  /*
-   * int ret = 0;
-   * int i = 0;
-   * while (i < nr_cpus) {
-   *   int * cpu_value = map_lookup_percpu_elem(map, key, i);
-   *   if (cpu_value == NULL) {
-   *     if (i == 0)
-   *        log_error("Key not found")
-   *     else
-   *        debug("No cpu found for cpu id: %lu", i) // Mostly for AOT
-   *     break;
-   *   }
-   *   // update ret for sum, count, avg, min, max
-   *   i++;
-   * }
-   * return ret;
-   */
+  // int ret = 0;
+  // int i = 0;
+  // while (i < nr_cpus) {
+  //   int * cpu_value = map_lookup_percpu_elem(map, key, i);
+  //   if (cpu_value == NULL) {
+  //     if (i == 0)
+  //        log_error("Key not found")
+  //     else
+  //        debug("No cpu found for cpu id: %lu", i) // Mostly for AOT
+  //     break;
+  //   }
+  //   // update ret for sum, count, avg, min, max
+  //   i++;
+  // }
+  // return ret;
 
   assert(ctx && ctx->getType() == GET_PTR_TY());
 
@@ -1039,21 +1033,19 @@ void IRBuilderBPF::createPerCpuMinMax(AllocaInst *ret,
   Value *is_val_set = CreateLoad(
       getInt64Ty(), CreateGEP(value_type, cast, { getInt64(0), getInt32(1) }));
 
-  /*
-   * (ret, is_ret_set, min_max_val, is_val_set) {
-   * // if the min_max_val is 0, which is the initial map value,
-   * // we need to know if it was explicitly set by user
-   * if (!is_val_set == 1) {
-   *   return;
-   * }
-   * if (!is_ret_set == 1) {
-   *   ret = min_max_val;
-   *   is_ret_set = 1;
-   * } else if (min_max_val > ret) { // or min_max_val < ret if min operation
-   *   ret = min_max_val;
-   *   is_ret_set = 1;
-   * }
-   */
+  // (ret, is_ret_set, min_max_val, is_val_set) {
+  // // if the min_max_val is 0, which is the initial map value,
+  // // we need to know if it was explicitly set by user
+  // if (!is_val_set == 1) {
+  //   return;
+  // }
+  // if (!is_ret_set == 1) {
+  //   ret = min_max_val;
+  //   is_ret_set = 1;
+  // } else if (min_max_val > ret) { // or min_max_val < ret if min operation
+  //   ret = min_max_val;
+  //   is_ret_set = 1;
+  // }
 
   llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock *val_set_success = BasicBlock::Create(module_.getContext(),
@@ -1281,12 +1273,10 @@ void IRBuilderBPF::CreateCheckSetRecursion(const location &loc,
   CreateCondBr(set_condition, merge_block, value_is_set_block);
 
   SetInsertPoint(value_is_set_block);
-  /*
-   * The counter is set, we need to exit early from the probe.
-   * Most of the time this will happen for the functions that can lead
-   * to a crash e.g. "queued_spin_lock_slowpath" but it can also happen
-   * for nested probes e.g. "page_fault_user" -> "print".
-   */
+  // The counter is set, we need to exit early from the probe.
+  // Most of the time this will happen for the functions that can lead
+  // to a crash e.g. "queued_spin_lock_slowpath" but it can also happen
+  // for nested probes e.g. "page_fault_user" -> "print".
   CreateAtomicIncCounter(to_string(MapType::EventLossCounter),
                          bpftrace_.event_loss_cnt_key_);
   CreateRet(getInt64(early_exit_ret));
@@ -1585,27 +1575,26 @@ Value *IRBuilderBPF::CreateStrncmp(Value *str1,
                                    uint64_t n,
                                    bool inverse)
 {
-  /*
-  // This function compares each character of the two string.
-  // It returns true if all are equal and false if any are different
-  // strcmp(String val1, String val2)
-     {
-        for (size_t i = 0; i < n; i++)
-        {
-
-          if (val1[i] != val2[i])
-          {
-            return false;
-          }
-          if (val1[i] == NULL)
-          {
-            return true;
-          }
-        }
-
-        return true;
-     }
-  */
+  // This function compares each character of the two string. It returns true
+  // if all are equal and false if any are different.
+  //
+  //  strcmp(String val1, String val2)
+  //  {
+  //     for (size_t i = 0; i < n; i++)
+  //     {
+  //
+  //       if (val1[i] != val2[i])
+  //       {
+  //         return false;
+  //       }
+  //       if (val1[i] == NULL)
+  //       {
+  //         return true;
+  //       }
+  //     }
+  //
+  //     return true;
+  //  }
 
   // Check if the compared strings are literals.
   // If so, we can avoid storing the literal in memory.
@@ -1686,32 +1675,32 @@ Value *IRBuilderBPF::CreateStrcontains(Value *val1,
                                        uint64_t str2_size,
                                        bool inverse)
 {
-  /*
   // This function compares whether the string val1 contains the string val2.
   // It returns true if val2 is contained by val1, false if not contained.
-  // strcontains(String val1, String val2, int str1_size, int str2_size)
-     {
-        for (size_t j = 0; (str1_size >= str2_size) && (j <= str1_size -
-  str2_size); j++)
-        {
-          for (size_t i = 0; i < str2_size; i++)
-          {
-            if (val2[i] == NULL)
-            {
-              return true;
-            }
-            if (val1[i + j] != val2[i])
-            {
-              break;
-            }
-          }
-          if (val1[j] == NULL) {
-            return false;
-          }
-        }
-        return false;
-     }
-  */
+  //
+  //  strcontains(String val1, String val2, int str1_size, int str2_size)
+  //  {
+  //    for (size_t j = 0; (str1_size >= str2_size) && (j <= str1_size -
+  //   str2_size); j++)
+  //    {
+  //      for (size_t i = 0; i < str2_size; i++)
+  //      {
+  //        if (val2[i] == NULL)
+  //        {
+  //          return true;
+  //        }
+  //        if (val1[i + j] != val2[i])
+  //        {
+  //          break;
+  //        }
+  //      }
+  //      if (val1[j] == NULL) {
+  //        return false;
+  //      }
+  //    }
+  //    return false;
+  //  }
+
   // Check if the compared strings are literals.
   // If so, we can avoid storing the literal in memory.
   std::optional<std::string> literal1 = ValToString(val1);
@@ -1864,21 +1853,21 @@ Value *IRBuilderBPF::CreateIntegerArrayCmpUnrolled(Value *ctx,
                                                    const bool inverse,
                                                    const location &loc)
 {
-  /*
-   // This function compares each character of the two arrays.
-   // It returns true if all are equal and false if any are different
-   // cmp([]char val1, []char val2)
-   {
-      for (size_t i = 0; i < n; i++)
-      {
-        if (val1[i] != val2[i])
-        {
-          return false;
-        }
-      }
-      return true;
-   }
-*/
+  // This function compares each character of the two arrays. It returns true
+  // if all are equal and false if any are different.
+  //
+  //  cmp([]char val1, []char val2)
+  //  {
+  //    for (size_t i = 0; i < n; i++)
+  //    {
+  //      if (val1[i] != val2[i])
+  //      {
+  //        return false;
+  //      }
+  //    }
+  //    return true;
+  //  }
+
   auto elem_type = *val1_type.GetElementTy();
   const size_t num = val1_type.GetNumElements();
 
@@ -1961,21 +1950,21 @@ Value *IRBuilderBPF::CreateIntegerArrayCmp(Value *ctx,
                                            const location &loc,
                                            MDNode *metadata)
 {
-  /*
-   // This function compares each character of the two arrays.
-   // It returns true if all are equal and false if any are different
-   // cmp([]char val1, []char val2)
-   {
-      for (size_t i = 0; i < n; i++)
-      {
-        if (val1[i] != val2[i])
-        {
-          return false;
-        }
-      }
-      return true;
-   }
-*/
+  // This function compares each character of the two arrays.  It returns true
+  // if all are equal and false if any are different.
+  //
+  //  cmp([]char val1, []char val2)
+  //  {
+  //    for (size_t i = 0; i < n; i++)
+  //    {
+  //      if (val1[i] != val2[i])
+  //      {
+  //        return false;
+  //      }
+  //    }
+  //    return true;
+  //  }
+
   auto elem_type = *val1_type.GetElementTy();
   const size_t num = val1_type.GetNumElements();
 
@@ -2680,12 +2669,10 @@ Value *IRBuilderBPF::CreateRegisterRead(Value *ctx,
 static bool return_zero_if_err(libbpf::bpf_func_id func_id)
 {
   switch (func_id) {
-    /*
-     * When these function fails, bpftrace stores zero as a result.
-     * A user script can check an error by seeing the value.
-     * Therefore error checks of these functions are omitted if
-     * helper_check_level == 1.
-     */
+    // When these function fails, bpftrace stores zero as a result.
+    // A user script can check an error by seeing the value.
+    // Therefore error checks of these functions are omitted if
+    // helper_check_level == 1.
     case libbpf::BPF_FUNC_probe_read:
     case libbpf::BPF_FUNC_probe_read_str:
     case libbpf::BPF_FUNC_probe_read_kernel:

--- a/src/ast/pass_manager.h
+++ b/src/ast/pass_manager.h
@@ -17,9 +17,7 @@ class Program;
 class SemanticAnalyser;
 class Pass;
 
-/**
-   Result of a pass run
- */
+// Result of a pass run
 class PassResult {
 public:
   static PassResult Error(const std::string &pass);
@@ -43,9 +41,7 @@ public:
     return errcode_;
   }
 
-  /**
-     Return the pass in which the failure occurred
-   */
+  // Return the pass in which the failure occurred
   const std::optional<std::string> GetErrorPass()
   {
     return errpass_;
@@ -81,28 +77,24 @@ private:
   std::optional<std::string> errmsg_;
 };
 
-/**
-   Context/config for passes
-
-   Note: Most state should end up in the BPFtrace class instead of here
-*/
+// Context/config for passes
+//
+// Note: Most state should end up in the BPFtrace class instead of here
 
 struct PassContext {
 public:
-  PassContext(BPFtrace &b, ASTContext &ast_ctx) : b(b), ast_ctx(ast_ctx){};
+  PassContext(BPFtrace &b, ASTContext &ast_ctx) : b(b), ast_ctx(ast_ctx) {};
   BPFtrace &b;
   ASTContext &ast_ctx;
 };
 
 using PassFPtr = std::function<PassResult(PassContext &)>;
 
-/*
-  Base pass
-*/
+// Base pass
 class Pass {
 public:
   Pass() = delete;
-  Pass(std::string name, PassFPtr fn) : fn_(fn), name(name){};
+  Pass(std::string name, PassFPtr fn) : fn_(fn), name(name) {};
 
   virtual ~Pass() = default;
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2292,11 +2292,9 @@ void CodegenLLVM::compareStructure(SizedType &our_type, llvm::Type *llvm_type)
   }
 }
 
-/*
- * createTuple
- *
- * Constructs a tuple on the scratch buffer or stack from the provided values.
- */
+// createTuple
+//
+// Constructs a tuple on the scratch buffer or stack from the provided values.
 Value *CodegenLLVM::createTuple(
     const SizedType &tuple_type,
     const std::vector<std::pair<llvm::Value *, const location *>> &vals,
@@ -3535,12 +3533,10 @@ void CodegenLLVM::createFormatStringCall(Call &call,
                                          const std::string &call_name,
                                          AsyncAction async_action)
 {
-  /*
-   * perf event output has: uint64_t id, vargs
-   * The id maps to bpftrace_.*_args_, and is a way to define the
-   * types and offsets of each of the arguments, and share that between BPF and
-   * user-space for printing.
-   */
+  // perf event output has: uint64_t id, vargs
+  // The id maps to bpftrace_.*_args_, and is a way to define the
+  // types and offsets of each of the arguments, and share that between BPF and
+  // user-space for printing.
   std::vector<llvm::Type *> elements = { b_.getInt64Ty() }; // ID
 
   const auto &args = std::get<1>(call_args.at(id));
@@ -4013,13 +4009,11 @@ void CodegenLLVM::optimize()
   PMB.OptLevel = 3;
   legacy::PassManager PM;
   PM.add(createFunctionInliningPass());
-  /*
-   * llvm < 4.0 needs
-   * PM.add(createAlwaysInlinerPass());
-   * llvm >= 4.0 needs
-   * PM.add(createAlwaysInlinerLegacyPass());
-   * use below 'stable' workaround
-   */
+  // llvm < 4.0 needs
+  // PM.add(createAlwaysInlinerPass());
+  // llvm >= 4.0 needs
+  // PM.add(createAlwaysInlinerLegacyPass());
+  // use below 'stable' workaround
   LLVMAddAlwaysInlinerPass(reinterpret_cast<LLVMPassManagerRef>(&PM));
   PMB.populateModulePassManager(PM);
 
@@ -4504,16 +4498,14 @@ llvm::Function *CodegenLLVM::createMapLenCallback()
 llvm::Function *CodegenLLVM::createForEachMapCallback(const For &f,
                                                       llvm::Type *ctx_t)
 {
-  /*
-   * Create a callback function suitable for passing to bpf_for_each_map_elem,
-   * of the form:
-   *
-   *   static int cb(struct map *map, void *key, void *value, void *ctx)
-   *   {
-   *     $decl = (key, value);
-   *     [stmts...]
-   *   }
-   */
+  // Create a callback function suitable for passing to bpf_for_each_map_elem,
+  // of the form:
+  //
+  //   static int cb(struct map *map, void *key, void *value, void *ctx)
+  //   {
+  //     $decl = (key, value);
+  //     [stmts...]
+  //   }
 
   auto saved_ip = b_.saveIP();
 

--- a/src/ast/passes/collect_nodes.h
+++ b/src/ast/passes/collect_nodes.h
@@ -7,12 +7,10 @@
 
 namespace bpftrace::ast {
 
-/*
- * CollectNodes
- *
- * Recurses into the provided node and builds a list of all descendants of the
- * requested type which match a predicate.
- */
+// CollectNodes
+//
+// Recurses into the provided node and builds a list of all descendants of the
+// requested type which match a predicate.
 template <typename NodeT>
 class CollectNodes : public Visitor<CollectNodes<NodeT>> {
 public:

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -53,7 +53,7 @@ bpf_probe_attach_type attachtype(ProbeType t)
 libbpf::bpf_prog_type progtype(ProbeType t)
 {
   switch (t) {
-    // clang-format off
+      // clang-format off
     case ProbeType::special:    return libbpf::BPF_PROG_TYPE_RAW_TRACEPOINT; break;
     case ProbeType::kprobe:     return libbpf::BPF_PROG_TYPE_KPROBE; break;
     case ProbeType::kretprobe:  return libbpf::BPF_PROG_TYPE_KPROBE; break;
@@ -82,7 +82,7 @@ libbpf::bpf_prog_type progtype(ProbeType t)
 std::string progtypeName(libbpf::bpf_prog_type t)
 {
   switch (t) {
-    // clang-format off
+      // clang-format off
     case libbpf::BPF_PROG_TYPE_KPROBE:     return "BPF_PROG_TYPE_KPROBE";     break;
     case libbpf::BPF_PROG_TYPE_TRACEPOINT: return "BPF_PROG_TYPE_TRACEPOINT"; break;
     case libbpf::BPF_PROG_TYPE_PERF_EVENT: return "BPF_PROG_TYPE_PERF_EVENT"; break;

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -116,19 +116,17 @@ void BpfBytecode::update_global_vars(BPFtrace &bpftrace)
 }
 
 namespace {
-/*
- * Searches the verifier's log for err_pattern. If a match is found, extracts
- * the name and ID of the problematic helper and throws a HelperVerifierError.
- *
- * Example verfier log extract:
- *     [...]
- *     36: (b7) r3 = 64                      ; R3_w=64
- *     37: (85) call bpf_d_path#147
- *     helper call is not allowed in probe
- *     [...]
- *
- *  In the above log, "bpf_d_path" is the helper's name and "147" is the ID.
- */
+// Searches the verifier's log for err_pattern. If a match is found, extracts
+// the name and ID of the problematic helper and throws a HelperVerifierError.
+//
+// Example verfier log extract:
+//     [...]
+//     36: (b7) r3 = 64                      ; R3_w=64
+//     37: (85) call bpf_d_path#147
+//     helper call is not allowed in probe
+//     [...]
+//
+//  In the above log, "bpf_d_path" is the helper's name and "147" is the ID.
 void maybe_throw_helper_verifier_error(std::string_view log,
                                        std::string_view err_pattern,
                                        const std::string &exception_msg_suffix)

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -510,7 +510,7 @@ bool BPFfeature::has_uprobe_multi()
   }
 #else
   has_uprobe_multi_ = false;
-#endif // HAVE_LIBBPF_UPROBE_MULTI
+#endif                       // HAVE_LIBBPF_UPROBE_MULTI
   return *has_uprobe_multi_; // NOLINT(bugprone-unchecked-optional-access)
 }
 

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -62,9 +62,7 @@ private:
   uint32_t max_entries_;
 };
 
-/**
-   Internal map types
-*/
+// Internal map types
 enum class MapType {
   // Also update to_string
   PerfEvent,

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2050,20 +2050,18 @@ bool BPFtrace::has_btf_data() const
   return btf_ && btf_->has_data();
 }
 
-/*
- * This prevents an ABBA deadlock when attaching to spin lock internal
- * functions e.g. "fentry:queued_spin_lock_slowpath".
- *
- * Specifically, if there are two hash maps (non percpu) being accessed by
- * two different CPUs by two bpf progs then we can get in a situation where,
- * because there are progs attached to spin lock internals, a lock is taken for
- * one map while a different lock is trying to be acquired for the other map.
- * This is specific to fentry/fexit (kfunc/kretfunc) as kprobes have kernel
- * protections against this type of deadlock.
- *
- * Note: it would be better if this was in resource analyzer but we need
- * probe_matcher to get the list of functions for the attach point
- */
+// This prevents an ABBA deadlock when attaching to spin lock internal
+// functions e.g. "fentry:queued_spin_lock_slowpath".
+//
+// Specifically, if there are two hash maps (non percpu) being accessed by
+// two different CPUs by two bpf progs then we can get in a situation where,
+// because there are progs attached to spin lock internals, a lock is taken for
+// one map while a different lock is trying to be acquired for the other map.
+// This is specific to fentry/fexit (kfunc/kretfunc) as kprobes have kernel
+// protections against this type of deadlock.
+//
+// Note: it would be better if this was in resource analyzer but we need
+// probe_matcher to get the list of functions for the attach point.
 void BPFtrace::fentry_recursion_check(ast::Program *prog)
 {
   for (auto *probe : prog->probes) {

--- a/src/btf.h
+++ b/src/btf.h
@@ -13,7 +13,7 @@
 
 // Taken from libbpf
 #define BTF_INFO_ENC(kind, kind_flag, vlen)                                    \
-  ((!!(kind_flag) << 31) | ((kind) << 24) | ((vlen)&BTF_MAX_VLEN))
+  ((!!(kind_flag) << 31) | ((kind) << 24) | ((vlen) & BTF_MAX_VLEN))
 #define BTF_TYPE_ENC(name, info, size_or_type) (name), (info), (size_or_type)
 #define BTF_INT_ENC(encoding, bits_offset, nr_bits)                            \
   ((encoding) << 24 | (bits_offset) << 16 | (nr_bits))
@@ -103,11 +103,9 @@ private:
   std::set<std::string> get_all_structs_from_btf(const struct btf* btf) const;
   std::unordered_set<std::string> get_all_iters_from_btf(
       const struct btf* btf) const;
-  /*
-   * Similar to btf_type_skip_modifiers this returns the id of the first
-   * type that is not a BTF_KIND_TYPE_TAG while also populating the tags set
-   * with the tag/attribute names from the BTF_KIND_TYPE_TAG types it finds.
-   */
+  // Similar to btf_type_skip_modifiers this returns the id of the first
+  // type that is not a BTF_KIND_TYPE_TAG while also populating the tags set
+  // with the tag/attribute names from the BTF_KIND_TYPE_TAG types it finds.
   __u32 get_type_tags(std::unordered_set<std::string>& tags,
                       const BTFId& btf_id) const;
 

--- a/src/child.h
+++ b/src/child.h
@@ -14,71 +14,55 @@ struct child_args {
 
 class ChildProcBase {
 public:
-  /**
-     Parse command and fork a child process.
-
-     \param cmd Command to run
-   */
+  // Parse command and fork a child process.
+  //
+  // \param cmd Command to run
   ChildProcBase() = default;
   virtual ~ChildProcBase() = default;
 
-  /**
-     let child run (execve).
-
-     \param pause If set the child will be paused(stopped) just
-     after `execve`. To resume the child `resume` will have to
-     be called.
-  */
+  // let child run (execve).
+  //
+  // \param pause If set the child will be paused(stopped) just
+  // after `execve`. To resume the child `resume` will have to
+  // be called.
   virtual void run(bool pause = false) = 0;
 
-  /**
-     Ask child to terminate
-
-     \param force Forcefully kill the child (SIGKILL)
-  */
+  // Ask child to terminate
+  //
+  // \param force Forcefully kill the child (SIGKILL)
   virtual void terminate(bool force = false) = 0;
 
-  /**
-     Whether the child process is still alive or not
-  */
+  // Whether the child process is still alive or not
   virtual bool is_alive() = 0;
 
-  /**
-     return the child pid
-  */
+  // return the child pid
   pid_t pid()
   {
     return child_pid_;
   };
 
-  /**
-     Get child exit code, if any. This should only be called when the child has
-     finished (i.e. when is_alive() returns false)
-
-     \return The exit code of the child or -1 if the child hasn't been
-  terminated (by a signal)
-
-  */
+  // Get child exit code, if any. This should only be called when the child has
+  // finished (i.e. when is_alive() returns false)
+  //
+  // \return The exit code of the child or -1 if the child hasn't been
+  // terminated (by a signal)
+  //
   int exit_code()
   {
     return exit_code_;
   };
 
-  /**
-     Get termination signal, if any. This should only be called when the child
-     has finished (i.e. when is_alive() returns false)
-
-     \return A signal ID or -1 if the child hasn't been terminated (by a signal)
-  */
+  // Get termination signal, if any. This should only be called when the child
+  // has finished (i.e. when is_alive() returns false)
+  //
+  // \return A signal ID or -1 if the child hasn't been terminated (by a signal)
   int term_signal()
   {
     return term_signal_;
   };
 
-  /**
-     Resume a paused child. Only valid when run() has been called with
-     pause=true
-   */
+  // Resume a paused child. Only valid when run() has been called with
+  // pause=true
   virtual void resume(void) = 0;
 
 protected:
@@ -89,16 +73,14 @@ protected:
 
 class ChildProc : public ChildProcBase {
 public:
-  /**
-    Parse command and fork a child process. The child is run with the same
-    permissions and environment variables as bpftrace.
-
-    \param the command to run, with up to 255 optional arguments. If the
-  executables path isn't fully specified it the current PATH will be searched.
-  If more than one binary with the same name is found in the PATH an exception
-  is raised.
-
-  */
+  // Parse command and fork a child process. The child is run with the same
+  // permissions and environment variables as bpftrace.
+  //
+  // \param the command to run, with up to 255 optional arguments. If the
+  //   executables path isn't fully specified it the current PATH will be
+  //   searched. If more than one binary with the same name is found in the PATH
+  //   an exception is raised.
+  //
   ChildProc(std::string cmd);
   ~ChildProc();
 

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -88,12 +88,10 @@ static std::string get_clang_string(CXString string)
   return str;
 }
 
-/*
- * get_named_parent
- *
- * Find the parent struct of the field pointed to by the cursor.
- * Anonymous structs are skipped.
- */
+// get_named_parent
+//
+// Find the parent struct of the field pointed to by the cursor.
+// Anonymous structs are skipped.
 static CXCursor get_named_parent(CXCursor c)
 {
   CXCursor parent = clang_getCursorSemanticParent(c);
@@ -552,33 +550,31 @@ void ClangParser::resolve_incomplete_types_from_btf(
   }
 }
 
-/*
- * Parse the program using Clang.
- *
- * Type resolution rules:
- *
- * If BTF is available, necessary types are retrieved from there, otherwise we
- * rely on headers and types supplied by the user (we also include linux/types.h
- * in some cases, e.g., for tracepoints).
- *
- * The following types are taken from BTF (if available):
- * 1. Types explicitly used in the program (taken from bpftrace.btf_set_).
- * 2. Types used by some of the defined types (as struct members). This step
- *    is done recursively, however, as it may take long time, there is a
- *    maximal depth set. It is computed as the maximum level of nested field
- *    accesses in the program and can be manually overridden using
- *    the BPFTRACE_MAX_TYPE_RES_ITERATIONS env variable.
- * 3. Typedefs used by some of the defined types. These are also resolved
- *    recursively, however, they must be resolved completely as any unknown
- *    typedef will cause the parser to fail (even if the type is not used in
- *    the program).
- *
- * If any of the above steps retrieves a definition that redefines some existing
- * (user-defined) type, no BTF types are used and all types must be provided.
- * In practice, this means that user may use kernel types without providing
- * their definitions but once he redefines any kernel type, he must provide all
- * necessary definitions.
- */
+// Parse the program using Clang.
+//
+// Type resolution rules:
+//
+// If BTF is available, necessary types are retrieved from there, otherwise we
+// rely on headers and types supplied by the user (we also include linux/types.h
+// in some cases, e.g., for tracepoints).
+//
+// The following types are taken from BTF (if available):
+// 1. Types explicitly used in the program (taken from bpftrace.btf_set_).
+// 2. Types used by some of the defined types (as struct members). This step
+//    is done recursively, however, as it may take long time, there is a
+//    maximal depth set. It is computed as the maximum level of nested field
+//    accesses in the program and can be manually overridden using
+//    the BPFTRACE_MAX_TYPE_RES_ITERATIONS env variable.
+// 3. Typedefs used by some of the defined types. These are also resolved
+//    recursively, however, they must be resolved completely as any unknown
+//    typedef will cause the parser to fail (even if the type is not used in
+//    the program).
+//
+// If any of the above steps retrieves a definition that redefines some existing
+// (user-defined) type, no BTF types are used and all types must be provided.
+// In practice, this means that user may use kernel types without providing
+// their definitions but once he redefines any kernel type, he must provide all
+// necessary definitions.
 bool ClangParser::parse(ast::Program *program,
                         BPFtrace &bpftrace,
                         std::vector<std::string> extra_flags)
@@ -685,12 +681,10 @@ bool ClangParser::parse(ast::Program *program,
   return visit_children(cursor, bpftrace);
 }
 
-/*
- * Parse the given Clang diagnostics message and if it has one of the forms:
- *   unknown type name 'type_t'
- *   use of undeclared identifier 'type_t'
- * return type_t.
- */
+// Parse the given Clang diagnostics message and if it has one of the forms:
+//   unknown type name 'type_t'
+//   use of undeclared identifier 'type_t'
+// return type_t.
 std::optional<std::string> ClangParser::ClangParser::get_unknown_type(
     const std::string &diagnostic_msg)
 {

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -21,34 +21,26 @@ public:
 
 private:
   bool visit_children(CXCursor &cursor, BPFtrace &bpftrace);
-  /*
-   * The user might have written some struct definitions that rely on types
-   * supplied by BTF data.
-   *
-   * This method will pull out any forward-declared / incomplete struct
-   * definitions and return the types (in string form) of the unresolved types.
-   *
-   * Note that this method does not report "errors". This is because the user
-   * could have typo'd and actually referenced a non-existent type. Put
-   * differently, this method is best effort.
-   */
+  // The user might have written some struct definitions that rely on types
+  // supplied by BTF data.
+  //
+  // This method will pull out any forward-declared / incomplete struct
+  // definitions and return the types (in string form) of the unresolved types.
+  //
+  // Note that this method does not report "errors". This is because the user
+  // could have typo'd and actually referenced a non-existent type. Put
+  // differently, this method is best effort.
   std::unordered_set<std::string> get_incomplete_types();
-  /*
-   * Iteratively check for incomplete types, pull their definitions from BTF,
-   * and update the input files with the definitions.
-   */
+  // Iteratively check for incomplete types, pull their definitions from BTF,
+  // and update the input files with the definitions.
   void resolve_incomplete_types_from_btf(BPFtrace &bpftrace,
                                          const ast::ProbeList &probes);
 
-  /*
-   * Collect names of types defined by typedefs that are in non-included
-   * headers as they may pose problems for clang parser.
-   */
+  // Collect names of types defined by typedefs that are in non-included
+  // headers as they may pose problems for clang parser.
   std::unordered_set<std::string> get_unknown_typedefs();
-  /*
-   * Iteratively check for unknown typedefs, pull their definitions from BTF,
-   * and update the input files with the definitions.
-   */
+  // Iteratively check for unknown typedefs, pull their definitions from BTF,
+  // and update the input files with the definitions.
   void resolve_unknown_typedefs_from_btf(BPFtrace &bpftrace);
 
   static std::optional<std::string> get_unknown_type(
@@ -85,11 +77,9 @@ private:
                                        unsigned num_unsaved_files,
                                        unsigned options);
 
-    /*
-     * Check diagnostics and collect all error messages.
-     * Return true if an error occurred. If bail_on_error is false, only fail
-     * on fatal errors.
-     */
+    // Check diagnostics and collect all error messages.
+    // Return true if an error occurred. If bail_on_error is false, only fail
+    // on fatal errors.
     bool check_diagnostics(bool bail_on_error);
 
     CXCursor get_translation_unit_cursor();

--- a/src/config.h
+++ b/src/config.h
@@ -209,7 +209,7 @@ private:
 class ConfigSetter {
 public:
   explicit ConfigSetter(Config &config, ConfigSource source)
-      : config_(config), source_(source){};
+      : config_(config), source_(source) {};
 
   bool set(ConfigKeyBool key, bool val)
   {

--- a/src/container/cstring_view.h
+++ b/src/container/cstring_view.h
@@ -5,18 +5,16 @@
 
 namespace bpftrace {
 
-/*
- * cstring_view
- *
- * A restricted version of std::string_view which guarantees that the underlying
- * string buffer will be null-terminated. This can be useful when interacting
- * with C APIs while avoiding the use of char* and unnecessary copies from using
- * std::string.
- *
- * We only allow constructing cstring_view from types which are guaranteed to
- * store null-terminated strings. All modifiers or operations on cstring_view
- * will also maintain the null-terminated property.
- */
+// cstring_view
+//
+// A restricted version of std::string_view which guarantees that the underlying
+// string buffer will be null-terminated. This can be useful when interacting
+// with C APIs while avoiding the use of char* and unnecessary copies from using
+// std::string.
+//
+// We only allow constructing cstring_view from types which are guaranteed to
+// store null-terminated strings. All modifiers or operations on cstring_view
+// will also maintain the null-terminated property.
 class cstring_view : public std::string_view {
 public:
   constexpr cstring_view(const char *str) noexcept : std::string_view{ str }

--- a/src/format_string.h
+++ b/src/format_string.h
@@ -11,30 +11,22 @@
 
 namespace bpftrace {
 
-/**
- * validate_fmt makes sure that the type are valid for the format specifiers
- */
+// validate_fmt makes sure that the type are valid for the format specifiers
 std::string validate_format_string(const std::string &fmt,
                                    std::vector<Field> args,
                                    const std::string call_func);
 
 struct Field;
-/*
-**
-*/
+
 class FormatString {
 private:
-  /**
-   * Split the format string on format specifiers, e.g.
-   * 'foo %s bar' -> [ 'foo %s', 'bar' ]
-   */
+  // Split the format string on format specifiers, e.g.
+  // 'foo %s bar' -> [ 'foo %s', 'bar' ]
   void split();
 
 public:
-  /*
-   * NOTE: As format strings are used as a vector of tuples the cereal
-   * serialization can get hairy. Having a public constructor makes it easier.
-   */
+  // NOTE: As format strings are used as a vector of tuples the cereal
+  // serialization can get hairy. Having a public constructor makes it easier.
   FormatString() = default;
 
   FormatString(const char *s) : fmt_(s)
@@ -44,22 +36,16 @@ public:
   {
   }
 
-  /**
-   * format formats the format string with the given args. Its up to the caller
-   * to ensure that the argument types match those of the call to validate_types
-   */
+  // format formats the format string with the given args. Its up to the caller
+  // to ensure that the argument types match those of the call to validate_types
   void format(std::ostream &out,
               std::vector<std::unique_ptr<IPrintable>> &args);
 
-  /**
-   * format_str is similar to format but returns a string instead of writing to
-   * an ostream
-   */
+  // format_str is similar to format but returns a string instead of writing to
+  // an ostream
   std::string format_str(std::vector<std::unique_ptr<IPrintable>> &args);
 
-  /**
-   * length returns the length of the format string
-   */
+  // length returns the length of the format string
   inline size_t length() const noexcept
   {
     return fmt_.length();
@@ -69,17 +55,13 @@ public:
     return length();
   };
 
-  /**
-   * str returns the format string as std::string
-   */
+  // str returns the format string as std::string
   inline std::string str() const
   {
     return fmt_;
   };
 
-  /**
-   * c_str returns the format string as c string
-   * */
+  // c_str returns the format string as c string
   inline const char *c_str() const noexcept
   {
     return fmt_.c_str();

--- a/src/functions.cpp
+++ b/src/functions.cpp
@@ -92,17 +92,15 @@ bool can_implicit_cast(const SizedType &from, const SizedType &to)
 }
 } // namespace
 
-/*
- * Find the best function by name for the given argument types.
- *
- * Returns either a single function or nullptr, when no such function exists.
- *
- * When there are multiple candidate functions with the same name, prefer the
- * non-builtin over the builtin function.
- *
- * Valid functions have the correct name and all arguments can be implicitly
- * casted into all parameter types.
- */
+// Find the best function by name for the given argument types.
+//
+// Returns either a single function or nullptr, when no such function exists.
+//
+// When there are multiple candidate functions with the same name, prefer the
+// non-builtin over the builtin function.
+//
+// Valid functions have the correct name and all arguments can be implicitly
+// casted into all parameter types.
 const Function *FunctionRegistry::get(std::string_view ns,
                                       std::string_view name,
                                       const std::vector<SizedType> &arg_types,

--- a/src/functions.h
+++ b/src/functions.h
@@ -11,9 +11,7 @@
 
 namespace bpftrace {
 
-/**
- * A parameter for a BpfScript function
- */
+// A parameter for a BpfScript function
 class Param {
 public:
   Param(std::string name, const SizedType &type)
@@ -35,18 +33,14 @@ private:
   SizedType type_;
 };
 
-/**
- * Represents the type of a function which is callable in a BpfScript program.
- *
- * The function's implementation is not contained here.
- */
+// Represents the type of a function which is callable in a BpfScript program.
+//
+// The function's implementation is not contained here.
 class Function {
 public:
-  /**
-   * "Builtin" functions are hardcoded into bpftrace.
-   * "Script" functions are user-defined in BpfScript.
-   * "External" functions are imported from pre-compiled BPF programs.
-   */
+  // "Builtin" functions are hardcoded into bpftrace.
+  // "Script" functions are user-defined in BpfScript.
+  // "External" functions are imported from pre-compiled BPF programs.
   enum class Origin {
     Builtin,
     Script,
@@ -88,12 +82,10 @@ private:
   Origin origin_;
 };
 
-/**
- * Registry of callable functions
- *
- * Non-builtin functions are not allowed to share the same name. When a builtin
- * and a non-builtin function share a name, the non-builtin is preferred.
- */
+// Registry of callable functions
+//
+// Non-builtin functions are not allowed to share the same name. When a builtin
+// and a non-builtin function share a name, the non-builtin is preferred.
 class FunctionRegistry {
 public:
   const Function *add(Function::Origin origin,
@@ -106,9 +98,7 @@ public:
                       const SizedType &return_type,
                       const std::vector<Param> &params);
 
-  /**
-   * Returns the best match for the given function name and arguments
-   */
+  // Returns the best match for the given function name and arguments
   const Function *get(std::string_view ns,
                       std::string_view name,
                       const std::vector<SizedType> &arg_types,

--- a/src/libbpf/bpf.h
+++ b/src/libbpf/bpf.h
@@ -356,9 +356,8 @@ enum bpf_attach_type {
 	FN(cgrp_storage_delete),
 
 
-/* integer value in 'imm' field of BPF_CALL instruction selects which helper
- * function eBPF program intends to call
- */
+// integer value in 'imm' field of BPF_CALL instruction selects which helper
+// function eBPF program intends to call
 #define __BPF_ENUM_FN(x) BPF_FUNC_ ## x
 enum bpf_func_id {
 	__BPF_FUNC_MAPPER(__BPF_ENUM_FN)

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -127,9 +127,8 @@ void Log::log_with_location(LogType type,
     msg.pop_back();
   }
 
-  /* For a multi line error only the line range is printed:
-     <filename>:<start_line>-<end_line>: ERROR: <message>
-  */
+  // For a multi line error only the line range is printed:
+  //     <filename>:<start_line>-<end_line>: ERROR: <message>
   if (l.begin.line < l.end.line) {
     out << l.begin.line << "-" << l.end.line << ": " << typestr << msg
         << std::endl
@@ -137,19 +136,17 @@ void Log::log_with_location(LogType type,
     return;
   }
 
-  /*
-    For a single line error the format is:
-
-    <filename>:<line>:<start_col>-<end_col>: ERROR: <message>
-    <source line>
-    <marker>
-
-    E.g.
-
-    file.bt:1:10-20: error: <message>
-    i:s:1   /1 < "str"/
-            ~~~~~~~~~~
-  */
+  // For a single line error the format is:
+  //
+  // <filename>:<line>:<start_col>-<end_col>: ERROR: <message>
+  // <source line>
+  // <marker>
+  //
+  // E.g.
+  //
+  // file.bt:1:10-20: error: <message>
+  // i:s:1   /1 < "str"/
+  //         ~~~~~~~~~~
   out << l.begin.line << ":" << l.begin.column << "-" << l.end.column;
   out << ": " << typestr << msg << std::endl << color_end;
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -328,11 +328,9 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
       return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
     }
     case Type::avg_t: {
-      /*
-       * on this code path, avg is calculated in the kernel while
-       * printing the entire map is handled in a different function
-       * which shouldn't call this
-       */
+      // on this code path, avg is calculated in the kernel while
+      // printing the entire map is handled in a different function
+      // which shouldn't call this
       assert(!is_per_cpu);
       if (type.IsSigned()) {
         return std::to_string(read_data<int64_t>(value.data()) / div);

--- a/src/printf.h
+++ b/src/printf.h
@@ -40,7 +40,7 @@ enum class ArgumentType {
 
 class IPrintable {
 public:
-  virtual ~IPrintable(){};
+  virtual ~IPrintable() {};
   virtual int print(char* buf,
                     size_t size,
                     const char* fmt,

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -32,9 +32,7 @@ static int add_symbol(const char* symname,
   return 0;
 }
 
-/*
- * Finds all matches of search_input in the provided input stream.
- */
+// Finds all matches of search_input in the provided input stream.
 std::set<std::string> ProbeMatcher::get_matches_in_stream(
     const std::string& search_input,
     std::istream& symbol_stream,
@@ -97,11 +95,9 @@ std::set<std::string> ProbeMatcher::get_matches_in_stream(
   return matches;
 }
 
-/*
- * Get matches of search_input (containing a wildcard) for a given probe_type.
- * probe_type determines where to take the candidate matches from.
- * Some probe types (e.g. uprobe) require target to be specified.
- */
+// Get matches of search_input (containing a wildcard) for a given probe_type.
+// probe_type determines where to take the candidate matches from.
+// Some probe types (e.g. uprobe) require target to be specified.
 std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     const ProbeType& probe_type,
     const std::string& target,
@@ -199,9 +195,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     return {};
 }
 
-/*
- * Find all matches of search_input in set
- */
+// Find all matches of search_input in set
 std::set<std::string> ProbeMatcher::get_matches_in_set(
     const std::string& search_input,
     const std::set<std::string>& set)
@@ -333,10 +327,8 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_list(
   return std::make_unique<std::istringstream>(symbols);
 }
 
-/*
- * Get list of kernel probe types for the purpose of listing.
- * Ignore return probes and aliases.
- */
+// Get list of kernel probe types for the purpose of listing.
+// Ignore return probes and aliases.
 std::unique_ptr<std::istream> ProbeMatcher::kernel_probe_list()
 {
   std::string probes;
@@ -356,10 +348,8 @@ std::unique_ptr<std::istream> ProbeMatcher::kernel_probe_list()
   return std::make_unique<std::istringstream>(probes);
 }
 
-/*
- * Get list of userspace probe types for the purpose of listing.
- * Ignore return probes.
- */
+// Get list of userspace probe types for the purpose of listing.
+// Ignore return probes.
 std::unique_ptr<std::istream> ProbeMatcher::userspace_probe_list()
 {
   std::string probes;

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -60,25 +60,17 @@ public:
   }
   virtual ~ProbeMatcher() = default;
 
-  /*
-   * Get all matches for attach point containing a wildcard.
-   * The output strings format depends on the probe type.
-   */
+  // Get all matches for attach point containing a wildcard.
+  // The output strings format depends on the probe type.
   std::set<std::string> get_matches_for_ap(
       const ast::AttachPoint &attach_point);
-  /*
-   * Expanding probe type containing a wildcard.
-   */
+  // Expanding probe type containing a wildcard.
   std::set<std::string> expand_probetype_kernel(const std::string &probe_type);
   std::set<std::string> expand_probetype_userspace(
       const std::string &probe_type);
-  /*
-   * Match all probes in prog and print them to stdout.
-   */
+  // Match all probes in prog and print them to stdout.
   void list_probes(ast::Program *prog);
-  /*
-   * Print definitions of structures matching search.
-   */
+  // Print definitions of structures matching search.
   void list_structs(const std::string &search);
 
   const BPFtrace *bpftrace_;

--- a/src/procmon.h
+++ b/src/procmon.h
@@ -9,14 +9,10 @@ public:
   ProcMonBase() = default;
   virtual ~ProcMonBase() = default;
 
-  /**
-     Whether the process is still alive
-  */
+  // Whether the process is still alive
   virtual bool is_alive(void) = 0;
 
-  /**
-     pid of the process being monitored
-  */
+  // pid of the process being monitored
   pid_t pid(void)
   {
     return pid_;

--- a/src/types.h
+++ b/src/types.h
@@ -182,9 +182,7 @@ private:
   }
 
 public:
-  /**
-     Tuple/struct accessors
-  */
+  // Tuple/struct accessors
   std::vector<Field> &GetFields() const;
   bool HasField(const std::string &name) const;
   const Field &GetField(const std::string &name) const;
@@ -192,14 +190,10 @@ public:
   ssize_t GetFieldCount() const;
   std::weak_ptr<const Struct> GetStruct() const;
 
-  /**
-     Required alignment for this type when used inside a tuple
-   */
+  // Required alignment for this type when used inside a tuple
   ssize_t GetInTupleAlignment() const;
 
-  /**
-     Dump the underlying structure for debug purposes
-  */
+  // Dump the underlying structure for debug purposes
   void DumpStructure(std::ostream &os);
 
   AddrSpace GetAS() const

--- a/src/usdt.cpp
+++ b/src/usdt.cpp
@@ -42,10 +42,8 @@ static void usdt_probe_each(struct bcc_usdt *usdt_probe)
   current_pid_paths.emplace(usdt_probe->bin_path);
 }
 
-/**
- * Move the current pid paths onto the pid_to_paths_cache, and clear
- * current_pid_paths.
- */
+// Move the current pid paths onto the pid_to_paths_cache, and clear
+// current_pid_paths.
 static void cache_current_pid_paths(int pid)
 {
   usdt_pid_to_paths_cache[pid].merge(current_pid_paths);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -546,10 +546,8 @@ bool wildcard_match(std::string_view str,
   return true;
 }
 
-/*
- * Splits input string by '*' delimiter and return the individual parts.
- * Sets start_wildcard and end_wildcard if input starts or ends with '*'.
- */
+// Splits input string by '*' delimiter and return the individual parts.
+// Sets start_wildcard and end_wildcard if input starts or ends with '*'.
 std::vector<std::string> get_wildcard_tokens(const std::string &input,
                                              bool &start_wildcard,
                                              bool &end_wildcard)
@@ -936,20 +934,17 @@ std::string exec_system(const char *cmd)
   return result;
 }
 
-/*
-Original resolve_binary_path API defaulting to bpftrace's mount namespace
-*/
+// Original resolve_binary_path API defaulting to bpftrace's mount namespace
 std::vector<std::string> resolve_binary_path(const std::string &cmd)
 {
   const char *env_paths = getenv("PATH");
   return resolve_binary_path(cmd, env_paths, -1);
 }
 
-/*
-If a pid is specified, the binary path is taken relative to its own PATH if
-it is in a different mount namespace. Otherwise, the path is resolved relative
-to the local PATH env var for bpftrace's own mount namespace if it is set
-*/
+// If a pid is specified, the binary path is taken relative to its own PATH if
+// it is in a different mount namespace. Otherwise, the path is resolved
+// relative to the local PATH env var for bpftrace's own mount namespace if it
+// is set
 std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid)
 {
   std::string env_paths = "";
@@ -975,11 +970,9 @@ std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid)
   }
 }
 
-/*
-Check whether 'path' refers to a ELF file. Errors are swallowed silently and
-result in return of 'nullopt'. On success, the ELF type (e.g., ET_DYN) is
-returned.
-*/
+// Check whether 'path' refers to a ELF file. Errors are swallowed silently and
+// result in return of 'nullopt'. On success, the ELF type (e.g., ET_DYN) is
+// returned.
 static std::optional<int> is_elf(const std::string &path)
 {
   int fd;
@@ -1027,9 +1020,7 @@ static bool has_exec_permission(const std::string &path)
   return (perms & perms::owner_exec) != perms::none;
 }
 
-/*
-Check whether 'path' refers to an executable ELF file.
-*/
+// Check whether 'path' refers to an executable ELF file.
 bool is_exe(const std::string &path)
 {
   if (auto e_type = is_elf(path)) {
@@ -1038,10 +1029,9 @@ bool is_exe(const std::string &path)
   return false;
 }
 
-/*
-Private interface to resolve_binary_path, used for the exposed variants above,
-allowing for a PID whose mount namespace should be optionally considered.
-*/
+// Private interface to resolve_binary_path, used for the exposed variants
+// above, allowing for a PID whose mount namespace should be optionally
+// considered.
 static std::vector<std::string> resolve_binary_path(const std::string &cmd,
                                                     const char *env_paths,
                                                     int pid)
@@ -1092,19 +1082,17 @@ std::string path_for_pid_mountns(int pid, const std::string &path)
   return pid_relative_path.str();
 }
 
-/*
-Determines if the target process is in a different mount namespace from
-bpftrace.
-
-If a process is in a different mount namespace (eg, container) it is very
-likely that any references to local paths will not be valid, and that paths
-need to be made relative to the PID.
-
-If an invalid PID is specified or doesn't exist, it returns false.
-True is only returned if the namespace of the target process could be read and
-it doesn't match that of bpftrace. If there was an error reading either mount
-namespace, it will throw an exception
-*/
+// Determines if the target process is in a different mount namespace from
+// bpftrace.
+//
+// If a process is in a different mount namespace (eg, container) it is very
+// likely that any references to local paths will not be valid, and that paths
+// need to be made relative to the PID.
+//
+// If an invalid PID is specified or doesn't exist, it returns false.
+// True is only returned if the namespace of the target process could be read
+// and it doesn't match that of bpftrace. If there was an error reading either
+// mount namespace, it will throw an exception
 static bool pid_in_different_mountns(int pid)
 {
   if (pid <= 0)
@@ -1302,12 +1290,10 @@ std::string hex_format_buffer(const char *buf,
   return str;
 }
 
-/*
- * Attaching to these kernel functions with fentry/fexit (kfunc/kretfunc)
- * could lead to a recursive loop and kernel crash so we need additional
- * generated BPF code to protect against this if one of these are being
- * attached to.
- */
+// Attaching to these kernel functions with fentry/fexit (kfunc/kretfunc)
+// could lead to a recursive loop and kernel crash so we need additional
+// generated BPF code to protect against this if one of these are being
+// attached to.
 bool is_recursive_func(const std::string &func_name)
 {
   return RECURSIVE_KERNEL_FUNCS.find(func_name) != RECURSIVE_KERNEL_FUNCS.end();
@@ -1315,12 +1301,10 @@ bool is_recursive_func(const std::string &func_name)
 
 static bool is_bad_func(std::string &func)
 {
-  /*
-   * Certain kernel functions are known to cause system stability issues if
-   * traced (but not marked "notrace" in the kernel) so they should be filtered
-   * out as the list is built. The list of functions have been taken from the
-   * bpf kernel selftests (bpf/prog_tests/kprobe_multi_test.c).
-   */
+  // Certain kernel functions are known to cause system stability issues if
+  // traced (but not marked "notrace" in the kernel) so they should be filtered
+  // out as the list is built. The list of functions have been taken from the
+  // bpf kernel selftests (bpf/prog_tests/kprobe_multi_test.c).
   static const std::unordered_set<std::string> bad_funcs = {
     "arch_cpu_idle", "default_idle", "bpf_dispatcher_xdp_func"
   };
@@ -1383,9 +1367,7 @@ FuncsModulesMap parse_traceable_funcs()
 #endif
 }
 
-/**
- * Search for LINUX_VERSION_CODE in the vDSO, returning 0 if it can't be found.
- */
+// Search for LINUX_VERSION_CODE in the vDSO, returning 0 if it can't be found.
 static uint32_t _find_version_note(unsigned long base)
 {
   auto ehdr = reinterpret_cast<const ElfW(Ehdr) *>(base);
@@ -1459,11 +1441,9 @@ static uint32_t kernel_version_from_khdr()
   return 0;
 }
 
-/**
- * Find a LINUX_VERSION_CODE matching the host kernel. The build-time constant
- * may not match if bpftrace is compiled on a different Linux version than it's
- * used on, e.g. if built with Docker.
- */
+// Find a LINUX_VERSION_CODE matching the host kernel. The build-time constant
+// may not match if bpftrace is compiled on a different Linux version than it's
+// used on, e.g. if built with Docker.
 uint32_t kernel_version(KernelVersionMethod method)
 {
   static std::optional<uint32_t> a0, a1, a2;

--- a/tests/codegen/late_variable_decl.cpp
+++ b/tests/codegen/late_variable_decl.cpp
@@ -13,22 +13,22 @@ TEST(codegen, late_variable_decl)
       if (1) {
 				$x = 1;
 			}
-			
+
 			unroll(1) {
 				$x = 2;
 			}
-			
+
 			$i = 1;
       while($i) {
         --$i;
         $x = 3;
       }
-			
+
 			@map[16] = 32;
       for ($kv : @map) {
         $x = 4;
       }
-			
+
       let $x = 5;
     })",
        NAME);

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -150,14 +150,14 @@ public:
   {
     child_pid_ = 1337;
   };
-  ~MockChildProc(){};
+  ~MockChildProc() {};
 
-  void terminate(bool force __attribute__((unused)) = false) override{};
+  void terminate(bool force __attribute__((unused)) = false) override {};
   bool is_alive() override
   {
     return true;
   };
-  void resume(void) override{};
+  void resume(void) override {};
 
   void run(bool pause = false) override
   {


### PR DESCRIPTION
The codebase current has three different comment styles. In addition to the C++ style, two C-styles exist. One is the standard multi-line style:

```
/*
 * ...
 */
```

But also a style that omits the leading '*', which is generally recommended for Doxygen blocks (see below for more on this):

```
/**
   ...
 */
```

In a visitor change [1], the existing comment style was preserved but in a review the ask was made to change the style for consistency. To do so, this change is pulling forward all the comments in the code base to a single consistent style, and documenting this requirement in the coding style docs.

This change is using the C++ style, because it is the most dominant style currently (accounting for the majority of comments):

```
$ git grep -E '(^\/\*$|^ \* |^\/\*\*$)' .|grep -E '\.(yy|cpp|h):'|wc -l
334
$ git grep -E '(^\s*//)' .|grep -E '\.(yy|cpp|h):'|wc -l
2902
```

For posterity, this change was generated using an awk script, followed by stripping trailing whitespace and an auto-format. Manual verification and tweaking was done to ensure that the output was reasonable.

The awk script was:

```
/\/\*.*\*\// {
    print
    next
}
/^\s*\/\*\*\s*$/ {
    in_comment = 1
    trim = length($0)
    next
}
/^\s*\/\*\s*$/ {
    in_comment = 1
    next
}
/\/\/.*/ {
    print
    next
}
/"[^"]*\/\// {
    print
    next
}
/"[^"]*\/\*/ {
    print
    next
}
/\s*\/\*/ {
    in_comment = 1
    sub(/\/\*/, "//", $0)
    print
    next
}
/^\s*\*\/\s*$/ && in_comment {
    in_comment = 0
    next
}
/ \*.*\*\/$/ && in_comment {
    in_comment = 0
    sub(/ \*\//, "", $0)
    sub(/ \*/, "//", $0)
    print
    next
}
/\s+\*\// && in_comment {
    in_comment = 0
    sub(/\*\//, "", $0)
    print
    next
}
/ \*$/ && in_comment {
    sub(/ \*/, "//", $0)
    print
    next
}
/ \* / && in_comment {
    sub(/ \* /, "// ", $0)
    print
    next
}
/^   / && in_comment {
    $0 = substr($0, 0, trim-2) "//" substr($0, trim+1)
    print
    next
}
in_comment {
    $0 = "// " $0
    print
    next
}
{ print }
```

While the command run was:

```
find . -name \*.cpp -o -name \*.h | while read filename; do cat $filename | awk -f <script> > $filename.new; mv $filename.new $filename; sed -i 's/[[:space:]]*$//' $filename; clang-format -i $filename; done
```

While some incidental formatting changes may exist (due to the need to format the whole file rather than just the comment sections), an effort was taken to not change the content of the comments beyond the style.

Regarding doxygen blocks, there are only three places that these appear to use any documentation annotations: the VTable, the visitor classes and the Child file. These are using the old `\\`-prefixed names.

While these have not been changed, it does not appear that any automated documentation is being generated or checked. It is recommended to unify the style and then agree on a uniform standard for documentation, unless this has already been established.

[1] https://github.com/bpftrace/bpftrace/pull/3699#discussion_r1925945883

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
