### PR TITLE
Add 'lookup_percpu_elem' to bpffeature

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -292,6 +292,7 @@ EXPECT len: 1
 TIMEOUT 1
 
 NAME print_per_cpu_map_vals
+REQUIRES_FEATURE lookup_percpu_elem
 PROG BEGIN { @a = avg(5); @c = count(); @s = sum(5); @mn = min(1); @mx = max(-1); print((@a, @c, @s, @mn, @mx)); exit(); }
 EXPECT (5, 1, 5, 1, -1)
 TIMEOUT 3

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -3,6 +3,7 @@
 from collections import namedtuple
 import os
 import platform
+from runner import Runner
 
 DEFAULT_TIMEOUT = 5
 
@@ -192,26 +193,7 @@ class TestParser(object):
             elif item_name == 'ARCH':
                 arch = [x.strip() for x in line.split("|")]
             elif item_name == 'REQUIRES_FEATURE':
-                features = {
-                    "loop",
-                    "btf",
-                    "fentry",
-                    "probe_read_kernel",
-                    "dpath",
-                    "uprobe_refcount",
-                    "signal",
-                    "iter",
-                    "libpath_resolv",
-                    "dwarf",
-                    "kernel_dwarf",
-                    "aot",
-                    "kprobe_multi",
-                    "uprobe_multi",
-                    "skboutput",
-                    "get_tai_ns",
-                    "get_func_ip",
-                    "jiffies64",
-                }
+                features = set(Runner.get_bpffeature().keys())
 
                 for f in line.split(" "):
                     f = f.strip()

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -136,7 +136,7 @@ class Runner(object):
 
     @staticmethod
     @lru_cache(maxsize=1)
-    def __get_bpffeature():
+    def get_bpffeature():
         p = subprocess.Popen(
             [BPFTRACE_BIN, "--info"],
             stdout=subprocess.PIPE,
@@ -164,6 +164,7 @@ class Runner(object):
         bpffeature["get_tai_ns"] = output.find("get_ktime_ns: yes") != -1
         bpffeature["get_func_ip"] = output.find("get_func_ip: yes") != -1
         bpffeature["jiffies64"] = output.find("jiffies64: yes") != -1
+        bpffeature["lookup_percpu_elem"] = output.find("lookup_percpu_elem: yes") != -1
         return bpffeature
 
 
@@ -319,7 +320,7 @@ class Runner(object):
                             return Runner.SKIP_REQUIREMENT_UNSATISFIED
 
             if test.feature_requirement or test.neg_feature_requirement:
-                bpffeature = Runner.__get_bpffeature()
+                bpffeature = Runner.get_bpffeature()
 
                 for feature in test.feature_requirement:
                     if feature not in bpffeature:

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -74,10 +74,12 @@ PROG BEGIN { @map[0] = 0; $var1 = 123; $var2 = "abc"; for ($kv : @map) { print((
 EXPECT (123, abc)
 
 NAME map two keys with a per cpu aggregation
+REQUIRES_FEATURE lookup_percpu_elem
 PROG BEGIN { @map[16,17] = count(); @map[16,17] = count(); @map[1,2] = count(); for ($kv : @map) { print($kv); } exit(); }
 EXPECT ((16, 17), 2)
 EXPECT ((1, 2), 1)
 
 NAME map stack key with a per cpu aggregation
+REQUIRES_FEATURE lookup_percpu_elem
 PROG BEGIN { @map[kstack(raw)] = count(); for ($kv : @map) { print($kv.1); } exit(); }
 EXPECT 1

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -260,30 +260,37 @@ EXPECT stdin:1:37-41: WARNING: Can't lookup map element because it does not exis
 TIMEOUT 1
 
 NAME per_cpu_map_count_if
+REQUIRES_FEATURE lookup_percpu_elem
 PROG i:ms:1 { @ = count(); if (@ > 5) { printf("done\n"); exit(); }}
 EXPECT done
 
 NAME per_cpu_map_min_if
+REQUIRES_FEATURE lookup_percpu_elem
 PROG BEGIN { @ = 10; } i:ms:1 { @--; @mn = min(@); if (@mn < 5) { printf("done\n"); exit(); }}
 EXPECT done
 
 NAME per_cpu_map_max_if
+REQUIRES_FEATURE lookup_percpu_elem
 PROG BEGIN { @ = 1; } i:ms:1 { @++; @mx = max(@); if (@mx > 5) { printf("done\n"); exit(); }}
 EXPECT done
 
 NAME per_cpu_map_avg_if
+REQUIRES_FEATURE lookup_percpu_elem
 PROG BEGIN { @ = avg(1); @ = avg(1); @ = avg(10); if (@ == 4) { printf("done\n"); exit(); }}
 EXPECT done
 
 NAME per_cpu_map_arithmetic
+REQUIRES_FEATURE lookup_percpu_elem
 PROG BEGIN { @a = sum(10); @b = count(); $c = @a + @b; if ($c == 11) { printf("done\n"); } exit();}
 EXPECT done
 
 NAME per_cpu_map_cast
+REQUIRES_FEATURE lookup_percpu_elem
 PROG BEGIN { @a = count(); @b = sum(10); printf("%d-%d\n", (uint64)@a, (int64)@b); exit();}
 EXPECT 1-10
 
 NAME per_cpu_map_as_map_key
+REQUIRES_FEATURE lookup_percpu_elem
 PROG BEGIN {@a = count(); @b = sum(5); @c = min(1); @d = max(10); @e = avg(7); @[@a, @b, @c, @d, @e] = 1; exit(); }
 EXPECT @[1, 5, 1, 10, 7]: 1
 

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -7,6 +7,7 @@ PROG BEGIN { @=avg(-30); @=avg(-10); exit(); }
 EXPECT @: -20
 
 NAME avg cast negative values
+REQUIRES_FEATURE lookup_percpu_elem
 PROG BEGIN { @ = avg(-1); @ = avg(-1); @ = avg(-10); if (@ == -4) { printf("done\n"); exit(); }}
 EXPECT done
 


### PR DESCRIPTION
Multiple runtime tests in `other` require the `lookup_percpu_elem` Kernel feature, but don't express the requirement in their test's `REQUIRES_FEATURE`. This lead to test failure when running on a older Kernel that doesn't support `lookup_percpu_elem`.

This PR adds parsing of the `lookup_percpu_elem` bpffeature and uses it on the mentionned runtime tests in `other`.
It also de-duplicate the bpffeature set from `parser.py`.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
