### PR TITLE
bpffeature: Fix detection for tracing programs

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -365,7 +365,7 @@ bool BPFfeature::has_d_path()
     return *has_d_path_;
 
   struct bpf_insn insns[] = {
-    BPF_LDX_MEM(BPF_W, BPF_REG_1, BPF_REG_1, 0),
+    BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_1, 0),
     BPF_MOV64_REG(BPF_REG_2, BPF_REG_10),
     BPF_ALU64_IMM(BPF_ADD, BPF_REG_2, -8),
     BPF_MOV64_IMM(BPF_REG_6, 0),
@@ -538,7 +538,7 @@ bool BPFfeature::has_skb_output()
     return false;
 
   struct bpf_insn insns[] = {
-    BPF_LDX_MEM(BPF_W, BPF_REG_1, BPF_REG_1, 0),
+    BPF_LDX_MEM(BPF_DW, BPF_REG_1, BPF_REG_1, 0),
     BPF_LD_MAP_FD(BPF_REG_2, map_fd),
     BPF_MOV64_IMM(BPF_REG_3, 0),
     BPF_MOV64_REG(BPF_REG_4, BPF_REG_10),


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Eric Hagberg from Jane Street reports:

After the upstream fix [0] for tracing programs rejecting narrow loads for pointer arguments in context, bpftrace began failing feature detection for dpath and skboutput.

For instance, bpftrace --info would say no for both cases, and attempting to attach a program like so:

  bpftrace -e 'kfunc:security_file_open { printf("%s", path(args->file->f_path)); }'

would yield an error:

  stdin:1:41-64: ERROR: BPF_FUNC_d_path not available for your kernel

Fix this by doing the right thing and performing 64-bit loads into the context to form a pointer in R1.

  [0]: https://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf.git/commit/?id=659b9ba7cb2d

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
