### PR TITLE
Don't error on variable use before assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to
   - [#3752](https://github.com/bpftrace/bpftrace/pull/3752)
 - Increase default values for max_bpf_progs and max_probes
   - [#3808](https://github.com/bpftrace/bpftrace/pull/3808)
+- Allow use of variables before they are assigned
+  - [#3832](https://github.com/bpftrace/bpftrace/pull/3832)
 #### Deprecated
 #### Removed
 - Drop support for LLVM 14 and 15

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1813,12 +1813,10 @@ void SemanticAnalyser::visit(Map &map)
 void SemanticAnalyser::visit(Variable &var)
 {
   if (auto *found = find_variable(var.ident)) {
-    if (found->was_assigned) {
-      var.type = found->type;
-    } else {
-      LOG(ERROR, var.loc, err_)
+    var.type = found->type;
+    if (!found->was_assigned) {
+      LOG(WARNING, var.loc, out_)
           << "Variable used before it was assigned: " << var.ident;
-      var.type = CreateNone();
     }
     return;
   }


### PR DESCRIPTION
In sticking with our current doc, this allows
users to use variables before they are assigned
but we'll still issue a warning as this may be
uintended and yield unexpected results for some
builtins.

Master PR: https://github.com/bpftrace/bpftrace/pull/3832

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
