### PR TITLE
Warn when probing a partially inlined function

### DIFF
--- a/.github/include/aot_skip.txt
+++ b/.github/include/aot_skip.txt
@@ -154,6 +154,7 @@ aot.variable.map nested tuple string resize
 aot.variable.map key nested tuple string resize
 aot.variable.map key tuple with casted ints
 aot.dwarf.uprobe without dwarf
+aot.dwarf.uprobe inline without dwarf
 aot.dwarf.uprobe inlined function - func
 aot.dwarf.uprobe inlined function - probe
 aot.dwarf.uprobe inlined function - ustack

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -185,6 +185,20 @@ int BPFtrace::add_probe(const ast::AttachPoint &ap,
 
           locations_from_dwarf = true;
         }
+
+        // Check if the function is inlined and warn
+        // the user about missing calls to inlined instances.
+        if (!config_.get(ConfigKeyBool::probe_inline)) {
+          auto inst_count =
+              dwarf->get_function_locations(probe.attach_point, true).size();
+          if (inst_count > 1) {
+            LOG(WARNING) << "Function \"" << probe.attach_point
+                         << "\" is partially inlined, bpftrace will miss calls "
+                            "to inlined instances.";
+            LOG(HINT)
+                << "Set `probe_inline = 1` config to probe all instances.";
+          }
+        }
       }
     }
 

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -87,6 +87,8 @@ PROG config = { symbol_source = "symbol_table"; probe_inline = 1; }
      uprobe:./testprogs/inline_function:square { @count++ }
      uretprobe:./testprogs/inline_function:main { exit() }
 EXPECT @count: 1
+EXPECT_NONE WARNING: Function "square" is partially inlined, bpftrace will miss calls to inlined instances.
+EXPECT_NONE HINT: Set `probe_inline = 1` config to probe all instances.
 REQUIRES_FEATURE dwarf
 AFTER ./testprogs/inline_function
 
@@ -95,6 +97,8 @@ PROG config = { probe_inline = 0 }
      uprobe:./testprogs/inline_function:square { @count++ }
      uretprobe:./testprogs/inline_function:main { exit() }
 EXPECT @count: 1
+EXPECT WARNING: Function "square" is partially inlined, bpftrace will miss calls to inlined instances.
+       HINT: Set `probe_inline = 1` config to probe all instances.
 REQUIRES_FEATURE dwarf
 AFTER ./testprogs/inline_function
 


### PR DESCRIPTION
Functions can exist both as symbol in the program and as inlined instances in the body of another function, at the same time. When probing such a function, the user expects to attach to all calls/instances and gets confused if calls are missing.

This commit adds a warning for uprobes and kprobes that are partially inlined. It looks at the number of locations returned by `dwarf->get_function_locations()`, with `include_inline` set to `True`, and display a warning if there are more than __one__ location. The warning is raised only when DWARF is available and the config `probe_inline` is disabled.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
