### PR TITLE
Fix extant memory leaks

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -399,10 +399,11 @@ AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
     // If the target has form "libXXX" then we use BCC to find the correct path
     // to the given library as it may differ across systems.
     auto libname = parts_[1].substr(3);
-    const char *lib_path = bcc_procutils_which_so(libname.c_str(),
-                                                  bpftrace_.pid());
-    if (lib_path)
+    auto lib_path = bcc_procutils_which_so(libname.c_str(), bpftrace_.pid());
+    if (lib_path) {
       ap_->target = lib_path;
+      ::free(lib_path);
+    }
   }
 
   if (ap_->target.empty()) {

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -156,7 +156,9 @@ void FieldAnalyser::visit(Unop &unop)
 {
   Visit(*unop.expr);
   if (unop.op == Operator::MUL && sized_type_.IsPtrTy()) {
-    sized_type_ = *sized_type_.GetPointeeTy();
+    // Need a temporary to prevent UAF from self-referential assignment
+    auto tmp = *sized_type_.GetPointeeTy();
+    sized_type_ = std::move(tmp);
     resolve_fields(sized_type_);
   }
 }

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -42,6 +42,7 @@
 #include "log.h"
 #include "printf.h"
 #include "resolve_cgroupid.h"
+#include "scopeguard.h"
 #include "utils.h"
 
 namespace bpftrace {
@@ -918,6 +919,10 @@ int BPFtrace::run(BpfBytecode bytecode)
   err = setup_output();
   if (err)
     return err;
+  SCOPE_EXIT
+  {
+    teardown_output();
+  };
 
   err = create_pcaps();
   if (err) {
@@ -1056,8 +1061,6 @@ int BPFtrace::run(BpfBytecode bytecode)
   }
 
   poll_output(/* drain */ true);
-
-  teardown_output();
 
   return 0;
 }

--- a/src/scopeguard.h
+++ b/src/scopeguard.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <functional>
+
+// Need two levels of indirection here for __LINE__ to correctly expand
+#define _CONCAT2(a, b) a##b
+#define _CONCAT(a, b) _CONCAT2(a, b)
+#define _ANON_VAR(str) _CONCAT(str, __LINE__)
+
+namespace bpftrace {
+
+enum class ScopeGuardExit {};
+
+class ScopeGuard {
+public:
+  explicit ScopeGuard(std::function<void()> fn)
+  {
+    fn_ = fn;
+  }
+
+  ~ScopeGuard()
+  {
+    if (fn_) {
+      fn_();
+    }
+  }
+
+private:
+  std::function<void()> fn_;
+};
+
+inline ScopeGuard operator+(ScopeGuardExit, std::function<void()> fn)
+{
+  return ScopeGuard(fn);
+}
+
+} // namespace bpftrace
+
+#define SCOPE_EXIT auto _ANON_VAR(SCOPE_EXIT_STATE) = ScopeGuardExit() + [&]()

--- a/src/usyms.cpp
+++ b/src/usyms.cpp
@@ -2,6 +2,8 @@
 
 #include "usyms.h"
 
+#include "scopeguard.h"
+
 namespace bpftrace {
 
 Usyms::Usyms(const Config &config) : config_(config)
@@ -98,6 +100,19 @@ std::string Usyms::resolve(uint64_t addr,
   }
 
   if (psyms && bcc_symcache_resolve(psyms, addr, &usym) == 0) {
+    SCOPE_EXIT
+    {
+      // This is a horrible hack to work around the fact that
+      // bcc does not tell if you if demangling succeeded.
+      // B/c if demangling failed, it returns a string that
+      // you cannot free.
+      //
+      // This relies on the fact that bcc will not change the
+      // `demangle_name = name` fallback. Since blazesym is
+      // coming (written 2/4/25), this should be fine for now.
+      if (usym.demangle_name != usym.name)
+        ::free(const_cast<char *>(usym.demangle_name));
+    };
     if (config_.get(ConfigKeyBool::cpp_demangle))
       symbol << usym.demangle_name;
     else

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(bpftrace_test
   resource_analyser.cpp
   required_resources.cpp
   return_path_analyser.cpp
+  scopeguard.cpp
   semantic_analyser.cpp
   tracepoint_format_parser.cpp
   types.cpp

--- a/tests/btf_common.h
+++ b/tests/btf_common.h
@@ -56,10 +56,14 @@ protected:
     // clear the environment and remove the temp files
     unsetenv("BPFTRACE_BTF");
     unsetenv("BPFTRACE_AVAILABLE_FUNCTIONS_TEST");
-    if (btf_path_)
+    if (btf_path_) {
       std::remove(btf_path_);
-    if (funcs_path_)
+      ::free(btf_path_);
+    }
+    if (funcs_path_) {
       std::remove(funcs_path_);
+      ::free(funcs_path_);
+    }
   }
 
   char *btf_path_ = nullptr;
@@ -84,8 +88,10 @@ protected:
   {
     // clear the environment and remove the temp files
     unsetenv("BPFTRACE_BTF");
-    if (btf_path_)
+    if (btf_path_) {
       std::remove(btf_path_);
+      ::free(btf_path_);
+    }
   }
 
   char *btf_path_ = nullptr;

--- a/tests/scopeguard.cpp
+++ b/tests/scopeguard.cpp
@@ -1,0 +1,81 @@
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "scopeguard.h"
+
+#include <exception>
+
+namespace bpftrace {
+
+TEST(ScopeGuardTest, InnerScope)
+{
+  int x = 5;
+
+  {
+    SCOPE_EXIT
+    {
+      x++;
+    };
+  }
+
+  EXPECT_EQ(x, 6);
+}
+
+TEST(ScopeGuardTest, FunctionReturn)
+{
+  int x = 5;
+
+  [&]() {
+    SCOPE_EXIT
+    {
+      x++;
+    };
+
+    x++;
+    return;
+  }();
+
+  EXPECT_EQ(x, 7);
+}
+
+TEST(ScopeGuardTest, ExceptionContext)
+{
+  int x = 5;
+
+  try {
+    [&]() {
+      SCOPE_EXIT
+      {
+        x++;
+      };
+
+      throw std::runtime_error("exception");
+    }();
+  } catch (const std::exception &) {
+    EXPECT_EQ(x, 6);
+    x++;
+  }
+
+  EXPECT_EQ(x, 7);
+}
+
+TEST(ScopeGuardTest, MultipleGuards)
+{
+  int x = 5;
+
+  {
+    SCOPE_EXIT
+    {
+      x++;
+    };
+
+    SCOPE_EXIT
+    {
+      x++;
+    };
+  }
+
+  EXPECT_EQ(x, 7);
+}
+
+} // namespace bpftrace


### PR DESCRIPTION
This fixes all memory leaks that can be exposed by our test suite.
IOW, I ran the entire test suite under BUILD_ASAN=1.

This excludes the multiple thousands of leaks from LLDB. I will
follow up with a broader plan for dealing with that after.

The end goal is we run all CI jobs with ASAN and then delete
the memleak-tests.sh jobs from CI to repurpose that capacity
for vmtest jobs.

See individual commits for more details.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
