### PR TITLE
CI: do not build ASAN for LLVM <=16

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -45,6 +45,7 @@ NIX_TARGET_KERNEL = os.environ.get("NIX_TARGET_KERNEL", "")
 TOOLS_TEST_OLDVERSION = os.environ.get("TOOLS_TEST_OLDVERSION", "")
 TOOLS_TEST_DISABLE = os.environ.get("TOOLS_TEST_DISABLE", "")
 AOT_ALLOWLIST_FILE = os.environ.get("AOT_ALLOWLIST_FILE", "")
+BUILD_ASAN = os.environ.get("BUILD_ASAN", "1")
 
 
 class TestStatus(Enum):
@@ -161,12 +162,12 @@ def configure():
         f"-DCMAKE_C_COMPILER={CC}",
         f"-DCMAKE_CXX_COMPILER={CXX}",
         f"-DCMAKE_BUILD_TYPE={CMAKE_BUILD_TYPE}",
+        f"-DBUILD_ASAN={BUILD_ASAN}",
 
         # Static configs
         f"-DCMAKE_VERBOSE_MAKEFILE=1",
         f"-DBUILD_TESTING=1",
         f"-DENABLE_SKB_OUTPUT=1",
-        f"-DBUILD_ASAN=1",
     ]
     # fmt: on
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,12 +38,15 @@ jobs:
         - NAME: LLVM 14
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm14
+          BUILD_ASAN: 0
         - NAME: LLVM 15
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm15
+          BUILD_ASAN: 0
         - NAME: LLVM 16
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm16
+          BUILD_ASAN: 0
         - NAME: LLVM 17
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm17


### PR DESCRIPTION
While working on #3772, I ran into what looks like a memleak in older LLVM versions.

It looks like LLVM versions <=16 contain a memleak in `DIBuilder` which only manifests when creating debug info for kfuncs. We now only have a single kfunc (`bpf_map_sum_elem_count`) which is only used for LLVM >=17 so the issue did not appear, yet, however, adding new kfuncs will trigger it.

It looks like this is a bug in older LLVM versions so the simplest thing for us is to disable ASAN on these versions.

This adds a new CI env variable `BUILD_ASAN` (turned on by default) which allows to disable ASAN for specific jobs.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
