### PR TITLE
Fix warning about multi-line comments

### DIFF
--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -402,7 +402,7 @@ void ResourceAnalyser::visit(AssignMapStatement &assignment)
 {
   // CodegenLLVM traverses the AST like:
   //      AssignmentMapStatement a
-  //        /                    \
+  //        |                    |
   //    visit(a.expr)        visit(a.map.key_expr)
   //
   // CodegenLLVM avoid traversing into the map node via visit(a.map)
@@ -410,9 +410,9 @@ void ResourceAnalyser::visit(AssignMapStatement &assignment)
   //
   // However, ResourceAnalyser traverses the AST differently:
   //      AssignmentMapStatement a
-  //        /                    \
+  //        |                    |
   //    visit(a.expr)        visit(a.map)
-  //                               \
+  //                               |
   //                           visit(a.map.key_expr)
   //
   // Unfortunately, calling ResourceAnalser::visit(a.map) will trigger


### PR DESCRIPTION
ae4322fb ("cleanup: standardize comment style") triggered some new build warnings:

```
[63/105] Building CXX object src/ast/CMakeFiles/ast.dir/passes/resource_analyser.cpp.o
/home/dxu/dev/bpftrace/src/ast/passes/resource_analyser.cpp:405:3: warning: multi-line comment [-Wcomment]
  405 |   //        /                    \
      |   ^
/home/dxu/dev/bpftrace/src/ast/passes/resource_analyser.cpp:413:3: warning: multi-line comment [-Wcomment]
  413 |   //        /                    \
      |   ^
/home/dxu/dev/bpftrace/src/ast/passes/resource_analyser.cpp:415:3: warning: multi-line comment [-Wcomment]
  415 |   //                               \
      |   ^
```

Fix by switching to an uglier character :(

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
