### PR TITLE
trivial: fix README build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bpftrace
 
-[![Build Status](https://github.com/bpftrace/bpftrace/workflows/CI/badge.svg?branch=master)](https://github.com/bpftrace/bpftrace/actions?query=workflow%3ACI+branch%3Amaster)
+[![Build Status](https://github.com/bpftrace/bpftrace/actions/workflows/ci.yml/badge.svg)](https://github.com/bpftrace/bpftrace/actions/workflows/ci.yml)
 [![IRC#bpftrace](https://img.shields.io/badge/IRC-bpftrace-blue.svg)](https://webchat.oftc.net/?channels=bpftrace)
 [![CodeQL](https://github.com/bpftrace/bpftrace/actions/workflows/codeql.yml/badge.svg)](https://github.com/bpftrace/bpftrace/actions/workflows/codeql.yml)
 


### PR DESCRIPTION
Not sure when this changed, but the badge has been inactive for a while. Point to the CI workflow.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
