### PR TITLE
ci: Bring back nix caching

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -14,9 +14,17 @@ jobs:
   build-and-upload:
     runs-on: ubuntu-latest
 
+    # For flakehub cache
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@v11
+    - uses: DeterminateSystems/nix-installer-action@v16
+      with:
+        determinate: true
+    - uses: DeterminateSystems/flakehub-cache-action@v1
 
     - name: Build appimage
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,27 @@ concurrency:
 jobs:
   clang-format:
     runs-on: ubuntu-latest
+    # For flakehub cache
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - uses: DeterminateSystems/nix-installer-action@v11
+    - uses: DeterminateSystems/nix-installer-action@v16
+      with:
+        determinate: true
+    - uses: DeterminateSystems/flakehub-cache-action@v1
     - name: clang-format
       run: nix develop --command git clang-format --diff origin/master
 
   build_test:
     runs-on: ubuntu-latest
+    # For flakehub cache
+    permissions:
+      id-token: write
+      contents: read
     continue-on-error: true
     strategy:
       matrix:
@@ -72,7 +83,10 @@ jobs:
           RUN_TESTS: 0
     steps:
     - uses: actions/checkout@v2
-    - uses: DeterminateSystems/nix-installer-action@v11
+    - uses: DeterminateSystems/nix-installer-action@v16
+      with:
+        determinate: true
+    - uses: DeterminateSystems/flakehub-cache-action@v1
     - uses: ./.github/actions/configure_kvm
     - name: Load kernel modules
       # nf_tables and xfs are necessary for testing kernel modules BTF support

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,8 @@ jobs:
       actions: read
       contents: read
       security-events: write
+      # For flakehub cache
+      id-token: write
 
     strategy:
       fail-fast: false
@@ -33,7 +35,10 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: DeterminateSystems/nix-installer-action@v11
+      - uses: DeterminateSystems/nix-installer-action@v16
+        with:
+          determinate: true
+      - uses: DeterminateSystems/flakehub-cache-action@v1
 
       - name: Configure (cpp)
         if: ${{ matrix.language == 'cpp' }}

--- a/.github/workflows/flakehub.yml
+++ b/.github/workflows/flakehub.yml
@@ -1,0 +1,35 @@
+# This job pushes tagged releases to flakehub.
+
+name: Flakehub
+
+on:
+  push:
+    tags:
+      - v?[0-9]+.[0-9]+.[0-9]+*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: The existing tag to publish to FlakeHub
+        type: string
+        required: true
+
+jobs:
+  flakehub-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ (inputs.tag != null) && format('refs/tags/{0}', inputs.tag) || '' }}
+      - uses: DeterminateSystems/nix-installer-action@v16
+        with:
+          determinate: true
+      - uses: DeterminateSystems/flakehub-cache-action@v1
+      - uses: DeterminateSystems/flakehub-push@v5
+        with:
+          visibility: public
+          name: bpftrace/bpftrace
+          tag: ${{ inputs.tag }}
+          include-output-paths: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,16 +7,20 @@ on:
   release:
     types: [published]
 
-permissions:
-  contents: write
-
 jobs:
   build-upload:
     runs-on: ubuntu-latest
+    permissions:
+      # For flakehub cache
+      id-token: write
+      # For artifact upload
+      contents: write
     steps:
     - uses: actions/checkout@v3
-    - uses: DeterminateSystems/nix-installer-action@v11
-
+    - uses: DeterminateSystems/nix-installer-action@v16
+      with:
+        determinate: true
+    - uses: DeterminateSystems/flakehub-cache-action@v1
     - name: Build artifacts
       run: nix develop --command bash -c "OUT=./assets ./scripts/create-assets.sh"
 

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -17,9 +17,14 @@ jobs:
       actions: read
       contents: read
       pull-requests: write
+      # For flakehub cache
+      id-token: write
 
     steps:
       - uses: actions/checkout@v3
-      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/nix-installer-action@v16
+        with:
+          determinate: true
+      - uses: DeterminateSystems/flakehub-cache-action@v1
       - name: Run clang-tidy
         run: ./scripts/clang_tidy.sh


### PR DESCRIPTION
Due to GHA changing the cache API [0], we had to delete the magic-nix-cache-action. As a result, we saw about a 20% regression in CI times.

Now that we have access to the open source tier of flakehub cache, let's bring it back. Flakehub cache is a bit more interesting than GHA cache as developers/users can potentially connect to it and access a pre-warmed cache built from CI.

[0]: https://determinate.systems/posts/magic-nix-cache-free-tier-eol/

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
