### PR TITLE
Always mock BPFfeature

### DIFF
--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -265,7 +265,6 @@ TEST(bpftrace, add_probes_wildcard)
 TEST(bpftrace, add_probes_wildcard_kprobe_multi)
 {
   auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_symbols_from_traceable_funcs(false))
       .Times(2);
@@ -307,7 +306,7 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
 TEST(bpftrace, add_probes_wildcard_no_matches_kprobe_multi)
 {
   auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_symbols_from_traceable_funcs(false))
       .Times(1);
@@ -357,7 +356,7 @@ TEST(bpftrace, add_probes_kernel_module_wildcard)
   auto bpftrace = get_strict_mock_bpftrace();
   // We enable kprobe_multi here but it doesn't support the module:function
   // syntax so full expansion should be done anyways.
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_symbols_from_traceable_funcs(true))
       .Times(1);
@@ -390,7 +389,7 @@ TEST(bpftrace, add_probes_kernel_module_function_wildcard)
   auto bpftrace = get_strict_mock_bpftrace();
   // We enable kprobe_multi here but it doesn't support the module:function
   // syntax so full expansion should be done anyways.
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_symbols_from_traceable_funcs(true))
       .Times(1);
@@ -469,7 +468,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
 TEST(bpftrace, add_probes_uprobe_wildcard_uprobe_multi)
 {
   auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_func_symbols_from_file(0, "/bin/sh"))
       .Times(2);
@@ -521,7 +520,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file)
 TEST(bpftrace, add_probes_uprobe_wildcard_file_uprobe_multi)
 {
   auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_func_symbols_from_file(0, "/bin/*sh"))
       .Times(2);
@@ -561,7 +560,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
 TEST(bpftrace, add_probes_uprobe_wildcard_no_matches_multi)
 {
   auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_func_symbols_from_file(0, "/bin/sh"))
       .Times(1);
@@ -1174,7 +1173,7 @@ void check_probe(Probe &p, ProbeType type, const std::string &name)
 TEST_F(bpftrace_btf, add_probes_fentry)
 {
   auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   parse_probe("fentry:func_1,fexit:func_1 {}", *bpftrace);
 
   ASSERT_EQ(2U, bpftrace->get_probes().size());
@@ -1208,7 +1207,7 @@ TEST_F(bpftrace_btf, add_probes_kprobe)
 TEST_F(bpftrace_btf, add_probes_iter_task)
 {
   auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   parse_probe("iter:task {}", *bpftrace);
 
   ASSERT_EQ(1U, bpftrace->get_probes().size());
@@ -1220,7 +1219,7 @@ TEST_F(bpftrace_btf, add_probes_iter_task)
 TEST_F(bpftrace_btf, add_probes_iter_task_file)
 {
   auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   parse_probe("iter:task_file {}", *bpftrace);
 
   ASSERT_EQ(1U, bpftrace->get_probes().size());
@@ -1232,7 +1231,7 @@ TEST_F(bpftrace_btf, add_probes_iter_task_file)
 TEST_F(bpftrace_btf, add_probes_iter_task_vma)
 {
   auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   parse_probe("iter:task_vma {}", *bpftrace);
 
   ASSERT_EQ(1U, bpftrace->get_probes().size());

--- a/tests/codegen/builtin_cpid.cpp
+++ b/tests/codegen/builtin_cpid.cpp
@@ -6,12 +6,11 @@ namespace codegen {
 
 TEST(codegen, builtin_cpid)
 {
-  MockBPFtrace bpftrace;
-  bpftrace.child_ = std::make_unique<MockChildProc>("");
-  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  bpftrace.helper_check_level_ = 0;
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->child_ = std::make_unique<MockChildProc>("");
+  bpftrace->helper_check_level_ = 0;
 
-  test(bpftrace, "kprobe:f { @ = cpid }", NAME);
+  test(*bpftrace, "kprobe:f { @ = cpid }", NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/builtin_pid_tid.cpp
+++ b/tests/codegen/builtin_pid_tid.cpp
@@ -11,12 +11,11 @@ TEST(codegen, builtin_pid_tid)
 
 TEST(codegen, builtin_pid_tid_namespace)
 {
-  MockBPFtrace bpftrace;
-  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  bpftrace.mock_in_init_pid_ns = false;
-  bpftrace.helper_check_level_ = 0;
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->mock_in_init_pid_ns = false;
+  bpftrace->helper_check_level_ = 0;
 
-  test(bpftrace, "kprobe:f { @x = pid; @y = tid }", NAME);
+  test(*bpftrace, "kprobe:f { @x = pid; @y = tid }", NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/call_join.cpp
+++ b/tests/codegen/call_join.cpp
@@ -15,7 +15,6 @@ TEST(codegen, call_join)
 TEST(codegen, call_join_with_debug)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   bpftrace->debug_output_ = true;
   test(*bpftrace,
        "struct arg { char **argv } kprobe:f { $x = (struct arg *) 0; "

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -25,8 +25,6 @@ TEST(codegen, call_kstack_mapids)
   ClangParser clang;
   clang.parse(driver.ctx.root, *bpftrace);
 
-  // Override to mockbpffeature.
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
@@ -61,8 +59,6 @@ TEST(codegen, call_kstack_modes_mapids)
   ClangParser clang;
   clang.parse(driver.ctx.root, *bpftrace);
 
-  // Override to mockbpffeature.
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -25,8 +25,6 @@ TEST(codegen, call_ustack_mapids)
   ClangParser clang;
   clang.parse(driver.ctx.root, *bpftrace);
 
-  // Override to mockbpffeature.
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
@@ -61,8 +59,6 @@ TEST(codegen, call_ustack_modes_mapids)
   ClangParser clang;
   clang.parse(driver.ctx.root, *bpftrace);
 
-  // Override to mockbpffeature.
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -101,7 +101,6 @@ static void test(const std::string &input,
                  bool safe_mode = true)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   bpftrace->safe_mode_ = safe_mode;
 
   test(*bpftrace, input, name);

--- a/tests/codegen/fentry_recursion_check.cpp
+++ b/tests/codegen/fentry_recursion_check.cpp
@@ -6,11 +6,10 @@ namespace codegen {
 
 TEST(codegen, fentry_recursion_check)
 {
-  MockBPFtrace bpftrace;
-  bpftrace.need_recursion_check_ = true;
-  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->need_recursion_check_ = true;
 
-  test(bpftrace,
+  test(*bpftrace,
        "fentry:queued_spin_lock_slowpath { }"
        "tracepoint:exceptions:page_fault_user { }",
        NAME);
@@ -18,11 +17,10 @@ TEST(codegen, fentry_recursion_check)
 
 TEST(codegen, fentry_recursion_check_with_predicate)
 {
-  MockBPFtrace bpftrace;
-  bpftrace.need_recursion_check_ = true;
-  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->need_recursion_check_ = true;
 
-  test(bpftrace, "fentry:queued_spin_lock_slowpath / pid == 1234 / { }", NAME);
+  test(*bpftrace, "fentry:queued_spin_lock_slowpath / pid == 1234 / { }", NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -67,8 +67,6 @@ TEST(codegen, printf_offsets)
   ClangParser clang;
   clang.parse(driver.ctx.root, *bpftrace);
 
-  // Override to mockbpffeature.
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -15,7 +15,6 @@ TEST(codegen, regression_957)
   Driver driver(*bpftrace);
 
   ASSERT_EQ(driver.parse_str("t:sched:sched_one* { cat(\"%s\", probe); }"), 0);
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 

--- a/tests/codegen/runtime_error_check.cpp
+++ b/tests/codegen/runtime_error_check.cpp
@@ -7,7 +7,7 @@ namespace codegen {
 TEST(codegen, runtime_error_check_lookup_percpu)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 1;
 
   test(*bpftrace, "kprobe:f { @ = count(); $a = @; }", NAME);
@@ -16,7 +16,7 @@ TEST(codegen, runtime_error_check_lookup_percpu)
 TEST(codegen, runtime_error_check_delete)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 1;
 
   test(*bpftrace, "kprobe:f { @x[1] = 1; delete(@x, 1) }", NAME);
@@ -25,7 +25,7 @@ TEST(codegen, runtime_error_check_delete)
 TEST(codegen, runtime_error_check_pid_tid)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 1;
 
   test(*bpftrace, "kprobe:f { @x = pid; @y = tid }", NAME);
@@ -34,7 +34,7 @@ TEST(codegen, runtime_error_check_pid_tid)
 TEST(codegen, runtime_error_check_comm)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 1;
 
   test(*bpftrace, "kprobe:f { @x = comm; }", NAME);
@@ -43,7 +43,7 @@ TEST(codegen, runtime_error_check_comm)
 TEST(codegen, runtime_error_check_signal)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 1;
   bpftrace->safe_mode_ = false;
 
@@ -53,7 +53,7 @@ TEST(codegen, runtime_error_check_signal)
 TEST(codegen, runtime_error_check_path)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 1;
 
   test(*bpftrace, "fentry:filp_close { path((uint8 *)0); }", NAME);
@@ -62,7 +62,7 @@ TEST(codegen, runtime_error_check_path)
 TEST(codegen, runtime_error_check_printf)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 1;
 
   test(*bpftrace, "iter:task_file { printf(\"%d\", 1); }", NAME);
@@ -71,7 +71,7 @@ TEST(codegen, runtime_error_check_printf)
 TEST(codegen, runtime_error_check_for_map)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 1;
 
   test(*bpftrace,
@@ -82,7 +82,7 @@ TEST(codegen, runtime_error_check_for_map)
 TEST(codegen, runtime_error_check_stack)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 1;
 
   test(*bpftrace, "kprobe:f { @x = ustack; @y = kstack }", NAME);
@@ -91,7 +91,7 @@ TEST(codegen, runtime_error_check_stack)
 TEST(codegen, runtime_error_check_lookup_no_warning)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 1;
 
   test(*bpftrace, "kprobe:f { @++; }", NAME);
@@ -100,7 +100,7 @@ TEST(codegen, runtime_error_check_lookup_no_warning)
 TEST(codegen, runtime_error_check_lookup)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   bpftrace->helper_check_level_ = 2;
 
   test(*bpftrace, "kprobe:f { @++; }", NAME);

--- a/tests/codegen/scratch_buffer.cpp
+++ b/tests/codegen/scratch_buffer.cpp
@@ -13,7 +13,6 @@ static void test_stack_or_scratch_buffer(const std::string &input,
                                          uint64_t on_stack_limit)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   auto configs = ConfigSetter(bpftrace->config_, ConfigSource::script);
   configs.set(ConfigKeyInt::on_stack_limit, on_stack_limit);
   configs.set(ConfigKeyInt::max_strlen, MAX_STRLEN);

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -44,7 +44,7 @@ void test(BPFtrace &bpftrace,
 void test(const std::string &input, bool expected_result)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   test(*bpftrace, input, {}, expected_result);
 }
 
@@ -53,7 +53,7 @@ void test(const std::string &input,
           bool expected_result)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   test(*bpftrace, input, expected_error, expected_result);
 }
 

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -149,6 +149,8 @@ std::unique_ptr<MockBPFtrace> get_mock_bpftrace()
   setup_mock_probe_matcher(*probe_matcher);
   bpftrace->set_mock_probe_matcher(std::move(probe_matcher));
 
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
   return bpftrace;
 }
 
@@ -161,6 +163,8 @@ std::unique_ptr<MockBPFtrace> get_strict_mock_bpftrace()
       bpftrace.get());
   setup_mock_probe_matcher(*probe_matcher);
   bpftrace->set_mock_probe_matcher(std::move(probe_matcher));
+
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
 
   return bpftrace;
 }

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -41,7 +41,6 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 void test(const std::string &input, int expected_result = 0)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   test(*bpftrace, input, expected_result);
 }
 

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -32,8 +32,6 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
   ClangParser clang;
   clang.parse(driver.ctx.root, *bpftrace);
 
-  // Override to mockbpffeature.
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -50,7 +50,6 @@ void test(const std::string &input,
           std::optional<uint64_t> on_stack_limit = std::nullopt)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   auto configs = ConfigSetter(bpftrace->config_, ConfigSource::script);
   configs.set(ConfigKeyInt::on_stack_limit, on_stack_limit.value_or(0));
   return test(*bpftrace, input, expected_result, out);

--- a/tests/return_path_analyser.cpp
+++ b/tests/return_path_analyser.cpp
@@ -39,7 +39,6 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 void test(const std::string &input, int expected_result = 0)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   test(*bpftrace, input, expected_result);
 }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -31,8 +31,6 @@ void test_for_warning(BPFtrace &bpftrace,
 
   ASSERT_EQ(driver.parse_str(input), 0);
   std::stringstream out;
-  // Override to mockbpffeature.
-  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.ctx, bpftrace, out);
   semantics.analyse();
   if (invert)


### PR DESCRIPTION
Make sure that BPFfeature is always mocked
when using the bpftrace mock for two reasons:
- so we don't accidentally rely on host state
- reduce boilerplate by setting the default to 'true'

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
