### PR TITLE
bpftrace: Store Config as a unique_ptr

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -563,7 +563,7 @@ CallInst *IRBuilderBPF::CreateGetStackScratchMap(StackType stack_type,
 Value *IRBuilderBPF::CreateGetStrAllocation(const std::string &name,
                                             const location &loc)
 {
-  const auto max_strlen = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
+  const auto max_strlen = bpftrace_.config_->get(ConfigKeyInt::max_strlen);
   const auto str_type = CreateArray(max_strlen, CreateInt8());
   return createAllocation(bpftrace::globalvars::GlobalVar::GET_STR_BUFFER,
                           GetType(str_type),
@@ -661,7 +661,7 @@ Value *IRBuilderBPF::createAllocation(
     std::optional<std::function<size_t(AsyncIds &)>> gen_async_id_cb)
 {
   const auto obj_size = module_.getDataLayout().getTypeAllocSize(obj_type);
-  const auto on_stack_limit = bpftrace_.config_.get(
+  const auto on_stack_limit = bpftrace_.config_->get(
       ConfigKeyInt::on_stack_limit);
   if (obj_size > on_stack_limit) {
     return CreatePointerCast(
@@ -683,7 +683,7 @@ Value *IRBuilderBPF::createScratchBuffer(
   // ValueType var[MAX_CPU_ID + 1][num_elements]
   auto type = globalvars::get_type(globalvar,
                                    bpftrace_.resources,
-                                   bpftrace_.config_);
+                                   *bpftrace_.config_);
 
   // Get CPU ID
   auto cpu_id = CreateGetCpuId(loc);

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -146,8 +146,8 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
   std::string &raw_ident = assignment.config_var;
 
   std::string err_msg;
-  const auto maybeConfigKey = bpftrace_.config_.get_config_key(raw_ident,
-                                                               err_msg);
+  const auto maybeConfigKey = bpftrace_.config_->get_config_key(raw_ident,
+                                                                err_msg);
 
   if (!maybeConfigKey.has_value()) {
     LOG(ERROR, assignment.loc, err_) << err_msg;

--- a/src/ast/passes/config_analyser.h
+++ b/src/ast/passes/config_analyser.h
@@ -21,7 +21,7 @@ public:
                           std::ostream &out = std::cerr)
       : Visitor<ConfigAnalyser>(ctx),
         bpftrace_(bpftrace),
-        config_setter_(ConfigSetter(bpftrace.config_, ConfigSource::script)),
+        config_setter_(ConfigSetter(*bpftrace.config_, ConfigSource::script)),
         out_(out)
   {
   }

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -295,7 +295,7 @@ void ResourceAnalyser::visit(Call &call)
   }
 
   if (call.func == "str" || call.func == "buf" || call.func == "path") {
-    const auto max_strlen = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
+    const auto max_strlen = bpftrace_.config_->get(ConfigKeyInt::max_strlen);
     if (exceeds_stack_limit(max_strlen))
       resources_.str_buffers++;
   }
@@ -443,7 +443,7 @@ void ResourceAnalyser::visit(Ternary &ternary)
   // blow it up. So we need a scratch buffer for it.
 
   if (ternary.type.IsStringTy()) {
-    const auto max_strlen = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
+    const auto max_strlen = bpftrace_.config_->get(ConfigKeyInt::max_strlen);
     if (exceeds_stack_limit(max_strlen))
       resources_.str_buffers++;
   }
@@ -479,7 +479,7 @@ void ResourceAnalyser::visit(VarDeclStatement &decl)
 
 bool ResourceAnalyser::exceeds_stack_limit(size_t size)
 {
-  return size > bpftrace_.config_.get(ConfigKeyInt::on_stack_limit);
+  return size > bpftrace_.config_->get(ConfigKeyInt::on_stack_limit);
 }
 
 bool ResourceAnalyser::uses_usym_table(const std::string &fun)

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -212,7 +212,7 @@ void SemanticAnalyser::visit(String &string)
   if (func_ == "printf" && func_arg_idx_ == 0)
     return;
 
-  auto str_len = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
+  auto str_len = bpftrace_.config_->get(ConfigKeyInt::max_strlen);
   if (!is_compile_time_func(func_) && string.str.size() > str_len - 1) {
     LOG(ERROR, string.loc, err_)
         << "String is too long (over " << str_len << " bytes): " << string.str;
@@ -443,11 +443,11 @@ void SemanticAnalyser::visit(Builtin &builtin)
     builtin.type.SetAS(find_addrspace(type));
   } else if (builtin.ident == "kstack") {
     builtin.type = CreateStack(true,
-                               StackType{ .mode = bpftrace_.config_.get(
+                               StackType{ .mode = bpftrace_.config_->get(
                                               ConfigKeyStackMode::default_) });
   } else if (builtin.ident == "ustack") {
     builtin.type = CreateStack(false,
-                               StackType{ .mode = bpftrace_.config_.get(
+                               StackType{ .mode = bpftrace_.config_->get(
                                               ConfigKeyStackMode::default_) });
   } else if (builtin.ident == "comm") {
     builtin.type = CreateString(COMM_SIZE);
@@ -492,7 +492,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
     for (auto *attach_point : probe->attach_points) {
       ProbeType type = probetype(attach_point->provider);
       if (type == ProbeType::uprobe &&
-          bpftrace_.config_.get(ConfigKeyBool::probe_inline))
+          bpftrace_.config_->get(ConfigKeyBool::probe_inline))
         LOG(ERROR, builtin.loc, err_)
             << "The " + builtin.ident + " builtin can only be used when "
             << "the probe_inline config is disabled.";
@@ -523,7 +523,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
             << "The " + builtin.ident
             << " builtin can only be used with 'kprobes' and 'uprobes' probes";
       if (type == ProbeType::uprobe &&
-          bpftrace_.config_.get(ConfigKeyBool::probe_inline))
+          bpftrace_.config_->get(ConfigKeyBool::probe_inline))
         LOG(ERROR, builtin.loc, err_)
             << "The " + builtin.ident + " builtin can only be used when "
             << "the probe_inline config is disabled.";
@@ -590,7 +590,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
     } else if (type == ProbeType::fentry || type == ProbeType::fexit ||
                type == ProbeType::uprobe) {
       if (type == ProbeType::uprobe &&
-          bpftrace_.config_.get(ConfigKeyBool::probe_inline))
+          bpftrace_.config_->get(ConfigKeyBool::probe_inline))
         LOG(ERROR, builtin.loc, err_)
             << "The args builtin can only be used when "
             << "the probe_inline config is disabled.";
@@ -892,7 +892,7 @@ void SemanticAnalyser::visit(Call &call)
             << "argument (" << t << " provided)";
       }
 
-      auto strlen = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
+      auto strlen = bpftrace_.config_->get(ConfigKeyInt::max_strlen);
 
       if (call.vargs.size() == 2 && check_arg(call, Type::integer, 1, false)) {
         auto &size_arg = *call.vargs.at(1);
@@ -938,7 +938,8 @@ void SemanticAnalyser::visit(Call &call)
     }
     has_pos_param_ = false;
   } else if (call.func == "buf") {
-    const uint64_t max_strlen = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
+    const uint64_t max_strlen = bpftrace_.config_->get(
+        ConfigKeyInt::max_strlen);
     if (max_strlen >
         std::numeric_limits<decltype(AsyncEvent::Buf::length)>::max()) {
       LOG(ERROR, call.loc, err_)
@@ -1424,7 +1425,7 @@ void SemanticAnalyser::visit(Call &call)
             << arg.type.GetTy() << " provided)";
       }
 
-      auto call_type_size = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
+      auto call_type_size = bpftrace_.config_->get(ConfigKeyInt::max_strlen);
       if (call.vargs.size() == 2) {
         if (check_arg(call, Type::integer, 1, true)) {
           auto size = bpftrace_.get_int_literal(call.vargs.at(1));
@@ -1648,7 +1649,7 @@ void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
   }
 
   StackType stack_type;
-  stack_type.mode = bpftrace_.config_.get(ConfigKeyStackMode::default_);
+  stack_type.mode = bpftrace_.config_->get(ConfigKeyStackMode::default_);
 
   switch (call.vargs.size()) {
     case 0:
@@ -3247,7 +3248,7 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       LOG(ERROR, ap.loc, err_) << "kprobes should be attached to a function";
     if (is_final_pass()) {
       // Warn if user tries to attach to a non-traceable function
-      if (bpftrace_.config_.get(ConfigKeyMissingProbes::default_) !=
+      if (bpftrace_.config_->get(ConfigKeyMissingProbes::default_) !=
               ConfigMissingProbes::ignore &&
           !has_wildcard(ap.func) && !bpftrace_.is_traceable_func(ap.func)) {
         LOG(WARNING, ap.loc, out_)

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -441,7 +441,7 @@ bool AttachedProbe::resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps)
     if (!sym.start) {
       const std::string msg = "Could not resolve symbol: " + probe_.path + ":" +
                               symbol;
-      auto missing_probes = bpftrace_.config_.get(
+      auto missing_probes = bpftrace_.config_->get(
           ConfigKeyMissingProbes::default_);
       if (!has_multiple_aps || missing_probes == ConfigMissingProbes::error) {
         throw FatalUserException(msg + ", cannot attach probe.");
@@ -612,7 +612,7 @@ void AttachedProbe::attach_kprobe()
   // If the user requested to ignore warnings on non-existing probes and the
   // function is not traceable, do not even try to attach as that would yield
   // warnings from BCC which we don't want to see.
-  if (bpftrace_.config_.get(ConfigKeyMissingProbes::default_) ==
+  if (bpftrace_.config_->get(ConfigKeyMissingProbes::default_) ==
           ConfigMissingProbes::ignore &&
       probe_.name != probe_.orig_name &&
       (funcname != "" || probe_.address != 0) &&
@@ -639,7 +639,7 @@ void AttachedProbe::attach_kprobe()
 
   if (perf_event_fd < 0) {
     if (probe_.orig_name != probe_.name &&
-        bpftrace_.config_.get(ConfigKeyMissingProbes::default_) ==
+        bpftrace_.config_->get(ConfigKeyMissingProbes::default_) ==
             ConfigMissingProbes::warn) {
       // a wildcard expansion couldn't probe something, just print a warning
       // as this is normal for some kernel functions (eg, do_debug())

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -94,15 +94,15 @@ class BPFtrace {
 public:
   BPFtrace(std::unique_ptr<Output> o = std::make_unique<TextOutput>(std::cout),
            BPFnofeature no_feature = BPFnofeature(),
-           Config config = Config())
+           std::unique_ptr<Config> config = std::make_unique<Config>())
       : out_(std::move(o)),
         feature_(std::make_unique<BPFfeature>(no_feature)),
         probe_matcher_(std::make_unique<ProbeMatcher>(this)),
         ncpus_(get_possible_cpus().size()),
         max_cpu_id_(get_max_cpu_id()),
-        config_(config),
-        ksyms_(config_),
-        usyms_(config_)
+        config_(std::move(config)),
+        ksyms_(*config_),
+        usyms_(*config_)
   {
   }
   virtual ~BPFtrace();
@@ -236,7 +236,7 @@ public:
   int ncpus_;
   int online_cpus_;
   int max_cpu_id_;
-  Config config_;
+  std::unique_ptr<Config> config_;
 
 private:
   Ksyms ksyms_;

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -528,7 +528,7 @@ void ClangParser::resolve_incomplete_types_from_btf(
       field_lvl = probe->tp_args_structs_level;
 
   unsigned max_iterations = std::max(
-      bpftrace.config_.get(ConfigKeyInt::max_type_res_iterations), field_lvl);
+      bpftrace.config_->get(ConfigKeyInt::max_type_res_iterations), field_lvl);
 
   bool check_incomplete_types = true;
   for (unsigned i = 0; i < max_iterations && check_incomplete_types; i++) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include <getopt.h>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <optional>
 #include <sys/resource.h>
 #include <sys/utsname.h>
@@ -252,7 +253,7 @@ static std::optional<struct timespec> get_delta_taitime()
 
 static void parse_env(BPFtrace& bpftrace)
 {
-  ConfigSetter config_setter(bpftrace.config_, ConfigSource::env_var);
+  ConfigSetter config_setter(*bpftrace.config_, ConfigSource::env_var);
   get_uint64_env_var("BPFTRACE_MAX_STRLEN", [&](uint64_t x) {
     config_setter.set(ConfigKeyInt::max_strlen, x);
   });
@@ -772,8 +773,8 @@ int main(int argc, char* argv[])
 
   libbpf_set_print(libbpf_print);
 
-  Config config = Config(!args.cmd_str.empty());
-  BPFtrace bpftrace(std::move(output), args.no_feature, config);
+  auto config = std::make_unique<Config>(!args.cmd_str.empty());
+  BPFtrace bpftrace(std::move(output), args.no_feature, std::move(config));
 
   parse_env(bpftrace);
 

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -60,7 +60,7 @@ int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
   std::cout << "\n\n";
 
   // Print maps if needed (true by default).
-  if (bpftrace.config_.get(ConfigKeyBool::print_maps_on_exit))
+  if (bpftrace.config_->get(ConfigKeyBool::print_maps_on_exit))
     err = bpftrace.print_maps();
 
   if (bpftrace.child_) {

--- a/tests/codegen/scratch_buffer.cpp
+++ b/tests/codegen/scratch_buffer.cpp
@@ -13,7 +13,7 @@ static void test_stack_or_scratch_buffer(const std::string &input,
                                          uint64_t on_stack_limit)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(bpftrace->config_, ConfigSource::script);
+  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
   configs.set(ConfigKeyInt::on_stack_limit, on_stack_limit);
   configs.set(ConfigKeyInt::max_strlen, MAX_STRLEN);
 

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -106,39 +106,39 @@ TEST(config_analyser, config_setting)
 {
   auto bpftrace = get_mock_bpftrace();
 
-  EXPECT_NE(bpftrace->config_.get(ConfigKeyInt::max_map_keys), 9);
+  EXPECT_NE(bpftrace->config_->get(ConfigKeyInt::max_map_keys), 9);
   test(*bpftrace, "config = { BPFTRACE_MAX_MAP_KEYS=9 } BEGIN { }");
-  EXPECT_EQ(bpftrace->config_.get(ConfigKeyInt::max_map_keys), 9);
+  EXPECT_EQ(bpftrace->config_->get(ConfigKeyInt::max_map_keys), 9);
 
-  EXPECT_NE(bpftrace->config_.get(ConfigKeyStackMode::default_),
+  EXPECT_NE(bpftrace->config_->get(ConfigKeyStackMode::default_),
             StackMode::perf);
   test(*bpftrace, "config = { stack_mode=perf } BEGIN { }");
-  EXPECT_EQ(bpftrace->config_.get(ConfigKeyStackMode::default_),
+  EXPECT_EQ(bpftrace->config_->get(ConfigKeyStackMode::default_),
             StackMode::perf);
 
-  EXPECT_NE(bpftrace->config_.get(ConfigKeyUserSymbolCacheType::default_),
+  EXPECT_NE(bpftrace->config_->get(ConfigKeyUserSymbolCacheType::default_),
             UserSymbolCacheType::per_program);
-  EXPECT_NE(bpftrace->config_.get(ConfigKeyInt::log_size), 150);
+  EXPECT_NE(bpftrace->config_->get(ConfigKeyInt::log_size), 150);
   test(*bpftrace,
        "config = { BPFTRACE_CACHE_USER_SYMBOLS=\"PER_PROGRAM\"; log_size=150 "
        "} BEGIN { }");
-  EXPECT_EQ(bpftrace->config_.get(ConfigKeyUserSymbolCacheType::default_),
+  EXPECT_EQ(bpftrace->config_->get(ConfigKeyUserSymbolCacheType::default_),
             UserSymbolCacheType::per_program);
-  EXPECT_EQ(bpftrace->config_.get(ConfigKeyInt::log_size), 150);
+  EXPECT_EQ(bpftrace->config_->get(ConfigKeyInt::log_size), 150);
 
   // When liblldb is present, the default config for symbol_source is "dwarf",
   // otherwise the default is "symbol_table".
 #ifdef HAVE_LIBLLDB
-  EXPECT_EQ(bpftrace->config_.get(ConfigKeySymbolSource::default_),
+  EXPECT_EQ(bpftrace->config_->get(ConfigKeySymbolSource::default_),
             ConfigSymbolSource::dwarf);
   test(*bpftrace, "config = { symbol_source = \"symbol_table\" } BEGIN { }");
-  EXPECT_EQ(bpftrace->config_.get(ConfigKeySymbolSource::default_),
+  EXPECT_EQ(bpftrace->config_->get(ConfigKeySymbolSource::default_),
             ConfigSymbolSource::symbol_table);
 #else
-  EXPECT_EQ(bpftrace->config_.get(ConfigKeySymbolSource::default_),
+  EXPECT_EQ(bpftrace->config_->get(ConfigKeySymbolSource::default_),
             ConfigSymbolSource::symbol_table);
   test(*bpftrace, "config = { symbol_source = \"dwarf\" } BEGIN { }");
-  EXPECT_EQ(bpftrace->config_.get(ConfigKeySymbolSource::default_),
+  EXPECT_EQ(bpftrace->config_->get(ConfigKeySymbolSource::default_),
             ConfigSymbolSource::dwarf);
 #endif
 }

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -50,7 +50,7 @@ void test(const std::string &input,
           std::optional<uint64_t> on_stack_limit = std::nullopt)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(bpftrace->config_, ConfigSource::script);
+  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
   configs.set(ConfigKeyInt::on_stack_limit, on_stack_limit.value_or(0));
   return test(*bpftrace, input, expected_result, out);
 }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4594,7 +4594,7 @@ TEST_F(semantic_analyser_btf, binop_late_ptr_resolution)
 TEST(semantic_analyser, buf_strlen_too_large)
 {
   auto bpftrace = get_mock_bpftrace();
-  ConfigSetter configs{ bpftrace->config_, ConfigSource::script };
+  ConfigSetter configs{ *bpftrace->config_, ConfigSource::script };
   configs.set(ConfigKeyInt::max_strlen, 9999999999);
 
   test_error(*bpftrace, "uprobe:/bin/sh:f { buf(arg0, 4) }", R"(


### PR DESCRIPTION
Previously, we were storing config by value and then giving references out to Usyms and Ksyms. If bpftrace instance were to ever be copied or moved, it would be UB, as those references are pointing to invalid memory.

Switch to storing Config as a unique_ptr so that its location is stable.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
