### PR TITLE
Update blazesym snapshot

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,7 +85,7 @@ if (USE_BLAZESYM)
   FetchContent_Declare(
     blazesym
     GIT_REPOSITORY https://github.com/libbpf/blazesym.git
-    GIT_TAG ccc02c14cc79b86018d2f56764448fb86a984a2a
+    GIT_TAG 6beb39ebc8e3a604c7b483951c85c831c1bbe0d1
   )
   FetchContent_MakeAvailable(blazesym)
 

--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -69,10 +69,10 @@ std::optional<std::string> Ksyms::resolve_blazesym_int(uint64_t addr,
     .type_size = sizeof(src),
     // Use default system-wide kallsyms file.
     .kallsyms = NULL,
-    // Disable discovery and usage of kernel image.
+    // Disable discovery and usage of a vmlinux file.
     // TODO: We should eventually support that, incorporating discovery logic
     //       from find_vmlinux().
-    .kernel_image = "",
+    .vmlinux = "",
   };
 #pragma GCC diagnostic pop
   uint64_t addrs[1] = { addr };


### PR DESCRIPTION
Update the blazesym snapshot we use. This version includes a new API for caching process VMA metadata (https://github.com/libbpf/blazesym/pull/991), which we will require for user space address symbolization. With this version we also include the Cargo.lock, which is required for the ongoing nixification work (#3787).

All changes: https://github.com/libbpf/blazesym/compare/ccc02c14cc79b86018d2f56764448fb86a984a2a...6beb39ebc8e3a604c7b483951c85c831c1bbe0d1

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
