### PR TITLE
update cmake for zlib libraries

### DIFF
--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -21,4 +21,4 @@ if (KERNEL_HEADERS_DIR)
 endif()
 target_compile_definitions(util PUBLIC KERNEL_HEADERS_DIR="${KERNEL_HEADERS_DIR}")
 
-target_link_libraries(util debugfs)
+target_link_libraries(util debugfs ${ZLIB_LIBRARIES})


### PR DESCRIPTION
When this PR landed[1] it caused two
of our distro builds to fail wit this error:
`90.10 /usr/bin/ld: /usr/lib/x86_64-linux-gnu/libbpf.so: undefined reference to symbol 'gzgets'`

I think it's because the CMakeLists file
for utils no longer includes the zlib libraries.

This change moves them to the right CMakeLists file.

[1] https://github.com/bpftrace/bpftrace/pull/3881

Failing jobs:
https://github.com/bpftrace/bpftrace/actions/runs/13845989045/job/38744400466

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
