### PR TITLE
Add "Design Principles" doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,33 @@ Contributions are welcome! Please see the [development section](#development) be
 
 ## Development
 
+* [Design Principles](docs/design_principles.md)
 * [Coding Guidelines](docs/coding_guidelines.md)
+* [RFC Process](#rfc-process)
 * [Development Guide](docs/developers.md)
 * [Development Roadmap](https://docs.google.com/document/d/17729Rlyo1xzlJObzHpFLDzeCVgvwRh0ktAmMEJLK-EU/edit)
 * [Fuzzing](docs/fuzzing.md)
 * [Nix](docs/nix.md)
 * [Release Process](docs/release_process.md)
 * [Tests](tests/README.md)
+* [DCO](#developers-certificate-of-origin)
+
+## RFC Process
+
+This is for "substantial" or breaking changes. Bug fixes, doc updates, small features, and issues tagged with "good first issue" can utilize the normal github pull request workflow.
+
+1. Create a new issue, where the title is prefixed with "RFC" and apply the RFC tag ([example](https://github.com/bpftrace/bpftrace/issues/2954)). Be sure to include the goal(s) of this change, potential downsides (if applicable), and other solutions you've considered. This issue is where discussions can be had about the overall design and approach. For the most part implementation details should NOT be discussed as they often lead to bike-shedding of the overall proposal.
+
+1. If there is either positive signal from one or more of the maintainers or a lack of negative signal feel free to create a POC and, when you're ready, submit a pull request (linking to the original RFC). This is a good place to have others experiment with your POC and discuss implementation details. 
+  - It's entirely possible that this POC exposes underlying issues in the original, approved RFC. That's OK! Return to the original RFC and explain why the approved solution does not work or needs adjustment. If the changes are significant enough, the maintainers might ask for an additional approval of the new approach on the RFC. It's also possible that the RFC then gets rejected; these things happen and they are a normal part of the development process.
+  - Depending on the change, you might be asked to gate this behind a "config flag". Meaning that users have to explicitly opt-in to this feature via the addition of a config flag in their script e.g. ```config = { experimental_my_feature=true }``` This allows us to increase development velocity and wait for more user feedback without permanently adding it to bpftrace. Now, it is possible that this feature still may end up getting removed and not added to the language due to user issues or changes in design direction. However, there will be plenty of communication between the maintainers and the original author if this is the case.
+  
+1. If the POC is approved by two or more maintainers, please follow the current pull request checklist:
+ - add it to the CHANGELOG
+ - update the adoc
+ - ensure there are unit tests, runtime tests, and codegen tests
+ 
+**Note**:  
 
 ## Developer's Certificate of Origin
 

--- a/docs/design_principles.md
+++ b/docs/design_principles.md
@@ -1,0 +1,54 @@
+# Design Principles
+
+This document exists so that there is a clear understanding of what bpftrace does and does not do. While we are excited to see community contributions, we are not likely to choose a path that goes against these principles. This document is as much for current and future maintainers as it is for new and existing contributors. This is a living document and subject to change.
+
+## bpftrace Mission Statement
+Provide a quick and easy way for people to write observability-based BPF programs, especially for people unfamiliar with the complexities of eBPF (e.g. the verifier, kernel/userspace interaction, attachment, program loading, memory access, and the various types of BPF maps).
+
+## Language Goals
+These are in priority order:
+
+1. conciseness / one-liners
+1. readability / easy to understand
+1. clean abstraction from eBPF
+1. ability to quickly iterate
+1. composability
+1. good performance in both kernel and userspace
+1. speed of program initialization/start-up
+
+## Language Non-Goals
+
+1. testability
+1. debuggability (no gdb or self-tracing) 
+1. dynamic typing
+1. Classes / Inheritance
+1. metaprogramming
+1. exception handling
+1. BPF security, LSM, XDP, Scheduling
+1. BPF concepts that don't pertain to observability or can’t be abstracted cleanly
+
+## Stability
+
+We value API stability and we would like bpftrace to work on as many past versions of the Linux kernel as possible ([dependency support](./dependency_support.md)). However, due to the speed of kernel development, especially in the BPF space, we need to ~~keep up~~ PUSH the community forward, which means sometimes we need to break things.
+
+We prefer the stability in the sense of “It is heavily used in production, and when something changes, there is a clear migration path” e.g. this [migration guide](./migration_guide.md).
+
+When we deprecate a pattern, we study its usage and, when appropriate, add deprecation warnings in an upcoming release before removing/changing it completely.
+
+We don’t deprecate anything without a good reason. We recognize that sometimes deprecations warnings cause frustration but we add them because deprecations clean up the road for the improvements and new features that we and many people in the community consider valuable.
+
+## Implementation
+
+We try to provide an elegant, intuitive, and surprise-free experience when users are writing/running bpftrace scripts. We are less concerned with the implementation being elegant. The real world is far from perfect, and to a reasonable extent we prefer to write ugly code if it means the user does not have to write it. When we evaluate new code, we are looking for an implementation that is correct, performant, tested, and will not lead to mounds of tech debt.
+
+We prefer boring code to clever code. Code is disposable and often changes. So it is important that it doesn’t introduce new internal abstractions unless absolutely necessary. Verbose code that is easy to move around, change, and remove is preferred to elegant code that is prematurely abstracted and hard to change.
+
+## Design Review
+
+Many changes, including bug fixes and documentation improvements can be implemented and reviewed via the normal GitHub pull request workflow. Some changes, though, are "substantial" or breaking, and we ask that these be put through the [RFC process](../CONTRIBUTING.md#rfc-process) and produce a consensus among bpftrace's maintainers.
+
+This process is intended to provide a consistent and controlled path for changes to bpftrace so that all stakeholders can be confident about the direction of the project.
+
+## Evolution
+
+Like many open source projects, bpftrace is evolving. As we learn more about our customers and what they need from a tool that promises fast kernel-based observability/tracing, we will adapt and grow bpftrace to meet those needs. We also want to grow the bpftrace community with transparency, responsiveness, kindness, and collaboration. Let's build something awesome together!


### PR DESCRIPTION
Also add "RFC Process" section to
contributing, which is linked to
from the Design Principles doc.

A lot of language was borrowed from
React and Rust:
- https://legacy.reactjs.org/docs/design-principles.html
- https://github.com/reactjs/rfcs
- https://github.com/rust-lang/rfcs

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
