### PR TITLE
Fix flaky tracepoint_multiattach_missing test

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -371,12 +371,12 @@ RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit\n"); }' -
 EXPECT hit
 
 NAME tracepoint_missing
-PROG t:syscalls:nonsense { printf("hit"); exit(); }
+PROG t:syscalls:nonsense { print("hit"); exit(); }
 EXPECT stdin:1:1-20: ERROR: tracepoint not found: syscalls:nonsense
 WILL_FAIL
 
 NAME tracepoint_multiattach_missing
-PROG t:syscalls:sys_exit_nanosleep,t:syscalls:nonsense { printf("hit"); exit(); }
+PROG t:syscalls:sys_exit_nanosleep,t:syscalls:nonsense { print("hit"); exit(); }
 EXPECT hit
 AFTER ./testprogs/syscall nanosleep 1e8
 WILL_FAIL
@@ -408,7 +408,7 @@ EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME rawtracepoint_missing
-PROG rawtracepoint:nonsense { printf("hit"); exit(); }
+PROG rawtracepoint:nonsense { print("hit"); exit(); }
 EXPECT ERROR: Probe does not exist: rawtracepoint:nonsense
 WILL_FAIL
 


### PR DESCRIPTION
This is because it was using printf, which
doesn't automatically insert a line break.
So sometimes the output would look like:
"hithit".

Also changed the other instances of printf("hit")
even though they are error cases.

This is the error in CI:
```
[  FAILED  ] probe.tracepoint_multiattach_missing (405 ms)
	Command: /home/runner/work/bpftrace/bpftrace/build-ci/src/bpftrace  -e 't:syscalls:sys_exit_nanosleep,t:syscalls:nonsense { printf("hit"); exit(); }'
	Expected: hit
	Found:
stdin:1:31-50: WARNING: tracepoint not found: syscalls:nonsense\nt:syscalls:sys_exit_nanosleep,t:syscalls:nonsense { printf("hit"); exit(); }\n                              ~~~~~~~~~~~~~~~~~~~\nAttaching 2 probes...\nopen(/sys/kernel/debug/tracing/events/syscalls/nonsense/id): No such file or directory\n__BPFTRACE_NOTIFY_PROBES_ATTACHED\nhithit\n\n
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
