### PR TITLE
Re-enable bpf_map_sum_elem_count() on LLVM <17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,6 @@ jobs:
     strategy:
       matrix:
         env:
-        - NAME: LLVM 14
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm14
-        - NAME: LLVM 15
-          CMAKE_BUILD_TYPE: Debug
-          NIX_TARGET: .#bpftrace-llvm15
         - NAME: LLVM 16
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm16

--- a/flake.nix
+++ b/flake.nix
@@ -228,8 +228,6 @@
             bpftrace-llvm18 = mkBpftrace 18;
             bpftrace-llvm17 = mkBpftrace 17;
             bpftrace-llvm16 = mkBpftrace 16;
-            bpftrace-llvm15 = mkBpftrace 15;
-            bpftrace-llvm14 = mkBpftrace 14;
 
             # Self-contained static binary with all dependencies
             appimage = nix-appimage.mkappimage.${system} {
@@ -286,8 +284,6 @@
             bpftrace-llvm18 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm18;
             bpftrace-llvm17 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm17;
             bpftrace-llvm16 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm16;
-            bpftrace-llvm15 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm15;
-            bpftrace-llvm14 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm14;
           };
         });
 }

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -47,6 +47,29 @@ void DIBuilderBPF::createFunctionDebugInfo(llvm::Function &func,
                                          0,
                                          DINode::FlagPrototyped,
                                          flags);
+#if LLVM_VERSION_MAJOR < 17
+  // There's a bug in LLVM <17 in DIBuilder::createFunction when called for a
+  // function declaration. It creates an empty temporary MDTuple for
+  // RetainedNodes inside DISubprogram which is, in addition, never freed.
+  //
+  // We generate function declaration debug info for kfuncs so this causes
+  // two issues when kfuncs are used on LLVM <17:
+  //
+  // 1. The generated LLVM IR is invalid and its verification will fail.
+  // 2. There is a memory leak introduced by the above createFunction call.
+  //
+  // To fix both problems, delete the temporary MDTuple here.
+  //
+  // Note that the issue was fixed in LLVM 17 by
+  //
+  //  https://github.com/llvm/llvm-project/commit/ed506dd6cecd9653cf9202bfe195891a33482852
+  //
+  // which removes the creation of the temporary MDTuple.
+  //
+  if (is_declaration) {
+    llvm::MDNode::deleteTemporary(subprog->getRetainedNodes().get());
+  }
+#endif
 
   for (size_t i = 0; i < args.fields.size(); i++) {
     createParameterVariable(subprog,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1325,8 +1325,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       // it, otherwise fall back to bpf_for_each_map_elem with a custom callback
       if (map_has_single_elem(map.type, map.key_type)) {
         return ScopedExpr(b_.getInt64(1));
-      } else if (LLVM_VERSION_MAJOR >= 17 &&
-                 bpftrace_.feature_->has_kernel_func(
+      } else if (bpftrace_.feature_->has_kernel_func(
                      Kfunc::bpf_map_sum_elem_count) &&
                  !is_array_map(map.type, map.key_type)) {
         return ScopedExpr(CreateKernelFuncCall(Kfunc::bpf_map_sum_elem_count,


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

#3683 disabled usage of the `bpf_map_sum_elem_count` kfunc on LLVM <17 as it was failing LLVM IR code verification. There were two issues reported:

1. ```
    Call parameter type does not match function signature!
    %"struct map_t"* @AT_
     i8*  %len = call i64 @bpf_map_sum_elem_count(%"struct map_t"* @AT_)
    ```
    This one can be solved by simply adding a pointer cast.

2. ```
    Expected no forward declarations!
    !75 = <temporary!> !{}
    ```
    The reason for this failure is a bug in LLVM <17 in `DIBuilder::createFunction` when called for a function declaration (which we do for kfuncs). It creates an empty temporary `MDTuple` for `RetainedNodes` inside `DISubprogram` which is, in addition, never freed and therefore introduces a memory leak. The bug was fixed by https://github.com/llvm/llvm-project/commit/ed506dd6cecd9653cf9202bfe195891a33482852.

    This can be solved by deleting the temporary `MDTuple`.

Unfortunately, resolving the above two problems was not sufficient and LLVM IR verification kept complaining:
```
inlinable function call in a function with debug info must have a !dbg location
  %len = call i64 @bpf_map_sum_elem_count(i8* bitcast (%"struct map_t"* @AT_ to i8*))
```

This one turned out to be tricky to resolve. I tried to add a debug location to the call but then I was hitting a segfault in LLVM which I was not able to get rid of. So, in the end, I decided to disable LLVM IR verification for runtime tests using kfuncs on affected LLVM versions (only 14 and 15 as this check is relaxed in LLVM 16 by https://github.com/llvm/llvm-project/commit/041ec822421aae33f064d96a21607e550766dd4d). 

This is not an ideal solution as it will require us to explicitly disable IR verification for each test using kfunc which we add but I don't have anything better at the moment. Good thing is that we will stop supporting LLVM 15 once LLVM 21 is out (per our policy to support the last 6 versions) which will happen in September this year.

Note that the above issues would happen to any kfunc call so keeping the feature disabled is not a viable solution as we will eventually want to use more kfuncs.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
