### PR TITLE
Nix-ify blazesym

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to
   - [#3656](https://github.com/bpftrace/bpftrace/pull/3656)
 - `len` now also accepts `ustack` and `kstack` as arguments
   - [#3769](https://github.com/bpftrace/bpftrace/pull/3769)
-- `blazesym` can now be used for kernel address symbolication, if configured & built with `USE_BLAZESYM`
+- `blazesym` will be used for kernel address symbolication if found during build
   - [#3760](https://github.com/bpftrace/bpftrace/pull/3760)
+  - [#3787](https://github.com/bpftrace/bpftrace/pull/3787)
 - Published aarch64 appimage builds from master
   - [#3795](https://github.com/bpftrace/bpftrace/pull/3795)
 #### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ set(BUILD_TESTING ON CACHE BOOL "Build test suite")
 set(ENABLE_TEST_VALIDATE_CODEGEN ON CACHE BOOL "Run LLVM IR validation tests")
 set(BUILD_FUZZ OFF CACHE BOOL "Build bpftrace for fuzzing")
 set(USE_LIBFUZZER OFF CACHE BOOL "Use libfuzzer for fuzzing")
-set(USE_BLAZESYM OFF CACHE BOOL "Use blazesym for symbolization matters")
 set(FUZZ_TARGET "codegen" CACHE STRING "Fuzzing target")
 set(ENABLE_SYSTEMD OFF CACHE BOOL "Enable systemd integration")
 set(KERNEL_HEADERS_DIR "" CACHE PATH "Hard-code kernel headers directory")
@@ -133,6 +132,8 @@ if(ENABLE_SYSTEMD)
   pkg_check_modules(libsystemd REQUIRED IMPORTED_TARGET libsystemd)
 endif()
 
+find_package(LibBlazesym)
+
 if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)
 endif()
@@ -210,6 +211,10 @@ endif(HAVE_LIBBPF_UPROBE_MULTI)
 
 if(ENABLE_SYSTEMD)
   set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_LIBSYSTEMD)
+endif()
+
+if(LIBBLAZESYM_FOUND)
+  set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_BLAZESYM)
 endif()
 
 add_subdirectory(src)

--- a/cmake/FindLibBlazesym.cmake
+++ b/cmake/FindLibBlazesym.cmake
@@ -1,0 +1,29 @@
+# - Try to find libblazesym
+# Once done this will define
+#
+#  LIBBLAZESYM_FOUND - system has libblazesym
+#  LIBBLAZESYM_INCLUDE_DIRS - the libblazesym include directory
+#  LIBBLAZESYM_LIBRARIES - Link these to use libblazesym
+#
+
+
+find_path (LIBBLAZESYM_INCLUDE_DIRS
+  NAMES
+    blazesym.h
+  PATHS
+    ENV CPATH)
+
+find_library (LIBBLAZESYM_LIBRARIES
+  NAMES
+    blazesym_c
+  PATHS
+    ENV LIBRARY_PATH
+    ENV LD_LIBRARY_PATH)
+
+include (FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibBlazesym "Please install the libblazesym development package"
+  LIBBLAZESYM_LIBRARIES
+  LIBBLAZESYM_INCLUDE_DIRS)
+
+mark_as_advanced(LIBBLAZESYM_INCLUDE_DIRS LIBBLAZESYM_LIBRARIES)

--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,23 @@
         "type": "github"
       }
     },
+    "blazesym": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739543304,
+        "narHash": "sha256-9kJdqi1lCi+rk/X4/9O0foo+tJf9tcYS4tTKcu/ICFU=",
+        "owner": "libbpf",
+        "repo": "blazesym",
+        "rev": "6beb39ebc8e3a604c7b483951c85c831c1bbe0d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "libbpf",
+        "repo": "blazesym",
+        "rev": "6beb39ebc8e3a604c7b483951c85c831c1bbe0d1",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -48,6 +65,26 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "naersk": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1736429655,
+        "narHash": "sha256-BwMekRuVlSB9C0QgwKMICiJ5EVbLGjfe4qyueyNQyGI=",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "0621e47bd95542b8e1ce2ee2d65d6a1f887a13ce",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "naersk",
         "type": "github"
       }
     },
@@ -96,7 +133,9 @@
     },
     "root": {
       "inputs": {
+        "blazesym": "blazesym",
         "flake-utils": "flake-utils",
+        "naersk": "naersk",
         "nix-appimage": "nix-appimage",
         "nixpkgs": "nixpkgs"
       }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,6 +102,7 @@ if (USE_BLAZESYM)
 endif()
 
 install(TARGETS ${BPFTRACE} DESTINATION ${CMAKE_INSTALL_BINDIR})
+target_compile_definitions(${BPFTRACE} PRIVATE ${BPFTRACE_FLAGS})
 target_link_libraries(${BPFTRACE} libbpftrace)
 
 if (BUILD_FUZZ)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,36 +69,10 @@ add_executable(${BPFTRACE}
   ${MAIN_SRC}
 )
 
-# TODO: Add support for using "system" blazesym and linking dynamically. Then,
-#       also honor `STATIC_LINKING` properly.
-if (USE_BLAZESYM)
-  include(FetchContent)
-  set(FETCHCONTENT_QUIET TRUE)
-
-  FetchContent_Declare(
-      Corrosion
-      GIT_REPOSITORY https://github.com/corrosion-rs/corrosion.git
-      GIT_TAG v0.5.1
-  )
-  FetchContent_MakeAvailable(Corrosion)
-
-  FetchContent_Declare(
-    blazesym
-    GIT_REPOSITORY https://github.com/libbpf/blazesym.git
-    GIT_TAG 6beb39ebc8e3a604c7b483951c85c831c1bbe0d1
-  )
-  FetchContent_MakeAvailable(blazesym)
-
-  corrosion_import_crate(
-    MANIFEST_PATH ${blazesym_SOURCE_DIR}/Cargo.toml
-    CRATE_TYPES staticlib
-    CRATES blazesym-c
-  )
-
-  target_compile_definitions(runtime PRIVATE USE_BLAZESYM=${USE_BLAZESYM})
-  target_compile_definitions(${BPFTRACE} PRIVATE USE_BLAZESYM=${USE_BLAZESYM})
-  target_include_directories(runtime PRIVATE ${blazesym_SOURCE_DIR}/capi/include)
-  target_link_libraries(runtime blazesym_c)
+# TODO: Honor `STATIC_LINKING` properly.
+if(LIBBLAZESYM_FOUND)
+  target_include_directories(runtime PRIVATE ${LIBBLAZESYM_INCLUDE_DIRS})
+  target_link_libraries(runtime ${LIBBLAZESYM_LIBRARIES})
 endif()
 
 install(TARGETS ${BPFTRACE} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/aot/CMakeLists.txt
+++ b/src/aot/CMakeLists.txt
@@ -16,6 +16,7 @@ if(NOT LIBBCC_BPF_CONTAINS_RUNTIME)
 endif()
 
 add_executable(bpftrace-aotrt aot_main.cpp)
+target_compile_definitions(bpftrace-aotrt PRIVATE ${BPFTRACE_FLAGS})
 target_link_libraries(bpftrace-aotrt aot runtime arch ast ast_defs cxxdemangler_stdlib)
 install(TARGETS bpftrace-aotrt DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -15,7 +15,7 @@ Config::Config(bool has_cmd)
     { ConfigKeyBool::lazy_symbolication, { .value = false } },
     { ConfigKeyBool::probe_inline, { .value = false } },
     { ConfigKeyBool::print_maps_on_exit, { .value = true } },
-#ifndef USE_BLAZESYM
+#ifndef HAVE_BLAZESYM
     { ConfigKeyBool::use_blazesym, { .value = false } },
 #else
     { ConfigKeyBool::use_blazesym, { .value = true } },

--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -68,7 +68,7 @@ std::optional<std::string> Ksyms::resolve_blazesym_int(uint64_t addr,
   blaze_symbolize_src_kernel src = {
     .type_size = sizeof(src),
     // Use default system-wide kallsyms file.
-    .kallsyms = NULL,
+    .kallsyms = nullptr,
     // Disable discovery and usage of a vmlinux file.
     // TODO: We should eventually support that, incorporating discovery logic
     //       from find_vmlinux().
@@ -79,7 +79,7 @@ std::optional<std::string> Ksyms::resolve_blazesym_int(uint64_t addr,
 
   const blaze_syms *syms = blaze_symbolize_kernel_abs_addrs(
       symbolizer_, &src, addrs, ARRAY_SIZE(addrs));
-  if (syms == NULL)
+  if (syms == nullptr)
     return std::nullopt;
   SCOPE_EXIT
   {

--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -1,7 +1,7 @@
 #include <sstream>
 
 #include <bcc/bcc_syms.h>
-#ifdef USE_BLAZESYM
+#ifdef HAVE_BLAZESYM
 #include <blazesym.h>
 #endif
 
@@ -29,7 +29,7 @@ Ksyms::~Ksyms()
   if (ksyms_)
     bcc_free_symcache(ksyms_, -1);
 
-#ifdef USE_BLAZESYM
+#ifdef HAVE_BLAZESYM
   if (symbolizer_)
     blaze_symbolizer_free(symbolizer_);
 #endif
@@ -52,7 +52,7 @@ std::string Ksyms::resolve_bcc(uint64_t addr, bool show_offset)
   return stringify_addr(addr);
 }
 
-#ifdef USE_BLAZESYM
+#ifdef HAVE_BLAZESYM
 std::optional<std::string> Ksyms::resolve_blazesym_int(uint64_t addr,
                                                        bool show_offset)
 {
@@ -110,7 +110,7 @@ std::string Ksyms::resolve_blazesym(uint64_t addr, bool show_offset)
 
 std::string Ksyms::resolve(uint64_t addr, bool show_offset)
 {
-#ifdef USE_BLAZESYM
+#ifdef HAVE_BLAZESYM
   if (config_.get(ConfigKeyBool::use_blazesym))
     return resolve_blazesym(addr, show_offset);
 #endif

--- a/src/ksyms.h
+++ b/src/ksyms.h
@@ -20,7 +20,7 @@ private:
   const Config &config_;
   void *ksyms_{ nullptr };
 
-#ifdef USE_BLAZESYM
+#ifdef HAVE_BLAZESYM
   struct blaze_symbolizer *symbolizer_{ nullptr };
 
   std::optional<std::string> resolve_blazesym_int(uint64_t addr,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -339,7 +339,7 @@ static void parse_env(BPFtrace& bpftrace)
   });
 
   get_bool_env_var("BPFTRACE_USE_BLAZESYM", [&](bool x) {
-#ifndef USE_BLAZESYM
+#ifndef HAVE_BLAZESYM
     if (x) {
       LOG(ERROR) << "BPFTRACE_USE_BLAZESYM requires blazesym support enabled "
                     "during build.";


### PR DESCRIPTION
This PR builds blazesym in nix. With this, we get caching as well as a
distro friendly build.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
