### PR TITLE
codegen: Locations for helpers are no longer optional

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -446,11 +446,11 @@ CallInst *IRBuilderBPF::CreateHelperCall(libbpf::bpf_func_id func_id,
                                          FunctionType *helper_type,
                                          ArrayRef<Value *> args,
                                          const Twine &Name,
-                                         const location *loc)
+                                         const location &loc)
 {
-  if (loc && bpftrace_.helper_use_loc_.find(func_id) ==
-                 bpftrace_.helper_use_loc_.end())
-    bpftrace_.helper_use_loc_[func_id] = *loc;
+  if (bpftrace_.helper_use_loc_.find(func_id) ==
+      bpftrace_.helper_use_loc_.end())
+    bpftrace_.helper_use_loc_[func_id] = loc;
   PointerType *helper_ptr_type = PointerType::get(helper_type, 0);
   Constant *helper_func = ConstantExpr::getCast(Instruction::IntToPtr,
                                                 getInt64(func_id),
@@ -1777,7 +1777,7 @@ CallInst *IRBuilderBPF::CreateGetNs(TimestampMode ts, const location &loc)
   // u64 ktime_get_*ns()
   // Return: current ktime
   FunctionType *gettime_func_type = FunctionType::get(getInt64Ty(), false);
-  return CreateHelperCall(fn, gettime_func_type, {}, "get_ns", &loc);
+  return CreateHelperCall(fn, gettime_func_type, {}, "get_ns", loc);
 }
 
 CallInst *IRBuilderBPF::CreateJiffies64(const location &loc)
@@ -1786,7 +1786,7 @@ CallInst *IRBuilderBPF::CreateJiffies64(const location &loc)
   // Return: jiffies (BITS_PER_LONG == 64) or jiffies_64 (otherwise)
   FunctionType *jiffies64_func_type = FunctionType::get(getInt64Ty(), false);
   return CreateHelperCall(
-      libbpf::BPF_FUNC_jiffies64, jiffies64_func_type, {}, "jiffies64", &loc);
+      libbpf::BPF_FUNC_jiffies64, jiffies64_func_type, {}, "jiffies64", loc);
 }
 
 Value *IRBuilderBPF::CreateIntegerArrayCmp(Value *ctx,
@@ -1916,7 +1916,7 @@ CallInst *IRBuilderBPF::CreateGetPidTgid(const location &loc)
                           getpidtgid_func_type,
                           {},
                           "get_pid_tgid",
-                          &loc);
+                          loc);
 }
 
 void IRBuilderBPF::CreateGetNsPidTgid(Value *ctx,
@@ -1943,7 +1943,7 @@ void IRBuilderBPF::CreateGetNsPidTgid(Value *ctx,
                                     getnspidtgid_func_type,
                                     { dev, ino, ret, getInt32(struct_size) },
                                     "get_ns_pid_tgid",
-                                    &loc);
+                                    loc);
   CreateHelperErrorCond(
       ctx, call, libbpf::BPF_FUNC_get_ns_current_pid_tgid, loc);
 }
@@ -1967,7 +1967,7 @@ CallInst *IRBuilderBPF::CreateGetCurrentCgroupId(const location &loc)
                           getcgroupid_func_type,
                           {},
                           "get_cgroup_id",
-                          &loc);
+                          loc);
 }
 
 CallInst *IRBuilderBPF::CreateGetUidGid(const location &loc)
@@ -1979,7 +1979,7 @@ CallInst *IRBuilderBPF::CreateGetUidGid(const location &loc)
                           getuidgid_func_type,
                           {},
                           "get_uid_gid",
-                          &loc);
+                          loc);
 }
 
 CallInst *IRBuilderBPF::CreateGetNumaId(const location &loc)
@@ -1991,7 +1991,7 @@ CallInst *IRBuilderBPF::CreateGetNumaId(const location &loc)
                           numaid_func_type,
                           {},
                           "get_numa_id",
-                          &loc);
+                          loc);
 }
 
 CallInst *IRBuilderBPF::CreateGetCpuId(const location &loc)
@@ -2003,7 +2003,7 @@ CallInst *IRBuilderBPF::CreateGetCpuId(const location &loc)
                           getcpuid_func_type,
                           {},
                           "get_cpu_id",
-                          &loc);
+                          loc);
 }
 
 CallInst *IRBuilderBPF::CreateGetCurrentTask(const location &loc)
@@ -2015,7 +2015,7 @@ CallInst *IRBuilderBPF::CreateGetCurrentTask(const location &loc)
                           getcurtask_func_type,
                           {},
                           "get_cur_task",
-                          &loc);
+                          loc);
 }
 
 CallInst *IRBuilderBPF::CreateGetRandom(const location &loc)
@@ -2027,7 +2027,7 @@ CallInst *IRBuilderBPF::CreateGetRandom(const location &loc)
                           getrandom_func_type,
                           {},
                           "get_random",
-                          &loc);
+                          loc);
 }
 
 CallInst *IRBuilderBPF::CreateGetStack(Value *ctx,
@@ -2055,7 +2055,7 @@ CallInst *IRBuilderBPF::CreateGetStack(Value *ctx,
                                     getstack_func_type,
                                     { ctx, buf, stack_size, flags_val },
                                     "get_stack",
-                                    &loc);
+                                    loc);
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_get_stack, loc);
   return call;
 }
@@ -2074,7 +2074,7 @@ CallInst *IRBuilderBPF::CreateGetFuncIp(Value *ctx, const location &loc)
                           getfuncip_func_type,
                           { ctx },
                           "get_func_ip",
-                          &loc);
+                          loc);
 }
 
 CallInst *IRBuilderBPF::CreatePerCpuPtr(Value *var,
@@ -2091,7 +2091,7 @@ CallInst *IRBuilderBPF::CreatePerCpuPtr(Value *var,
                           percpuptr_func_type,
                           { var, cpu },
                           "per_cpu_ptr",
-                          &loc);
+                          loc);
 }
 
 CallInst *IRBuilderBPF::CreateThisCpuPtr(Value *var, const location &loc)
@@ -2107,7 +2107,7 @@ CallInst *IRBuilderBPF::CreateThisCpuPtr(Value *var, const location &loc)
                           percpuptr_func_type,
                           { var },
                           "this_cpu_ptr",
-                          &loc);
+                          loc);
 }
 
 void IRBuilderBPF::CreateGetCurrentComm(Value *ctx,
@@ -2127,14 +2127,14 @@ void IRBuilderBPF::CreateGetCurrentComm(Value *ctx,
                                     getcomm_func_type,
                                     { buf, getInt64(size) },
                                     "get_comm",
-                                    &loc);
+                                    loc);
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_get_current_comm, loc);
 }
 
 void IRBuilderBPF::CreateOutput(Value *ctx,
                                 Value *data,
                                 size_t size,
-                                const location *loc)
+                                const location &loc)
 {
   assert(ctx && ctx->getType() == getPtrTy());
   assert(data && data->getType()->isPointerTy());
@@ -2148,7 +2148,7 @@ void IRBuilderBPF::CreateOutput(Value *ctx,
 
 void IRBuilderBPF::CreateRingbufOutput(Value *data,
                                        size_t size,
-                                       const location *loc)
+                                       const location &loc)
 {
   Value *map_ptr = GetMapVar(to_string(MapType::Ringbuf));
 
@@ -2282,7 +2282,7 @@ void IRBuilderBPF::CreateMapElemAdd(Value *ctx,
 void IRBuilderBPF::CreatePerfEventOutput(Value *ctx,
                                          Value *data,
                                          size_t size,
-                                         const location *loc)
+                                         const location &loc)
 {
   Value *map_ptr = GetMapVar(to_string(MapType::PerfEvent));
 
@@ -2340,7 +2340,7 @@ void IRBuilderBPF::CreateTracePrintk(Value *fmt_ptr,
                    traceprintk_func_type,
                    args,
                    "trace_printk",
-                   &loc);
+                   loc);
 }
 
 void IRBuilderBPF::CreateSignal(Value *ctx, Value *sig, const location &loc)
@@ -2563,7 +2563,7 @@ void IRBuilderBPF::CreateHelperError(Value *ctx,
 
   auto &layout = module_.getDataLayout();
   auto struct_size = layout.getTypeAllocSize(helper_error_struct);
-  CreateOutput(ctx, buf, struct_size, &loc);
+  CreateOutput(ctx, buf, struct_size, loc);
   CreateLifetimeEnd(buf);
 }
 
@@ -2617,7 +2617,7 @@ void IRBuilderBPF::CreatePath(Value *ctx,
                                     d_path_func_type,
                                     { path, buf, sz },
                                     "d_path",
-                                    &loc);
+                                    loc);
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_d_path, loc);
 }
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -174,7 +174,7 @@ public:
                              FunctionType *helper_type,
                              ArrayRef<Value *> args,
                              const Twine &Name,
-                             const location *loc = nullptr);
+                             const location &loc);
   CallInst *createCall(FunctionType *callee_type,
                        Value *callee,
                        ArrayRef<Value *> args,
@@ -183,10 +183,7 @@ public:
                             AllocaInst *buf,
                             size_t size,
                             const location &loc);
-  void CreateOutput(Value *ctx,
-                    Value *data,
-                    size_t size,
-                    const location *loc = nullptr);
+  void CreateOutput(Value *ctx, Value *data, size_t size, const location &loc);
   void CreateAtomicIncCounter(const std::string &map_name, uint32_t idx);
   void CreateMapElemInit(Value *ctx,
                          Map &map,
@@ -337,13 +334,11 @@ private:
 
   llvm::Type *getKernelPointerStorageTy();
   llvm::Type *getUserPointerStorageTy();
-  void CreateRingbufOutput(Value *data,
-                           size_t size,
-                           const location *loc = nullptr);
+  void CreateRingbufOutput(Value *data, size_t size, const location &loc);
   void CreatePerfEventOutput(Value *ctx,
                              Value *data,
                              size_t size,
-                             const location *loc = nullptr);
+                             const location &loc);
 
   void createPerCpuSum(AllocaInst *ret, CallInst *call, const SizedType &type);
   void createPerCpuMinMax(AllocaInst *ret,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -969,7 +969,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     b_.CreateOutput(ctx_,
                     perfdata,
                     8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_,
-                    &call.loc);
+                    call.loc);
 
     b_.CreateBr(failure_callback);
 
@@ -1186,7 +1186,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
         code,
         b_.CreateGEP(exit_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
 
-    b_.CreateOutput(ctx_, buf, struct_size, &call.loc);
+    b_.CreateOutput(ctx_, buf, struct_size, call.loc);
     b_.CreateLifetimeEnd(buf);
 
     createRet();
@@ -1267,7 +1267,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                                    { b_.getInt64(0), b_.getInt32(1) });
     b_.CreateStore(b_.GetIntSameSize(id, elements.at(1)), ident_ptr);
 
-    b_.CreateOutput(ctx_, buf, getStructSize(event_struct), &call.loc);
+    b_.CreateOutput(ctx_, buf, getStructSize(event_struct), call.loc);
     return ScopedExpr(buf, [this, buf] { b_.CreateLifetimeEnd(buf); });
   } else if (call.func == "len") {
     if (call.vargs.at(0)->type.IsStack()) {
@@ -1324,7 +1324,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
         b_.GetIntSameSize(async_ids_.time(), elements.at(1)),
         b_.CreateGEP(time_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
 
-    b_.CreateOutput(ctx_, buf, getStructSize(time_struct), &call.loc);
+    b_.CreateOutput(ctx_, buf, getStructSize(time_struct), call.loc);
     return ScopedExpr(buf, [this, buf] { b_.CreateLifetimeEnd(buf); });
   } else if (call.func == "strftime") {
     auto elements = AsyncEvent::Strftime().asLLVMType(b_);
@@ -1441,7 +1441,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                          b_.getInt64Ty(),
                          false /* unsigned */),
         b_.CreateGEP(unwatch_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
-    b_.CreateOutput(ctx_, buf, struct_size, &call.loc);
+    b_.CreateOutput(ctx_, buf, struct_size, call.loc);
     return ScopedExpr(buf, [this, buf] { b_.CreateLifetimeEnd(buf); });
   } else if (call.func == "bswap") {
     bpftrace::ast::Expression *arg = call.vargs.at(0);
@@ -2757,7 +2757,7 @@ void CodegenLLVM::generateProbe(Probe &probe,
   if ((pt == ProbeType::watchpoint || pt == ProbeType::asyncwatchpoint) &&
       current_attach_point_->func.size())
     generateWatchpointSetupProbe(
-        func_type, name, current_attach_point_->address, index);
+        func_type, name, current_attach_point_->address, index, probe.loc);
 }
 
 void CodegenLLVM::add_probe(AttachPoint &ap,
@@ -3558,7 +3558,7 @@ void CodegenLLVM::createFormatStringCall(Call &call,
       b_.CreateStore(scoped_arg.value(), offset);
   }
 
-  b_.CreateOutput(ctx_, fmt_args, struct_size, &call.loc);
+  b_.CreateOutput(ctx_, fmt_args, struct_size, call.loc);
   if (dyn_cast<AllocaInst>(fmt_args))
     b_.CreateLifetimeEnd(fmt_args);
 }
@@ -3567,7 +3567,8 @@ void CodegenLLVM::generateWatchpointSetupProbe(
     FunctionType *func_type,
     const std::string &expanded_probe_name,
     int arg_num,
-    int index)
+    int index,
+    const location &loc)
 {
   auto func_name = get_function_name_for_watchpoint_setup(expanded_probe_name,
                                                           index);
@@ -3608,7 +3609,7 @@ void CodegenLLVM::generateWatchpointSetupProbe(
   b_.CreateStore(
       addr,
       b_.CreateGEP(watchpoint_struct, buf, { b_.getInt64(0), b_.getInt32(2) }));
-  b_.CreateOutput(ctx, buf, struct_size);
+  b_.CreateOutput(ctx, buf, struct_size, loc);
   b_.CreateLifetimeEnd(buf);
 
   createRet();
@@ -3660,7 +3661,7 @@ void CodegenLLVM::createPrintMapCall(Call &call)
                                 { b_.getInt64(0), b_.getInt32(arg_idx + 1) }));
   }
 
-  b_.CreateOutput(ctx_, buf, getStructSize(print_struct), &call.loc);
+  b_.CreateOutput(ctx_, buf, getStructSize(print_struct), call.loc);
   b_.CreateLifetimeEnd(buf);
 }
 
@@ -3706,7 +3707,7 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int id)
     b_.CreateStore(value, content_offset);
   }
 
-  b_.CreateOutput(ctx_, buf, struct_size, &call.loc);
+  b_.CreateOutput(ctx_, buf, struct_size, call.loc);
   if (dyn_cast<AllocaInst>(buf))
     b_.CreateLifetimeEnd(buf);
 }

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -268,7 +268,8 @@ private:
   void generateWatchpointSetupProbe(FunctionType *func_type,
                                     const std::string &expanded_probe_name,
                                     int arg_num,
-                                    int index);
+                                    int index,
+                                    const location &loc);
 
   ScopedExpr readDatastructElemFromStack(ScopedExpr &&scoped_src,
                                          Value *index,


### PR DESCRIPTION
Stacked PRs:
 * #3855
 * #3862
 * __->__#3854
 * #3853
 * #3852


--- --- ---

### codegen: Locations for helpers are no longer optional


Since locations are availabale for all nodes via a previous fix, these
locations can be made mandatory during code generation. This ensures
that any error will result in a meaningful location, and paves the way
for a subsequent improvement.

Signed-off-by: Adin Scannell <amscanne@meta.com>
