### PR TITLE
Standardize long ret values

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -2042,7 +2042,7 @@ CallInst *IRBuilderBPF::CreateGetStack(Value *ctx,
   // Return: The non-negative copied *buf* length equal to or less than
   // *size* on success, or a negative error in case of failure.
   FunctionType *getstack_func_type = FunctionType::get(
-      getInt32Ty(),
+      getInt64Ty(),
       { getPtrTy(), getPtrTy(), getInt32Ty(), getInt64Ty() },
       false);
   CallInst *call = CreateHelperCall(libbpf::BPF_FUNC_get_stack,
@@ -2384,7 +2384,7 @@ CallInst *IRBuilderBPF::CreateSkbOutput(Value *skb,
 
   // long bpf_skb_output(void *skb, struct bpf_map *map, u64 flags,
   //                     void *data, u64 size)
-  FunctionType *skb_output_func_type = FunctionType::get(getInt32Ty(),
+  FunctionType *skb_output_func_type = FunctionType::get(getInt64Ty(),
                                                          { skb->getType(),
                                                            map_ptr->getType(),
                                                            getInt64Ty(),

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -205,7 +205,7 @@ ScopedExpr CodegenLLVM::kstack_ustack(const std::string &ident,
 
   Value *stack_size = b_.CreateGetStack(
       ctx_, is_ustack, stack_trace, stack_type, loc);
-  Value *condition = b_.CreateICmpSGE(stack_size, b_.getInt32(0));
+  Value *condition = b_.CreateICmpSGE(stack_size, b_.getInt64(0));
   b_.CreateCondBr(condition, get_stack_success, get_stack_fail);
 
   b_.SetInsertPoint(get_stack_fail);
@@ -215,8 +215,8 @@ ScopedExpr CodegenLLVM::kstack_ustack(const std::string &ident,
   b_.CreateBr(merge_block);
   b_.SetInsertPoint(get_stack_success);
 
-  Value *num_frames = b_.CreateUDiv(stack_size, b_.getInt32(uint64_size));
-  b_.CreateStore(b_.CreateIntCast(num_frames, b_.getInt64Ty(), false),
+  Value *num_frames = b_.CreateUDiv(stack_size, b_.getInt64(uint64_size));
+  b_.CreateStore(num_frames,
                  b_.CreateGEP(stack_key_struct,
                               stack_key,
                               { b_.getInt64(0), b_.getInt32(1) }));

--- a/tests/codegen/llvm/builtin_kstack.ll
+++ b/tests/codegen/llvm/builtin_kstack.ll
@@ -49,19 +49,18 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
-  %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 0)
-  %1 = icmp sge i32 %get_stack, 0
+  %get_stack = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 0)
+  %1 = icmp sge i64 %get_stack, 0
   br i1 %1, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %2 = udiv i32 %get_stack, 8
+  %2 = udiv i64 %get_stack, 8
   %3 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
-  %4 = zext i32 %2 to i64
-  store i64 %4, ptr %3, align 8
-  %5 = trunc i32 %2 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %5, i64 1)
-  %6 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %6, align 8
+  store i64 %2, ptr %3, align 8
+  %4 = trunc i64 %2 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %4, i64 1)
+  %5 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %5, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -56,19 +56,18 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
-  %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %4 = icmp sge i32 %get_stack, 0
+  %get_stack = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
+  %4 = icmp sge i64 %get_stack, 0
   br i1 %4, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %5 = udiv i32 %get_stack, 8
+  %5 = udiv i64 %get_stack, 8
   %6 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
-  %7 = zext i32 %5 to i64
-  store i64 %7, ptr %6, align 8
-  %8 = trunc i32 %5 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %8, i64 1)
-  %9 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %9, align 8
+  store i64 %5, ptr %6, align 8
+  %7 = trunc i64 %5 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %7, i64 1)
+  %8 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %8, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 

--- a/tests/codegen/llvm/call_kstack.ll
+++ b/tests/codegen/llvm/call_kstack.ll
@@ -70,19 +70,18 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
-  %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 0)
-  %1 = icmp sge i32 %get_stack, 0
+  %get_stack = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 0)
+  %1 = icmp sge i64 %get_stack, 0
   br i1 %1, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %2 = udiv i32 %get_stack, 8
+  %2 = udiv i64 %get_stack, 8
   %3 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
-  %4 = zext i32 %2 to i64
-  store i64 %4, ptr %3, align 8
-  %5 = trunc i32 %2 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %5, i64 1)
-  %6 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %6, align 8
+  store i64 %2, ptr %3, align 8
+  %4 = trunc i64 %2 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %4, i64 1)
+  %5 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %5, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -111,19 +110,18 @@ lookup_stack_scratch_failure7:                    ; preds = %merge_block
 
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
   call void @llvm.memset.p0.i64(ptr align 1 %lookup_stack_scratch_map6, i8 0, i64 48, i1 false)
-  %get_stack12 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 48, i64 0)
-  %7 = icmp sge i32 %get_stack12, 0
-  br i1 %7, label %get_stack_success10, label %get_stack_fail11
+  %get_stack12 = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 48, i64 0)
+  %6 = icmp sge i64 %get_stack12, 0
+  br i1 %6, label %get_stack_success10, label %get_stack_fail11
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
-  %8 = udiv i32 %get_stack12, 8
-  %9 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
-  %10 = zext i32 %8 to i64
-  store i64 %10, ptr %9, align 8
-  %11 = trunc i32 %8 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %11, i64 1)
-  %12 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_213, ptr %12, align 8
+  %7 = udiv i64 %get_stack12, 8
+  %8 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
+  store i64 %7, ptr %8, align 8
+  %9 = trunc i64 %7 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %9, i64 1)
+  %10 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, ptr %10, align 8
   %update_elem14 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_6, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
@@ -145,19 +143,18 @@ lookup_stack_scratch_failure21:                   ; preds = %merge_block4
 
 lookup_stack_scratch_merge22:                     ; preds = %merge_block4
   %probe_read_kernel24 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map20, i32 1016, ptr null)
-  %get_stack27 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map20, i32 1016, i64 0)
-  %13 = icmp sge i32 %get_stack27, 0
-  br i1 %13, label %get_stack_success25, label %get_stack_fail26
+  %get_stack27 = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map20, i32 1016, i64 0)
+  %11 = icmp sge i64 %get_stack27, 0
+  br i1 %11, label %get_stack_success25, label %get_stack_fail26
 
 get_stack_success25:                              ; preds = %lookup_stack_scratch_merge22
-  %14 = udiv i32 %get_stack27, 8
-  %15 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 1
-  %16 = zext i32 %14 to i64
-  store i64 %16, ptr %15, align 8
-  %17 = trunc i32 %14 to i8
-  %murmur_hash_228 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map20, i8 %17, i64 1)
-  %18 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 0
-  store i64 %murmur_hash_228, ptr %18, align 8
+  %12 = udiv i64 %get_stack27, 8
+  %13 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 1
+  store i64 %12, ptr %13, align 8
+  %14 = trunc i64 %12 to i8
+  %murmur_hash_228 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map20, i8 %14, i64 1)
+  %15 = getelementptr %kstack_key, ptr %stack_key16, i64 0, i32 0
+  store i64 %murmur_hash_228, ptr %15, align 8
   %update_elem29 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_perf_127, ptr %stack_key16, ptr %lookup_stack_scratch_map20, i64 0)
   br label %merge_block18
 

--- a/tests/codegen/llvm/call_len_ustack_kstack.ll
+++ b/tests/codegen/llvm/call_len_ustack_kstack.ll
@@ -76,19 +76,18 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
-  %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %6 = icmp sge i32 %get_stack, 0
+  %get_stack = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
+  %6 = icmp sge i64 %get_stack, 0
   br i1 %6, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %7 = udiv i32 %get_stack, 8
+  %7 = udiv i64 %get_stack, 8
   %8 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
-  %9 = zext i32 %7 to i64
-  store i64 %9, ptr %8, align 8
-  %10 = trunc i32 %7 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %10, i64 1)
-  %11 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %11, align 8
+  store i64 %7, ptr %8, align 8
+  %9 = trunc i64 %7 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %9, i64 1)
+  %10 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %10, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -99,12 +98,12 @@ stack_scratch_failure3:                           ; preds = %lookup_stack_scratc
   br label %merge_block4
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success11, %get_stack_fail12
-  %12 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
-  %13 = load i64, ptr %12, align 8
+  %11 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
+  %12 = load i64, ptr %11, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  store i64 %13, ptr %"@y_val", align 8
+  store i64 %12, ptr %"@y_val", align 8
   %update_elem16 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -115,19 +114,18 @@ lookup_stack_scratch_failure7:                    ; preds = %merge_block
 
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
   %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map6, i32 1016, ptr null)
-  %get_stack13 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 1016, i64 0)
-  %14 = icmp sge i32 %get_stack13, 0
-  br i1 %14, label %get_stack_success11, label %get_stack_fail12
+  %get_stack13 = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 1016, i64 0)
+  %13 = icmp sge i64 %get_stack13, 0
+  br i1 %13, label %get_stack_success11, label %get_stack_fail12
 
 get_stack_success11:                              ; preds = %lookup_stack_scratch_merge8
-  %15 = udiv i32 %get_stack13, 8
-  %16 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
-  %17 = zext i32 %15 to i64
-  store i64 %17, ptr %16, align 8
-  %18 = trunc i32 %15 to i8
-  %murmur_hash_214 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %18, i64 1)
-  %19 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_214, ptr %19, align 8
+  %14 = udiv i64 %get_stack13, 8
+  %15 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 1
+  store i64 %14, ptr %15, align 8
+  %16 = trunc i64 %14 to i8
+  %murmur_hash_214 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %16, i64 1)
+  %17 = getelementptr %kstack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_214, ptr %17, align 8
   %update_elem15 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -77,19 +77,18 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
-  %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %4 = icmp sge i32 %get_stack, 0
+  %get_stack = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
+  %4 = icmp sge i64 %get_stack, 0
   br i1 %4, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %5 = udiv i32 %get_stack, 8
+  %5 = udiv i64 %get_stack, 8
   %6 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
-  %7 = zext i32 %5 to i64
-  store i64 %7, ptr %6, align 8
-  %8 = trunc i32 %5 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %8, i64 1)
-  %9 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %9, align 8
+  store i64 %5, ptr %6, align 8
+  %7 = trunc i64 %5 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %7, i64 1)
+  %8 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %8, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -100,13 +99,13 @@ stack_scratch_failure3:                           ; preds = %lookup_stack_scratc
   br label %merge_block4
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
-  %10 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 2
+  %9 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 2
   %get_pid_tgid15 = call i64 inttoptr (i64 14 to ptr)()
-  %11 = lshr i64 %get_pid_tgid15, 32
-  %pid16 = trunc i64 %11 to i32
-  store i32 %pid16, ptr %10, align 4
-  %12 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 3
-  store i32 0, ptr %12, align 4
+  %10 = lshr i64 %get_pid_tgid15, 32
+  %pid16 = trunc i64 %10 to i32
+  store i32 %pid16, ptr %9, align 4
+  %11 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 3
+  store i32 0, ptr %11, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   %update_elem17 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %stack_key2, i64 0)
@@ -125,19 +124,18 @@ lookup_stack_scratch_failure7:                    ; preds = %merge_block
 
 lookup_stack_scratch_merge8:                      ; preds = %merge_block
   call void @llvm.memset.p0.i64(ptr align 1 %lookup_stack_scratch_map6, i8 0, i64 48, i1 false)
-  %get_stack12 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 48, i64 256)
-  %13 = icmp sge i32 %get_stack12, 0
-  br i1 %13, label %get_stack_success10, label %get_stack_fail11
+  %get_stack12 = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map6, i32 48, i64 256)
+  %12 = icmp sge i64 %get_stack12, 0
+  br i1 %12, label %get_stack_success10, label %get_stack_fail11
 
 get_stack_success10:                              ; preds = %lookup_stack_scratch_merge8
-  %14 = udiv i32 %get_stack12, 8
-  %15 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 1
-  %16 = zext i32 %14 to i64
-  store i64 %16, ptr %15, align 8
-  %17 = trunc i32 %14 to i8
-  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %17, i64 1)
-  %18 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 0
-  store i64 %murmur_hash_213, ptr %18, align 8
+  %13 = udiv i64 %get_stack12, 8
+  %14 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 1
+  store i64 %13, ptr %14, align 8
+  %15 = trunc i64 %13 to i8
+  %murmur_hash_213 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map6, i8 %15, i64 1)
+  %16 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 0
+  store i64 %murmur_hash_213, ptr %16, align 8
   %update_elem14 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_bpftrace_6, ptr %stack_key2, ptr %lookup_stack_scratch_map6, i64 0)
   br label %merge_block4
 
@@ -148,13 +146,13 @@ stack_scratch_failure19:                          ; preds = %lookup_stack_scratc
   br label %merge_block20
 
 merge_block20:                                    ; preds = %stack_scratch_failure19, %get_stack_success27, %get_stack_fail28
-  %19 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 2
+  %17 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 2
   %get_pid_tgid32 = call i64 inttoptr (i64 14 to ptr)()
-  %20 = lshr i64 %get_pid_tgid32, 32
-  %pid33 = trunc i64 %20 to i32
-  store i32 %pid33, ptr %19, align 4
-  %21 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 3
-  store i32 0, ptr %21, align 4
+  %18 = lshr i64 %get_pid_tgid32, 32
+  %pid33 = trunc i64 %18 to i32
+  store i32 %pid33, ptr %17, align 4
+  %19 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 3
+  store i32 0, ptr %19, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@z_key")
   store i64 0, ptr %"@z_key", align 8
   %update_elem34 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_z, ptr %"@z_key", ptr %stack_key18, i64 0)
@@ -166,19 +164,18 @@ lookup_stack_scratch_failure23:                   ; preds = %merge_block4
 
 lookup_stack_scratch_merge24:                     ; preds = %merge_block4
   %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map22, i32 1016, ptr null)
-  %get_stack29 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map22, i32 1016, i64 256)
-  %22 = icmp sge i32 %get_stack29, 0
-  br i1 %22, label %get_stack_success27, label %get_stack_fail28
+  %get_stack29 = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map22, i32 1016, i64 256)
+  %20 = icmp sge i64 %get_stack29, 0
+  br i1 %20, label %get_stack_success27, label %get_stack_fail28
 
 get_stack_success27:                              ; preds = %lookup_stack_scratch_merge24
-  %23 = udiv i32 %get_stack29, 8
-  %24 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 1
-  %25 = zext i32 %23 to i64
-  store i64 %25, ptr %24, align 8
-  %26 = trunc i32 %23 to i8
-  %murmur_hash_230 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map22, i8 %26, i64 1)
-  %27 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 0
-  store i64 %murmur_hash_230, ptr %27, align 8
+  %21 = udiv i64 %get_stack29, 8
+  %22 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 1
+  store i64 %21, ptr %22, align 8
+  %23 = trunc i64 %21 to i8
+  %murmur_hash_230 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map22, i8 %23, i64 1)
+  %24 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 0
+  store i64 %murmur_hash_230, ptr %24, align 8
   %update_elem31 = call i64 inttoptr (i64 2 to ptr)(ptr @stack_perf_127, ptr %stack_key18, ptr %lookup_stack_scratch_map22, i64 0)
   br label %merge_block20
 

--- a/tests/codegen/llvm/count_cast_loop_stack_key.ll
+++ b/tests/codegen/llvm/count_cast_loop_stack_key.ll
@@ -51,19 +51,18 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
-  %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 0)
-  %1 = icmp sge i32 %get_stack, 0
+  %get_stack = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 0)
+  %1 = icmp sge i64 %get_stack, 0
   br i1 %1, label %get_stack_success, label %get_stack_fail
 
 get_stack_success:                                ; preds = %lookup_stack_scratch_merge
-  %2 = udiv i32 %get_stack, 8
+  %2 = udiv i64 %get_stack, 8
   %3 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 1
-  %4 = zext i32 %2 to i64
-  store i64 %4, ptr %3, align 8
-  %5 = trunc i32 %2 to i8
-  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %5, i64 1)
-  %6 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
-  store i64 %murmur_hash_2, ptr %6, align 8
+  store i64 %2, ptr %3, align 8
+  %4 = trunc i64 %2 to i8
+  %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %4, i64 1)
+  %5 = getelementptr %kstack_key, ptr %stack_key, i64 0, i32 0
+  store i64 %murmur_hash_2, ptr %5, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @stack_raw_127, ptr %stack_key, ptr %lookup_stack_scratch_map, i64 0)
   br label %merge_block
 
@@ -71,9 +70,9 @@ get_stack_fail:                                   ; preds = %lookup_stack_scratc
   br label %merge_block
 
 lookup_success:                                   ; preds = %merge_block
-  %7 = load i64, ptr %lookup_elem, align 8
-  %8 = add i64 %7, 1
-  store i64 %8, ptr %lookup_elem, align 8
+  %6 = load i64, ptr %lookup_elem, align 8
+  %7 = add i64 %6, 1
+  store i64 %7, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %merge_block

--- a/tests/codegen/llvm/runtime_error_check_stack.ll
+++ b/tests/codegen/llvm/runtime_error_check_stack.ll
@@ -76,16 +76,16 @@ lookup_stack_scratch_failure:                     ; preds = %entry
 
 lookup_stack_scratch_merge:                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map, i32 1016, ptr null)
-  %get_stack = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
-  %6 = icmp sge i32 %get_stack, 0
-  br i1 %6, label %helper_merge, label %helper_failure
+  %get_stack = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map, i32 1016, i64 256)
+  %6 = trunc i64 %get_stack to i32
+  %7 = icmp sge i32 %6, 0
+  br i1 %7, label %helper_merge, label %helper_failure
 
 get_stack_success:                                ; preds = %helper_merge
-  %7 = udiv i32 %get_stack, 8
-  %8 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
-  %9 = zext i32 %7 to i64
-  store i64 %9, ptr %8, align 8
-  %10 = trunc i32 %7 to i8
+  %8 = udiv i64 %get_stack, 8
+  %9 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 1
+  store i64 %8, ptr %9, align 8
+  %10 = trunc i64 %8 to i8
   %murmur_hash_2 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map, i8 %10, i64 1)
   %11 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 0
   store i64 %murmur_hash_2, ptr %11, align 8
@@ -104,13 +104,13 @@ helper_failure:                                   ; preds = %lookup_stack_scratc
   %15 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
   store i64 0, ptr %15, align 8
   %16 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
-  store i32 %get_stack, ptr %16, align 4
+  store i32 %6, ptr %16, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 helper_merge:                                     ; preds = %counter_merge, %lookup_stack_scratch_merge
-  %17 = icmp sge i32 %get_stack, 0
+  %17 = icmp sge i64 %get_stack, 0
   br i1 %17, label %get_stack_success, label %get_stack_fail
 
 event_loss_counter:                               ; preds = %helper_failure
@@ -233,16 +233,16 @@ lookup_stack_scratch_failure33:                   ; preds = %helper_merge16
 
 lookup_stack_scratch_merge34:                     ; preds = %helper_merge16
   %probe_read_kernel36 = call i64 inttoptr (i64 113 to ptr)(ptr %lookup_stack_scratch_map32, i32 1016, ptr null)
-  %get_stack39 = call i32 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map32, i32 1016, i64 0)
-  %29 = icmp sge i32 %get_stack39, 0
-  br i1 %29, label %helper_merge41, label %helper_failure40
+  %get_stack39 = call i64 inttoptr (i64 67 to ptr)(ptr %0, ptr %lookup_stack_scratch_map32, i32 1016, i64 0)
+  %29 = trunc i64 %get_stack39 to i32
+  %30 = icmp sge i32 %29, 0
+  br i1 %30, label %helper_merge41, label %helper_failure40
 
 get_stack_success37:                              ; preds = %helper_merge41
-  %30 = udiv i32 %get_stack39, 8
-  %31 = getelementptr %kstack_key, ptr %stack_key28, i64 0, i32 1
-  %32 = zext i32 %30 to i64
-  store i64 %32, ptr %31, align 8
-  %33 = trunc i32 %30 to i8
+  %31 = udiv i64 %get_stack39, 8
+  %32 = getelementptr %kstack_key, ptr %stack_key28, i64 0, i32 1
+  store i64 %31, ptr %32, align 8
+  %33 = trunc i64 %31 to i8
   %murmur_hash_253 = call i64 @murmur_hash_2(ptr %lookup_stack_scratch_map32, i8 %33, i64 1)
   %34 = getelementptr %kstack_key, ptr %stack_key28, i64 0, i32 0
   store i64 %murmur_hash_253, ptr %34, align 8
@@ -261,13 +261,13 @@ helper_failure40:                                 ; preds = %lookup_stack_scratc
   %38 = getelementptr %helper_error_t, ptr %helper_error_t42, i64 0, i32 1
   store i64 3, ptr %38, align 8
   %39 = getelementptr %helper_error_t, ptr %helper_error_t42, i64 0, i32 2
-  store i32 %get_stack39, ptr %39, align 4
+  store i32 %29, ptr %39, align 4
   %ringbuf_output43 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t42, i64 20, i64 0)
   %ringbuf_loss46 = icmp slt i64 %ringbuf_output43, 0
   br i1 %ringbuf_loss46, label %event_loss_counter44, label %counter_merge45
 
 helper_merge41:                                   ; preds = %counter_merge45, %lookup_stack_scratch_merge34
-  %40 = icmp sge i32 %get_stack39, 0
+  %40 = icmp sge i64 %get_stack39, 0
   br i1 %40, label %get_stack_success37, label %get_stack_fail38
 
 event_loss_counter44:                             ; preds = %helper_failure40


### PR DESCRIPTION
For all BPF helpers that return long
we set that type to int64 except in
two cases: bpf_skb_output, bpf_get_stack.

This updates those two cases to also
treat long as 64 bits instead of 32.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
