### PR TITLE
Drop support for LLVM 14 and 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to
   - [#3808](https://github.com/bpftrace/bpftrace/pull/3808)
 #### Deprecated
 #### Removed
+- Drop support for LLVM 14 and 15
+  - [#3825](https://github.com/bpftrace/bpftrace/pull/3825)
 #### Fixed
 - Fix json output for none type
   - [#3692](https://github.com/bpftrace/bpftrace/pull/3692)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ else()
   find_package(LLVM REQUIRED)
 endif()
 
-set(MIN_LLVM_MAJOR 13)
+set(MIN_LLVM_MAJOR 16)
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   # We assume bpftrace is not being packaged when CMAKE_BUILD_TYPE=Debug.
   # So allow building with any LLVM version. This is purely for developers.

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -395,7 +395,7 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype,
     if (emit_codegen_types)
       ty = getInt64Ty();
     else
-      ty = GET_PTR_TY();
+      ty = getPtrTy();
   } else if (stype.IsVoidTy()) {
     ty = getVoidTy();
   } else {
@@ -473,9 +473,7 @@ Value *IRBuilderBPF::GetMapVar(const std::string &map_name)
 
 Value *IRBuilderBPF::GetNull()
 {
-  return ConstantExpr::getCast(Instruction::IntToPtr,
-                               getInt64(0),
-                               GET_PTR_TY());
+  return ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), getPtrTy());
 }
 
 CallInst *IRBuilderBPF::CreateMapLookup(Map &map,
@@ -489,7 +487,7 @@ CallInst *IRBuilderBPF::createMapLookup(const std::string &map_name,
                                         Value *key,
                                         const std::string &name)
 {
-  return createMapLookup(map_name, key, GET_PTR_TY(), name);
+  return createMapLookup(map_name, key, getPtrTy(), name);
 }
 
 CallInst *IRBuilderBPF::createMapLookup(const std::string &map_name,
@@ -517,7 +515,7 @@ CallInst *IRBuilderBPF::createPerCpuMapLookup(const std::string &map_name,
                                               Value *cpu,
                                               const std::string &name)
 {
-  return createPerCpuMapLookup(map_name, key, cpu, GET_PTR_TY(), name);
+  return createPerCpuMapLookup(map_name, key, cpu, getPtrTy(), name);
 }
 
 CallInst *IRBuilderBPF::createPerCpuMapLookup(const std::string &map_name,
@@ -545,7 +543,7 @@ CallInst *IRBuilderBPF::CreateGetJoinMap(BasicBlock *failure_callback,
                                          const location &loc)
 {
   return createGetScratchMap(
-      to_string(MapType::Join), "join", GET_PTR_TY(), loc, failure_callback);
+      to_string(MapType::Join), "join", getPtrTy(), loc, failure_callback);
 }
 
 CallInst *IRBuilderBPF::CreateGetStackScratchMap(StackType stack_type,
@@ -664,12 +662,8 @@ Value *IRBuilderBPF::createAllocation(
   const auto on_stack_limit = bpftrace_.config_.get(
       ConfigKeyInt::on_stack_limit);
   if (obj_size > on_stack_limit) {
-    return CreatePointerCast(
-        createScratchBuffer(globalvar,
-                            loc,
-                            gen_async_id_cb ? (*gen_async_id_cb)(async_ids_)
-                                            : 0),
-        obj_type->getPointerTo());
+    return createScratchBuffer(
+        globalvar, loc, gen_async_id_cb ? (*gen_async_id_cb)(async_ids_) : 0);
   }
   return CreateAllocaBPF(obj_type, name);
 }
@@ -700,8 +694,7 @@ Value *IRBuilderBPF::createScratchBuffer(
   // 2nd/3rd/4th indexes actually index into the array
   // See https://llvm.org/docs/LangRef.html#id236
   return CreateGEP(GetType(type),
-                   CreatePointerCast(module_.getGlobalVariable(config.name),
-                                     GetType(type)->getPointerTo()),
+                   module_.getGlobalVariable(config.name),
                    { getInt64(0), bounded_cpu_id, getInt64(key), getInt64(0) });
 }
 
@@ -731,7 +724,7 @@ CallInst *IRBuilderBPF::createGetScratchMap(const std::string &map_name,
       module_.getContext(), "lookup_" + name + "_failure", parent);
   BasicBlock *lookup_merge_block = BasicBlock::Create(
       module_.getContext(), "lookup_" + name + "_merge", parent);
-  Value *condition = CreateICmpNE(CreateIntCast(call, GET_PTR_TY(), true),
+  Value *condition = CreateICmpNE(CreateIntCast(call, getPtrTy(), true),
                                   GetNull(),
                                   "lookup_" + name + "_cond");
   CreateCondBr(condition, lookup_merge_block, lookup_failure_block);
@@ -763,7 +756,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
                                          Value *key,
                                          const location &loc)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   return CreateMapLookupElem(ctx, map.ident, key, map.type, loc);
 }
 
@@ -773,7 +766,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
                                          SizedType &type,
                                          const location &loc)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   CallInst *call = createMapLookup(map_name, key);
 
   // Check if result == 0
@@ -788,10 +781,8 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
                                                       "lookup_merge",
                                                       parent);
 
-  Value *value = CreatePointerCast(
-      CreateReadMapValueAllocation(type, "lookup_elem_val", loc),
-      GetType(type)->getPointerTo());
-  Value *condition = CreateICmpNE(CreateIntCast(call, GET_PTR_TY(), true),
+  Value *value = CreateReadMapValueAllocation(type, "lookup_elem_val", loc);
+  Value *condition = CreateICmpNE(CreateIntCast(call, getPtrTy(), true),
                                   GetNull(),
                                   "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
@@ -801,9 +792,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
     CreateMemcpyBPF(value, call, type.GetSize());
   else {
     assert(GetType(type) == getInt64Ty());
-    // createMapLookup  returns an u8*
-    auto *cast = CreatePointerCast(call, value->getType(), "cast");
-    CreateStore(CreateLoad(getInt64Ty(), cast), value);
+    CreateStore(CreateLoad(getInt64Ty(), call), value);
   }
   CreateBr(lookup_merge_block);
 
@@ -848,7 +837,7 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
   // }
   // return ret;
 
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
 
   const std::string &map_name = map.ident;
 
@@ -896,7 +885,7 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Value *ctx,
   BasicBlock *lookup_failure_block = BasicBlock::Create(module_.getContext(),
                                                         "lookup_failure",
                                                         lookup_parent);
-  Value *condition = CreateICmpNE(CreateIntCast(call, GET_PTR_TY(), true),
+  Value *condition = CreateICmpNE(CreateIntCast(call, getPtrTy(), true),
                                   GetNull(),
                                   "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
@@ -1012,8 +1001,7 @@ void IRBuilderBPF::createPerCpuSum(AllocaInst *ret,
                                    CallInst *call,
                                    const SizedType &type)
 {
-  auto *cast = CreatePointerCast(call, GetType(type)->getPointerTo(), "cast");
-  CreateStore(CreateAdd(CreateLoad(GetType(type), cast),
+  CreateStore(CreateAdd(CreateLoad(GetType(type), call),
                         CreateLoad(getInt64Ty(), ret)),
               ret);
 }
@@ -1024,14 +1012,13 @@ void IRBuilderBPF::createPerCpuMinMax(AllocaInst *ret,
                                       const SizedType &type)
 {
   auto *value_type = GetMapValueType(type);
-  auto *cast = CreatePointerCast(call, value_type->getPointerTo(), "cast");
   bool is_max = type.IsMaxTy();
 
   Value *mm_val = CreateLoad(
-      getInt64Ty(), CreateGEP(value_type, cast, { getInt64(0), getInt32(0) }));
+      getInt64Ty(), CreateGEP(value_type, call, { getInt64(0), getInt32(0) }));
 
   Value *is_val_set = CreateLoad(
-      getInt64Ty(), CreateGEP(value_type, cast, { getInt64(0), getInt32(1) }));
+      getInt64Ty(), CreateGEP(value_type, call, { getInt64(0), getInt32(1) }));
 
   // (ret, is_ret_set, min_max_val, is_val_set) {
   // // if the min_max_val is 0, which is the initial map value,
@@ -1114,13 +1101,12 @@ void IRBuilderBPF::createPerCpuAvg(AllocaInst *total,
                                    const SizedType &type)
 {
   auto *value_type = GetMapValueType(type);
-  auto *cast = CreatePointerCast(call, value_type->getPointerTo(), "cast");
 
   Value *total_val = CreateLoad(
-      getInt64Ty(), CreateGEP(value_type, cast, { getInt64(0), getInt32(0) }));
+      getInt64Ty(), CreateGEP(value_type, call, { getInt64(0), getInt32(0) }));
 
   Value *count_val = CreateLoad(
-      getInt64Ty(), CreateGEP(value_type, cast, { getInt64(0), getInt32(1) }));
+      getInt64Ty(), CreateGEP(value_type, call, { getInt64(0), getInt32(1) }));
 
   CreateStore(CreateAdd(total_val, CreateLoad(getInt64Ty(), total)), total);
   CreateStore(CreateAdd(count_val, CreateLoad(getInt64Ty(), count)), count);
@@ -1134,7 +1120,7 @@ void IRBuilderBPF::CreateMapUpdateElem(Value *ctx,
                                        int64_t flags)
 {
   Value *map_ptr = GetMapVar(map_ident);
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   assert(key->getType()->isPointerTy());
   assert(val->getType()->isPointerTy());
 
@@ -1163,7 +1149,7 @@ void IRBuilderBPF::CreateMapDeleteElem(Value *ctx,
                                        Value *key,
                                        const location &loc)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   assert(key->getType()->isPointerTy());
   Value *map_ptr = GetMapVar(map.ident);
 
@@ -1197,11 +1183,9 @@ Value *IRBuilderBPF::CreateForEachMapElem(Value *ctx,
   // callback is long (*callback_fn)(struct bpf_map *map, const void *key, void
   // *value, void *ctx);
 
-  auto *int8_ptr = getInt8Ty()->getPointerTo();
-
   FunctionType *for_each_map_type = FunctionType::get(
       getInt64Ty(),
-      { map_ptr->getType(), callback->getType(), int8_ptr, getInt64Ty() },
+      { map_ptr->getType(), callback->getType(), getPtrTy(), getInt64Ty() },
       false);
   PointerType *for_each_map_ptr_type = PointerType::get(for_each_map_type, 0);
 
@@ -1214,7 +1198,7 @@ Value *IRBuilderBPF::CreateForEachMapElem(Value *ctx,
       for_each_map_func,
       { map_ptr,
         callback,
-        callback_ctx ? CreateBitCast(callback_ctx, int8_ptr) : GetNull(),
+        callback_ctx ? CreateIntToPtr(callback_ctx, getPtrTy()) : GetNull(),
         /*flags=*/getInt64(0) },
       "for_each_map_elem");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_for_each_map_elem, loc);
@@ -1245,8 +1229,8 @@ void IRBuilderBPF::CreateCheckSetRecursion(const location &loc,
   // Make the verifier happy with a null check even though the value should
   // never be null for key 0.
   Value *condition = CreateICmpNE(
-      CreateIntCast(call, GET_PTR_TY(), true),
-      ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), GET_PTR_TY()),
+      CreateIntCast(call, getPtrTy(), true),
+      ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), getPtrTy()),
       "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
@@ -1255,7 +1239,7 @@ void IRBuilderBPF::CreateCheckSetRecursion(const location &loc,
   CreateLifetimeEnd(key);
 
   // createMapLookup  returns an u8*
-  auto *cast = CreatePointerCast(call, getInt64Ty(), "cast");
+  auto *cast = CreatePtrToInt(call, getInt64Ty(), "cast");
 
   Value *prev_value = CREATE_ATOMIC_RMW(AtomicRMWInst::BinOp::Xchg,
                                         cast,
@@ -1315,8 +1299,8 @@ void IRBuilderBPF::CreateUnSetRecursion(const location &loc)
   // Make the verifier happy with a null check even though the value should
   // never be null for key 0.
   Value *condition = CreateICmpNE(
-      CreateIntCast(call, GET_PTR_TY(), true),
-      ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), GET_PTR_TY()),
+      CreateIntCast(call, getPtrTy(), true),
+      ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), getPtrTy()),
       "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
@@ -1325,7 +1309,7 @@ void IRBuilderBPF::CreateUnSetRecursion(const location &loc)
   CreateLifetimeEnd(key);
 
   // createMapLookup  returns an u8*
-  auto *cast = CreatePointerCast(call, getInt64Ty(), "cast");
+  auto *cast = CreatePtrToInt(call, getInt64Ty(), "cast");
   CreateStore(getInt64(0), cast);
 
   CreateBr(merge_block);
@@ -1349,7 +1333,7 @@ void IRBuilderBPF::CreateProbeRead(Value *ctx,
                                    AddrSpace as,
                                    const location &loc)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   assert(size && size->getType()->getIntegerBitWidth() <= 32);
   size = CreateIntCast(size, getInt32Ty(), false);
 
@@ -1389,7 +1373,7 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
                                            AddrSpace as,
                                            const location &loc)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   assert(size && size->getType()->isIntegerTy());
   if ([[maybe_unused]] auto *dst_alloca = dyn_cast<AllocaInst>(dst)) {
     assert(dst_alloca->getAllocatedType()->isArrayTy() &&
@@ -1423,7 +1407,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
                                             AddrSpace as,
                                             const location &loc)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   // Argument size must be 1, 2, 4, or 8. See
   // https://sourceware.org/systemtap/wiki/UserSpaceProbeImplementation
   int abs_size = std::abs(argument->size);
@@ -1519,7 +1503,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
                                             AddrSpace as,
                                             const location &loc)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   struct bcc_usdt_argument argument;
 
   void *usdt;
@@ -1605,17 +1589,11 @@ Value *IRBuilderBPF::CreateStrncmp(Value *str1,
                                                      parent);
 
     Value *l;
-    auto *ptr_l = CreateGEP(getInt8Ty(),
-                            CreatePointerCast(str1,
-                                              getInt8Ty()->getPointerTo()),
-                            { getInt32(i) });
+    auto *ptr_l = CreateGEP(getInt8Ty(), str1, { getInt32(i) });
     l = CreateLoad(getInt8Ty(), ptr_l);
 
     Value *r;
-    auto *ptr_r = CreateGEP(getInt8Ty(),
-                            CreatePointerCast(str2,
-                                              getInt8Ty()->getPointerTo()),
-                            { getInt32(i) });
+    auto *ptr_r = CreateGEP(getInt8Ty(), str2, { getInt32(i) });
     r = CreateLoad(getInt8Ty(), ptr_r);
 
     Value *cmp = CreateICmpNE(l, r, "strcmp.cmp");
@@ -1720,8 +1698,6 @@ Value *IRBuilderBPF::CreateStrcontains(Value *haystack,
   AllocaInst *i = CreateAllocaBPF(getInt64Ty(), "strcontains.i");
   CreateStore(getInt64(0), i);
   AllocaInst *j = CreateAllocaBPF(getInt64Ty(), "strcontains.j");
-  needle = CreatePointerCast(needle, getInt8Ty()->getPointerTo());
-  haystack = CreatePointerCast(haystack, getInt8Ty()->getPointerTo());
   Value *null_byte = getInt8(0);
 
   CreateBr(empty_check);
@@ -2079,7 +2055,7 @@ CallInst *IRBuilderBPF::CreateGetStack(Value *ctx,
                                        StackType stack_type,
                                        const location &loc)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
 
   int flags = 0;
   if (ustack)
@@ -2092,7 +2068,7 @@ CallInst *IRBuilderBPF::CreateGetStack(Value *ctx,
   // *size* on success, or a negative error in case of failure.
   FunctionType *getstack_func_type = FunctionType::get(
       getInt32Ty(),
-      { GET_PTR_TY(), GET_PTR_TY(), getInt32Ty(), getInt64Ty() },
+      { getPtrTy(), getPtrTy(), getInt32Ty(), getInt64Ty() },
       false);
   CallInst *call = CreateHelperCall(libbpf::BPF_FUNC_get_stack,
                                     getstack_func_type,
@@ -2111,7 +2087,7 @@ CallInst *IRBuilderBPF::CreateGetFuncIp(Value *ctx, const location &loc)
   //		0 for kprobes placed within the function (not at the entry).
   //		Address of the probe for uprobe and return uprobe.
   FunctionType *getfuncip_func_type = FunctionType::get(getInt64Ty(),
-                                                        { GET_PTR_TY() },
+                                                        { getPtrTy() },
                                                         false);
   return CreateHelperCall(libbpf::BPF_FUNC_get_func_ip,
                           getfuncip_func_type,
@@ -2129,7 +2105,7 @@ CallInst *IRBuilderBPF::CreatePerCpuPtr(Value *var,
   //    A pointer pointing to the kernel percpu variable on
   //    cpu, or NULL, if cpu is invalid.
   FunctionType *percpuptr_func_type = FunctionType::get(
-      GET_PTR_TY(), { GET_PTR_TY(), getInt64Ty() }, false);
+      getPtrTy(), { getPtrTy(), getInt64Ty() }, false);
   return CreateHelperCall(libbpf::BPF_FUNC_per_cpu_ptr,
                           percpuptr_func_type,
                           { var, cpu },
@@ -2143,8 +2119,8 @@ CallInst *IRBuilderBPF::CreateThisCpuPtr(Value *var, const location &loc)
   // Return:
   //    A pointer pointing to the kernel percpu variable on
   //    this cpu. May never be NULL.
-  FunctionType *percpuptr_func_type = FunctionType::get(GET_PTR_TY(),
-                                                        { GET_PTR_TY() },
+  FunctionType *percpuptr_func_type = FunctionType::get(getPtrTy(),
+                                                        { getPtrTy() },
                                                         false);
   return CreateHelperCall(libbpf::BPF_FUNC_this_cpu_ptr,
                           percpuptr_func_type,
@@ -2179,7 +2155,7 @@ void IRBuilderBPF::CreateOutput(Value *ctx,
                                 size_t size,
                                 const location *loc)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   assert(data && data->getType()->isPointerTy());
 
   if (bpftrace_.feature_->has_map_ringbuf()) {
@@ -2243,15 +2219,14 @@ void IRBuilderBPF::CreateAtomicIncCounter(const std::string &map_name,
                                                       "lookup_merge",
                                                       parent);
 
-  Value *condition = CreateICmpNE(CreateIntCast(call, GET_PTR_TY(), true),
+  Value *condition = CreateICmpNE(CreateIntCast(call, getPtrTy(), true),
                                   GetNull(),
                                   "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
   SetInsertPoint(lookup_success_block);
-  Value *val = CreatePointerCast(call, getInt64Ty()->getPointerTo());
   CREATE_ATOMIC_RMW(AtomicRMWInst::BinOp::Add,
-                    val,
+                    call,
                     getInt64(1),
                     8,
                     AtomicOrdering::SequentiallyConsistent);
@@ -2299,7 +2274,7 @@ void IRBuilderBPF::CreateMapElemAdd(Value *ctx,
                                                       parent);
 
   AllocaInst *value = CreateAllocaBPF(type, "lookup_elem_val");
-  Value *condition = CreateICmpNE(CreateIntCast(call, GET_PTR_TY(), true),
+  Value *condition = CreateICmpNE(CreateIntCast(call, getPtrTy(), true),
                                   GetNull(),
                                   "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
@@ -2307,7 +2282,7 @@ void IRBuilderBPF::CreateMapElemAdd(Value *ctx,
   SetInsertPoint(lookup_success_block);
 
   // createMapLookup  returns an u8*
-  auto *cast = CreatePointerCast(call, value->getType(), "cast");
+  auto *cast = CreatePtrToInt(call, value->getType(), "cast");
   CreateStore(CreateAdd(CreateLoad(value->getAllocatedType(), cast), val),
               cast);
 
@@ -2336,7 +2311,7 @@ void IRBuilderBPF::CreatePerfEventOutput(Value *ctx,
   // long bpf_perf_event_output(struct pt_regs *ctx, struct bpf_map *map,
   //                            u64 flags, void *data, u64 size)
   FunctionType *perfoutput_func_type = FunctionType::get(getInt64Ty(),
-                                                         { GET_PTR_TY(),
+                                                         { getPtrTy(),
                                                            map_ptr->getType(),
                                                            getInt64Ty(),
                                                            data->getType(),
@@ -2363,10 +2338,7 @@ void IRBuilderBPF::CreateDebugOutput(std::string fmt_str,
       ArrayType::get(getInt8Ty(), fmt_str.length() + 1), "fmt_str");
   CreateMemsetBPF(fmt, getInt8(0), fmt_str.length() + 1);
   CreateStore(const_str, fmt);
-  CreateTracePrintk(CreatePointerCast(fmt, getInt8Ty()->getPointerTo()),
-                    getInt32(fmt_str.length() + 1),
-                    values,
-                    loc);
+  CreateTracePrintk(fmt, getInt32(fmt_str.length() + 1), values, loc);
 }
 
 void IRBuilderBPF::CreateTracePrintk(Value *fmt_ptr,
@@ -2381,7 +2353,7 @@ void IRBuilderBPF::CreateTracePrintk(Value *fmt_ptr,
 
   // long bpf_trace_printk(const char *fmt, u32 fmt_size, ...)
   FunctionType *traceprintk_func_type = FunctionType::get(
-      getInt64Ty(), { GET_PTR_TY(), getInt32Ty() }, true);
+      getInt64Ty(), { getPtrTy(), getInt32Ty() }, true);
 
   CreateHelperCall(libbpf::BPF_FUNC_trace_printk,
                    traceprintk_func_type,
@@ -2411,7 +2383,7 @@ void IRBuilderBPF::CreateOverrideReturn(Value *ctx, Value *rc)
   // long bpf_override_return(struct pt_regs *regs, u64 rc)
   // Return: 0
   FunctionType *override_func_type = FunctionType::get(
-      getInt64Ty(), { GET_PTR_TY(), getInt64Ty() }, false);
+      getInt64Ty(), { getPtrTy(), getInt64Ty() }, false);
   PointerType *override_func_ptr_type = PointerType::get(override_func_type, 0);
   Constant *override_func = ConstantExpr::getCast(
       Instruction::IntToPtr,
@@ -2582,7 +2554,7 @@ void IRBuilderBPF::CreateHelperError(Value *ctx,
                                      libbpf::bpf_func_id func_id,
                                      const location &loc)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   assert(return_value && return_value->getType() == getInt32Ty());
 
   if (bpftrace_.helper_check_level_ == 0 ||
@@ -2622,7 +2594,7 @@ void IRBuilderBPF::CreateHelperErrorCond(Value *ctx,
                                          const location &loc,
                                          bool compare_zero)
 {
-  assert(ctx && ctx->getType() == GET_PTR_TY());
+  assert(ctx && ctx->getType() == getPtrTy());
   if (bpftrace_.helper_check_level_ == 0 ||
       (bpftrace_.helper_check_level_ == 1 && return_zero_if_err(func_id)))
     return;
@@ -2659,7 +2631,7 @@ void IRBuilderBPF::CreatePath(Value *ctx,
   // int bpf_d_path(struct path *path, char *buf, u32 sz)
   // Return: 0 or error
   FunctionType *d_path_func_type = FunctionType::get(
-      getInt64Ty(), { GET_PTR_TY(), buf->getType(), getInt32Ty() }, false);
+      getInt64Ty(), { getPtrTy(), buf->getType(), getInt32Ty() }, false);
   CallInst *call = CreateHelperCall(libbpf::bpf_func_id::BPF_FUNC_d_path,
                                     d_path_func_type,
                                     { path, buf, sz },
@@ -2680,7 +2652,7 @@ void IRBuilderBPF::CreateSeqPrintf(Value *ctx,
   // Return: 0 or error
   FunctionType *seq_printf_func_type = FunctionType::get(
       getInt64Ty(),
-      { getInt64Ty(), GET_PTR_TY(), getInt32Ty(), GET_PTR_TY(), getInt32Ty() },
+      { getInt64Ty(), getPtrTy(), getInt32Ty(), getPtrTy(), getInt32Ty() },
       false);
   PointerType *seq_printf_func_ptr_type = PointerType::get(seq_printf_func_type,
                                                            0);
@@ -2760,10 +2732,7 @@ llvm::Value *IRBuilderBPF::CreateDatastructElemLoad(
   // Pointer size for the given address space doesn't match the BPF-side
   // representation. Use ptr_storage_ty as the load type and cast the result
   // back to int64.
-  llvm::Value *expr = CreateLoad(
-      ptr_storage_ty,
-      CreatePointerCast(ptr, ptr_storage_ty->getPointerTo()),
-      isVolatile);
+  llvm::Value *expr = CreateLoad(ptr_storage_ty, ptr, isVolatile);
 
   return CreateIntCast(expr, getInt64Ty(), false);
 }
@@ -2788,16 +2757,6 @@ llvm::Value *IRBuilderBPF::CreateSafeGEP(llvm::Type *ty,
     assert(ptr->getType()->isIntegerTy());
     ptr = CreateIntToPtr(ptr, ty->getPointerTo());
   }
-
-#if LLVM_VERSION_MAJOR <= 14
-  // Older versions of LLVM check that the type matches the GEP. Newer versions
-  // do not use this cast because we need to specifically preserve the pattern
-  // `GEP(preserveStaticOffsets(ctx))`, which doesn't exist on older versions.
-  if (ptr->getType() != ty->getPointerTo()) {
-    assert(ptr->getType()->isPointerTy());
-    ptr = CreatePointerCast(ptr, ty->getPointerTo());
-  }
-#endif
 
 #if LLVM_VERSION_MAJOR >= 18
   if (!preserve_static_offset_) {

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -15,12 +15,6 @@
 #define CREATE_ATOMIC_RMW(op, ptr, val, align, order)                          \
   CreateAtomicRMW((op), (ptr), (val), MaybeAlign((align)), (order))
 
-#if LLVM_VERSION_MAJOR >= 15
-#define GET_PTR_TY() getPtrTy()
-#else
-#define GET_PTR_TY() getInt8PtrTy()
-#endif
-
 namespace bpftrace {
 namespace ast {
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -26,11 +26,7 @@
 #if LLVM_VERSION_MAJOR <= 16
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
 #endif
-#if LLVM_VERSION_MAJOR >= 14
 #include <llvm/MC/TargetRegistry.h>
-#else
-#include <llvm/Support/TargetRegistry.h>
-#endif
 
 #include <llvm/Support/TargetSelect.h>
 
@@ -81,12 +77,7 @@ CodegenLLVM::CodegenLLVM(ASTContext &ctx,
                                   "generic",
                                   "",
                                   TargetOptions(),
-#if LLVM_VERSION_MAJOR >= 16
-                                  std::optional<Reloc::Model>()
-#else
-                                  Optional<Reloc::Model>()
-#endif
-                                      ));
+                                  std::optional<Reloc::Model>()));
 #if LLVM_VERSION_MAJOR >= 18
   target_machine_->setOptLevel(llvm::CodeGenOptLevel::Aggressive);
 #else
@@ -215,10 +206,8 @@ ScopedExpr CodegenLLVM::kstack_ustack(const std::string &ident,
                                                   "get_stack_fail",
                                                   parent);
 
-  Value *ptr_to_stack_trace = b_.CreatePointerCast(stack_trace,
-                                                   b_.GET_PTR_TY());
   Value *stack_size = b_.CreateGetStack(
-      ctx_, is_ustack, ptr_to_stack_trace, stack_type, loc);
+      ctx_, is_ustack, stack_trace, stack_type, loc);
   Value *condition = b_.CreateICmpSGE(stack_size, b_.getInt32(0));
   b_.CreateCondBr(condition, get_stack_success, get_stack_fail);
 
@@ -250,7 +239,7 @@ ScopedExpr CodegenLLVM::kstack_ustack(const std::string &ident,
   // More details here: https://github.com/bpftrace/bpftrace/issues/2962
   Value *murmur_hash_2 = b_.CreateCall(
       murmur_hash_2_func_,
-      { ptr_to_stack_trace, trunc_nr_stack_frames, seed },
+      { stack_trace, trunc_nr_stack_frames, seed },
       "murmur_hash_2");
 
   b_.CreateStore(murmur_hash_2,
@@ -512,7 +501,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                                                         parent);
 
     Value *lookup_condition = b_.CreateICmpNE(
-        b_.CreateIntCast(lookup, b_.GET_PTR_TY(), true),
+        b_.CreateIntCast(lookup, b_.getPtrTy(), true),
         b_.GetNull(),
         "lookup_cond");
     b_.CreateCondBr(lookup_condition,
@@ -521,17 +510,13 @@ ScopedExpr CodegenLLVM::visit(Call &call)
 
     b_.SetInsertPoint(lookup_success_block);
 
-    auto *cast = b_.CreatePointerCast(lookup,
-                                      mm_struct_ty->getPointerTo(),
-                                      "cast");
-
     Value *mm_val = b_.CreateLoad(
         b_.getInt64Ty(),
-        b_.CreateGEP(mm_struct_ty, cast, { b_.getInt64(0), b_.getInt32(0) }));
+        b_.CreateGEP(mm_struct_ty, lookup, { b_.getInt64(0), b_.getInt32(0) }));
 
     Value *is_set_val = b_.CreateLoad(
         b_.getInt64Ty(),
-        b_.CreateGEP(mm_struct_ty, cast, { b_.getInt64(0), b_.getInt32(1) }));
+        b_.CreateGEP(mm_struct_ty, lookup, { b_.getInt64(0), b_.getInt32(1) }));
 
     BasicBlock *is_set_block = BasicBlock::Create(module_->getContext(),
                                                   "is_set",
@@ -565,10 +550,10 @@ ScopedExpr CodegenLLVM::visit(Call &call)
 
     b_.CreateStore(
         expr,
-        b_.CreateGEP(mm_struct_ty, cast, { b_.getInt64(0), b_.getInt32(0) }));
+        b_.CreateGEP(mm_struct_ty, lookup, { b_.getInt64(0), b_.getInt32(0) }));
     b_.CreateStore(
         b_.getInt64(1),
-        b_.CreateGEP(mm_struct_ty, cast, { b_.getInt64(0), b_.getInt32(1) }));
+        b_.CreateGEP(mm_struct_ty, lookup, { b_.getInt64(0), b_.getInt32(1) }));
 
     b_.CreateBr(lookup_merge_block);
 
@@ -622,7 +607,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                                                         parent);
 
     Value *lookup_condition = b_.CreateICmpNE(
-        b_.CreateIntCast(lookup, b_.GET_PTR_TY(), true),
+        b_.CreateIntCast(lookup, b_.getPtrTy(), true),
         b_.GetNull(),
         "lookup_cond");
     b_.CreateCondBr(lookup_condition,
@@ -631,24 +616,26 @@ ScopedExpr CodegenLLVM::visit(Call &call)
 
     b_.SetInsertPoint(lookup_success_block);
 
-    auto *cast = b_.CreatePointerCast(lookup,
-                                      avg_struct_ty->getPointerTo(),
-                                      "cast");
+    Value *total_val = b_.CreateLoad(b_.getInt64Ty(),
+                                     b_.CreateGEP(avg_struct_ty,
+                                                  lookup,
+                                                  { b_.getInt64(0),
+                                                    b_.getInt32(0) }));
 
-    Value *total_val = b_.CreateLoad(
-        b_.getInt64Ty(),
-        b_.CreateGEP(avg_struct_ty, cast, { b_.getInt64(0), b_.getInt32(0) }));
+    Value *count_val = b_.CreateLoad(b_.getInt64Ty(),
+                                     b_.CreateGEP(avg_struct_ty,
+                                                  lookup,
+                                                  { b_.getInt64(0),
+                                                    b_.getInt32(1) }));
 
-    Value *count_val = b_.CreateLoad(
-        b_.getInt64Ty(),
-        b_.CreateGEP(avg_struct_ty, cast, { b_.getInt64(0), b_.getInt32(1) }));
-
-    b_.CreateStore(
-        b_.CreateAdd(total_val, expr),
-        b_.CreateGEP(avg_struct_ty, cast, { b_.getInt64(0), b_.getInt32(0) }));
-    b_.CreateStore(
-        b_.CreateAdd(b_.getInt64(1), count_val),
-        b_.CreateGEP(avg_struct_ty, cast, { b_.getInt64(0), b_.getInt32(1) }));
+    b_.CreateStore(b_.CreateAdd(total_val, expr),
+                   b_.CreateGEP(avg_struct_ty,
+                                lookup,
+                                { b_.getInt64(0), b_.getInt32(0) }));
+    b_.CreateStore(b_.CreateAdd(b_.getInt64(1), count_val),
+                   b_.CreateGEP(avg_struct_ty,
+                                lookup,
+                                { b_.getInt64(0), b_.getInt32(1) }));
 
     b_.CreateBr(lookup_merge_block);
 
@@ -769,14 +756,9 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     auto scoped_key = getMapKey(map, call.vargs.at(1));
 
     CallInst *lookup = b_.CreateMapLookup(map, scoped_key.value());
-    Value *expr = b_.CreateICmpNE(
-        b_.CreateIntCast(lookup, b_.GET_PTR_TY(), true),
-        b_.GetNull(),
-        "has_key");
-#if LLVM_VERSION_MAJOR <= 14
-    // Got to cast to the correct type for earlier versions of LLVM
-    expr = b_.CreateIntCast(expr, b_.getInt8Ty(), false);
-#endif
+    Value *expr = b_.CreateICmpNE(b_.CreateIntCast(lookup, b_.getPtrTy(), true),
+                                  b_.GetNull(),
+                                  "has_key");
     return ScopedExpr(expr);
   } else if (call.func == "str") {
     uint64_t max_strlen = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
@@ -839,15 +821,13 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       length = b_.getInt32(fixed_buffer_length);
     }
 
-    Value *stack_or_scratch_buf = b_.CreateGetStrAllocation("buf", call.loc);
+    Value *buf = b_.CreateGetStrAllocation("buf", call.loc);
     auto elements = AsyncEvent::Buf().asLLVMType(b_, fixed_buffer_length);
     std::ostringstream dynamic_sized_struct_name;
     dynamic_sized_struct_name << "buffer_" << fixed_buffer_length << "_t";
     StructType *buf_struct = b_.GetStructType(dynamic_sized_struct_name.str(),
                                               elements,
                                               true);
-    Value *buf = b_.CreatePointerCast(stack_or_scratch_buf,
-                                      buf_struct->getPointerTo());
 
     Value *buf_len_offset = b_.CreateGEP(buf_struct,
                                          buf,
@@ -900,7 +880,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                                     ? Instruction::BitCast
                                     : Instruction::IntToPtr,
                                 value,
-                                b_.GET_PTR_TY()),
+                                b_.getPtrTy()),
                   sz,
                   call.loc);
 
@@ -916,7 +896,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     return ScopedExpr(b_.getInt64(addr));
   } else if (call.func == "percpu_kaddr") {
     auto name = bpftrace_.get_string_literal(call.vargs.at(0));
-    auto var = b_.CreatePointerCast(DeclareKernelVar(name), b_.GET_PTR_TY());
+    auto var = DeclareKernelVar(name);
     Value *percpu_ptr;
     if (call.vargs.size() == 1) {
       percpu_ptr = b_.CreateThisCpuPtr(var, call.loc);
@@ -952,13 +932,9 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     Value *perfdata = b_.CreateGetJoinMap(failure_callback, call.loc);
 
     // arg0
-    b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::join)),
-                   b_.CreatePointerCast(perfdata,
-                                        b_.getInt64Ty()->getPointerTo()));
+    b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::join)), perfdata);
     b_.CreateStore(b_.getInt64(async_ids_.join()),
-                   b_.CreatePointerCast(
-                       b_.CreateGEP(b_.getInt8Ty(), perfdata, b_.getInt64(8)),
-                       b_.getInt64Ty()->getPointerTo()));
+                   b_.CreateGEP(b_.getInt8Ty(), perfdata, b_.getInt64(8)));
 
     SizedType elem_type = CreatePointer(CreateInt8(), addrspace);
     size_t ptr_width = b_.getPointerStorageTy(addrspace)->getIntegerBitWidth();
@@ -1060,7 +1036,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     } else {
       b_.CreateStore(
           b_.CreateIntCast(scoped_inet.value(), b_.getInt32Ty(), false),
-          b_.CreatePointerCast(inet_offset, b_.getInt32Ty()->getPointerTo()));
+          inet_offset);
     }
 
     return ScopedExpr(buf, [this, buf]() { b_.CreateLifetimeEnd(buf); });
@@ -1130,8 +1106,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
         Value *offset = b_.CreateGEP(b_.GetType(data_type),
                                      data,
                                      { b_.getInt64(0), b_.getInt32(i - 1) });
-        b_.CreateStore(
-            value, b_.CreateBitCast(offset, value->getType()->getPointerTo()));
+        b_.CreateStore(value, offset);
 
         // keep the expression alive, so it's still there
         // for following seq_printf call
@@ -1146,9 +1121,9 @@ ScopedExpr CodegenLLVM::visit(Call &call)
 
       // and finally the seq_printf call
       b_.CreateSeqPrintf(ctx_,
-                         b_.CreateIntToPtr(fmt, b_.GET_PTR_TY()),
+                         b_.CreateIntToPtr(fmt, b_.getPtrTy()),
                          b_.getInt32(size),
-                         b_.CreatePointerCast(data, b_.GET_PTR_TY()),
+                         data,
                          b_.getInt32(data_size),
                          call.loc);
       return ScopedExpr();
@@ -1175,7 +1150,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       exprs.emplace_back(std::move(scoped_expr));
     }
 
-    b_.CreateTracePrintk(b_.CreateIntToPtr(fmt, b_.GET_PTR_TY()),
+    b_.CreateTracePrintk(b_.CreateIntToPtr(fmt, b_.getPtrTy()),
                          b_.getInt32(size),
                          values,
                          call.loc);
@@ -1209,9 +1184,6 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     if (call.vargs.size() == 1) {
       auto scoped_expr = visit(call.vargs.at(0));
       code = scoped_expr.value();
-#if LLVM_VERSION_MAJOR <= 14
-      code = b_.CreateIntCast(code, b_.getInt8Ty(), false);
-#endif
     }
     b_.CreateStore(
         code,
@@ -1652,18 +1624,6 @@ ScopedExpr CodegenLLVM::binop_buf(Binop &binop)
   return ScopedExpr(b_.CreateStrncmp(left_string, right_string, len, inverse));
 }
 
-// Looks like LLVM <= 14 IR verifier doesn't like when you assign an i1 into an
-// i64. So zero extend there but don't penalize newer LLVM releases.
-//
-// Just LSB needs to be set for bools. If we do a sign extend then all bits
-// will be set (which performs correctly) but printing out the value will be -1
-// which is confusing. So zero extend instead.
-#if LLVM_VERSION_MAJOR <= 14
-#define MAYBE_ZERO_EXTEND(e) b_.CreateIntCast(e, b_.getInt64Ty(), false)
-#else
-#define MAYBE_ZERO_EXTEND(e) e
-#endif
-
 ScopedExpr CodegenLLVM::binop_int(Binop &binop)
 {
   auto scoped_left = visit(binop.left);
@@ -1690,30 +1650,24 @@ ScopedExpr CodegenLLVM::binop_int(Binop &binop)
 
   switch (binop.op) {
     case Operator::EQ:
-      return ScopedExpr(MAYBE_ZERO_EXTEND(b_.CreateICmpEQ(lhs, rhs)),
-                        std::move(del));
+      return ScopedExpr(b_.CreateICmpEQ(lhs, rhs), std::move(del));
     case Operator::NE:
-      return ScopedExpr(MAYBE_ZERO_EXTEND(b_.CreateICmpNE(lhs, rhs)),
-                        std::move(del));
+      return ScopedExpr(b_.CreateICmpNE(lhs, rhs), std::move(del));
     case Operator::LE:
-      return ScopedExpr(MAYBE_ZERO_EXTEND(do_signed
-                                              ? b_.CreateICmpSLE(lhs, rhs)
-                                              : b_.CreateICmpULE(lhs, rhs)),
+      return ScopedExpr(do_signed ? b_.CreateICmpSLE(lhs, rhs)
+                                  : b_.CreateICmpULE(lhs, rhs),
                         std::move(del));
     case Operator::GE:
-      return ScopedExpr(MAYBE_ZERO_EXTEND(do_signed
-                                              ? b_.CreateICmpSGE(lhs, rhs)
-                                              : b_.CreateICmpUGE(lhs, rhs)),
+      return ScopedExpr(do_signed ? b_.CreateICmpSGE(lhs, rhs)
+                                  : b_.CreateICmpUGE(lhs, rhs),
                         std::move(del));
     case Operator::LT:
-      return ScopedExpr(MAYBE_ZERO_EXTEND(do_signed
-                                              ? b_.CreateICmpSLT(lhs, rhs)
-                                              : b_.CreateICmpULT(lhs, rhs)),
+      return ScopedExpr(do_signed ? b_.CreateICmpSLT(lhs, rhs)
+                                  : b_.CreateICmpULT(lhs, rhs),
                         std::move(del));
     case Operator::GT:
-      return ScopedExpr(MAYBE_ZERO_EXTEND(do_signed
-                                              ? b_.CreateICmpSGT(lhs, rhs)
-                                              : b_.CreateICmpUGT(lhs, rhs)),
+      return ScopedExpr(do_signed ? b_.CreateICmpSGT(lhs, rhs)
+                                  : b_.CreateICmpUGT(lhs, rhs),
                         std::move(del));
     case Operator::LEFT:
       return ScopedExpr(b_.CreateShl(lhs, rhs), std::move(del));
@@ -2050,17 +2004,6 @@ ScopedExpr CodegenLLVM::visit(FieldAccess &acc)
                         std::move(scoped_arg));
     else if (probe_type == ProbeType::uprobe) {
       llvm::Type *args_type = b_.UprobeArgsType(type);
-#if LLVM_VERSION_MAJOR <= 14
-      // LLVM <= 14 doesn't have opaque pointers, so we need to cast args to the
-      // correct pointer type
-      Value *args = scoped_arg.value();
-      if (auto *ptr_ty = dyn_cast<PointerType>(args->getType())) {
-        if (ptr_ty->getPointerElementType() != args_type->getPointerTo())
-          scoped_arg = ScopedExpr(
-              b_.CreatePointerCast(args, args_type->getPointerTo()),
-              std::move(scoped_arg));
-      }
-#endif
       return readDatastructElemFromStack(std::move(scoped_arg),
                                          b_.getInt32(acc.type.funcarg_idx),
                                          args_type,
@@ -2111,7 +2054,7 @@ ScopedExpr CodegenLLVM::visit(FieldAccess &acc)
         if (type.IsCtxAccess()) {
           // The offset is specified in absolute terms here; and the load
           // will implicitly convert to the intended field_type.
-          Value *src = b_.CreateSafeGEP(b_.GET_PTR_TY(),
+          Value *src = b_.CreateSafeGEP(b_.getPtrTy(),
                                         scoped_arg.value(),
                                         b_.getInt64(field.offset));
           raw = b_.CreateLoad(field_type, src, true);
@@ -2165,8 +2108,6 @@ ScopedExpr CodegenLLVM::visit(FieldAccess &acc)
         value = b_.CreateIntCast(value, b_.getInt64Ty(), false);
         value = b_.CreateAnd(value, b_.getInt64(0xFFFF));
         value = b_.CreateSafeGEP(b_.getInt32Ty(), ctx_, value);
-        value = b_.CreatePointerCast(value,
-                                     b_.GetType(field.type)->getPointerTo());
         return ScopedExpr(value);
       }
     } else {
@@ -2230,8 +2171,6 @@ ScopedExpr CodegenLLVM::visit(Cast &cast)
         // array is on the stack - just cast the pointer
         if (array->getType()->isIntegerTy())
           array = b_.CreateIntToPtr(array, int_ty->getPointerTo());
-        else
-          array = b_.CreatePointerCast(array, int_ty->getPointerTo());
       } else {
         // array is in memory - need to proberead
         auto buf = b_.CreateAllocaBPF(cast.type);
@@ -2252,9 +2191,7 @@ ScopedExpr CodegenLLVM::visit(Cast &cast)
     // it to an array pointer.
     auto v = b_.CreateAllocaBPF(scoped_expr.value()->getType());
     b_.CreateStore(scoped_expr.value(), v);
-    return ScopedExpr(
-        b_.CreatePointerCast(v, b_.GetType(cast.type)->getPointerTo()),
-        [this, v] { b_.CreateLifetimeEnd(v); });
+    return ScopedExpr(v, [this, v] { b_.CreateLifetimeEnd(v); });
   } else {
     // FIXME(amscanne): The existing behavior is to simply pass the existing
     // expression back up when it is neither an integer nor an array.
@@ -2341,11 +2278,10 @@ void CodegenLLVM::createTupleCopy(const SizedType &expr_type,
     SizedType &t_type = expr_type.GetField(i).type;
     Value *offset_val = b_.CreateGEP(
         array_ty,
-        b_.CreatePointerCast(src_val, array_ty->getPointerTo()),
+        src_val,
         { b_.getInt64(0), b_.getInt64(expr_type.GetField(i).offset) });
     Value *dst = b_.CreateGEP(tuple_ty,
-                              b_.CreatePointerCast(dst_val,
-                                                   tuple_ty->getPointerTo()),
+                              dst_val,
                               { b_.getInt32(0), b_.getInt32(i) });
     if (t_type.IsTupleTy() && !t_type.IsSameSizeRecursive(var_type)) {
       createTupleCopy(t_type, var_type.GetField(i).type, dst, offset_val);
@@ -2705,16 +2641,7 @@ ScopedExpr CodegenLLVM::visit(For &f)
   if (!ctx_fields.empty()) {
     // Pack pointers to variables into context struct for use in the callback
 
-#if LLVM_VERSION_MAJOR < 15
-    std::vector<llvm::Type *> ctx_field_types;
-    ctx_field_types.reserve(ctx_fields.size());
-    for (const auto &field : ctx_fields) {
-      ctx_field_types.push_back(b_.GetType(field.type)->getPointerTo());
-    }
-#else
-    std::vector<llvm::Type *> ctx_field_types(ctx_fields.size(),
-                                              b_.GET_PTR_TY());
-#endif
+    std::vector<llvm::Type *> ctx_field_types(ctx_fields.size(), b_.getPtrTy());
     ctx_t = StructType::create(ctx_field_types, "ctx_t");
     ctx = b_.CreateAllocaBPF(ctx_t, "ctx");
 
@@ -2723,11 +2650,6 @@ ScopedExpr CodegenLLVM::visit(For &f)
       auto *field_expr = getVariable(field.name).value;
       auto *ctx_field_ptr = b_.CreateSafeGEP(
           ctx_t, ctx, { b_.getInt64(0), b_.getInt32(i) }, "ctx." + field.name);
-#if LLVM_VERSION_MAJOR < 15
-      // An extra cast is required for older LLVM versions, pre-opaque-pointers
-      ctx_field_ptr = b_.CreatePointerCast(
-          ctx_field_ptr, field_expr->getType()->getPointerTo());
-#endif
       b_.CreateStore(field_expr, ctx_field_ptr);
     }
   }
@@ -2886,7 +2808,7 @@ ScopedExpr CodegenLLVM::visit(Subprog &subprog)
   std::vector<llvm::Type *> arg_types;
   // First argument is for passing ctx pointer for output, rest are proper
   // arguments to the function
-  arg_types.push_back(b_.GET_PTR_TY());
+  arg_types.push_back(b_.getPtrTy());
   std::transform(subprog.args.begin(),
                  subprog.args.end(),
                  std::back_inserter(arg_types),
@@ -2990,7 +2912,7 @@ int CodegenLLVM::getReturnValueForProbe(ProbeType probe_type)
 ScopedExpr CodegenLLVM::visit(Probe &probe)
 {
   FunctionType *func_type = FunctionType::get(b_.getInt64Ty(),
-                                              { b_.GET_PTR_TY() }, // ctx
+                                              { b_.getPtrTy() }, // ctx
                                               false);
 
   // We begin by saving state that gets changed by the codegen pass, so we
@@ -3104,19 +3026,13 @@ ScopedExpr CodegenLLVM::getMapKey(Map &map, Expression *key_expr)
     } else {
       if (key_expr->type.IsArrayTy() || key_expr->type.IsRecordTy()) {
         // We need to read the entire array/struct and save it
-        b_.CreateProbeRead(ctx_,
-                           b_.CreatePointerCast(
-                               key, b_.GetType(key_expr->type)->getPointerTo()),
-                           key_expr->type,
-                           scoped_key_expr.value(),
-                           key_expr->loc);
+        b_.CreateProbeRead(
+            ctx_, key, key_expr->type, scoped_key_expr.value(), key_expr->loc);
       } else {
         b_.CreateStore(b_.CreateIntCast(scoped_key_expr.value(),
                                         b_.getInt64Ty(),
                                         key_expr->type.IsSigned()),
-                       b_.CreatePointerCast(
-                           key,
-                           scoped_key_expr.value()->getType()->getPointerTo()));
+                       key);
       }
     }
     // Either way we hold on to the original key, to ensure that its lifetime
@@ -3200,12 +3116,10 @@ ScopedExpr CodegenLLVM::getMultiMapKey(Map &map,
       Value *key_elem = b_.CreateIntCast(scoped_expr.value(),
                                          b_.getInt64Ty(),
                                          map.key_expr->type.IsSigned());
-      Value *dst_ptr = b_.CreatePointerCast(
-          offset_val, scoped_expr.value()->getType()->getPointerTo());
       if (aligned)
-        b_.CreateStore(key_elem, dst_ptr);
+        b_.CreateStore(key_elem, offset_val);
       else
-        b_.createAlignedStore(key_elem, dst_ptr, 1);
+        b_.createAlignedStore(key_elem, offset_val, 1);
     }
   }
   offset += map_key_size;
@@ -3214,13 +3128,10 @@ ScopedExpr CodegenLLVM::getMultiMapKey(Map &map,
     Value *offset_val = b_.CreateGEP(key_type,
                                      key,
                                      { b_.getInt64(0), b_.getInt64(offset) });
-    Value *offset_val_cast = b_.CreatePointerCast(
-        offset_val, extra_key->getType()->getPointerTo());
-
     if (aligned)
-      b_.CreateStore(extra_key, offset_val_cast);
+      b_.CreateStore(extra_key, offset_val);
     else
-      b_.createAlignedStore(extra_key, offset_val_cast, 1);
+      b_.createAlignedStore(extra_key, offset_val, 1);
     offset += module_->getDataLayout().getTypeAllocSize(extra_key->getType());
   }
 
@@ -3791,9 +3702,7 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int id)
     else
       b_.CreateProbeRead(ctx_, content_offset, arg.type, value, arg.loc);
   } else {
-    auto ptr = b_.CreatePointerCast(content_offset,
-                                    value->getType()->getPointerTo());
-    b_.CreateStore(value, ptr);
+    b_.CreateStore(value, content_offset);
   }
 
   b_.CreateOutput(ctx_, buf, struct_size, &call.loc);
@@ -4034,7 +3943,6 @@ void CodegenLLVM::optimize()
 {
   assert(state_ == State::IR);
 
-#if LLVM_VERSION_MAJOR >= 14
   PipelineTuningOptions pto;
   pto.LoopUnrolling = false;
   pto.LoopInterleaving = false;
@@ -4060,22 +3968,6 @@ void CodegenLLVM::optimize()
       llvm::OptimizationLevel::O3,
       /*LTOPreLink=*/false);
   mpm.run(*module_, mam);
-
-#else
-  PassManagerBuilder PMB;
-  PMB.OptLevel = 3;
-  legacy::PassManager PM;
-  PM.add(createFunctionInliningPass());
-  // llvm < 4.0 needs
-  // PM.add(createAlwaysInlinerPass());
-  // llvm >= 4.0 needs
-  // PM.add(createAlwaysInlinerLegacyPass());
-  // use below 'stable' workaround
-  LLVMAddAlwaysInlinerPass(reinterpret_cast<LLVMPassManagerRef>(&PM));
-  PMB.populateModulePassManager(PM);
-
-  PM.run(*module_.get());
-#endif
 
   state_ = State::OPT;
 }
@@ -4196,12 +4088,6 @@ ScopedExpr CodegenLLVM::readDatastructElemFromStack(ScopedExpr &&scoped_src,
 
   Value *src = b_.CreateGEP(data_type, src_data, { b_.getInt32(0), index });
 
-  // It may happen that the result pointer type is not correct, in such case
-  // do a typecast
-  auto dst_type = b_.GetType(elem_type);
-  if (src->getType() != dst_type->getPointerTo())
-    src = b_.CreatePointerCast(src, dst_type->getPointerTo());
-
   if (elem_type.IsIntegerTy() || elem_type.IsPtrTy()) {
     // Load the correct type from src
     return ScopedExpr(
@@ -4241,10 +4127,6 @@ ScopedExpr CodegenLLVM::probereadDatastructElem(ScopedExpr &&scoped_src,
   // We treat this access as a raw byte offset, but may then subsequently need
   // to cast the pointer to the expected value.
   Value *src = b_.CreateSafeGEP(b_.getInt8Ty(), scoped_src.value(), offset);
-
-  auto dst_type = b_.GetType(elem_type);
-  if (dst_type != b_.getInt8Ty())
-    src = b_.CreatePointerCast(src, dst_type->getPointerTo());
 
   if (elem_type.IsRecordTy() || elem_type.IsArrayTy()) {
     // For nested arrays and structs, just pass the pointer along and
@@ -4380,7 +4262,7 @@ llvm::Function *CodegenLLVM::createMurmurHash2Func()
   // https://github.com/aappleby/smhasher/blob/92cf3702fcfaadc84eb7bef59825a23e0cd84f56/src/MurmurHash2.cpp
   auto saved_ip = b_.saveIP();
 
-  std::array<llvm::Type *, 3> args = { b_.GET_PTR_TY(),
+  std::array<llvm::Type *, 3> args = { b_.getPtrTy(),
                                        b_.getInt8Ty(),
                                        b_.getInt64Ty() };
   FunctionType *callback_type = FunctionType::get(b_.getInt64Ty(), args, false);
@@ -4407,8 +4289,7 @@ llvm::Function *CodegenLLVM::createMurmurHash2Func()
   Value *m = b_.getInt64(0xc6a4a7935bd1e995LLU);
   Value *r = b_.getInt64(47);
 
-  Value *stack_addr = b_.CreatePointerCast(callback->getArg(0),
-                                           b_.getInt64Ty()->getPointerTo());
+  Value *stack_addr = callback->getArg(0);
 
   b_.CreateStore(callback->getArg(1), nr_stack_frames);
   b_.CreateStore(callback->getArg(2), seed_addr);
@@ -4527,7 +4408,7 @@ llvm::Function *CodegenLLVM::createMapLenCallback()
   auto saved_ip = b_.saveIP();
 
   std::array<llvm::Type *, 4> args = {
-    b_.GET_PTR_TY(), b_.GET_PTR_TY(), b_.GET_PTR_TY(), b_.GET_PTR_TY()
+    b_.getPtrTy(), b_.getPtrTy(), b_.getPtrTy(), b_.getPtrTy()
   };
 
   FunctionType *callback_type = FunctionType::get(b_.getInt64Ty(), args, false);
@@ -4572,13 +4453,8 @@ llvm::Function *CodegenLLVM::createForEachMapCallback(For &f, llvm::Type *ctx_t)
 
   auto saved_ip = b_.saveIP();
 
-#if LLVM_VERSION_MAJOR < 15
-  llvm::Type *ctx_ptr_ty = ctx_t ? ctx_t->getPointerTo() : b_.GET_PTR_TY();
-#else
-  llvm::Type *ctx_ptr_ty = b_.GET_PTR_TY();
-#endif
   std::array<llvm::Type *, 4> args = {
-    b_.GET_PTR_TY(), b_.GET_PTR_TY(), b_.GET_PTR_TY(), ctx_ptr_ty
+    b_.getPtrTy(), b_.getPtrTy(), b_.getPtrTy(), b_.getPtrTy()
   };
 
   FunctionType *callback_type = FunctionType::get(b_.getInt64Ty(), args, false);
@@ -4645,12 +4521,7 @@ llvm::Function *CodegenLLVM::createForEachMapCallback(For &f, llvm::Type *ctx_t)
 
     auto *ctx_field_ptr = b_.CreateGEP(
         ctx_t, ctx, { b_.getInt64(0), b_.getInt32(i) }, "ctx." + field.name);
-#if LLVM_VERSION_MAJOR < 15
-    auto *field_ty = getVariable(field.name).value->getType();
-#else
-    auto *field_ty = b_.GET_PTR_TY();
-#endif
-    getVariable(field.name).value = b_.CreateLoad(field_ty,
+    getVariable(field.name).value = b_.CreateLoad(b_.getPtrTy(),
                                                   ctx_field_ptr,
                                                   field.name);
   }

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -48,11 +48,6 @@ Dwarf::Dwarf(BPFtrace *bpftrace, std::string file_path)
 
 bool Dwarf::has_debug_info()
 {
-#if LLVM_VERSION_MAJOR <= 13
-  // LLVM 13 statistics does not contain a field for the DebugInfo size.
-  // So we can't verify the presence of DebugInfo and we assume it is present.
-  return true;
-#else
   // Verify that the target contains DebugInfo.
   if (auto stats = target_.GetStatistics())
     if (auto modules = stats.GetValueForKey("modules"))
@@ -60,8 +55,6 @@ bool Dwarf::has_debug_info()
         if (auto hasDebugInfo = module.GetValueForKey("debugInfoByteSize"))
           if (hasDebugInfo.GetIntegerValue() > 0)
             return true;
-#endif
-
   return false;
 }
 
@@ -182,9 +175,7 @@ SizedType Dwarf::get_stype(lldb::SBType type, bool resolve_structs)
         case lldb::eBasicTypeSignedChar:
         case lldb::eBasicTypeWChar:
         case lldb::eBasicTypeSignedWChar:
-#if LLVM_VERSION_MAJOR >= 15
         case lldb::eBasicTypeChar8:
-#endif
         case lldb::eBasicTypeChar16:
         case lldb::eBasicTypeChar32:
         case lldb::eBasicTypeShort:
@@ -230,9 +221,7 @@ SizedType Dwarf::get_stype(lldb::SBType type, bool resolve_structs)
         case lldb::eBasicTypeChar:
         case lldb::eBasicTypeSignedChar:
         case lldb::eBasicTypeUnsignedChar:
-#if LLVM_VERSION_MAJOR >= 15
         case lldb::eBasicTypeChar8:
-#endif
           return CreateString(length);
         default:
           return CreateArray(length, inner_stype);


### PR DESCRIPTION
#3809 removed support for LLVM 14 and 15 and therefore we can drop all the code conditionally compiled for these versions.

In addition, LLVM 14 was the last one which required typed (non-opaque) pointers so we can now remove all pointer casts from codegen. This removes all usages of `CreatePointerCast`. In some cases, it was doing int-to-ptr cast so I explicitly replaced it by `CreateIntToPtr`. In general, the transformations were done such that codegen tests do not change.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
