### PR TITLE
test: Don't require a single instance of `bpftrace_test`

### DIFF
--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -16,6 +16,7 @@
 #include "util/symbols.h"
 #include "util/system.h"
 #include "util/wildcard.h"
+#include "gmock/gmock-matchers.h"
 #include "gtest/gtest.h"
 
 namespace bpftrace::test::utils {
@@ -414,12 +415,10 @@ TEST(utils, find_near_self)
 TEST(utils, get_pids_for_program)
 {
   auto pids = get_pids_for_program("/proc/self/exe");
-
-  ASSERT_EQ(pids.size(), 1);
-  ASSERT_EQ(pids[0], getpid());
+  EXPECT_THAT(pids, testing::Contains(getpid()));
 
   pids = get_pids_for_program("/doesnotexist");
-  ASSERT_EQ(pids.size(), 0);
+  EXPECT_EQ(pids.size(), 0);
 }
 
 TEST(utils, round_up_to_next_power_of_two)


### PR DESCRIPTION
This updates the util tests to avoid failing when more than one instance of `bpftrace_test` (or whatever test binary) happens to be running at the same time. Instead, it merely requires that *at least* one instance of this test is running is suitable checks that the current process is one of them.

This enables the use of tools such as `gtest-parallel` to easily run the suite in parallel, taking a time of several minutes down to just a few seconds:

```
$ time gtest-parallel tests/bpftrace_test
[825/825] semantic_analyser.struct_member_keywords (9426 ms)

real	0m9.548s
user	4m21.008s
sys	4m35.737s
```

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
