### PR TITLE
Add issue template for release tracking

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,36 @@
+---
+name: Release tracker
+about: Create a tracker issue for the upcoming release. Should be used by maintainers only.
+
+---
+
+<!-- 
+The title of the issue should be "Release v0.<minor>.0".
+
+Fill in the placeholders in the checklist below:
+
+- <minor> is the release minor number 
+- <llvm> is the LLVM major number
+- <branching-date> is the date of creating the release branch
+- <release-date> is date of bpftrace release
+
+For details on the release process, see docs/release_process.md.
+For LLVM release schedule, see https://llvm.org/.
+-->
+
+### Release progress
+
+- [ ] Create release branch `release/v0.<minor>.x` (<branching-date>)
+- [ ] Add support for LLVM <llvm>
+  - [ ] Bump `MAX_LLVM_MAJOR` in [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt)
+  - [ ] Add new Nix target in [flake.nix](https://github.com/bpftrace/bpftrace/blob/master/flake.nix)
+  - [ ] Add CI job to [.github/workflows/ci.yml](https://github.com/bpftrace/bpftrace/blob/master/.github/workflows/ci.yml)
+- [ ] Update LLVM in Nixpkgs to <llvm>.1.0
+- [ ] **Release bpftrace 0.<minor>.0 (<release-date>)**
+  - [ ] Mark the release in [CHANGELOG.md](https://github.com/bpftrace/bpftrace/blob/master/CHANGELOG.md)
+  - [ ] Update `bpftrace_VERSION_*` in [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt)
+  - [ ] Draft a new release in GitHub
+- [ ] Forward-port [CHANGELOG.md](https://github.com/bpftrace/bpftrace/blob/master/CHANGELOG.md) and [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt) changes to the master branch.
+
+See [Release Process](docs/release_process.md) for general information on the
+release process.

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -35,6 +35,14 @@ Overview of the release cadence is as follows:
 | LLVM release           | usually second Tuesday of Mar/Sep   | [LLVM release schedule](https://llvm.org/docs/HowToReleaseLLVM.html) |
 | bpftrace release       | **2 weeks after the LLVM release**  | [Tagging a release](#tagging-a-release)                              |
 
+## Preparing for a release
+
+Once the release dates are clarified (approximately 6 weeks before the release),
+do the following steps to track the release in a public manner:
+
+1. Update the release dates at the top of this document and on the [bpftrace website](https://github.com/bpftrace/website/blob/master/src/pages/release-schedule.md).
+1. Create a new tracker issue in GitHub from the "Release tracker" template.
+
 ## Creating a release branch
 
 A release branch should be created four weeks before the planned bpftrace


### PR DESCRIPTION
When preparing a new release, there is a number of steps that need to be done. To help maintainers not forget any step and also to publicly track progress on the release, I propose that we create a tracker issue on GitHub for each release.

This adds a new GitHub issue template which contains a checklist with the steps to be done when preparing a release.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
