### PR TITLE
Add Map Declaration syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to
   - [#3841](https://github.com/bpftrace/bpftrace/pull/3841)
 - Add simple block expressions
   - [#3780](https://github.com/bpftrace/bpftrace/pull/3780)
+- Add map declaration syntax (behind an "unstable" config flag)
+  - [#3863](https://github.com/bpftrace/bpftrace/pull/3863)
 #### Changed
 - `probe` builtin is now represented as a string type
   - [#3638](https://github.com/bpftrace/bpftrace/pull/3638)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -906,6 +906,35 @@ All valid identifiers can be used as `name`.
 
 The data type of a variable is automatically determined during first assignment and cannot be changed afterwards.
 
+==== Maps Declarations
+
+Maps can also be declared in the global scope, before probes and after the config e.g.
+----
+config = {
+    unstable_map_decl=1;
+}
+
+let @a = hash(100);
+let @b = percpulruhash(20);
+
+BEGIN { ... }
+----
+
+The utility of this is that you can specify different underlying BPF map types.
+Currently these are available in bpftrace:
+- hash (BPF_MAP_TYPE_HASH)
+- lruhash (BPF_MAP_TYPE_LRU_HASH)
+- percpuhash (BPF_MAP_TYPE_PERCPU_HASH)
+- percpulruhash (BPF_MAP_TYPE_LRU_PERCPU_HASH)
+- percpuarray (BPF_MAP_TYPE_PERCPU_ARRAY)
+
+Additionally, map declarations must supply a single argument: **max entries** e.g. `let @a = lruhash(100);`
+All maps that are not declared in the global scope utilize the default set in the config variable "max_map_keys".
+However, it's best practice to declare maps up front as using the default can lead to lost map update events (if the map is full) or over allocation of memory if the map is intended to only store a few entries.
+
+**Warning** this feature is experimental and may be subject to changes.
+It also requires the 'unstable_map_decl' config being set to 1.
+
 ==== Maps without Explicit Keys
 
 Values can be assigned directly to maps without a key (sometimes refered to as scalar maps).

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -90,6 +90,18 @@ Offsetof::Offsetof(Diagnostics &d,
 {
 }
 
+MapDeclStatement::MapDeclStatement(Diagnostics &d,
+                                   std::string ident,
+                                   std::string bpf_type,
+                                   int max_entries,
+                                   Location &&loc)
+    : Expression(d, std::move(loc)),
+      ident(std::move(ident)),
+      bpf_type(std::move(bpf_type)),
+      max_entries(max_entries)
+{
+}
+
 Map::Map(Diagnostics &d, std::string ident, Location &&loc)
     : Expression(d, std::move(loc)), ident(std::move(ident))
 {
@@ -335,6 +347,7 @@ Subprog::Subprog(Diagnostics &d,
 Program::Program(Diagnostics &d,
                  std::string c_definitions,
                  Config *config,
+                 MapDeclList &&map_decls,
                  SubprogList &&functions,
                  ProbeList &&probes,
                  Location &&loc)
@@ -342,7 +355,8 @@ Program::Program(Diagnostics &d,
       c_definitions(std::move(c_definitions)),
       config(config),
       functions(std::move(functions)),
-      probes(std::move(probes))
+      probes(std::move(probes)),
+      map_decls(std::move(map_decls))
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -214,6 +214,18 @@ public:
   std::vector<std::string> field;
 };
 
+class MapDeclStatement : public Expression {
+public:
+  explicit MapDeclStatement(Diagnostics &d,
+                            std::string ident,
+                            std::string bpf_type,
+                            int max_entries,
+                            Location &&loc);
+  std::string ident;
+  std::string bpf_type;
+  int max_entries;
+};
+
 class Map : public Expression {
 public:
   explicit Map(Diagnostics &d, std::string ident, Location &&loc);
@@ -315,6 +327,8 @@ public:
 
   Expression *expr = nullptr;
 };
+
+using MapDeclList = std::vector<MapDeclStatement *>;
 
 class VarDeclStatement : public Statement {
 public:
@@ -594,6 +608,7 @@ public:
   Program(Diagnostics &d,
           std::string c_definitions,
           Config *config,
+          MapDeclList &&map_decls,
           SubprogList &&functions,
           ProbeList &&probes,
           Location &&loc);
@@ -602,6 +617,7 @@ public:
   Config *config = nullptr;
   SubprogList functions;
   ProbeList probes;
+  MapDeclList map_decls;
 };
 
 std::string opstr(const Binop &binop);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -178,9 +178,6 @@ private:
                        Value *dst_val,
                        Value *src_val);
 
-  libbpf::bpf_map_type get_map_type(const SizedType &val_type,
-                                    const SizedType &key_type);
-  bool is_array_map(const SizedType &val_type, const SizedType &key_type);
   bool map_has_single_elem(const SizedType &val_type,
                            const SizedType &key_type);
   void generate_maps(const RequiredResources &rr, const CodegenResources &cr);

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -136,6 +136,18 @@ void Printer::visit(Offsetof &offof)
   --depth_;
 }
 
+void Printer::visit(MapDeclStatement &decl)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "map decl: " << decl.ident << std::endl;
+
+  ++depth_;
+  std::string indentType(depth_, ' ');
+  out_ << indentType << "bpf type: " << decl.bpf_type << std::endl;
+  out_ << indentType << "max entries: " << decl.max_entries << std::endl;
+  --depth_;
+}
+
 void Printer::visit(Map &map)
 {
   std::string indent(depth_, ' ');
@@ -444,6 +456,10 @@ void Printer::visit(Program &program)
 
   ++depth_;
   visit(program.config);
+  --depth_;
+
+  ++depth_;
+  visit(program.map_decls);
   --depth_;
 
   ++depth_;

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -23,6 +23,7 @@ public:
   void visit(Sizeof &szof);
   void visit(Offsetof &offof);
   void visit(Map &map);
+  void visit(MapDeclStatement &decl);
   void visit(Variable &var);
   void visit(Binop &binop);
   void visit(Unop &unop);

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -3,6 +3,11 @@
 #include "ast/pass_manager.h"
 #include "ast/visitor.h"
 #include "required_resources.h"
+#include <bpf/libbpf.h>
+
+namespace libbpf {
+#include "libbpf/bpf.h"
+} // namespace libbpf
 
 namespace bpftrace::ast {
 
@@ -25,6 +30,7 @@ public:
   void visit(Builtin &map);
   void visit(Call &call);
   void visit(Map &map);
+  void visit(MapDeclStatement &decl);
   void visit(Tuple &tuple);
   void visit(For &f);
   void visit(Ternary &ternary);
@@ -52,6 +58,8 @@ private:
   BPFtrace &bpftrace_;
   // Current probe we're analysing
   Probe *probe_{ nullptr };
+  std::unordered_map<std::string, std::pair<libbpf::bpf_map_type, int>>
+      map_decls_;
 
   int next_map_id_ = 0;
 };

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -6,6 +6,10 @@
 #include "collect_nodes.h"
 #include "types.h"
 
+namespace libbpf {
+#include "libbpf/bpf.h"
+} // namespace libbpf
+
 namespace bpftrace::ast {
 
 struct variable {
@@ -74,6 +78,7 @@ public:
   void visit(Sizeof &szof);
   void visit(Offsetof &offof);
   void visit(Map &map);
+  void visit(MapDeclStatement &decl);
   void visit(Variable &var);
   void visit(Binop &binop);
   void visit(Unop &unop);
@@ -180,6 +185,7 @@ private:
   std::map<Node *, CollectNodes<Variable>> for_vars_referenced_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, SizedType> map_key_;
+  std::map<std::string, libbpf::bpf_map_type> bpf_map_type_;
 
   uint32_t loop_depth_ = 0;
   bool has_begin_probe_ = false;

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -84,6 +84,10 @@ public:
   {
     return visitAndReplace(&ofof.expr);
   }
+  R visit(MapDeclStatement &decl __attribute__((__unused__)))
+  {
+    return default_value();
+  }
   R visit(Map &map)
   {
     return visitAndReplace(&map.key_expr);
@@ -207,9 +211,11 @@ public:
   }
   R visit(Program &program)
   {
+    // This order is important
     visitImpl(program.functions);
-    visitImpl(program.probes);
     visitAndReplace(&program.config);
+    visitImpl(program.map_decls);
+    visitImpl(program.probes);
     return default_value();
   }
 

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <string_view>
 
 #include <bpf/libbpf.h>
 #include <linux/bpf.h>
+
+#include "types.h"
 
 namespace libbpf {
 #include "libbpf/bpf.h"
@@ -97,5 +100,15 @@ inline bool is_bpf_map_clearable(libbpf::bpf_map_type map_type)
   return map_type != libbpf::BPF_MAP_TYPE_ARRAY &&
          map_type != libbpf::BPF_MAP_TYPE_PERCPU_ARRAY;
 }
+
+libbpf::bpf_map_type get_bpf_map_type(const SizedType &val_type,
+                                      const SizedType &key_type);
+std::optional<libbpf::bpf_map_type> get_bpf_map_type(const std::string &name);
+std::string get_bpf_map_type_str(libbpf::bpf_map_type map_type);
+void add_bpf_map_types_hint(std::stringstream &hint);
+bool is_array_map(const SizedType &val_type, const SizedType &key_type);
+bool bpf_map_types_compatible(const SizedType &val_type,
+                              const SizedType &key_type,
+                              libbpf::bpf_map_type kind);
 
 } // namespace bpftrace

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -15,6 +15,7 @@ Config::Config(bool has_cmd)
     { ConfigKeyBool::lazy_symbolication, { .value = false } },
     { ConfigKeyBool::probe_inline, { .value = false } },
     { ConfigKeyBool::print_maps_on_exit, { .value = true } },
+    { ConfigKeyBool::unstable_map_decl, { .value = false } },
 #ifndef HAVE_BLAZESYM
     { ConfigKeyBool::use_blazesym, { .value = false } },
 #else

--- a/src/config.h
+++ b/src/config.h
@@ -27,6 +27,7 @@ enum class ConfigKeyBool {
   probe_inline,
   print_maps_on_exit,
   use_blazesym,
+  unstable_map_decl,
 };
 
 enum class ConfigKeyInt {
@@ -102,6 +103,7 @@ const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
   { "missing_probes", ConfigKeyMissingProbes::default_ },
   { "print_maps_on_exit", ConfigKeyBool::print_maps_on_exit },
   { "use_blazesym", ConfigKeyBool::use_blazesym },
+  { "unstable_map_decl", ConfigKeyBool::unstable_map_decl },
 };
 
 // These are not tracked by the config class

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -744,8 +744,12 @@ static ast::ASTContext buildListProgram(const std::string& search)
   auto ap = ast.make_node<ast::AttachPoint>(search, true, location());
   auto probe = ast.make_node<ast::Probe>(
       ast::AttachPointList({ ap }), nullptr, nullptr, location());
-  ast.root = ast.make_node<ast::Program>(
-      "", nullptr, ast::SubprogList(), ast::ProbeList({ probe }), location());
+  ast.root = ast.make_node<ast::Program>("",
+                                         nullptr,
+                                         ast::MapDeclList(),
+                                         ast::SubprogList(),
+                                         ast::ProbeList({ probe }),
+                                         location());
   return ast;
 }
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -219,7 +219,9 @@ std::string Output::get_helper_error_msg(int func_id, int retcode) const
 {
   std::string msg;
   if (func_id == libbpf::BPF_FUNC_map_update_elem && retcode == -E2BIG) {
-    msg = "Map full; can't update element. Try increasing max_map_keys config";
+    msg = "Map full; can't update element. Try increasing max_map_keys config "
+          "or manually setting the max entries in a map declaration e.g. `let "
+          "@a = hash(5000)`";
   } else if (func_id == libbpf::BPF_FUNC_map_delete_elem &&
              retcode == -ENOENT) {
     msg = "Can't delete map element because it does not exist.";

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <bpf/libbpf.h>
 #include <cstdint>
 #include <istream>
 #include <ostream>
@@ -14,6 +15,10 @@
 #include "format_string.h"
 #include "struct.h"
 #include "types.h"
+
+namespace libbpf {
+#include "libbpf/bpf.h"
+} // namespace libbpf
 
 namespace bpftrace {
 
@@ -83,13 +88,21 @@ struct MapInfo {
   std::optional<LinearHistogramArgs> lhist_args;
   std::optional<int> hist_bits_arg;
   int id = -1;
+  int max_entries = -1;
+  libbpf::bpf_map_type bpf_type = libbpf::BPF_MAP_TYPE_HASH;
 
 private:
   friend class cereal::access;
   template <typename Archive>
   void serialize(Archive &archive)
   {
-    archive(key_type, value_type, lhist_args, hist_bits_arg, id);
+    archive(key_type,
+            value_type,
+            lhist_args,
+            hist_bits_arg,
+            id,
+            max_entries,
+            bpf_type);
   }
 };
 

--- a/tests/codegen/llvm/map_hash.ll
+++ b/tests/codegen/llvm/map_hash.ll
@@ -1,0 +1,100 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_a = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !50 {
+entry:
+  %"@a_val" = alloca i64, align 8
+  %"@a_key" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
+  store i64 1, ptr %"@a_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
+  store i64 1, ptr %"@a_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %"@a_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 1, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 320, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 10, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
+!23 = !{!24, !29}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
+!27 = !{!28}
+!28 = !DISubrange(count: 27, lowerBound: 0)
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 262144, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
+!37 = !{!38, !43, !44, !19}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 2, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !45, size: 64, offset: 128)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !20, !34}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !55)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!18, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!54 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/map_lruhash.ll
+++ b/tests/codegen/llvm/map_lruhash.ll
@@ -1,0 +1,104 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_a = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !54 {
+entry:
+  %"@a_val" = alloca i64, align 8
+  %"@a_key" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
+  store i64 1, ptr %"@a_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
+  store i64 1, ptr %"@a_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %"@a_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 288, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 9, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 320, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 10, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
+!23 = !{!24, !29}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
+!27 = !{!28}
+!28 = !DISubrange(count: 27, lowerBound: 0)
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 262144, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
+!37 = !{!38, !43, !48, !19}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 2, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 1, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !20, !34}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !59)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!18, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !58, size: 64)
+!58 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!59 = !{!60}
+!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/codegen/llvm/map_percpuarray.ll
+++ b/tests/codegen/llvm/map_percpuarray.ll
@@ -1,0 +1,118 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_a = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !50 {
+entry:
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@a_key" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
+  store i64 0, ptr %"@a_key", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_a, ptr %"@a_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %1 = load i64, ptr %lookup_elem, align 8
+  %2 = add i64 %1, 1
+  store i64 %2, ptr %lookup_elem, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
+  store i64 1, ptr %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %initial_value, i64 1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 192, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 6, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 1, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
+!21 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
+!25 = !{!26, !31}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !29)
+!29 = !{!30}
+!30 = !DISubrange(count: 27, lowerBound: 0)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 262144, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !11, !16, !19}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 2, lowerBound: 0)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !21, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !22, !36, !45}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !55)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!21, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!54 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/map_percpuhash.ll
+++ b/tests/codegen/llvm/map_percpuhash.ll
@@ -1,0 +1,124 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_a = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !20
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !34
+@num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !51
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !56 {
+entry:
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@a_key" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
+  store i64 1, ptr %"@a_key", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_a, ptr %"@a_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %1 = load i64, ptr %lookup_elem, align 8
+  %2 = add i64 %1, 1
+  store i64 %2, ptr %lookup_elem, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
+  store i64 1, ptr %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %initial_value, i64 1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!55}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !16, !19}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 160, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 5, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 320, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 10, lowerBound: 0)
+!16 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !17, size: 64, offset: 128)
+!17 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
+!18 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!19 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !17, size: 64, offset: 192)
+!20 = !DIGlobalVariableExpression(var: !21, expr: !DIExpression())
+!21 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!22 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !23)
+!23 = !{!24, !29}
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !25, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !27)
+!27 = !{!28}
+!28 = !DISubrange(count: 27, lowerBound: 0)
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !30, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 262144, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !37)
+!37 = !{!38, !43, !48, !19}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 2, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 1, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !49, size: 64, offset: 128)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
+!52 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
+!54 = !{!0, !20, !34, !51}
+!55 = !{i32 2, !"Debug Info Version", i32 3}
+!56 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !61)
+!57 = !DISubroutineType(types: !58)
+!58 = !{!18, !59}
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
+!60 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!61 = !{!62}
+!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)

--- a/tests/codegen/llvm/map_percpulruhash.ll
+++ b/tests/codegen/llvm/map_percpulruhash.ll
@@ -1,0 +1,120 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@AT_a = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !30
+@num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !47
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !52 {
+entry:
+  %initial_value = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@a_key" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
+  store i64 1, ptr %"@a_key", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_a, ptr %"@a_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %1 = load i64, ptr %lookup_elem, align 8
+  %2 = add i64 %1, 1
+  store i64 %2, ptr %lookup_elem, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
+  store i64 1, ptr %initial_value, align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %initial_value, i64 1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!49}
+!llvm.module.flags = !{!51}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !4)
+!4 = !{!5, !11, !12, !15}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 320, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 10, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !6, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !13, size: 64, offset: 128)
+!13 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !14, size: 64)
+!14 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!15 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !13, size: 64, offset: 192)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !19)
+!19 = !{!20, !25}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 27, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 262144, lowerBound: 0)
+!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
+!31 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !33)
+!33 = !{!34, !39, !44, !15}
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !35, size: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 2, lowerBound: 0)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !40, size: 64, offset: 64)
+!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !42)
+!42 = !{!43}
+!43 = !DISubrange(count: 1, lowerBound: 0)
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !45, size: 64, offset: 128)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
+!48 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !14, isLocal: false, isDefinition: true)
+!49 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !50)
+!50 = !{!0, !16, !30, !47}
+!51 = !{i32 2, !"Debug Info Version", i32 3}
+!52 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !53, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !49, retainedNodes: !57)
+!53 = !DISubroutineType(types: !54)
+!54 = !{!14, !55}
+!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
+!56 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!57 = !{!58}
+!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !55)

--- a/tests/codegen/llvm/map_unused.ll
+++ b/tests/codegen/llvm/map_unused.ll
@@ -1,0 +1,71 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license"
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
+@event_loss_counter = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !16
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !39 {
+entry:
+  ret i64 0
+}
+
+attributes #0 = { nounwind }
+
+!llvm.dbg.cu = !{!36}
+!llvm.module.flags = !{!38}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !4)
+!4 = !{!5, !11}
+!5 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !6, size: 64)
+!6 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !7, size: 64)
+!7 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 864, elements: !9)
+!8 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!9 = !{!10}
+!10 = !DISubrange(count: 27, lowerBound: 0)
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 8388608, elements: !14)
+!14 = !{!15}
+!15 = !DISubrange(count: 262144, lowerBound: 0)
+!16 = !DIGlobalVariableExpression(var: !17, expr: !DIExpression())
+!17 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !18, isLocal: false, isDefinition: true)
+!18 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !19)
+!19 = !{!20, !25, !30, !33}
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !21, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 64, elements: !23)
+!23 = !{!24}
+!24 = !DISubrange(count: 2, lowerBound: 0)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !26, size: 64, offset: 64)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !8, size: 32, elements: !28)
+!28 = !{!29}
+!29 = !DISubrange(count: 1, lowerBound: 0)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!36 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !37)
+!37 = !{!0, !16}
+!38 = !{i32 2, !"Debug Info Version", i32 3}
+!39 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !40, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !36, retainedNodes: !44)
+!40 = !DISubroutineType(types: !41)
+!41 = !{!35, !42}
+!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
+!43 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!44 = !{!45}
+!45 = !DILocalVariable(name: "ctx", arg: 1, scope: !39, file: !2, type: !42)

--- a/tests/codegen/map_declarations.cpp
+++ b/tests/codegen/map_declarations.cpp
@@ -1,0 +1,64 @@
+#include "common.h"
+
+namespace bpftrace::test::codegen {
+
+TEST(codegen, map_hash)
+{
+  auto bpftrace = get_mock_bpftrace();
+  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
+  configs.set(ConfigKeyBool::unstable_map_decl, true);
+
+  test(*bpftrace, R"(let @a = hash(10); BEGIN { @a[1] = 1; })", NAME);
+}
+
+TEST(codegen, map_lruhash)
+{
+  auto bpftrace = get_mock_bpftrace();
+  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
+  configs.set(ConfigKeyBool::unstable_map_decl, true);
+
+  test(*bpftrace, R"(let @a = lruhash(10); BEGIN { @a[1] = 1; })", NAME);
+}
+
+TEST(codegen, map_percpuhash)
+{
+  auto bpftrace = get_mock_bpftrace();
+  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
+  configs.set(ConfigKeyBool::unstable_map_decl, true);
+
+  test(*bpftrace,
+       R"(let @a = percpuhash(10); BEGIN { @a[1] = count(); })",
+       NAME);
+}
+
+TEST(codegen, map_percpulruhash)
+{
+  auto bpftrace = get_mock_bpftrace();
+  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
+  configs.set(ConfigKeyBool::unstable_map_decl, true);
+
+  test(*bpftrace,
+       R"(let @a = percpulruhash(10); BEGIN { @a[1] = count(); })",
+       NAME);
+}
+
+TEST(codegen, map_percpuarray)
+{
+  auto bpftrace = get_mock_bpftrace();
+  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
+  configs.set(ConfigKeyBool::unstable_map_decl, true);
+
+  test(*bpftrace, R"(let @a = percpuarray(1); BEGIN { @a = count(); })", NAME);
+}
+
+// Make sure it doesn't make it to codegen
+TEST(codegen, map_unused)
+{
+  auto bpftrace = get_mock_bpftrace();
+  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
+  configs.set(ConfigKeyBool::unstable_map_decl, true);
+
+  test(*bpftrace, R"(let @a = hash(1); BEGIN { 1 })", NAME);
+}
+
+} // namespace bpftrace::test::codegen

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2958,4 +2958,40 @@ Program
 )");
 }
 
+TEST(Parser, map_declarations)
+{
+  test("let @a = hash(5); BEGIN { $x; }", R"(
+Program
+ map decl: @a
+  bpf type: hash
+  max entries: 5
+ BEGIN
+  variable: $x
+)");
+
+  test("let @a = hash(2); let @b = percpuhash(7); BEGIN { $x; }", R"(
+Program
+ map decl: @a
+  bpf type: hash
+  max entries: 2
+ map decl: @b
+  bpf type: percpuhash
+  max entries: 7
+ BEGIN
+  variable: $x
+)");
+
+  test_parse_failure("@a = hash(); BEGIN { $x; }", R"(
+stdin:1:1-3: ERROR: syntax error, unexpected map, expecting {
+@a = hash(); BEGIN { $x; }
+~~
+)");
+
+  test_parse_failure("let @a = hash(); BEGIN { $x; }", R"(
+stdin:1:10-16: ERROR: syntax error, unexpected ), expecting integer
+let @a = hash(); BEGIN { $x; }
+         ~~~~~~
+)");
+}
+
 } // namespace bpftrace::test::parser

--- a/tests/runtime/map
+++ b/tests/runtime/map
@@ -1,0 +1,19 @@
+NAME map declaration lruhash
+PROG config = { unstable_map_decl=1 } let @a = lruhash(1); BEGIN { @a[1] = 1; @a[2] = 2; exit(); }
+EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
+EXPECT @a[2]: 2
+
+NAME map declaration hash
+PROG config = { unstable_map_decl=1 } let @a = hash(1); BEGIN { @a[1] = 1; @a[2] = 2; exit(); }
+EXPECT_REGEX .*WARNING: Map full; can't update element.*
+EXPECT @a[1]: 1
+
+NAME map declaration percpuhash
+PROG config = { unstable_map_decl=1 } let @a = percpuhash(1); BEGIN { @a[1] = count(); @a[2] = count(); exit(); }
+EXPECT_REGEX .*WARNING: Map full; can't update element.*
+EXPECT @a[1]: 1
+
+NAME map declaration percpulruhash
+PROG config = { unstable_map_decl=1 } let @a = percpulruhash(1); BEGIN { @a[1] = count(); @a[2] = count(); exit(); }
+EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
+EXPECT @a[2]: 1


### PR DESCRIPTION
This gives users the ability to both
specify a BPF map type and the
number of max entries.

Example:
```
let @a = hash(10);
let @b = lruhash(100);

BEGIN {
  @a[1] = "hi";
  @b[1] = "bye";
}
```

The available BPF map types:
- BPF_MAP_TYPE_HASH
- BPF_MAP_TYPE_LRU_HASH
- BPF_MAP_TYPE_PERCPU_HASH
- BPF_MAP_TYPE_PERCPU_ARRAY
- BPF_MAP_TYPE_LRU_PERCPU_HASH


##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
