### PR TITLE
Accept block expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
   - [#3811](https://github.com/bpftrace/bpftrace/pull/3811)
 - Add support for LLVM 20
   - [#3841](https://github.com/bpftrace/bpftrace/pull/3841)
+- Add simple block expressions
+  - [#3780](https://github.com/bpftrace/bpftrace/pull/3780)
 #### Changed
 - `probe` builtin is now represented as a string type
   - [#3638](https://github.com/bpftrace/bpftrace/pull/3638)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -730,6 +730,21 @@ Scratch variables must be initialized before using these operators.
 
 Note `{plus}{plus}`/`--` on a shared global variable can lose updates. See <<map-functions-count, `count()`>> for more details.
 
+==== Block Expressions
+
+A block can be used as expression, as long as the last statement of the block
+is an expression with no trailing semi-colon.
+
+```
+let $a = {
+  let $b = 1;
+  $b
+};
+// $a is 1
+```
+
+This can be used anywhere an expression can be used.
+
 === Preamble
 
 Preprocessor and type definitions take place in the preamble:

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -361,11 +361,18 @@ public:
   Expression *expr = nullptr;
 };
 
-class Block : public Statement {
+class Block : public Expression {
 public:
   Block(Diagnostics &d, StatementList &&stmts, Location &&loc);
+  Block(Diagnostics &d,
+        StatementList &&stmts,
+        Expression *expr,
+        Location &&loc);
 
   StatementList stmts;
+  // Depending on how it is parsed, a block can also be evaluated as an
+  // expression. This follows all other statements in the block.
+  Expression *expr = nullptr;
 };
 
 class If : public Statement {

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2692,11 +2692,11 @@ ScopedExpr CodegenLLVM::visit(AttachPoint &)
 ScopedExpr CodegenLLVM::visit(Block &block)
 {
   scope_stack_.push_back(&block);
-  for (Statement *stmt : block.stmts)
-    visit(*stmt);
+  visit(block.stmts);
+  ScopedExpr value = visit(block.expr);
   scope_stack_.pop_back();
 
-  return ScopedExpr();
+  return value;
 }
 
 void CodegenLLVM::generateProbe(Probe &probe,

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3446,7 +3446,11 @@ void SemanticAnalyser::visit(Block &block)
 {
   scope_stack_.push_back(&block);
   accept_statements(block.stmts);
+  visit(block.expr);
   scope_stack_.pop_back();
+  if (block.expr) {
+    block.type = block.expr->type;
+  }
 }
 
 void SemanticAnalyser::visit(Probe &probe)

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -196,6 +196,7 @@ public:
   R visit(Block &block)
   {
     visitImpl(block.stmts);
+    visitAndReplace(&block.expr);
     return default_value();
   }
   R visit(Subprog &subprog)
@@ -328,7 +329,8 @@ public:
                               ArrayAccess *,
                               Cast *,
                               Tuple *,
-                              Ternary *>(expr);
+                              Ternary *,
+                              Block *>(expr);
   }
   R visitAndReplace(Statement **stmt)
   {
@@ -338,7 +340,6 @@ public:
                               AssignMapStatement *,
                               AssignVarStatement *,
                               AssignConfigVarStatement *,
-                              Block *,
                               If *,
                               Unroll *,
                               Jump *,

--- a/tests/codegen/block_expression.cpp
+++ b/tests/codegen/block_expression.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, block_expression)
+{
+  test("kprobe:f { $a = { let $b = 4; $b } }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/block_expression_complex.cpp
+++ b/tests/codegen/block_expression_complex.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, block_expression_complex)
+{
+  test("kprobe:f { @x = { let $p = pid; avg(pid) } }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/block_expression_cond.cpp
+++ b/tests/codegen/block_expression_cond.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, block_expression_cond)
+{
+  test("kprobe:f { if ({ let $a = true; $a }) { exit() } }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/block_expression.ll
+++ b/tests/codegen/llvm/block_expression.ll
@@ -1,0 +1,84 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+entry:
+  %"$a" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
+  store i64 0, ptr %"$a", align 8
+  %"$b" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$b")
+  store i64 0, ptr %"$b", align 8
+  store i64 4, ptr %"$b", align 8
+  %1 = load i64, ptr %"$b", align 8
+  store i64 %1, ptr %"$a", align 8
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/llvm/block_expression_complex.ll
+++ b/tests/codegen/llvm/block_expression_complex.ll
@@ -1,0 +1,144 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%avg_stas_val = type { i64, i64 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
+@num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !52
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !57 {
+entry:
+  %avg_struct = alloca %avg_stas_val, align 8
+  %"@x_key" = alloca i64, align 8
+  %"$p" = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$p")
+  store i32 0, ptr %"$p", align 4
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  store i32 %pid, ptr %"$p", align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
+  store i64 0, ptr %"@x_key", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %2 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %2 to i32
+  %3 = zext i32 %pid2 to i64
+  %lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %4 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %5 = load i64, ptr %4, align 8
+  %6 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %7 = load i64, ptr %6, align 8
+  %8 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 0
+  %9 = add i64 %5, %3
+  store i64 %9, ptr %8, align 8
+  %10 = getelementptr %avg_stas_val, ptr %lookup_elem, i64 0, i32 1
+  %11 = add i64 1, %7
+  store i64 %11, ptr %10, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %avg_struct)
+  %12 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 0
+  store i64 %3, ptr %12, align 8
+  %13 = getelementptr %avg_stas_val, ptr %avg_struct, i64 0, i32 1
+  store i64 1, ptr %13, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %avg_struct, i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %avg_struct)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!54}
+!llvm.module.flags = !{!56}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 160, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 5, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 1, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !22)
+!22 = !{!23, !24}
+!23 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !18, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !25, size: 64, offset: 64)
+!25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !11, !49, !51}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !50, size: 64, offset: 128)
+!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !25, size: 64)
+!51 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
+!53 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!54 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !55)
+!55 = !{!0, !26, !40, !52}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !54, retainedNodes: !62)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!18, !60}
+!60 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !61, size: 64)
+!61 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !57, file: !2, type: !60)

--- a/tests/codegen/llvm/block_expression_cond.ll
+++ b/tests/codegen/llvm/block_expression_cond.ll
@@ -1,0 +1,125 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+%exit_t = type <{ i64, i8 }>
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+entry:
+  %key = alloca i32, align 4
+  %exit = alloca %exit_t, align 8
+  %"$a" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
+  store i64 0, ptr %"$a", align 8
+  store i64 1, ptr %"$a", align 8
+  %1 = load i64, ptr %"$a", align 8
+  %true_cond = icmp ne i64 %1, 0
+  br i1 %true_cond, label %if_body, label %if_end
+
+if_body:                                          ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
+  %2 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
+  store i64 30000, ptr %2, align 8
+  %3 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
+  store i8 0, ptr %3, align 1
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+if_end:                                           ; preds = %deadcode, %entry
+  ret i64 0
+
+event_loss_counter:                               ; preds = %if_body
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
+  store i32 0, ptr %key, align 4
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %if_body
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %exit)
+  ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %4 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
+  br label %counter_merge
+
+deadcode:                                         ; No predecessors!
+  br label %if_end
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -330,3 +330,7 @@ NAME exit code
 PROG BEGIN { exit(69); }
 RETURN_CODE 69
 TIMEOUT 1
+
+NAME block expression
+PROG BEGIN { let $a = { let $b = 1; $b }; print($a); exit(); }
+EXPECT 1

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -683,3 +683,7 @@ NAME kstack len
 PROG k:do_nanosleep { @ = len(kstack); exit() }
 EXPECT_REGEX @: \d+$
 AFTER ./testprogs/syscall nanosleep  1e8
+
+NAME block expression with map assignment
+PROG BEGIN { @ = { let $a = 100; avg($a) }; exit(); }
+EXPECT @: 100

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4896,4 +4896,28 @@ TEST(semantic_analyser, no_maximum_passes)
        "@c = @b; @b = @a; } interval:s:1 { @a = 1; }");
 }
 
+TEST(semantic_analyser, block_expressions)
+{
+  // Illegal, check that variable is not available
+  test_error("BEGIN { let $x = { let $y = $x; $y }; print($x) }", R"(
+stdin:1:29-31: ERROR: Undefined or undeclared variable: $x
+BEGIN { let $x = { let $y = $x; $y }; print($x) }
+                            ~~
+)");
+
+  // Good, variable is not shadowed
+  test("BEGIN { let $x = { let $x = 1; $x }; print($x) }", R"(
+Program
+ BEGIN
+  decl
+   variable: $x :: [int64]
+   decl
+    variable: $x :: [int64]
+    int: 1 :: [int64]
+   variable: $x :: [int64]
+  call: print
+   variable: $x :: [int64]
+)");
+}
+
 } // namespace bpftrace::test::semantic_analyser


### PR DESCRIPTION
These are a specific form of blocks (e.g. `{ ... } `) which are
terminated by an expression that has no semi-value. They are accepted
anywhere that an expression is accepted.

When assigned to a map, block expressions will automatically propagate
the map semantics to the final statement in the expression.

An example of a block expression:
```
BEGIN { $y = 0; @x = { $z = 1; $z }; @a = @x ? { let $c = $y; $c+5 } : { let $b = 4; $b }; exit() }
```

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
