### PR TITLE
tests: fix kretprobe_order

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -106,7 +106,7 @@ AFTER ./testprogs/syscall read
 
 NAME kprobe_order
 RUN {{BPFTRACE}} runtime/scripts/kprobe_order.bt
-EXPECT first second
+EXPECT_REGEX (first)+ second
 AFTER /bin/bash -c "./testprogs/syscall nanosleep 1001";
 
 NAME kprobe_offset


### PR DESCRIPTION
It is possible that the first probe fires multiple times before the second probe is attached. The test should use a regular expression to allow for this possibility.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- [ ] The new behaviour is covered by tests
