### PR TITLE
Add feature check for map_lookup_percpu_elem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
   - [#3678](https://github.com/bpftrace/bpftrace/pull/3678)
 - Change max_strlen default from 64 to 1024
   - [#3713](https://github.com/bpftrace/bpftrace/pull/3713)
+- Add feature check for castable map reads
+  - [#3752](https://github.com/bpftrace/bpftrace/pull/3752)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -241,6 +241,10 @@ public:
   Expression *key_expr = nullptr;
   SizedType key_type;
   bool skip_key_validation = false;
+  // This is for a feature check on reading per-cpu maps
+  // which involve calling map_lookup_percpu_elem
+  // https://github.com/bpftrace/bpftrace/issues/3755
+  bool is_read = true;
 
 private:
   Map(const Map &other) = default;

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -604,6 +604,7 @@ std::string BPFfeature::report()
     { "jiffies64", to_str(has_helper_jiffies64()) },
     { "for_each_map_elem", to_str(has_helper_for_each_map_elem()) },
     { "get_ns_current_pid_tgid", to_str(has_helper_get_ns_current_pid_tgid()) },
+    { "lookup_percpu_elem", to_str(has_helper_map_lookup_percpu_elem()) },
   };
 
   std::vector<std::pair<std::string, std::string>> features = {

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -129,6 +129,7 @@ public:
   DEFINE_HELPER_TEST(jiffies64, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(for_each_map_elem, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(get_ns_current_pid_tgid, libbpf::BPF_PROG_TYPE_KPROBE);
+  DEFINE_HELPER_TEST(map_lookup_percpu_elem, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(kprobe, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(tracepoint, libbpf::BPF_PROG_TYPE_TRACEPOINT);
   DEFINE_PROG_TEST(perf_event, libbpf::BPF_PROG_TYPE_PERF_EVENT);

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -128,6 +128,7 @@ public:
     has_jiffies64_ = std::make_optional<bool>(has_features);
     has_for_each_map_elem_ = std::make_optional<bool>(has_features);
     has_get_ns_current_pid_tgid_ = std::make_optional<bool>(has_features);
+    has_map_lookup_percpu_elem_ = std::make_optional<bool>(has_features);
   };
 
   void has_loop(bool has)


### PR DESCRIPTION
This feature wasn't added till 5.19
so we need to check if it's available.

https://github.com/bpftrace/bpftrace/issues/3732

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
