### PR TITLE
vmtest oldest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
           NIX_TARGET: .#bpftrace-llvm19
           CC: clang
           CXX: clang++
+        - NAME: Oldest kernel (LLVM 19 Debug)
+          CMAKE_BUILD_TYPE: Debug
+          NIX_TARGET: .#bpftrace-llvm19
+          NIX_TARGET_KERNEL: .#kernel-5_4
         - NAME: Latest kernel (LLVM 19 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm19

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         - NAME: Oldest kernel (LLVM 19 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm19
-          NIX_TARGET_KERNEL: .#kernel-5_4
+          NIX_TARGET_KERNEL: .#kernel-5_10
         - NAME: Latest kernel (LLVM 19 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm19

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         - NAME: Oldest kernel (LLVM 19 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm19
-          NIX_TARGET_KERNEL: .#kernel-5_10
+          NIX_TARGET_KERNEL: .#kernel-5_15
         - NAME: Latest kernel (LLVM 19 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm19

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,56 +24,13 @@ jobs:
     strategy:
       matrix:
         env:
-        - NAME: LLVM 14
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm14
-        - NAME: LLVM 15
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm15
-        - NAME: LLVM 16
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm16
-        - NAME: LLVM 17
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm17
-        - NAME: LLVM 18
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm18
-        - NAME: LLVM 19 Release
-          CMAKE_BUILD_TYPE: Release
-          NIX_TARGET: .#bpftrace-llvm19
         - NAME: LLVM 19 Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm19
-        - NAME: LLVM 19 Clang Debug
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm19
-          CC: clang
-          CXX: clang++
         - NAME: Oldest kernel (LLVM 19 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm19
           NIX_TARGET_KERNEL: .#kernel-5_15
-        - NAME: Latest kernel (LLVM 19 Debug)
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm19
-          NIX_TARGET_KERNEL: .#kernel-6_12
-        - NAME: AOT (LLVM 19 Debug)
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm19
-          RUN_TESTS: 0
-          RUN_AOT_TESTS: 1
-          AOT_SKIPLIST_FILE: .github/include/aot_skip.txt
-        - NAME: Memleak test (LLVM 19 Debug)
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm19
-          RUN_MEMLEAK_TEST: 1
-          RUN_TESTS: 0
-        - NAME: Memleak test (LLVM 19 Release)
-          CMAKE_BUILD_TYPE: Release
-          NIX_TARGET: .#bpftrace-llvm19
-          RUN_MEMLEAK_TEST: 1
-          RUN_TESTS: 0
     steps:
     - uses: actions/checkout@v2
     - uses: DeterminateSystems/nix-installer-action@v11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: DeterminateSystems/nix-installer-action@v11
     - uses: ./.github/actions/configure_kvm
-    - name: Load kernel modules
-      # nf_tables and xfs are necessary for testing kernel modules BTF support
-      run: |
-        sudo modprobe nf_tables
-        sudo modprobe xfs
     - name: Build and test
       env: ${{matrix.env}}
       run: ./.github/include/ci.py

--- a/flake.nix
+++ b/flake.nix
@@ -239,7 +239,7 @@
             };
 
             # Kernels to run runtime tests against
-            kernel-5_10 = mkKernel "5.10.234" "sha256:0l2396k5qqiqfzvrgqh8z2by1fkmx26rw9v1h8nafqw99q02w0wi";
+            kernel-5_15 = mkKernel "5.15.177" "sha256:0mp08m8m9fsck5asc1a2c09hv95dkfx3p1hq5qgxzixgzckp13q8";
             kernel-6_12 = mkKernel "6.12.12" "sha256:1inhcvz52n8p73x6iw7m68galqn0xib6xq1hyhf2s6c46my0bm30";
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -238,15 +238,9 @@
               ];
             };
 
-            # Kernels to run runtime tests against.
-            #
-            # Right now these just mirror the published kernels at
-            # https://github.com/bpftrace/kernels. Over time we'll firm up our
-            # kernel test policy.
-            kernel-5_15 = mkKernel "5.15" "sha256:05awbz25mbiy47zl7xvaf9c37zb6z71sk12flbqli7yppi7ryd13";
-            kernel-6_1 = mkKernel "6.1" "sha256:1b7bal1l8zy2fkr1dbp0jxsrzjas4yna78psj9bwwbs9qzrcf5m9";
-            kernel-6_6 = mkKernel "6.6" "sha256:19chnfwv84mc0anyf263vgg2x7sczypx8rangd34nf3sywb5cv5y";
-            kernel-6_12 = mkKernel "6.12" "sha256:1va2jx3w70gaiqxa8mfl3db7axk2viys8qf65l9qyjy024vn26ib";
+            # Kernels to run runtime tests against
+            kernel-5_4 = mkKernel "5.4.290" "sha256:0nfsx7c2vwj5syaais3y6d2mvngdn89vni652r5yvcqdlmjb13bl";
+            kernel-6_12 = mkKernel "6.12.12" "sha256:1inhcvz52n8p73x6iw7m68galqn0xib6xq1hyhf2s6c46my0bm30";
           };
 
           # Define apps that can be run with `nix run`

--- a/flake.nix
+++ b/flake.nix
@@ -239,7 +239,7 @@
             };
 
             # Kernels to run runtime tests against
-            kernel-5_4 = mkKernel "5.4.290" "sha256:0nfsx7c2vwj5syaais3y6d2mvngdn89vni652r5yvcqdlmjb13bl";
+            kernel-5_10 = mkKernel "5.10.234" "sha256:0l2396k5qqiqfzvrgqh8z2by1fkmx26rw9v1h8nafqw99q02w0wi";
             kernel-6_12 = mkKernel "6.12.12" "sha256:1inhcvz52n8p73x6iw7m68galqn0xib6xq1hyhf2s6c46my0bm30";
           };
 


### PR DESCRIPTION
Trying to understand the vmtest results for the oldest supported Kernel.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
