### PR TITLE
clang-tidy all the things

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,21 +1,23 @@
-Checks: |
-  -*
-  bugprone-suspicious-memset-usage
-  bugprone-unchecked-optional-access
-  bugprone-undefined-memory-manipulation
-  bugprone-unused-raii
-  bugprone-use-after-move
-  google-readability-casting
-  modernize-concat-nested-namespaces
-  modernize-deprecated-headers
-  modernize-loop-convert
-  modernize-make-shared
-  modernize-make-unique
-  modernize-raw-string-literal
-  modernize-use-nullptr
-  modernize-use-override
-  modernize-redundant-void-arg
-  performance-unnecessary-copy-initialization
+Checks:
+  - -*
+  - bugprone-suspicious-memset-usage
+  - bugprone-unchecked-optional-access
+  - bugprone-undefined-memory-manipulation
+  - bugprone-unused-raii
+  - bugprone-use-after-move
+  - google-readability-casting
+  - modernize-concat-nested-namespaces
+  - modernize-deprecated-headers
+  - modernize-loop-convert
+  - modernize-make-shared
+  - modernize-make-unique
+  - modernize-raw-string-literal
+  - modernize-use-nullptr
+  - modernize-use-override
+  - modernize-redundant-void-arg
+  - performance-unnecessary-copy-initialization
 
 WarningsAsErrors: "*"
 UseColor: true
+HeaderFilterRegex: ".*"
+ExcludeHeaderFilterRegex: ".*/parser.tab.hh"

--- a/src/act_helpers.h
+++ b/src/act_helpers.h
@@ -10,7 +10,6 @@
 // counterpart has members of the same type and offset.
 
 #include <cstddef>
-#include <type_traits>
 
 namespace act_helpers {
 

--- a/src/aot/aot.h
+++ b/src/aot/aot.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <memory>
 #include <string>
 
 #include "bpftrace.h"
 #include "required_resources.h"
 
-namespace bpftrace {
-namespace aot {
+namespace bpftrace::aot {
 
 static constexpr std::string_view AOT_SHIM_NAME = "bpftrace-aotrt";
 
@@ -18,5 +16,4 @@ int generate(const RequiredResources &resources,
 
 int load(BPFtrace &bpftrace, const std::string &in);
 
-} // namespace aot
-} // namespace bpftrace
+} // namespace bpftrace::aot

--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <stdexcept>
 #include <string>
 #include <vector>
 
-namespace bpftrace {
-namespace arch {
+namespace bpftrace::arch {
 
 int offset(std::string reg_name);
 int max_arg();
@@ -20,5 +18,4 @@ std::vector<std::string> invalid_watchpoint_modes();
 // Returns the width in bits of kernel pointers.
 int get_kernel_ptr_width();
 
-} // namespace arch
-} // namespace bpftrace
+} // namespace bpftrace::arch

--- a/src/arch/arm.cpp
+++ b/src/arch/arm.cpp
@@ -7,8 +7,7 @@
 
 #include <sys/utsname.h>
 
-namespace bpftrace {
-namespace arch {
+namespace bpftrace::arch {
 
 namespace {
 
@@ -224,5 +223,4 @@ int get_kernel_ptr_width()
   return 64;
 }
 
-} // namespace arch
-} // namespace bpftrace
+} // namespace bpftrace::arch

--- a/src/arch/loongarch64.cpp
+++ b/src/arch/loongarch64.cpp
@@ -7,8 +7,7 @@
 // SP points to the first argument that is passed on the stack
 #define ARG0_STACK 0
 
-namespace bpftrace {
-namespace arch {
+namespace bpftrace::arch {
 
 // clang-format off
 static std::array<std::string, 34> registers = {
@@ -159,5 +158,4 @@ int get_kernel_ptr_width()
   return 64;
 }
 
-} // namespace arch
-} // namespace bpftrace
+} // namespace bpftrace::arch

--- a/src/arch/mips64.cpp
+++ b/src/arch/mips64.cpp
@@ -7,8 +7,7 @@
 // SP + 8 points to the first argument that is passed on the stack
 #define ARG0_STACK 8
 
-namespace bpftrace {
-namespace arch {
+namespace bpftrace::arch {
 
 // clang-format off
 static std::array<std::string, 32> registers = {
@@ -164,5 +163,4 @@ int get_kernel_ptr_width()
   return 64;
 }
 
-} // namespace arch
-} // namespace bpftrace
+} // namespace bpftrace::arch

--- a/src/arch/ppc64.cpp
+++ b/src/arch/ppc64.cpp
@@ -1,6 +1,5 @@
 #include "arch.h"
 
-#include <algorithm>
 #include <array>
 #include <set>
 #include <vector>
@@ -11,8 +10,7 @@
 // For big endian 64 bit, sp + 48 + 8 regs save area + argX
 #define ARG0_STACK_BE 112
 
-namespace bpftrace {
-namespace arch {
+namespace bpftrace::arch {
 
 // clang-format off
 static std::vector<std::set<std::string>> registers = {
@@ -142,5 +140,4 @@ int get_kernel_ptr_width()
   return 64;
 }
 
-} // namespace arch
-} // namespace bpftrace
+} // namespace bpftrace::arch

--- a/src/arch/riscv64.cpp
+++ b/src/arch/riscv64.cpp
@@ -7,8 +7,7 @@
 // SP points to the first argument that is passed on the stack
 #define ARG0_STACK 0
 
-namespace bpftrace {
-namespace arch {
+namespace bpftrace::arch {
 
 // clang-format off
 static std::array<std::string, 32> registers = {
@@ -113,5 +112,4 @@ int get_kernel_ptr_width()
   return 64;
 }
 
-} // namespace arch
-} // namespace bpftrace
+} // namespace bpftrace::arch

--- a/src/arch/s390.cpp
+++ b/src/arch/s390.cpp
@@ -1,7 +1,6 @@
 #include "arch.h"
 #include "utils.h"
 
-#include <algorithm>
 #include <array>
 #include <set>
 #include <vector>
@@ -11,8 +10,7 @@
 // arguments can be found starting at sp+160
 #define ARG0_STACK 160
 
-namespace bpftrace {
-namespace arch {
+namespace bpftrace::arch {
 
 // clang-format off
 static std::vector<std::set<std::string>> registers = {
@@ -103,5 +101,4 @@ int get_kernel_ptr_width()
   return 64;
 }
 
-} // namespace arch
-} // namespace bpftrace
+} // namespace bpftrace::arch

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -3,8 +3,8 @@
 #include <algorithm>
 
 #include "ast/context.h"
-#include "ast/visitor.h"
 #include "log.h"
+#include "utils.h"
 
 namespace bpftrace::ast {
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -7,10 +7,8 @@
 #include "diagnostic.h"
 #include "types.h"
 #include "usdt.h"
-#include "utils.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 class ASTContext;
 
@@ -103,7 +101,7 @@ class Variable;
 class Expression : public Node {
 public:
   Expression(Diagnostics &d, Location &&loc) : Node(d, std::move(loc)) {};
-  virtual ~Expression() = default;
+  ~Expression() override = default;
 
   SizedType type;
   Map *key_for_map = nullptr;
@@ -602,5 +600,4 @@ std::string opstr(const Jump &jump);
 SizedType ident_to_record(const std::string &ident, int pointer_level = 0);
 SizedType ident_to_sized_type(const std::string &ident);
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -11,19 +11,17 @@
 namespace llvm {
 class Type;
 } // namespace llvm
-namespace bpftrace {
-namespace ast {
+
+namespace bpftrace::ast {
 class IRBuilderBPF;
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast
 
 // The main goal here is to keep the struct definitions close to each other,
 // making it easier to spot type mismatches.
 //
 // If you update a type, remember to update the .cpp too!
 
-namespace bpftrace {
-namespace AsyncEvent {
+namespace bpftrace::AsyncEvent {
 
 struct Print {
   uint64_t action_id;
@@ -121,5 +119,4 @@ struct Exit {
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
-} // namespace AsyncEvent
-} // namespace bpftrace
+} // namespace bpftrace::AsyncEvent

--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -1,7 +1,8 @@
 #pragma once
 
-namespace bpftrace {
-namespace ast {
+#include <functional>
+
+namespace bpftrace::ast {
 
 // Add new ids here
 #define FOR_LIST_OF_ASYNC_IDS(DO)                                              \
@@ -52,5 +53,4 @@ private:
   FOR_LIST_OF_ASYNC_IDS(DEFINE_MEMBER_VAR)
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -3,15 +3,12 @@
 #include "ast/ast.h"
 #include "ast/context.h"
 #include "ast/int_parser.h"
-#include "log.h"
 #include "types.h"
 #include <algorithm>
 #include <bcc/bcc_proc.h>
 #include <exception>
-#include <functional>
 #include <iostream>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace bpftrace::ast {

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -1,15 +1,13 @@
 #pragma once
 
 #include <optional>
-#include <ostream>
 #include <sstream>
 #include <vector>
 
 #include "ast/ast.h"
 #include "bpftrace.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 class AttachPointParser {
 public:
@@ -63,5 +61,4 @@ private:
   bool listing_;
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -1,9 +1,8 @@
 #pragma once
 
-#include "bpftrace.h"
+#include "ast/ast.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 inline bool needMemcpy(const SizedType &stype)
 {
@@ -38,5 +37,4 @@ bool needAssignMapStatementAllocation(const AssignMapStatement &assignment);
 bool needMapKeyAllocation(const Map &map);
 bool needMapKeyAllocation(const Map &map, Expression *key_expr);
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -5,8 +5,7 @@
 
 #include "ast/diagnostic.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 class Location;
 class Node;
@@ -90,5 +89,4 @@ private:
   std::shared_ptr<ASTSource> source_;
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/diagnostic.h
+++ b/src/ast/diagnostic.h
@@ -5,13 +5,11 @@
 #include <memory>
 #include <sstream>
 #include <string>
-#include <variant>
 #include <vector>
 
 #include "ast/location.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 // Diagnostic reflects a single error at a single source location. This is a
 // simple wrapper around a string for that message, and the location class.
@@ -128,5 +126,4 @@ private:
   std::vector<std::vector<std::unique_ptr<Diagnostic>>> diagnostics_;
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -1,18 +1,15 @@
 #pragma once
 
-#include "functions.h"
-#include "types.h"
-
 #include <linux/bpf.h>
+#include <llvm/IR/DIBuilder.h>
+
+#include "types.h"
 
 namespace libbpf {
 #include "libbpf/bpf.h"
 } // namespace libbpf
 
-#include <llvm/IR/DIBuilder.h>
-
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 using namespace llvm;
 
@@ -71,5 +68,4 @@ private:
   std::unordered_map<std::string, DIType *> structs_;
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/int_parser.h
+++ b/src/ast/int_parser.h
@@ -1,9 +1,7 @@
 #include <cstdint>
 #include <string>
 
-namespace bpftrace {
-namespace ast {
-namespace int_parser {
+namespace bpftrace::ast::int_parser {
 
 //   String -> int conversion specific to bpftrace
 //
@@ -17,6 +15,4 @@ namespace int_parser {
 int64_t to_int(const std::string &num, int base);
 uint64_t to_uint(const std::string &num, int base);
 
-} // namespace int_parser
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast::int_parser

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1,11 +1,8 @@
 #include "ast/irbuilderbpf.h"
 
-#include <iostream>
-#include <sstream>
-#include <thread>
-
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/Module.h>
+#include <sstream>
 
 #include "arch/arch.h"
 #include "ast/async_event_types.h"
@@ -14,7 +11,6 @@
 #include "bpftrace.h"
 #include "globalvars.h"
 #include "log.h"
-#include "utils.h"
 
 namespace libbpf {
 #include "libbpf/bpf.h"

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -1,10 +1,8 @@
 #pragma once
 
 #include <bcc/bcc_usdt.h>
-
 #include <llvm/Config/llvm-config.h>
 #include <llvm/IR/IRBuilder.h>
-
 #include <optional>
 
 #include "ast/ast.h"
@@ -15,8 +13,7 @@
 #define CREATE_ATOMIC_RMW(op, ptr, val, align, order)                          \
   CreateAtomicRMW((op), (ptr), (val), MaybeAlign((align)), (order))
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 using namespace llvm;
 
@@ -354,5 +351,4 @@ private:
   llvm::Function *preserve_static_offset_ = nullptr;
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/pass_manager.h
+++ b/src/ast/pass_manager.h
@@ -2,9 +2,7 @@
 
 #include <functional>
 #include <iostream>
-#include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace bpftrace {

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -6,9 +6,7 @@
 #include <csignal>
 #include <cstdio>
 #include <ctime>
-#include <filesystem>
 #include <fstream>
-#include <limits>
 #include <llvm/IR/GlobalValue.h>
 
 #if LLVM_VERSION_MAJOR <= 16
@@ -37,7 +35,6 @@
 #include "ast/context.h"
 #include "ast/signal_bt.h"
 #include "bpfmap.h"
-#include "collect_nodes.h"
 #include "globalvars.h"
 #include "log.h"
 #include "tracepoint_format_parser.h"

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <functional>
 #include <optional>
 #include <tuple>
 
@@ -22,8 +21,7 @@
 #include "kfuncs.h"
 #include "required_resources.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 using namespace llvm;
 
@@ -154,7 +152,7 @@ public:
   ScopedExpr createLogicalOr(Binop &binop);
 
   // Exists to make calling from a debugger easier
-  void DumpIR(void);
+  void DumpIR();
   void DumpIR(std::ostream &out);
   void DumpIR(const std::string filename);
   void createFormatStringCall(Call &call,
@@ -181,7 +179,7 @@ public:
                        Value *dst_val,
                        Value *src_val);
 
-  void generate_ir(void);
+  void generate_ir();
   libbpf::bpf_map_type get_map_type(const SizedType &val_type,
                                     const SizedType &key_type);
   bool is_array_map(const SizedType &val_type, const SizedType &key_type);
@@ -190,13 +188,13 @@ public:
   void generate_maps(const RequiredResources &rr, const CodegenResources &cr);
   void generate_global_vars(const RequiredResources &resources,
                             const ::bpftrace::Config &bpftrace_config);
-  void optimize(void);
-  bool verify(void);
+  void optimize();
+  bool verify();
   BpfBytecode emit(bool disassemble);
   void emit_elf(const std::string &filename);
   void emit(raw_pwrite_stream &stream);
   // Combine generate_ir, optimize and emit into one call
-  BpfBytecode compile(void);
+  BpfBytecode compile();
 
 private:
   static constexpr char LLVMTargetTriple[] = "bpf-pc-linux";
@@ -367,5 +365,4 @@ private:
   State state_ = State::INIT;
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/codegen_resources.cpp
+++ b/src/ast/passes/codegen_resources.cpp
@@ -1,7 +1,5 @@
 #include "codegen_resources.h"
 
-#include "ast/async_event_types.h"
-#include "struct.h"
 #include "types.h"
 
 namespace bpftrace::ast {

--- a/src/ast/passes/codegen_resources.h
+++ b/src/ast/passes/codegen_resources.h
@@ -1,13 +1,11 @@
 #pragma once
 
-#include <cstdint>
 #include <unordered_set>
 
 #include "ast/visitor.h"
 #include "config.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 struct CodegenResources {
   bool needs_elapsed_map = false;
@@ -34,5 +32,4 @@ private:
   CodegenResources resources_;
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -5,7 +5,6 @@
 
 #include "ast/ast.h"
 #include "config.h"
-#include "log.h"
 #include "types.h"
 
 namespace bpftrace::ast {

--- a/src/ast/passes/config_analyser.h
+++ b/src/ast/passes/config_analyser.h
@@ -1,16 +1,12 @@
 #pragma once
 
-#include <unordered_set>
-
 #include "ast/pass_manager.h"
 #include "ast/visitor.h"
-#include "bpffeature.h"
 #include "bpftrace.h"
 #include "config.h"
 #include "types.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 class ConfigAnalyser : public Visitor<ConfigAnalyser> {
 public:
@@ -48,5 +44,4 @@ private:
 
 Pass CreateConfigPass();
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -1,11 +1,9 @@
 #include "field_analyser.h"
 
 #include <cassert>
-#include <iostream>
 
 #include "arch/arch.h"
 #include "dwarf_parser.h"
-#include "log.h"
 #include "probe_matcher.h"
 
 namespace bpftrace::ast {

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <string>
-#include <unordered_set>
 
 #include "ast/pass_manager.h"
 #include "ast/visitor.h"
@@ -11,8 +10,7 @@ namespace libbpf {
 #include "libbpf/bpf.h"
 } // namespace libbpf
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 class FieldAnalyser : public Visitor<FieldAnalyser> {
 public:
@@ -55,5 +53,4 @@ private:
 
 Pass CreateFieldAnalyserPass();
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/pid_filter_pass.h
+++ b/src/ast/passes/pid_filter_pass.h
@@ -4,8 +4,7 @@
 #include "ast/visitor.h"
 #include "bpftrace.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 class PidFilterPass : public Visitor<PidFilterPass> {
 public:
@@ -24,5 +23,4 @@ private:
 
 Pass CreatePidFilterPass();
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/portability_analyser.h
+++ b/src/ast/passes/portability_analyser.h
@@ -3,8 +3,7 @@
 #include "ast/pass_manager.h"
 #include "ast/visitor.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 // Checks if a script uses any non-portable bpftrace features that AOT
 // cannot handle.
@@ -23,5 +22,4 @@ public:
 
 Pass CreatePortabilityPass();
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -2,7 +2,6 @@
 
 #include <cctype>
 #include <iomanip>
-#include <regex>
 #include <sstream>
 
 #include "ast/ast.h"

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -4,8 +4,7 @@
 
 #include "ast/visitor.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 class Printer : public Visitor<Printer> {
 public:
@@ -56,5 +55,4 @@ private:
   std::string type(const SizedType &ty);
 };
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -5,8 +5,6 @@
 #include "ast/async_event_types.h"
 #include "ast/codegen_helper.h"
 #include "bpftrace.h"
-#include "globalvars.h"
-#include "log.h"
 #include "struct.h"
 
 namespace bpftrace::ast {

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -4,8 +4,7 @@
 #include "ast/visitor.h"
 #include "required_resources.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 // Resource analysis pass on AST
 //
@@ -59,5 +58,4 @@ private:
 
 Pass CreateResourcePass();
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -1,5 +1,4 @@
 #include "return_path_analyser.h"
-#include "log.h"
 
 namespace bpftrace::ast {
 

--- a/src/ast/passes/return_path_analyser.h
+++ b/src/ast/passes/return_path_analyser.h
@@ -3,8 +3,7 @@
 #include "ast/pass_manager.h"
 #include "ast/visitor.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 class ReturnPathAnalyser : public Visitor<ReturnPathAnalyser, bool> {
 public:
@@ -19,5 +18,4 @@ public:
 
 Pass CreateReturnPathPass();
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1083,8 +1083,8 @@ void SemanticAnalyser::visit(Call &call)
 
     auto &arg = *call.vargs.at(0);
     if (!(arg.type.IsIntTy() || arg.type.IsPtrTy())) {
-      call.addError() << "() only supports int or pointer arguments"
-                      << " (" << arg.type.GetTy() << " provided)";
+      call.addError() << "() only supports int or pointer arguments" << " ("
+                      << arg.type.GetTy() << " provided)";
     }
 
     if (call.vargs.size() > 1)
@@ -1295,8 +1295,7 @@ void SemanticAnalyser::visit(Call &call)
         Map &map = static_cast<Map &>(arg);
         if (map.key_expr) {
           call.addError() << "The map passed to " << call.func
-                          << "() should not be "
-                          << "indexed by a key";
+                          << "() should not be " << "indexed by a key";
         }
       }
     }
@@ -1310,8 +1309,7 @@ void SemanticAnalyser::visit(Call &call)
         Map &map = static_cast<Map &>(arg);
         if (map.key_expr) {
           call.addError() << "The map passed to " << call.func
-                          << "() should not be "
-                          << "indexed by a key";
+                          << "() should not be " << "indexed by a key";
         }
       }
     }
@@ -1322,8 +1320,7 @@ void SemanticAnalyser::visit(Call &call)
         Map &map = static_cast<Map &>(arg);
         if (map.key_expr) {
           call.addError() << "The map passed to " << call.func
-                          << "() should not be "
-                          << "indexed by a key";
+                          << "() should not be " << "indexed by a key";
         }
       } else if (!arg.type.IsStack())
         call.addError() << "len() expects a map or stack to be provided";
@@ -1514,8 +1511,8 @@ If you're seeing errors, try clamping the string sizes. For example:
     if (!arg->type.IsIntTy() && !arg->type.IsArrayTy() &&
         !arg->type.IsByteArray() && !arg->type.IsPtrTy())
       call.addError() << call.func
-                      << "() only supports array or pointer arguments"
-                      << " (" << arg->type.GetTy() << " provided)";
+                      << "() only supports array or pointer arguments" << " ("
+                      << arg->type.GetTy() << " provided)";
 
     auto type = arg->type;
     if ((type.IsArrayTy() || type.IsByteArray()) && type.GetSize() != 6)
@@ -1615,14 +1612,12 @@ void SemanticAnalyser::visit(Offsetof &offof)
   SizedType record = offof.record;
   for (const auto &field : offof.field) {
     if (!record.IsRecordTy()) {
-      offof.addError() << "'" << record << "' "
-                       << "is not a record type.";
+      offof.addError() << "'" << record << "' " << "is not a record type.";
     } else if (!bpftrace_.structs.Has(record.GetName())) {
       offof.addError() << "'" << record.GetName() << "' does not exist.";
     } else if (!record.HasField(field)) {
       offof.addError() << "'" << record.GetName() << "' "
-                       << "has no field named "
-                       << "'" << field << "'";
+                       << "has no field named " << "'" << field << "'";
     } else {
       // Get next sub-field
       record = record.GetField(field).type;
@@ -1996,7 +1991,7 @@ void SemanticAnalyser::binop_ptr(Binop &binop)
     default:;
   }
 
-  auto invalid_op = [&binop, this, &lht, &rht]() {
+  auto invalid_op = [&binop, &lht, &rht]() {
     binop.addError() << "The " << opstr(binop)
                      << " operator can not be used on expressions of types "
                      << lht << ", " << rht;
@@ -2674,8 +2669,8 @@ void SemanticAnalyser::visit(FieldAccess &acc)
     const auto record = it.second.lock();
     if (!record->HasField(acc.field)) {
       acc.addError() << "Struct/union of type '" << cast_type
-                     << "' does not contain "
-                     << "a field named '" << acc.field << "'";
+                     << "' does not contain " << "a field named '" << acc.field
+                     << "'";
     } else {
       const auto &field = record->GetField(acc.field);
 

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -1,17 +1,12 @@
 #pragma once
 
-#include <unordered_set>
-
 #include "ast/pass_manager.h"
 #include "ast/visitor.h"
-#include "bpffeature.h"
 #include "bpftrace.h"
 #include "collect_nodes.h"
-#include "config.h"
 #include "types.h"
 
-namespace bpftrace {
-namespace ast {
+namespace bpftrace::ast {
 
 struct variable {
   SizedType type;
@@ -160,7 +155,7 @@ private:
   Expression *dereference_if_needed(Expression *expr);
 
   bool has_error() const;
-  bool in_loop(void)
+  bool in_loop()
   {
     return loop_depth_ > 0;
   };
@@ -195,5 +190,4 @@ private:
 
 Pass CreateSemanticPass();
 
-} // namespace ast
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <string>
+#include <optional>
+#include <variant>
 
 #include "ast/ast.h"
 #include "ast/context.h"

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -6,7 +6,6 @@
 #include <cstring>
 #include <elf.h>
 #include <fcntl.h>
-#include <fstream>
 #include <iostream>
 #include <linux/hw_breakpoint.h>
 #include <linux/limits.h>
@@ -14,7 +13,6 @@
 #include <sys/ioctl.h>
 #include <sys/syscall.h>
 #include <sys/utsname.h>
-#include <tuple>
 #include <unistd.h>
 
 #include <bcc/bcc_elf.h>

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -1,18 +1,15 @@
 #pragma once
 
+#include <bcc/libbpf.h>
 #include <functional>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #include "bpffeature.h"
 #include "bpfprogram.h"
 #include "btf.h"
-#include "config.h"
 #include "types.h"
 #include "usdt.h"
-
-#include <bcc/libbpf.h>
 
 namespace bpftrace {
 
@@ -40,7 +37,7 @@ private:
   std::string eventname() const;
   void resolve_offset_kprobe();
   bool resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps);
-  void attach_multi_kprobe(void);
+  void attach_multi_kprobe();
   void attach_multi_uprobe(std::optional<int> pid);
   void attach_kprobe();
   void attach_uprobe(std::optional<int> pid, bool safe_mode);
@@ -65,16 +62,16 @@ private:
   void attach_software(std::optional<int> pid);
   void attach_hardware(std::optional<int> pid);
   void attach_watchpoint(std::optional<int> pid, const std::string &mode);
-  void attach_fentry(void);
-  int detach_fentry(void);
+  void attach_fentry();
+  int detach_fentry();
   void attach_iter(std::optional<int> pid);
-  int detach_iter(void);
-  void attach_raw_tracepoint(void);
-  int detach_raw_tracepoint(void);
+  int detach_iter();
+  void attach_raw_tracepoint();
+  int detach_raw_tracepoint();
 
   static std::map<std::string, int> cached_prog_fds_;
   bool use_cached_progfd(BPFfeature &feature);
-  void cache_progfd(void);
+  void cache_progfd();
 
   Probe &probe_;
   std::vector<int> perf_event_fds_;

--- a/src/bfd-disasm.h
+++ b/src/bfd-disasm.h
@@ -7,9 +7,9 @@ namespace bpftrace {
 class BfdDisasm : public IDisasm {
 public:
   BfdDisasm(std::string &path);
-  ~BfdDisasm();
+  ~BfdDisasm() override;
 
-  AlignState is_aligned(uint64_t offset, uint64_t pc);
+  AlignState is_aligned(uint64_t offset, uint64_t pc) override;
 
 private:
   int fd_ = -1;

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -13,9 +13,7 @@
 
 #include "bpf_assembler.h"
 #include "btf.h"
-#include "debugfs.h"
 #include "dwarf_parser.h"
-#include "probe_matcher.h"
 #include "tracefs.h"
 #include "utils.h"
 
@@ -705,10 +703,6 @@ bool BPFfeature::has_iter(std::string name)
 
 bool BPFfeature::has_kernel_dwarf()
 {
-#ifndef HAVE_LIBLLDB
-  return false;
-#endif
-
   auto vmlinux = find_vmlinux();
   if (!vmlinux.has_value())
     return false;

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -2,7 +2,6 @@
 
 #include "btf.h"
 #include "kfuncs.h"
-#include <memory>
 #include <optional>
 #include <string>
 
@@ -105,7 +104,7 @@ public:
 
   bool has_kernel_func(Kfunc kfunc);
 
-  std::string report(void);
+  std::string report();
 
   DEFINE_MAP_TEST(array, libbpf::BPF_MAP_TYPE_ARRAY);
   DEFINE_MAP_TEST(hash, libbpf::BPF_MAP_TYPE_HASH);

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstddef>
 #include <string>
 #include <string_view>
 

--- a/src/bpfprogram.cpp
+++ b/src/bpfprogram.cpp
@@ -1,14 +1,12 @@
-#include "bpfprogram.h"
-
-#include "attached_probe.h"
-#include "log.h"
-#include "utils.h"
-
 #include <bpf/bpf.h>
 #include <elf.h>
 #include <linux/bpf.h>
 #include <linux/btf.h>
-#include <stdexcept>
+
+#include "attached_probe.h"
+#include "bpfprogram.h"
+#include "log.h"
+#include "utils.h"
 
 namespace bpftrace {
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1,36 +1,32 @@
-#include "btf.h"
 #include <algorithm>
 #include <arpa/inet.h>
+#include <bcc/bcc_elf.h>
+#include <bcc/bcc_syms.h>
+#include <bcc/perf_reader.h>
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
 #include <cassert>
 #include <cerrno>
 #include <cinttypes>
+#include <csignal>
 #include <cstdio>
 #include <cstring>
 #include <ctime>
+#include <elf.h>
+#include <fcntl.h>
 #include <fstream>
 #include <glob.h>
-#include <iomanip>
 #include <iostream>
 #include <ranges>
 #include <regex>
 #include <sstream>
 #include <sys/epoll.h>
-
-#include <bcc/bcc_elf.h>
-#include <csignal>
-#include <elf.h>
-#include <fcntl.h>
 #include <sys/personality.h>
 #include <sys/prctl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
-
-#include <bcc/bcc_syms.h>
-#include <bcc/perf_reader.h>
-#include <bpf/bpf.h>
-#include <bpf/libbpf.h>
 #ifdef HAVE_LIBSYSTEMD
 #include <systemd/sd-daemon.h>
 #endif
@@ -40,6 +36,7 @@
 #include "bpfmap.h"
 #include "bpfprogram.h"
 #include "bpftrace.h"
+#include "btf.h"
 #include "log.h"
 #include "printf.h"
 #include "resolve_cgroupid.h"

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <time.h>
-
 #include <cstdint>
 #include <iostream>
 #include <map>
@@ -231,7 +229,7 @@ public:
   std::unordered_set<std::string> btf_set_;
   std::unique_ptr<ChildProcBase> child_;
   std::unique_ptr<ProcMonBase> procmon_;
-  std::optional<pid_t> pid(void) const
+  std::optional<pid_t> pid() const
   {
     if (procmon_) {
       return procmon_->pid();
@@ -264,13 +262,13 @@ private:
   int setup_event_loss();
   // when the ringbuf feature is available, enable ringbuf for built-ins like
   // printf, cat.
-  bool is_ringbuf_enabled(void) const
+  bool is_ringbuf_enabled() const
   {
     return feature_->has_map_ringbuf();
   }
   // when the ringbuf feature is unavailable or built-in skboutput is used,
   // enable perf_event
-  bool is_perf_event_enabled(void) const
+  bool is_perf_event_enabled() const
   {
     return !feature_->has_map_ringbuf() || resources.needs_perf_event_map;
   }

--- a/src/btf.h
+++ b/src/btf.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include "types.h"
+
 #include <cstddef>
 #include <linux/types.h>
 #include <map>
 #include <optional>
-#include <regex>
 #include <set>
 #include <string>
 #include <unistd.h>
@@ -58,7 +58,7 @@ public:
   };
   ~BTF();
 
-  bool has_data(void) const;
+  bool has_data() const;
   size_t objects_cnt() const
   {
     return btf_objects.size();
@@ -119,7 +119,7 @@ private:
   BPFtrace* bpftrace_ = nullptr;
 };
 
-inline bool BTF::has_data(void) const
+inline bool BTF::has_data() const
 {
   return state == OK;
 }

--- a/src/child.h
+++ b/src/child.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <csignal>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -63,7 +62,7 @@ public:
 
   // Resume a paused child. Only valid when run() has been called with
   // pause=true
-  virtual void resume(void) = 0;
+  virtual void resume() = 0;
 
 protected:
   pid_t child_pid_ = -1;
@@ -82,7 +81,7 @@ public:
   //   an exception is raised.
   //
   ChildProc(std::string cmd);
-  ~ChildProc();
+  ~ChildProc() override;
 
   // Disallow copying as the internal state will get out of sync which will
   // cause issues.
@@ -94,7 +93,7 @@ public:
   void run(bool pause = false) override;
   void terminate(bool force = false) override;
   bool is_alive() override;
-  void resume(void) override;
+  void resume() override;
 
 private:
   enum class State {

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -1,6 +1,5 @@
 #include <cstring>
 #include <iostream>
-#include <limits>
 #include <regex>
 #include <sstream>
 #include <utility>
@@ -9,7 +8,6 @@
 #include "llvm/Config/llvm-config.h"
 
 #include "ast/ast.h"
-#include "ast/passes/field_analyser.h"
 #include "btf.h"
 #include "clang_parser.h"
 #include "log.h"
@@ -384,7 +382,7 @@ bool ClangParser::visit_children(CXCursor &cursor, BPFtrace &bpftrace)
           if (enum_name.empty()) {
             std::ostringstream name;
             name << "enum <anon_" << anon_enum_count << ">";
-            enum_name = std::move(name.str());
+            enum_name = name.str();
           }
           auto variant_name = get_clang_string(clang_getCursorSpelling(c));
           auto variant_value = clang_getEnumConstantDeclValue(c);

--- a/src/config.h
+++ b/src/config.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstdint>
-#include <iostream>
 #include <map>
 #include <optional>
 #include <set>

--- a/src/debugfs.h
+++ b/src/debugfs.h
@@ -2,8 +2,7 @@
 
 #include <string>
 
-namespace bpftrace {
-namespace debugfs {
+namespace bpftrace::debugfs {
 
 std::string path();
 
@@ -14,5 +13,4 @@ inline std::string kprobes_blacklist()
   return path("kprobes/blacklist");
 }
 
-} // namespace debugfs
-} // namespace bpftrace
+} // namespace bpftrace::debugfs

--- a/src/driver.h
+++ b/src/driver.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <fstream>
 #include <string_view>
 
 #include "ast/ast.h"

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include "struct.h"
-#include "types.h"
-
 #include <memory>
-#include <optional>
 #include <string>
 #include <vector>
+
+#include "struct.h"
+#include "types.h"
 
 #ifdef HAVE_LIBLLDB
 #include <lldb/API/SBDebugger.h>
@@ -62,8 +61,6 @@ private:
 } // namespace bpftrace
 
 #else // HAVE_LIBLLDB
-
-#include "log.h"
 
 namespace bpftrace {
 class BPFtrace;

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -1,11 +1,9 @@
-#include "format_string.h"
-#include "log.h"
-#include "struct.h"
-#include "utils.h"
-
 #include <unordered_map>
 #include <unordered_set>
-#include <utility>
+
+#include "format_string.h"
+#include "struct.h"
+#include "utils.h"
 
 namespace bpftrace {
 

--- a/src/format_string.h
+++ b/src/format_string.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <ostream>
-#include <regex>
 #include <string>
 #include <tuple>
 #include <vector>

--- a/src/functions.h
+++ b/src/functions.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <optional>
 #include <ostream>
 #include <string>
 #include <unordered_map>

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -1,16 +1,14 @@
-#include "globalvars.h"
-
-#include "bpftrace.h"
-#include "log.h"
-#include "types.h"
-#include "utils.h"
-
 #include <bpf/bpf.h>
 #include <bpf/btf.h>
 #include <elf.h>
 #include <map>
-#include <stdexcept>
 #include <sys/mman.h>
+
+#include "bpftrace.h"
+#include "globalvars.h"
+#include "log.h"
+#include "types.h"
+#include "utils.h"
 
 namespace bpftrace::globalvars {
 

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <optional>
-#include <set>
 #include <string>
 
 #include "bpftrace.h"
@@ -10,8 +9,7 @@
 #include <bpf/bpf.h>
 #include <bpf/btf.h>
 
-namespace bpftrace {
-namespace globalvars {
+namespace bpftrace::globalvars {
 
 std::string to_string(GlobalVar global_var);
 std::optional<GlobalVar> from_string(std::string_view name);
@@ -69,5 +67,4 @@ SizedType get_type(GlobalVar global_var,
                    const Config &bpftrace_config);
 std::unordered_set<std::string> get_section_names();
 
-} // namespace globalvars
-} // namespace bpftrace
+} // namespace bpftrace::globalvars

--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -1,11 +1,10 @@
+#include <bcc/bcc_syms.h>
 #include <sstream>
 
-#include <bcc/bcc_syms.h>
 #ifdef HAVE_BLAZESYM
 #include <blazesym.h>
 #endif
 
-#include "config.h"
 #include "ksyms.h"
 #include "scopeguard.h"
 #include "utils.h"
@@ -20,6 +19,7 @@ std::string stringify_addr(uint64_t addr)
 } // namespace
 
 namespace bpftrace {
+
 Ksyms::Ksyms(const Config &config) : config_(config)
 {
 }
@@ -116,4 +116,5 @@ std::string Ksyms::resolve(uint64_t addr, bool show_offset)
 #endif
   return resolve_bcc(addr, show_offset);
 }
+
 } // namespace bpftrace

--- a/src/ksyms.h
+++ b/src/ksyms.h
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <optional>
 #include <string>
+
+#include "config.h"
 
 namespace bpftrace {
 class Config;
@@ -10,7 +13,6 @@ class Ksyms {
 public:
   Ksyms(const Config &config);
   ~Ksyms();
-
   Ksyms(Ksyms &) = delete;
   Ksyms &operator=(const Ksyms &) = delete;
 

--- a/src/lockdown.cpp
+++ b/src/lockdown.cpp
@@ -1,9 +1,6 @@
-#include <algorithm>
-#include <fstream>
-
 #include <cerrno>
-
 #include <fcntl.h>
+#include <fstream>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>

--- a/src/lockdown.h
+++ b/src/lockdown.h
@@ -2,10 +2,7 @@
 
 #include <iostream>
 
-#include "bpffeature.h"
-
-namespace bpftrace {
-namespace lockdown {
+namespace bpftrace::lockdown {
 
 enum class LockdownState {
   None,
@@ -17,5 +14,4 @@ enum class LockdownState {
 LockdownState detect();
 void emit_warning(std::ostream &out);
 
-} //  namespace lockdown
-} //  namespace bpftrace
+} //  namespace bpftrace::lockdown

--- a/src/log.h
+++ b/src/log.h
@@ -123,7 +123,7 @@ public:
                __attribute__((unused)) LogType,
                std::ostream& out = std::cerr)
       : LogStream(file, line, LogType::BUG, out) {};
-  [[noreturn]] ~LogStreamBug();
+  [[noreturn]] ~LogStreamBug() override;
 };
 
 // Usage examples:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,3 @@
-#include <array>
 #include <bpf/libbpf.h>
 #include <cstdio>
 #include <cstring>
@@ -16,7 +15,6 @@
 #include "aot/aot.h"
 #include "ast/diagnostic.h"
 #include "ast/pass_manager.h"
-
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/config_analyser.h"
 #include "ast/passes/field_analyser.h"
@@ -25,7 +23,6 @@
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/return_path_analyser.h"
 #include "ast/passes/semantic_analyser.h"
-
 #include "bpffeature.h"
 #include "bpftrace.h"
 #include "btf.h"

--- a/src/output.h
+++ b/src/output.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iomanip>
 #include <iostream>
 #include <map>
 #include <vector>
@@ -226,9 +225,9 @@ public:
       uint32_t div,
       const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
           &values_by_key) const override;
-  virtual void value(BPFtrace &bpftrace,
-                     const SizedType &ty,
-                     std::vector<uint8_t> &value) const override;
+  void value(BPFtrace &bpftrace,
+             const SizedType &ty,
+             std::vector<uint8_t> &value) const override;
 
   void message(MessageType type,
                const std::string &msg,
@@ -248,13 +247,13 @@ protected:
                            bool is_map_key = false) const override;
   static std::string hist_index_label(uint32_t index, uint32_t bits);
   static std::string lhist_index_label(int number, int step);
-  virtual std::string hist_to_str(const std::vector<uint64_t> &values,
-                                  uint32_t div,
-                                  uint32_t k) const override;
-  virtual std::string lhist_to_str(const std::vector<uint64_t> &values,
-                                   int min,
-                                   int max,
-                                   int step) const override;
+  std::string hist_to_str(const std::vector<uint64_t> &values,
+                          uint32_t div,
+                          uint32_t k) const override;
+  std::string lhist_to_str(const std::vector<uint64_t> &values,
+                           int min,
+                           int max,
+                           int step) const override;
 
   std::string map_key_to_str(BPFtrace &bpftrace,
                              const BpfMap &map,
@@ -301,9 +300,9 @@ public:
       uint32_t div,
       const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
           &values_by_key) const override;
-  virtual void value(BPFtrace &bpftrace,
-                     const SizedType &ty,
-                     std::vector<uint8_t> &value) const override;
+  void value(BPFtrace &bpftrace,
+             const SizedType &ty,
+             std::vector<uint8_t> &value) const override;
 
   void message(MessageType type,
                const std::string &msg,

--- a/src/pcap_writer.h
+++ b/src/pcap_writer.h
@@ -21,7 +21,7 @@ public:
   }
 
   bool open(std::string file);
-  void close(void);
+  void close();
 
   bool write(uint64_t ns, void *pkt, unsigned int size);
 

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -1,8 +1,7 @@
 #include "printf.h"
 
 #include "log.h"
-#include "printf_format_types.h"
-#include "struct.h"
+#include "utils.h"
 
 #include <cstdint>
 

--- a/src/printf.h
+++ b/src/printf.h
@@ -2,9 +2,7 @@
 
 #include <optional>
 #include <regex>
-#include <sstream>
 
-#include "ast/ast.h"
 #include "printf_format_types.h"
 #include "types.h"
 

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -1,9 +1,7 @@
 #include <algorithm>
 #include <dirent.h>
 #include <fstream>
-#include <iomanip>
 #include <iostream>
-#include <regex>
 #include <string>
 #include <vector>
 

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -1,11 +1,9 @@
 #pragma once
 
-#include "ast/ast.h"
-
-#include <set>
-#include <sstream>
-
 #include <linux/perf_event.h>
+#include <set>
+
+#include "ast/ast.h"
 
 namespace bpftrace {
 
@@ -104,7 +102,7 @@ private:
   virtual std::unique_ptr<std::istream> adjust_rawtracepoint(
       std::istream &symbol_list) const;
 
-  std::unique_ptr<std::istream> get_iter_symbols(void) const;
+  std::unique_ptr<std::istream> get_iter_symbols() const;
 
   std::unique_ptr<std::istream> kernel_probe_list();
   std::unique_ptr<std::istream> userspace_probe_list();

--- a/src/procmon.cpp
+++ b/src/procmon.cpp
@@ -7,7 +7,6 @@
 #include <unistd.h>
 
 #include "procmon.h"
-#include "utils.h"
 
 namespace bpftrace {
 

--- a/src/procmon.h
+++ b/src/procmon.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <string>
 #include <unistd.h>
 
 namespace bpftrace {
@@ -10,10 +9,10 @@ public:
   virtual ~ProcMonBase() = default;
 
   // Whether the process is still alive
-  virtual bool is_alive(void) = 0;
+  virtual bool is_alive() = 0;
 
   // pid of the process being monitored
-  pid_t pid(void)
+  pid_t pid()
   {
     return pid_;
   };
@@ -34,7 +33,7 @@ public:
   ProcMon(ProcMon&&) = delete;
   ProcMon& operator=(ProcMon&&) = delete;
 
-  bool is_alive(void) override;
+  bool is_alive() override;
 
 private:
   int pidfd_ = -1;

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -1,5 +1,3 @@
-#include "required_resources.h"
-
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/map.hpp>
 #include <cereal/types/memory.hpp>
@@ -9,8 +7,7 @@
 #include <cereal/types/unordered_set.hpp>
 #include <cereal/types/vector.hpp>
 
-#include "bpftrace.h"
-#include "log.h"
+#include "required_resources.h"
 #include "utils.h"
 
 namespace bpftrace {

--- a/src/resolve_cgroupid.cpp
+++ b/src/resolve_cgroupid.cpp
@@ -18,10 +18,7 @@
 #include <cstring>
 #include <fcntl.h>
 
-#include <stdexcept>
-
 #include "act_helpers.h"
-#include "log.h"
 #include "resolve_cgroupid.h"
 #include "utils.h"
 

--- a/src/tracefs.h
+++ b/src/tracefs.h
@@ -2,8 +2,7 @@
 
 #include <string>
 
-namespace bpftrace {
-namespace tracefs {
+namespace bpftrace::tracefs {
 
 std::string path();
 
@@ -27,5 +26,4 @@ inline std::string available_filter_functions()
 std::string event_format_file(const std::string &category,
                               const std::string &event);
 
-} // namespace tracefs
-} // namespace bpftrace
+} // namespace bpftrace::tracefs

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -5,8 +5,6 @@
 
 #include "ast/ast.h"
 #include "bpftrace.h"
-#include "log.h"
-#include "struct.h"
 #include "tracefs.h"
 #include "tracepoint_format_parser.h"
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -4,8 +4,6 @@
 #include <sstream>
 
 #include "ast/async_event_types.h"
-#include "bpftrace.h"
-#include "log.h"
 #include "struct.h"
 #include "types.h"
 #include "utils.h"

--- a/src/types.h
+++ b/src/types.h
@@ -3,9 +3,7 @@
 #include <cassert>
 #include <map>
 #include <memory>
-#include <optional>
 #include <ostream>
-#include <sstream>
 #include <string>
 #include <sys/types.h>
 #include <unistd.h>
@@ -253,7 +251,7 @@ public:
     is_signed_ = is_signed;
   }
 
-  bool IsSigned(void) const;
+  bool IsSigned() const;
 
   size_t GetSize() const
   {
@@ -348,115 +346,115 @@ public:
   {
     return IsIntTy() && name_.size();
   }
-  bool IsNoneTy(void) const
+  bool IsNoneTy() const
   {
     return type_ == Type::none;
   };
-  bool IsVoidTy(void) const
+  bool IsVoidTy() const
   {
     return type_ == Type::voidtype;
   };
-  bool IsIntegerTy(void) const
+  bool IsIntegerTy() const
   {
     return type_ == Type::integer;
   };
-  bool IsHistTy(void) const
+  bool IsHistTy() const
   {
     return type_ == Type::hist_t;
   };
-  bool IsLhistTy(void) const
+  bool IsLhistTy() const
   {
     return type_ == Type::lhist_t;
   };
-  bool IsCountTy(void) const
+  bool IsCountTy() const
   {
     return type_ == Type::count_t;
   };
-  bool IsSumTy(void) const
+  bool IsSumTy() const
   {
     return type_ == Type::sum_t;
   };
-  bool IsMinTy(void) const
+  bool IsMinTy() const
   {
     return type_ == Type::min_t;
   };
-  bool IsMaxTy(void) const
+  bool IsMaxTy() const
   {
     return type_ == Type::max_t;
   };
-  bool IsAvgTy(void) const
+  bool IsAvgTy() const
   {
     return type_ == Type::avg_t;
   };
-  bool IsStatsTy(void) const
+  bool IsStatsTy() const
   {
     return type_ == Type::stats_t;
   };
-  bool IsKstackTy(void) const
+  bool IsKstackTy() const
   {
     return type_ == Type::kstack_t;
   };
-  bool IsUstackTy(void) const
+  bool IsUstackTy() const
   {
     return type_ == Type::ustack_t;
   };
-  bool IsStringTy(void) const
+  bool IsStringTy() const
   {
     return type_ == Type::string;
   };
-  bool IsKsymTy(void) const
+  bool IsKsymTy() const
   {
     return type_ == Type::ksym_t;
   };
-  bool IsUsymTy(void) const
+  bool IsUsymTy() const
   {
     return type_ == Type::usym_t;
   };
-  bool IsUsernameTy(void) const
+  bool IsUsernameTy() const
   {
     return type_ == Type::username;
   };
-  bool IsInetTy(void) const
+  bool IsInetTy() const
   {
     return type_ == Type::inet;
   };
-  bool IsStackModeTy(void) const
+  bool IsStackModeTy() const
   {
     return type_ == Type::stack_mode;
   };
-  bool IsArrayTy(void) const
+  bool IsArrayTy() const
   {
     return type_ == Type::array;
   };
-  bool IsRecordTy(void) const
+  bool IsRecordTy() const
   {
     return type_ == Type::record;
   };
-  bool IsBufferTy(void) const
+  bool IsBufferTy() const
   {
     return type_ == Type::buffer;
   };
-  bool IsTupleTy(void) const
+  bool IsTupleTy() const
   {
     return type_ == Type::tuple;
   };
-  bool IsTimestampTy(void) const
+  bool IsTimestampTy() const
   {
     return type_ == Type::timestamp;
   };
-  bool IsMacAddressTy(void) const
+  bool IsMacAddressTy() const
   {
     return type_ == Type::mac_address;
   };
-  bool IsCgroupPathTy(void) const
+  bool IsCgroupPathTy() const
   {
     return type_ == Type::cgroup_path_t;
   };
-  bool IsStrerrorTy(void) const
+  bool IsStrerrorTy() const
   {
     return type_ == Type::strerror_t;
   };
-  bool IsTimestampModeTy(void) const
+  bool IsTimestampModeTy() const
   {
     return type_ == Type::timestamp_mode;
   }

--- a/src/usdt.cpp
+++ b/src/usdt.cpp
@@ -1,16 +1,13 @@
-#include "usdt.h"
-#include "log.h"
-#include "utils.h"
-
-#include <csignal>
-
 #include <algorithm>
-#include <iostream>
+#include <bcc/bcc_elf.h>
+#include <bcc/bcc_usdt.h>
+#include <csignal>
 #include <unordered_map>
 #include <unordered_set>
 
-#include <bcc/bcc_elf.h>
-#include <bcc/bcc_usdt.h>
+#include "log.h"
+#include "usdt.h"
+#include "utils.h"
 
 static std::unordered_set<std::string> path_cache;
 static std::unordered_set<int> pid_cache;

--- a/src/usyms.h
+++ b/src/usyms.h
@@ -1,13 +1,11 @@
 #pragma once
 
+#include <bcc/bcc_syms.h>
 #include <cstdint>
 #include <map>
 #include <string>
 
-#include "types.h"
 #include "utils.h"
-
-#include <bcc/bcc_syms.h>
 
 namespace bpftrace {
 class Config;

--- a/src/util/result.cpp
+++ b/src/util/result.cpp
@@ -1,3 +1,6 @@
+
+#include <llvm/Support/raw_os_ostream.h>
+
 #include "util/result.h"
 
 namespace bpftrace {

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -3,8 +3,6 @@
 #include <iostream>
 
 #include "llvm/Support/Error.h"
-#include "llvm/Support/ErrorOr.h"
-#include "llvm/Support/raw_os_ostream.h"
 
 namespace bpftrace {
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -6,7 +6,6 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
-#include <limits>
 #include <map>
 #include <memory>
 #include <optional>
@@ -33,10 +32,8 @@
 #include <unistd.h>
 #include <zlib.h>
 
-#include "bpftrace.h"
 #include "debugfs.h"
 #include "log.h"
-#include "probe_matcher.h"
 #include "scopeguard.h"
 #include "tracefs.h"
 #include "utils.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,7 +9,6 @@
 #include <map>
 #include <optional>
 #include <set>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <sys/utsname.h>
@@ -379,7 +378,7 @@ stats<T> stats_value(const std::vector<uint8_t> &value, int nvalues)
     ret.count += cpu_count;
     ret.total += val;
   }
-  ret.avg = (T)(ret.total / ret.count);
+  ret.avg = static_cast<T>(ret.total / ret.count);
   return ret;
 }
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -7,9 +7,11 @@
 #include "bpftrace.h"
 #include "clang_parser.h"
 #include "driver.h"
+#include "dwarf_common.h"
 #include "mocks.h"
 #include "tracefs.h"
-#include "gmock/gmock.h"
+#include "gmock/gmock-matchers.h"
+#include "gmock/gmock-nice-strict.h"
 #include "gtest/gtest.h"
 
 namespace bpftrace::test::bpftrace {
@@ -712,8 +714,6 @@ TEST(bpftrace, add_probes_uprobe_no_demangling)
 }
 
 #ifdef HAVE_LIBLLDB
-#include "dwarf_common.h"
-
 class bpftrace_dwarf : public test_dwarf {};
 
 TEST_F(bpftrace_dwarf, add_probes_uprobe_symbol_source)
@@ -748,7 +748,6 @@ TEST_F(bpftrace_dwarf, add_probes_uprobe_symbol_source)
     ASSERT_EQ(probe.address, 0);
   }
 }
-
 #endif
 
 TEST(bpftrace, add_probes_usdt)

--- a/tests/btf_common.h
+++ b/tests/btf_common.h
@@ -2,8 +2,10 @@
 
 #include <array>
 #include <cstdint>
+#include <unistd.h>
 
 #include "data/btf_data.h"
+#include "gtest/gtest.h"
 
 namespace {
 constexpr std::array<uint8_t, 4> INVALID_BTF_DATA = { 0xDE, 0xAD, 0xBE, 0xEF };

--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -1,21 +1,18 @@
 #include <csignal>
+#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include <string>
-#include <system_error>
-
-#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
+#include <system_error>
 
 #include "child.h"
 #include "childhelper.h"
-#include "utils.h"
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::child {
 

--- a/tests/childhelper.h
+++ b/tests/childhelper.h
@@ -1,12 +1,15 @@
-#include <time.h>
-
 #include "child.h"
 #include "utils.h"
+#include "gtest/gtest.h"
 
-namespace bpftrace {
-namespace test {
+namespace {
 
-static int msleep(int msec)
+using bpftrace::ChildProc;
+using bpftrace::ChildProcBase;
+using bpftrace::StderrSilencer;
+using bpftrace::StdoutSilencer;
+
+inline int msleep(int msec)
 {
   struct timespec sleep = { .tv_sec = 0, .tv_nsec = msec * 1000000L };
   struct timespec rem = {};
@@ -15,14 +18,14 @@ static int msleep(int msec)
   return 0;
 }
 
-static void wait_for(ChildProcBase *child, int msec_timeout)
+inline void wait_for(ChildProcBase *child, int msec_timeout)
 {
   constexpr int wait = 10;
   while (child->is_alive() && msec_timeout > 0)
     msec_timeout -= wait - msleep(wait);
 }
 
-static std::unique_ptr<ChildProc> getChild(std::string cmd)
+inline std::unique_ptr<ChildProc> getChild(std::string cmd)
 {
   std::unique_ptr<ChildProc> child;
   {
@@ -37,5 +40,4 @@ static std::unique_ptr<ChildProc> getChild(std::string cmd)
   return child;
 }
 
-} // namespace test
-} // namespace bpftrace
+} // namespace

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -1,14 +1,11 @@
-#include "clang_parser.h"
-
-#include <iostream>
-#include <utility>
+#include <llvm/Config/llvm-config.h>
 
 #include "ast/passes/field_analyser.h"
 #include "bpftrace.h"
+#include "clang_parser.h"
 #include "driver.h"
 #include "struct.h"
 #include "gtest/gtest.h"
-#include <llvm/Config/llvm-config.h>
 
 namespace bpftrace::test::clang_parser {
 
@@ -704,10 +701,9 @@ TEST_F(clang_parser_btf, btf)
   EXPECT_EQ(foo2_field.offset, 8);
 }
 
-TEST_F(clang_parser_btf, btf_arrays_multi_dim)
+// Disabled because BTF flattens multi-dimensional arrays #3082.
+TEST_F(clang_parser_btf, DISABLED_btf_arrays_multi_dim)
 {
-  GTEST_SKIP() << "BTF flattens multi-dimensional arrays #3082";
-
   BPFtrace bpftrace;
   bpftrace.parse_btf({});
   parse("struct Foo { struct Arrays a; };", bpftrace);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -1,29 +1,22 @@
 #pragma once
 
-#include <regex>
-
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
-#include "../mocks.h"
+#include <fstream>
+#include <iostream>
 
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/pid_filter_pass.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/semantic_analyser.h"
-
-#include "bpffeature.h"
 #include "bpftrace.h"
+#include "btf_common.h"
 #include "clang_parser.h"
 #include "driver.h"
-#include "tracepoint_format_parser.h"
+#include "gtest/gtest.h"
 
-#include "btf_common.h"
+#include "../mocks.h"
 
-namespace bpftrace {
-namespace test {
-namespace codegen {
+namespace bpftrace::test::codegen {
 
 #define NAME (::testing::UnitTest::GetInstance()->current_test_info()->name())
 
@@ -112,6 +105,4 @@ static void test(const std::string &input,
   test(*bpftrace, input, name);
 }
 
-} // namespace codegen
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test::codegen

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -1,8 +1,5 @@
 #include "config.h"
-#include "mocks.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include <iostream>
 
 namespace bpftrace::test {
 

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -1,11 +1,9 @@
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
 #include "ast/passes/config_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 #include "clang_parser.h"
 #include "driver.h"
 #include "mocks.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::config_analyser {
 

--- a/tests/cstring_view.cpp
+++ b/tests/cstring_view.cpp
@@ -1,7 +1,7 @@
+#include <type_traits>
+
 #include "container/cstring_view.h"
 #include "gtest/gtest.h"
-
-#include <type_traits>
 
 namespace bpftrace::test::cstring_view {
 

--- a/tests/dwarf_common.h
+++ b/tests/dwarf_common.h
@@ -1,13 +1,16 @@
 #pragma once
 
-#include <sys/stat.h>
+#ifdef HAVE_LIBLLDB
 
 #include <cstdio>
 #include <fcntl.h>
 #include <fstream>
+#include <iostream>
 #include <stdexcept>
+#include <sys/stat.h>
 
 #include "data/dwarf_data.h"
+#include "gtest/gtest.h"
 
 class test_dwarf : public ::testing::Test {
 protected:
@@ -35,3 +38,5 @@ protected:
   static constexpr const char *bin_ = "/tmp/bpftrace-test-dwarf-data";
   static constexpr const char *cxx_bin_ = dwarf_data_cxx_path;
 };
+
+#endif

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -1,5 +1,6 @@
 #include "ast/passes/field_analyser.h"
 #include "driver.h"
+#include "dwarf_common.h"
 #include "mocks.h"
 #include "gtest/gtest.h"
 
@@ -183,10 +184,9 @@ TEST_F(field_analyser_btf, btf_arrays)
   EXPECT_EQ(arrs->GetField("flexible").offset, 64);
 }
 
-TEST_F(field_analyser_btf, btf_arrays_multi_dim)
+// Disabled because BTF flattens multi-dimensional arrays #3082.
+TEST_F(field_analyser_btf, DISABLED_btf_arrays_multi_dim)
 {
-  GTEST_SKIP() << "BTF flattens multi-dimensional arrays #3082";
-
   BPFtrace bpftrace;
   bpftrace.parse_btf({});
   test(bpftrace,
@@ -393,9 +393,6 @@ TEST_F(field_analyser_btf, btf_anon_union_first_in_struct)
 }
 
 #ifdef HAVE_LIBLLDB
-
-#include "dwarf_common.h"
-
 class field_analyser_dwarf : public test_dwarf {};
 
 TEST_F(field_analyser_dwarf, uprobe_args)
@@ -702,10 +699,9 @@ TEST_F(field_analyser_dwarf, parse_inheritance_multi)
   EXPECT_EQ(cls->GetField("rabc").offset, 24);
 }
 
-TEST_F(field_analyser_dwarf, parse_struct_anonymous_fields)
+// Disable because anonymous fields not supported #3084.
+TEST_F(field_analyser_dwarf, DISALBED_parse_struct_anonymous_fields)
 {
-  GTEST_SKIP() << "Anonymous fields not supported #3084";
-
   BPFtrace bpftrace;
   std::string uprobe = "uprobe:" + std::string(bin_);
   test(bpftrace, uprobe + ":func_1 { $x = args.foo2->g; }", 0);
@@ -817,7 +813,6 @@ TEST(field_analyser_subprog, struct_cast)
 {
   test("struct x { int a; } fn f(): void { $s = (struct x *)0; }", 0);
 }
-
 #endif // HAVE_LIBLLDB
 
 } // namespace bpftrace::test::field_analyser

--- a/tests/function_registry.cpp
+++ b/tests/function_registry.cpp
@@ -1,12 +1,10 @@
-#include "functions.h"
-
 #include <sstream>
 
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
+#include "functions.h"
 #include "log.h"
 #include "struct.h"
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::function_registry {
 

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -1,8 +1,7 @@
-#include "log.h"
-#include "mocks.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
 #include <iostream>
+
+#include "log.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::log {
 

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -1,5 +1,6 @@
 #include "mocks.h"
 #include "tracefs.h"
+#include "gmock/gmock-nice-strict.h"
 
 namespace bpftrace::test {
 
@@ -57,11 +58,11 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
       });
 
   ON_CALL(matcher, get_func_symbols_from_file(_, "/bin/*sh"))
-      .WillByDefault([sh_usyms, bash_usyms](std::optional<int>,
-                                            const std::string &) {
-        return std::unique_ptr<std::istream>(
-            new std::istringstream(sh_usyms + bash_usyms));
-      });
+      .WillByDefault(
+          [sh_usyms, bash_usyms](std::optional<int>, const std::string &) {
+            return std::unique_ptr<std::istream>(
+                new std::istringstream(sh_usyms + bash_usyms));
+          });
 
   std::string sh_usdts = "/bin/sh:prov1:tp1\n"
                          "/bin/sh:prov1:tp2\n"
@@ -74,11 +75,11 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
         return std::unique_ptr<std::istream>(new std::istringstream(sh_usdts));
       });
   ON_CALL(matcher, get_symbols_from_usdt(_, "/bin/*sh"))
-      .WillByDefault([sh_usdts, bash_usdts](std::optional<int>,
-                                            const std::string &) {
-        return std::unique_ptr<std::istream>(
-            new std::istringstream(sh_usdts + bash_usdts));
-      });
+      .WillByDefault(
+          [sh_usdts, bash_usdts](std::optional<int>, const std::string &) {
+            return std::unique_ptr<std::istream>(
+                new std::istringstream(sh_usdts + bash_usdts));
+          });
 }
 
 void setup_mock_bpftrace(MockBPFtrace &bpftrace)

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -1,15 +1,13 @@
 #pragma once
 
-#include "gmock/gmock.h"
-
 #include "bpffeature.h"
 #include "bpftrace.h"
 #include "child.h"
 #include "probe_matcher.h"
 #include "procmon.h"
+#include "gmock/gmock-function-mocker.h"
 
-namespace bpftrace {
-namespace test {
+namespace bpftrace::test {
 
 class MockProbeMatcher : public ProbeMatcher {
 public:
@@ -144,14 +142,14 @@ public:
   {
     child_pid_ = 1337;
   };
-  ~MockChildProc() {};
+  ~MockChildProc() override {};
 
   void terminate(bool force __attribute__((unused)) = false) override {};
   bool is_alive() override
   {
     return true;
   };
-  void resume(void) override {};
+  void resume() override {};
 
   void run(bool pause = false) override
   {
@@ -168,7 +166,7 @@ public:
 
   ~MockProcMon() override = default;
 
-  bool is_alive(void) override
+  bool is_alive() override
   {
     if (pid_ > 0)
       return true;
@@ -196,5 +194,4 @@ public:
 
 std::unique_ptr<MockUSDTHelper> get_mock_usdt_helper(int num_locations);
 
-} // namespace test
-} // namespace bpftrace
+} // namespace bpftrace::test

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -1,11 +1,9 @@
-#include "output.h"
-
-#include <gtest/gtest.h>
 #include <sstream>
 
 #include "bpfmap.h"
-#include "bpftrace.h"
 #include "mocks.h"
+#include "output.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::output {
 

--- a/tests/pid_filter_pass.cpp
+++ b/tests/pid_filter_pass.cpp
@@ -1,11 +1,9 @@
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
 #include "ast/passes/pid_filter_pass.h"
 #include "ast/passes/printer.h"
 #include "clang_parser.h"
 #include "driver.h"
 #include "mocks.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::pid_filter_pass {
 

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -1,13 +1,10 @@
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
-#include "ast/passes/field_analyser.h"
 #include "ast/passes/portability_analyser.h"
+#include "ast/passes/field_analyser.h"
 #include "ast/passes/semantic_analyser.h"
-
 #include "clang_parser.h"
 #include "driver.h"
 #include "mocks.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::portability_analyser {
 

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -3,12 +3,9 @@
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/semantic_analyser.h"
-
-#include "bpftrace.h"
 #include "clang_parser.h"
 #include "driver.h"
 #include "mocks.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace bpftrace::test::probe {

--- a/tests/procmon.cpp
+++ b/tests/procmon.cpp
@@ -1,13 +1,9 @@
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
 #include <ctime>
 
-#include "child.h"
-#include "procmon.h"
-
 #include "childhelper.h"
-#include "utils.h"
+#include "procmon.h"
+#include "gmock/gmock-matchers.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::procmon {
 

--- a/tests/required_resources.cpp
+++ b/tests/required_resources.cpp
@@ -1,13 +1,11 @@
-#include "required_resources.h"
-
 #include <iostream>
 #include <sstream>
 
-#include <gtest/gtest.h>
-
 #include "format_string.h"
+#include "required_resources.h"
 #include "struct.h"
 #include "types.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test {
 

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -1,12 +1,10 @@
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
-#include "ast/passes/field_analyser.h"
 #include "ast/passes/resource_analyser.h"
+#include "ast/passes/field_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 #include "clang_parser.h"
 #include "driver.h"
 #include "mocks.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::resource_analyser {
 

--- a/tests/result.cpp
+++ b/tests/result.cpp
@@ -1,6 +1,5 @@
-#include "gtest/gtest.h"
-
 #include "util/result.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::result {
 

--- a/tests/return_path_analyser.cpp
+++ b/tests/return_path_analyser.cpp
@@ -1,12 +1,10 @@
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-
-#include "ast/passes/field_analyser.h"
 #include "ast/passes/return_path_analyser.h"
+#include "ast/passes/field_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 #include "clang_parser.h"
 #include "driver.h"
 #include "mocks.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::return_path_analyser {
 

--- a/tests/scopeguard.cpp
+++ b/tests/scopeguard.cpp
@@ -1,9 +1,7 @@
-#include <gmock/gmock.h>
-#include <gtest/gtest.h>
+#include <exception>
 
 #include "scopeguard.h"
-
-#include <exception>
+#include "gtest/gtest.h"
 
 namespace bpftrace {
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1,12 +1,11 @@
 #include "ast/passes/semantic_analyser.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/printer.h"
-#include "bpffeature.h"
 #include "bpftrace.h"
 #include "clang_parser.h"
 #include "driver.h"
+#include "dwarf_common.h"
 #include "mocks.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace bpftrace::test::semantic_analyser {
@@ -1997,8 +1996,6 @@ TEST(semantic_analyser, unop_increment_decrement)
 }
 
 #ifdef HAVE_LIBLLDB
-#include "dwarf_common.h"
-
 class semantic_analyser_dwarf : public test_dwarf {};
 
 TEST_F(semantic_analyser_dwarf, reference_into_deref)

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -1,7 +1,7 @@
 #include "tracepoint_format_parser.h"
+#include "driver.h"
 #include "mocks.h"
 #include "gtest/gtest.h"
-#include <driver.h>
 
 using namespace testing;
 

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -1,6 +1,5 @@
 #include "types.h"
 #include "struct.h"
-#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace bpftrace::test::types {

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1,15 +1,14 @@
 #include <cstdlib>
 #include <cstring>
+#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
-
-#include "utils.h"
-#include "gmock/gmock.h"
-#include "gtest/gtest.h"
-#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include "utils.h"
+#include "gtest/gtest.h"
 
 namespace bpftrace::test::utils {
 


### PR DESCRIPTION
This commit does the following, primarily for headers, which were not
previously checked:

* Concatenate nested namespaces (modernize-concat-nested-namespaces)
* Drop void from `foo(void)` (modernize-redundant-void-arg)
* Remove any unused includes (misc-include-cleaner)
* Use `override` instead of `virtual` (modernize-use-override)
* Try to ensure a consistent include order:
  => All "system" libraries (which we include llvm, and bbc)
  => All "internal" libraries (which includes gtest, gmock and others)
* Remove unused variables and ensure dead code is blocked by
  `#if` appropriately, to prevent compiler warnings
* Use `DISABLED_` in favor of `GTEST_SKIP()` if the test is skipped
  100% of the time; this removes the dead code warnings
* Remove `std::move` that prevents temporary copy elision

The `.clang-tidy` configuration is adjusted to check headers.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
