### PR TITLE
Fix build error

### DIFF
--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3290,7 +3290,7 @@ TEST(semantic_analyser, strcontains_large_warnings)
       /* invert= */ true);
 
   auto bpftrace = get_mock_bpftrace();
-  ConfigSetter configs{ bpftrace->config_, ConfigSource::script };
+  ConfigSetter configs{ *bpftrace->config_, ConfigSource::script };
   configs.set(ConfigKeyInt::max_strlen, 16);
   test_for_warning(
       *bpftrace,


### PR DESCRIPTION
3ff27681 ("bpftrace: Store Config as a unique_ptr") raced with f2cecc4e ("semantic: Warn on big strcontains() strings") and thus caused a compilation failure.

Fix forward here.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
