### PR TITLE
misc: add default configuration for VSCode devcontainers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:bullseye
+
+# Required nix install dependencies.
+RUN apt-get update && apt-get install -y curl bzip2 adduser direnv vim
+RUN su - vscode -c 'sh <(curl -L https://releases.nixos.org/nix/nix-2.26.3/install) --no-daemon'
+RUN su - vscode -c 'mkdir -p ~/.config/nix && echo "extra-experimental-features = nix-command flakes" > ~/.config/nix/nix.conf'
+RUN su - vscode -c 'nix-env -iA nixpkgs.direnv'
+RUN su - vscode -c 'direnv hook bash >> ~/.bashrc'
+USER vscode

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "build": { "dockerfile": "Dockerfile" },
+   "customizations": {
+    "vscode": {
+      "extensions": [
+        "mkhl.direnv",
+        "llvm-vs-code-extensions.vscode-clangd",
+        "ms-vscode.cmake-tools"
+      ]
+    }
+  },
+  "postStartCommand": "nix develop -c true && direnv allow"
+}

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 build-*/
 tests/runtime/*.pyc
+.direnv
 .vagrant
 tests/**/*.bc
 *~

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "cmake.buildDirectory": "${workspaceFolder}/build-vscode",
+    "clangd.arguments": [
+        "-background-index",
+        "-compile-commands-dir=${workspaceFolder}/build-vscode"
+    ]
+}


### PR DESCRIPTION
This wraps the existing nix configuration by using `direnv`. Essentially we build a devcontainer that has Nix for the current user, and immediately enter the default devshell.

##### Checklist

- [x] ~Language changes are updated in `man/adoc/bpftrace.adoc`~ Developer documentation is updated
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
