### PR TITLE
log: fix reference binding for `LogStream`

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -76,7 +76,7 @@ void Log::take_input(LogType type,
   }
 }
 
-LogStream::LogStream(std::string file,
+LogStream::LogStream(const std::string& file,
                      int line,
                      LogType type,
                      std::ostream& out)
@@ -84,7 +84,7 @@ LogStream::LogStream(std::string file,
 {
 }
 
-LogStream::LogStream(std::string file,
+LogStream::LogStream(const std::string& file,
                      int line,
                      LogType type,
                      std::string&& source_location,

--- a/src/log.h
+++ b/src/log.h
@@ -74,11 +74,11 @@ private:
 
 class LogStream {
 public:
-  LogStream(std::string file,
+  LogStream(const std::string& file,
             int line,
             LogType type,
             std::ostream& out = std::cerr);
-  LogStream(std::string file,
+  LogStream(const std::string& file,
             int line,
             LogType type,
             std::string&& source_location,


### PR DESCRIPTION
Not sure how this snuck in there during the refactor, but the reference binding for two log constructors was not correct. This is unused at the moment, except for the `DEBUG` and `BUG` cases (the latter of which goes through a separate constructor).

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
