### PR TITLE
Add `ErrorOr` and associated types

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(runtime STATIC
   debugfs.cpp
   usdt.cpp
   utils.cpp
+  util/result.cpp
   pcap_writer.cpp
   ksyms.cpp
   usyms.cpp

--- a/src/util/result.cpp
+++ b/src/util/result.cpp
@@ -1,0 +1,13 @@
+#include "util/result.h"
+
+namespace bpftrace {
+
+std::ostream& operator<<(std::ostream& out, const llvm::Error& err)
+{
+  llvm::raw_os_ostream raw_ostream(out);
+  raw_ostream << err;
+  raw_ostream.flush();
+  return out;
+}
+
+} // namespace bpftrace


### PR DESCRIPTION
In order to avoid reinventing the wheel, these are imported directly from LLVM, with a header providing a layer of indirection.

These errors must be checked and consumed in order to proceed, providing a layer of safety and enforcing good practices for error checking.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~ No language changes.
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~ No user visible changes.
- ~[ ] The new behaviour is covered by tests~ Aliases and documentation primarily.
