### PR TITLE
Fix size mismatch for `stack_key`s

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -161,12 +161,14 @@ StructType *IRBuilderBPF::GetStackStructType(bool is_ustack)
       getInt32Ty(), // nr_stack_frames
       getInt32Ty(), // pid
       getInt32Ty(), // probe id
+      getInt32Ty(), // __padding, see #3870
     };
     return GetStructType("ustack_key", elements, false);
   } else {
     std::vector<llvm::Type *> elements{
       getInt64Ty(), // stack id
       getInt32Ty(), // nr_stack_frames
+      getInt32Ty(), // __padding, see #3870
     };
     return GetStructType("kstack_key", elements, false);
   }

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -177,14 +177,9 @@ ScopedExpr CodegenLLVM::kstack_ustack(const std::string &ident,
 
   StructType *stack_key_struct = b_.GetStackStructType(is_ustack);
   AllocaInst *stack_key = b_.CreateAllocaBPF(stack_key_struct, "stack_key");
-  b_.CreateStore(b_.getInt64(0),
-                 b_.CreateGEP(stack_key_struct,
-                              stack_key,
-                              { b_.getInt64(0), b_.getInt32(0) }));
-  b_.CreateStore(b_.getInt32(0),
-                 b_.CreateGEP(stack_key_struct,
-                              stack_key,
-                              { b_.getInt64(0), b_.getInt32(1) }));
+  b_.CreateMemsetBPF(stack_key,
+                     b_.getInt8(0),
+                     datalayout().getTypeStoreSize(stack_key_struct));
 
   llvm::Function *parent = b_.GetInsertBlock()->getParent();
   BasicBlock *stack_scratch_failure = BasicBlock::Create(

--- a/tests/codegen/llvm/builtin_kstack.ll
+++ b/tests/codegen/llvm/builtin_kstack.ll
@@ -8,7 +8,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr }
 %"struct map_t.3" = type { ptr, ptr, ptr, ptr }
-%kstack_key = type { i64, i32 }
+%kstack_key = type { i64, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -26,10 +26,7 @@ entry:
   %lookup_stack_scratch_key = alloca i32, align 4
   %stack_key = alloca %kstack_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
-  %1 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
-  store i64 0, ptr %1, align 8
-  %2 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
-  store i32 0, ptr %2, align 4
+  call void @llvm.memset.p0.i64(ptr align 1 %stack_key, i8 0, i64 16, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
   store i32 0, ptr %lookup_stack_scratch_key, align 4
   %lookup_stack_scratch_map = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key)
@@ -53,17 +50,17 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
   %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 0)
-  %3 = icmp sge i32 %get_stack, 0
-  br i1 %3, label %get_stack_success, label %get_stack_fail
+  %1 = icmp sge i32 %get_stack, 0
+  br i1 %1, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %4 = udiv i32 %get_stack, 8
-  %5 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
-  store i32 %4, ptr %5, align 4
-  %6 = trunc i32 %4 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %6, i64 1)
-  %7 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %7, align 8
+  %2 = udiv i32 %get_stack, 8
+  %3 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %2, ptr %3, align 4
+  %4 = trunc i32 %2 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %4, i64 1)
+  %5 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %5, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -154,9 +151,13 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
+
 attributes #0 = { nounwind }
 attributes #1 = { alwaysinline }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
 !llvm.dbg.cu = !{!81}
 !llvm.module.flags = !{!83}

--- a/tests/codegen/llvm/call_kstack.ll
+++ b/tests/codegen/llvm/call_kstack.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.5" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.6" = type { ptr, ptr }
 %"struct map_t.7" = type { ptr, ptr, ptr, ptr }
-%kstack_key = type { i64, i32 }
+%kstack_key = type { i64, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -40,10 +40,7 @@ entry:
   %lookup_stack_scratch_key = alloca i32, align 4
   %stack_key = alloca %kstack_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
-  %1 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
-  store i64 0, ptr %1, align 8
-  %2 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
-  store i32 0, ptr %2, align 4
+  call void @llvm.memset.p0.i64(ptr align 1 %stack_key, i8 0, i64 16, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
   store i32 0, ptr %lookup_stack_scratch_key, align 4
   %lookup_stack_scratch_map = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key)
@@ -60,10 +57,7 @@ merge_block:                                      ; preds = %stack_scratch_failu
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %stack_key, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key2)
-  %3 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 0, ptr %3, align 8
-  %4 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 0, ptr %4, align 4
+  call void @llvm.memset.p0.i64(ptr align 1 %stack_key2, i8 0, i64 16, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key5)
   store i32 0, ptr %lookup_stack_scratch_key5, align 4
   %lookup_stack_scratch_map6 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key5)
@@ -77,17 +71,17 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
   %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 0)
-  %5 = icmp sge i32 %get_stack, 0
-  br i1 %5, label %get_stack_success, label %get_stack_fail
+  %1 = icmp sge i32 %get_stack, 0
+  br i1 %1, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %6 = udiv i32 %get_stack, 8
-  %7 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
-  store i32 %6, ptr %7, align 4
-  %8 = trunc i32 %6 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %8, i64 1)
-  %9 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %9, align 8
+  %2 = udiv i32 %get_stack, 8
+  %3 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %2, ptr %3, align 4
+  %4 = trunc i32 %2 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %4, i64 1)
+  %5 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %5, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -103,10 +97,7 @@ merge_block4:                                     ; preds = %stack_scratch_failu
   %update_elem15 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %stack_key2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key16)
-  %10 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 0
-  store i64 0, ptr %10, align 8
-  %11 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 1
-  store i32 0, ptr %11, align 4
+  call void @llvm.memset.p0.i64(ptr align 1 %stack_key16, i8 0, i64 16, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key19)
   store i32 0, ptr %lookup_stack_scratch_key19, align 4
   %lookup_stack_scratch_map20 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key19)
@@ -120,17 +111,17 @@ lookup_stack_scratch_failure7:                    ; preds = %merge_block
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
   call void @llvm.memset.p0.i64(ptr align 1 %lookup_stack_scratch_map6, i8 0, i64 48, i1 false)
   %get_stack12 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 48, i64 0)
-  %12 = icmp sge i32 %get_stack12, 0
-  br i1 %12, label %get_stack_success10, label %get_stack_fail11
+  %6 = icmp sge i32 %get_stack12, 0
+  br i1 %6, label %get_stack_success10, label %get_stack_fail11
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
-  %13 = udiv i32 %get_stack12, 8
-  %14 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 %13, ptr %14, align 4
-  %15 = trunc i32 %13 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %15, i64 1)
-  %16 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_213, ptr %16, align 8
+  %7 = udiv i32 %get_stack12, 8
+  %8 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 %7, ptr %8, align 4
+  %9 = trunc i32 %7 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %9, i64 1)
+  %10 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, ptr %10, align 8
   %update_elem14 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_6, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
@@ -153,17 +144,17 @@ lookup_stack_scratch_failure21:                   ; preds = %merge_block4
 lookup_stack_scratch_merge22:                     ; preds = %merge_block4
   %probe_read_kernel24 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map20, i32 1016, ptr null)
   %get_stack27 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map20, i32 1016, i64 0)
-  %17 = icmp sge i32 %get_stack27, 0
-  br i1 %17, label %get_stack_success25, label %get_stack_fail26
+  %11 = icmp sge i32 %get_stack27, 0
+  br i1 %11, label %get_stack_success25, label %get_stack_fail26
 
 get_stack_success25:                              ; preds = %lookup_stack_scratch_merge22
-  %18 = udiv i32 %get_stack27, 8
-  %19 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 1
-  store i32 %18, ptr %19, align 4
-  %20 = trunc i32 %18 to i8
-  %murmur_hash_228 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map20, i8 %20, i64 1)
-  %21 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 0
-  store i64 %murmur_hash_228, ptr %21, align 8
+  %12 = udiv i32 %get_stack27, 8
+  %13 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 1
+  store i32 %12, ptr %13, align 4
+  %14 = trunc i32 %12 to i8
+  %murmur_hash_228 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map20, i8 %14, i64 1)
+  %15 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 0
+  store i64 %murmur_hash_228, ptr %15, align 8
   %update_elem29 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_perf_127, ptr %stack_key16, ptr %lookup_stack_scratch_map20, i64 0)
   br label %merge_block18
 

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -12,7 +12,7 @@ target triple = "bpf-pc-linux"
 %"struct map_t.5" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.6" = type { ptr, ptr }
 %"struct map_t.7" = type { ptr, ptr, ptr, ptr }
-%ustack_key = type { i64, i32, i32, i32 }
+%ustack_key = type { i64, i32, i32, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license"
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !0
@@ -40,10 +40,7 @@ entry:
   %lookup_stack_scratch_key = alloca i32, align 4
   %stack_key = alloca %ustack_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
-  %1 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
-  store i64 0, ptr %1, align 8
-  %2 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
-  store i32 0, ptr %2, align 4
+  call void @llvm.memset.p0.i64(ptr align 1 %stack_key, i8 0, i64 24, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key)
   store i32 0, ptr %lookup_stack_scratch_key, align 4
   %lookup_stack_scratch_map = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key)
@@ -55,22 +52,19 @@ stack_scratch_failure:                            ; preds = %lookup_stack_scratc
   br label %merge_block
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
-  %3 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 2
+  %1 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 2
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
-  %4 = lshr i64 %get_pid_tgid, 32
-  %pid = trunc i64 %4 to i32
-  store i32 %pid, ptr %3, align 4
-  %5 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 3
-  store i32 0, ptr %5, align 4
+  %2 = lshr i64 %get_pid_tgid, 32
+  %pid = trunc i64 %2 to i32
+  store i32 %pid, ptr %1, align 4
+  %3 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 3
+  store i32 0, ptr %3, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %stack_key, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key2)
-  %6 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 0, ptr %6, align 8
-  %7 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 0, ptr %7, align 4
+  call void @llvm.memset.p0.i64(ptr align 1 %stack_key2, i8 0, i64 24, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key5)
   store i32 0, ptr %lookup_stack_scratch_key5, align 4
   %lookup_stack_scratch_map6 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key5)
@@ -84,17 +78,17 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
   %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %8 = icmp sge i32 %get_stack, 0
-  br i1 %8, label %get_stack_success, label %get_stack_fail
+  %4 = icmp sge i32 %get_stack, 0
+  br i1 %4, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %9 = udiv i32 %get_stack, 8
-  %10 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
-  store i32 %9, ptr %10, align 4
-  %11 = trunc i32 %9 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %11, i64 1)
-  %12 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %12, align 8
+  %5 = udiv i32 %get_stack, 8
+  %6 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
+  store i32 %5, ptr %6, align 4
+  %7 = trunc i32 %5 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %7, i64 1)
+  %8 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %8, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -105,22 +99,19 @@ stack_scratch_failure3:                           ; preds = %lookup_stack_scratc
   br label %merge_block4
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
-  %13 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 2
+  %9 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 2
   %get_pid_tgid15 = call i64 inttoptr (i64 14 to ptr)()
-  %14 = lshr i64 %get_pid_tgid15, 32
-  %pid16 = trunc i64 %14 to i32
-  store i32 %pid16, ptr %13, align 4
-  %15 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 3
-  store i32 0, ptr %15, align 4
+  %10 = lshr i64 %get_pid_tgid15, 32
+  %pid16 = trunc i64 %10 to i32
+  store i32 %pid16, ptr %9, align 4
+  %11 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 3
+  store i32 0, ptr %11, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   %update_elem17 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %stack_key2, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key18)
-  %16 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 0
-  store i64 0, ptr %16, align 8
-  %17 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 1
-  store i32 0, ptr %17, align 4
+  call void @llvm.memset.p0.i64(ptr align 1 %stack_key18, i8 0, i64 24, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_stack_scratch_key21)
   store i32 0, ptr %lookup_stack_scratch_key21, align 4
   %lookup_stack_scratch_map22 = call ptr inttoptr (i64 1 to ptr)(ptr @stack_scratch, ptr %lookup_stack_scratch_key21)
@@ -134,17 +125,17 @@ lookup_stack_scratch_failure7:                    ; preds = %merge_block
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
   call void @llvm.memset.p0.i64(ptr align 1 %lookup_stack_scratch_map6, i8 0, i64 48, i1 false)
   %get_stack12 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 48, i64 256)
-  %18 = icmp sge i32 %get_stack12, 0
-  br i1 %18, label %get_stack_success10, label %get_stack_fail11
+  %12 = icmp sge i32 %get_stack12, 0
+  br i1 %12, label %get_stack_success10, label %get_stack_fail11
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
-  %19 = udiv i32 %get_stack12, 8
-  %20 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 1
-  store i32 %19, ptr %20, align 4
-  %21 = trunc i32 %19 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %21, i64 1)
-  %22 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_213, ptr %22, align 8
+  %13 = udiv i32 %get_stack12, 8
+  %14 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 1
+  store i32 %13, ptr %14, align 4
+  %15 = trunc i32 %13 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %15, i64 1)
+  %16 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, ptr %16, align 8
   %update_elem14 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_6, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
@@ -155,13 +146,13 @@ stack_scratch_failure19:                          ; preds = %lookup_stack_scratc
   br label %merge_block20
 
 merge_block20:                                    ; preds = %stack_scratch_failure19, %get_stack_success27, %get_stack_fail28
-  %23 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 2
+  %17 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 2
   %get_pid_tgid32 = call i64 inttoptr (i64 14 to ptr)()
-  %24 = lshr i64 %get_pid_tgid32, 32
-  %pid33 = trunc i64 %24 to i32
-  store i32 %pid33, ptr %23, align 4
-  %25 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 3
-  store i32 0, ptr %25, align 4
+  %18 = lshr i64 %get_pid_tgid32, 32
+  %pid33 = trunc i64 %18 to i32
+  store i32 %pid33, ptr %17, align 4
+  %19 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 3
+  store i32 0, ptr %19, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@z_key")
   store i64 0, ptr %"@z_key", align 8
   %update_elem34 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_z, ptr %"@z_key", ptr %stack_key18, i64 0)
@@ -174,17 +165,17 @@ lookup_stack_scratch_failure23:                   ; preds = %merge_block4
 lookup_stack_scratch_merge24:                     ; preds = %merge_block4
   %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map22, i32 1016, ptr null)
   %get_stack29 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map22, i32 1016, i64 256)
-  %26 = icmp sge i32 %get_stack29, 0
-  br i1 %26, label %get_stack_success27, label %get_stack_fail28
+  %20 = icmp sge i32 %get_stack29, 0
+  br i1 %20, label %get_stack_success27, label %get_stack_fail28
 
 get_stack_success27:                              ; preds = %lookup_stack_scratch_merge24
-  %27 = udiv i32 %get_stack29, 8
-  %28 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 1
-  store i32 %27, ptr %28, align 4
-  %29 = trunc i32 %27 to i8
-  %murmur_hash_230 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map22, i8 %29, i64 1)
-  %30 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 0
-  store i64 %murmur_hash_230, ptr %30, align 8
+  %21 = udiv i32 %get_stack29, 8
+  %22 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 1
+  store i32 %21, ptr %22, align 4
+  %23 = trunc i32 %21 to i8
+  %murmur_hash_230 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map22, i8 %23, i64 1)
+  %24 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 0
+  store i64 %murmur_hash_230, ptr %24, align 8
   %update_elem31 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_perf_127, ptr %stack_key18, ptr %lookup_stack_scratch_map22, i64 0)
   br label %merge_block20
 


### PR DESCRIPTION
When printing a stack (either `ustack` or `kstack`), we pass a stack key through the ring buffer and `bpftrace` can retrieve the stack trace using it.

This stack key structure is defined twice, with different sizes:
1. as a `bpftrace` SizedType, which is 16 bytes and account for padding,
2. as a `llvm` StructType, which is 12 bytes and without padding. This lead to generating a `memcpy` of 16 bytes, instead of 12, triggering a verifier error for accessing the unitialized padding.

This patch fixes the issue by explicitly adding the padding to the `u|kstack_key` to fix the size mismatch.
We can't fix the issue by changing `src/types.c SizedType::CreateStack()` as the padding needs to be accounted for in case the stack is part of a tuple.

Somehow, the problem appears on Kernel 5.15, but not when I try on 5.19.
There must have been a change in the eBPF verifier between those two versions?

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
