### PR TITLE
nix: Remove unnecessary overlays

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,11 +38,18 @@
               owner = "libbpf";
               repo = "libbpf";
               rev = "v${libbpfVersion}";
-              # If you don't know the hash the first time, set:
-              # hash = "";
+              # Nix uses the hash to do lookups in its cache as well as check that the
+              # download from the internet hasn't changed. Therefore, it's necessary to
+              # update the hash every time you update the source. Failure to update the
+              # hash in a cached environment (warm development host and CI) will cause
+              # nix to use the old source and then fail at some point in the future when
+              # the stale cached content is evicted.
+              #
+              # If you don't know the hash, set:
+              #   sha256 = "";
               # then nix will fail the build with such an error message:
-              # hash mismatch in fixed-output derivation '/nix/store/m1ga09c0z1a6n7rj8ky3s31dpgalsn0n-source':
-              # specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+              #   hash mismatch in fixed-output derivation '/nix/store/m1ga09c0z1a6n7rj8ky3s31dpgalsn0n-source':
+              #   specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
               # got:    sha256-173gxk0ymiw94glyjzjizp8bv8g72gwkjhacigd1an09jshdrjb4
               sha256 = "sha256-+L/rbp0a3p4PHq1yTJmuMcNj0gT5sqAPeaNRo3Sh6U8=";
             };
@@ -57,6 +64,7 @@
               owner = "iovisor";
               repo = "bcc";
               rev = "v${bccVersion}";
+              # See above
               sha256 = "sha256-6dT3seLuEVQNKWiYGLK1ajXzW7pb62S/GQ0Lp4JdGjc=";
             };
           };

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
           # Define lambda that returns a derivation for bpftrace given llvm version as input
           mkBpftrace =
             llvmVersion:
-              pkgs.stdenv.mkDerivation rec {
+              pkgs.stdenv.mkDerivation {
                 name = "bpftrace";
 
                 src = self;

--- a/flake.nix
+++ b/flake.nix
@@ -74,33 +74,39 @@
           # Define lambda that returns a derivation for bpftrace given llvm version as input
           mkBpftrace =
             llvmVersion:
-              with pkgs;
               pkgs.stdenv.mkDerivation rec {
                 name = "bpftrace";
 
                 src = self;
 
-                nativeBuildInputs = [ cmake ninja bison flex gcc clang ];
+                nativeBuildInputs = [
+                  pkgs.bison
+                  pkgs.clang
+                  pkgs.cmake
+                  pkgs.flex
+                  pkgs.gcc
+                  pkgs.ninja
+                ];
 
                 buildInputs = [
-                  asciidoctor
-                  cereal
-                  elfutils
-                  gtest
-                  libbfd
-                  libelf
-                  libffi
-                  libopcodes
-                  libpcap
-                  libsystemtap
+                  overlayedPkgs.bcc
+                  overlayedPkgs.libbpf
+                  pkgs.asciidoctor
+                  pkgs.cereal
+                  pkgs.elfutils
+                  pkgs.gtest
+                  pkgs.libbfd
+                  pkgs.libelf
+                  pkgs.libffi
+                  pkgs.libopcodes
+                  pkgs.libpcap
+                  pkgs.libsystemtap
                   pkgs."llvmPackages_${toString llvmVersion}".libclang
                   pkgs."llvmPackages_${toString llvmVersion}".lldb
                   pkgs."llvmPackages_${toString llvmVersion}".llvm
-                  overlayedPkgs.bcc
-                  overlayedPkgs.libbpf
-                  pahole
-                  xxd
-                  zlib
+                  pkgs.pahole
+                  pkgs.xxd
+                  pkgs.zlib
                 ];
 
                 # Release flags


### PR DESCRIPTION
Nix overlays are most useful when you want to operate on the entire dependency graph. For our use case, we only want to modify libbpf and bcc.

The canonical way (AFAIK) to do that is by using overrides. This commit removes an unnecessary level of indirection and achieves the same thing.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
