### PR TITLE
[BACKPORT] codegen: str: Fix off-by-one error for clamped string size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to
   - [#3805](https://github.com/bpftrace/bpftrace/pull/3805)
 - Fix strcontains() correctness bug where matches could be lost if both strings are non-literal
   - [#3811](https://github.com/bpftrace/bpftrace/pull/3811)
+- Fix str() bug where optional size parameter did not count towards NUL terminator
+  - [#3849](https://github.com/bpftrace/bpftrace/pull/3849)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -766,12 +766,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     Value *strlen = b_.getInt64(max_strlen);
     if (call.vargs.size() > 1) {
       auto scoped_arg = visit(call.vargs.at(1));
-      Value *cast = b_.CreateIntCast(scoped_arg.value(), b_.getInt64Ty(), true);
-      Value *proposed_strlen = b_.CreateAdd(cast,
-                                            b_.getInt64(1)); // add 1 to
-                                                             // accommodate
-                                                             // probe_read_str's
-                                                             // null byte
+      Value *proposed_strlen = scoped_arg.value();
 
       // integer comparison: unsigned less-than-or-equal-to
       CmpInst::Predicate P = CmpInst::ICMP_ULE;

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -23,22 +23,21 @@ entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i64, ptr %1, i64 13
   %arg1 = load volatile i64, ptr %2, align 8
-  %3 = add i64 %arg1, 1
-  %str.min.cmp = icmp ule i64 %3, 1024
-  %str.min.select = select i1 %str.min.cmp, i64 %3, i64 1024
+  %str.min.cmp = icmp ule i64 %arg1, 1024
+  %str.min.select = select i1 %str.min.cmp, i64 %arg1, i64 1024
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %4 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %4
-  %5 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %5, i32 1024, ptr null)
-  %6 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %7 = getelementptr i64, ptr %6, i64 14
-  %arg0 = load volatile i64, ptr %7, align 8
-  %8 = trunc i64 %str.min.select to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %5, i32 %8, i64 %arg0)
+  %3 = load i64, ptr @max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %3
+  %4 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 1024, ptr null)
+  %5 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %6 = getelementptr i64, ptr %5, i64 14
+  %arg0 = load volatile i64, ptr %6, align 8
+  %7 = trunc i64 %str.min.select to i32
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %4, i32 %7, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %5, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %4, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   ret i64 0
 }

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -28,7 +28,7 @@ entry:
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
   %4 = getelementptr i64, ptr %3, i64 14
   %arg0 = load volatile i64, ptr %4, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 7, i64 %arg0)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 6, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %2, i64 0)

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -87,6 +87,11 @@ ENV BPFTRACE_MAX_STRLEN=5
 AFTER ./testprogs/syscall execve ./testprogs/true &>/dev/null
 EXPECT_REGEX P: /...\.\.
 
+NAME explicit string truncation
+PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/true" / { print(str(args.argv[1], 5)); exit(); }
+AFTER ./testprogs/true zztest
+EXPECT zzte
+
 NAME str_truncated_custom
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
 ENV BPFTRACE_MAX_STRLEN=5 BPFTRACE_STR_TRUNC_TRAILER=_xxx

--- a/tests/runtime/strcontains
+++ b/tests/runtime/strcontains
@@ -17,6 +17,11 @@ TIMEOUT 1
 # Clamping is done to not blow verifier complexity limits
 ENV BPFTRACE_MAX_STRLEN=64
 
+NAME string truncation does not affect matching
+PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/true" / { print(strcontains(str(args.argv[1], 6), str(args.argv[2], 4))); exit(); }
+AFTER ./testprogs/true zztest test
+EXPECT 1
+
 NAME basic substring match
 PROG BEGIN { print(strcontains("hello-test-world", "test")); exit(); }
 EXPECT 1


### PR DESCRIPTION
In the bpfscript type system, string types have known sizes. The known size is understood by the rest of the type system to include the NUL terminator. The bpftrace.adoc documentation confirms this:

    In case the string is longer than the specified length only `length
    - 1` bytes are copied and a NULL byte is appended at the end.

However for the current code, if the clamped size was provided, codegen injected an extra byte to make room for the NUL terminator.

This is wrong, as it causes C strings that are larger than the clamped size to have its NUL terminator past the end of the bpfscript string. One way this breaks things is that now strcontains() fails to see the NUL terminator during its search, which causes a miss when it otherwise should've been a match. See attached runtime test for example.

Fix by removing the extra byte.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
