### PR TITLE
nix: Slim down appimage

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,10 @@
           # Override to specify the bcc build we want.
           # First overrides with the above libbpf and then overrides the rev.
           bccVersion = "0.33.0";
-          bcc = (pkgs.bcc.override { libbpf = libbpf; }).overridePythonAttrs {
+          bcc = (pkgs.bcc.override {
+            libbpf = libbpf;
+            llvmPackages = pkgs."llvmPackages_${toString defaultLlvmVersion}";
+          }).overridePythonAttrs {
             version = bccVersion;
             src = pkgs.fetchFromGitHub {
               owner = "iovisor";


### PR DESCRIPTION
This brings down appimage size from 215M -> 169M by removing a a separate LLVM toolchain that bcc uses. Just make it use our default one instead of a potentially different one.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
