### PR TITLE
fix: add test for result and tweak APIs

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(bpftrace_test
   config_analyser.cpp
   pid_filter_pass.cpp
   resource_analyser.cpp
+  result.cpp
   required_resources.cpp
   return_path_analyser.cpp
   scopeguard.cpp

--- a/tests/result.cpp
+++ b/tests/result.cpp
@@ -1,0 +1,94 @@
+#include "gtest/gtest.h"
+
+#include "util/result.h"
+
+namespace bpftrace::test::result {
+
+class NotOK : public ErrorInfo<NotOK> {
+public:
+  static char ID;
+  void log(llvm::raw_ostream &OS) const override
+  {
+    OS << "Not OK.";
+  }
+};
+
+class ReallyNotOK : public ErrorInfo<ReallyNotOK> {
+public:
+  static char ID;
+  void log(llvm::raw_ostream &OS) const override
+  {
+    OS << "Really not OK.";
+  }
+};
+
+char NotOK::ID;
+char ReallyNotOK::ID;
+
+static Result<> alwaysOK()
+{
+  return OK();
+}
+
+static Result<> alwaysNotOK()
+{
+  return make_error<NotOK>();
+}
+
+static Result<bool> maybeOK(bool ok, bool really_bad)
+{
+  if (!ok) {
+    if (really_bad)
+      return make_error<ReallyNotOK>();
+    return make_error<NotOK>();
+  }
+  return really_bad; // Arbitrary value.
+}
+
+TEST(result, okay)
+{
+  auto ok = alwaysOK();
+  EXPECT_TRUE(bool(ok));
+}
+
+TEST(result, not_okay)
+{
+  auto ok = alwaysNotOK();
+  EXPECT_FALSE(bool(ok));
+}
+
+TEST(result, values)
+{
+  auto ok = maybeOK(true, false);
+  EXPECT_TRUE(bool(ok));
+  EXPECT_FALSE(*ok);
+  ok = maybeOK(true, true);
+  EXPECT_TRUE(bool(ok));
+  EXPECT_TRUE(*ok);
+}
+
+TEST(result, handle_err_found)
+{
+  auto ok = maybeOK(false, false);
+  if (!ok) {
+    auto nowOk = handleErrors(std::move(ok), [](const NotOK &) {});
+    EXPECT_TRUE(bool(nowOk)); // Should now be fine.
+  }
+}
+
+TEST(result, handle_err_missing)
+{
+  auto ok = maybeOK(false, true);
+  if (!ok) {
+    auto nowOk = handleErrors(std::move(ok), [](const NotOK &) {});
+    EXPECT_FALSE(bool(nowOk)); // Should still have an error.
+  }
+}
+
+TEST(result, handle_inline)
+{
+  auto ok = handleErrors(maybeOK(true, false), [](const NotOK &) {});
+  EXPECT_TRUE(bool(ok)); // Handled above.
+}
+
+} // namespace bpftrace::test::result


### PR DESCRIPTION
As suggested, this implements perfect forwarding. When implementing the test, it was also apparent that collisions with `llvm::handleErrors` might cause some issues, so the signature was changed to allow for the result itself to move directly (and constrained against only these). This also makes the inline handling cleaner.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- [x] The new behaviour is covered by tests
