### PR TITLE
Fix calls to ConfigSetter constructor

### DIFF
--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -722,7 +722,7 @@ TEST_F(bpftrace_dwarf, add_probes_uprobe_symbol_source)
 
   {
     BPFtrace bpftrace;
-    ConfigSetter configs{ bpftrace.config_, ConfigSource::script };
+    ConfigSetter configs{ *bpftrace.config_, ConfigSource::script };
     configs.set_symbol_source_config("dwarf");
     parse_probe(uprobe, bpftrace);
 
@@ -736,7 +736,7 @@ TEST_F(bpftrace_dwarf, add_probes_uprobe_symbol_source)
 
   {
     BPFtrace bpftrace;
-    ConfigSetter configs{ bpftrace.config_, ConfigSource::script };
+    ConfigSetter configs{ *bpftrace.config_, ConfigSource::script };
     configs.set_symbol_source_config("symbol_table");
     parse_probe(uprobe, bpftrace);
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -293,7 +293,7 @@ kprobe:f { fake }
 TEST(semantic_analyser, builtin_variables_inline)
 {
   auto bpftrace = get_mock_bpftrace();
-  ConfigSetter configs{ bpftrace->config_, ConfigSource::script };
+  ConfigSetter configs{ *bpftrace->config_, ConfigSource::script };
   configs.set(ConfigKeyBool::probe_inline, true);
 
   // Check argument builtins are rejected when `probe_inline` is enabled.


### PR DESCRIPTION
#3797 changed the constructor of `ConfigSetter` to accept a reference to `BPFtrace` rather than a pointer but failed to update three calls to the constructor in tests which are only executed if `HAVE_LIBLLDB` is set.

Fix the problematic calls.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
