### PR TITLE
trivial: cleanups from 605217e

### DIFF
--- a/src/util/result.cpp
+++ b/src/util/result.cpp
@@ -1,4 +1,3 @@
-
 #include <llvm/Support/raw_os_ostream.h>
 
 #include "util/result.h"

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -700,7 +700,7 @@ TEST_F(field_analyser_dwarf, parse_inheritance_multi)
 }
 
 // Disable because anonymous fields not supported #3084.
-TEST_F(field_analyser_dwarf, DISALBED_parse_struct_anonymous_fields)
+TEST_F(field_analyser_dwarf, DISABLED_parse_struct_anonymous_fields)
 {
   BPFtrace bpftrace;
   std::string uprobe = "uprobe:" + std::string(bin_);


### PR DESCRIPTION
Interestingly, the class of tests defined for `field_analyser_dwarf` must not be running at all due to my fat fingering. I will try to follow-up and set up a CI job for these configurations.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
