### PR TITLE
Remove reference to utilizing types for let

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -973,13 +973,6 @@ if ($a == 1) {
 
 If no assignment is specified variables will initialize to 0.
 
-You can also specify the type in the declaration e.g.
-```
-let $x: uint8;
-let $y: uint8 = 7;
-let $a: string = "hiya";
-```
-
 'map' variables use BPF 'maps'.
 These exist for the lifetime of `bpftrace` itself and can be accessed from all action blocks and user-space.
 Map names always start with a `@`, e.g. `@mymap`.


### PR DESCRIPTION
Because the type system is very incomplete
currently, don't surface to users the
ability to specify the type in let declarations.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
