### PR TITLE
bash-completion: directly specifies the script

### DIFF
--- a/scripts/bash-completion/bpftrace
+++ b/scripts/bash-completion/bpftrace
@@ -13,7 +13,7 @@ _bpftrace_filedir()
 
 _bpftrace()
 {
-  local cur prev words
+  local cur prev words argument
 
   _init_completion -- "$@" || return
 
@@ -21,6 +21,10 @@ _bpftrace()
                   --usdt-file-activation --unsafe -q --info -k -kk
                   -V --version --no-warnings -v --dry-run -d
                   --emit-elf --emit-llvm'
+
+  if [[ $cur == -* ]]; then
+    argument=$cur
+  fi
 
   case ${prev} in
   -B)
@@ -57,10 +61,15 @@ _bpftrace()
     ;;
   esac
 
-  # Just drop -e content completion, because it's very complex.
-  if ([[ ${cur} == -* ]] || [[ -z ${cur} ]]) && [[ ${prev} != -e ]]; then
-    COMPREPLY=( $(compgen -W "${all_args}" -- ${cur}) )
-    return
+  # bpftrace directly specifies the script, like: bpftrace a.bt
+  if [[ ! ${argument} ]]; then
+    _bpftrace_filedir
+  else
+    # Just drop -e content completion, because it's very complex.
+    if ([[ ${cur} == -* ]] || [[ -z ${cur} ]]) && [[ ${prev} != -e ]]; then
+      COMPREPLY=( $(compgen -W "${all_args}" -- ${cur}) )
+      return
+    fi
   fi
 }
 


### PR DESCRIPTION
bpftrace directly specifies the script, like:

    $ sudo bpftrace tools/[tab]
    bashreadline.bt             mdflush_example.txt         syscount.bt
    bashreadline_example.txt    naptime.bt                  syscount_example.txt
    biolatency.bt               naptime_example.txt         tcpaccept.bt
    biolatency_example.txt      old/                        tcpaccept_example.txt
    ...

    $ sudo bpftrace tools/open[tab]
    $ sudo bpftrace tools/opensnoop[tab]
    opensnoop.bt           opensnoop_example.txt
    $ sudo bpftrace tools/opensnoop.[tab]
    $ sudo bpftrace tools/opensnoop.bt

If you want to complete an optional parameter, you need to type a '-' and then press [tab]:

    $ sudo bpftrace -[tab]
    -B                      --help                  -p
    -c                      -I                      -q
    -d                      --include               --unsafe
    --dry-run               --info                  --usdt-file-activation
    -e                      -k                      -v
    --emit-elf              -kk                     -V
    --emit-llvm             -l                      --version
    -f                      --no-warnings
    -h                      -o
