### PR TITLE
Add pid targeting/filtering for all probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
   - [#3752](https://github.com/bpftrace/bpftrace/pull/3752)
 - Increase default values for max_bpf_progs and max_probes
   - [#3808](https://github.com/bpftrace/bpftrace/pull/3808)
+- `-p` CLI flag now applies to all probes (except BEGIN/END)
+  - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -159,9 +159,10 @@ Errors are still written to stderr.
 
 === *-p* _PID_
 
-Attach to the process with _PID_.
+Attach to the process with or filter actions by _PID_.
 If the process terminates, bpftrace will also terminate.
-When using USDT probes, uprobes, and uretprobes they will be attached to only this process.
+When using USDT, uprobes, uretprobes, hardware, software, profile, interval, watchpoint, or asyncwatchpoint probes they will be attached to only this process.
+For all other probes, except BEGIN/END, the pid will act like a predicate to filter out events not from that pid.
 For listing uprobes/uretprobes set the target to '*' and the process's address space will be searched for the symbols.
 
 === *-q*

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(ast STATIC
   passes/semantic_analyser.cpp
   passes/codegen_llvm.cpp
   passes/return_path_analyser.cpp
+  passes/pid_filter_pass.cpp
 )
 
 target_compile_definitions(ast PRIVATE ${BPFTRACE_FLAGS})

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1515,7 +1515,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
                                             int usdt_location_index,
                                             int arg_num,
                                             Builtin &builtin,
-                                            pid_t pid,
+                                            std::optional<pid_t> pid,
                                             AddrSpace as,
                                             const location &loc)
 {
@@ -1524,9 +1524,9 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
 
   void *usdt;
 
-  if (pid) {
+  if (pid.has_value()) {
     // FIXME use attach_point->target when iovisor/bcc#2064 is merged
-    usdt = bcc_usdt_new_frompid(pid, nullptr);
+    usdt = bcc_usdt_new_frompid(*pid, nullptr);
   } else {
     usdt = bcc_usdt_new_frompath(attach_point->target.c_str());
   }

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -122,7 +122,7 @@ public:
                                 int usdt_location_index,
                                 int arg_name,
                                 Builtin &builtin,
-                                pid_t pid,
+                                std::optional<pid_t> pid,
                                 AddrSpace as,
                                 const location &loc);
   Value *CreateStrncmp(Value *str1, Value *str2, uint64_t n, bool inverse);

--- a/src/ast/passes/pid_filter_pass.cpp
+++ b/src/ast/passes/pid_filter_pass.cpp
@@ -1,0 +1,88 @@
+#include "pid_filter_pass.h"
+
+#include "ast/ast.h"
+
+namespace bpftrace::ast {
+
+Pass CreatePidFilterPass()
+{
+  auto fn = [](PassContext &ctx) {
+    auto pid_filter = PidFilterPass(ctx.ast_ctx, ctx.b);
+    pid_filter.analyse();
+    return PassResult::Success();
+  };
+
+  return Pass("PidFilter", fn);
+};
+
+void PidFilterPass::analyse()
+{
+  visit(ctx_.root);
+}
+
+void PidFilterPass::visit(Probe &probe)
+{
+  bool needs_pid_filter = false;
+
+  for (AttachPoint *ap : probe.attach_points) {
+    if (bpftrace_.pid() > 0 && probe_needs_pid_filter(ap)) {
+      needs_pid_filter = true;
+    }
+  }
+
+  if (needs_pid_filter) {
+    probe.block->stmts.insert(probe.block->stmts.begin(),
+                              add_pid_filter(probe.loc));
+  }
+}
+
+// If the probe can't filter by pid when attaching
+// then we inject custom AST to filter by pid.
+// Note: this doesn't work for AOT as the code has already
+// been generated
+bool PidFilterPass::probe_needs_pid_filter(AttachPoint *ap)
+{
+  ProbeType type = probetype(ap->provider);
+
+  switch (type) {
+    case ProbeType::kprobe:
+    case ProbeType::kretprobe:
+    case ProbeType::fentry:
+    case ProbeType::fexit:
+    case ProbeType::tracepoint:
+    case ProbeType::rawtracepoint:
+      return true;
+    case ProbeType::uprobe:
+    case ProbeType::uretprobe:
+    case ProbeType::usdt:
+    case ProbeType::watchpoint:
+    case ProbeType::asyncwatchpoint:
+    case ProbeType::invalid:
+    case ProbeType::iter:
+    case ProbeType::profile:
+    case ProbeType::interval:
+    case ProbeType::software:
+    case ProbeType::hardware:
+    // We don't filter by pid for BEGIN/END probes
+    case ProbeType::special:
+      return false;
+  }
+
+  return false;
+}
+
+Statement *PidFilterPass::add_pid_filter(const location &loc)
+{
+  return ctx_.make_node<If>(
+      ctx_.make_node<Binop>(ctx_.make_node<Builtin>("pid", loc),
+                            Operator::NE,
+                            ctx_.make_node<Integer>(bpftrace_.pid(), loc),
+                            loc),
+      ctx_.make_node<Block>(std::vector<Statement *>{ ctx_.make_node<Jump>(
+                                JumpType::RETURN, loc) },
+                            loc),
+      ctx_.make_node<Block>(std::vector<Statement *>{}, loc),
+      loc);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/pid_filter_pass.cpp
+++ b/src/ast/passes/pid_filter_pass.cpp
@@ -4,43 +4,11 @@
 
 namespace bpftrace::ast {
 
-Pass CreatePidFilterPass()
-{
-  auto fn = [](PassContext &ctx) {
-    auto pid_filter = PidFilterPass(ctx.ast_ctx, ctx.b);
-    pid_filter.analyse();
-    return PassResult::Success();
-  };
-
-  return Pass("PidFilter", fn);
-};
-
-void PidFilterPass::analyse()
-{
-  visit(ctx_.root);
-}
-
-void PidFilterPass::visit(Probe &probe)
-{
-  bool needs_pid_filter = false;
-
-  for (AttachPoint *ap : probe.attach_points) {
-    if (bpftrace_.pid().has_value() && probe_needs_pid_filter(ap)) {
-      needs_pid_filter = true;
-    }
-  }
-
-  if (needs_pid_filter) {
-    probe.block->stmts.insert(probe.block->stmts.begin(),
-                              add_pid_filter(probe.loc));
-  }
-}
-
 // If the probe can't filter by pid when attaching
 // then we inject custom AST to filter by pid.
 // Note: this doesn't work for AOT as the code has already
 // been generated
-bool PidFilterPass::probe_needs_pid_filter(AttachPoint *ap)
+bool probe_needs_pid_filter(AttachPoint *ap)
 {
   ProbeType type = probetype(ap->provider);
 
@@ -71,19 +39,50 @@ bool PidFilterPass::probe_needs_pid_filter(AttachPoint *ap)
   return false;
 }
 
-Statement *PidFilterPass::add_pid_filter(const location &loc)
+Statement *create_pid_filter(ASTContext &ctx, int pid, const location &loc)
 {
-  return ctx_.make_node<If>(
-      ctx_.make_node<Binop>(ctx_.make_node<Builtin>("pid", loc),
-                            Operator::NE,
-                            ctx_.make_node<Integer>(bpftrace_.pid().value_or(0),
-                                                    loc),
-                            loc),
-      ctx_.make_node<Block>(std::vector<Statement *>{ ctx_.make_node<Jump>(
-                                JumpType::RETURN, loc) },
-                            loc),
-      ctx_.make_node<Block>(std::vector<Statement *>{}, loc),
+  return ctx.make_node<If>(
+      ctx.make_node<Binop>(ctx.make_node<Builtin>("pid", loc),
+                           Operator::NE,
+                           ctx.make_node<Integer>(pid, loc),
+                           loc),
+      ctx.make_node<Block>(std::vector<Statement *>{ ctx.make_node<Jump>(
+                               JumpType::RETURN, loc) },
+                           loc),
+      ctx.make_node<Block>(std::vector<Statement *>{}, loc),
       loc);
+}
+
+Pass CreatePidFilterPass()
+{
+  auto fn = [](PassContext &ctx) {
+    auto pid_filter = PidFilterPass(ctx.ast_ctx, ctx.b);
+    pid_filter.analyse();
+    return PassResult::Success();
+  };
+
+  return Pass("PidFilter", fn);
+};
+
+void PidFilterPass::analyse()
+{
+  visit(ctx_.root);
+}
+
+void PidFilterPass::visit(Probe &probe)
+{
+  const auto pid = bpftrace_.pid();
+  if (!pid.has_value()) {
+    return;
+  }
+
+  for (AttachPoint *ap : probe.attach_points) {
+    if (probe_needs_pid_filter(ap)) {
+      probe.block->stmts.insert(probe.block->stmts.begin(),
+                                create_pid_filter(ctx_, *pid, probe.loc));
+      return;
+    }
+  }
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/pid_filter_pass.cpp
+++ b/src/ast/passes/pid_filter_pass.cpp
@@ -25,7 +25,7 @@ void PidFilterPass::visit(Probe &probe)
   bool needs_pid_filter = false;
 
   for (AttachPoint *ap : probe.attach_points) {
-    if (bpftrace_.pid() > 0 && probe_needs_pid_filter(ap)) {
+    if (bpftrace_.pid().has_value() && probe_needs_pid_filter(ap)) {
       needs_pid_filter = true;
     }
   }
@@ -76,7 +76,8 @@ Statement *PidFilterPass::add_pid_filter(const location &loc)
   return ctx_.make_node<If>(
       ctx_.make_node<Binop>(ctx_.make_node<Builtin>("pid", loc),
                             Operator::NE,
-                            ctx_.make_node<Integer>(bpftrace_.pid(), loc),
+                            ctx_.make_node<Integer>(bpftrace_.pid().value_or(0),
+                                                    loc),
                             loc),
       ctx_.make_node<Block>(std::vector<Statement *>{ ctx_.make_node<Jump>(
                                 JumpType::RETURN, loc) },

--- a/src/ast/passes/pid_filter_pass.h
+++ b/src/ast/passes/pid_filter_pass.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+#include "ast/visitor.h"
+#include "bpftrace.h"
+
+namespace bpftrace {
+namespace ast {
+
+class PidFilterPass : public Visitor<PidFilterPass> {
+public:
+  explicit PidFilterPass(ASTContext &ctx, BPFtrace &bpftrace)
+      : Visitor<PidFilterPass>(ctx), bpftrace_(bpftrace)
+  {
+  }
+
+  using Visitor<PidFilterPass>::visit;
+  void visit(Probe &probe);
+
+  void analyse();
+
+private:
+  BPFtrace &bpftrace_;
+  bool probe_needs_pid_filter(AttachPoint *attach_point);
+  Statement *add_pid_filter(const location &loc);
+};
+
+Pass CreatePidFilterPass();
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/passes/pid_filter_pass.h
+++ b/src/ast/passes/pid_filter_pass.h
@@ -21,8 +21,6 @@ public:
 
 private:
   BPFtrace &bpftrace_;
-  bool probe_needs_pid_filter(AttachPoint *attach_point);
-  Statement *add_pid_filter(const location &loc);
 };
 
 Pass CreatePidFilterPass();

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -24,7 +24,7 @@ class AttachedProbe {
 public:
   AttachedProbe(Probe &probe,
                 const BpfProgram &prog,
-                int pid,
+                std::optional<int> pid,
                 BPFtrace &bpftrace,
                 bool safe_mode = true);
   ~AttachedProbe();
@@ -41,9 +41,9 @@ private:
   void resolve_offset_kprobe();
   bool resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps);
   void attach_multi_kprobe(void);
-  void attach_multi_uprobe(int pid);
+  void attach_multi_uprobe(std::optional<int> pid);
   void attach_kprobe();
-  void attach_uprobe(int pid, bool safe_mode);
+  void attach_uprobe(std::optional<int> pid, bool safe_mode);
 
   // Note: the following usdt attachment functions will only activate a
   // semaphore if one exists.
@@ -57,17 +57,17 @@ private:
                   int pid,
                   const std::string &fn_name,
                   void *ctx);
-  void attach_usdt(int pid, BPFfeature &feature);
+  void attach_usdt(std::optional<int> pid, BPFfeature &feature);
 
   void attach_tracepoint();
-  void attach_profile(int pid);
-  void attach_interval(int pid);
-  void attach_software(int pid);
-  void attach_hardware(int pid);
-  void attach_watchpoint(int pid, const std::string &mode);
+  void attach_profile(std::optional<int> pid);
+  void attach_interval(std::optional<int> pid);
+  void attach_software(std::optional<int> pid);
+  void attach_hardware(std::optional<int> pid);
+  void attach_watchpoint(std::optional<int> pid, const std::string &mode);
   void attach_fentry(void);
   int detach_fentry(void);
-  void attach_iter(int pid);
+  void attach_iter(std::optional<int> pid);
   int detach_iter(void);
   void attach_raw_tracepoint(void);
   int detach_raw_tracepoint(void);

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -22,7 +22,6 @@ std::string progtypeName(libbpf::bpf_prog_type t);
 
 class AttachedProbe {
 public:
-  AttachedProbe(Probe &probe, const BpfProgram &prog, BPFtrace &bpftrace);
   AttachedProbe(Probe &probe,
                 const BpfProgram &prog,
                 int pid,
@@ -61,14 +60,14 @@ private:
   void attach_usdt(int pid, BPFfeature &feature);
 
   void attach_tracepoint();
-  void attach_profile();
-  void attach_interval();
-  void attach_software();
-  void attach_hardware();
+  void attach_profile(int pid);
+  void attach_interval(int pid);
+  void attach_software(int pid);
+  void attach_hardware(int pid);
   void attach_watchpoint(int pid, const std::string &mode);
   void attach_fentry(void);
   int detach_fentry(void);
-  void attach_iter(void);
+  void attach_iter(int pid);
   int detach_iter(void);
   void attach_raw_tracepoint(void);
   int detach_raw_tracepoint(void);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -778,7 +778,8 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_probe(
           std::make_unique<AttachedProbe>(probe, program, pid, *this));
       return ret;
     } else {
-      ret.emplace_back(std::make_unique<AttachedProbe>(probe, program, *this));
+      ret.emplace_back(
+          std::make_unique<AttachedProbe>(probe, program, pid, *this));
       return ret;
     }
   } catch (const EnospcException &e) {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -229,9 +229,12 @@ public:
   std::unordered_set<std::string> btf_set_;
   std::unique_ptr<ChildProcBase> child_;
   std::unique_ptr<ProcMonBase> procmon_;
-  pid_t pid(void) const
+  std::optional<pid_t> pid(void) const
   {
-    return procmon_ ? procmon_->pid() : 0;
+    if (procmon_) {
+      return procmon_->pid();
+    }
+    return std::nullopt;
   }
   int ncpus_;
   int online_cpus_;
@@ -249,7 +252,7 @@ private:
   std::vector<std::unique_ptr<AttachedProbe>> attach_usdt_probe(
       Probe &probe,
       const BpfProgram &program,
-      int pid,
+      std::optional<int> pid,
       bool file_activation);
   int create_pcaps();
   void close_pcaps();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/config_analyser.h"
 #include "ast/passes/field_analyser.h"
+#include "ast/passes/pid_filter_pass.h"
 #include "ast/passes/portability_analyser.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/return_path_analyser.h"
@@ -100,7 +101,7 @@ void usage(std::ostream& out)
   out << "    --include FILE add an #include file before preprocessing" << std::endl;
   out << "    -l [search|filename]" << std::endl;
   out << "                   list kernel probes or probes in a program" << std::endl;
-  out << "    -p PID         enable USDT probes on PID" << std::endl;
+  out << "    -p PID         filter actions and enable USDT probes on PID" << std::endl;
   out << "    -c 'CMD'       run CMD and enable USDT probes on resulting process" << std::endl;
   out << "    --usdt-file-activation" << std::endl;
   out << "                   activate usdt semaphores based on file path" << std::endl;
@@ -432,6 +433,7 @@ ast::PassManager CreateDynamicPM()
 {
   ast::PassManager pm;
   pm.AddPass(ast::CreateConfigPass());
+  pm.AddPass(ast::CreatePidFilterPass());
   pm.AddPass(ast::CreateSemanticPass());
   pm.AddPass(ast::CreateResourcePass());
   pm.AddPass(ast::CreateReturnPathPass());

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -239,7 +239,7 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_traceable_funcs(
 }
 
 std::unique_ptr<std::istream> ProbeMatcher::get_func_symbols_from_file(
-    int pid,
+    std::optional<int> pid,
     const std::string& path) const
 {
   if (path.empty())
@@ -247,8 +247,8 @@ std::unique_ptr<std::istream> ProbeMatcher::get_func_symbols_from_file(
 
   std::vector<std::string> real_paths;
   if (path == "*") {
-    if (pid > 0)
-      real_paths = get_mapped_paths_for_pid(pid);
+    if (pid.has_value())
+      real_paths = get_mapped_paths_for_pid(*pid);
     else
       real_paths = get_mapped_paths_for_running_pids();
   } else if (path.find('*') != std::string::npos)
@@ -280,14 +280,14 @@ std::unique_ptr<std::istream> ProbeMatcher::get_func_symbols_from_file(
 }
 
 std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_usdt(
-    int pid,
+    std::optional<int> pid,
     const std::string& target) const
 {
   std::string probes;
   usdt_probe_list usdt_probes;
 
-  if (pid > 0)
-    usdt_probes = USDTHelper::probes_for_pid(pid);
+  if (pid.has_value())
+    usdt_probes = USDTHelper::probes_for_pid(*pid);
   else if (target == "*")
     usdt_probes = USDTHelper::probes_for_all_pids();
   else if (!target.empty()) {
@@ -535,7 +535,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
       // If PID is specified, targets in symbol_stream will have the
       // "/proc/<PID>/root" prefix followed by an absolute path, so we make the
       // target absolute and add a leading wildcard.
-      if (bpftrace_->pid() > 0) {
+      if (bpftrace_->pid().has_value()) {
         if (!target.empty()) {
           if (auto abs_target = abs_path(target))
             target = "*" + abs_target.value();

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -93,10 +93,10 @@ private:
   virtual std::unique_ptr<std::istream> get_symbols_from_file(
       const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_func_symbols_from_file(
-      int pid,
+      std::optional<int> pid,
       const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_usdt(
-      int pid,
+      std::optional<int> pid,
       const std::string &target) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_list(
       const std::vector<ProbeListItem> &probes_list) const;

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -21,7 +21,7 @@ class USDTHelper {
 public:
   virtual ~USDTHelper() = default;
 
-  virtual std::optional<usdt_probe_entry> find(int pid,
+  virtual std::optional<usdt_probe_entry> find(std::optional<int> pid,
                                                const std::string &target,
                                                const std::string &provider,
                                                const std::string &name);

--- a/src/utils.h
+++ b/src/utils.h
@@ -222,7 +222,8 @@ bool is_type_name(std::string_view str);
 std::string exec_system(const char *cmd);
 bool is_exe(const std::string &path);
 std::vector<std::string> resolve_binary_path(const std::string &cmd);
-std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid);
+std::vector<std::string> resolve_binary_path(const std::string &cmd,
+                                             std::optional<int> pid);
 std::string path_for_pid_mountns(int pid, const std::string &path);
 void cat_file(const char *filename, size_t, std::ostream &);
 std::string str_join(const std::vector<std::string> &list,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(bpftrace_test
   procmon.cpp
   probe.cpp
   config_analyser.cpp
+  pid_filter_pass.cpp
   resource_analyser.cpp
   required_resources.cpp
   return_path_analyser.cpp

--- a/tests/README.md
+++ b/tests/README.md
@@ -147,7 +147,7 @@ not known until test time. The following runtime variables are available for the
 `RUN` directive:
 
 * `{{BPFTRACE}}`: Path to bpftrace executable
-* `{{BEFORE_PID}}`: Process ID of the process in `BEFORE` directive
+* `{{BEFORE_PID}}`: Process ID of the process in the first `BEFORE` directive
 
 ### Test programs
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -21,6 +21,8 @@ using ::testing::StrictMock;
 
 static const int STRING_SIZE = 64;
 
+static const std::optional<int> no_pid = std::nullopt;
+
 static const std::string kprobe_name(const std::string &attach_point,
                                      const std::string &target,
                                      uint64_t func_offset)
@@ -444,7 +446,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
   auto bpftrace = get_strict_mock_bpftrace();
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file(0, "/bin/sh"))
+              get_func_symbols_from_file(no_pid, "/bin/sh"))
       .Times(1);
 
   parse_probe("uprobe:/bin/sh:*open {}", *bpftrace);
@@ -470,7 +472,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_uprobe_multi)
   auto bpftrace = get_strict_mock_bpftrace();
 
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file(0, "/bin/sh"))
+              get_func_symbols_from_file(no_pid, "/bin/sh"))
       .Times(2);
 
   parse_probe("uprobe:/bin/sh:*open {}", *bpftrace);
@@ -491,7 +493,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file)
   auto bpftrace = get_strict_mock_bpftrace();
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file(0, "/bin/*sh"))
+              get_func_symbols_from_file(no_pid, "/bin/*sh"))
       .Times(1);
 
   parse_probe("uprobe:/bin/*sh:*open {}", *bpftrace);
@@ -522,7 +524,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file_uprobe_multi)
   auto bpftrace = get_strict_mock_bpftrace();
 
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file(0, "/bin/*sh"))
+              get_func_symbols_from_file(no_pid, "/bin/*sh"))
       .Times(2);
 
   parse_probe("uprobe:/bin/*sh:*open {}", *bpftrace);
@@ -548,7 +550,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
   auto bpftrace = get_strict_mock_bpftrace();
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file(0, "/bin/sh"))
+              get_func_symbols_from_file(no_pid, "/bin/sh"))
       .Times(1);
 
   parse_probe("uprobe:/bin/sh:foo* {}", *bpftrace);
@@ -562,7 +564,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_no_matches_multi)
   auto bpftrace = get_strict_mock_bpftrace();
 
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file(0, "/bin/sh"))
+              get_func_symbols_from_file(no_pid, "/bin/sh"))
       .Times(1);
 
   parse_probe("uprobe:/bin/sh:foo* {}", *bpftrace);
@@ -608,7 +610,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
     auto bpftrace = get_strict_mock_bpftrace();
     bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
     EXPECT_CALL(*bpftrace->mock_probe_matcher,
-                get_func_symbols_from_file(0, "/bin/sh"))
+                get_func_symbols_from_file(no_pid, "/bin/sh"))
         .Times(1);
 
     std::string prog = provider + ":/bin/sh:cpp:cpp_mangled{}";
@@ -639,7 +641,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
   auto bpftrace = get_strict_mock_bpftrace();
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file(0, "/bin/sh"))
+              get_func_symbols_from_file(no_pid, "/bin/sh"))
       .Times(1);
 
   parse_probe("uprobe:/bin/sh:cpp:\"cpp_mangled(int)\"{}", *bpftrace);
@@ -658,7 +660,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
   auto bpftrace = get_strict_mock_bpftrace();
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file(0, "/bin/sh"))
+              get_func_symbols_from_file(no_pid, "/bin/sh"))
       .Times(1);
 
   parse_probe("uprobe:/bin/sh:cpp:cpp_man*{}", *bpftrace);
@@ -692,7 +694,7 @@ TEST(bpftrace, add_probes_uprobe_no_demangling)
 {
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file(0, "/bin/sh"))
+              get_func_symbols_from_file(no_pid, "/bin/sh"))
       .Times(0);
 
   // Without the :cpp prefix, only look for non-mangled "cpp_mangled" symbol
@@ -765,7 +767,7 @@ TEST(bpftrace, add_probes_usdt_wildcard)
 {
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_usdt(0, "/bin/*sh"))
+              get_symbols_from_usdt(no_pid, "/bin/*sh"))
       .Times(1);
 
   parse_probe("usdt:/bin/*sh:prov*:tp* {}", *bpftrace, 1);
@@ -787,7 +789,7 @@ TEST(bpftrace, add_probes_usdt_empty_namespace)
 {
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_usdt(0, "/bin/sh"))
+              get_symbols_from_usdt(no_pid, "/bin/sh"))
       .Times(1);
 
   parse_probe("usdt:/bin/sh:tp1 {}", *bpftrace, 1);
@@ -805,7 +807,7 @@ TEST(bpftrace, add_probes_usdt_empty_namespace_conflict)
 {
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_usdt(0, "/bin/sh"))
+              get_symbols_from_usdt(no_pid, "/bin/sh"))
       .Times(1);
 
   parse_probe("usdt:/bin/sh:tp {}", *bpftrace, 1);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -9,6 +9,7 @@
 
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/field_analyser.h"
+#include "ast/passes/pid_filter_pass.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 
@@ -60,6 +61,9 @@ static void test(BPFtrace &bpftrace,
   clang.parse(driver.ctx.root, bpftrace);
 
   ASSERT_EQ(driver.parse_str(input), 0);
+
+  ast::PidFilterPass pid_filter(driver.ctx, bpftrace);
+  pid_filter.analyse();
 
   ast::SemanticAnalyser semantics(driver.ctx, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);

--- a/tests/codegen/llvm/pid_filter.ll
+++ b/tests/codegen/llvm/pid_filter.ll
@@ -1,0 +1,94 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !39 {
+entry:
+  %"$x" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
+  store i64 0, ptr %"$x", align 8
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %1 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %1 to i32
+  %2 = zext i32 %pid to i64
+  %3 = icmp ne i64 %2, 1
+  %true_cond = icmp ne i1 %3, false
+  br i1 %true_cond, label %if_body, label %if_end
+
+if_body:                                          ; preds = %entry
+  ret i64 0
+
+if_end:                                           ; preds = %unreach, %entry
+  store i64 1, ptr %"$x", align 8
+  ret i64 0
+
+unreach:                                          ; No predecessors!
+  br label %if_end
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/pid_filter.cpp
+++ b/tests/codegen/pid_filter.cpp
@@ -1,0 +1,17 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, pid_filter)
+{
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->procmon_ = std::make_unique<MockProcMon>(1);
+
+  test(*bpftrace, "kprobe:f { $x = 1 }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -52,12 +52,13 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
                          "/bin/sh:_Z18cpp_mangled_suffixv\n";
   std::string bash_usyms = "/bin/bash:first_open\n";
   ON_CALL(matcher, get_func_symbols_from_file(_, "/bin/sh"))
-      .WillByDefault([sh_usyms](int, const std::string &) {
+      .WillByDefault([sh_usyms](std::optional<int>, const std::string &) {
         return std::unique_ptr<std::istream>(new std::istringstream(sh_usyms));
       });
 
   ON_CALL(matcher, get_func_symbols_from_file(_, "/bin/*sh"))
-      .WillByDefault([sh_usyms, bash_usyms](int, const std::string &) {
+      .WillByDefault([sh_usyms, bash_usyms](std::optional<int>,
+                                            const std::string &) {
         return std::unique_ptr<std::istream>(
             new std::istringstream(sh_usyms + bash_usyms));
       });
@@ -69,11 +70,12 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
                          "/bin/sh:nahprov:tp\n";
   std::string bash_usdts = "/bin/bash:prov1:tp3\n";
   ON_CALL(matcher, get_symbols_from_usdt(_, "/bin/sh"))
-      .WillByDefault([sh_usdts](int, const std::string &) {
+      .WillByDefault([sh_usdts](std::optional<int>, const std::string &) {
         return std::unique_ptr<std::istream>(new std::istringstream(sh_usdts));
       });
   ON_CALL(matcher, get_symbols_from_usdt(_, "/bin/*sh"))
-      .WillByDefault([sh_usdts, bash_usdts](int, const std::string &) {
+      .WillByDefault([sh_usdts, bash_usdts](std::optional<int>,
+                                            const std::string &) {
         return std::unique_ptr<std::istream>(
             new std::istringstream(sh_usdts + bash_usdts));
       });
@@ -174,7 +176,7 @@ std::unique_ptr<MockUSDTHelper> get_mock_usdt_helper(int num_locations)
   auto usdt_helper = std::make_unique<NiceMock<MockUSDTHelper>>();
 
   ON_CALL(*usdt_helper, find(_, _, _, _))
-      .WillByDefault([num_locations](int,
+      .WillByDefault([num_locations](std::optional<int>,
                                      const std::string &,
                                      const std::string &,
                                      const std::string &) {

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -25,10 +25,10 @@ public:
   MOCK_CONST_METHOD1(get_symbols_from_traceable_funcs,
                      std::unique_ptr<std::istream>(bool with_modules));
   MOCK_CONST_METHOD2(get_symbols_from_usdt,
-                     std::unique_ptr<std::istream>(int pid,
+                     std::unique_ptr<std::istream>(std::optional<int> pid,
                                                    const std::string &target));
   MOCK_CONST_METHOD2(get_func_symbols_from_file,
-                     std::unique_ptr<std::istream>(int pid,
+                     std::unique_ptr<std::istream>(std::optional<int> pid,
                                                    const std::string &path));
 #pragma GCC diagnostic pop
 };
@@ -193,7 +193,7 @@ public:
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
   MOCK_METHOD4(find,
-               std::optional<usdt_probe_entry>(int pid,
+               std::optional<usdt_probe_entry>(std::optional<int> pid,
                                                const std::string &target,
                                                const std::string &provider,
                                                const std::string &name));

--- a/tests/pid_filter_pass.cpp
+++ b/tests/pid_filter_pass.cpp
@@ -1,0 +1,97 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "ast/passes/pid_filter_pass.h"
+#include "ast/passes/printer.h"
+#include "clang_parser.h"
+#include "driver.h"
+#include "mocks.h"
+
+namespace bpftrace::test::pid_filter_pass {
+
+using ::testing::_;
+using ::testing::HasSubstr;
+
+void test(std::string_view input, bool has_pid, bool has_filter)
+{
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace& bpftrace = *mock_bpftrace;
+  if (has_pid) {
+    bpftrace.procmon_ = std::make_unique<MockProcMon>(1);
+  }
+
+  Driver driver(bpftrace);
+  std::stringstream msg;
+  msg << "\nInput:\n" << input << "\n\nOutput:\n";
+
+  ASSERT_EQ(driver.parse_str(input), 0);
+
+  ClangParser clang;
+  ASSERT_TRUE(clang.parse(driver.ctx.root, bpftrace));
+
+  ASSERT_EQ(driver.parse_str(input), 0);
+  ast::PidFilterPass pid_filter(driver.ctx, bpftrace);
+  pid_filter.analyse();
+
+  std::string_view expected_ast = R"(
+  if
+   !=
+    builtin: pid
+    int: 1
+   then
+    return
+)";
+
+  std::ostringstream out;
+  ast::Printer printer(driver.ctx, out);
+  printer.print();
+
+  if (has_filter) {
+    EXPECT_THAT(out.str(), HasSubstr(expected_ast));
+  } else {
+    EXPECT_THAT(out.str(), Not(HasSubstr(expected_ast)));
+  }
+}
+
+TEST(pid_filter_pass, add_filter)
+{
+  std::vector<std::string> filter_probes = {
+    "kprobe:f",
+    "kretprobe:f",
+    "fentry:f",
+    "fexit:f",
+    "tracepoint:category:event",
+    "rawtracepoint:event",
+  };
+
+  for (auto& probe : filter_probes) {
+    test(probe + " { 1 }", true, true);
+  }
+}
+
+TEST(pid_filter_pass, no_add_filter)
+{
+  // Sanity check: no pid, no filter
+  test("kprobe:f { 1 }", false, false);
+  test("profile:hz:99 { 1 }", false, false);
+
+  std::vector<std::string> no_filter_probes = {
+    "BEGIN",
+    "END",
+    "uprobe:/bin/sh:f",
+    "uretprobe:/bin/sh:f",
+    "usdt:sh:probe",
+    "watchpoint:0x0:8:rw",
+    "asyncwatchpoint:func1+arg2:8:rw",
+    "profile:ms:1",
+    "interval:s:1",
+    "software:faults:1000",
+    "hardware:cache-references:1000000",
+  };
+
+  for (auto& probe : no_filter_probes) {
+    test(probe + " { 1 }", true, false);
+  }
+}
+
+} // namespace bpftrace::test::pid_filter_pass

--- a/tests/pid_filter_pass.cpp
+++ b/tests/pid_filter_pass.cpp
@@ -94,4 +94,10 @@ TEST(pid_filter_pass, no_add_filter)
   }
 }
 
+TEST(pid_filter_pass, mixed_probes)
+{
+  test("kprobe:f, uprobe:/bin/sh:f { 1 }", true, true);
+  test("usdt:sh:probe, uprobe:/bin/sh:f, profile:ms:1 { 1 }", true, false);
+}
+
 } // namespace bpftrace::test::pid_filter_pass

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -394,8 +394,6 @@ class Runner(object):
                 if test.new_pidns:
                     # This can be fixed in the future if needed
                     raise ValueError(f"BEFORE_PID cannot be used with NEW_PIDNS")
-                if len(test.befores) > 1:
-                    raise ValueError(f"test has {len(test.befores)} BEFORE clauses but BEFORE_PID usage requires exactly one")
 
                 child_name = test.befores[0].strip().split()[-1]
                 child_name = os.path.basename(child_name)

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -499,3 +499,16 @@ NAME sanitise probe name
 PROG uprobe:./testprogs/uprobe_namesan:fn* { printf("ok\n"); exit(); }
 EXPECT ok
 AFTER ./testprogs/uprobe_namesan
+
+NAME pid filter software
+RUN {{BPFTRACE}} -e 'software:cpu-clock:10000000 { @[pid] = count(); if (len(@) != 1) { print("bad"); } }' -p {{BEFORE_PID}}
+EXPECT_NONE bad
+BEFORE ./testprogs/work_loop
+TIMEOUT 2
+
+NAME pid filter kprobe
+RUN {{BPFTRACE}} -e 'kprobe:do_nanosleep { @[pid] = count(); if (len(@) != 1) { print("bad"); } }' -p {{BEFORE_PID}}
+EXPECT_NONE bad
+BEFORE ./testprogs/nanosleep_loop
+BEFORE ./testprogs/nanosleep_loop
+TIMEOUT 2

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2334,7 +2334,7 @@ TEST(semantic_analyser, watchpoint_function)
   test(*bpftrace, "w:func1.one_two+arg2:8:rw { 1 }");
   test(*bpftrace, "watchpoint:func1+arg99999:8:rw { 1 }", 1);
 
-  bpftrace->procmon_ = std::make_unique<MockProcMon>(0);
+  bpftrace->procmon_ = nullptr;
   test(*bpftrace, "watchpoint:func1+arg2:8:rw { 1 }", 1);
 }
 
@@ -2351,7 +2351,7 @@ TEST(semantic_analyser, asyncwatchpoint)
   // asyncwatchpoint's may not use absolute addresses
   test(*bpftrace, "asyncwatchpoint:0x1234:8:rw { 1 }", 1);
 
-  bpftrace->procmon_ = std::make_unique<MockProcMon>(0);
+  bpftrace->procmon_ = nullptr;
   test(*bpftrace, "watchpoint:func1+arg2:8:rw { 1 }", 1);
 }
 #endif // if defined(__x86_64__) || defined(__aarch64__)

--- a/tests/testprogs/nanosleep_loop.c
+++ b/tests/testprogs/nanosleep_loop.c
@@ -1,0 +1,27 @@
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <sys/types.h>
+
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
+{
+  struct timespec req;
+  req.tv_sec = 0;
+  req.tv_nsec = 100;
+  double time = 100000000.0;
+  req.tv_sec = (int)(time / 1e9);
+  req.tv_nsec = (int)(time - req.tv_sec * 1e9);
+  for (int i = 0; i < 10000; ++i) {
+    int r = syscall(SYS_nanosleep, &req, NULL);
+    if (r) {
+      perror("Error in syscall nanosleep");
+      return 1;
+    }
+  }
+  return 0;
+}

--- a/tests/testprogs/work_loop.c
+++ b/tests/testprogs/work_loop.c
@@ -1,0 +1,23 @@
+#include <unistd.h>
+
+int doWork(int *n, int o)
+{
+  return *n += o;
+}
+
+void spin()
+{
+  int i = 0;
+  while (1) {
+    int n = 1;
+    doWork(&n, i);
+    usleep(10);
+    ++i;
+  }
+}
+
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
+{
+  spin();
+  return 0;
+}


### PR DESCRIPTION
Currently the `-p` (pid) CLI option
only applies to uprobes/uretprobes/usdts.
However this causes confusion as you can
get events from all pids for any other
kind of probe[1].

This change adds pid filtering at the attach
point when possible or, for probes that
do not support a pid filter when attaching,
modifies the AST by adding this to the start:
```
if (pid != TARGETED_PID) {
  return;
}
```

[1] https://github.com/bpftrace/bpftrace/issues/254

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
