### PR TITLE
Move ARRAY_SIZE macro into utils.h

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -21,8 +21,6 @@
 
 namespace bpftrace {
 
-#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
-
 int BPFnofeature::parse(const char* str)
 {
   for (auto feat : split_string(str, ',')) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,6 +19,8 @@
 #include <variant>
 #include <vector>
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 namespace bpftrace {
 
 struct vmlinux_location {


### PR DESCRIPTION
Move the ARRAY_SIZE macro from bpffeature.cpp into utils.h, to make it available to more parts of the program. It really is a "utility" style macro, so this seems like a fitting location.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
