### PR TITLE
Increase defaults for max_bpf_progs and max_probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
   - [#3713](https://github.com/bpftrace/bpftrace/pull/3713)
 - Add feature check for castable map reads
   - [#3752](https://github.com/bpftrace/bpftrace/pull/3752)
+- Increase default values for max_bpf_progs and max_probes
+  - [#3808](https://github.com/bpftrace/bpftrace/pull/3808)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3701,7 +3701,7 @@ Log size in bytes.
 
 === max_bpf_progs
 
-Default: 512
+Default: 1024
 
 This is the maximum number of BPF programs (functions) that bpftrace can generate.
 The main purpose of this limit is to prevent bpftrace from hanging since generating a lot of probes
@@ -3723,7 +3723,7 @@ There are some cases where you will want to, for example: sampling stack traces,
 
 === max_probes
 
-Default: 512
+Default: 1024
 
 This is the maximum number of probes that bpftrace can attach to.
 Increasing the value will consume more memory, increase startup times, and can incur high performance overhead or even freeze/crash the

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -21,10 +21,10 @@ Config::Config(bool has_cmd)
     { ConfigKeyBool::use_blazesym, { .value = true } },
 #endif
     { ConfigKeyInt::log_size, { .value = static_cast<uint64_t>(1000000) } },
-    { ConfigKeyInt::max_bpf_progs, { .value = static_cast<uint64_t>(512) } },
+    { ConfigKeyInt::max_bpf_progs, { .value = static_cast<uint64_t>(1024) } },
     { ConfigKeyInt::max_cat_bytes, { .value = static_cast<uint64_t>(10240) } },
     { ConfigKeyInt::max_map_keys, { .value = static_cast<uint64_t>(4096) } },
-    { ConfigKeyInt::max_probes, { .value = static_cast<uint64_t>(512) } },
+    { ConfigKeyInt::max_probes, { .value = static_cast<uint64_t>(1024) } },
     { ConfigKeyInt::max_strlen, { .value = static_cast<uint64_t>(1024) } },
     { ConfigKeyInt::max_type_res_iterations,
       { .value = static_cast<uint64_t>(0) } },

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,10 +130,10 @@ void usage(std::ostream& out)
   out << "    BPFTRACE_KERNEL_SOURCE            [default: /lib/modules/$(uname -r)] kernel headers directory" << std::endl;
   out << "    BPFTRACE_LAZY_SYMBOLICATION       [default: 0] symbolicate lazily/on-demand" << std::endl;
   out << "    BPFTRACE_LOG_SIZE                 [default: 1000000] log size in bytes" << std::endl;
-  out << "    BPFTRACE_MAX_BPF_PROGS            [default: 512] max number of generated BPF programs" << std::endl;
+  out << "    BPFTRACE_MAX_BPF_PROGS            [default: 1024] max number of generated BPF programs" << std::endl;
   out << "    BPFTRACE_MAX_CAT_BYTES            [default: 10k] maximum bytes read by cat builtin" << std::endl;
   out << "    BPFTRACE_MAX_MAP_KEYS             [default: 4096] max keys in a map" << std::endl;
-  out << "    BPFTRACE_MAX_PROBES               [default: 512] max number of probes" << std::endl;
+  out << "    BPFTRACE_MAX_PROBES               [default: 1024] max number of probes" << std::endl;
   out << "    BPFTRACE_MAX_STRLEN               [default: 1024] bytes on BPF stack per str()" << std::endl;
   out << "    BPFTRACE_MAX_TYPE_RES_ITERATIONS  [default: 0] number of levels of nested field accesses for tracepoint args" << std::endl;
   out << "    BPFTRACE_PERF_RB_PAGES            [default: 64] pages per CPU to allocate for ring buffer" << std::endl;

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -491,7 +491,7 @@ TIMEOUT 2
 # match and so we should fail on exceeding BPFTRACE_MAX_BPF_PROGS.
 NAME bpf_programs_limit
 PROG k:* { @[probe] = count(); }
-EXPECT_REGEX ERROR: Failed to compile: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 512.\nYou can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
+EXPECT_REGEX ERROR: Failed to compile: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 1024.\nYou can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
 WILL_FAIL
 TIMEOUT 2
 


### PR DESCRIPTION
This is to solve an issue with the bpftrace
Hands on Lab exercise.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
