### PR TITLE
ast: make AST nodes consistent

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -11,8 +11,9 @@
 #include "utils.h"
 
 namespace bpftrace {
-
 namespace ast {
+
+class ASTContext;
 
 enum class JumpType {
   INVALID = 0,
@@ -61,11 +62,10 @@ enum class ExpansionType {
 
 class Node {
 public:
-  Node() = default;
   Node(location loc) : loc(loc) {};
   virtual ~Node() = default;
 
-  Node(const Node &) = default;
+  Node(const Node &) = delete;
   Node &operator=(const Node &) = delete;
   Node(Node &&) = delete;
   Node &operator=(Node &&) = delete;
@@ -77,14 +77,7 @@ class Map;
 class Variable;
 class Expression : public Node {
 public:
-  Expression() = default;
   Expression(location loc) : Node(loc) {};
-  virtual ~Expression() = default;
-
-  Expression(const Expression &) = default;
-  Expression &operator=(const Expression &) = delete;
-  Expression(Expression &&) = delete;
-  Expression &operator=(Expression &&) = delete;
 
   SizedType type;
   Map *key_for_map = nullptr;
@@ -102,9 +95,6 @@ public:
 
   int64_t n;
   bool is_negative;
-
-private:
-  Integer(const Integer &other) = default;
 };
 
 class PositionalParameter : public Expression {
@@ -116,9 +106,6 @@ public:
   PositionalParameterType ptype;
   long n;
   bool is_in_str = false;
-
-private:
-  PositionalParameter(const PositionalParameter &other) = default;
 };
 
 class String : public Expression {
@@ -126,9 +113,6 @@ public:
   explicit String(const std::string &str, location loc);
 
   std::string str;
-
-private:
-  String(const String &other) = default;
 };
 
 class StackMode : public Expression {
@@ -136,9 +120,6 @@ public:
   explicit StackMode(const std::string &mode, location loc);
 
   std::string mode;
-
-private:
-  StackMode(const StackMode &other) = default;
 };
 
 class Identifier : public Expression {
@@ -146,9 +127,6 @@ public:
   explicit Identifier(const std::string &ident, location loc);
 
   std::string ident;
-
-private:
-  Identifier(const Identifier &other) = default;
 };
 
 class Builtin : public Expression {
@@ -164,9 +142,6 @@ public:
     return !ident.compare(0, 3, "arg") && ident.size() == 4 &&
            ident.at(3) >= '0' && ident.at(3) <= '9';
   }
-
-private:
-  Builtin(const Builtin &other) = default;
 };
 
 class Call : public Expression {
@@ -176,9 +151,6 @@ public:
 
   std::string func;
   ExpressionList vargs;
-
-private:
-  Call(const Call &other) = default;
 };
 
 class Sizeof : public Expression {
@@ -188,9 +160,6 @@ public:
 
   Expression *expr = nullptr;
   SizedType argtype;
-
-private:
-  Sizeof(const Sizeof &other) = default;
 };
 
 class Offsetof : public Expression {
@@ -201,9 +170,6 @@ public:
   SizedType record;
   Expression *expr = nullptr;
   std::vector<std::string> field;
-
-private:
-  Offsetof(const Offsetof &other) = default;
 };
 
 class Map : public Expression {
@@ -219,9 +185,6 @@ public:
   // which involve calling map_lookup_percpu_elem
   // https://github.com/bpftrace/bpftrace/issues/3755
   bool is_read = true;
-
-private:
-  Map(const Map &other) = default;
 };
 
 class Variable : public Expression {
@@ -229,9 +192,6 @@ public:
   explicit Variable(const std::string &ident, location loc);
 
   std::string ident;
-
-private:
-  Variable(const Variable &other) = default;
 };
 
 class Binop : public Expression {
@@ -241,25 +201,15 @@ public:
   Expression *left = nullptr;
   Expression *right = nullptr;
   Operator op;
-
-private:
-  Binop(const Binop &other) = default;
 };
 
 class Unop : public Expression {
 public:
-  Unop(Operator op, Expression *expr, location loc = location());
-  Unop(Operator op,
-       Expression *expr,
-       bool is_post_op = false,
-       location loc = location());
+  Unop(Operator op, Expression *expr, bool is_post_op, location loc);
 
   Expression *expr = nullptr;
   Operator op;
   bool is_post_op;
-
-private:
-  Unop(const Unop &other) = default;
 };
 
 class FieldAccess : public Expression {
@@ -271,9 +221,6 @@ public:
   Expression *expr = nullptr;
   std::string field;
   ssize_t index = -1;
-
-private:
-  FieldAccess(const FieldAccess &other) = default;
 };
 
 class ArrayAccess : public Expression {
@@ -283,9 +230,6 @@ public:
 
   Expression *expr = nullptr;
   Expression *indexpr = nullptr;
-
-private:
-  ArrayAccess(const ArrayAccess &other) = default;
 };
 
 class Cast : public Expression {
@@ -293,9 +237,6 @@ public:
   Cast(SizedType type, Expression *expr, location loc);
 
   Expression *expr = nullptr;
-
-private:
-  Cast(const Cast &other) = default;
 };
 
 class Tuple : public Expression {
@@ -303,21 +244,11 @@ public:
   Tuple(ExpressionList &&elems, location loc);
 
   ExpressionList elems;
-
-private:
-  Tuple(const Tuple &other) = default;
 };
 
 class Statement : public Node {
 public:
-  Statement() = default;
   Statement(location loc) : Node(loc) {};
-  virtual ~Statement() = default;
-
-  Statement(const Statement &) = default;
-  Statement &operator=(const Statement &) = delete;
-  Statement(Statement &&) = delete;
-  Statement &operator=(Statement &&) = delete;
 };
 
 using StatementList = std::vector<Statement *>;
@@ -327,84 +258,61 @@ public:
   explicit ExprStatement(Expression *expr, location loc);
 
   Expression *expr = nullptr;
-
-private:
-  ExprStatement(const ExprStatement &other) = default;
 };
 
 class VarDeclStatement : public Statement {
 public:
-  VarDeclStatement(Variable *var, SizedType type, location loc = location());
-  VarDeclStatement(Variable *var, location loc = location());
+  VarDeclStatement(Variable *var, SizedType type, location loc);
+  VarDeclStatement(Variable *var, location loc);
 
   Variable *var = nullptr;
   bool set_type = false;
-
-private:
-  VarDeclStatement(const VarDeclStatement &other) = default;
 };
 
 class AssignMapStatement : public Statement {
 public:
-  AssignMapStatement(Map *map, Expression *expr, location loc = location());
+  AssignMapStatement(Map *map, Expression *expr, location loc);
 
   Map *map = nullptr;
   Expression *expr = nullptr;
-
-private:
-  AssignMapStatement(const AssignMapStatement &other) = default;
 };
 
 class AssignVarStatement : public Statement {
 public:
-  AssignVarStatement(Variable *var,
-                     Expression *expr,
-                     location loc = location());
+  AssignVarStatement(Variable *var, Expression *expr, location loc);
   AssignVarStatement(VarDeclStatement *var_decl_stmt,
                      Expression *expr,
-                     location loc = location());
+                     location loc);
 
   VarDeclStatement *var_decl_stmt = nullptr;
   Variable *var = nullptr;
   Expression *expr = nullptr;
-
-private:
-  AssignVarStatement(const AssignVarStatement &other) = default;
 };
 
 class AssignConfigVarStatement : public Statement {
 public:
   AssignConfigVarStatement(const std::string &config_var,
                            Expression *expr,
-                           location loc = location());
+                           location loc);
 
   std::string config_var;
   Expression *expr = nullptr;
-
-private:
-  AssignConfigVarStatement(const AssignConfigVarStatement &other) = default;
 };
 
 class Block : public Statement {
 public:
-  Block(StatementList &&stmts);
+  Block(StatementList &&stmts, location loc);
 
   StatementList stmts;
-
-private:
-  Block(const Block &other) = default;
 };
 
 class If : public Statement {
 public:
-  If(Expression *cond, Block *if_block, Block *else_block);
+  If(Expression *cond, Block *if_block, Block *else_block, location loc);
 
   Expression *cond = nullptr;
   Block *if_block = nullptr;
   Block *else_block = nullptr;
-
-private:
-  If(const If &other) = default;
 };
 
 class Unroll : public Statement {
@@ -414,27 +322,21 @@ public:
   long int var = 0;
   Expression *expr = nullptr;
   Block *block = nullptr;
-
-private:
-  Unroll(const Unroll &other) = default;
 };
 
 class Jump : public Statement {
 public:
-  Jump(JumpType ident, Expression *return_value, location loc = location())
+  Jump(JumpType ident, Expression *return_value, location loc)
       : Statement(loc), ident(ident), return_value(return_value)
   {
   }
-  Jump(JumpType ident, location loc = location())
+  Jump(JumpType ident, location loc)
       : Statement(loc), ident(ident), return_value(nullptr)
   {
   }
 
   JumpType ident = JumpType::INVALID;
   Expression *return_value;
-
-private:
-  Jump(const Jump &other) = default;
 };
 
 class Predicate : public Node {
@@ -442,9 +344,6 @@ public:
   explicit Predicate(Expression *expr, location loc);
 
   Expression *expr = nullptr;
-
-private:
-  Predicate(const Predicate &other) = default;
 };
 
 class Ternary : public Expression {
@@ -465,9 +364,6 @@ public:
 
   Expression *cond = nullptr;
   Block *block = nullptr;
-
-private:
-  While(const While &other) = default;
 };
 
 class For : public Statement {
@@ -481,31 +377,26 @@ public:
   Expression *expr = nullptr;
   StatementList stmts;
   SizedType ctx_type;
-
-private:
-  For(const For &other) = default;
 };
 
 class Config : public Statement {
 public:
-  Config(StatementList &&stmts) : stmts(std::move(stmts))
-  {
-  }
+  Config(StatementList &&stmts, location loc)
+      : Statement(loc), stmts(std::move(stmts)) {};
 
   StatementList stmts;
-
-private:
-  Config(const Config &other) = default;
 };
 
 class AttachPoint : public Node {
 public:
-  explicit AttachPoint(const std::string &raw_input, location loc = location());
-  AttachPoint(const std::string &raw_input, bool ignore_invalid)
-      : AttachPoint(raw_input)
-  {
-    this->ignore_invalid = ignore_invalid;
-  }
+  AttachPoint(const std::string &raw_input, bool ignore_invalid, location loc);
+
+  // Currently, the AST node itself is used to store metadata related to probe
+  // expansion and attachment. This is done through `create_expansion_copy`
+  // below.  Since the nodes are not currently copyable by default (this is
+  // currently fraught, as nodes may have backreferences that are not updated
+  // in these cases), these fields are copied manually. *Until this is fixed,
+  // if you are adding new fields, be sure to update `create_expansion_copy`.
 
   // Raw, unparsed input from user, eg. kprobe:vfs_read
   std::string raw_input;
@@ -531,21 +422,23 @@ public:
 
   std::string name() const;
 
-  AttachPoint create_expansion_copy(const std::string &match) const;
+  AttachPoint &create_expansion_copy(ASTContext &ctx,
+                                     const std::string &match) const;
 
   int index() const;
   void set_index(int index);
 
 private:
-  AttachPoint(const AttachPoint &other) = default;
-
   int index_ = 0;
 };
 using AttachPointList = std::vector<AttachPoint *>;
 
 class Probe : public Node {
 public:
-  Probe(AttachPointList &&attach_points, Predicate *pred, Block *block);
+  Probe(AttachPointList &&attach_points,
+        Predicate *pred,
+        Block *block,
+        location loc);
 
   AttachPointList attach_points;
   Predicate *pred = nullptr;
@@ -563,20 +456,18 @@ public:
   bool has_ap_of_probetype(ProbeType probe_type);
 
 private:
-  Probe(const Probe &other) = default;
   int index_ = 0;
 };
 using ProbeList = std::vector<Probe *>;
 
 class SubprogArg : public Node {
 public:
-  SubprogArg(std::string name, SizedType type);
+  SubprogArg(std::string name, SizedType type, location loc);
 
   std::string name() const;
   SizedType type;
 
 private:
-  SubprogArg(const SubprogArg &other) = default;
   std::string name_;
 };
 using SubprogArgList = std::vector<SubprogArg *>;
@@ -586,7 +477,8 @@ public:
   Subprog(std::string name,
           SizedType return_type,
           SubprogArgList &&args,
-          StatementList &&stmts);
+          StatementList &&stmts,
+          location loc);
 
   SubprogArgList args;
   SizedType return_type;
@@ -595,7 +487,6 @@ public:
   std::string name() const;
 
 private:
-  Subprog(const Subprog &other) = default;
   std::string name_;
 };
 using SubprogList = std::vector<Subprog *>;
@@ -605,15 +496,13 @@ public:
   Program(const std::string &c_definitions,
           Config *config,
           SubprogList &&functions,
-          ProbeList &&probes);
+          ProbeList &&probes,
+          location loc);
 
   std::string c_definitions;
   Config *config = nullptr;
   SubprogList functions;
   ProbeList probes;
-
-private:
-  Program(const Program &other) = default;
 };
 
 std::string opstr(const Binop &binop);

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -163,8 +163,9 @@ AttachPointParser::State AttachPointParser::parse_attachpoint(AttachPoint &ap)
       raw_input = probe_type + ":" + raw_input;
       // New attach points have ignore_invalid set to true - probe types for
       // which raw_input has invalid number of parts will be ignored (instead
-      // of throwing an error)
-      new_attach_points.push_back(ctx_.make_node<AttachPoint>(raw_input, true));
+      // of throwing an error). These will have the same associated location.
+      new_attach_points.push_back(
+          ctx_.make_node<AttachPoint>(raw_input, true, ap.loc));
     }
     return NEW_APS;
   }

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2898,12 +2898,12 @@ void CodegenLLVM::add_probe(AttachPoint &ap,
 
       std::string full_func_id = name + "_loc" + std::to_string(i);
       generateProbe(probe, full_func_id, probefull_, func_type, i);
-      bpftrace_.add_probe(ap, probe, i);
+      bpftrace_.add_probe(Visitor::ctx_, ap, probe, i);
       current_usdt_location_index_++;
     }
   } else {
     generateProbe(probe, name, probefull_, func_type);
-    bpftrace_.add_probe(ap, probe);
+    bpftrace_.add_probe(Visitor::ctx_, ap, probe);
   }
   current_attach_point_ = nullptr;
 }
@@ -3052,7 +3052,8 @@ ScopedExpr CodegenLLVM::visit(Probe &probe)
         if (attach_point->index() == 0)
           attach_point->set_index(getNextIndexForProbe());
 
-        auto match_ap = attach_point->create_expansion_copy(match);
+        auto &match_ap = attach_point->create_expansion_copy(Visitor::ctx_,
+                                                             match);
         add_probe(match_ap, probe, match, func_type);
         generated = true;
       }

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -100,7 +100,8 @@ Probe BPFtrace::generate_probe(const ast::AttachPoint &ap,
   return probe;
 }
 
-int BPFtrace::add_probe(const ast::AttachPoint &ap,
+int BPFtrace::add_probe(ast::ASTContext &ctx,
+                        const ast::AttachPoint &ap,
                         const ast::Probe &p,
                         int usdt_location_idx)
 {
@@ -131,7 +132,7 @@ int BPFtrace::add_probe(const ast::AttachPoint &ap,
       assert(type == ProbeType::uprobe || type == ProbeType::uretprobe);
       std::unordered_map<std::string, Probe> target_map;
       for (const auto &func : matches) {
-        ast::AttachPoint match_ap = ap.create_expansion_copy(func);
+        ast::AttachPoint &match_ap = ap.create_expansion_copy(ctx, func);
         // Use the original (possibly wildcarded) function name
         match_ap.func = ap.func;
         auto found = target_map.find(match_ap.target);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -106,7 +106,8 @@ public:
   {
   }
   virtual ~BPFtrace();
-  virtual int add_probe(const ast::AttachPoint &ap,
+  virtual int add_probe(ast::ASTContext &ctx,
+                        const ast::AttachPoint &ap,
                         const ast::Probe &p,
                         int usdt_location_idx = 0);
   Probe generateWatchpointSetupProbe(const ast::AttachPoint &ap,

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -10,126 +10,126 @@ using bpftrace::ast::Probe;
 
 TEST(ast, probe_name_special)
 {
-  AttachPoint ap1{ "" };
+  AttachPoint ap1("", false, location());
   ap1.provider = "BEGIN";
-  Probe begin({ &ap1 }, nullptr, {});
+  Probe begin({ &ap1 }, nullptr, {}, location());
   EXPECT_EQ(begin.name(), "BEGIN");
 
-  AttachPoint ap2{ "" };
+  AttachPoint ap2("", false, location());
   ap2.provider = "END";
-  Probe end({ &ap2 }, nullptr, {});
+  Probe end({ &ap2 }, nullptr, {}, location());
   EXPECT_EQ(end.name(), "END");
 }
 
 TEST(ast, probe_name_kprobe)
 {
-  AttachPoint ap1{ "" };
+  AttachPoint ap1("", false, location());
   ap1.provider = "kprobe";
   ap1.func = "sys_read";
 
-  AttachPoint ap2{ "" };
+  AttachPoint ap2("", false, location());
   ap2.provider = "kprobe";
   ap2.func = "sys_write";
 
-  AttachPoint ap3{ "" };
+  AttachPoint ap3("", false, location());
   ap3.provider = "kprobe";
   ap3.func = "sys_read";
   ap3.func_offset = 10;
 
-  Probe kprobe1({ &ap1 }, nullptr, {});
+  Probe kprobe1({ &ap1 }, nullptr, {}, location());
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  Probe kprobe2({ &ap1, &ap2 }, nullptr, {});
+  Probe kprobe2({ &ap1, &ap2 }, nullptr, {}, location());
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
 
-  Probe kprobe3({ &ap1, &ap2, &ap3 }, nullptr, {});
+  Probe kprobe3({ &ap1, &ap2, &ap3 }, nullptr, {}, location());
   EXPECT_EQ(kprobe3.name(),
             "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");
 }
 
 TEST(ast, probe_name_uprobe)
 {
-  AttachPoint ap1{ "" };
+  AttachPoint ap1("", false, location());
   ap1.provider = "uprobe";
   ap1.target = "/bin/sh";
   ap1.func = "readline";
-  Probe uprobe1({ &ap1 }, nullptr, {});
+  Probe uprobe1({ &ap1 }, nullptr, {}, location());
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
-  AttachPoint ap2{ "" };
+  AttachPoint ap2("", false, location());
   ap2.provider = "uprobe";
   ap2.target = "/bin/sh";
   ap2.func = "somefunc";
-  Probe uprobe2({ &ap1, &ap2 }, nullptr, {});
+  Probe uprobe2({ &ap1, &ap2 }, nullptr, {}, location());
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
 
-  AttachPoint ap3{ "" };
+  AttachPoint ap3("", false, location());
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.address = 1000;
-  Probe uprobe3({ &ap1, &ap2, &ap3 }, nullptr, {});
+  Probe uprobe3({ &ap1, &ap2, &ap3 }, nullptr, {}, location());
   EXPECT_EQ(
       uprobe3.name(),
       "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
 
-  AttachPoint ap4{ "" };
+  AttachPoint ap4("", false, location());
   ap4.provider = "uprobe";
   ap4.target = "/bin/sh";
   ap4.func = "somefunc";
   ap4.func_offset = 10;
-  Probe uprobe4({ &ap1, &ap2, &ap3, &ap4 }, nullptr, {});
+  Probe uprobe4({ &ap1, &ap2, &ap3, &ap4 }, nullptr, {}, location());
   EXPECT_EQ(uprobe4.name(),
             "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/"
             "sh:1000,uprobe:/bin/sh:somefunc+10");
 
-  AttachPoint ap5{ "" };
+  AttachPoint ap5("", false, location());
   ap5.provider = "uprobe";
   ap5.target = "/bin/sh";
   ap5.address = 10;
-  Probe uprobe5({ &ap5 }, nullptr, {});
+  Probe uprobe5({ &ap5 }, nullptr, {}, location());
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
 
-  AttachPoint ap6{ "" };
+  AttachPoint ap6("", false, location());
   ap6.provider = "uretprobe";
   ap6.target = "/bin/sh";
   ap6.address = 10;
-  Probe uprobe6({ &ap6 }, nullptr, {});
+  Probe uprobe6({ &ap6 }, nullptr, {}, location());
   EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
 }
 
 TEST(ast, probe_name_usdt)
 {
-  AttachPoint ap1{ "" };
+  AttachPoint ap1("", false, location());
   ap1.provider = "usdt";
   ap1.target = "/bin/sh";
   ap1.func = "probe1";
-  Probe usdt1({ &ap1 }, nullptr, {});
+  Probe usdt1({ &ap1 }, nullptr, {}, location());
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
-  AttachPoint ap2{ "" };
+  AttachPoint ap2("", false, location());
   ap2.provider = "usdt";
   ap2.target = "/bin/sh";
   ap2.func = "probe2";
-  Probe usdt2({ &ap1, &ap2 }, nullptr, {});
+  Probe usdt2({ &ap1, &ap2 }, nullptr, {}, location());
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
 }
 
 TEST(ast, attach_point_name)
 {
-  AttachPoint ap1{ "" };
+  AttachPoint ap1("", false, location());
   ap1.provider = "kprobe";
   ap1.func = "sys_read";
-  AttachPoint ap2{ "" };
+  AttachPoint ap2("", false, location());
   ap2.provider = "kprobe";
   ap2.func = "sys_thisone";
-  AttachPoint ap3{ "" };
+  AttachPoint ap3("", false, location());
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.func = "readline";
-  Probe kprobe({ &ap1, &ap2, &ap3 }, nullptr, {});
+  Probe kprobe({ &ap1, &ap2, &ap3 }, nullptr, {}, location());
   EXPECT_EQ(ap2.name(), "kprobe:sys_thisone");
 
-  Probe uprobe({ &ap1, &ap2, &ap3 }, nullptr, {});
+  Probe uprobe({ &ap1, &ap2, &ap3 }, nullptr, {}, location());
   EXPECT_EQ(ap3.name(), "uprobe:/bin/sh:readline");
 }
 

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -1,6 +1,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "ast/ast.h"
 #include "common.h"
 
 namespace bpftrace {
@@ -15,8 +16,11 @@ public:
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
-  MOCK_METHOD3(add_probe,
-               int(const ast::AttachPoint &, const ast::Probe &, int));
+  MOCK_METHOD4(add_probe,
+               int(ast::ASTContext &,
+                   const ast::AttachPoint &,
+                   const ast::Probe &,
+                   int));
 #pragma GCC diagnostic pop
 
   int resolve_uname(const std::string &name,
@@ -106,7 +110,7 @@ TEST(codegen, printf_offsets)
 TEST(codegen, probe_count)
 {
   MockBPFtrace bpftrace;
-  EXPECT_CALL(bpftrace, add_probe(_, _, _)).Times(2);
+  EXPECT_CALL(bpftrace, add_probe(_, _, _, _)).Times(2);
 
   Driver driver(bpftrace);
 

--- a/tests/collect_nodes.cpp
+++ b/tests/collect_nodes.cpp
@@ -33,9 +33,8 @@ TEST(CollectNodes, indirect)
 {
   ASTContext ctx;
   auto &var = *ctx.make_node<Variable>("myvar", bpftrace::location{});
-  auto &unop = *ctx.make_node<Unop>(Operator::INCREMENT,
-                                    &var,
-                                    bpftrace::location{});
+  auto &unop = *ctx.make_node<Unop>(
+      Operator::INCREMENT, &var, false, bpftrace::location{});
 
   CollectNodes<Variable> visitor(ctx);
   visitor.visit(unop);
@@ -47,9 +46,8 @@ TEST(CollectNodes, none)
 {
   ASTContext ctx;
   auto &map = *ctx.make_node<Map>("myvar", bpftrace::location{});
-  auto &unop = *ctx.make_node<Unop>(Operator::INCREMENT,
-                                    &map,
-                                    bpftrace::location{});
+  auto &unop = *ctx.make_node<Unop>(
+      Operator::INCREMENT, &map, false, bpftrace::location{});
 
   CollectNodes<Variable> visitor(ctx);
   visitor.visit(unop);
@@ -61,14 +59,12 @@ TEST(CollectNodes, multiple_runs)
 {
   ASTContext ctx;
   auto &var1 = *ctx.make_node<Variable>("myvar1", bpftrace::location{});
-  auto &unop1 = *ctx.make_node<Unop>(Operator::INCREMENT,
-                                     &var1,
-                                     bpftrace::location{});
+  auto &unop1 = *ctx.make_node<Unop>(
+      Operator::INCREMENT, &var1, false, bpftrace::location{});
 
   auto &var2 = *ctx.make_node<Variable>("myvar2", bpftrace::location{});
-  auto &unop2 = *ctx.make_node<Unop>(Operator::INCREMENT,
-                                     &var2,
-                                     bpftrace::location{});
+  auto &unop2 = *ctx.make_node<Unop>(
+      Operator::INCREMENT, &var2, false, bpftrace::location{});
 
   CollectNodes<Variable> visitor(ctx);
   visitor.visit(unop1);

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -284,9 +284,9 @@ TEST(Parser, positional_param_attachpoint)
 stdin:1:1-12: ERROR: Found trailing text 'a' in positional parameter index. Try quoting the trailing text.
 uprobe:$1a { 1 }
 ~~~~~~~~~~~
-stdin:1:1-1: ERROR: No attach points for probe
+stdin:1:1-18: ERROR: No attach points for probe
 uprobe:$1a { 1 }
-
+~~~~~~~~~~~~~~~~
 )");
 
   test_parse_failure(bpftrace, R"(uprobe:$a { 1 })", R"(
@@ -2326,9 +2326,9 @@ TEST(Parser, long_param_overflow)
 TEST(Parser, empty_arguments)
 {
   test_parse_failure("::k::vfs_open:: { 1 }", R"(
-stdin:1:1-1: ERROR: No attach points for probe
+stdin:1:1-26: ERROR: No attach points for probe
 ::k::vfs_open:: { 1 }
-
+~~~~~~~~~~~~~~~~~~~~~
 )");
 
   // Error location is incorrect: #3063
@@ -2339,9 +2339,9 @@ k:vfs_open:: { 1 }
 )");
 
   test_parse_failure(":w:0x10000000:8:rw { 1 }", R"(
-stdin:1:1-1: ERROR: No attach points for probe
+stdin:1:1-25: ERROR: No attach points for probe
 :w:0x10000000:8:rw { 1 }
-
+~~~~~~~~~~~~~~~~~~~~~~~~
 )");
 }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -967,9 +967,9 @@ kprobe:f { @[delete(@x)] = 1; }
 )");
 
   test_error("kprobe:f { @x = 1; if(delete(@x)) { 123 } }", R"(
-stdin:1:1-1: ERROR: Invalid condition in if(): none
+stdin:1:20-42: ERROR: Invalid condition in if(): none
 kprobe:f { @x = 1; if(delete(@x)) { 123 } }
-
+                   ~~~~~~~~~~~~~~~~~~~~~~
 )");
 
   test_error("kprobe:f { @x = 1; delete(@x) ? 0 : 1; }", R"(


### PR DESCRIPTION
Currently *most* AST nodes have a location, some have a location optionally passed, and some have none. To unify diagnostics and reporting, make all the AST nodes consistent and leverage the type system: all nodes must have a location. This fixes several gaps in the parser.

If a location is not available, then a location can be constructed somehow from the original source locations. It is simply not helpful to produce errors that tie in no way to the source file.

Additionally, make AST nodes non-copyable. This was done in part for *only* the AttachPoint, which is expanded. In the future, this should either be done 1) as a true expansion of the AST, so that subsequent passes can operate on the newly expanded probes as expanded or 2) not a property of the AST itself, and existing in a side-structure. I suspect that a mix a both will be required, but right now it lives in a strange ambiguity within the AST.

This change is a non-functional change in preparation for additional internal improvements.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[X] The new behaviour is covered by tests~
