### PR TITLE
Add basic `mergeable` workflow

### DIFF
--- a/.github/workflows/mergeable.yml
+++ b/.github/workflows/mergeable.yml
@@ -1,0 +1,15 @@
+name: Mergeable
+
+on: [pull_request]
+
+jobs:
+  # This checks if the PR is towards a user branch. All other branches are
+  # allowed, but the user should push manually in this case.
+  user:
+    name: User branch check
+    runs-on: ubuntu-latest
+    steps:
+    - if: startsWith(github.base_ref, 'user/')
+      run: |
+        echo "### user/ branch found; do not merge :no_entry_sign:" >> $GITHUB_STEP_SUMMARY
+        exit 1


### PR DESCRIPTION
This currently contains a check to ensure that the base branch is not a `user/` branch. This should provide a simple gate against accidents. The check can be expanded in the future if needed.
