### PR TITLE
Add "license" config variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
   - [#3780](https://github.com/bpftrace/bpftrace/pull/3780)
 - Add map declaration syntax (behind an "unstable" config flag)
   - [#3863](https://github.com/bpftrace/bpftrace/pull/3863)
+- Add license config to specify BPF license
+  - [#3905](https://github.com/bpftrace/bpftrace/pull/3905)
 #### Changed
 - `probe` builtin is now represented as a string type
   - [#3638](https://github.com/bpftrace/bpftrace/pull/3638)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3652,6 +3652,12 @@ Default: 0
 
 For user space symbols, symbolicate lazily/on-demand (1) or symbolicate everything ahead of time (0).
 
+=== license
+
+Default: "GPL"
+
+The license bpftrace will use to load BPF programs into the linux kernel.
+
 ==== log_size
 
 Default: 1000000
@@ -3835,6 +3841,13 @@ BEGIN { @=*uptr(kaddr("do_poweroff")) }
 
 bpftrace tries to automatically set the correct address space for a pointer based on the probe type, but might fail in cases where it is unclear.
 The address space can be changed with the <<functions-kptr, kptrs>> and <<functios-uptr, uptr>> functions.
+
+=== BPF License
+
+By default bpftrace uses "GPL", which is actually "GPL version 2", as the license it uses to load BPF programs into the kernel.
+Some other examples of compatible licenses are: "GPL v2" and "Dual MPL/GPL".
+You can specify a different license using the "license" config variable.
+link:https://docs.kernel.org/bpf/bpf_licensing.html#using-bpf-programs-in-the-linux-kernel[#Read more about BPF programs and licensing].
 
 === BTF Support
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -447,7 +447,7 @@ CodegenLLVM::CodegenLLVM(ASTContext &ast,
                          llvm::DEBUG_METADATA_VERSION);
 
   // Set license of BPF programs
-  const std::string license = "GPL";
+  const std::string license = bpftrace_.config_->get(ConfigKeyString::license);
   auto license_size = license.size() + 1;
   auto license_var = llvm::dyn_cast<GlobalVariable>(
       module_->getOrInsertGlobal(LICENSE,

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -230,6 +230,17 @@ void BpfBytecode::load_progs(const RequiredResources &resources,
           "pointer arithmetic on ptr_or_null_ prohibited, null-check it first",
           ": result needs to be null-checked before accessing fields");
 
+      auto err_pos = log.find("from non-GPL compatible program");
+      if (err_pos != log.npos) {
+        LOG(ERROR) << "Your bpftrace program cannot load because you are using "
+                      "a license that is non-GPL compatible. License: "
+                   << config.get(ConfigKeyString::license);
+        LOG(HINT)
+            << "Read more about BPF programs and licensing: "
+               "https://docs.kernel.org/bpf/"
+               "bpf_licensing.html#using-bpf-programs-in-the-linux-kernel";
+      }
+
       std::stringstream errmsg;
       errmsg << "Error loading BPF program for " << name << ".";
       if (bt_verbose) {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -32,6 +32,7 @@ Config::Config(bool has_cmd)
     { ConfigKeyInt::on_stack_limit, { .value = static_cast<uint64_t>(32) } },
     { ConfigKeyInt::perf_rb_pages, { .value = static_cast<uint64_t>(64) } },
     { ConfigKeyStackMode::default_, { .value = StackMode::bpftrace } },
+    { ConfigKeyString::license, { .value = std::string("GPL") } },
     { ConfigKeyString::str_trunc_trailer, { .value = std::string("..") } },
     { ConfigKeySymbolSource::default_,
       { .value =

--- a/src/config.h
+++ b/src/config.h
@@ -43,6 +43,7 @@ enum class ConfigKeyInt {
 };
 
 enum class ConfigKeyString {
+  license,
   str_trunc_trailer,
 };
 
@@ -87,6 +88,7 @@ const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
   { "cache_user_symbols", ConfigKeyUserSymbolCacheType::default_ },
   { "cpp_demangle", ConfigKeyBool::cpp_demangle },
   { "lazy_symbolication", ConfigKeyBool::lazy_symbolication },
+  { "license", ConfigKeyString::license },
   { "log_size", ConfigKeyInt::log_size },
   { "max_bpf_progs", ConfigKeyInt::max_bpf_progs },
   { "max_cat_bytes", ConfigKeyInt::max_cat_bytes },

--- a/tests/codegen/license.cpp
+++ b/tests/codegen/license.cpp
@@ -1,0 +1,18 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, license)
+{
+  auto bpftrace = get_mock_bpftrace();
+  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
+  configs.set(ConfigKeyString::license, "Dual BSD/GPL");
+
+  test(*bpftrace, "kprobe:f { @x = 1; }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/license.ll
+++ b/tests/codegen/llvm/license.ll
@@ -1,0 +1,100 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [13 x i8] c"Dual BSD/GPL\00", section "license", !dbg !0
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @kprobe_f_1(ptr %0) section "s_kprobe_f_1" !dbg !51 {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
+  store i64 0, ptr %"@x_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  store i64 1, ptr %"@x_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!48}
+!llvm.module.flags = !{!50}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 104, elements: !5)
+!4 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!5 = !{!6}
+!6 = !DISubrange(count: 13, lowerBound: 0)
+!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
+!8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
+!10 = !{!11, !17, !18, !21}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !{!16}
+!16 = !DISubrange(count: 1, lowerBound: 0)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
+!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
+!20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
+!25 = !{!26, !31}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
+!29 = !{!30}
+!30 = !DISubrange(count: 27, lowerBound: 0)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 262144, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !17, !45, !21}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 64, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 2, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !46, size: 64, offset: 128)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!48 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !49)
+!49 = !{!0, !7, !22, !36}
+!50 = !{i32 2, !"Debug Info Version", i32 3}
+!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !48, retainedNodes: !55)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!20, !54}
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -341,3 +341,12 @@ EXPECT FOO
 NAME no symbolize int cast to unknown enum variant
 PROG enum BAZ { FOO = 333, BAR }; BEGIN { $x = 444; print((enum BAZ)$x); exit(); }
 EXPECT 444
+
+NAME valid license
+PROG config={license="Dual BSD/GPL"} BEGIN { @p[1] = 1; print(len(@p)); exit(); }
+EXPECT 1
+
+NAME invalid license
+PROG config={license="Potato"} BEGIN { @p[1] = 1; print(len(@p)); exit(); }
+EXPECT ERROR: Your bpftrace program cannot load because you are using a license that is non-GPL compatible. License: Potato
+WILL_FAIL


### PR DESCRIPTION
This is so users can specify a different
license than "GPL", which is what bpftrace
currently uses to load all BPF programs.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
