### PR TITLE
ast: split context into separate file

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 
+#include "ast/context.h"
 #include "ast/visitor.h"
 #include "log.h"
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
 #include <string>
 #include <vector>
 
@@ -511,36 +510,6 @@ std::string opstr(const Jump &jump);
 
 SizedType ident_to_record(const std::string &ident, int pointer_level = 0);
 SizedType ident_to_sized_type(const std::string &ident);
-
-template <typename T>
-concept NodeType = std::derived_from<T, Node>;
-
-// Manages the lifetime of AST nodes.
-//
-// Nodes allocated by an ASTContext will be kept alive for the duration of the
-// owning ASTContext object.
-class ASTContext {
-public:
-  Program *root = nullptr;
-
-  // Creates and returns a pointer to an AST node.
-  template <NodeType T, typename... Args>
-  T *make_node(Args &&...args)
-  {
-    auto uniq_ptr = std::make_unique<T>(std::forward<Args>(args)...);
-    auto *raw_ptr = uniq_ptr.get();
-    nodes_.push_back(std::move(uniq_ptr));
-    return raw_ptr;
-  }
-
-  unsigned int node_count()
-  {
-    return nodes_.size();
-  }
-
-private:
-  std::vector<std::unique_ptr<Node>> nodes_;
-};
 
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -1,6 +1,7 @@
 #include "ast/attachpoint_parser.h"
 
-#include "ast.h"
+#include "ast/ast.h"
+#include "ast/context.h"
 #include "ast/int_parser.h"
 #include "log.h"
 #include "types.h"

--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+namespace bpftrace {
+namespace ast {
+
+class Node;
+class Program;
+
+template <typename T>
+concept NodeType = std::derived_from<T, Node>;
+
+// Manages the lifetime of AST nodes.
+//
+// Nodes allocated by an ASTContext will be kept alive for the duration of the
+// owning ASTContext object.
+class ASTContext {
+public:
+  Program *root = nullptr;
+
+  // Creates and returns a pointer to an AST node.
+  template <NodeType T, typename... Args>
+  T *make_node(Args &&...args)
+  {
+    auto uniq_ptr = std::make_unique<T>(std::forward<Args>(args)...);
+    auto *raw_ptr = uniq_ptr.get();
+    nodes_.push_back(std::move(uniq_ptr));
+    return raw_ptr;
+  }
+
+  unsigned int node_count()
+  {
+    return nodes_.size();
+  }
+
+private:
+  std::vector<std::unique_ptr<Node>> nodes_;
+};
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -34,6 +34,7 @@
 #include "ast/ast.h"
 #include "ast/async_event_types.h"
 #include "ast/codegen_helper.h"
+#include "ast/context.h"
 #include "ast/signal_bt.h"
 #include "bpfmap.h"
 #include "collect_nodes.h"

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -10,6 +10,7 @@
 #include "arch/arch.h"
 #include "ast/ast.h"
 #include "ast/async_event_types.h"
+#include "ast/context.h"
 #include "ast/signal_bt.h"
 #include "collect_nodes.h"
 #include "config.h"

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -3,6 +3,7 @@
 #include <string>
 
 #include "ast/ast.h"
+#include "ast/context.h"
 
 namespace bpftrace::ast {
 

--- a/src/driver.h
+++ b/src/driver.h
@@ -4,6 +4,7 @@
 #include <string_view>
 
 #include "ast/ast.h"
+#include "ast/context.h"
 #include "bpftrace.h"
 
 typedef void *yyscan_t;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -32,6 +32,7 @@ class Node;
 } // namespace ast
 } // namespace bpftrace
 #include "ast/ast.h"
+#include "ast/context.h"
 }
 
 %{

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -2,6 +2,7 @@
 #include "gtest/gtest.h"
 
 #include "ast/ast.h"
+#include "ast/context.h"
 #include "common.h"
 
 namespace bpftrace {

--- a/tests/collect_nodes.cpp
+++ b/tests/collect_nodes.cpp
@@ -1,4 +1,5 @@
 #include "ast/passes/collect_nodes.h"
+#include "ast/context.h"
 #include "gtest/gtest.h"
 
 #include <functional>


### PR DESCRIPTION
Each of these files use their own forward declarations, and individual implementations need only include the file that matters. This paves the way for some additional functionality in the ASTContext itself, and separates concerns for individual AST nodes.

This is necessary because we will need to deal with multiple soruce files in the future to support `import`. Currently, the top-level file calls `set_source` on the log singleton. However, this will not scale as additional files are parsed: my intent is to hang the raw source off each `ASTContext` and/or the future `Diagnostics` class.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
