### PR TITLE
tests: runtime: Simplify sigint test

### DIFF
--- a/tests/runtime/signals
+++ b/tests/runtime/signals
@@ -5,7 +5,8 @@ REQUIRES command -v strace
 TIMEOUT 3
 
 NAME sigint quit
-RUN {{BPFTRACE}} -e 'END { printf("%s %d", "SUCCESS", 1) }' & (./testprogs/syscall nanosleep 1e9 && /usr/bin/env kill -s SIGINT $!)
+PROG END { printf("%s %d\n", "SUCCESS", 1) }
+AFTER pkill -SIGINT bpftrace
 EXPECT SUCCESS 1
 TIMEOUT 2
 


### PR DESCRIPTION
The test was overly complicated. So simplify it.

Also add a newline for the printf to ensure the output is immediately printed out.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
