### PR TITLE
Unify pass structure in preparation for larger changes

### DIFF
--- a/src/ast/pass_manager.cpp
+++ b/src/ast/pass_manager.cpp
@@ -12,8 +12,8 @@ void print(PassContext &ctx, const std::string &name, std::ostream &out)
 {
   out << "\nAST after: " << name << std::endl;
   out << "-------------------\n";
-  ast::Printer printer(ctx.ast_ctx, out);
-  printer.print();
+  ast::Printer printer(out);
+  printer.visit(ctx.ast_ctx.root);
   out << std::endl;
 }
 } // namespace

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -310,6 +310,7 @@ private:
 
   GlobalVariable *DeclareKernelVar(const std::string &name);
 
+  ASTContext &astctx_;
   BPFtrace &bpftrace_;
   std::unique_ptr<USDTHelper> usdt_helper_;
   std::unique_ptr<LLVMContext> context_;

--- a/src/ast/passes/codegen_resources.cpp
+++ b/src/ast/passes/codegen_resources.cpp
@@ -7,15 +7,14 @@
 namespace bpftrace::ast {
 
 CodegenResourceAnalyser::CodegenResourceAnalyser(
-    ASTContext &ctx,
     const ::bpftrace::Config &config)
-    : Visitor<CodegenResourceAnalyser>(ctx), config_(config)
+    : config_(config)
 {
 }
 
-CodegenResources CodegenResourceAnalyser::analyse()
+CodegenResources CodegenResourceAnalyser::analyse(Program &program)
 {
-  visit(ctx_.root);
+  visit(program);
   return std::move(resources_);
 }
 

--- a/src/ast/passes/codegen_resources.h
+++ b/src/ast/passes/codegen_resources.h
@@ -22,8 +22,8 @@ struct CodegenResources {
 // logic makes things easier to understand and maintain.
 class CodegenResourceAnalyser : public Visitor<CodegenResourceAnalyser> {
 public:
-  CodegenResourceAnalyser(ASTContext &ctx, const ::bpftrace::Config &config);
-  CodegenResources analyse();
+  CodegenResourceAnalyser(const ::bpftrace::Config &config);
+  CodegenResources analyse(Program &program);
 
   using Visitor<CodegenResourceAnalyser>::visit;
   void visit(Builtin &map);

--- a/src/ast/passes/collect_nodes.h
+++ b/src/ast/passes/collect_nodes.h
@@ -14,9 +14,7 @@ namespace bpftrace::ast {
 template <typename NodeT>
 class CollectNodes : public Visitor<CollectNodes<NodeT>> {
 public:
-  explicit CollectNodes(ASTContext &ctx)
-      : Visitor<CollectNodes<NodeT>>(ctx),
-        pred_([](const auto &) { return true; })
+  explicit CollectNodes() : pred_([](const auto &) { return true; })
   {
   }
 

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -168,7 +168,7 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
 Pass CreateConfigPass()
 {
   auto fn = [](PassContext &ctx) {
-    auto configs = ConfigAnalyser(ctx.ast_ctx, ctx.b);
+    auto configs = ConfigAnalyser(ctx.b);
     configs.visit(ctx.ast_ctx.root);
   };
 

--- a/src/ast/passes/config_analyser.h
+++ b/src/ast/passes/config_analyser.h
@@ -14,9 +14,8 @@ namespace ast {
 
 class ConfigAnalyser : public Visitor<ConfigAnalyser> {
 public:
-  explicit ConfigAnalyser(ASTContext &ctx, BPFtrace &bpftrace)
-      : Visitor<ConfigAnalyser>(ctx),
-        bpftrace_(bpftrace),
+  explicit ConfigAnalyser(BPFtrace &bpftrace)
+      : bpftrace_(bpftrace),
         config_setter_(ConfigSetter(*bpftrace.config_, ConfigSource::script))
   {
   }
@@ -48,5 +47,6 @@ private:
 };
 
 Pass CreateConfigPass();
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -324,7 +324,7 @@ void FieldAnalyser::visit(Subprog &subprog)
 Pass CreateFieldAnalyserPass()
 {
   auto fn = [](PassContext &ctx) {
-    FieldAnalyser analyser(ctx.ast_ctx, ctx.b);
+    FieldAnalyser analyser(ctx.b);
     analyser.visit(ctx.ast_ctx.root);
   };
 

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -16,10 +16,8 @@ namespace ast {
 
 class FieldAnalyser : public Visitor<FieldAnalyser> {
 public:
-  explicit FieldAnalyser(ASTContext &ctx, BPFtrace &bpftrace)
-      : Visitor<FieldAnalyser>(ctx),
-        bpftrace_(bpftrace),
-        prog_type_(libbpf::BPF_PROG_TYPE_UNSPEC)
+  explicit FieldAnalyser(BPFtrace &bpftrace)
+      : bpftrace_(bpftrace), prog_type_(libbpf::BPF_PROG_TYPE_UNSPEC)
   {
   }
 

--- a/src/ast/passes/pid_filter_pass.cpp
+++ b/src/ast/passes/pid_filter_pass.cpp
@@ -39,7 +39,9 @@ bool probe_needs_pid_filter(AttachPoint *ap)
   return false;
 }
 
-Statement *create_pid_filter(ASTContext &ctx, int pid, const location &loc)
+static Statement *create_pid_filter(ASTContext &ctx,
+                                    int pid,
+                                    const location &loc)
 {
   return ctx.make_node<If>(
       ctx.make_node<Binop>(ctx.make_node<Builtin>("pid", loc),
@@ -63,22 +65,17 @@ void PidFilterPass::visit(Probe &probe)
   for (AttachPoint *ap : probe.attach_points) {
     if (probe_needs_pid_filter(ap)) {
       probe.block->stmts.insert(probe.block->stmts.begin(),
-                                create_pid_filter(ctx_, *pid, probe.loc));
+                                create_pid_filter(ast_, *pid, probe.loc));
       return;
     }
   }
-}
-
-void PidFilterPass::analyse()
-{
-  visit(ctx_.root);
 }
 
 Pass CreatePidFilterPass()
 {
   auto fn = [](PassContext &ctx) {
     auto pid_filter = PidFilterPass(ctx.ast_ctx, ctx.b);
-    pid_filter.analyse();
+    pid_filter.visit(ctx.ast_ctx.root);
   };
 
   return Pass("PidFilter", fn);

--- a/src/ast/passes/pid_filter_pass.h
+++ b/src/ast/passes/pid_filter_pass.h
@@ -9,17 +9,16 @@ namespace ast {
 
 class PidFilterPass : public Visitor<PidFilterPass> {
 public:
-  explicit PidFilterPass(ASTContext &ctx, BPFtrace &bpftrace)
-      : Visitor<PidFilterPass>(ctx), bpftrace_(bpftrace)
+  explicit PidFilterPass(ASTContext &ast, BPFtrace &bpftrace)
+      : ast_(ast), bpftrace_(bpftrace)
   {
   }
 
   using Visitor<PidFilterPass>::visit;
   void visit(Probe &probe);
 
-  void analyse();
-
 private:
+  ASTContext &ast_;
   BPFtrace &bpftrace_;
 };
 

--- a/src/ast/passes/portability_analyser.cpp
+++ b/src/ast/passes/portability_analyser.cpp
@@ -6,11 +6,6 @@
 
 namespace bpftrace::ast {
 
-PortabilityAnalyser::PortabilityAnalyser(ASTContext &ctx)
-    : Visitor<PortabilityAnalyser>(ctx)
-{
-}
-
 void PortabilityAnalyser::visit(PositionalParameter &param)
 {
   // Positional params are only known at runtime. Currently, codegen directly
@@ -93,7 +88,7 @@ void PortabilityAnalyser::visit(AttachPoint &ap)
 Pass CreatePortabilityPass()
 {
   auto fn = [](PassContext &ctx) {
-    PortabilityAnalyser analyser(ctx.ast_ctx);
+    PortabilityAnalyser analyser;
     analyser.visit(ctx.ast_ctx.root);
     if (!ctx.ast_ctx.diagnostics().ok()) {
       // Used by runtime test framework to know when to skip an AOT test

--- a/src/ast/passes/portability_analyser.h
+++ b/src/ast/passes/portability_analyser.h
@@ -13,8 +13,6 @@ namespace ast {
 // features.
 class PortabilityAnalyser : public Visitor<PortabilityAnalyser> {
 public:
-  PortabilityAnalyser(ASTContext &ctx);
-
   using Visitor<PortabilityAnalyser>::visit;
   void visit(PositionalParameter &param);
   void visit(Builtin &builtin);

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -10,13 +10,6 @@
 
 namespace bpftrace::ast {
 
-void Printer::print()
-{
-  ++depth_;
-  visit(ctx_.root);
-  --depth_;
-}
-
 std::string Printer::type(const SizedType &ty)
 {
   if (ty.IsNoneTy())

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -9,12 +9,9 @@ namespace ast {
 
 class Printer : public Visitor<Printer> {
 public:
-  explicit Printer(ASTContext &ctx, std::ostream &out)
-      : Visitor<Printer>(ctx), out_(out)
+  explicit Printer(std::ostream &out) : out_(out)
   {
   }
-
-  void print();
 
   using Visitor<Printer>::visit;
   void visit(Integer &integer);
@@ -52,10 +49,9 @@ public:
   void visit(Subprog &subprog);
   void visit(Program &program);
 
-  int depth_ = -1;
-
 private:
   std::ostream &out_;
+  int depth_ = 0;
 
   std::string type(const SizedType &ty);
 };

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -18,9 +18,7 @@ namespace ast {
 // example the helper error metadata is still being collected during codegen.
 class ResourceAnalyser : public Visitor<ResourceAnalyser> {
 public:
-  ResourceAnalyser(ASTContext &ctx, BPFtrace &bpftrace);
-
-  RequiredResources analyse();
+  ResourceAnalyser(BPFtrace &bpftrace);
 
   using Visitor<ResourceAnalyser>::visit;
   void visit(Probe &probe);
@@ -34,6 +32,10 @@ public:
   void visit(AssignMapStatement &assignment);
   void visit(AssignVarStatement &assignment);
   void visit(VarDeclStatement &decl);
+
+  // This will move the compute resources value, it should be called only
+  // after the top-level visit.
+  RequiredResources resources();
 
 private:
   // Determines whether the given function uses userspace symbol resolution.

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -3,11 +3,6 @@
 
 namespace bpftrace::ast {
 
-ReturnPathAnalyser::ReturnPathAnalyser(ASTContext &ctx)
-    : Visitor<ReturnPathAnalyser, bool>(ctx)
-{
-}
-
 bool ReturnPathAnalyser::visit(Program &prog)
 {
   for (Subprog *subprog : prog.functions) {
@@ -60,7 +55,7 @@ bool ReturnPathAnalyser::visit(If &if_node)
 Pass CreateReturnPathPass()
 {
   auto fn = [](PassContext &ctx) {
-    auto return_path = ReturnPathAnalyser(ctx.ast_ctx);
+    ReturnPathAnalyser return_path;
     return_path.visit(ctx.ast_ctx.root);
   };
 

--- a/src/ast/passes/return_path_analyser.h
+++ b/src/ast/passes/return_path_analyser.h
@@ -8,11 +8,8 @@ namespace ast {
 
 class ReturnPathAnalyser : public Visitor<ReturnPathAnalyser, bool> {
 public:
-  explicit ReturnPathAnalyser(ASTContext &ctx);
-
   // visit methods return true iff all return paths of the analyzed code
-  // (represented by the given node) return a value
-  // For details for concrete node type see the implementations
+  // (represented by the given node) return a value.
   using Visitor<ReturnPathAnalyser, bool>::visit;
   bool visit(Program &prog);
   bool visit(Subprog &subprog);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2455,7 +2455,7 @@ void SemanticAnalyser::visit(For &f)
 
   // Validate body
   // This could be relaxed in the future:
-  CollectNodes<Jump> jumps(ctx_);
+  CollectNodes<Jump> jumps;
   jumps.visit(f.stmts);
   for (const Jump &n : jumps.nodes()) {
     n.addError() << "'" << opstr(n)
@@ -2487,7 +2487,7 @@ void SemanticAnalyser::visit(For &f)
       // inside the for loop to get the types of the referenced variables but
       // only after we have the map's key/value type so we can also check
       // the usages of the created $kv tuple variable.
-      auto [iter, _] = for_vars_referenced_.try_emplace(&f, ctx_);
+      auto [iter, _] = for_vars_referenced_.try_emplace(&f);
       auto &collector = iter->second;
       collector.visit(stmt, [this, &found_vars](const auto &var) {
         if (found_vars.find(var.ident) != found_vars.end())
@@ -2534,7 +2534,7 @@ void SemanticAnalyser::visit(For &f)
 
   // Currently, we do not pass BPF context to the callback so disable builtins
   // which require ctx access.
-  CollectNodes<Builtin> builtins(ctx_);
+  CollectNodes<Builtin> builtins;
   builtins.visit(f.stmts);
   for (const Builtin &builtin : builtins.nodes()) {
     if (builtin.type.IsCtxAccess() || builtin.is_argx() ||
@@ -2548,7 +2548,7 @@ void SemanticAnalyser::visit(For &f)
   // have been visited.
   std::vector<SizedType> ctx_types;
   std::vector<std::string_view> ctx_idents;
-  auto [iter, _] = for_vars_referenced_.try_emplace(&f, ctx_);
+  auto [iter, _] = for_vars_referenced_.try_emplace(&f);
   auto &collector = iter->second;
   for (const Variable &var : collector.nodes()) {
     ctx_types.push_back(CreatePointer(var.type, AddrSpace::bpf));

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -62,10 +62,7 @@ public:
                             BPFtrace &bpftrace,
                             bool has_child = true,
                             bool listing = false)
-      : Visitor<SemanticAnalyser>(ctx),
-        bpftrace_(bpftrace),
-        listing_(listing),
-        has_child_(has_child)
+      : ctx_(ctx), bpftrace_(bpftrace), listing_(listing), has_child_(has_child)
   {
   }
 
@@ -108,6 +105,7 @@ public:
   void visit(Subprog &subprog);
 
 private:
+  ASTContext &ctx_;
   PassTracker pass_tracker_;
   BPFtrace &bpftrace_;
   bool listing_;

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -25,10 +25,6 @@ namespace bpftrace::ast {
 template <typename Impl, typename R = void>
 class Visitor {
 public:
-  Visitor(ASTContext &ctx) : ctx_(ctx)
-  {
-  }
-
   // See above; specific replace methods may be defined.
   template <typename T>
   T *replace(T *node, [[maybe_unused]] R *result)
@@ -274,13 +270,6 @@ public:
     return default_value();
   }
 
-private:
-  template <typename T>
-  R visitImpl(T &t)
-  {
-    Impl *impl = static_cast<Impl *>(this);
-    return impl->visit(t);
-  }
   template <typename T>
   R visitAndReplace(T **t)
   {
@@ -294,12 +283,6 @@ private:
       impl->visit(orig);
       *t = impl->replace(orig, nullptr);
       return default_value();
-    }
-  }
-  R default_value()
-  {
-    if constexpr (!std::is_void_v<R>) {
-      return R();
     }
   }
 
@@ -363,8 +346,19 @@ private:
                               Config *>(stmt);
   }
 
-protected:
-  ASTContext &ctx_;
+private:
+  template <typename T>
+  R visitImpl(T &t)
+  {
+    Impl *impl = static_cast<Impl *>(this);
+    return impl->visit(t);
+  }
+  R default_value()
+  {
+    if constexpr (!std::is_void_v<R>) {
+      return R();
+    }
+  }
 };
 
 } // namespace bpftrace::ast

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -369,7 +369,7 @@ static void parse_env(BPFtrace& bpftrace)
 
   bpftrace.parse_btf(driver.list_modules());
 
-  ast::FieldAnalyser fields(driver.ctx, bpftrace);
+  ast::FieldAnalyser fields(bpftrace);
   fields.visit(driver.ctx.root);
   if (!driver.ctx.diagnostics().ok()) {
     driver.ctx.diagnostics().emit(std::cerr);

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -27,7 +27,7 @@ bool TracepointFormatParser::parse(ast::ASTContext &ctx, BPFtrace &bpftrace)
   if (probes_with_tracepoint.empty())
     return true;
 
-  ast::TracepointArgsVisitor n(ctx);
+  ast::TracepointArgsVisitor n;
   if (!bpftrace.has_btf_data())
     program->c_definitions += "#include <linux/types.h>\n";
   for (ast::Probe *probe : probes_with_tracepoint) {

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -12,11 +12,6 @@ namespace ast {
 
 class TracepointArgsVisitor : public Visitor<TracepointArgsVisitor> {
 public:
-  explicit TracepointArgsVisitor(ASTContext &ctx)
-      : Visitor<TracepointArgsVisitor>(ctx)
-  {
-  }
-
   using Visitor<TracepointArgsVisitor>::visit;
   void visit(Builtin &builtin)
   {

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -41,7 +41,7 @@ static auto parse_probe(const std::string &str,
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(str), 0);
 
-  ast::FieldAnalyser fields(driver.ctx, bpftrace);
+  ast::FieldAnalyser fields(bpftrace);
   fields.visit(driver.ctx.root);
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -23,7 +23,7 @@ static void parse(const std::string &input,
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(extended_input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx, bpftrace);
+  ast::FieldAnalyser fields(bpftrace);
   fields.visit(driver.ctx.root);
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -29,8 +29,9 @@ TEST(codegen, call_kstack_mapids)
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
-  bpftrace->resources = resource_analyser.analyse();
+  ast::ResourceAnalyser resource_analyser(*bpftrace);
+  resource_analyser.visit(driver.ctx.root);
+  bpftrace->resources = resource_analyser.resources();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
   ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
@@ -63,8 +64,9 @@ TEST(codegen, call_kstack_modes_mapids)
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
-  bpftrace->resources = resource_analyser.analyse();
+  ast::ResourceAnalyser resource_analyser(*bpftrace);
+  resource_analyser.visit(driver.ctx.root);
+  bpftrace->resources = resource_analyser.resources();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
   ast::CodegenLLVM codegen(driver.ctx, *bpftrace);

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -29,8 +29,9 @@ TEST(codegen, call_ustack_mapids)
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
-  bpftrace->resources = resource_analyser.analyse();
+  ast::ResourceAnalyser resource_analyser(*bpftrace);
+  resource_analyser.visit(driver.ctx.root);
+  bpftrace->resources = resource_analyser.resources();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
   ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
@@ -63,8 +64,9 @@ TEST(codegen, call_ustack_modes_mapids)
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
-  bpftrace->resources = resource_analyser.analyse();
+  ast::ResourceAnalyser resource_analyser(*bpftrace);
+  resource_analyser.visit(driver.ctx.root);
+  bpftrace->resources = resource_analyser.resources();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
   ast::CodegenLLVM codegen(driver.ctx, *bpftrace);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -54,7 +54,7 @@ static void test(BPFtrace &bpftrace,
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx, bpftrace);
+  ast::FieldAnalyser fields(bpftrace);
   fields.visit(driver.ctx.root);
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
@@ -64,14 +64,15 @@ static void test(BPFtrace &bpftrace,
   ASSERT_EQ(driver.parse_str(input), 0);
 
   ast::PidFilterPass pid_filter(driver.ctx, bpftrace);
-  pid_filter.analyse();
+  pid_filter.visit(driver.ctx.root);
 
   ast::SemanticAnalyser semantics(driver.ctx, bpftrace);
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx, bpftrace);
-  bpftrace.resources = resource_analyser.analyse();
+  ast::ResourceAnalyser resource_analyser(bpftrace);
+  resource_analyser.visit(driver.ctx.root);
+  bpftrace.resources = resource_analyser.resources();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
   std::stringstream out;

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -67,8 +67,9 @@ TEST(codegen, printf_offsets)
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
-  bpftrace->resources = resource_analyser.analyse();
+  ast::ResourceAnalyser resource_analyser(*bpftrace);
+  resource_analyser.visit(driver.ctx.root);
+  bpftrace->resources = resource_analyser.resources();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
   ast::CodegenLLVM codegen(driver.ctx, *bpftrace);

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -19,8 +19,9 @@ TEST(codegen, regression_957)
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
-  bpftrace->resources = resource_analyser.analyse();
+  ast::ResourceAnalyser resource_analyser(*bpftrace);
+  resource_analyser.visit(driver.ctx.root);
+  bpftrace->resources = resource_analyser.resources();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
   ast::CodegenLLVM codegen(driver.ctx, *bpftrace);

--- a/tests/collect_nodes.cpp
+++ b/tests/collect_nodes.cpp
@@ -24,7 +24,7 @@ TEST(CollectNodes, direct)
   ASTContext ctx;
   auto &var = *ctx.make_node<Variable>("myvar", bpftrace::location{});
 
-  CollectNodes<Variable> visitor(ctx);
+  CollectNodes<Variable> visitor;
   visitor.visit(var);
 
   test({ var }, visitor.nodes());
@@ -37,7 +37,7 @@ TEST(CollectNodes, indirect)
   auto &unop = *ctx.make_node<Unop>(
       Operator::INCREMENT, &var, false, bpftrace::location{});
 
-  CollectNodes<Variable> visitor(ctx);
+  CollectNodes<Variable> visitor;
   visitor.visit(unop);
 
   test({ var }, visitor.nodes());
@@ -50,7 +50,7 @@ TEST(CollectNodes, none)
   auto &unop = *ctx.make_node<Unop>(
       Operator::INCREMENT, &map, false, bpftrace::location{});
 
-  CollectNodes<Variable> visitor(ctx);
+  CollectNodes<Variable> visitor;
   visitor.visit(unop);
 
   test({}, visitor.nodes());
@@ -67,7 +67,7 @@ TEST(CollectNodes, multiple_runs)
   auto &unop2 = *ctx.make_node<Unop>(
       Operator::INCREMENT, &var2, false, bpftrace::location{});
 
-  CollectNodes<Variable> visitor(ctx);
+  CollectNodes<Variable> visitor;
   visitor.visit(unop1);
   visitor.visit(unop2);
 
@@ -82,7 +82,7 @@ TEST(CollectNodes, multiple_children)
   auto &binop = *ctx.make_node<Binop>(
       &var1, Operator::PLUS, &var2, bpftrace::location{});
 
-  CollectNodes<Variable> visitor(ctx);
+  CollectNodes<Variable> visitor;
   visitor.visit(binop);
 
   test({ var1, var2 }, visitor.nodes());
@@ -96,7 +96,7 @@ TEST(CollectNodes, predicate)
   auto &binop = *ctx.make_node<Binop>(
       &var1, Operator::PLUS, &var2, bpftrace::location{});
 
-  CollectNodes<Variable> visitor(ctx);
+  CollectNodes<Variable> visitor;
   visitor.visit(binop, [](const auto &var) { return var.ident == "myvar2"; });
 
   test({ var2 }, visitor.nodes());
@@ -113,7 +113,7 @@ TEST(CollectNodes, nested)
   auto &binop2 = *ctx.make_node<Binop>(
       &binop1, Operator::MINUS, &var3, bpftrace::location{});
 
-  CollectNodes<Binop> visitor(ctx);
+  CollectNodes<Binop> visitor;
   visitor.visit(binop2,
                 [](const auto &binop) { return binop.op == Operator::PLUS; });
 

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -30,7 +30,7 @@ void test(BPFtrace &bpftrace,
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
-  ast::ConfigAnalyser config_analyser(driver.ctx, bpftrace);
+  ast::ConfigAnalyser config_analyser(bpftrace);
   config_analyser.visit(driver.ctx.root);
   ASSERT_EQ(driver.ctx.diagnostics().ok(), expected_result) << msg.str();
 

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -11,14 +11,13 @@ using ::testing::_;
 
 void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 {
-  std::stringstream out;
   std::stringstream msg;
   msg << "\nInput:\n" << input << "\n\nOutput:\n";
 
   Driver driver(bpftrace);
   EXPECT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx, bpftrace);
+  ast::FieldAnalyser fields(bpftrace);
   fields.visit(driver.ctx.root);
   ASSERT_EQ(int(!driver.ctx.diagnostics().ok()), expected_result);
 }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -39,8 +39,8 @@ void test(BPFtrace &bpftrace, std::string_view input, std::string_view expected)
     expected.remove_prefix(1); // Remove initial '\n'
 
   std::ostringstream out;
-  Printer printer(driver.ctx, out);
-  printer.print();
+  Printer printer(out);
+  printer.visit(driver.ctx.root);
   EXPECT_EQ(expected, out.str());
 }
 

--- a/tests/pid_filter_pass.cpp
+++ b/tests/pid_filter_pass.cpp
@@ -31,7 +31,7 @@ void test(std::string_view input, bool has_pid, bool has_filter)
 
   ASSERT_EQ(driver.parse_str(input), 0);
   ast::PidFilterPass pid_filter(driver.ctx, bpftrace);
-  pid_filter.analyse();
+  pid_filter.visit(driver.ctx.root);
 
   std::string_view expected_ast = R"(
   if
@@ -43,8 +43,8 @@ void test(std::string_view input, bool has_pid, bool has_filter)
 )";
 
   std::ostringstream out;
-  ast::Printer printer(driver.ctx, out);
-  printer.print();
+  ast::Printer printer(out);
+  printer.visit(driver.ctx.root);
 
   if (has_filter) {
     EXPECT_THAT(out.str(), HasSubstr(expected_ast));

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -18,13 +18,12 @@ using ::testing::_;
 void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 {
   Driver driver(bpftrace);
-  std::stringstream out;
   std::stringstream msg;
   msg << "\nInput:\n" << input << "\n\nOutput:\n";
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx, bpftrace);
+  ast::FieldAnalyser fields(bpftrace);
   fields.visit(driver.ctx.root);
   ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
 
@@ -36,7 +35,7 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
 
-  ast::PortabilityAnalyser portability(driver.ctx);
+  ast::PortabilityAnalyser portability;
   portability.visit(driver.ctx.root);
   ASSERT_EQ(int(!driver.ctx.diagnostics().ok()), expected_result) << msg.str();
 }

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -26,7 +26,7 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx, *bpftrace);
+  ast::FieldAnalyser fields(*bpftrace);
   fields.visit(driver.ctx.root);
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
@@ -37,8 +37,9 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx, *bpftrace);
-  bpftrace->resources = resource_analyser.analyse();
+  ast::ResourceAnalyser resource_analyser(*bpftrace);
+  resource_analyser.visit(driver.ctx.root);
+  bpftrace->resources = resource_analyser.resources();
   ASSERT_TRUE(driver.ctx.diagnostics().ok());
 
   ast::CodegenLLVM codegen(driver.ctx, *bpftrace);

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -24,7 +24,7 @@ void test(BPFtrace &bpftrace,
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx, bpftrace);
+  ast::FieldAnalyser fields(bpftrace);
   fields.visit(driver.ctx.root);
   ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
 
@@ -36,8 +36,9 @@ void test(BPFtrace &bpftrace,
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
 
-  ast::ResourceAnalyser resource_analyser(driver.ctx, bpftrace);
-  auto r = resource_analyser.analyse();
+  ast::ResourceAnalyser resource_analyser(bpftrace);
+  resource_analyser.visit(driver.ctx.root);
+  auto r = resource_analyser.resources();
   ASSERT_EQ(driver.ctx.diagnostics().ok(), expected_result) << msg.str();
 
   if (out_p)

--- a/tests/return_path_analyser.cpp
+++ b/tests/return_path_analyser.cpp
@@ -21,7 +21,7 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx, bpftrace);
+  ast::FieldAnalyser fields(bpftrace);
   fields.visit(driver.ctx.root);
   ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
 
@@ -33,7 +33,7 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
   semantics.analyse();
   ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
 
-  ast::ReturnPathAnalyser return_path(driver.ctx);
+  ast::ReturnPathAnalyser return_path;
   return_path.visit(driver.ctx.root);
   ASSERT_EQ(int(!driver.ctx.diagnostics().ok()), expected_result) << msg.str();
 }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -69,7 +69,7 @@ void test(BPFtrace &bpftrace,
   bpftrace.safe_mode_ = safe_mode;
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.ctx, bpftrace);
+  ast::FieldAnalyser fields(bpftrace);
   fields.visit(driver.ctx.root);
   ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
 
@@ -213,8 +213,8 @@ void test(BPFtrace &bpftrace,
     expected_ast.remove_prefix(1); // Remove initial '\n'
 
   std::ostringstream out;
-  ast::Printer printer(driver.ctx, out);
-  printer.print();
+  ast::Printer printer(out);
+  printer.visit(driver.ctx.root);
 
   if (expected_ast[0] == '*' && expected_ast[expected_ast.size() - 1] == '*') {
     // Remove globs from beginning and end

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -261,7 +261,8 @@ TEST(tracepoint_format_parser, args_field_access)
   // Test computing the level of nested structs accessed from tracepoint args
   BPFtrace bpftrace;
   Driver driver(bpftrace);
-  ast::TracepointArgsVisitor visitor(driver.ctx);
+  ast::TracepointArgsVisitor visitor;
+  visitor.visit(driver.ctx.root);
 
   EXPECT_EQ(driver.parse_str("BEGIN { args.f1->f2->f3 }"), 0);
   visitor.visit(*driver.ctx.root->probes.at(0));


### PR DESCRIPTION
Stacked PRs:
 * #3855
 * #3854
 * #3853
 * #3852
 * __->__#3835
 * #3834


--- --- ---

### Unify pass structure in preparation for larger changes


This change tweaks some of the visitors and passes to have a more
consistent interface, and avoid any extraneous plumbing. Notably, a full
AST context is no longer require for the visitor, and we avoid plumbing
a full output stream into visitors where it doesn't make sense. In the
future, these direct call sites will be transformed into instances of
the passes, rather than a direct use of the objects.

This change is being done in preparation for a larger change to
introduce more structure into the passes. Currently, passes have a large
number of undocumented side-effects, namely mutating parts of the
`BPFtrace` "god object". This fact has led to the duplication of pass
logic in many places in the code (for example, every pass test runs
every prior pass, since one can't enumerate all the side-effects) and a
lot of complexity that has prevented factoring passes.

The coming change will introduce a set of structured inputs and outputs
for each pass, and allow us to slowly pull state from the `BPFtrace`
object. Then, individual tests can simply enumerate the input state that
they expect in the pass context, and not construct every prior pass in
order to test the logic in the current one.

Signed-off-by: Adin Scannell <amscanne@meta.com>
