### PR TITLE
types: Clarify that CreateString() size includes NUL

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -517,6 +517,7 @@ SizedType CreateUInt32();
 SizedType CreateUInt64();
 SizedType CreateEnum(size_t bits, const std::string &name);
 
+// Create a string of `size` bytes, inclusive of NUL terminator.
 SizedType CreateString(size_t size);
 SizedType CreateArray(size_t num_elements, const SizedType &element_type);
 SizedType CreatePointer(const SizedType &pointee_type,


### PR DESCRIPTION
Make this clearer, as without docs it could be interpreted ambiguously.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
