### PR TITLE
Wire `Diagnostics` to AST nodes

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -10,160 +10,194 @@ namespace bpftrace::ast {
 
 static constexpr std::string_view ENUM = "enum ";
 
-Integer::Integer(int64_t n, location loc, bool is_negative)
-    : Expression(loc), n(n), is_negative(is_negative)
+Integer::Integer(Diagnostics &d, int64_t n, location loc, bool is_negative)
+    : Expression(d, loc), n(n), is_negative(is_negative)
 {
   is_literal = true;
 }
 
-String::String(const std::string &str, location loc) : Expression(loc), str(str)
+String::String(Diagnostics &d, const std::string &str, location loc)
+    : Expression(d, loc), str(str)
 {
   is_literal = true;
 }
 
-StackMode::StackMode(const std::string &mode, location loc)
-    : Expression(loc), mode(mode)
+StackMode::StackMode(Diagnostics &d, const std::string &mode, location loc)
+    : Expression(d, loc), mode(mode)
 {
   is_literal = true;
 }
 
-Builtin::Builtin(const std::string &ident, location loc)
-    : Expression(loc), ident(is_deprecated(ident))
+Builtin::Builtin(Diagnostics &d, const std::string &ident, location loc)
+    : Expression(d, loc), ident(is_deprecated(ident))
 {
 }
 
-Identifier::Identifier(const std::string &ident, location loc)
-    : Expression(loc), ident(ident)
+Identifier::Identifier(Diagnostics &d, const std::string &ident, location loc)
+    : Expression(d, loc), ident(ident)
 {
 }
 
-PositionalParameter::PositionalParameter(PositionalParameterType ptype,
+PositionalParameter::PositionalParameter(Diagnostics &d,
+                                         PositionalParameterType ptype,
                                          long n,
                                          location loc)
-    : Expression(loc), ptype(ptype), n(n)
+    : Expression(d, loc), ptype(ptype), n(n)
 {
   is_literal = true;
 }
 
-Call::Call(const std::string &func, location loc)
-    : Expression(loc), func(is_deprecated(func))
+Call::Call(Diagnostics &d, const std::string &func, location loc)
+    : Expression(d, loc), func(is_deprecated(func))
 {
 }
 
-Call::Call(const std::string &func, ExpressionList &&vargs, location loc)
-    : Expression(loc), func(is_deprecated(func)), vargs(std::move(vargs))
+Call::Call(Diagnostics &d,
+           const std::string &func,
+           ExpressionList &&vargs,
+           location loc)
+    : Expression(d, loc), func(is_deprecated(func)), vargs(std::move(vargs))
 {
 }
 
-Sizeof::Sizeof(SizedType type, location loc) : Expression(loc), argtype(type)
+Sizeof::Sizeof(Diagnostics &d, SizedType type, location loc)
+    : Expression(d, loc), argtype(type)
 {
 }
 
-Sizeof::Sizeof(Expression *expr, location loc) : Expression(loc), expr(expr)
+Sizeof::Sizeof(Diagnostics &d, Expression *expr, location loc)
+    : Expression(d, loc), expr(expr)
 {
 }
 
-Offsetof::Offsetof(SizedType record,
+Offsetof::Offsetof(Diagnostics &d,
+                   SizedType record,
                    std::vector<std::string> &field,
                    location loc)
-    : Expression(loc), record(record), field(field)
+    : Expression(d, loc), record(record), field(field)
 {
 }
 
-Offsetof::Offsetof(Expression *expr,
+Offsetof::Offsetof(Diagnostics &d,
+                   Expression *expr,
                    std::vector<std::string> &field,
                    location loc)
-    : Expression(loc), expr(expr), field(field)
+    : Expression(d, loc), expr(expr), field(field)
 {
 }
 
-Map::Map(const std::string &ident, location loc) : Expression(loc), ident(ident)
+Map::Map(Diagnostics &d, const std::string &ident, location loc)
+    : Expression(d, loc), ident(ident)
 {
   is_map = true;
 }
 
-Map::Map(const std::string &ident, Expression &expr, location loc)
-    : Expression(loc), ident(ident), key_expr(&expr)
+Map::Map(Diagnostics &d,
+         const std::string &ident,
+         Expression &expr,
+         location loc)
+    : Expression(d, loc), ident(ident), key_expr(&expr)
 {
   is_map = true;
   key_expr->key_for_map = this;
 }
 
-Variable::Variable(const std::string &ident, location loc)
-    : Expression(loc), ident(ident)
+Variable::Variable(Diagnostics &d, const std::string &ident, location loc)
+    : Expression(d, loc), ident(ident)
 {
   is_variable = true;
 }
 
-Binop::Binop(Expression *left, Operator op, Expression *right, location loc)
-    : Expression(loc), left(left), right(right), op(op)
+Binop::Binop(Diagnostics &d,
+             Expression *left,
+             Operator op,
+             Expression *right,
+             location loc)
+    : Expression(d, loc), left(left), right(right), op(op)
 {
 }
 
-Unop::Unop(Operator op, Expression *expr, bool is_post_op, location loc)
-    : Expression(loc), expr(expr), op(op), is_post_op(is_post_op)
+Unop::Unop(Diagnostics &d,
+           Operator op,
+           Expression *expr,
+           bool is_post_op,
+           location loc)
+    : Expression(d, loc), expr(expr), op(op), is_post_op(is_post_op)
 {
 }
 
-Ternary::Ternary(Expression *cond,
+Ternary::Ternary(Diagnostics &d,
+                 Expression *cond,
                  Expression *left,
                  Expression *right,
                  location loc)
-    : Expression(loc), cond(cond), left(left), right(right)
+    : Expression(d, loc), cond(cond), left(left), right(right)
 {
 }
 
-FieldAccess::FieldAccess(Expression *expr,
+FieldAccess::FieldAccess(Diagnostics &d,
+                         Expression *expr,
                          const std::string &field,
                          location loc)
-    : Expression(loc), expr(expr), field(field)
+    : Expression(d, loc), expr(expr), field(field)
 {
 }
 
-FieldAccess::FieldAccess(Expression *expr, ssize_t index, location loc)
-    : Expression(loc), expr(expr), index(index)
+FieldAccess::FieldAccess(Diagnostics &d,
+                         Expression *expr,
+                         ssize_t index,
+                         location loc)
+    : Expression(d, loc), expr(expr), index(index)
 {
 }
 
-ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr, location loc)
-    : Expression(loc), expr(expr), indexpr(indexpr)
+ArrayAccess::ArrayAccess(Diagnostics &d,
+                         Expression *expr,
+                         Expression *indexpr,
+                         location loc)
+    : Expression(d, loc), expr(expr), indexpr(indexpr)
 {
 }
 
-Cast::Cast(SizedType cast_type, Expression *expr, location loc)
-    : Expression(loc), expr(expr)
+Cast::Cast(Diagnostics &d, SizedType cast_type, Expression *expr, location loc)
+    : Expression(d, loc), expr(expr)
 {
   type = cast_type;
 }
 
-Tuple::Tuple(ExpressionList &&elems, location loc)
-    : Expression(loc), elems(std::move(elems))
+Tuple::Tuple(Diagnostics &d, ExpressionList &&elems, location loc)
+    : Expression(d, loc), elems(std::move(elems))
 {
 }
 
-ExprStatement::ExprStatement(Expression *expr, location loc)
-    : Statement(loc), expr(expr)
+ExprStatement::ExprStatement(Diagnostics &d, Expression *expr, location loc)
+    : Statement(d, loc), expr(expr)
 {
 }
 
-AssignMapStatement::AssignMapStatement(Map *map, Expression *expr, location loc)
-    : Statement(loc), map(map), expr(expr)
+AssignMapStatement::AssignMapStatement(Diagnostics &d,
+                                       Map *map,
+                                       Expression *expr,
+                                       location loc)
+    : Statement(d, loc), map(map), expr(expr)
 {
   expr->map = map;
 };
 
-AssignVarStatement::AssignVarStatement(Variable *var,
+AssignVarStatement::AssignVarStatement(Diagnostics &d,
+                                       Variable *var,
                                        Expression *expr,
                                        location loc)
-    : Statement(loc), var(var), expr(expr)
+    : Statement(d, loc), var(var), expr(expr)
 {
   expr->var = var;
 }
 
-AssignVarStatement::AssignVarStatement(VarDeclStatement *var_decl_stmt,
+AssignVarStatement::AssignVarStatement(Diagnostics &d,
+                                       VarDeclStatement *var_decl_stmt,
                                        Expression *expr,
                                        location loc)
-    : Statement(loc),
+    : Statement(d, loc),
       var_decl_stmt(var_decl_stmt),
       var(var_decl_stmt->var),
       expr(expr)
@@ -172,64 +206,78 @@ AssignVarStatement::AssignVarStatement(VarDeclStatement *var_decl_stmt,
 }
 
 AssignConfigVarStatement::AssignConfigVarStatement(
+    Diagnostics &d,
     const std::string &config_var,
     Expression *expr,
     location loc)
-    : Statement(loc), config_var(config_var), expr(expr)
+    : Statement(d, loc), config_var(config_var), expr(expr)
 {
 }
 
-VarDeclStatement::VarDeclStatement(Variable *var, SizedType type, location loc)
-    : Statement(loc), var(var), set_type(true)
+VarDeclStatement::VarDeclStatement(Diagnostics &d,
+                                   Variable *var,
+                                   SizedType type,
+                                   location loc)
+    : Statement(d, loc), var(var), set_type(true)
 {
   var->type = std::move(type);
 }
 
-VarDeclStatement::VarDeclStatement(Variable *var, location loc)
-    : Statement(loc), var(var)
+VarDeclStatement::VarDeclStatement(Diagnostics &d, Variable *var, location loc)
+    : Statement(d, loc), var(var)
 {
   var->type = CreateNone();
 }
 
-Predicate::Predicate(Expression *expr, location loc) : Node(loc), expr(expr)
+Predicate::Predicate(Diagnostics &d, Expression *expr, location loc)
+    : Node(d, loc), expr(expr)
 {
 }
 
-AttachPoint::AttachPoint(const std::string &raw_input,
+AttachPoint::AttachPoint(Diagnostics &d,
+                         const std::string &raw_input,
                          bool ignore_invalid,
                          location loc)
-    : Node(loc), raw_input(raw_input), ignore_invalid(ignore_invalid)
+    : Node(d, loc), raw_input(raw_input), ignore_invalid(ignore_invalid)
 {
 }
 
-Block::Block(StatementList &&stmts, location loc)
-    : Statement(loc), stmts(std::move(stmts))
+Block::Block(Diagnostics &d, StatementList &&stmts, location loc)
+    : Statement(d, loc), stmts(std::move(stmts))
 {
 }
 
-If::If(Expression *cond, Block *if_block, Block *else_block, location loc)
-    : Statement(loc), cond(cond), if_block(if_block), else_block(else_block)
+If::If(Diagnostics &d,
+       Expression *cond,
+       Block *if_block,
+       Block *else_block,
+       location loc)
+    : Statement(d, loc), cond(cond), if_block(if_block), else_block(else_block)
 {
 }
 
-Unroll::Unroll(Expression *expr, Block *block, location loc)
-    : Statement(loc), expr(expr), block(block)
+Unroll::Unroll(Diagnostics &d, Expression *expr, Block *block, location loc)
+    : Statement(d, loc), expr(expr), block(block)
 {
 }
 
-Probe::Probe(AttachPointList &&attach_points,
+Probe::Probe(Diagnostics &d,
+             AttachPointList &&attach_points,
              Predicate *pred,
              Block *block,
              location loc)
-    : Node(loc),
+    : Node(d, loc),
       attach_points(std::move(attach_points)),
       pred(pred),
       block(block)
 {
 }
 
-SubprogArg::SubprogArg(std::string name, SizedType type, location loc)
-    : Node(loc), type(std::move(type)), name_(std::move(name))
+SubprogArg::SubprogArg(Diagnostics &d,
+                       std::string name,
+                       SizedType type,
+                       location loc)
+    : Node(d, loc), type(std::move(type)), name_(std::move(name))
 {
 }
 
@@ -238,12 +286,13 @@ std::string SubprogArg::name() const
   return name_;
 }
 
-Subprog::Subprog(std::string name,
+Subprog::Subprog(Diagnostics &d,
+                 std::string name,
                  SizedType return_type,
                  SubprogArgList &&args,
                  StatementList &&stmts,
                  location loc)
-    : Node(loc),
+    : Node(d, loc),
       args(std::move(args)),
       return_type(std::move(return_type)),
       stmts(std::move(stmts)),
@@ -251,12 +300,13 @@ Subprog::Subprog(std::string name,
 {
 }
 
-Program::Program(const std::string &c_definitions,
+Program::Program(Diagnostics &d,
+                 const std::string &c_definitions,
                  Config *config,
                  SubprogList &&functions,
                  ProbeList &&probes,
                  location loc)
-    : Node(loc),
+    : Node(d, loc),
       c_definitions(c_definitions),
       config(config),
       functions(std::move(functions)),

--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -18,13 +18,14 @@ concept NodeType = std::derived_from<T, Node>;
 // owning ASTContext object.
 class ASTContext {
 public:
-  Program *root = nullptr;
+  ASTContext() : diagnostics_(std::make_unique<Diagnostics>()) {};
 
   // Creates and returns a pointer to an AST node.
   template <NodeType T, typename... Args>
   T *make_node(Args &&...args)
   {
-    auto uniq_ptr = std::make_unique<T>(std::forward<Args>(args)...);
+    auto uniq_ptr = std::make_unique<T>(*diagnostics_.get(),
+                                        std::forward<Args>(args)...);
     auto *raw_ptr = uniq_ptr.get();
     nodes_.push_back(std::move(uniq_ptr));
     return raw_ptr;
@@ -35,8 +36,19 @@ public:
     return nodes_.size();
   }
 
+  // Callers should avoid mutating diagnostics through this method. It is
+  // non-const to allow for tests to clear the set, but this should be avoided
+  // except in the context of a test.
+  Diagnostics &diagnostics() const
+  {
+    return *diagnostics_.get();
+  }
+
+  Program *root = nullptr;
+
 private:
   std::vector<std::unique_ptr<Node>> nodes_;
+  std::unique_ptr<Diagnostics> diagnostics_;
 };
 
 } // namespace ast

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -6,130 +6,136 @@ namespace bpftrace::test::ast {
 
 using bpftrace::ast::AttachPoint;
 using bpftrace::ast::AttachPointList;
+using bpftrace::ast::Diagnostics;
 using bpftrace::ast::Probe;
 
 TEST(ast, probe_name_special)
 {
-  AttachPoint ap1("", false, location());
+  Diagnostics d;
+  AttachPoint ap1(d, "", false, location());
   ap1.provider = "BEGIN";
-  Probe begin({ &ap1 }, nullptr, {}, location());
+  Probe begin(d, { &ap1 }, nullptr, {}, location());
   EXPECT_EQ(begin.name(), "BEGIN");
 
-  AttachPoint ap2("", false, location());
+  AttachPoint ap2(d, "", false, location());
   ap2.provider = "END";
-  Probe end({ &ap2 }, nullptr, {}, location());
+  Probe end(d, { &ap2 }, nullptr, {}, location());
   EXPECT_EQ(end.name(), "END");
 }
 
 TEST(ast, probe_name_kprobe)
 {
-  AttachPoint ap1("", false, location());
+  Diagnostics d;
+  AttachPoint ap1(d, "", false, location());
   ap1.provider = "kprobe";
   ap1.func = "sys_read";
 
-  AttachPoint ap2("", false, location());
+  AttachPoint ap2(d, "", false, location());
   ap2.provider = "kprobe";
   ap2.func = "sys_write";
 
-  AttachPoint ap3("", false, location());
+  AttachPoint ap3(d, "", false, location());
   ap3.provider = "kprobe";
   ap3.func = "sys_read";
   ap3.func_offset = 10;
 
-  Probe kprobe1({ &ap1 }, nullptr, {}, location());
+  Probe kprobe1(d, { &ap1 }, nullptr, {}, location());
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  Probe kprobe2({ &ap1, &ap2 }, nullptr, {}, location());
+  Probe kprobe2(d, { &ap1, &ap2 }, nullptr, {}, location());
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
 
-  Probe kprobe3({ &ap1, &ap2, &ap3 }, nullptr, {}, location());
+  Probe kprobe3(d, { &ap1, &ap2, &ap3 }, nullptr, {}, location());
   EXPECT_EQ(kprobe3.name(),
             "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");
 }
 
 TEST(ast, probe_name_uprobe)
 {
-  AttachPoint ap1("", false, location());
+  Diagnostics d;
+  AttachPoint ap1(d, "", false, location());
   ap1.provider = "uprobe";
   ap1.target = "/bin/sh";
   ap1.func = "readline";
-  Probe uprobe1({ &ap1 }, nullptr, {}, location());
+  Probe uprobe1(d, { &ap1 }, nullptr, {}, location());
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
-  AttachPoint ap2("", false, location());
+  AttachPoint ap2(d, "", false, location());
   ap2.provider = "uprobe";
   ap2.target = "/bin/sh";
   ap2.func = "somefunc";
-  Probe uprobe2({ &ap1, &ap2 }, nullptr, {}, location());
+  Probe uprobe2(d, { &ap1, &ap2 }, nullptr, {}, location());
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
 
-  AttachPoint ap3("", false, location());
+  AttachPoint ap3(d, "", false, location());
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.address = 1000;
-  Probe uprobe3({ &ap1, &ap2, &ap3 }, nullptr, {}, location());
+  Probe uprobe3(d, { &ap1, &ap2, &ap3 }, nullptr, {}, location());
   EXPECT_EQ(
       uprobe3.name(),
       "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
 
-  AttachPoint ap4("", false, location());
+  AttachPoint ap4(d, "", false, location());
   ap4.provider = "uprobe";
   ap4.target = "/bin/sh";
   ap4.func = "somefunc";
   ap4.func_offset = 10;
-  Probe uprobe4({ &ap1, &ap2, &ap3, &ap4 }, nullptr, {}, location());
+  Probe uprobe4(d, { &ap1, &ap2, &ap3, &ap4 }, nullptr, {}, location());
   EXPECT_EQ(uprobe4.name(),
             "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/"
             "sh:1000,uprobe:/bin/sh:somefunc+10");
 
-  AttachPoint ap5("", false, location());
+  AttachPoint ap5(d, "", false, location());
   ap5.provider = "uprobe";
   ap5.target = "/bin/sh";
   ap5.address = 10;
-  Probe uprobe5({ &ap5 }, nullptr, {}, location());
+  Probe uprobe5(d, { &ap5 }, nullptr, {}, location());
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
 
-  AttachPoint ap6("", false, location());
+  AttachPoint ap6(d, "", false, location());
   ap6.provider = "uretprobe";
   ap6.target = "/bin/sh";
   ap6.address = 10;
-  Probe uprobe6({ &ap6 }, nullptr, {}, location());
+  Probe uprobe6(d, { &ap6 }, nullptr, {}, location());
   EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
 }
 
 TEST(ast, probe_name_usdt)
 {
-  AttachPoint ap1("", false, location());
+  Diagnostics d;
+  AttachPoint ap1(d, "", false, location());
   ap1.provider = "usdt";
   ap1.target = "/bin/sh";
   ap1.func = "probe1";
-  Probe usdt1({ &ap1 }, nullptr, {}, location());
+  Probe usdt1(d, { &ap1 }, nullptr, {}, location());
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
-  AttachPoint ap2("", false, location());
+  AttachPoint ap2(d, "", false, location());
   ap2.provider = "usdt";
   ap2.target = "/bin/sh";
   ap2.func = "probe2";
-  Probe usdt2({ &ap1, &ap2 }, nullptr, {}, location());
+  Probe usdt2(d, { &ap1, &ap2 }, nullptr, {}, location());
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
 }
 
 TEST(ast, attach_point_name)
 {
-  AttachPoint ap1("", false, location());
+  Diagnostics d;
+  AttachPoint ap1(d, "", false, location());
   ap1.provider = "kprobe";
   ap1.func = "sys_read";
-  AttachPoint ap2("", false, location());
+  AttachPoint ap2(d, "", false, location());
   ap2.provider = "kprobe";
   ap2.func = "sys_thisone";
-  AttachPoint ap3("", false, location());
+  AttachPoint ap3(d, "", false, location());
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.func = "readline";
-  Probe kprobe({ &ap1, &ap2, &ap3 }, nullptr, {}, location());
+  Probe kprobe(d, { &ap1, &ap2, &ap3 }, nullptr, {}, location());
   EXPECT_EQ(ap2.name(), "kprobe:sys_thisone");
 
-  Probe uprobe({ &ap1, &ap2, &ap3 }, nullptr, {}, location());
+  Probe uprobe(d, { &ap1, &ap2, &ap3 }, nullptr, {}, location());
   EXPECT_EQ(ap3.name(), "uprobe:/bin/sh:readline");
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #3835
 * #3834
 * __->__#3833


--- --- ---

### Wire `Diagnostics` to AST nodes


This connects the newly introduced `Diagnostics` and `Diagnostic` class
to the AST nodes.

Signed-off-by: Adin Scannell <amscanne@meta.com>
