### PR TITLE
ci: binary: Upload aarch64 appimages

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -12,7 +12,10 @@ on:
 
 jobs:
   build-and-upload:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        runner: [ubuntu-latest, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.runner }}
 
     # For flakehub cache
     permissions:
@@ -34,5 +37,5 @@ jobs:
     - name: Upload appimage
       uses: actions/upload-artifact@v4
       with:
-        name: bpftrace
+        name: bpftrace-${{ runner.arch }}
         path: ./bpftrace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
   - [#3769](https://github.com/bpftrace/bpftrace/pull/3769)
 - `blazesym` can now be used for kernel address symbolication, if configured & built with `USE_BLAZESYM`
   - [#3760](https://github.com/bpftrace/bpftrace/pull/3760)
+- Published aarch64 appimage builds from master
+  - [#3795](https://github.com/bpftrace/bpftrace/pull/3795)
 #### Changed
 - `probe` builtin is now represented as a string type
   - [#3638](https://github.com/bpftrace/bpftrace/pull/3638)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -160,7 +160,7 @@ To download the official release artifacts, see the
 
 To download the bleeding edge AppImage, go to the
 [workflow page](https://github.com/bpftrace/bpftrace/actions/workflows/binary.yml)
-and select the latest run. You should find an uploaded artifact like below:
+and select the latest run. You should find an uploaded artifact(s) like below:
 
 <img src="./images/ci_appimage_artifact.png" width="40%" height="40%">
 


### PR DESCRIPTION
A long requested piece of infrastructure.

With this, we'll start publishing aarch64 appimages as well as x86-64
from master.

Tested on my fork: https://github.com/danobi/bpftrace/actions/runs/13335374551

The aarch64 appimage runs just fine on my aarch64 machine (finally got one).

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
