### PR TITLE
ast: use new PassManager when possible

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -780,4 +780,12 @@ AttachPointParser::State AttachPointParser::raw_tracepoint_parser()
   return OK;
 }
 
+Pass CreateParseAttachpointsPass()
+{
+  return Pass::create("attachpoints", [](ASTContext &ast, BPFtrace &b) {
+    AttachPointParser ap_parser(ast, b, false);
+    ap_parser.parse();
+  });
+}
+
 } // namespace bpftrace::ast

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "ast/ast.h"
+#include "ast/pass_manager.h"
 #include "bpftrace.h"
 
 namespace bpftrace::ast {
@@ -60,5 +61,8 @@ private:
   AttachPointList new_attach_points;
   bool listing_;
 };
+
+// The attachpoints are expanded in their own separate pass.
+Pass CreateParseAttachpointsPass();
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "ast/attachpoint_parser.h"
+#include "ast/pass_manager.h"
+#include "ast/passes/field_analyser.h"
+#include "btf.h"
+#include "clang_parser.h"
+#include "driver.h"
+#include "tracepoint_format_parser.h"
+
+namespace bpftrace::ast {
+
+// AllParsePasses returns a `MultiPass` representing all parser passes, in
+// the expected order. This should be used unless there's a reason not to.
+inline std::vector<Pass> AllParsePasses(
+    std::vector<std::string> &&extra_flags = {})
+{
+  std::vector<Pass> passes;
+  passes.emplace_back(CreateParsePass());
+  passes.emplace_back(CreateParseAttachpointsPass());
+  passes.emplace_back(CreateParseBTFPass());
+  passes.emplace_back(CreateParseTracepointFormatPass());
+  passes.emplace_back(CreateFieldAnalyserPass());
+  passes.emplace_back(CreateClangPass(std::move(extra_flags)));
+  // The source and syntax is reparsed because it uses the `macros_` which are
+  // set during the clang parse to expand identifiers within the lexer.
+  passes.emplace_back(CreateParsePass());
+  passes.emplace_back(CreateParseAttachpointsPass());
+  passes.emplace_back(CreateParseBTFPass());
+  return passes;
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -4002,10 +4002,11 @@ void SemanticAnalyser::resolve_struct_type(SizedType &type, Node &node)
   }
 }
 
-Pass CreateSemanticPass()
+Pass CreateSemanticPass(bool listing)
 {
-  auto fn = [](ASTContext &ast, BPFtrace &b) {
-    SemanticAnalyser semantics(ast, b, !b.cmd_.empty());
+  auto fn = [listing](ASTContext &ast, BPFtrace &b) {
+    SemanticAnalyser semantics(
+        ast, b, !b.cmd_.empty() || b.child_ != nullptr, listing);
     semantics.analyse();
   };
 

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -188,6 +188,6 @@ private:
   bool has_pos_param_ = false;
 };
 
-Pass CreateSemanticPass();
+Pass CreateSemanticPass(bool listing = false);
 
 } // namespace bpftrace::ast

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -1,10 +1,3 @@
-#include "btf.h"
-#include "arch/arch.h"
-#include "bpftrace.h"
-#include "log.h"
-#include "probe_matcher.h"
-#include "tracefs/tracefs.h"
-#include "types.h"
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
@@ -28,7 +21,15 @@
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 
+#include "arch/arch.h"
+#include "ast/context.h"
+#include "ast/pass_manager.h"
 #include "bpftrace.h"
+#include "btf.h"
+#include "log.h"
+#include "probe_matcher.h"
+#include "tracefs/tracefs.h"
+#include "types.h"
 
 namespace bpftrace {
 
@@ -885,6 +886,14 @@ SizedType BTF::get_var_type(const std::string &var_name)
     return CreateNone();
 
   return get_stype(BTFId{ .btf = var_id.btf, .id = t->type });
+}
+
+ast::Pass CreateParseBTFPass()
+{
+  return ast::Pass::create(
+      "btf", []([[maybe_unused]] ast::ASTContext &ast, BPFtrace &b) {
+        b.parse_btf(b.list_modules(ast));
+      });
 }
 
 } // namespace bpftrace

--- a/src/btf.h
+++ b/src/btf.h
@@ -11,6 +11,8 @@
 #include <unistd.h>
 #include <unordered_set>
 
+#include "ast/pass_manager.h"
+
 // Taken from libbpf
 #define BTF_INFO_ENC(kind, kind_flag, vlen)                                    \
   ((!!(kind_flag) << 31) | ((kind) << 24) | ((vlen) & BTF_MAX_VLEN))
@@ -123,5 +125,7 @@ inline bool BTF::has_data() const
 {
   return state == OK;
 }
+
+ast::Pass CreateParseBTFPass();
 
 } // namespace bpftrace

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -1,15 +1,26 @@
 #pragma once
 
+#include <clang-c/Index.h>
 #include <unordered_set>
 
+#include "ast/pass_manager.h"
 #include "bpftrace.h"
-#include <clang-c/Index.h>
+#include "util/result.h"
 
 namespace bpftrace {
 
 namespace ast {
 class Program;
 }
+
+class ClangParseError : public ErrorInfo<ClangParseError> {
+public:
+  static char ID;
+  void log(llvm::raw_ostream &OS) const override
+  {
+    OS << "Clang parse error";
+  }
+};
 
 class ClangParser {
 public:
@@ -93,5 +104,7 @@ private:
     std::vector<std::string> error_msgs;
   };
 };
+
+ast::Pass CreateClangPass(std::vector<std::string> &&extra_flags = {});
 
 } // namespace bpftrace

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -25,21 +25,6 @@ void Driver::parse()
   yy_scan_string(ctx.source_->contents.c_str(), scanner);
   parser.parse();
   yylex_destroy(scanner);
-
-  // Before proceeding, ensure that the size of the AST isn't past prescribed
-  // limits. This functionality goes back to 80642a994, where it was added in
-  // order to prevent stack overflow during fuzzing. It traveled through the
-  // passes and visitor pattern, and this is a final return to the simplest
-  // possible form. It is not necessary to walk the full AST in order to
-  // determine the number of nodes. This can be done before any passes.
-  if (ctx.diagnostics().ok()) {
-    auto node_count = ctx.node_count();
-    if (node_count > bpftrace.max_ast_nodes_) {
-      ctx.root->addError() << "node count (" << node_count
-                           << ") exceeds the limit (" << bpftrace.max_ast_nodes_
-                           << ")";
-    }
-  }
 }
 
 void Driver::error(const location &l, const std::string &m)
@@ -47,6 +32,30 @@ void Driver::error(const location &l, const std::string &m)
   // This path is normally not allowed, however we don't yet have nodes
   // constructed. Therefore, we add diagnostics directly via the private field.
   ctx.diagnostics_->addError(ctx.wrap(l)) << m;
+}
+
+ast::Pass CreateParsePass(bool debug)
+{
+  return ast::Pass::create("parse", [debug](ast::ASTContext &ast, BPFtrace &b) {
+    Driver driver(ast, b, debug);
+    driver.parse();
+
+    // Before proceeding, ensure that the size of the AST isn't past prescribed
+    // limits. This functionality goes back to 80642a994, where it was added in
+    // order to prevent stack overflow during fuzzing. It traveled through the
+    // passes and visitor pattern, and this is a final return to the simplest
+    // possible form. It is not necessary to walk the full AST in order to
+    // determine the number of nodes. This can be done before any passes.
+    if (ast.diagnostics().ok()) {
+      assert(ast.root != nullptr);
+      auto node_count = ast.node_count();
+      if (node_count > b.max_ast_nodes_) {
+        ast.root->addError()
+            << "node count (" << node_count << ") exceeds the limit ("
+            << b.max_ast_nodes_ << ")";
+      }
+    }
+  });
 }
 
 } // namespace bpftrace

--- a/src/driver.h
+++ b/src/driver.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ast/context.h"
+#include "ast/pass_manager.h"
 #include "bpftrace.h"
 
 using yyscan_t = void *;
@@ -25,5 +26,7 @@ public:
   BPFtrace &bpftrace;
   const bool debug;
 };
+
+ast::Pass CreateParsePass(bool debug = false);
 
 } // namespace bpftrace

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -270,4 +270,11 @@ std::string TracepointFormatParser::get_tracepoint_struct(
   return format_struct;
 }
 
+ast::Pass CreateParseTracepointFormatPass()
+{
+  return ast::Pass::create("tracepoint", [](ast::ASTContext &ast, BPFtrace &b) {
+    TracepointFormatParser::parse(ast, b);
+  });
+}
+
 } // namespace bpftrace

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -3,6 +3,7 @@
 #include <istream>
 #include <set>
 
+#include "ast/pass_manager.h"
 #include "ast/visitor.h"
 #include "bpftrace.h"
 
@@ -63,5 +64,7 @@ protected:
                                            const std::string &event_name,
                                            BPFtrace &bpftrace);
 };
+
+ast::Pass CreateParseTracepointFormatPass();
 
 } // namespace bpftrace

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -22,32 +22,14 @@ kprobe:f {
   @z = ustack(6)
 })");
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(ast, *bpftrace);
-
-  driver.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ast::AttachPointParser ap_parser(ast, *bpftrace, false);
-  ap_parser.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ClangParser clang;
-  clang.parse(ast.root, *bpftrace);
-
-  driver.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ap_parser.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ast::SemanticAnalyser semantics(ast, *bpftrace);
-  semantics.analyse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ast::ResourceAnalyser resource_analyser(*bpftrace);
-  resource_analyser.visit(ast.root);
-  bpftrace->resources = resource_analyser.resources();
-  ASSERT_TRUE(ast.diagnostics().ok());
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put<BPFtrace>(*bpftrace)
+                .add(ast::AllParsePasses())
+                .add(ast::CreateSemanticPass())
+                .add(ast::CreateResourcePass())
+                .run();
+  ASSERT_TRUE(ok && ast.diagnostics().ok());
 
   ast::CodegenLLVM codegen(ast, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();
@@ -72,32 +54,14 @@ kprobe:f {
   @z = ustack()
 })");
   auto bpftrace = get_mock_bpftrace();
-  Driver driver(ast, *bpftrace);
-
-  driver.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ast::AttachPointParser ap_parser(ast, *bpftrace, false);
-  ap_parser.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ClangParser clang;
-  clang.parse(ast.root, *bpftrace);
-
-  driver.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ap_parser.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ast::SemanticAnalyser semantics(ast, *bpftrace);
-  semantics.analyse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ast::ResourceAnalyser resource_analyser(*bpftrace);
-  resource_analyser.visit(ast.root);
-  bpftrace->resources = resource_analyser.resources();
-  ASSERT_TRUE(ast.diagnostics().ok());
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put<BPFtrace>(*bpftrace)
+                .add(ast::AllParsePasses())
+                .add(ast::CreateSemanticPass())
+                .add(ast::CreateResourcePass())
+                .run();
+  ASSERT_TRUE(ok && ast.diagnostics().ok());
 
   ast::CodegenLLVM codegen(ast, *bpftrace);
   bpftrace->bytecode_ = codegen.compile();

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -1,9 +1,6 @@
 #include "ast/passes/config_analyser.h"
+#include "ast/passes/parser.h"
 #include "ast/passes/semantic_analyser.h"
-
-#include "ast/attachpoint_parser.h"
-#include "clang_parser.h"
-#include "driver.h"
 #include "mocks.h"
 #include "gtest/gtest.h"
 
@@ -17,32 +14,18 @@ void test(BPFtrace &bpftrace,
           bool expected_result)
 {
   ast::ASTContext ast("stdin", input);
-  Driver driver(ast, bpftrace);
   std::stringstream msg;
   msg << "\nInput:\n" << input << "\n\nOutput:\n";
 
-  driver.parse();
-  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
-
-  ast::AttachPointParser ap_parser(ast, bpftrace, false);
-  ap_parser.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ClangParser clang;
-  ASSERT_TRUE(clang.parse(ast.root, bpftrace));
-
-  driver.parse();
-  ASSERT_TRUE(ast.diagnostics().ok()) << msg.str();
-
-  ap_parser.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
-
-  ast::SemanticAnalyser semantics(ast, bpftrace, false);
-  semantics.analyse();
-
-  ast::ConfigAnalyser config_analyser(bpftrace);
-  config_analyser.visit(ast.root);
-  ASSERT_EQ(ast.diagnostics().ok(), expected_result) << msg.str();
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put(bpftrace)
+                .add(ast::AllParsePasses())
+                .add(ast::CreateSemanticPass())
+                .add(ast::CreateConfigPass())
+                .run();
+  ASSERT_TRUE(bool(ok)) << msg.str();
+  EXPECT_EQ(ast.diagnostics().ok(), expected_result) << msg.str();
 
   if (expected_error.data()) {
     if (!expected_error.empty() && expected_error[0] == '\n')


### PR DESCRIPTION
Stacked PRs:
 * #3888
 * #3885
 * __->__#3869


--- --- ---

### ast: use new PassManager when possible


This change introduces trivial pass wrappers for the `Driver`,
`TracepointFormatParser`, `AttachpointParser` and `BTF` parser. These
are then collected into a function `AllParsePasses` which has a
canonical order for these passes used by `main`.

The passes are then used across the board by the various tests and
`main` itself, in order to take the first step towards standardizing
this plumbing.

Signed-off-by: Adin Scannell <amscanne@meta.com>
