### PR TITLE
[RFC] Introduce and document new release process

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -7,9 +7,61 @@ This document describes the bpftrace release process.
 We choose to follow semantic versioning. Note that this doesn't matter much for
 major version < 1 but will matter a lot for >= 1.0.0 releases.
 
-See https://semver.org/ .
+See https://semver.org/.
 
-## Branching model
+## Release cadence
+
+bpftrace is released twice a year. Since our biggest dependency, which also
+tends to break things, is LLVM, we align with the [LLVM release
+schedule](https://llvm.org/docs/HowToReleaseLLVM.html). In particular, a minor
+bpftrace release should happen **two weeks after a major LLVM release**.
+
+In addition, four weeks before the bpftrace release, we create a stabilized
+release branch, which will only receive bug fixes affecting the release itself.
+The branch will also serve as a target for future (post-release) bug fixes that
+should get into that minor release (by creating a new "patch" release).
+
+Overview of the release cadence is as follows:
+
+| Task                   | Approximate date                    | Details                                                              |
+| ---------------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| release branch created | **2 weeks before the LLVM release** | [Creating a release branch](#creating-a-release-branch)              |
+| LLVM release           | usually second Tuesday of Mar/Sep   | [LLVM release schedule](https://llvm.org/docs/HowToReleaseLLVM.html) |
+| bpftrace release       | **2 weeks after the LLVM release**  | [Tagging a release](#tagging-a-release)                              |
+
+## Creating a release branch
+
+A release branch should be created four weeks before the planned bpftrace
+release. From that moment, only relevant bug fixes should be backported to the
+branch.
+
+The purpose of this release branch is to give sufficient time to test features
+in the upcoming bpftrace release without blocking the development on the master
+branch.
+
+When creating a branch, the following steps should be performed. Any changes to
+the code should be done in the master branch first and then backported to the
+release branch. In the rare case when the master-first approach is not possible
+(e.g. a feature present exclusively on master blocks the LLVM update), the
+changes can be done in the release branch first and forward-ported to master
+afterwards.
+
+1. Create a new branch according to the [Branching model](#branching-model).
+1. Update Nixpkgs to the latest version to get the latest (pre-release) LLVM by
+   running
+   ```
+   nix flake update
+   ```
+   and committing the `flake.lock` changes to the repo. At this time, the `-rc2`
+   or `-rc3` version of LLVM should be available.
+1. Bump the supported LLVM version in [CMakeLists.txt](../CMakeLists.txt) and
+   [flake.nix](../flake.nix), resolve any potential issues, and add a CI job to
+   [.github/workflows/ci.yml](../.github/workflows/ci.yml) for the new version.
+1. Once the final LLVM is released and present in Nixpkgs (usually 2-5 days
+   after the LLVM release), repeat step 2 to get the released LLVM in the CI
+   environment.
+
+### Branching model
 
 There should be one release branch per "major release" (we are currently
 pre-1.0, "major" refers to semver minor version). The name should follow the
@@ -21,23 +73,26 @@ Example branch names:
     * release/1.0.x
     * release/1.1.x
 
-Backport PRs should be opened against the relevant release branch.
-
 ## Tagging a release
 
-You must do these things to formally release a version:
+You must do the following steps to formally release a version.
 
-1. Create a new release branch if one does not already exist.
-1. Mark the release in the CHANGELOG by replacing the `## Unreleased` header
-   with `## [VERSION] date`.
+In the release branch:
+
+1. Mark the release in [CHANGELOG.md](../CHANGELOG.md) by replacing the `##
+   Unreleased` header with `## [VERSION] date`.
 1. Update `bpftrace_VERSION_MAJOR`, `bpftrace_VERSION_MINOR`, and
-   `bpftrace_VERSION_PATCH` in `CMakeLists.txt` to the target version.
-1. Tag a release. We do this in the github UI by clicking "releases" (on same line
-   as "commits"), then "Draft a new release". The tag version and release title
-   should be the same and in `vX.Y.Z` format. The tag description should
-   be the same as what you added to `CHANGELOG.md`.
-1. Check that automation picks up the new release and uploads release assets
-   to the release.
-1. If automation fails, please fix the automation for next time and also manually
-   build+upload artifacts by running `scripts/create-assets.sh` from bpftrace root
-   dir and attach the generated archives to the release.
+   `bpftrace_VERSION_PATCH` in [CMakeLists.txt](../CMakeLists.txt) to the target
+   version.
+1. Tag a release. We do this in the github UI by clicking "releases" (on same
+   line as "commits"), then "Draft a new release". The tag version and release
+   title should be the same and in `vX.Y.Z` format. The tag description should
+   be the same as what you added to CHANGELOG.md.
+1. Check that automation picks up the new release and uploads release assets to
+   the release.
+1. If automation fails, please fix the automation for next time and also
+   manually build+upload artifacts by running `scripts/create-assets.sh` from
+   bpftrace root dir and attach the generated archives to the release.
+
+Once the release is out:
+1. Forward-port the CHANGELOG.md changes from the release branch to master.


### PR DESCRIPTION
This proposes a new release process for bpftrace.

The main features of the proposed process are:
- Releases are aligned with LLVM releases, happening two weeks after an LLVM major release.
- Release branch is cut four weeks before the release (two weeks before the LLVM release) to give sufficient time for testing the released features while not blocking master.

See the new `docs/release_process.md` for details (rendered [here](https://github.com/viktormalik/bpftrace/blob/release-process/docs/release_process.md)).

This depends on #3792 but there's no code dependency so the PRs can be merged in any order.

If we agree on this process, the next steps would be to:
- Agree on when the next release happens:
  - LLVM 20 is planned for March 11 which is quite close (we'd have to cut the release branch on Feb 25) but we'll want to have a release with LLVM 20 support so we will need at least a patch release anyways.
  - LLVM 21 is planned for mid-September, that would make bpftrace release end-of-September.
- Publish the schedule for the next release somewhere, preferably linked from the README (I'm thinking a new doc `docs/release_schedule.md`).

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
