### PR TITLE
Invert the `Driver`/`ASTContext` relationship

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ast_defs STATIC
   ast.cpp
   context.cpp
+  int_parser.cpp
   location.cpp
 )
 add_dependencies(ast_defs parser)
@@ -11,7 +12,6 @@ add_library(ast STATIC
   codegen_helper.cpp
   diagnostic.cpp
   dibuilderbpf.cpp
-  int_parser.cpp
   irbuilderbpf.cpp
   pass_manager.cpp
   signal.cpp

--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -5,7 +5,11 @@
 
 #include "ast/diagnostic.h"
 
-namespace bpftrace::ast {
+namespace bpftrace {
+
+class Driver;
+
+namespace ast {
 
 class Location;
 class Node;
@@ -60,10 +64,7 @@ public:
     return nodes_.size();
   }
 
-  // Callers should avoid mutating diagnostics through this method. It is
-  // non-const to allow for tests to clear the set, but this should be avoided
-  // except in the context of a test.
-  Diagnostics &diagnostics() const
+  const Diagnostics &diagnostics() const
   {
     return *diagnostics_.get();
   }
@@ -87,6 +88,9 @@ private:
   std::vector<std::unique_ptr<Node>> nodes_;
   std::unique_ptr<Diagnostics> diagnostics_;
   std::shared_ptr<ASTSource> source_;
+
+  friend class bpftrace::Driver;
 };
 
-} // namespace bpftrace::ast
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/diagnostic.cpp
+++ b/src/ast/diagnostic.cpp
@@ -18,15 +18,16 @@ void Diagnostics::emit(std::ostream& out, Severity s) const
 
 void Diagnostics::emit(std::ostream& out, Severity s, const Diagnostic& d) const
 {
+  auto& loc = d.loc();
   switch (s) {
     case Severity::Warning:
-      LOG(WARNING, d.loc(), out) << d.msg();
+      LOG(WARNING, loc.source_location(), loc.source_context(), out) << d.msg();
       if (auto msg = d.hint(); msg.size() > 0) {
         LOG(HINT, out) << msg;
       }
       break;
     case Severity::Error:
-      LOG(ERROR, d.loc(), out) << d.msg();
+      LOG(ERROR, loc.source_location(), loc.source_context(), out) << d.msg();
       if (auto msg = d.hint(); msg.size() > 0) {
         LOG(HINT, out) << msg;
       }

--- a/src/ast/diagnostic.h
+++ b/src/ast/diagnostic.h
@@ -11,6 +11,8 @@
 
 namespace bpftrace::ast {
 
+class ASTSource;
+
 // Diagnostic reflects a single error at a single source location. This is a
 // simple wrapper around a string for that message, and the location class.
 class Diagnostic {
@@ -124,6 +126,8 @@ private:
   // N.B. we store diagnostics as a pointer because the lifetime is returned
   // early above, so they must not be moving at any point.
   std::vector<std::vector<std::unique_ptr<Diagnostic>>> diagnostics_;
+
+  friend class Node;
 };
 
 } // namespace bpftrace::ast

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -446,9 +446,7 @@ CallInst *IRBuilderBPF::CreateHelperCall(libbpf::bpf_func_id func_id,
                                          const Twine &Name,
                                          const Location &loc)
 {
-  if (bpftrace_.helper_use_loc_.find(func_id) ==
-      bpftrace_.helper_use_loc_.end())
-    bpftrace_.helper_use_loc_[func_id] = loc;
+  bpftrace_.helper_use_loc_[func_id].emplace_back(func_id, loc);
   PointerType *helper_ptr_type = PointerType::get(helper_type, 0);
   Constant *helper_func = ConstantExpr::getCast(Instruction::IntToPtr,
                                                 getInt64(func_id),
@@ -2541,9 +2539,8 @@ void IRBuilderBPF::CreateHelperError(Value *ctx,
     return;
 
   int error_id = async_ids_.helper_error();
-  bpftrace_.resources.helper_error_info[error_id] = { .func_id = func_id,
-                                                      .loc = loc };
-
+  bpftrace_.resources.helper_error_info.try_emplace(
+      error_id, HelperErrorInfo(func_id, loc));
   auto elements = AsyncEvent::HelperError().asLLVMType(*this);
   StructType *helper_error_struct = GetStructType("helper_error_t",
                                                   elements,

--- a/src/ast/location.h
+++ b/src/ast/location.h
@@ -8,14 +8,7 @@
 
 #include "location.hh"
 
-namespace bpftrace {
-
-// See below.
-class Log;
-class LogStream;
-class LogSink;
-
-namespace ast {
+namespace bpftrace::ast {
 
 class ASTSource;
 
@@ -89,14 +82,6 @@ private:
   range_t line_range_;
   range_t column_range_;
   std::shared_ptr<ASTSource> source_;
-
-  // Currently, the LogStream and LogSink classes will reach in and use
-  // line_range_ and column_range_ directly, because the `source_` will not be
-  // populated. This will be removed as soon as this member is valid.
-  friend class bpftrace::Log;
-  friend class bpftrace::LogStream;
-  friend class bpftrace::LogSink;
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -55,6 +55,7 @@ extern bool bt_verbose;
 extern bool dry_run;
 
 enum class DebugStage {
+  Parse,
   Ast,
   Codegen,
   CodegenOpt,
@@ -64,6 +65,8 @@ enum class DebugStage {
 };
 
 const std::unordered_map<std::string_view, DebugStage> debug_stages = {
+  // clang-format off
+  { "parse", DebugStage::Parse },
   { "ast", DebugStage::Ast },
   { "codegen", DebugStage::Codegen },
   { "codegen-opt", DebugStage::CodegenOpt },
@@ -72,6 +75,7 @@ const std::unordered_map<std::string_view, DebugStage> debug_stages = {
 #endif
   { "libbpf", DebugStage::Libbpf },
   { "verifier", DebugStage::Verifier },
+  // clang-format on
 };
 
 class WildcardException : public std::exception {
@@ -190,11 +194,12 @@ public:
   StructManager structs;
   FunctionRegistry functions;
   std::map<std::string, std::string> macros_;
-  // Map of enum variant_name to (variant_value, enum_name)
+  // Map of enum variant_name to (variant_value, enum_name).
   std::map<std::string, std::tuple<uint64_t, std::string>> enums_;
-  // Map of enum_name to map of variant_value to variant_name
+  // Map of enum_name to map of variant_value to variant_name.
   std::map<std::string, std::map<uint64_t, std::string>> enum_defs_;
-  std::map<libbpf::bpf_func_id, ast::Location> helper_use_loc_;
+  // For each helper, list of all generated call sites.
+  std::map<libbpf::bpf_func_id, std::vector<HelperErrorInfo>> helper_use_loc_;
   const FuncsModulesMap &get_traceable_funcs() const;
   KConfig kconfig;
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -1,8 +1,4 @@
-#include <iostream>
-
-#include "ast/attachpoint_parser.h"
 #include "driver.h"
-#include "log.h"
 #include "parser.tab.hh"
 
 struct yy_buffer_state;
@@ -15,52 +11,20 @@ extern bpftrace::location loc;
 
 namespace bpftrace {
 
-Driver::Driver(BPFtrace &bpftrace, std::ostream &o)
-    : bpftrace_(bpftrace), out_(o)
+void Driver::parse()
 {
-}
-
-void Driver::source(std::string_view filename, std::string_view script)
-{
-  Log::get().set_source(filename, script);
-}
-
-// Kept for the test suite
-int Driver::parse_str(std::string_view script)
-{
-  source("stdin", script);
-  return parse();
-}
-
-int Driver::parse()
-{
-  // Reset previous state if we parse more than once
-  ctx = {};
-
-  // Reset source location info on every pass
+  // Reset source location info on every pass.
   loc.initialize();
 
   yyscan_t scanner;
   yylex_init(&scanner);
   Parser parser(*this, scanner);
-  if (debug_) {
+  if (debug) {
     parser.set_debug_level(1);
   }
-  yy_scan_string(Log::get().get_source().c_str(), scanner);
+  yy_scan_string(ctx.source_->contents.c_str(), scanner);
   parser.parse();
   yylex_destroy(scanner);
-
-  if (!failed_) {
-    ast::AttachPointParser ap_parser(ctx, bpftrace_, listing_);
-    if (ap_parser.parse() || !ctx.diagnostics().ok()) {
-      ctx.diagnostics().emit(out_);
-      failed_ = true;
-    }
-  }
-
-  if (failed_) {
-    ctx = {};
-  }
 
   // Before proceeding, ensure that the size of the AST isn't past prescribed
   // limits. This functionality goes back to 80642a994, where it was added in
@@ -68,29 +32,21 @@ int Driver::parse()
   // passes and visitor pattern, and this is a final return to the simplest
   // possible form. It is not necessary to walk the full AST in order to
   // determine the number of nodes. This can be done before any passes.
-  auto node_count = ctx.node_count();
-  if (node_count > bpftrace_.max_ast_nodes_) {
-    LOG(ERROR, out_) << "node count (" << node_count << ") exceeds the limit ("
-                     << bpftrace_.max_ast_nodes_ << ")";
-    failed_ = true;
+  if (ctx.diagnostics().ok()) {
+    auto node_count = ctx.node_count();
+    if (node_count > bpftrace.max_ast_nodes_) {
+      ctx.root->addError() << "node count (" << node_count
+                           << ") exceeds the limit (" << bpftrace.max_ast_nodes_
+                           << ")";
+    }
   }
-
-  // Keep track of errors thrown ourselves, since the result of
-  // parser_->parse() doesn't take scanner errors into account,
-  // only parser errors.
-  return failed_;
 }
 
 void Driver::error(const location &l, const std::string &m)
 {
-  LOG(ERROR, l, out_) << m;
-  failed_ = true;
-}
-
-void Driver::error(const std::string &m)
-{
-  LOG(ERROR, out_) << m;
-  failed_ = true;
+  // This path is normally not allowed, however we don't yet have nodes
+  // constructed. Therefore, we add diagnostics directly via the private field.
+  ctx.diagnostics_->addError(ctx.wrap(l)) << m;
 }
 
 } // namespace bpftrace

--- a/src/driver.h
+++ b/src/driver.h
@@ -1,40 +1,29 @@
 #pragma once
 
-#include <string_view>
-
-#include "ast/ast.h"
 #include "ast/context.h"
 #include "bpftrace.h"
 
 using yyscan_t = void *;
 
+#define YY_DECL                                                                \
+  bpftrace::Parser::symbol_type yylex(bpftrace::Driver &driver,                \
+                                      yyscan_t yyscanner)
+
 namespace bpftrace {
+
+class Parser;
 
 class Driver {
 public:
-  explicit Driver(BPFtrace &bpftrace, std::ostream &o = std::cerr);
-
-  int parse();
-  int parse_str(std::string_view script);
-  void source(std::string_view, std::string_view);
-  void error(std::ostream &, const location &, const std::string &);
+  explicit Driver(ast::ASTContext &ctx, BPFtrace &bpftrace, bool debug = false)
+      : ctx(ctx), bpftrace(bpftrace), debug(debug) {};
+  void parse();
   void error(const location &l, const std::string &m);
-  void error(const std::string &m);
-  ast::ASTContext ctx;
 
-  void debug()
-  {
-    debug_ = true;
-  };
-
-  BPFtrace &bpftrace_;
-
-  bool listing_ = false;
-
-private:
-  std::ostream &out_;
-  bool failed_ = false;
-  bool debug_ = false;
+  // These are accessible to the parser and lexer, but are not mutable.
+  ast::ASTContext &ctx;
+  BPFtrace &bpftrace;
+  const bool debug;
 };
 
 } // namespace bpftrace

--- a/src/functions.h
+++ b/src/functions.h
@@ -6,6 +6,7 @@
 #include <utility>
 #include <vector>
 
+#include "ast/ast.h"
 #include "ast/location.h"
 #include "types.h"
 
@@ -102,8 +103,7 @@ public:
   const Function *get(std::string_view ns,
                       std::string_view name,
                       const std::vector<SizedType> &arg_types,
-                      const ast::Location &loc,
-                      std::ostream &out = std::cerr) const;
+                      const ast::Node &node) const;
 
 private:
   struct FqName {

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include "driver.h"
-#include "parser.tab.hh"
-
-#define YY_DECL                                                                \
-  bpftrace::Parser::symbol_type yylex(bpftrace::Driver &driver,                \
-                                      yyscan_t yyscanner)
-YY_DECL;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -9,7 +9,6 @@
 #include "utils.h"
 #include "parser.tab.hh"
 #include "ast/int_parser.h"
-#include "lexer.h"
 
 bpftrace::location loc;
 static std::string struct_type;
@@ -251,9 +250,9 @@ struct|union|enum       {
 
 {ident}                 {
                           static int unput_count = 0;
-                          if (driver.bpftrace_.macros_.count(yytext) != 0)
+                          if (driver.bpftrace.macros_.count(yytext) != 0)
                           {
-                            const char *s = driver.bpftrace_.macros_[yytext].c_str();
+                            const char *s = driver.bpftrace.macros_.find(yytext)->second.c_str();
                             int z;
                             // NOTE(mmarchini) workaround for simple recursive
                             // macros. More complex recursive macros (for

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -4,7 +4,7 @@
 
 namespace bpftrace {
 
-std::string logtype_str(LogType t)
+static std::string logtype_str(LogType t)
 {
   switch (t) {
       // clang-format off
@@ -37,70 +37,15 @@ Log& Log::get()
 }
 
 void Log::take_input(LogType type,
-                     std::optional<ast::Location> loc,
+                     std::optional<std::string>&& source_location,
+                     std::optional<std::vector<std::string>>&& source_context,
                      std::ostream& out,
-                     std::string&& input)
+                     std::string&& msg)
 {
-  if (loc) {
-    if (src_.empty()) {
-      std::cerr << "Log: cannot resolve location before calling set_source()."
-                << std::endl;
-      out << log_format_output(type, std::move(input));
-    } else if (loc->line_range_.first == 0 || loc->line_range_.second == 0) {
-      std::cerr << "Log: invalid location." << std::endl;
-      out << log_format_output(type, std::move(input));
-    } else if (loc->line_range_.first > loc->line_range_.second) {
-      std::cerr << "Log: loc.begin > loc.end: " << loc->line_range_.first << ":"
-                << loc->line_range_.second << std::endl;
-      out << log_format_output(type, std::move(input));
-    } else {
-      log_with_location(type, *loc, out, input);
-    }
-  } else {
-    out << log_format_output(type, std::move(input));
+  if (!msg.empty() && msg.back() == '\n') {
+    msg.pop_back();
   }
-}
 
-std::string Log::log_format_output(LogType type, std::string&& input)
-{
-  if (!is_colorize_) {
-    return logtype_str(type) + std::move(input) + '\n';
-  }
-  std::string color;
-  switch (type) {
-    case LogType::ERROR:
-      color = LogColor::RED;
-      break;
-    case LogType::WARNING:
-      color = LogColor::YELLOW;
-      break;
-    default:
-      return logtype_str(type) + std::move(input) + '\n';
-  }
-  return color + logtype_str(type) + std::move(input) + LogColor::RESET + '\n';
-}
-
-const std::string Log::get_source_line(unsigned int n)
-{
-  // Get the Nth source line (N is 0-based). Return an empty string if it
-  // doesn't exist
-  std::string line;
-  std::stringstream ss(src_);
-  for (unsigned int idx = 0; idx <= n; idx++) {
-    std::getline(ss, line);
-    if (ss.eof() && idx == n)
-      return line;
-    if (!ss)
-      return "";
-  }
-  return line;
-}
-
-void Log::log_with_location(LogType type,
-                            ast::Location l,
-                            std::ostream& out,
-                            const std::string& m)
-{
   const char* color_begin = LogColor::DEFAULT;
   const char* color_end = LogColor::DEFAULT;
   if (is_colorize_) {
@@ -118,121 +63,87 @@ void Log::log_with_location(LogType type,
     }
   }
   out << color_begin;
-  if (filename_.size()) {
-    out << filename_ << ":";
+  if (source_location) {
+    out << *source_location << ": ";
   }
-
-  std::string msg(m);
   const std::string& typestr = logtype_str(type);
+  out << typestr << msg << color_end << std::endl;
 
-  if (!msg.empty() && msg.back() == '\n') {
-    msg.pop_back();
-  }
-
-  // For a multi line error only the line range is printed:
-  //     <filename>:<start_line>-<end_line>: ERROR: <message>
-  if (l.line_range_.first < l.line_range_.second) {
-    out << l.line_range_.first << "-" << l.line_range_.second << ": " << typestr
-        << msg << std::endl
-        << color_end;
-    return;
-  }
-
-  // For a single line error the format is:
-  //
-  // <filename>:<line>:<start_col>-<end_col>: ERROR: <message>
-  // <source line>
-  // <marker>
-  //
-  // E.g.
-  //
-  // file.bt:1:10-20: error: <message>
-  // i:s:1   /1 < "str"/
-  //         ~~~~~~~~~~
-  out << l.line_range_.first << ":" << l.column_range_.first << "-"
-      << l.column_range_.second;
-  out << ": " << typestr << msg << std::endl << color_end;
-
-  // for bpftrace::position, valid line# starts from 1
-  std::string srcline = get_source_line(l.line_range_.first - 1);
-
-  if (srcline == "") {
-    return;
-  }
-
-  // To get consistent printing all tabs will be replaced with 4 spaces
-  for (auto c : srcline) {
-    if (c == '\t')
-      out << "    ";
-    else
-      out << c;
-  }
-  out << std::endl;
-
-  for (unsigned int x = 0;
-       x < srcline.size() &&
-       x < (static_cast<unsigned int>(l.column_range_.second) - 1);
-       x++) {
-    char marker = (x < (static_cast<unsigned int>(l.column_range_.first) - 1))
-                      ? ' '
-                      : '~';
-    if (srcline[x] == '\t') {
-      out << std::string(4, marker);
-    } else {
-      out << marker;
+  if (source_context) {
+    for (const auto& s : *source_context) {
+      out << s << std::endl;
     }
   }
-  out << std::endl;
 }
 
 LogStream::LogStream(std::string file,
                      int line,
                      LogType type,
                      std::ostream& out)
-    : sink_(Log::get()),
-      type_(type),
-      loc_(std::nullopt),
-      out_(out),
-      log_file_(std::move(file)),
-      log_line_(line)
+    : file_(file), line_(line), type_(type), out_(out)
 {
 }
 
 LogStream::LogStream(std::string file,
                      int line,
                      LogType type,
-                     ast::Location loc,
+                     std::string&& source_location,
                      std::ostream& out)
-    : sink_(Log::get()),
+    : file_(file),
+      line_(line),
       type_(type),
-      loc_(std::ref(loc)),
-      out_(out),
-      log_file_(std::move(file)),
-      log_line_(line)
+      source_location_(std::move(source_location)),
+      out_(out)
+{
+}
+
+LogStream::LogStream(const std::string& file,
+                     int line,
+                     LogType type,
+                     std::string&& source_location,
+                     std::vector<std::string>&& source_context,
+                     std::ostream& out)
+    : file_(file),
+      line_(line),
+      type_(type),
+      source_location_(std::move(source_location)),
+      source_context_(std::move(source_context)),
+      out_(out)
 {
 }
 
 LogStream::~LogStream()
 {
-  if (sink_.is_enabled(type_)) {
+  auto& sink = Log::get();
+  if (sink.is_enabled(type_)) {
     auto msg = buf_.str();
     if (type_ == LogType::DEBUG)
       msg = internal_location() + msg;
-
-    sink_.take_input(type_, loc_, out_, std::move(msg));
+    // Pass ownership of all the things to the sink itself, which will evaluate
+    // what's available and what's not.
+    sink.take_input(type_,
+                    std::move(source_location_),
+                    std::move(source_context_),
+                    out_,
+                    std::move(msg));
   }
 }
 
 std::string LogStream::internal_location()
 {
   std::ostringstream ss;
-  ss << "[" << log_file_ << ":" << log_line_ << "] ";
+  ss << "[" << file_ << ":" << line_ << "] ";
   return ss.str();
 }
 
 [[noreturn]] LogStreamBug::~LogStreamBug()
 {
-  sink_.take_input(type_, loc_, out_, internal_location() + buf_.str());
+  auto& sink = Log::get();
+  sink.take_input(type_,
+                  std::nullopt,
+                  std::nullopt,
+                  out_,
+                  internal_location() + buf_.str());
   abort();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,7 @@
 #include <unistd.h>
 
 #include "aot/aot.h"
+#include "ast/attachpoint_parser.h"
 #include "ast/diagnostic.h"
 #include "ast/pass_manager.h"
 #include "ast/passes/codegen_llvm.h"
@@ -349,43 +350,42 @@ static void parse_env(BPFtrace& bpftrace)
   });
 }
 
-[[nodiscard]] std::optional<ast::ASTContext> parse(
-    BPFtrace& bpftrace,
-    const std::string& name,
-    const std::string& program,
-    const std::vector<std::string>& include_dirs,
-    const std::vector<std::string>& include_files)
+void parse(ast::ASTContext& ast,
+           BPFtrace& bpftrace,
+           const std::vector<std::string>& include_dirs,
+           const std::vector<std::string>& include_files)
 {
-  Driver driver(bpftrace);
-  driver.source(name, program);
-  int err;
+  Driver driver(ast,
+                bpftrace,
+                bt_debug.find(DebugStage::Parse) != bt_debug.end());
 
-  err = driver.parse();
-  if (err)
-    return std::nullopt;
+  driver.parse();
+  if (!ast.diagnostics().ok())
+    return;
 
-  bpftrace.parse_btf(bpftrace.list_modules(driver.ctx));
+  ast::AttachPointParser ap_parser(ast, bpftrace, false);
+  ap_parser.parse();
+  if (!ast.diagnostics().ok())
+    return;
+
+  bpftrace.parse_btf(bpftrace.list_modules(ast));
 
   ast::FieldAnalyser fields(bpftrace);
-  fields.visit(driver.ctx.root);
-  if (!driver.ctx.diagnostics().ok()) {
-    driver.ctx.diagnostics().emit(std::cerr);
-    return std::nullopt;
-  }
+  fields.visit(ast.root);
+  if (!ast.diagnostics().ok())
+    return;
 
-  if (TracepointFormatParser::parse(driver.ctx, bpftrace) == false) {
-    driver.ctx.diagnostics().emit(std::cerr);
-    return std::nullopt;
-  }
+  if (TracepointFormatParser::parse(ast, bpftrace) == false)
+    return;
 
   // NOTE(mmarchini): if there are no C definitions, clang parser won't run to
   // avoid issues in some versions. Since we're including files in the command
   // line, we want to force parsing, so we make sure C definitions are not
   // empty before going to clang parser stage.
-  if (!include_files.empty() && driver.ctx.root->c_definitions.empty())
-    driver.ctx.root->c_definitions = "#define __BPFTRACE_DUMMY__";
+  if (!include_files.empty() && ast.root->c_definitions.empty())
+    ast.root->c_definitions = "#define __BPFTRACE_DUMMY__";
 
-  bool should_clang_parse = !(driver.ctx.root->c_definitions.empty() &&
+  bool should_clang_parse = !(ast.root->c_definitions.empty() &&
                               bpftrace.btf_set_.empty());
 
   if (should_clang_parse) {
@@ -409,7 +409,7 @@ static void parse_env(BPFtrace& bpftrace)
       extra_flags.push_back(file);
     }
 
-    if (!clang.parse(driver.ctx.root, bpftrace, extra_flags)) {
+    if (!clang.parse(ast.root, bpftrace, extra_flags)) {
       if (!found_kernel_headers) {
         LOG(WARNING)
             << "Could not find kernel headers in " << ksrc << " / " << kobj
@@ -421,15 +421,15 @@ static void parse_env(BPFtrace& bpftrace)
             << "snippet:\nmodprobe kheaders && tar -C <directory> -xf "
             << "/sys/kernel/kheaders.tar.xz";
       }
-      return {};
+      return;
     }
   }
 
-  err = driver.parse();
-  if (err)
-    return {};
+  driver.parse();
+  if (!ast.diagnostics().ok())
+    return;
 
-  return std::move(driver.ctx);
+  ap_parser.parse();
 }
 
 void CreateDynamicPasses(ast::PassManager& pm)
@@ -775,6 +775,17 @@ bool is_colorize()
   }
 }
 
+static ast::ASTContext buildListProgram(const std::string& search)
+{
+  ast::ASTContext ast("listing", search);
+  auto ap = ast.make_node<ast::AttachPoint>(search, true, location());
+  auto probe = ast.make_node<ast::Probe>(
+      ast::AttachPointList({ ap }), nullptr, nullptr, location());
+  ast.root = ast.make_node<ast::Program>(
+      "", nullptr, ast::SubprogList(), ast::ProbeList({ probe }), location());
+  return ast;
+}
+
 int main(int argc, char* argv[])
 {
   Log::get().set_colorize(is_colorize());
@@ -853,7 +864,12 @@ int main(int argc, char* argv[])
     }
   }
 
-  // Listing probes when there is no program
+  // This is our primary program AST context. Initially it is empty, i.e. there
+  // is no filename set or source file. The way we set it up depends on the
+  // mode of execution below, and we expect that it will be reinitialized.
+  ast::ASTContext ast;
+
+  // Listing probes when there is no program.
   if (args.listing && args.script.empty() && args.filename.empty()) {
     check_is_root();
 
@@ -872,29 +888,27 @@ int main(int argc, char* argv[])
           << args.search << "\' as a search pattern.";
     }
 
-    Driver driver(bpftrace);
-    driver.listing_ = true;
-    driver.source("stdin", args.search);
+    // To list tracepoints, we construct a synthetic AST and then expand the
+    // probe. The raw contents of the program are the initial search provided.
+    ast = buildListProgram(args.search);
 
-    int err = driver.parse();
-    if (err)
-      return err;
+    // Parse and expand all the attachpoints. We don't need to descend into the
+    // actual driver here, since we know that the program is already formed.
+    ast::AttachPointParser ap_parser(ast, bpftrace, true);
+    ap_parser.parse();
 
-    bpftrace.parse_btf(bpftrace.list_modules(driver.ctx));
+    bpftrace.parse_btf(bpftrace.list_modules(ast));
 
-    ast::SemanticAnalyser semantics(driver.ctx, bpftrace, false, true);
-    err = semantics.analyse();
-    if (!driver.ctx.diagnostics().ok()) {
-      driver.ctx.diagnostics().emit(std::cerr);
+    ast::SemanticAnalyser semantics(ast, bpftrace, false, true);
+    semantics.analyse();
+    if (!ast.diagnostics().ok()) {
+      ast.diagnostics().emit(std::cerr);
       return 1;
     }
 
-    bpftrace.probe_matcher_->list_probes(driver.ctx.root);
+    bpftrace.probe_matcher_->list_probes(ast.root);
     return 0;
   }
-
-  std::string filename;
-  std::string program;
 
   if (!args.filename.empty()) {
     std::stringstream buf;
@@ -908,8 +922,7 @@ int main(int argc, char* argv[])
         buf << line << std::endl;
       }
 
-      filename = "stdin";
-      program = buf.str();
+      ast = ast::ASTContext("stdin", buf.str());
     } else {
       std::ifstream file(args.filename);
       if (file.fail()) {
@@ -918,15 +931,12 @@ int main(int argc, char* argv[])
         exit(1);
       }
 
-      filename = args.filename;
-      program = buf.str();
       buf << file.rdbuf();
-      program = buf.str();
+      ast = ast::ASTContext(args.filename, buf.str());
     }
   } else {
-    // Script is provided as a command line argument
-    filename = "stdin";
-    program = args.script;
+    // Script is provided as a command line argument.
+    ast = ast::ASTContext("stdin", args.script);
   }
 
   for (const auto& param : args.params) {
@@ -948,17 +958,18 @@ int main(int argc, char* argv[])
     enforce_infinite_rlimit();
   }
 
-  auto ast_ctx = parse(
-      bpftrace, filename, program, args.include_dirs, args.include_files);
-  if (!ast_ctx)
+  parse(ast, bpftrace, args.include_dirs, args.include_files);
+  if (!ast.diagnostics().ok()) {
+    ast.diagnostics().emit(std::cerr);
     return 1;
+  }
 
   if (args.listing) {
-    bpftrace.probe_matcher_->list_probes(ast_ctx->root);
+    bpftrace.probe_matcher_->list_probes(ast.root);
     return 0;
   }
 
-  ast::PassContext ctx(bpftrace, *ast_ctx);
+  ast::PassContext ctx(bpftrace, ast);
   ast::PassManager pm;
   switch (args.build_mode) {
     case BuildMode::DYNAMIC:
@@ -976,13 +987,13 @@ int main(int argc, char* argv[])
       break;
   }
 
-  bpftrace.fentry_recursion_check(ast_ctx->root);
+  bpftrace.fentry_recursion_check(ast.root);
 
   auto pmresult = pm.Run(ctx);
   if (pmresult)
     return 1;
 
-  ast::CodegenLLVM llvm(ctx.ast_ctx, bpftrace);
+  ast::CodegenLLVM llvm(ast, bpftrace);
   BpfBytecode bytecode;
   try {
     llvm.generate_ir();

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -833,14 +833,15 @@ void TextOutput::attached_probes(uint64_t num_probes) const
     out_ << "Attaching " << num_probes << " probes..." << std::endl;
 }
 
-void TextOutput::helper_error(int func_id,
-                              int retcode,
-                              const ast::Location &loc) const
+void TextOutput::helper_error(int retcode, const HelperErrorInfo &info) const
 {
-  LOG(WARNING, loc, out_) << get_helper_error_msg(func_id, retcode)
-                          << "\nAdditional Info - helper: "
-                          << libbpf::bpf_func_name[func_id]
-                          << ", retcode: " << retcode;
+  LOG(WARNING,
+      std::string(info.source_location),
+      std::vector(info.source_context),
+      out_)
+      << get_helper_error_msg(info.func_id, retcode)
+      << "\nAdditional Info - helper: " << libbpf::bpf_func_name[info.func_id]
+      << ", retcode: " << retcode;
 }
 
 std::string TextOutput::field_to_str(const std::string &name,
@@ -1132,15 +1133,13 @@ void JsonOutput::attached_probes(uint64_t num_probes) const
   message(MessageType::attached_probes, "probes", num_probes);
 }
 
-void JsonOutput::helper_error(int func_id,
-                              int retcode,
-                              const ast::Location &loc) const
+void JsonOutput::helper_error(int retcode, const HelperErrorInfo &info) const
 {
   out_ << R"({"type": "helper_error", "msg": ")"
-       << get_helper_error_msg(func_id, retcode) << R"(", "helper": ")"
-       << libbpf::bpf_func_name[func_id] << R"(", "retcode": )" << retcode
-       << ", \"line\": " << loc.line() << ", \"col\": " << loc.column() << "}"
-       << std::endl;
+       << get_helper_error_msg(info.func_id, retcode) << R"(", "helper": ")"
+       << libbpf::bpf_func_name[info.func_id] << R"(", "retcode": )" << retcode
+       << R"(, "filename": ")" << info.filename << R"(", "line": )" << info.line
+       << R"(, "col": )" << info.column << "}" << std::endl;
 }
 
 std::string JsonOutput::field_to_str(const std::string &name,

--- a/src/output.h
+++ b/src/output.h
@@ -6,6 +6,7 @@
 
 #include "ast/location.h"
 #include "bpfmap.h"
+#include "required_resources.h"
 #include "types.h"
 
 namespace bpftrace {
@@ -89,9 +90,7 @@ public:
                        bool nl = true) const = 0;
   virtual void lost_events(uint64_t lost) const = 0;
   virtual void attached_probes(uint64_t num_probes) const = 0;
-  virtual void helper_error(int func_id,
-                            int retcode,
-                            const ast::Location &loc) const = 0;
+  virtual void helper_error(int retcode, const HelperErrorInfo &info) const = 0;
 
 protected:
   std::ostream &out_;
@@ -234,9 +233,7 @@ public:
                bool nl = true) const override;
   void lost_events(uint64_t lost) const override;
   void attached_probes(uint64_t num_probes) const override;
-  void helper_error(int func_id,
-                    int retcode,
-                    const ast::Location &loc) const override;
+  void helper_error(int retcode, const HelperErrorInfo &info) const override;
 
 protected:
   std::string value_to_str(BPFtrace &bpftrace,
@@ -312,9 +309,7 @@ public:
                uint64_t value) const;
   void lost_events(uint64_t lost) const override;
   void attached_probes(uint64_t num_probes) const override;
-  void helper_error(int func_id,
-                    int retcode,
-                    const ast::Location &loc) const override;
+  void helper_error(int retcode, const HelperErrorInfo &info) const override;
 
 private:
   std::string json_escape(const std::string &str) const;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -10,7 +10,7 @@
 %define define_location_comparison
 %define parse.assert
 %define parse.trace
-%expect 5
+%expect 4
 
 %define parse.error verbose
 
@@ -39,7 +39,9 @@ class Node;
 #include <iostream>
 
 #include "driver.h"
-#include "lexer.h"
+#include "parser.tab.hh"
+
+YY_DECL;
 
 void yyerror(bpftrace::Driver &driver, const char *s);
 %}
@@ -321,23 +323,7 @@ probes_and_subprogs:
 probe:
                 attach_points pred block
                 {
-                  if (!driver.listing_)
-                    $$ = driver.ctx.make_node<ast::Probe>(std::move($1), $2, driver.ctx.make_node<ast::Block>(std::move($3), @3), @$);
-                  else
-                  {
-                    error(@$, "unexpected listing query format");
-                    YYERROR;
-                  }
-                }
-        |       attach_points END
-                {
-                  if (driver.listing_)
-                    $$ = driver.ctx.make_node<ast::Probe>(std::move($1), nullptr, driver.ctx.make_node<ast::Block>(ast::StatementList(), @$), @$);
-                  else
-                  {
-                    error(@$, "unexpected end of file, expected {");
-                    YYERROR;
-                  }
+                  $$ = driver.ctx.make_node<ast::Probe>(std::move($1), $2, driver.ctx.make_node<ast::Block>(std::move($3), @3), @$);
                 }
                 ;
 

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -1,9 +1,11 @@
 #include "ast/ast.h"
+#include "ast/context.h"
 
 #include "gtest/gtest.h"
 
 namespace bpftrace::test::ast {
 
+using bpftrace::ast::ASTContext;
 using bpftrace::ast::AttachPoint;
 using bpftrace::ast::AttachPointList;
 using bpftrace::ast::Diagnostics;
@@ -11,131 +13,150 @@ using bpftrace::ast::Probe;
 
 TEST(ast, probe_name_special)
 {
-  Diagnostics d;
-  AttachPoint ap1(d, "", false, location());
+  ASTContext ast;
+  auto &ap1 = *ast.make_node<AttachPoint>("", false, location());
   ap1.provider = "BEGIN";
-  Probe begin(d, { &ap1 }, nullptr, {}, location());
+  auto &begin = *ast.make_node<Probe>(
+      AttachPointList({ &ap1 }), nullptr, nullptr, location());
   EXPECT_EQ(begin.name(), "BEGIN");
 
-  AttachPoint ap2(d, "", false, location());
+  auto &ap2 = *ast.make_node<AttachPoint>("", false, location());
   ap2.provider = "END";
-  Probe end(d, { &ap2 }, nullptr, {}, location());
+  auto &end = *ast.make_node<Probe>(
+      AttachPointList({ &ap2 }), nullptr, nullptr, location());
   EXPECT_EQ(end.name(), "END");
 }
 
 TEST(ast, probe_name_kprobe)
 {
-  Diagnostics d;
-  AttachPoint ap1(d, "", false, location());
+  ASTContext ast;
+  auto &ap1 = *ast.make_node<AttachPoint>("", false, location());
   ap1.provider = "kprobe";
   ap1.func = "sys_read";
 
-  AttachPoint ap2(d, "", false, location());
+  auto &ap2 = *ast.make_node<AttachPoint>("", false, location());
   ap2.provider = "kprobe";
   ap2.func = "sys_write";
 
-  AttachPoint ap3(d, "", false, location());
+  auto &ap3 = *ast.make_node<AttachPoint>("", false, location());
   ap3.provider = "kprobe";
   ap3.func = "sys_read";
   ap3.func_offset = 10;
 
-  Probe kprobe1(d, { &ap1 }, nullptr, {}, location());
+  auto &kprobe1 = *ast.make_node<Probe>(
+      AttachPointList({ &ap1 }), nullptr, nullptr, location());
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  Probe kprobe2(d, { &ap1, &ap2 }, nullptr, {}, location());
+  auto &kprobe2 = *ast.make_node<Probe>(
+      AttachPointList({ &ap1, &ap2 }), nullptr, nullptr, location());
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
 
-  Probe kprobe3(d, { &ap1, &ap2, &ap3 }, nullptr, {}, location());
+  auto &kprobe3 = *ast.make_node<Probe>(
+      AttachPointList({ &ap1, &ap2, &ap3 }), nullptr, nullptr, location());
   EXPECT_EQ(kprobe3.name(),
             "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");
 }
 
 TEST(ast, probe_name_uprobe)
 {
-  Diagnostics d;
-  AttachPoint ap1(d, "", false, location());
+  ASTContext ast;
+  auto &ap1 = *ast.make_node<AttachPoint>("", false, location());
   ap1.provider = "uprobe";
   ap1.target = "/bin/sh";
   ap1.func = "readline";
-  Probe uprobe1(d, { &ap1 }, nullptr, {}, location());
+  auto &uprobe1 = *ast.make_node<Probe>(
+      AttachPointList({ &ap1 }), nullptr, nullptr, location());
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
-  AttachPoint ap2(d, "", false, location());
+  auto &ap2 = *ast.make_node<AttachPoint>("", false, location());
   ap2.provider = "uprobe";
   ap2.target = "/bin/sh";
   ap2.func = "somefunc";
-  Probe uprobe2(d, { &ap1, &ap2 }, nullptr, {}, location());
+  auto &uprobe2 = *ast.make_node<Probe>(
+      AttachPointList({ &ap1, &ap2 }), nullptr, nullptr, location());
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
 
-  AttachPoint ap3(d, "", false, location());
+  auto &ap3 = *ast.make_node<AttachPoint>("", false, location());
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.address = 1000;
-  Probe uprobe3(d, { &ap1, &ap2, &ap3 }, nullptr, {}, location());
+  auto &uprobe3 = *ast.make_node<Probe>(
+      AttachPointList({ &ap1, &ap2, &ap3 }), nullptr, nullptr, location());
   EXPECT_EQ(
       uprobe3.name(),
       "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
 
-  AttachPoint ap4(d, "", false, location());
+  auto &ap4 = *ast.make_node<AttachPoint>("", false, location());
   ap4.provider = "uprobe";
   ap4.target = "/bin/sh";
   ap4.func = "somefunc";
   ap4.func_offset = 10;
-  Probe uprobe4(d, { &ap1, &ap2, &ap3, &ap4 }, nullptr, {}, location());
+  auto &uprobe4 = *ast.make_node<Probe>(AttachPointList(
+                                            { &ap1, &ap2, &ap3, &ap4 }),
+                                        nullptr,
+                                        nullptr,
+                                        location());
   EXPECT_EQ(uprobe4.name(),
             "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/"
             "sh:1000,uprobe:/bin/sh:somefunc+10");
 
-  AttachPoint ap5(d, "", false, location());
+  auto &ap5 = *ast.make_node<AttachPoint>("", false, location());
   ap5.provider = "uprobe";
   ap5.target = "/bin/sh";
   ap5.address = 10;
-  Probe uprobe5(d, { &ap5 }, nullptr, {}, location());
+  auto &uprobe5 = *ast.make_node<Probe>(
+      AttachPointList({ &ap5 }), nullptr, nullptr, location());
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
 
-  AttachPoint ap6(d, "", false, location());
+  auto &ap6 = *ast.make_node<AttachPoint>("", false, location());
   ap6.provider = "uretprobe";
   ap6.target = "/bin/sh";
   ap6.address = 10;
-  Probe uprobe6(d, { &ap6 }, nullptr, {}, location());
+  auto &uprobe6 = *ast.make_node<Probe>(
+      AttachPointList({ &ap6 }), nullptr, nullptr, location());
   EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
 }
 
 TEST(ast, probe_name_usdt)
 {
-  Diagnostics d;
-  AttachPoint ap1(d, "", false, location());
+  ASTContext ast;
+  auto &ap1 = *ast.make_node<AttachPoint>("", false, location());
   ap1.provider = "usdt";
   ap1.target = "/bin/sh";
   ap1.func = "probe1";
-  Probe usdt1(d, { &ap1 }, nullptr, {}, location());
+  auto &usdt1 = *ast.make_node<Probe>(
+      AttachPointList({ &ap1 }), nullptr, nullptr, location());
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
-  AttachPoint ap2(d, "", false, location());
+  auto &ap2 = *ast.make_node<AttachPoint>("", false, location());
   ap2.provider = "usdt";
   ap2.target = "/bin/sh";
   ap2.func = "probe2";
-  Probe usdt2(d, { &ap1, &ap2 }, nullptr, {}, location());
+  auto &usdt2 = *ast.make_node<Probe>(
+      AttachPointList({ &ap1, &ap2 }), nullptr, nullptr, location());
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
 }
 
 TEST(ast, attach_point_name)
 {
-  Diagnostics d;
-  AttachPoint ap1(d, "", false, location());
+  ASTContext ast;
+  auto &ap1 = *ast.make_node<AttachPoint>("", false, location());
   ap1.provider = "kprobe";
   ap1.func = "sys_read";
-  AttachPoint ap2(d, "", false, location());
+  auto &ap2 = *ast.make_node<AttachPoint>("", false, location());
   ap2.provider = "kprobe";
   ap2.func = "sys_thisone";
-  AttachPoint ap3(d, "", false, location());
+  auto &ap3 = *ast.make_node<AttachPoint>("", false, location());
   ap3.provider = "uprobe";
   ap3.target = "/bin/sh";
   ap3.func = "readline";
-  Probe kprobe(d, { &ap1, &ap2, &ap3 }, nullptr, {}, location());
+
+  ast.make_node<Probe>(
+      AttachPointList({ &ap1, &ap2, &ap3 }), nullptr, nullptr, location());
   EXPECT_EQ(ap2.name(), "kprobe:sys_thisone");
 
-  Probe uprobe(d, { &ap1, &ap2, &ap3 }, nullptr, {}, location());
+  ast.make_node<Probe>(
+      AttachPointList({ &ap1, &ap2, &ap3 }), nullptr, nullptr, location());
   EXPECT_EQ(ap3.name(), "uprobe:/bin/sh:readline");
 }
 

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -1,4 +1,5 @@
 #include "bpfbytecode.h"
+#include "ast/attachpoint_parser.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/semantic_analyser.h"
 #include "driver.h"
@@ -8,18 +9,28 @@
 
 namespace bpftrace::test::bpfbytecode {
 
-BpfBytecode codegen(std::string_view input)
+BpfBytecode codegen(const std::string &input)
 {
   auto bpftrace = get_mock_bpftrace();
 
-  Driver driver(*bpftrace);
-  EXPECT_EQ(driver.parse_str(input), 0);
+  ast::ASTContext ast("stdin", input);
+  Driver driver(ast, *bpftrace);
 
-  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
+  driver.parse();
+  bool parse_ok = ast.diagnostics().ok();
+  EXPECT_TRUE(parse_ok);
+  if (!parse_ok) {
+    return {};
+  }
+
+  ast::AttachPointParser ap_parser(ast, *bpftrace, false);
+  ap_parser.parse();
+
+  ast::SemanticAnalyser semantics(ast, *bpftrace);
   semantics.analyse();
-  EXPECT_TRUE(driver.ctx.diagnostics().ok());
+  EXPECT_TRUE(ast.diagnostics().ok());
 
-  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
+  ast::CodegenLLVM codegen(ast, *bpftrace);
   return codegen.compile();
 }
 

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -15,26 +15,41 @@ TEST(codegen, call_kstack)
 
 TEST(codegen, call_kstack_mapids)
 {
+  ast::ASTContext ast("stdin", R"(
+kprobe:f {
+  @x = kstack(5);
+  @y = kstack(6);
+  @z = kstack(6)
+})");
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
+  Driver driver(ast, *bpftrace);
 
-  ASSERT_EQ(driver.parse_str(
-                "kprobe:f { @x = kstack(5); @y = kstack(6); @z = kstack(6) }"),
-            0);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::AttachPointParser ap_parser(ast, *bpftrace, false);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ClangParser clang;
-  clang.parse(driver.ctx.root, *bpftrace);
+  clang.parse(ast.root, *bpftrace);
 
-  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::SemanticAnalyser semantics(ast, *bpftrace);
   semantics.analyse();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ast::ResourceAnalyser resource_analyser(*bpftrace);
-  resource_analyser.visit(driver.ctx.root);
+  resource_analyser.visit(ast.root);
   bpftrace->resources = resource_analyser.resources();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
-  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
+  ast::CodegenLLVM codegen(ast, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 8);
@@ -49,27 +64,42 @@ TEST(codegen, call_kstack_mapids)
 
 TEST(codegen, call_kstack_modes_mapids)
 {
+  ast::ASTContext ast("stdin", R"(
+kprobe:f {
+  @w = kstack(raw);
+  @x = kstack(perf);
+  @y = kstack(bpftrace);
+  @z = kstack()
+})");
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
+  Driver driver(ast, *bpftrace);
 
-  ASSERT_EQ(driver.parse_str(
-                "kprobe:f { @w = kstack(raw); @x = kstack(perf); @y = "
-                "kstack(bpftrace); @z = kstack() }"),
-            0);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::AttachPointParser ap_parser(ast, *bpftrace, false);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ClangParser clang;
-  clang.parse(driver.ctx.root, *bpftrace);
+  clang.parse(ast.root, *bpftrace);
 
-  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::SemanticAnalyser semantics(ast, *bpftrace);
   semantics.analyse();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ast::ResourceAnalyser resource_analyser(*bpftrace);
-  resource_analyser.visit(driver.ctx.root);
+  resource_analyser.visit(ast.root);
   bpftrace->resources = resource_analyser.resources();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
-  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
+  ast::CodegenLLVM codegen(ast, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 10);

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -15,26 +15,41 @@ TEST(codegen, call_ustack)
 
 TEST(codegen, call_ustack_mapids)
 {
+  ast::ASTContext ast("stdin", R"(
+kprobe:f {
+  @x = ustack(5);
+  @y = ustack(6);
+  @z = ustack(6)
+})");
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
+  Driver driver(ast, *bpftrace);
 
-  ASSERT_EQ(driver.parse_str(
-                "kprobe:f { @x = ustack(5); @y = ustack(6); @z = ustack(6) }"),
-            0);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::AttachPointParser ap_parser(ast, *bpftrace, false);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ClangParser clang;
-  clang.parse(driver.ctx.root, *bpftrace);
+  clang.parse(ast.root, *bpftrace);
 
-  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::SemanticAnalyser semantics(ast, *bpftrace);
   semantics.analyse();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ast::ResourceAnalyser resource_analyser(*bpftrace);
-  resource_analyser.visit(driver.ctx.root);
+  resource_analyser.visit(ast.root);
   bpftrace->resources = resource_analyser.resources();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
-  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
+  ast::CodegenLLVM codegen(ast, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 8);
@@ -49,27 +64,42 @@ TEST(codegen, call_ustack_mapids)
 
 TEST(codegen, call_ustack_modes_mapids)
 {
+  ast::ASTContext ast("stdin", R"(
+kprobe:f {
+  @w = ustack(raw);
+  @x = ustack(perf);
+  @y = ustack(bpftrace);
+  @z = ustack()
+})");
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
+  Driver driver(ast, *bpftrace);
 
-  ASSERT_EQ(driver.parse_str(
-                "kprobe:f { @w = ustack(raw); @x = ustack(perf); @y = "
-                "ustack(bpftrace); @z = ustack() }"),
-            0);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::AttachPointParser ap_parser(ast, *bpftrace, false);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ClangParser clang;
-  clang.parse(driver.ctx.root, *bpftrace);
+  clang.parse(ast.root, *bpftrace);
 
-  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::SemanticAnalyser semantics(ast, *bpftrace);
   semantics.analyse();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ast::ResourceAnalyser resource_analyser(*bpftrace);
-  resource_analyser.visit(driver.ctx.root);
+  resource_analyser.visit(ast.root);
   bpftrace->resources = resource_analyser.resources();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
-  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
+  ast::CodegenLLVM codegen(ast, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
 
   ASSERT_EQ(bpftrace->bytecode_.maps().size(), 10);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -2,7 +2,9 @@
 
 #include <fstream>
 #include <iostream>
+#include <regex>
 
+#include "ast/attachpoint_parser.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/pid_filter_pass.h"
@@ -44,32 +46,44 @@ static void test(BPFtrace &bpftrace,
                  const std::string &input,
                  const std::string &name)
 {
-  Driver driver(bpftrace);
-  ASSERT_EQ(driver.parse_str(input), 0);
+  ast::ASTContext ast("stdin", input);
+  Driver driver(ast, bpftrace);
+
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::AttachPointParser ap_parser(ast, bpftrace, false);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ast::FieldAnalyser fields(bpftrace);
-  fields.visit(driver.ctx.root);
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  fields.visit(ast.root);
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ClangParser clang;
-  clang.parse(driver.ctx.root, bpftrace);
+  clang.parse(ast.root, bpftrace);
 
-  ASSERT_EQ(driver.parse_str(input), 0);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
-  ast::PidFilterPass pid_filter(driver.ctx, bpftrace);
-  pid_filter.visit(driver.ctx.root);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
-  ast::SemanticAnalyser semantics(driver.ctx, bpftrace);
+  ast::PidFilterPass pid_filter(ast, bpftrace);
+  pid_filter.visit(ast.root);
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::SemanticAnalyser semantics(ast, bpftrace);
   semantics.analyse();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ast::ResourceAnalyser resource_analyser(bpftrace);
-  resource_analyser.visit(driver.ctx.root);
+  resource_analyser.visit(ast.root);
   bpftrace.resources = resource_analyser.resources();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.ctx, bpftrace);
+  ast::CodegenLLVM codegen(ast, bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
   // Test that generated code compiles cleanly

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -1,4 +1,6 @@
 #include "ast/passes/field_analyser.h"
+
+#include "ast/attachpoint_parser.h"
 #include "driver.h"
 #include "dwarf_common.h"
 #include "mocks.h"
@@ -15,12 +17,18 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
   std::stringstream msg;
   msg << "\nInput:\n" << input << "\n\nOutput:\n";
 
-  Driver driver(bpftrace);
-  EXPECT_EQ(driver.parse_str(input), 0);
+  ast::ASTContext ast("stdin", input);
+  Driver driver(ast, bpftrace);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
+
+  ast::AttachPointParser ap_parser(ast, bpftrace, false);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ast::FieldAnalyser fields(bpftrace);
-  fields.visit(driver.ctx.root);
-  ASSERT_EQ(int(!driver.ctx.diagnostics().ok()), expected_result);
+  fields.visit(ast.root);
+  ASSERT_EQ(int(!ast.diagnostics().ok()), expected_result) << msg.str();
 }
 
 void test(const std::string &input, int expected_result = 0)

--- a/tests/function_registry.cpp
+++ b/tests/function_registry.cpp
@@ -1,7 +1,8 @@
 #include <sstream>
 
+#include "ast/ast.h"
+#include "ast/context.h"
 #include "functions.h"
-#include "log.h"
 #include "struct.h"
 #include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
@@ -16,7 +17,6 @@ class TestFunctionRegistryPopulated : public ::testing::Test {
 protected:
   TestFunctionRegistryPopulated()
   {
-    Log::get().set_source("", "");
     unique_no_args_ = reg_.add(
         Function::Origin::Builtin, "unique_no_args", CreateNone(), {});
     unique_int8_ = reg_.add(Function::Origin::Builtin,
@@ -144,10 +144,10 @@ void TestFunctionRegistryPopulated::test(
     const std::vector<SizedType> &arg_types,
     const Function *expected_result)
 {
-  std::stringstream out;
-  EXPECT_EQ(expected_result,
-            reg_.get("", func_name, arg_types, ast::Location(), out));
-  EXPECT_EQ("", out.str());
+  ast::ASTContext ast;
+  auto &call = *ast.make_node<ast::Call>(func_name, ast::Location());
+  EXPECT_EQ(expected_result, reg_.get("", func_name, arg_types, call));
+  EXPECT_TRUE(ast.diagnostics().ok());
 }
 
 void TestFunctionRegistryPopulated::test(
@@ -155,11 +155,15 @@ void TestFunctionRegistryPopulated::test(
     const std::vector<SizedType> &arg_types,
     std::string_view expected_error)
 {
-  std::stringstream out;
-  EXPECT_EQ(nullptr, reg_.get("", func_name, arg_types, ast::Location(), out));
+  ast::ASTContext ast;
+  auto &call = *ast.make_node<ast::Call>(func_name, ast::Location());
+  EXPECT_EQ(nullptr, reg_.get("", func_name, arg_types, call));
+  EXPECT_FALSE(ast.diagnostics().ok());
 
   if (expected_error[0] == '\n')
     expected_error.remove_prefix(1);
+  std::stringstream out;
+  ast.diagnostics().emit(out);
   EXPECT_THAT(out.str(), testing::HasSubstr(expected_error));
 }
 
@@ -334,11 +338,12 @@ TEST_F(TestFunctionRegistryPopulated, overloaded_origin)
 
 TEST(TestFunctionRegistry, add_namespaced)
 {
-  std::stringstream out; // To suppress (expected) errors from unit test output
   FunctionRegistry reg;
   auto *foo = reg.add(Function::Origin::Script, "ns", "foo", CreateNone(), {});
-  EXPECT_EQ(nullptr, reg.get("", "foo", {}, ast::Location(), out));
-  EXPECT_EQ(foo, reg.get("ns", "foo", {}, ast::Location(), out));
+  ast::ASTContext ast;
+  auto &call = *ast.make_node<ast::Call>("foo", ast::Location());
+  EXPECT_EQ(nullptr, reg.get("", "foo", {}, call));
+  EXPECT_EQ(foo, reg.get("ns", "foo", {}, call));
 }
 
 TEST(TestFunctionRegistry, add_duplicate_of_builtin)

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2,6 +2,8 @@
 #include <sstream>
 
 #include "ast/passes/printer.h"
+
+#include "ast/attachpoint_parser.h"
 #include "driver.h"
 #include "gtest/gtest.h"
 
@@ -10,12 +12,17 @@ namespace bpftrace::test::parser {
 using Printer = ast::Printer;
 
 void test_parse_failure(BPFtrace &bpftrace,
-                        std::string_view input,
+                        const std::string &input,
                         std::string_view expected_error)
 {
   std::stringstream out;
-  Driver driver(bpftrace, out);
-  EXPECT_EQ(driver.parse_str(input), 1);
+  ast::ASTContext ast("stdin", input);
+  Driver driver(ast, bpftrace);
+  driver.parse();
+  ast::AttachPointParser ap_parser(ast, bpftrace, false);
+  ap_parser.parse();
+  ASSERT_FALSE(ast.diagnostics().ok());
+  ast.diagnostics().emit(out);
 
   if (expected_error.data()) {
     if (!expected_error.empty() && expected_error[0] == '\n')
@@ -24,27 +31,35 @@ void test_parse_failure(BPFtrace &bpftrace,
   }
 }
 
-void test_parse_failure(std::string_view input, std::string_view expected_error)
+void test_parse_failure(const std::string &input,
+                        std::string_view expected_error)
 {
   BPFtrace bpftrace;
   test_parse_failure(bpftrace, input, expected_error);
 }
 
-void test(BPFtrace &bpftrace, std::string_view input, std::string_view expected)
+void test(BPFtrace &bpftrace,
+          const std::string &input,
+          std::string_view expected)
 {
-  Driver driver(bpftrace);
-  ASSERT_EQ(driver.parse_str(input), 0);
+  ast::ASTContext ast("stdin", input);
+  Driver driver(ast, bpftrace);
+
+  driver.parse();
+  ast::AttachPointParser ap_parser(ast, bpftrace, false);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   if (expected[0] == '\n')
     expected.remove_prefix(1); // Remove initial '\n'
 
   std::ostringstream out;
   Printer printer(out);
-  printer.visit(driver.ctx.root);
+  printer.visit(ast.root);
   EXPECT_EQ(expected, out.str());
 }
 
-void test(std::string_view input, std::string_view expected)
+void test(const std::string &input, std::string_view expected)
 {
   BPFtrace bpftrace;
   test(bpftrace, input, expected);
@@ -2166,8 +2181,11 @@ TEST(Parser, unexpected_symbol)
 {
   BPFtrace bpftrace;
   std::stringstream out;
-  Driver driver(bpftrace, out);
-  EXPECT_EQ(driver.parse_str("i:s:1 { < }"), 1);
+  ast::ASTContext ast("stdin", "i:s:1 { < }");
+  Driver driver(ast, bpftrace);
+  driver.parse();
+  ASSERT_FALSE(ast.diagnostics().ok());
+  ast.diagnostics().emit(out);
   std::string expected =
       R"(stdin:1:9-10: ERROR: syntax error, unexpected <
 i:s:1 { < }
@@ -2180,8 +2198,11 @@ TEST(Parser, string_with_tab)
 {
   BPFtrace bpftrace;
   std::stringstream out;
-  Driver driver(bpftrace, out);
-  EXPECT_EQ(driver.parse_str("i:s:1\t\t\t$a"), 1);
+  ast::ASTContext ast("stdin", "i:s:1\t\t\t$a");
+  Driver driver(ast, bpftrace);
+  driver.parse();
+  ASSERT_FALSE(ast.diagnostics().ok());
+  ast.diagnostics().emit(out);
   std::string expected =
       R"(stdin:1:9-11: ERROR: syntax error, unexpected variable, expecting {
 i:s:1            $a
@@ -2194,8 +2215,11 @@ TEST(Parser, unterminated_string)
 {
   BPFtrace bpftrace;
   std::stringstream out;
-  Driver driver(bpftrace, out);
-  EXPECT_EQ(driver.parse_str("kprobe:f { \"asdf }"), 1);
+  ast::ASTContext ast("stdin", "kprobe:f { \"asdf }");
+  Driver driver(ast, bpftrace);
+  driver.parse();
+  ASSERT_FALSE(ast.diagnostics().ok());
+  ast.diagnostics().emit(out);
   std::string expected =
       R"(stdin:1:12-19: ERROR: unterminated string
 kprobe:f { "asdf }
@@ -2224,7 +2248,7 @@ TEST(Parser, kprobe_offset)
        " kprobe:fn.abc+16\n");
 
   test_parse_failure("k:asdf+123abc", R"(
-stdin:1:1-14: ERROR: unexpected end of file, expected {
+stdin:1:1-14: ERROR: syntax error, unexpected end of file, expecting {
 k:asdf+123abc
 ~~~~~~~~~~~~~
 )");
@@ -2310,9 +2334,11 @@ TEST(Parser, long_param_overflow)
 {
   BPFtrace bpftrace;
   std::stringstream out;
-  Driver driver(bpftrace, out);
-  EXPECT_NO_THROW(
-      driver.parse_str("i:s:100 { @=$111111111111111111111111111 }"));
+  ast::ASTContext ast("stdin", "i:s:100 { @=$111111111111111111111111111 }");
+  Driver driver(ast, bpftrace);
+  EXPECT_NO_THROW(driver.parse());
+  ASSERT_FALSE(ast.diagnostics().ok());
+  ast.diagnostics().emit(out);
   std::string expected = "stdin:1:11-41: ERROR: param "
                          "$111111111111111111111111111 is out of "
                          "integer range [1, " +
@@ -2458,8 +2484,11 @@ TEST(Parser, tuple_assignment_error_message)
 {
   BPFtrace bpftrace;
   std::stringstream out;
-  Driver driver(bpftrace, out);
-  EXPECT_EQ(driver.parse_str("i:s:1 { @x = (1, 2); $x.1 = 1; }"), 1);
+  ast::ASTContext ast("stdin", "i:s:1 { @x = (1, 2); $x.1 = 1; }");
+  Driver driver(ast, bpftrace);
+  driver.parse();
+  ASSERT_FALSE(ast.diagnostics().ok());
+  ast.diagnostics().emit(out);
   std::string expected =
       R"(stdin:1:22-30: ERROR: Tuples are immutable once created. Consider creating a new tuple and assigning it instead.
 i:s:1 { @x = (1, 2); $x.1 = 1; }

--- a/tests/pid_filter_pass.cpp
+++ b/tests/pid_filter_pass.cpp
@@ -1,4 +1,5 @@
 #include "ast/passes/pid_filter_pass.h"
+#include "ast/attachpoint_parser.h"
 #include "ast/passes/printer.h"
 #include "clang_parser.h"
 #include "driver.h"
@@ -10,7 +11,7 @@ namespace bpftrace::test::pid_filter_pass {
 using ::testing::_;
 using ::testing::HasSubstr;
 
-void test(std::string_view input, bool has_pid, bool has_filter)
+void test(const std::string& input, bool has_pid, bool has_filter)
 {
   auto mock_bpftrace = get_mock_bpftrace();
   BPFtrace& bpftrace = *mock_bpftrace;
@@ -18,18 +19,29 @@ void test(std::string_view input, bool has_pid, bool has_filter)
     bpftrace.procmon_ = std::make_unique<MockProcMon>(1);
   }
 
-  Driver driver(bpftrace);
+  ast::ASTContext ast("stdin", input);
+  Driver driver(ast, bpftrace);
   std::stringstream msg;
   msg << "\nInput:\n" << input << "\n\nOutput:\n";
 
-  ASSERT_EQ(driver.parse_str(input), 0);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
+
+  ast::AttachPointParser ap_parser(ast, bpftrace, false);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ClangParser clang;
-  ASSERT_TRUE(clang.parse(driver.ctx.root, bpftrace));
+  ASSERT_TRUE(clang.parse(ast.root, bpftrace));
 
-  ASSERT_EQ(driver.parse_str(input), 0);
-  ast::PidFilterPass pid_filter(driver.ctx, bpftrace);
-  pid_filter.visit(driver.ctx.root);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
+
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::PidFilterPass pid_filter(ast, bpftrace);
+  pid_filter.visit(ast.root);
 
   std::string_view expected_ast = R"(
   if
@@ -42,7 +54,7 @@ void test(std::string_view input, bool has_pid, bool has_filter)
 
   std::ostringstream out;
   ast::Printer printer(out);
-  printer.visit(driver.ctx.root);
+  printer.visit(ast.root);
 
   if (has_filter) {
     EXPECT_THAT(out.str(), HasSubstr(expected_ast));

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -1,4 +1,5 @@
 
+#include "ast/attachpoint_parser.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/resource_analyser.h"
@@ -19,27 +20,33 @@ using bpftrace::ast::Probe;
 void gen_bytecode(const std::string &input, std::stringstream &out)
 {
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
+  ast::ASTContext ast("stdin", input);
+  Driver driver(ast, *bpftrace);
 
-  ASSERT_EQ(driver.parse_str(input), 0);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::AttachPointParser ap_parser(ast, *bpftrace, false);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ast::FieldAnalyser fields(*bpftrace);
-  fields.visit(driver.ctx.root);
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  fields.visit(ast.root);
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ClangParser clang;
-  clang.parse(driver.ctx.root, *bpftrace);
+  clang.parse(ast.root, *bpftrace);
 
-  ast::SemanticAnalyser semantics(driver.ctx, *bpftrace);
+  ast::SemanticAnalyser semantics(ast, *bpftrace);
   semantics.analyse();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ast::ResourceAnalyser resource_analyser(*bpftrace);
-  resource_analyser.visit(driver.ctx.root);
+  resource_analyser.visit(ast.root);
   bpftrace->resources = resource_analyser.resources();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok());
+  ASSERT_TRUE(ast.diagnostics().ok());
 
-  ast::CodegenLLVM codegen(driver.ctx, *bpftrace);
+  ast::CodegenLLVM codegen(ast, *bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
 }

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -1,4 +1,5 @@
 #include "ast/passes/resource_analyser.h"
+#include "ast/attachpoint_parser.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 #include "clang_parser.h"
@@ -15,29 +16,40 @@ void test(BPFtrace &bpftrace,
           bool expected_result = true,
           RequiredResources *out_p = nullptr)
 {
-  Driver driver(bpftrace);
+  ast::ASTContext ast("stdin", input);
+  Driver driver(ast, bpftrace);
   std::stringstream out;
   std::stringstream msg;
   msg << "\nInput:\n" << input << "\n\nOutput:\n";
 
-  ASSERT_EQ(driver.parse_str(input), 0);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
+
+  ast::AttachPointParser ap_parser(ast, bpftrace, false);
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
 
   ast::FieldAnalyser fields(bpftrace);
-  fields.visit(driver.ctx.root);
-  ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
+  fields.visit(ast.root);
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
 
   ClangParser clang;
-  ASSERT_TRUE(clang.parse(driver.ctx.root, bpftrace));
+  ASSERT_TRUE(clang.parse(ast.root, bpftrace));
 
-  ASSERT_EQ(driver.parse_str(input), 0);
-  ast::SemanticAnalyser semantics(driver.ctx, bpftrace, false);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
+
+  ap_parser.parse();
+  ASSERT_TRUE(ast.diagnostics().ok());
+
+  ast::SemanticAnalyser semantics(ast, bpftrace, false);
   semantics.analyse();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
 
   ast::ResourceAnalyser resource_analyser(bpftrace);
-  resource_analyser.visit(driver.ctx.root);
+  resource_analyser.visit(ast.root);
   auto r = resource_analyser.resources();
-  ASSERT_EQ(driver.ctx.diagnostics().ok(), expected_result) << msg.str();
+  ASSERT_EQ(ast.diagnostics().ok(), expected_result) << msg.str();
 
   if (out_p)
     *out_p = std::move(r);

--- a/tests/return_path_analyser.cpp
+++ b/tests/return_path_analyser.cpp
@@ -12,28 +12,32 @@ using ::testing::_;
 
 void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 {
-  Driver driver(bpftrace);
+  ast::ASTContext ast("stdin", input);
+  Driver driver(ast, bpftrace);
   std::stringstream out;
   std::stringstream msg;
   msg << "\nInput:\n" << input << "\n\nOutput:\n";
 
-  ASSERT_EQ(driver.parse_str(input), 0);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
 
   ast::FieldAnalyser fields(bpftrace);
-  fields.visit(driver.ctx.root);
-  ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
+  fields.visit(ast.root);
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
 
   ClangParser clang;
-  ASSERT_TRUE(clang.parse(driver.ctx.root, bpftrace));
+  ASSERT_TRUE(clang.parse(ast.root, bpftrace));
 
-  ASSERT_EQ(driver.parse_str(input), 0);
-  ast::SemanticAnalyser semantics(driver.ctx, bpftrace, false);
+  driver.parse();
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
+
+  ast::SemanticAnalyser semantics(ast, bpftrace, false);
   semantics.analyse();
-  ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
+  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
 
   ast::ReturnPathAnalyser return_path;
-  return_path.visit(driver.ctx.root);
-  ASSERT_EQ(int(!driver.ctx.diagnostics().ok()), expected_result) << msg.str();
+  return_path.visit(ast.root);
+  ASSERT_EQ(int(!ast.diagnostics().ok()), expected_result) << msg.str();
 }
 
 void test(const std::string &input, int expected_result = 0)

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -153,7 +153,7 @@ TIMEOUT 1
 
 NAME helper_error
 RUN {{BPFTRACE}} -k -q -f json -e 'struct foo {int a;}; BEGIN { $tmp = ((struct foo*) 0)->a; exit(); }'
-EXPECT {"type": "helper_error", "msg": "Bad address", "helper": "probe_read", "retcode": -14, "line": 1, "col": 37}
+EXPECT {"type": "helper_error", "msg": "Bad address", "helper": "probe_read", "retcode": -14, "filename": "stdin", "line": 1, "col": 37}
 TIMEOUT 1
 
 NAME cgroup_path

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1,4 +1,5 @@
 #include "ast/passes/semantic_analyser.h"
+#include "ast/attachpoint_parser.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/printer.h"
 #include "bpftrace.h"
@@ -15,238 +16,251 @@ namespace bpftrace::test::semantic_analyser {
 using ::testing::_;
 using ::testing::HasSubstr;
 
-void test_for_warning(BPFtrace &bpftrace,
-                      const std::string &input,
-                      const std::string &warning,
-                      bool invert = false,
-                      bool safe_mode = true)
+ast::ASTContext test_for_warning(BPFtrace &bpftrace,
+                                 const std::string &input,
+                                 const std::string &warning,
+                                 bool invert = false,
+                                 bool safe_mode = true)
 {
-  Driver driver(bpftrace);
+  ast::ASTContext ast("stdin", input);
+  Driver driver(ast, bpftrace);
   bpftrace.safe_mode_ = safe_mode;
-  ASSERT_EQ(driver.parse_str(input), 0);
+  driver.parse();
+  bool parse_ok = ast.diagnostics().ok();
+  EXPECT_TRUE(parse_ok);
+  if (!parse_ok) {
+    return ast;
+  }
 
   ClangParser clang;
-  clang.parse(driver.ctx.root, bpftrace);
+  clang.parse(ast.root, bpftrace);
 
-  ASSERT_EQ(driver.parse_str(input), 0);
-  ast::SemanticAnalyser semantics(driver.ctx, bpftrace);
+  driver.parse();
+  parse_ok = ast.diagnostics().ok();
+  EXPECT_TRUE(parse_ok);
+  if (!parse_ok) {
+    return ast;
+  }
+
+  ast::AttachPointParser ap_parser(ast, bpftrace, false);
+  ap_parser.parse();
+  EXPECT_TRUE(ast.diagnostics().ok());
+
+  ast::SemanticAnalyser semantics(ast, bpftrace);
   semantics.analyse();
 
   std::stringstream out;
-  driver.ctx.diagnostics().emit(out);
+  ast.diagnostics().emit(out);
   if (invert)
     EXPECT_THAT(out.str(), Not(HasSubstr(warning)));
   else
     EXPECT_THAT(out.str(), HasSubstr(warning));
+
+  return ast;
 }
 
-void test_for_warning(const std::string &input,
-                      const std::string &warning,
-                      bool invert = false,
-                      bool safe_mode = true)
+ast::ASTContext test_for_warning(const std::string &input,
+                                 const std::string &warning,
+                                 bool invert = false,
+                                 bool safe_mode = true)
 {
   auto bpftrace = get_mock_bpftrace();
-  test_for_warning(*bpftrace, input, warning, invert, safe_mode);
+  return test_for_warning(*bpftrace, input, warning, invert, safe_mode);
 }
 
-void test(BPFtrace &bpftrace,
-          bool mock_has_features,
-          Driver &driver,
-          std::string_view input,
-          int expected_result,
-          std::string_view expected_error = {},
-          bool safe_mode = true,
-          bool has_child = false)
+ast::ASTContext test(BPFtrace &bpftrace,
+                     bool mock_has_features,
+                     const std::string &input,
+                     int expected_result,
+                     std::string_view expected_error = "",
+                     bool safe_mode = true,
+                     bool has_child = false)
 {
-  if (!input.empty() && input[0] == '\n')
-    input.remove_prefix(1); // Remove initial '\n'
+  std::string local_input(input);
+  if (!local_input.empty() && local_input[0] == '\n')
+    local_input = local_input.substr(1); // Remove initial '\n'
+  ast::ASTContext ast("stdin", local_input);
+  Driver driver(ast, bpftrace);
 
   std::stringstream msg;
   msg << "\nInput:\n" << input << "\n\nOutput:\n";
-  driver.ctx.diagnostics().clear();
 
   bpftrace.safe_mode_ = safe_mode;
-  ASSERT_EQ(driver.parse_str(input), 0);
+  driver.parse();
+  bool parse_ok = ast.diagnostics().ok();
+  EXPECT_TRUE(parse_ok) << msg.str();
+  if (!parse_ok) {
+    return ast;
+  }
+
+  ast::AttachPointParser ap_parser(ast, bpftrace, false);
+  ap_parser.parse();
+  EXPECT_TRUE(ast.diagnostics().ok());
 
   ast::FieldAnalyser fields(bpftrace);
-  fields.visit(driver.ctx.root);
-  ASSERT_TRUE(driver.ctx.diagnostics().ok()) << msg.str();
+  fields.visit(ast.root);
+  EXPECT_TRUE(ast.diagnostics().ok()) << msg.str();
+  if (!ast.diagnostics().ok()) {
+    return ast;
+  }
 
   ClangParser clang;
-  clang.parse(driver.ctx.root, bpftrace);
+  clang.parse(ast.root, bpftrace);
 
-  driver.ctx.diagnostics().clear();
-  ASSERT_EQ(driver.parse_str(input), 0);
+  driver.parse();
+  parse_ok = ast.diagnostics().ok();
+  EXPECT_TRUE(parse_ok) << msg.str();
+  if (!parse_ok) {
+    return ast;
+  }
+
+  ap_parser.parse();
+  EXPECT_TRUE(ast.diagnostics().ok());
 
   // Override to mockbpffeature.
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(mock_has_features);
-  ast::SemanticAnalyser semantics(driver.ctx, bpftrace, has_child);
+  ast::SemanticAnalyser semantics(ast, bpftrace, has_child);
   if (expected_result == -1) {
     // Accept any failure result.
     semantics.analyse();
-    EXPECT_FALSE(driver.ctx.diagnostics().ok()) << msg.str();
+    EXPECT_FALSE(ast.diagnostics().ok()) << msg.str();
   } else if (expected_result == 0) {
     // Accept no errors.
     semantics.analyse();
     std::stringstream out;
-    driver.ctx.diagnostics().emit(out);
-    EXPECT_TRUE(driver.ctx.diagnostics().ok()) << msg.str() << out.str();
+    ast.diagnostics().emit(out);
+    EXPECT_TRUE(ast.diagnostics().ok()) << msg.str() << out.str();
   } else {
     EXPECT_EQ(expected_result, semantics.analyse()) << msg.str();
   }
-  if (expected_error.data()) {
+  if (expected_error.data() && !expected_error.empty()) {
     if (!expected_error.empty() && expected_error[0] == '\n')
       expected_error.remove_prefix(1); // Remove initial '\n'
 
     // Reproduce the full string.
     std::stringstream out;
-    driver.ctx.diagnostics().emit(out);
+    ast.diagnostics().emit(out);
     EXPECT_EQ(out.str(), expected_error);
   }
+
+  return ast;
 }
 
-void test(BPFtrace &bpftrace, std::string_view input, bool safe_mode = true)
+ast::ASTContext test(BPFtrace &bpftrace,
+                     const std::string &input,
+                     bool safe_mode = true)
 {
-  Driver driver(bpftrace);
-  test(bpftrace, true, driver, input, 0, {}, safe_mode, false);
+  return test(bpftrace, true, input, 0, {}, safe_mode, false);
 }
 
-void test(BPFtrace &bpftrace,
-          std::string_view input,
-          int expected_result,
-          bool safe_mode = true)
-{
-  // This function will eventually be deprecated in favour of test_error()
-  assert(expected_result != 0 &&
-         "Use test(BPFtrace&, std::string_view) for expected successes");
-  Driver driver(bpftrace);
-  test(bpftrace, true, driver, input, expected_result, {}, safe_mode, false);
-}
-
-void test(Driver &driver, std::string_view input)
-{
-  auto bpftrace = get_mock_bpftrace();
-  test(*bpftrace, true, driver, input, 0, {}, true, false);
-}
-
-void test(Driver &driver, std::string_view input, int expected_result)
+ast::ASTContext test(BPFtrace &bpftrace,
+                     const std::string &input,
+                     int expected_result,
+                     bool safe_mode = true)
 {
   // This function will eventually be deprecated in favour of test_error()
   assert(expected_result != 0 &&
-         "Use test(Driver&, std::string_view) for expected successes");
-  auto bpftrace = get_mock_bpftrace();
-  test(*bpftrace, true, driver, input, expected_result, {}, true, false);
+         "Use test(BPFtrace&, const std::string&) for expected successes");
+  return test(bpftrace, true, input, expected_result, {}, safe_mode, false);
 }
 
-void test(MockBPFfeature &feature, std::string_view input)
+ast::ASTContext test(MockBPFfeature &feature, const std::string &input)
 {
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
   bool mock_has_features = feature.has_features_;
-  test(*bpftrace, mock_has_features, driver, input, 0, {}, true, false);
+  return test(*bpftrace, mock_has_features, input, 0, {}, true, false);
 }
 
-void test(MockBPFfeature &feature,
-          std::string_view input,
-          int expected_result,
-          bool safe_mode = true)
+ast::ASTContext test(MockBPFfeature &feature,
+                     const std::string &input,
+                     int expected_result,
+                     bool safe_mode = true)
 {
   // This function will eventually be deprecated in favour of test_error()
-  assert(expected_result != 0 &&
-         "Use test(MockBPFfeature&, std::string_view) for expected successes");
+  assert(
+      expected_result != 0 &&
+      "Use test(MockBPFfeature&, const std::string&) for expected successes");
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
   bool mock_has_features = feature.has_features_;
-  test(*bpftrace,
-       mock_has_features,
-       driver,
-       input,
-       expected_result,
-       {},
-       safe_mode,
-       false);
+  return test(*bpftrace,
+              mock_has_features,
+              input,
+              expected_result,
+              {},
+              safe_mode,
+              false);
 }
 
-void test(std::string_view input,
-          int expected_result,
-          bool safe_mode,
-          bool has_child = false)
+ast::ASTContext test(const std::string &input,
+                     int expected_result,
+                     bool safe_mode,
+                     bool has_child = false)
 {
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
-  test(*bpftrace,
-       true,
-       driver,
-       input,
-       expected_result,
-       {},
-       safe_mode,
-       has_child);
+  return test(
+      *bpftrace, true, input, expected_result, {}, safe_mode, has_child);
 }
 
-void test(std::string_view input, int expected_result)
+ast::ASTContext test(const std::string &input, int expected_result)
 {
   // This function will eventually be deprecated in favour of test_error()
   assert(expected_result != 0 &&
-         "Use test(std::string_view) for expected successes");
+         "Use test(const std::string&) for expected successes");
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
-  test(*bpftrace, true, driver, input, expected_result, {}, true, false);
+  return test(*bpftrace, true, input, expected_result, {}, true, false);
 }
 
-void test(std::string_view input)
+ast::ASTContext test(const std::string &input)
 {
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
-  test(*bpftrace, true, driver, input, 0, {}, true, false);
+  return test(*bpftrace, true, input, 0, {}, true, false);
 }
 
-void test(BPFtrace &bpftrace,
-          std::string_view input,
-          std::string_view expected_ast)
+ast::ASTContext test(BPFtrace &bpftrace,
+                     const std::string &input,
+                     std::string_view expected_ast)
 {
-  Driver driver(bpftrace);
-  test(bpftrace, true, driver, input, 0, {}, true, false);
+  auto ast = test(bpftrace, true, input, 0, {}, true, false);
 
   if (expected_ast[0] == '\n')
     expected_ast.remove_prefix(1); // Remove initial '\n'
 
   std::ostringstream out;
   ast::Printer printer(out);
-  printer.visit(driver.ctx.root);
+  printer.visit(ast.root);
 
   if (expected_ast[0] == '*' && expected_ast[expected_ast.size() - 1] == '*') {
     // Remove globs from beginning and end
     expected_ast.remove_prefix(1);
     expected_ast.remove_suffix(1);
     EXPECT_THAT(out.str(), HasSubstr(expected_ast));
-    return;
+    return ast;
   }
 
   EXPECT_EQ(expected_ast, out.str());
+  return ast;
 }
 
-void test(std::string_view input, std::string_view expected_ast)
+ast::ASTContext test(const std::string &input, std::string_view expected_ast)
 {
   auto bpftrace = get_mock_bpftrace();
-  test(*bpftrace, input, expected_ast);
+  return test(*bpftrace, input, expected_ast);
 }
 
-void test_error(BPFtrace &bpftrace,
-                std::string_view input,
-                std::string_view expected_error,
-                bool has_features = true)
+ast::ASTContext test_error(BPFtrace &bpftrace,
+                           const std::string &input,
+                           std::string_view expected_error,
+                           bool has_features = true)
 {
-  Driver driver(bpftrace);
-  test(bpftrace, has_features, driver, input, -1, expected_error, true, false);
+  return test(bpftrace, has_features, input, -1, expected_error, true, false);
 }
 
-void test_error(std::string_view input,
-                std::string_view expected_error,
-                bool has_features = true)
+ast::ASTContext test_error(const std::string &input,
+                           std::string_view expected_error,
+                           bool has_features = true)
 {
   auto bpftrace = get_mock_bpftrace();
-  test_error(*bpftrace, input, expected_error, has_features);
+  return test_error(*bpftrace, input, expected_error, has_features);
 }
 
 TEST(semantic_analyser, builtin_variables)
@@ -1311,11 +1325,10 @@ TEST(semantic_analyser, call_str_2_lit)
 
   // Check the string size
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
-  test(driver, "kprobe:f { $x = str(arg0, 3); }");
+  auto ast = test("kprobe:f { $x = str(arg0, 3); }");
 
   auto x = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(0));
+      ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateString(3), x->var->type);
 }
 
@@ -1463,7 +1476,6 @@ TEST(semantic_analyser, call_uaddr)
 
   // The C struct parser should set the is_signed flag on signed types
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
   std::string prog = "uprobe:/bin/sh:main {"
                      "$a = uaddr(\"12345_1\");"
                      "$b = uaddr(\"12345_2\");"
@@ -1473,13 +1485,13 @@ TEST(semantic_analyser, call_uaddr)
                      "$f = uaddr(\"12345_33\");"
                      "}";
 
-  test(driver, prog);
+  auto ast = test(prog);
 
   std::vector<int> sizes = { 8, 16, 32, 64, 64, 64 };
 
   for (size_t i = 0; i < sizes.size(); i++) {
     auto v = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes.at(0)->block->stmts.at(i));
+        ast.root->probes.at(0)->block->stmts.at(i));
     EXPECT_TRUE(v->var->type.IsPtrTy());
     EXPECT_TRUE(v->var->type.GetPointeeTy()->IsIntTy());
     EXPECT_EQ((unsigned long int)sizes.at(i),
@@ -1762,31 +1774,30 @@ TEST(semantic_analyser, array_access)
        "arg0; @x = $s->y[5];}",
        3);
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
-  test(driver,
-       "struct MyStruct { int y[4]; } kprobe:f { $s = (struct MyStruct *) "
-       "arg0; @x = $s->y[0];}");
+  auto ast = test(
+      "struct MyStruct { int y[4]; } kprobe:f { $s = (struct MyStruct *) "
+      "arg0; @x = $s->y[0];}");
   auto assignment = static_cast<ast::AssignMapStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(1));
+      ast.root->probes.at(0)->block->stmts.at(1));
   EXPECT_EQ(CreateInt64(), assignment->map->type);
 
-  test(driver,
-       "struct MyStruct { int y[4]; } kprobe:f { $s = ((struct MyStruct *) "
-       "arg0)->y; @x = $s[0];}");
+  ast = test(
+      "struct MyStruct { int y[4]; } kprobe:f { $s = ((struct MyStruct *) "
+      "arg0)->y; @x = $s[0];}");
   auto array_var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(0));
+      ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateArray(4, CreateInt32()), array_var_assignment->var->type);
 
-  test(driver,
-       "struct MyStruct { int y[4]; } kprobe:f { @a[0] = ((struct MyStruct *) "
-       "arg0)->y; @x = @a[0][0];}");
+  ast = test(
+      "struct MyStruct { int y[4]; } kprobe:f { @a[0] = ((struct MyStruct *) "
+      "arg0)->y; @x = @a[0][0];}");
   auto array_map_assignment = static_cast<ast::AssignMapStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(0));
+      ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateArray(4, CreateInt32()), array_map_assignment->map->type);
 
-  test(driver, "kprobe:f { $s = (int32 *) arg0; $x = $s[0]; }");
+  ast = test("kprobe:f { $s = (int32 *) arg0; $x = $s[0]; }");
   auto var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(1));
+      ast.root->probes.at(0)->block->stmts.at(1));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
 
   // Positional parameter as index
@@ -1887,11 +1898,10 @@ TEST(semantic_analyser, array_compare)
 TEST(semantic_analyser, variable_type)
 {
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
-  test(driver, "kprobe:f { $x = 1 }");
+  auto ast = test("kprobe:f { $x = 1 }");
   auto st = CreateInt64();
   auto assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(0));
+      ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(st, assignment->var->type);
 }
 
@@ -1919,13 +1929,12 @@ TEST(semantic_analyser, unroll)
 TEST(semantic_analyser, map_integer_sizes)
 {
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
-  test(driver, "kprobe:f { $x = (int32) -1; @x = $x; }");
+  auto ast = test("kprobe:f { $x = (int32) -1; @x = $x; }");
 
   auto var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(0));
+      ast.root->probes.at(0)->block->stmts.at(0));
   auto map_assignment = static_cast<ast::AssignMapStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(1));
+      ast.root->probes.at(0)->block->stmts.at(1));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
   EXPECT_EQ(CreateInt64(), map_assignment->map->type);
 }
@@ -1933,22 +1942,20 @@ TEST(semantic_analyser, map_integer_sizes)
 TEST(semantic_analyser, binop_integer_promotion)
 {
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
-  test(driver, "kprobe:f { $x = (int32)5 + (int16)6 }");
+  auto ast = test("kprobe:f { $x = (int32)5 + (int16)6 }");
 
   auto var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(0));
+      ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
 }
 
 TEST(semantic_analyser, binop_integer_no_promotion)
 {
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
-  test(driver, "kprobe:f { $x = (int8)5 + (int8)6 }");
+  auto ast = test("kprobe:f { $x = (int8)5 + (int8)6 }");
 
   auto var_assignment = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(0));
+      ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateInt8(), var_assignment->var->type);
 }
 
@@ -2699,20 +2706,19 @@ TEST(semantic_analyser, field_access_sub_struct)
 TEST(semantic_analyser, field_access_is_internal)
 {
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
   std::string structs = "struct type1 { int x; }";
 
   {
-    test(driver, structs + "kprobe:f { $x = (*(struct type1*)0).x }");
-    auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
+    auto ast = test(structs + "kprobe:f { $x = (*(struct type1*)0).x }");
+    auto &stmts = ast.root->probes.at(0)->block->stmts;
     auto var_assignment1 = static_cast<ast::AssignVarStatement *>(stmts.at(0));
     EXPECT_FALSE(var_assignment1->var->type.is_internal);
   }
 
   {
-    test(driver,
-         structs + "kprobe:f { @type1 = *(struct type1*)0; $x = @type1.x }");
-    auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
+    auto ast = test(structs +
+                    "kprobe:f { @type1 = *(struct type1*)0; $x = @type1.x }");
+    auto &stmts = ast.root->probes.at(0)->block->stmts;
     auto map_assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
     auto var_assignment2 = static_cast<ast::AssignVarStatement *>(stmts.at(1));
     EXPECT_TRUE(map_assignment->map->type.is_internal);
@@ -2817,10 +2823,9 @@ TEST(semantic_analyser, positional_parameters)
   // Parameters can be used as string literals
   test(bpftrace, "kprobe:f { printf(\"%d\", cgroupid(str($2))); }");
 
-  Driver driver(bpftrace);
-  test(driver, "k:f { $1 }");
+  auto ast = test("k:f { $1 }");
   auto stmt = static_cast<ast::ExprStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(0));
+      ast.root->probes.at(0)->block->stmts.at(0));
   auto pp = static_cast<ast::PositionalParameter *>(stmt->expr);
   EXPECT_EQ(CreateUInt64(), pp->type);
   EXPECT_TRUE(pp->is_literal);
@@ -2982,22 +2987,21 @@ TEST(semantic_analyser, cast_sign)
 {
   // The C struct parser should set the is_signed flag on signed types
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
   std::string prog =
       "struct t { int s; unsigned int us; long l; unsigned long ul }; "
       "kprobe:f { "
       "  $t = ((struct t *)0xFF);"
       "  $s = $t->s; $us = $t->us; $l = $t->l; $lu = $t->ul; }";
-  test(driver, prog);
+  auto ast = test(prog);
 
   auto s = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(1));
+      ast.root->probes.at(0)->block->stmts.at(1));
   auto us = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(2));
+      ast.root->probes.at(0)->block->stmts.at(2));
   auto l = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(3));
+      ast.root->probes.at(0)->block->stmts.at(3));
   auto ul = static_cast<ast::AssignVarStatement *>(
-      driver.ctx.root->probes.at(0)->block->stmts.at(4));
+      ast.root->probes.at(0)->block->stmts.at(4));
   EXPECT_EQ(CreateInt32(), s->var->type);
   EXPECT_EQ(CreateUInt32(), us->var->type);
   EXPECT_EQ(CreateInt64(), l->var->type);
@@ -3015,7 +3019,6 @@ TEST(semantic_analyser, binop_sign)
                               ">=", "+",  "-", "/",  "*" };
   for (std::string op : operators) {
     BPFtrace bpftrace;
-    Driver driver(bpftrace);
     std::string prog = prog_pre + "$varA = $t->l " + op +
                        " $t->l; "
                        "$varB = $t->ul " +
@@ -3026,15 +3029,15 @@ TEST(semantic_analyser, binop_sign)
                        " $t->ul;"
                        "}";
 
-    test(driver, prog);
+    auto ast = test(prog);
     auto varA = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes.at(0)->block->stmts.at(1));
+        ast.root->probes.at(0)->block->stmts.at(1));
     EXPECT_EQ(CreateInt64(), varA->var->type);
     auto varB = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes.at(0)->block->stmts.at(2));
+        ast.root->probes.at(0)->block->stmts.at(2));
     EXPECT_EQ(CreateUInt64(), varB->var->type);
     auto varC = static_cast<ast::AssignVarStatement *>(
-        driver.ctx.root->probes.at(0)->block->stmts.at(3));
+        ast.root->probes.at(0)->block->stmts.at(3));
     EXPECT_EQ(CreateUInt64(), varC->var->type);
   }
 }
@@ -3428,13 +3431,12 @@ TEST(semantic_analyser, builtin_args)
 TEST(semantic_analyser, type_ctx)
 {
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
   std::string structs = "struct c {char c} struct x { long a; short b[4]; "
                         "struct c c; struct c *d;}";
-  test(driver,
-       structs + "kprobe:f { $x = (struct x*)ctx; $a = $x->a; $b = $x->b[0]; "
-                 "$c = $x->c.c; $d = $x->d->c;}");
-  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
+  auto ast = test(structs +
+                  "kprobe:f { $x = (struct x*)ctx; $a = $x->a; $b = $x->b[0]; "
+                  "$c = $x->c.c; $d = $x->d->c;}");
+  auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $x = (struct x*)ctx;
   auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
@@ -3494,9 +3496,9 @@ TEST(semantic_analyser, type_ctx)
   var = static_cast<ast::Variable *>(unop->expr);
   EXPECT_TRUE(var->type.IsPtrTy());
 
-  test(driver, "k:f, kr:f { @ = (uint64)ctx; }");
-  test(driver, "k:f, i:s:1 { @ = (uint64)ctx; }", 1);
-  test(driver, "t:sched:sched_one { @ = (uint64)ctx; }", 1);
+  test("k:f, kr:f { @ = (uint64)ctx; }");
+  test("k:f, i:s:1 { @ = (uint64)ctx; }", 1);
+  test("t:sched:sched_one { @ = (uint64)ctx; }", 1);
 }
 
 TEST(semantic_analyser, double_pointer_basic)
@@ -3510,10 +3512,8 @@ TEST(semantic_analyser, double_pointer_basic)
 
 TEST(semantic_analyser, double_pointer_int)
 {
-  BPFtrace bpftrace;
-  Driver driver(bpftrace);
-  test(driver, "kprobe:f { $pp = (int8 **)1; $p = *$pp; $val = *$p; }");
-  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
+  auto ast = test("kprobe:f { $pp = (int8 **)1; $p = *$pp; $val = *$p; }");
+  auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $pp = (int8 **)1;
   auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
@@ -3538,12 +3538,10 @@ TEST(semantic_analyser, double_pointer_int)
 
 TEST(semantic_analyser, double_pointer_struct)
 {
-  BPFtrace bpftrace;
-  Driver driver(bpftrace);
-  test(driver,
-       "struct Foo { char x; long y; }"
-       "kprobe:f { $pp = (struct Foo **)1; $p = *$pp; $val = $p->x; }");
-  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
+  auto ast = test(
+      "struct Foo { char x; long y; }"
+      "kprobe:f { $pp = (struct Foo **)1; $p = *$pp; $val = $p->x; }");
+  auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $pp = (struct Foo **)1;
   auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
@@ -3720,16 +3718,12 @@ TEST(semantic_analyser, tuple_indexing)
 TEST(semantic_analyser, tuple_assign_var)
 {
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
   SizedType ty = CreateTuple(
       bpftrace.structs.AddTuple({ CreateInt64(), CreateString(6) }));
-  test(bpftrace,
-       true,
-       driver,
-       R"_(BEGIN { $t = (1, "str"); $t = (4, "other"); })_",
-       0);
+  auto ast = test(
+      bpftrace, true, R"_(BEGIN { $t = (1, "str"); $t = (4, "other"); })_", 0);
 
-  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
+  auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $t = (1, "str");
   auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
@@ -3744,15 +3738,11 @@ TEST(semantic_analyser, tuple_assign_var)
 TEST(semantic_analyser, tuple_assign_map)
 {
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
   SizedType ty;
-  test(bpftrace,
-       true,
-       driver,
-       R"_(BEGIN { @ = (1, 3, 3, 7); @ = (0, 0, 0, 0); })_",
-       0);
+  auto ast = test(
+      bpftrace, true, R"_(BEGIN { @ = (1, 3, 3, 7); @ = (0, 0, 0, 0); })_", 0);
 
-  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
+  auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $t = (1, 3, 3, 7);
   auto assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
@@ -3771,14 +3761,13 @@ TEST(semantic_analyser, tuple_assign_map)
 TEST(semantic_analyser, tuple_nested)
 {
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
   SizedType ty_inner = CreateTuple(
       bpftrace.structs.AddTuple({ CreateInt64(), CreateInt64() }));
   SizedType ty = CreateTuple(
       bpftrace.structs.AddTuple({ CreateInt64(), ty_inner }));
-  test(bpftrace, true, driver, R"_(BEGIN { $t = (1,(1,2)); })_", 0);
+  auto ast = test(bpftrace, true, R"_(BEGIN { $t = (1,(1,2)); })_", 0);
 
-  auto &stmts = driver.ctx.root->probes.at(0)->block->stmts;
+  auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $t = (1, "str");
   auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
@@ -3918,36 +3907,31 @@ TEST(semantic_analyser, string_size)
 {
   // Size of the variable should be the size of the larger string (incl. null)
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
-  test(bpftrace, true, driver, R"_(BEGIN { $x = "hi"; $x = "hello"; })_", 0);
-  auto stmt = driver.ctx.root->probes.at(0)->block->stmts.at(0);
+  auto ast = test(bpftrace, true, R"_(BEGIN { $x = "hi"; $x = "hello"; })_", 0);
+  auto stmt = ast.root->probes.at(0)->block->stmts.at(0);
   auto var_assign = dynamic_cast<ast::AssignVarStatement *>(stmt);
   ASSERT_TRUE(var_assign->var->type.IsStringTy());
   ASSERT_EQ(var_assign->var->type.GetSize(), 6UL);
 
-  test(bpftrace, true, driver, R"_(k:f1 {@ = "hi";} k:f2 {@ = "hello";})_", 0);
-  stmt = driver.ctx.root->probes.at(0)->block->stmts.at(0);
+  ast = test(bpftrace, true, R"_(k:f1 {@ = "hi";} k:f2 {@ = "hello";})_", 0);
+  stmt = ast.root->probes.at(0)->block->stmts.at(0);
   auto map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
   ASSERT_TRUE(map_assign->map->type.IsStringTy());
   ASSERT_EQ(map_assign->map->type.GetSize(), 6UL);
 
-  test(bpftrace,
-       true,
-       driver,
-       R"_(k:f1 {@["hi"] = 0;} k:f2 {@["hello"] = 1;})_",
-       0);
-  stmt = driver.ctx.root->probes.at(0)->block->stmts.at(0);
+  ast = test(
+      bpftrace, true, R"_(k:f1 {@["hi"] = 0;} k:f2 {@["hello"] = 1;})_", 0);
+  stmt = ast.root->probes.at(0)->block->stmts.at(0);
   map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
   ASSERT_TRUE(map_assign->map->key_expr->type.IsStringTy());
   ASSERT_EQ(map_assign->map->key_expr->type.GetSize(), 3UL);
   ASSERT_EQ(map_assign->map->key_type.GetSize(), 6UL);
 
-  test(bpftrace,
-       true,
-       driver,
-       R"_(k:f1 {@["hi", 0] = 0;} k:f2 {@["hello", 1] = 1;})_",
-       0);
-  stmt = driver.ctx.root->probes.at(0)->block->stmts.at(0);
+  ast = test(bpftrace,
+             true,
+             R"_(k:f1 {@["hi", 0] = 0;} k:f2 {@["hello", 1] = 1;})_",
+             0);
+  stmt = ast.root->probes.at(0)->block->stmts.at(0);
   map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
   ASSERT_TRUE(map_assign->map->key_expr->type.IsTupleTy());
   ASSERT_TRUE(map_assign->map->key_expr->type.GetField(0).type.IsStringTy());
@@ -3956,12 +3940,11 @@ TEST(semantic_analyser, string_size)
   ASSERT_EQ(map_assign->map->key_expr->type.GetSize(), 16UL);
   ASSERT_EQ(map_assign->map->key_type.GetSize(), 16UL);
 
-  test(bpftrace,
-       true,
-       driver,
-       R"_(k:f1 {$x = ("hello", 0);} k:f2 {$x = ("hi", 0); })_",
-       0);
-  stmt = driver.ctx.root->probes.at(0)->block->stmts.at(0);
+  ast = test(bpftrace,
+             true,
+             R"_(k:f1 {$x = ("hello", 0);} k:f2 {$x = ("hi", 0); })_",
+             0);
+  stmt = ast.root->probes.at(0)->block->stmts.at(0);
   var_assign = dynamic_cast<ast::AssignVarStatement *>(stmt);
   ASSERT_TRUE(var_assign->var->type.IsTupleTy());
   ASSERT_TRUE(var_assign->var->type.GetField(0).type.IsStringTy());


### PR DESCRIPTION
Stacked PRs:
 * #3869
 * #3868
 * __->__#3855


--- --- ---

### Invert the `Driver`/`ASTContext` relationship


Right now, the global singleton logger keeps all the source context
(filename and source contents), and all logging is resolved with this.

In order to eventually support imports, additional files, etc. it is
necessary to break this hard dependency. This change makes a number of
minor adjustments, relying on the newly introduced diagnostics.

First, the `ASTContext` gains an `ASTSource` member which is effectively
the immutable source filename and contents that will be parsed. It is
useful to store this directly in the context, as it means that the
context carries all the information required to be reset and reparsed
(which is something done after clang parsing is done).

Next, the driver is made to *not* own the context, and the context is
simply passed to a temporary driver. In the future, the driver could be
implemented as a pass over the `ASTContext` containing the source (and
the pass could be done twice: once before clang parsing and once after).
This change greatly simplifies the driver, and will allow it to be used
as part of a standardized pass.

Next, the log plumbing is updated to require references to all the
needed contextual information: filename, contents and location. The
logger supports two modes: one needing this information completely, and
one that emits bare messages.

Finally, all the tests and various ergonomics of these classes are
updated. This is by far the largest contributor to this commit; it is
primarily a boilerplate change. Asuste observers may notice that a lot
of the plumbing and passes in both `main.cpp` and the individual tests
are starting to look similar; this is by design, over time these things
will converge into passes, and the amount of replicated boilerplate can
be greatly reduced.
There are some minor incidental changes that are note worthy as part of
this change:

* Since locations are only defined within the context of a single
  `ASTContext`, when helper information is recorded, those locations are
  translated to a filename, line and column number in the form of the
  `HelperErrorInfo`. This is fine, since the full source context for a
  helper error is unlikely to be useful.

* This *now* applies to both the runtime errors and verifier errors
  related to helpers. The verifier errors now record *all* instances of
  a helper, rather than just the first one, to provide high-quality
  errors.

Signed-off-by: Adin Scannell <amscanne@meta.com>
