### PR TITLE
globalvars: use reference type to prevent copying

### DIFF
--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -102,7 +102,7 @@ static std::map<GlobalVar, int> find_btf_var_offsets(
       vars_and_offsets[*global_var] = member->offset;
   }
 
-  for (const auto [global_var, offset] : vars_and_offsets) {
+  for (const auto &[global_var, offset] : vars_and_offsets) {
     if (offset < 0) {
       LOG(BUG) << "Global variable " << to_string(global_var)
                << " has not been added to the BPF code "
@@ -132,7 +132,7 @@ static void update_global_vars_rodata(
   }
 
   // Update the values for the global vars (using the above offsets)
-  for (const auto [global_var, offset] : vars_and_offsets) {
+  for (const auto &[global_var, offset] : vars_and_offsets) {
     int64_t *var = reinterpret_cast<int64_t *>(global_vars_buf + offset);
 
     switch (global_var) {


### PR DESCRIPTION
On Debian GNU/Linux 12 (bookworm) x86_64:

    $ make
    ...
    [ 79%] Building CXX object src/aot/CMakeFiles/aot.dir/aot.cpp.o
    /home/rongtao/Git/bpftrace/bpftrace/src/globalvars.cpp: In function ‘std::map<bpftrace::globalvars::GlobalVar, int> bpftrace::globalvars::find_btf_var_offsets(const bpf_object*, std::string_view, const std::unordered_set<GlobalVar>&)’:
    /home/rongtao/Git/bpftrace/bpftrace/src/globalvars.cpp:105:19: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const std::pair<const bpftrace::globalvars::GlobalVar, int>’ [-Wrange-loop-construct]
      105 |   for (const auto [global_var, offset] : vars_and_offsets) {
          |                   ^~~~~~~~~~~~~~~~~~~~
    /home/rongtao/Git/bpftrace/bpftrace/src/globalvars.cpp:105:19: note: use reference type to prevent copying
      105 |   for (const auto [global_var, offset] : vars_and_offsets) {
          |                   ^~~~~~~~~~~~~~~~~~~~
          |                   &
    /home/rongtao/Git/bpftrace/bpftrace/src/globalvars.cpp: In function ‘void bpftrace::globalvars::update_global_vars_rodata(const bpf_object*, std::string_view, bpf_map*, const std::unordered_set<GlobalVar>&, const bpftrace::BPFtrace&)’:
    /home/rongtao/Git/bpftrace/bpftrace/src/globalvars.cpp:135:19: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const std::pair<const bpftrace::globalvars::GlobalVar, int>’ [-Wrange-loop-construct]
      135 |   for (const auto [global_var, offset] : vars_and_offsets) {
          |                   ^~~~~~~~~~~~~~~~~~~~
    /home/rongtao/Git/bpftrace/bpftrace/src/globalvars.cpp:135:19: note: use reference type to prevent copying
      135 |   for (const auto [global_var, offset] : vars_and_offsets) {
          |                   ^~~~~~~~~~~~~~~~~~~~
          |                   &


