### PR TITLE
Nix: switch to unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,16 +80,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733511610,
-        "narHash": "sha256-GgkBDWJYObDbowLcbksXtkho4IncyTM6U6irbum6XpA=",
+        "lastModified": 1739451785,
+        "narHash": "sha256-3ebRdThRic9bHMuNi2IAA/ek9b32bsy8F5R4SvGTIog=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8b27a36b52d79a774bcda17dc1a2e9dad1bdce19",
+        "rev": "1128e89fd5e11bb25aedbfc287733c6502202ea9",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-24.11",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,10 +2,10 @@
   description = "High-level tracing language for Linux";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/release-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     nix-appimage = {
-      # We're maintaining a fork b/c upstream is missing support for 24.11
+      # We're maintaining a fork b/c upstream is missing support for unstable
       # and has also dropped the following feature we depend on:
       #   https://github.com/ralismark/nix-appimage/pull/9
       #

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1707,7 +1707,7 @@ Value *IRBuilderBPF::CreateStrcontains(Value *val1,
   std::optional<std::string> literal2 = ValToString(val2);
 
   if (literal1 && literal2) {
-    std::string s1 = literal1.value();
+    const std::string &s1 = literal1.value();
     std::string s2 = literal2.value();
     s2 = s2.substr(0, s2.size() - 1);
     std::size_t position = s1.find(s2);


### PR DESCRIPTION
The unstable Nix channel always contains the latest released LLVM, including (pre-)release candidates. Moving to unstable will allow us to test against new LLVM much earlier.

Fortunately, there are no issues with switching to unstable at the moment. If issues occur in future, it should be possible to only take a part of the packages (LLVM) from unstable.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
