### PR TITLE
Fix issue #3845: "No DWARF found" warning is inaccurate

### DIFF
--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -428,13 +428,18 @@ FuncParamLists ProbeMatcher::get_uprobe_params(
   for (auto& match : uprobes) {
     std::string fun = match;
     std::string path = erase_prefix(fun);
-    auto dwarf = Dwarf::GetFromBinary(nullptr, path);
-    if (dwarf)
+    if (auto dwarf = Dwarf::GetFromBinary(nullptr, path)) {
       params.emplace(match, dwarf->get_function_params(fun));
-    else {
-      if (warned_paths.insert(path).second)
+    } else {
+      if (warned_paths.insert(path).second) {
+#ifdef HAVE_LIBLLDB
         LOG(WARNING) << "No DWARF found for \"" << path << "\""
                      << ", cannot show parameter info";
+#else
+        LOG(WARNING) << "bpftrace was compiled without liblldb, "
+                     << "cannot show parameter info for \"" << path << "\"";
+#endif
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes the confusing warning message when bpftrace is built without `liblldb`.
The message was accusing the target of missing its debug info, but it is bpftrace itself that was build without DWARF support.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
