### PR TITLE
nix: Move blazesym rev to flake.lock

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -107,6 +107,37 @@ dxu@kashmir bpftrace]$ CC=afl-clang-fast CXX=afl-clang-fast++ cmake -B build-fuz
 
 This section has a few examples on how to interact with the Nix configuration.
 
+### Update flake inputs
+
+Flakes have external inputs in the `inputs = { ... }` section of `flake.nix`.
+
+To update a single input:
+```
+$ nix flake lock --update-input blazesym
+warning: updating lock file '/home/dxu/dev/bpftrace/flake.lock':
+• Updated input 'blazesym':
+    'github:libbpf/blazesym/6beb39ebc8e3a604c7b483951c85c831c1bbe0d1' (2025-02-14)
+  → 'github:libbpf/blazesym/285b17f15a12885544b21f1ae352928910656767' (2025-03-04)
+```
+
+To update a single input to a specific revision:
+```
+$ nix flake lock --override-input blazesym github:libbpf/blazesym/6beb39ebc8e3a604c7b483951c85c831c1bbe0d1
+warning: updating lock file '/home/dxu/dev/bpftrace/flake.lock':
+• Updated input 'blazesym':
+    'github:libbpf/blazesym/285b17f15a12885544b21f1ae352928910656767' (2025-03-04)
+  → 'github:libbpf/blazesym/6beb39ebc8e3a604c7b483951c85c831c1bbe0d1' (2025-02-14)
+```
+
+To update all inputs:
+```
+$ nix flake update
+warning: updating lock file '/home/dxu/dev/bpftrace/flake.lock':
+• Updated input 'nixpkgs':
+    'github:NixOS/nixpkgs/d9b69c3ec2a2e2e971c534065bdd53374bd68b97' (2025-02-24)
+  → 'github:NixOS/nixpkgs/02032da4af073d0f6110540c8677f16d4be0117f' (2025-03-03)
+```
+
 ### Format `*.nix` files
 
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -30,7 +30,6 @@
       "original": {
         "owner": "libbpf",
         "repo": "blazesym",
-        "rev": "6beb39ebc8e3a604c7b483951c85c831c1bbe0d1",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     blazesym = {
-      url = "github:libbpf/blazesym/6beb39ebc8e3a604c7b483951c85c831c1bbe0d1";
+      url = "github:libbpf/blazesym";
       flake = false;
     };
   };


### PR DESCRIPTION
Only updating the rev in flake.nix and *not also* running `nix flake lock --update-input $THE_INPUT` causes nix to use a stale revision, at least until the old revision is evicted from cache and you get an error.

In the meantime, you simply get old results without any warning.

Make this less likely to happen again for blazesym by moving the rev into flake.lock. This forces the updater to use the correct tooling.

Also update nix.md with some helpful examples.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
