### PR TITLE
Add len() variants for ustack and kstack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
   - [#3761](https://github.com/bpftrace/bpftrace/pull/3761)
 - Pointers may now be used in if conditions, tenary conditions and as operands in logical AND and OR expressions
   - [#3656](https://github.com/bpftrace/bpftrace/pull/3656)
+- `len` now also accepts `ustack` and `kstack` as arguments
+  - [#3769](https://github.com/bpftrace/bpftrace/pull/3769)
 #### Changed
 - `probe` builtin is now represented as a string type
   - [#3638](https://github.com/bpftrace/bpftrace/pull/3638)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -21,9 +21,9 @@ When _FILENAME_ is "_-_", bpftrace will read program code from stdin.
 
 == Description
 
-bpftrace is a high-level tracing language for Linux. bpftrace uses LLVM as 
-a backend to compile scripts to eBPF-bytecode and makes use of libbpf and bcc 
-for interacting with the Linux BPF subsystem, as well as existing Linux 
+bpftrace is a high-level tracing language for Linux. bpftrace uses LLVM as
+a backend to compile scripts to eBPF-bytecode and makes use of libbpf and bcc
+for interacting with the Linux BPF subsystem, as well as existing Linux
 tracing capabilities.
 
 == Examples
@@ -1334,6 +1334,10 @@ Tracing block I/O sizes > 0 bytes
 | Resolve kernel address
 | Async
 
+| <<functions-len, `len`>>
+| Count ustack/kstack frames
+| Sync
+
 | <<functions-macaddr, `macaddr`>>
 | Convert MAC address data
 | Sync
@@ -1712,6 +1716,16 @@ kprobe:do_nanosleep
  * do_nanosleep
  */
 ----
+
+[#functions-len]
+=== len
+
+.variants
+* `int64 len(ustack stack)`
+* `int64 len(kstack stack)`
+
+Retrieve the depth (measured in # of frames) of the call stack
+specified by `stack`.
 
 [#functions-macaddr]
 === macaddr

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -233,7 +233,7 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype, bool emit_codegen_types)
                             getOrCreateArray({}));
   }
 
-  if (stype.IsByteArray() || stype.IsRecordTy()) {
+  if (stype.IsByteArray() || stype.IsRecordTy() || stype.IsStack()) {
     auto subrange = getOrCreateSubrange(0, stype.GetSize());
     return createArrayType(
         stype.GetSize() * 8, 0, getInt8Ty(), getOrCreateArray({ subrange }));

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -147,6 +147,31 @@ AllocaInst *IRBuilderBPF::CreateUSym(Value *ctx,
   return buf;
 }
 
+StructType *IRBuilderBPF::GetStackStructType(bool is_ustack)
+{
+  // Kernel stacks should not be differentiated by pid, since the kernel
+  // address space is the same between pids (and when aggregating you *want*
+  // to be able to correlate between pids in most cases). User-space stacks
+  // are special because of ASLR, hence we also store the pid; probe id is
+  // stored for cases when only ELF resolution works (e.g. ASLR disabled and
+  // process exited).
+  if (is_ustack) {
+    std::vector<llvm::Type *> elements{
+      getInt64Ty(), // stack id
+      getInt32Ty(), // nr_stack_frames
+      getInt32Ty(), // pid
+      getInt32Ty(), // probe id
+    };
+    return GetStructType("ustack_key", elements, false);
+  } else {
+    std::vector<llvm::Type *> elements{
+      getInt64Ty(), // stack id
+      getInt32Ty(), // nr_stack_frames
+    };
+    return GetStructType("kstack_key", elements, false);
+  }
+}
+
 StructType *IRBuilderBPF::GetStructType(
     std::string name,
     const std::vector<llvm::Type *> &elements,

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -389,6 +389,8 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype,
     ty_name << "_tuple_t";
 
     ty = GetStructType(ty_name.str(), llvm_elems, false);
+  } else if (stype.IsStack()) {
+    ty = GetStackStructType(stype.IsUstackTy());
   } else if (stype.IsPtrTy()) {
     if (emit_codegen_types)
       ty = getInt64Ty();

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -230,6 +230,7 @@ public:
                              libbpf::bpf_func_id func_id,
                              const location &loc,
                              bool compare_zero = false);
+  StructType *GetStackStructType(bool is_ustack);
   StructType *GetStructType(std::string name,
                             const std::vector<llvm::Type *> &elements,
                             bool packed = false);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -179,13 +179,7 @@ void CodegenLLVM::kstack_ustack(const std::string &ident,
   const bool is_ustack = ident == "ustack";
   const auto uint64_size = sizeof(uint64_t);
 
-  std::vector<llvm::Type *> stack_key_elements = {
-    b_.getInt64Ty(), // stack id
-    b_.getInt32Ty(), // nr_stack_frames
-  };
-  StructType *stack_key_struct = b_.GetStructType("stack_key",
-                                                  stack_key_elements,
-                                                  false);
+  StructType *stack_key_struct = b_.GetStackStructType(is_ustack);
   AllocaInst *stack_key = b_.CreateAllocaBPF(stack_key_struct, "stack_key");
   b_.CreateStore(b_.getInt64(0),
                  b_.CreateGEP(stack_key_struct,
@@ -271,50 +265,22 @@ void CodegenLLVM::kstack_ustack(const std::string &ident,
   b_.CreateBr(merge_block);
   b_.SetInsertPoint(merge_block);
 
-  // Kernel stacks should not be differentiated by pid, since the kernel
-  // address space is the same between pids (and when aggregating you *want*
-  // to be able to correlate between pids in most cases). User-space stacks
-  // are special because of ASLR, hence we also store the pid; probe id is
-  // stored for cases when only ELF resolution works (e.g. ASLR disabled and
-  // process exited).
+  // ustack keys are special: see IRBuilderBPF::GetStackStructType()
   if (is_ustack) {
-    std::vector<llvm::Type *> elements = {
-      b_.getInt64Ty(), // stack id
-      b_.getInt32Ty(), // nr_stack_frames
-      b_.getInt32Ty(), // pid
-      b_.getInt32Ty(), // probe id
-    };
-    StructType *stack_struct = b_.GetStructType("stack_t", elements, false);
-    AllocaInst *buf = b_.CreateAllocaBPF(stack_struct, "stack_args");
-
-    // store stack id
-    Value *stackid = b_.CreateGEP(stack_key_struct,
-                                  stack_key,
-                                  { b_.getInt64(0), b_.getInt32(0) });
-    b_.CreateStore(
-        b_.CreateLoad(b_.getInt64Ty(), stackid),
-        b_.CreateGEP(stack_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
-    // store nr_stack_frames
-    Value *nr_stack_frames = b_.CreateGEP(stack_key_struct,
-                                          stack_key,
-                                          { b_.getInt64(0), b_.getInt32(1) });
-    b_.CreateStore(
-        b_.CreateLoad(b_.getInt32Ty(), nr_stack_frames),
-        b_.CreateGEP(stack_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
     // store pid
-    b_.CreateStore(
-        b_.CreateGetPid(ctx_, loc),
-        b_.CreateGEP(stack_struct, buf, { b_.getInt64(0), b_.getInt32(2) }));
+    b_.CreateStore(b_.CreateGetPid(ctx_, loc),
+                   b_.CreateGEP(stack_key_struct,
+                                stack_key,
+                                { b_.getInt64(0), b_.getInt32(2) }));
     // store probe id
-    b_.CreateStore(
-        b_.GetIntSameSize(get_probe_id(), elements.at(3)),
-        b_.CreateGEP(stack_struct, buf, { b_.getInt64(0), b_.getInt32(3) }));
-
-    expr_ = buf;
-    b_.CreateLifetimeEnd(stack_key);
-  } else {
-    expr_ = stack_key;
+    b_.CreateStore(b_.GetIntSameSize(get_probe_id(),
+                                     stack_key_struct->getTypeAtIndex(3)),
+                   b_.CreateGEP(stack_key_struct,
+                                stack_key,
+                                { b_.getInt64(0), b_.getInt32(3) }));
   }
+
+  expr_ = stack_key;
 }
 
 int CodegenLLVM::get_probe_id()
@@ -1305,18 +1271,13 @@ void CodegenLLVM::visit(Call &call)
     auto *arg = call.vargs.at(0);
     auto scoped_del = accept(arg);
 
-    std::vector<llvm::Type *> stack_key_elements = {
-      b_.getInt64Ty(), // stack id
-      b_.getInt32Ty(), // nr_stack_frames
-    };
-    StructType *stack_key_struct = b_.GetStructType("stack_key",
-                                                    stack_key_elements,
-                                                    false);
+    auto *stack_key_struct = b_.GetStackStructType(arg->type.IsUstackTy());
     Value *nr_stack_frames = b_.CreateGEP(stack_key_struct,
                                           expr_,
                                           { b_.getInt64(0), b_.getInt32(1) });
-    expr_ = b_.CreateLoad(b_.getInt32Ty(), nr_stack_frames);
-    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false);
+    expr_ = b_.CreateIntCast(b_.CreateLoad(b_.getInt32Ty(), nr_stack_frames),
+                             b_.getInt64Ty(),
+                             false);
   } else if (call.func == "len" /* && call.vargs.at(0)->is_map */) {
     auto &arg = *call.vargs.at(0);
     auto &map = static_cast<Map &>(arg);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1332,17 +1332,17 @@ void SemanticAnalyser::visit(Call &call)
   } else if (call.func == "len") {
     if (check_nargs(call, 1)) {
       auto &arg = *call.vargs.at(0);
-      if (!arg.is_map)
-        LOG(ERROR, call.loc, err_) << "len() expects a map to be provided";
-      else {
+      if (arg.is_map) {
         Map &map = static_cast<Map &>(arg);
         if (map.key_expr) {
           LOG(ERROR, call.loc, err_)
               << "The map passed to " << call.func << "() should not be "
               << "indexed by a key";
         }
-        call.type = CreateInt64();
-      }
+      } else if (!arg.type.IsStack())
+        LOG(ERROR, call.loc, err_)
+            << "len() expects a map or stack to be provided";
+      call.type = CreateInt64();
     }
   } else if (call.func == "time") {
     check_assignment(call, false, false, false);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -435,7 +435,8 @@ SizedType CreateRecord(const std::string &name, std::weak_ptr<Struct> record)
 
 SizedType CreateStack(bool kernel, StackType stack)
 {
-  // These sizes are based on the stack key (see CodegenLLVM::kstack_ustack)
+  // These sizes are based on the stack key (see
+  // IRBuilderBPF::GetStackStructType)
   auto st = SizedType(kernel ? Type::kstack_t : Type::ustack_t,
                       kernel ? 12 : 20);
   st.stack_type = stack;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -164,7 +164,6 @@ bool SizedType::operator==(const SizedType &t) const
 bool SizedType::IsByteArray() const
 {
   return type_ == Type::string || type_ == Type::usym_t ||
-         type_ == Type::kstack_t || type_ == Type::ustack_t ||
          type_ == Type::inet || type_ == Type::buffer ||
          type_ == Type::timestamp || type_ == Type::mac_address ||
          type_ == Type::cgroup_path_t;
@@ -172,7 +171,8 @@ bool SizedType::IsByteArray() const
 
 bool SizedType::IsAggregate() const
 {
-  return IsArrayTy() || IsByteArray() || IsTupleTy() || IsRecordTy();
+  return IsArrayTy() || IsByteArray() || IsTupleTy() || IsRecordTy() ||
+         IsStack();
 }
 
 bool SizedType::IsStack() const

--- a/tests/codegen/call_len.cpp
+++ b/tests/codegen/call_len.cpp
@@ -22,6 +22,11 @@ TEST_F(codegen_btf, call_len_map_sum_elem_count)
   test(PROG, NAME);
 }
 
+TEST_F(codegen_btf, call_len_ustack_kstack)
+{
+  test("kprobe:f { @x = len(ustack); @y = len(kstack); }", NAME);
+}
+
 } // namespace call_len
 
 } // namespace codegen

--- a/tests/codegen/llvm/builtin_kstack.ll
+++ b/tests/codegen/llvm/builtin_kstack.ll
@@ -8,7 +8,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr }
 %"struct map_t.3" = type { ptr, ptr, ptr, ptr }
-%stack_key = type { i64, i32 }
+%kstack_key = type { i64, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -24,11 +24,11 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !80 {
 entry:
   %"@x_key" = alloca i64, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stack_key = alloca %stack_key, align 8
+  %stack_key = alloca %kstack_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
-  %1 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  %1 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
   store i64 0, ptr %1, align 8
-  %2 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  %2 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
   store i32 0, ptr %2, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
   store i32 0, ptr %lookup_stack_scratch_key, align 4
@@ -58,11 +58,11 @@ lookup_stack_scratch_merge:                       ; preds = %entry
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
   %4 = udiv i32 %get_stack, 8
-  %5 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  %5 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
   store i32 %4, ptr %5, align 4
   %6 = trunc i32 %4 to i8
   %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %6, i64 1)
-  %7 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  %7 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
   store i64 %murmur_hash_2, ptr %7, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -8,8 +8,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr }
 %"struct map_t.3" = type { ptr, ptr, ptr, ptr }
-%stack_t = type { i64, i32, i32, i32 }
-%stack_key = type { i64, i32 }
+%ustack_key = type { i64, i32, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -24,13 +23,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !84 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %stack_args = alloca %stack_t, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stack_key = alloca %stack_key, align 8
+  %stack_key = alloca %ustack_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
-  %1 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  %1 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
   store i64 0, ptr %1, align 8
-  %2 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  %2 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
   store i32 0, ptr %2, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
   store i32 0, ptr %lookup_stack_scratch_key, align 4
@@ -43,26 +41,16 @@ stack_scratch_failure:                            ; preds = %lookup_stack_scratc
   br label %merge_block
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args)
-  %3 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
-  %4 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 0
-  %5 = load i64, ptr %3, align 8
-  store i64 %5, ptr %4, align 8
-  %6 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
-  %7 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 1
-  %8 = load i32, ptr %6, align 4
-  store i32 %8, ptr %7, align 4
-  %9 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 2
+  %3 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %10 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %10 to i32
-  store i32 %pid, ptr %9, align 4
-  %11 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
-  store i32 0, ptr %11, align 4
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key)
+  %4 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %4 to i32
+  store i32 %pid, ptr %3, align 4
+  %5 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 3
+  store i32 0, ptr %5, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %stack_args, i64 0)
+  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %stack_key, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 
@@ -72,17 +60,17 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
   %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %12 = icmp sge i32 %get_stack, 0
-  br i1 %12, label %get_stack_success, label %get_stack_fail
+  %6 = icmp sge i32 %get_stack, 0
+  br i1 %6, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %13 = udiv i32 %get_stack, 8
-  %14 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
-  store i32 %13, ptr %14, align 4
-  %15 = trunc i32 %13 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %15, i64 1)
-  %16 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %16, align 8
+  %7 = udiv i32 %get_stack, 8
+  %8 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %7, ptr %8, align 4
+  %9 = trunc i32 %7 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %9, i64 1)
+  %10 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %10, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 

--- a/tests/codegen/llvm/call_kstack.ll
+++ b/tests/codegen/llvm/call_kstack.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.5" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.6" = type { ptr, ptr }
 %"struct map_t.7" = type { ptr, ptr, ptr, ptr }
-%stack_key = type { i64, i32 }
+%kstack_key = type { i64, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -32,17 +32,17 @@ define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !93 {
 entry:
   %"@z_key" = alloca i64, align 8
   %lookup_stack_scratch_key19 = alloca i32, align 4
-  %stack_key16 = alloca %stack_key, align 8
+  %stack_key16 = alloca %kstack_key, align 8
   %"@y_key" = alloca i64, align 8
   %lookup_stack_scratch_key5 = alloca i32, align 4
-  %stack_key2 = alloca %stack_key, align 8
+  %stack_key2 = alloca %kstack_key, align 8
   %"@x_key" = alloca i64, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stack_key = alloca %stack_key, align 8
+  %stack_key = alloca %kstack_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
-  %1 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  %1 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
   store i64 0, ptr %1, align 8
-  %2 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  %2 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
   store i32 0, ptr %2, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
   store i32 0, ptr %lookup_stack_scratch_key, align 4
@@ -60,9 +60,9 @@ merge_block:                                      ; preds = %stack_scratch_failu
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %stack_key, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key2)
-  %3 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
+  %3 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
   store i64 0, ptr %3, align 8
-  %4 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  %4 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
   store i32 0, ptr %4, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key5)
   store i32 0, ptr %lookup_stack_scratch_key5, align 4
@@ -82,11 +82,11 @@ lookup_stack_scratch_merge:                       ; preds = %entry
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
   %6 = udiv i32 %get_stack, 8
-  %7 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  %7 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
   store i32 %6, ptr %7, align 4
   %8 = trunc i32 %6 to i8
   %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %8, i64 1)
-  %9 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  %9 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
   store i64 %murmur_hash_2, ptr %9, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
@@ -103,9 +103,9 @@ merge_block4:                                     ; preds = %stack_scratch_failu
   %update_elem15 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %stack_key2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key16)
-  %10 = getelementptr %stack_key, ptr %stack_key16, i64 0, i32 0
+  %10 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 0
   store i64 0, ptr %10, align 8
-  %11 = getelementptr %stack_key, ptr %stack_key16, i64 0, i32 1
+  %11 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 1
   store i32 0, ptr %11, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key19)
   store i32 0, ptr %lookup_stack_scratch_key19, align 4
@@ -125,11 +125,11 @@ lookup_stack_scratch_merge8:                      ; preds = %merge_block
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
   %13 = udiv i32 %get_stack12, 8
-  %14 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  %14 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
   store i32 %13, ptr %14, align 4
   %15 = trunc i32 %13 to i8
   %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %15, i64 1)
-  %16 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
+  %16 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
   store i64 %murmur_hash_213, ptr %16, align 8
   %update_elem14 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_6, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
@@ -158,11 +158,11 @@ lookup_stack_scratch_merge22:                     ; preds = %merge_block4
 
 get_stack_success25:                              ; preds = %lookup_stack_scratch_merge22
   %18 = udiv i32 %get_stack27, 8
-  %19 = getelementptr %stack_key, ptr %stack_key16, i64 0, i32 1
+  %19 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 1
   store i32 %18, ptr %19, align 4
   %20 = trunc i32 %18 to i8
   %murmur_hash_228 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map20, i8 %20, i64 1)
-  %21 = getelementptr %stack_key, ptr %stack_key16, i64 0, i32 0
+  %21 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 0
   store i64 %murmur_hash_228, ptr %21, align 8
   %update_elem29 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_perf_127, ptr %stack_key16, ptr %lookup_stack_scratch_map20, i64 0)
   br label %merge_block18

--- a/tests/codegen/llvm/call_len_ustack_kstack.ll
+++ b/tests/codegen/llvm/call_len_ustack_kstack.ll
@@ -9,8 +9,8 @@ target triple = "bpf-pc-linux"
 %"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.3" = type { ptr, ptr }
 %"struct map_t.4" = type { ptr, ptr, ptr, ptr }
-%stack_key = type { i64, i32 }
-%stack_t = type { i64, i32, i32, i32 }
+%kstack_key = type { i64, i32 }
+%ustack_key = type { i64, i32, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -28,16 +28,15 @@ entry:
   %"@y_val" = alloca i64, align 8
   %"@y_key" = alloca i64, align 8
   %lookup_stack_scratch_key5 = alloca i32, align 4
-  %stack_key2 = alloca %stack_key, align 8
+  %stack_key2 = alloca %kstack_key, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %stack_args = alloca %stack_t, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stack_key = alloca %stack_key, align 8
+  %stack_key = alloca %ustack_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
-  %1 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  %1 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
   store i64 0, ptr %1, align 8
-  %2 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  %2 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
   store i32 0, ptr %2, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
   store i32 0, ptr %lookup_stack_scratch_key, align 4
@@ -50,38 +49,28 @@ stack_scratch_failure:                            ; preds = %lookup_stack_scratc
   br label %merge_block
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args)
-  %3 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
-  %4 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 0
-  %5 = load i64, ptr %3, align 8
-  store i64 %5, ptr %4, align 8
-  %6 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
-  %7 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 1
-  %8 = load i32, ptr %6, align 4
-  store i32 %8, ptr %7, align 4
-  %9 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 2
+  %3 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %10 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %10 to i32
-  store i32 %pid, ptr %9, align 4
-  %11 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
-  store i32 0, ptr %11, align 4
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key)
-  %12 = getelementptr %stack_key, ptr %stack_args, i64 0, i32 1
-  %13 = load i32, ptr %12, align 4
-  %14 = zext i32 %13 to i64
+  %4 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %4 to i32
+  store i32 %pid, ptr %3, align 4
+  %5 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 3
+  store i32 0, ptr %5, align 4
+  %6 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
+  %7 = load i32, ptr %6, align 4
+  %8 = zext i32 %7 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %14, ptr %"@x_val", align 8
+  store i64 %8, ptr %"@x_val", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key2)
-  %15 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 0, ptr %15, align 8
-  %16 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 0, ptr %16, align 4
+  %9 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 0, ptr %9, align 8
+  %10 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 0, ptr %10, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key5)
   store i32 0, ptr %lookup_stack_scratch_key5, align 4
   %lookup_stack_scratch_map6 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key5)
@@ -95,17 +84,17 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
   %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %17 = icmp sge i32 %get_stack, 0
-  br i1 %17, label %get_stack_success, label %get_stack_fail
+  %11 = icmp sge i32 %get_stack, 0
+  br i1 %11, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %18 = udiv i32 %get_stack, 8
-  %19 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
-  store i32 %18, ptr %19, align 4
-  %20 = trunc i32 %18 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %20, i64 1)
-  %21 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %21, align 8
+  %12 = udiv i32 %get_stack, 8
+  %13 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %12, ptr %13, align 4
+  %14 = trunc i32 %12 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %14, i64 1)
+  %15 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %15, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -116,13 +105,13 @@ stack_scratch_failure3:                           ; preds = %lookup_stack_scratc
   br label %merge_block4
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success11, %get_stack_fail12
-  %22 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  %23 = load i32, ptr %22, align 4
-  %24 = zext i32 %23 to i64
+  %16 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
+  %17 = load i32, ptr %16, align 4
+  %18 = zext i32 %17 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  store i64 %24, ptr %"@y_val", align 8
+  store i64 %18, ptr %"@y_val", align 8
   %update_elem16 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -134,17 +123,17 @@ lookup_stack_scratch_failure7:                    ; preds = %merge_block
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
   %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map6, i32 1016, ptr null)
   %get_stack13 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 1016, i64 0)
-  %25 = icmp sge i32 %get_stack13, 0
-  br i1 %25, label %get_stack_success11, label %get_stack_fail12
+  %19 = icmp sge i32 %get_stack13, 0
+  br i1 %19, label %get_stack_success11, label %get_stack_fail12
 
 get_stack_success11:                              ; preds = %lookup_stack_scratch_merge8
-  %26 = udiv i32 %get_stack13, 8
-  %27 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 %26, ptr %27, align 4
-  %28 = trunc i32 %26 to i8
-  %murmur_hash_214 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %28, i64 1)
-  %29 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_214, ptr %29, align 8
+  %20 = udiv i32 %get_stack13, 8
+  %21 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 %20, ptr %21, align 4
+  %22 = trunc i32 %20 to i8
+  %murmur_hash_214 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %22, i64 1)
+  %23 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_214, ptr %23, align 8
   %update_elem15 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 

--- a/tests/codegen/llvm/call_len_ustack_kstack.ll
+++ b/tests/codegen/llvm/call_len_ustack_kstack.ll
@@ -1,0 +1,331 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.2" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.3" = type { ptr, ptr }
+%"struct map_t.4" = type { ptr, ptr, ptr, ptr }
+%stack_key = type { i64, i32 }
+%stack_t = type { i64, i32, i32, i32 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@stack_bpftrace_127 = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !18
+@stack_scratch = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !43
+@ringbuf = dso_local global %"struct map_t.3" zeroinitializer, section ".maps", !dbg !55
+@event_loss_counter = dso_local global %"struct map_t.4" zeroinitializer, section ".maps", !dbg !69
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !81 {
+entry:
+  %"@y_val" = alloca i64, align 8
+  %"@y_key" = alloca i64, align 8
+  %lookup_stack_scratch_key5 = alloca i32, align 4
+  %stack_key2 = alloca %stack_key, align 8
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %stack_args = alloca %stack_t, align 8
+  %lookup_stack_scratch_key = alloca i32, align 4
+  %stack_key = alloca %stack_key, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
+  %1 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  store i64 0, ptr %1, align 8
+  %2 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  store i32 0, ptr %2, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
+  store i32 0, ptr %lookup_stack_scratch_key, align 4
+  %lookup_stack_scratch_map = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_stack_scratch_key)
+  %lookup_stack_scratch_cond = icmp ne ptr %lookup_stack_scratch_map, null
+  br i1 %lookup_stack_scratch_cond, label %lookup_stack_scratch_merge, label %lookup_stack_scratch_failure
+
+stack_scratch_failure:                            ; preds = %lookup_stack_scratch_failure
+  br label %merge_block
+
+merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args)
+  %3 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  %4 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 0
+  %5 = load i64, ptr %3, align 8
+  store i64 %5, ptr %4, align 8
+  %6 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  %7 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 1
+  %8 = load i32, ptr %6, align 4
+  store i32 %8, ptr %7, align 4
+  %9 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 2
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %10 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %10 to i32
+  store i32 %pid, ptr %9, align 4
+  %11 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
+  store i32 0, ptr %11, align 4
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key)
+  %12 = getelementptr %stack_key, ptr %stack_args, i64 0, i32 1
+  %13 = load i32, ptr %12, align 4
+  %14 = zext i32 %13 to i64
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
+  store i64 0, ptr %"@x_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  store i64 %14, ptr %"@x_val", align 8
+  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key2)
+  %15 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 0, ptr %15, align 8
+  %16 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 0, ptr %16, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key5)
+  store i32 0, ptr %lookup_stack_scratch_key5, align 4
+  %lookup_stack_scratch_map6 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key5)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_stack_scratch_key5)
+  %lookup_stack_scratch_cond9 = icmp ne ptr %lookup_stack_scratch_map6, null
+  br i1 %lookup_stack_scratch_cond9, label %lookup_stack_scratch_merge8, label %lookup_stack_scratch_failure7
+
+lookup_stack_scratch_failure:                     ; preds = %entry
+  br label %stack_scratch_failure
+
+lookup_stack_scratch_merge:                       ; preds = %entry
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
+  %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
+  %17 = icmp sge i32 %get_stack, 0
+  br i1 %17, label %get_stack_success, label %get_stack_fail
+
+get_stack_success:                                ; preds = %lookup_stack_scratch_merge
+  %18 = udiv i32 %get_stack, 8
+  %19 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %18, ptr %19, align 4
+  %20 = trunc i32 %18 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %20, i64 1)
+  %21 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %21, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
+  br label %merge_block
+
+get_stack_fail:                                   ; preds = %lookup_stack_scratch_merge
+  br label %merge_block
+
+stack_scratch_failure3:                           ; preds = %lookup_stack_scratch_failure7
+  br label %merge_block4
+
+merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success11, %get_stack_fail12
+  %22 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  %23 = load i32, ptr %22, align 4
+  %24 = zext i32 %23 to i64
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
+  store i64 0, ptr %"@y_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
+  store i64 %24, ptr %"@y_val", align 8
+  %update_elem16 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
+  ret i64 0
+
+lookup_stack_scratch_failure7:                    ; preds = %merge_block
+  br label %stack_scratch_failure3
+
+lookup_stack_scratch_merge8:                      ; preds = %merge_block
+  %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map6, i32 1016, ptr null)
+  %get_stack13 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 1016, i64 0)
+  %25 = icmp sge i32 %get_stack13, 0
+  br i1 %25, label %get_stack_success11, label %get_stack_fail12
+
+get_stack_success11:                              ; preds = %lookup_stack_scratch_merge8
+  %26 = udiv i32 %get_stack13, 8
+  %27 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 %26, ptr %27, align 4
+  %28 = trunc i32 %26 to i8
+  %murmur_hash_214 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %28, i64 1)
+  %29 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_214, ptr %29, align 8
+  %update_elem15 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
+  br label %merge_block4
+
+get_stack_fail12:                                 ; preds = %lookup_stack_scratch_merge8
+  br label %merge_block4
+}
+
+; Function Attrs: alwaysinline
+define internal i64 @murmur_hash_2(ptr %0, i8 %1, i64 %2) #1 section "helpers" {
+entry:
+  %k = alloca i64, align 8
+  %i = alloca i8, align 1
+  %id = alloca i64, align 8
+  %seed_addr = alloca i64, align 8
+  %nr_stack_frames_addr = alloca i8, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %nr_stack_frames_addr)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %seed_addr)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %id)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %k)
+  store i8 %1, ptr %nr_stack_frames_addr, align 1
+  store i64 %2, ptr %seed_addr, align 8
+  %3 = load i8, ptr %nr_stack_frames_addr, align 1
+  %4 = zext i8 %3 to i64
+  %5 = mul i64 %4, -4132994306676758123
+  %6 = load i64, ptr %seed_addr, align 8
+  %7 = xor i64 %6, %5
+  store i64 %7, ptr %id, align 8
+  store i8 0, ptr %i, align 1
+  br label %while_cond
+
+while_cond:                                       ; preds = %while_body, %entry
+  %8 = load i8, ptr %nr_stack_frames_addr, align 1
+  %9 = load i8, ptr %i, align 1
+  %length.cmp = icmp ult i8 %9, %8
+  br i1 %length.cmp, label %while_body, label %while_end
+
+while_body:                                       ; preds = %while_cond
+  %10 = load i8, ptr %i, align 1
+  %11 = getelementptr i64, ptr %0, i8 %10
+  %12 = load i64, ptr %11, align 8
+  store i64 %12, ptr %k, align 8
+  %13 = load i64, ptr %k, align 8
+  %14 = mul i64 %13, -4132994306676758123
+  store i64 %14, ptr %k, align 8
+  %15 = load i64, ptr %k, align 8
+  %16 = lshr i64 %15, 47
+  %17 = load i64, ptr %k, align 8
+  %18 = xor i64 %17, %16
+  store i64 %18, ptr %k, align 8
+  %19 = load i64, ptr %k, align 8
+  %20 = mul i64 %19, -4132994306676758123
+  store i64 %20, ptr %k, align 8
+  %21 = load i64, ptr %k, align 8
+  %22 = load i64, ptr %id, align 8
+  %23 = xor i64 %22, %21
+  store i64 %23, ptr %id, align 8
+  %24 = load i64, ptr %id, align 8
+  %25 = mul i64 %24, -4132994306676758123
+  store i64 %25, ptr %id, align 8
+  %26 = load i8, ptr %i, align 1
+  %27 = add i8 %26, 1
+  store i8 %27, ptr %i, align 1
+  br label %while_cond
+
+while_end:                                        ; preds = %while_cond
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %nr_stack_frames_addr)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %seed_addr)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %k)
+  %28 = load i64, ptr %id, align 8
+  %zero_cond = icmp eq i64 %28, 0
+  br i1 %zero_cond, label %if_zero, label %if_end
+
+if_zero:                                          ; preds = %while_end
+  store i64 1, ptr %id, align 8
+  br label %if_end
+
+if_end:                                           ; preds = %if_zero, %while_end
+  %29 = load i64, ptr %id, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %id)
+  ret i64 %29
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { alwaysinline }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!78}
+!llvm.module.flags = !{!80}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !12, !15}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !13, size: 64, offset: 128)
+!13 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !14, size: 64)
+!14 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!15 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !13, size: 64, offset: 192)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!18 = !DIGlobalVariableExpression(var: !19, expr: !DIExpression())
+!19 = distinct !DIGlobalVariable(name: "stack_bpftrace_127", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!20 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !21)
+!21 = !{!22, !27, !32, !38}
+!22 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !23, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !25)
+!25 = !{!26}
+!26 = !DISubrange(count: 9, lowerBound: 0)
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !28, size: 64, offset: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 4194304, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 131072, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !33, size: 64, offset: 128)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !35, size: 96, elements: !36)
+!35 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!36 = !{!37}
+!37 = !DISubrange(count: 12, lowerBound: 0)
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !39, size: 64, offset: 192)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8128, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 127, lowerBound: 0)
+!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
+!44 = distinct !DIGlobalVariable(name: "stack_scratch", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!45 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !46)
+!46 = !{!47, !11, !52, !38}
+!47 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !48, size: 64)
+!48 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !49, size: 64)
+!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !50)
+!50 = !{!51}
+!51 = !DISubrange(count: 6, lowerBound: 0)
+!52 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !53, size: 64, offset: 128)
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!54 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
+!56 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !57, isLocal: false, isDefinition: true)
+!57 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !58)
+!58 = !{!59, !64}
+!59 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !60, size: 64)
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !62)
+!62 = !{!63}
+!63 = !DISubrange(count: 27, lowerBound: 0)
+!64 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !65, size: 64, offset: 64)
+!65 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !66, size: 64)
+!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !67)
+!67 = !{!68}
+!68 = !DISubrange(count: 262144, lowerBound: 0)
+!69 = !DIGlobalVariableExpression(var: !70, expr: !DIExpression())
+!70 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !71, isLocal: false, isDefinition: true)
+!71 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !72)
+!72 = !{!73, !11, !52, !15}
+!73 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !74, size: 64)
+!74 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !75, size: 64)
+!75 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !76)
+!76 = !{!77}
+!77 = !DISubrange(count: 2, lowerBound: 0)
+!78 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !79)
+!79 = !{!0, !16, !18, !43, !55, !69}
+!80 = !{i32 2, !"Debug Info Version", i32 3}
+!81 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !82, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !78, retainedNodes: !85)
+!82 = !DISubroutineType(types: !83)
+!83 = !{!14, !84}
+!84 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!85 = !{!86}
+!86 = !DILocalVariable(name: "ctx", arg: 1, scope: !81, file: !2, type: !84)

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -12,8 +12,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.5" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.6" = type { ptr, ptr }
 %"struct map_t.7" = type { ptr, ptr, ptr, ptr }
-%stack_t = type { i64, i32, i32, i32 }
-%stack_key = type { i64, i32 }
+%ustack_key = type { i64, i32, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -32,21 +31,18 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !97 {
 entry:
   %"@z_key" = alloca i64, align 8
-  %stack_args33 = alloca %stack_t, align 8
-  %lookup_stack_scratch_key22 = alloca i32, align 4
-  %stack_key19 = alloca %stack_key, align 8
+  %lookup_stack_scratch_key21 = alloca i32, align 4
+  %stack_key18 = alloca %ustack_key, align 8
   %"@y_key" = alloca i64, align 8
-  %stack_args15 = alloca %stack_t, align 8
   %lookup_stack_scratch_key5 = alloca i32, align 4
-  %stack_key2 = alloca %stack_key, align 8
+  %stack_key2 = alloca %ustack_key, align 8
   %"@x_key" = alloca i64, align 8
-  %stack_args = alloca %stack_t, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stack_key = alloca %stack_key, align 8
+  %stack_key = alloca %ustack_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
-  %1 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  %1 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
   store i64 0, ptr %1, align 8
-  %2 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  %2 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
   store i32 0, ptr %2, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
   store i32 0, ptr %lookup_stack_scratch_key, align 4
@@ -59,32 +55,22 @@ stack_scratch_failure:                            ; preds = %lookup_stack_scratc
   br label %merge_block
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args)
-  %3 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
-  %4 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 0
-  %5 = load i64, ptr %3, align 8
-  store i64 %5, ptr %4, align 8
-  %6 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
-  %7 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 1
-  %8 = load i32, ptr %6, align 4
-  store i32 %8, ptr %7, align 4
-  %9 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 2
+  %3 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %10 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %10 to i32
-  store i32 %pid, ptr %9, align 4
-  %11 = getelementptr %stack_t, ptr %stack_args, i64 0, i32 3
-  store i32 0, ptr %11, align 4
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key)
+  %4 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %4 to i32
+  store i32 %pid, ptr %3, align 4
+  %5 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 3
+  store i32 0, ptr %5, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %stack_args, i64 0)
+  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %stack_key, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key2)
-  %12 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 0, ptr %12, align 8
-  %13 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 0, ptr %13, align 4
+  %6 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 0, ptr %7, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key5)
   store i32 0, ptr %lookup_stack_scratch_key5, align 4
   %lookup_stack_scratch_map6 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key5)
@@ -98,17 +84,17 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
   %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %14 = icmp sge i32 %get_stack, 0
-  br i1 %14, label %get_stack_success, label %get_stack_fail
+  %8 = icmp sge i32 %get_stack, 0
+  br i1 %8, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %15 = udiv i32 %get_stack, 8
-  %16 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
-  store i32 %15, ptr %16, align 4
-  %17 = trunc i32 %15 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %17, i64 1)
-  %18 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %18, align 8
+  %9 = udiv i32 %get_stack, 8
+  %10 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %9, ptr %10, align 4
+  %11 = trunc i32 %9 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %11, i64 1)
+  %12 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %12, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -119,38 +105,28 @@ stack_scratch_failure3:                           ; preds = %lookup_stack_scratc
   br label %merge_block4
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args15)
-  %19 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  %20 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 0
-  %21 = load i64, ptr %19, align 8
-  store i64 %21, ptr %20, align 8
-  %22 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  %23 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 1
-  %24 = load i32, ptr %22, align 4
-  store i32 %24, ptr %23, align 4
-  %25 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 2
-  %get_pid_tgid16 = call i64 inttoptr (i64 14 to ptr)()
-  %26 = lshr i64 %get_pid_tgid16, 32
-  %pid17 = trunc i64 %26 to i32
-  store i32 %pid17, ptr %25, align 4
-  %27 = getelementptr %stack_t, ptr %stack_args15, i64 0, i32 3
-  store i32 0, ptr %27, align 4
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key2)
+  %13 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 2
+  %get_pid_tgid15 = call i64 inttoptr (i64 14 to ptr)()
+  %14 = lshr i64 %get_pid_tgid15, 32
+  %pid16 = trunc i64 %14 to i32
+  store i32 %pid16, ptr %13, align 4
+  %15 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 3
+  store i32 0, ptr %15, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
-  %update_elem18 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %stack_args15, i64 0)
+  %update_elem17 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %stack_key2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key19)
-  %28 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
-  store i64 0, ptr %28, align 8
-  %29 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
-  store i32 0, ptr %29, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key22)
-  store i32 0, ptr %lookup_stack_scratch_key22, align 4
-  %lookup_stack_scratch_map23 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key22)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_stack_scratch_key22)
-  %lookup_stack_scratch_cond26 = icmp ne ptr %lookup_stack_scratch_map23, null
-  br i1 %lookup_stack_scratch_cond26, label %lookup_stack_scratch_merge25, label %lookup_stack_scratch_failure24
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key18)
+  %16 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 0
+  store i64 0, ptr %16, align 8
+  %17 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 1
+  store i32 0, ptr %17, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key21)
+  store i32 0, ptr %lookup_stack_scratch_key21, align 4
+  %lookup_stack_scratch_map22 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key21)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_stack_scratch_key21)
+  %lookup_stack_scratch_cond25 = icmp ne ptr %lookup_stack_scratch_map22, null
+  br i1 %lookup_stack_scratch_cond25, label %lookup_stack_scratch_merge24, label %lookup_stack_scratch_failure23
 
 lookup_stack_scratch_failure7:                    ; preds = %merge_block
   br label %stack_scratch_failure3
@@ -158,72 +134,62 @@ lookup_stack_scratch_failure7:                    ; preds = %merge_block
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
   call void @llvm.memset.p0.i64(ptr align 1 %lookup_stack_scratch_map6, i8 0, i64 48, i1 false)
   %get_stack12 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 48, i64 256)
-  %30 = icmp sge i32 %get_stack12, 0
-  br i1 %30, label %get_stack_success10, label %get_stack_fail11
+  %18 = icmp sge i32 %get_stack12, 0
+  br i1 %18, label %get_stack_success10, label %get_stack_fail11
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
-  %31 = udiv i32 %get_stack12, 8
-  %32 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 %31, ptr %32, align 4
-  %33 = trunc i32 %31 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %33, i64 1)
-  %34 = getelementptr %stack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_213, ptr %34, align 8
+  %19 = udiv i32 %get_stack12, 8
+  %20 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 %19, ptr %20, align 4
+  %21 = trunc i32 %19 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %21, i64 1)
+  %22 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, ptr %22, align 8
   %update_elem14 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_6, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
 get_stack_fail11:                                 ; preds = %lookup_stack_scratch_merge8
   br label %merge_block4
 
-stack_scratch_failure20:                          ; preds = %lookup_stack_scratch_failure24
-  br label %merge_block21
+stack_scratch_failure19:                          ; preds = %lookup_stack_scratch_failure23
+  br label %merge_block20
 
-merge_block21:                                    ; preds = %stack_scratch_failure20, %get_stack_success28, %get_stack_fail29
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_args33)
-  %35 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
-  %36 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 0
-  %37 = load i64, ptr %35, align 8
-  store i64 %37, ptr %36, align 8
-  %38 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
-  %39 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 1
-  %40 = load i32, ptr %38, align 4
-  store i32 %40, ptr %39, align 4
-  %41 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 2
-  %get_pid_tgid34 = call i64 inttoptr (i64 14 to ptr)()
-  %42 = lshr i64 %get_pid_tgid34, 32
-  %pid35 = trunc i64 %42 to i32
-  store i32 %pid35, ptr %41, align 4
-  %43 = getelementptr %stack_t, ptr %stack_args33, i64 0, i32 3
-  store i32 0, ptr %43, align 4
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %stack_key19)
+merge_block20:                                    ; preds = %stack_scratch_failure19, %get_stack_success27, %get_stack_fail28
+  %23 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 2
+  %get_pid_tgid32 = call i64 inttoptr (i64 14 to ptr)()
+  %24 = lshr i64 %get_pid_tgid32, 32
+  %pid33 = trunc i64 %24 to i32
+  store i32 %pid33, ptr %23, align 4
+  %25 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 3
+  store i32 0, ptr %25, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@z_key")
   store i64 0, ptr %"@z_key", align 8
-  %update_elem36 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_z, ptr %"@z_key", ptr %stack_args33, i64 0)
+  %update_elem34 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_z, ptr %"@z_key", ptr %stack_key18, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@z_key")
   ret i64 0
 
-lookup_stack_scratch_failure24:                   ; preds = %merge_block4
-  br label %stack_scratch_failure20
+lookup_stack_scratch_failure23:                   ; preds = %merge_block4
+  br label %stack_scratch_failure19
 
-lookup_stack_scratch_merge25:                     ; preds = %merge_block4
-  %probe_read_kernel27 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map23, i32 1016, ptr null)
-  %get_stack30 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map23, i32 1016, i64 256)
-  %44 = icmp sge i32 %get_stack30, 0
-  br i1 %44, label %get_stack_success28, label %get_stack_fail29
+lookup_stack_scratch_merge24:                     ; preds = %merge_block4
+  %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map22, i32 1016, ptr null)
+  %get_stack29 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map22, i32 1016, i64 256)
+  %26 = icmp sge i32 %get_stack29, 0
+  br i1 %26, label %get_stack_success27, label %get_stack_fail28
 
-get_stack_success28:                              ; preds = %lookup_stack_scratch_merge25
-  %45 = udiv i32 %get_stack30, 8
-  %46 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 1
-  store i32 %45, ptr %46, align 4
-  %47 = trunc i32 %45 to i8
-  %murmur_hash_231 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map23, i8 %47, i64 1)
-  %48 = getelementptr %stack_key, ptr %stack_key19, i64 0, i32 0
-  store i64 %murmur_hash_231, ptr %48, align 8
-  %update_elem32 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_perf_127, ptr %stack_key19, ptr %lookup_stack_scratch_map23, i64 0)
-  br label %merge_block21
+get_stack_success27:                              ; preds = %lookup_stack_scratch_merge24
+  %27 = udiv i32 %get_stack29, 8
+  %28 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 1
+  store i32 %27, ptr %28, align 4
+  %29 = trunc i32 %27 to i8
+  %murmur_hash_230 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map22, i8 %29, i64 1)
+  %30 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 0
+  store i64 %murmur_hash_230, ptr %30, align 8
+  %update_elem31 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_perf_127, ptr %stack_key18, ptr %lookup_stack_scratch_map22, i64 0)
+  br label %merge_block20
 
-get_stack_fail29:                                 ; preds = %lookup_stack_scratch_merge25
-  br label %merge_block21
+get_stack_fail28:                                 ; preds = %lookup_stack_scratch_merge24
+  br label %merge_block20
 }
 
 ; Function Attrs: alwaysinline

--- a/tests/codegen/llvm/count_cast_loop_stack_key.ll
+++ b/tests/codegen/llvm/count_cast_loop_stack_key.ll
@@ -8,7 +8,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr }
 %"struct map_t.3" = type { ptr, ptr, ptr, ptr }
-%stack_key = type { i64, i32 }
+%kstack_key = type { i64, i32 }
 %kstack_count_t__tuple_t = type { [12 x i8], i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
@@ -27,11 +27,11 @@ entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
-  %stack_key = alloca %stack_key, align 8
+  %stack_key = alloca %kstack_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
-  %1 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  %1 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
   store i64 0, ptr %1, align 8
-  %2 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  %2 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
   store i32 0, ptr %2, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
   store i32 0, ptr %lookup_stack_scratch_key, align 4
@@ -60,11 +60,11 @@ lookup_stack_scratch_merge:                       ; preds = %entry
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
   %4 = udiv i32 %get_stack, 8
-  %5 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 1
+  %5 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
   store i32 %4, ptr %5, align 4
   %6 = trunc i32 %4 to i8
   %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %6, i64 1)
-  %7 = getelementptr %stack_key, ptr %stack_key, i64 0, i32 0
+  %7 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
   store i64 %murmur_hash_2, ptr %7, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_raw_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block

--- a/tests/codegen/llvm/count_cast_loop_stack_key.ll
+++ b/tests/codegen/llvm/count_cast_loop_stack_key.ll
@@ -9,7 +9,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.2" = type { ptr, ptr }
 %"struct map_t.3" = type { ptr, ptr, ptr, ptr }
 %kstack_key = type { i64, i32 }
-%kstack_count_t__tuple_t = type { [12 x i8], i64 }
+%kstack_count_t__tuple_t = type { %kstack_key, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -671,3 +671,13 @@ WILL_FAIL
 NAME clear on scalar map prevents printing
 PROG BEGIN { @xx = 5; clear(@xx); exit() }
 EXPECT_NONE @xx: 5
+
+NAME ustack len
+PROG u:./testprogs/uprobe_loop:uprobeFunction1 { $x = ustack(3); @ = len($x); exit(); }
+EXPECT @: 3
+AFTER ./testprogs/uprobe_loop
+
+NAME kstack len
+PROG k:do_nanosleep { @ = len(kstack); exit() }
+EXPECT_REGEX @: \d+$
+AFTER ./testprogs/syscall nanosleep  1e8

--- a/tests/runtime/pid_namespace
+++ b/tests/runtime/pid_namespace
@@ -25,6 +25,9 @@ EXPECT_REGEX         uprobeFunction1\+\d+$
 MIN_KERNEL 6.12
 
 # Target inside a PID namespace, bpftrace outside
+# This test assumes we're starting in the init-namespace, which
+# might not be true (e.g. on WSL2), so we skip it if that's not
+# the case.
 NAME ustack_outside
 RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_loop:uprobeFunction1 { print(ustack); exit(); }'
 AFTER unshare --fork --pid --mount-proc bash -c ./testprogs/uprobe_loop
@@ -33,3 +36,4 @@ EXPECT_REGEX         uprobeFunction1\+\d+$
                      main\+\d+$
 # See above
 MIN_KERNEL 6.12
+REQUIRES [ "$(stat -Lc %i /proc/1/ns/pid)" -eq "$((0xeffffffc))" ]

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1106,6 +1106,8 @@ TEST(semantic_analyser, call_len)
   test("kprobe:f { @x[0] = 0; len(@x, 1); }", 1);
   test("kprobe:f { @x[0] = 0; len(@x[2]); }", 1);
   test("kprobe:f { $x = 0; len($x); }", 1);
+  test("kprobe:f { len(ustack) }");
+  test("kprobe:f { len(kstack) }");
 }
 
 TEST(semantic_analyser, call_has_key)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1108,6 +1108,11 @@ TEST(semantic_analyser, call_len)
   test("kprobe:f { $x = 0; len($x); }", 1);
   test("kprobe:f { len(ustack) }");
   test("kprobe:f { len(kstack) }");
+  test_error("kprobe:f { len(0) }", R"(
+stdin:1:12-18: ERROR: len() expects a map or stack to be provided
+kprobe:f { len(0) }
+           ~~~~~~
+)");
 }
 
 TEST(semantic_analyser, call_has_key)


### PR DESCRIPTION
Allow calls to `len()` with stack arguments as a way to count the stack frames (#3767).

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
