### PR TITLE
man: bpftrace: Fix name of sample script 'bsize.bt'

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1240,7 +1240,7 @@ I got 42, hello (2 args)
 ello
 ----
 
-Script example, bsize.d:
+Script example, bsize.bt:
 
 ----
 #!/usr/local/bin/bpftrace


### PR DESCRIPTION
The manual uses he bsize.bt script as example but when naming it the first time it is mentioned as bsize.d. Fix the naming to be consistent with the usual suffix for bpftrace scripts and as used just in the following paragraph.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
