### PR TITLE
ast: replace `is_deprecated` with structured pass and warning

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(ast STATIC
 
   passes/codegen_resources.cpp
   passes/config_analyser.cpp
+  passes/deprecated.cpp
   passes/field_analyser.cpp
   passes/portability_analyser.cpp
   passes/printer.cpp

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -30,8 +30,8 @@ StackMode::StackMode(Diagnostics &d, std::string mode, Location &&loc)
   is_literal = true;
 }
 
-Builtin::Builtin(Diagnostics &d, const std::string &ident, Location &&loc)
-    : Expression(d, std::move(loc)), ident(is_deprecated(ident))
+Builtin::Builtin(Diagnostics &d, std::string ident, Location &&loc)
+    : Expression(d, std::move(loc)), ident(std::move(ident))
 {
 }
 
@@ -49,17 +49,17 @@ PositionalParameter::PositionalParameter(Diagnostics &d,
   is_literal = true;
 }
 
-Call::Call(Diagnostics &d, const std::string &func, Location &&loc)
-    : Expression(d, std::move(loc)), func(is_deprecated(func))
+Call::Call(Diagnostics &d, std::string func, Location &&loc)
+    : Expression(d, std::move(loc)), func(std::move(func))
 {
 }
 
 Call::Call(Diagnostics &d,
-           const std::string &func,
+           std::string func,
            ExpressionList &&vargs,
            Location &&loc)
     : Expression(d, std::move(loc)),
-      func(is_deprecated(func)),
+      func(std::move(func)),
       vargs(std::move(vargs))
 {
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -164,7 +164,7 @@ public:
 
 class Builtin : public Expression {
 public:
-  explicit Builtin(Diagnostics &d, const std::string &ident, Location &&loc);
+  explicit Builtin(Diagnostics &d, std::string ident, Location &&loc);
 
   std::string ident;
   int probe_id;
@@ -179,9 +179,9 @@ public:
 
 class Call : public Expression {
 public:
-  explicit Call(Diagnostics &d, const std::string &func, Location &&loc);
+  explicit Call(Diagnostics &d, std::string func, Location &&loc);
   Call(Diagnostics &d,
-       const std::string &func,
+       std::string func,
        ExpressionList &&vargs,
        Location &&loc);
 

--- a/src/ast/helpers.cpp
+++ b/src/ast/helpers.cpp
@@ -1,35 +1,9 @@
 #include <unordered_set>
-#include <vector>
 
 #include "ast/helpers.h"
 #include "log.h"
 
 namespace bpftrace {
-
-struct DeprecatedName {
-  std::string old_name;
-  std::string new_name;
-  bool show_warning = true;
-  bool replace_by_new_name = true;
-
-  bool matches(const std::string &name) const
-  {
-    // We allow a prefix match to match against builtins with number (argX)
-    if (old_name.back() == '*') {
-      std::string_view old_name_view{ old_name.c_str(), old_name.size() - 1 };
-      return name.rfind(old_name_view) == 0;
-    }
-
-    return name == old_name;
-  }
-};
-
-static std::vector<DeprecatedName> DEPRECATED_LIST = {
-  { .old_name = "sarg*",
-    .new_name = "*(reg(\"sp\") + <stack_offset>)",
-    .show_warning = true,
-    .replace_by_new_name = false }
-};
 
 static std::unordered_set<std::string> UNSAFE_BUILTIN_FUNCS = {
   "system",
@@ -40,30 +14,6 @@ static std::unordered_set<std::string> UNSAFE_BUILTIN_FUNCS = {
 static std::unordered_set<std::string> COMPILE_TIME_FUNCS = { "cgroupid" };
 
 static std::unordered_set<std::string> UPROBE_LANGS = { "cpp" };
-
-const std::string &is_deprecated(const std::string &str)
-{
-  for (auto &item : DEPRECATED_LIST) {
-    if (!item.matches(str)) {
-      continue;
-    }
-
-    if (item.show_warning) {
-      LOG(WARNING) << item.old_name
-                   << " is deprecated and will be removed in the future. Use "
-                   << item.new_name << " instead.";
-      item.show_warning = false;
-    }
-
-    if (item.replace_by_new_name) {
-      return item.new_name;
-    } else {
-      return str;
-    }
-  }
-
-  return str;
-}
 
 bool is_unsafe_func(const std::string &func_name)
 {

--- a/src/ast/helpers.h
+++ b/src/ast/helpers.h
@@ -4,7 +4,6 @@
 
 namespace bpftrace {
 
-const std::string &is_deprecated(const std::string &str);
 bool is_unsafe_func(const std::string &func_name);
 bool is_compile_time_func(const std::string &func_name);
 bool is_supported_lang(const std::string &lang);

--- a/src/ast/passes/deprecated.cpp
+++ b/src/ast/passes/deprecated.cpp
@@ -1,0 +1,80 @@
+#include <vector>
+
+#include "ast/passes/deprecated.h"
+#include "ast/visitor.h"
+
+namespace bpftrace::ast {
+
+namespace {
+
+class DeprecatedAnalyser : public Visitor<DeprecatedAnalyser> {
+public:
+  using Visitor<DeprecatedAnalyser>::visit;
+  void visit(Builtin &builtin);
+  void visit(Call &call);
+};
+
+struct DeprecatedName {
+  std::string old_name;
+  std::string new_name;
+
+  bool matches(const std::string &name) const
+  {
+    // We allow a prefix match to match against builtins with number (argX)
+    if (old_name.back() == '*') {
+      std::string_view old_name_view{ old_name.c_str(), old_name.size() - 1 };
+      return name.rfind(old_name_view) == 0;
+    }
+
+    return name == old_name;
+  }
+};
+
+} // namespace
+
+static void check(const std::vector<DeprecatedName> &list,
+                  const std::string &ident,
+                  Node &node)
+{
+  for (const auto &item : list) {
+    if (!item.matches(ident)) {
+      continue;
+    }
+
+    auto &warn = node.addWarning();
+    warn << item.old_name
+         << " is deprecated and will be removed in the future.";
+    warn.addHint() << "Use " << item.new_name << " instead.";
+  }
+}
+
+static std::vector<DeprecatedName> DEPRECATED_BUILTINS = {
+  {
+      .old_name = "sarg*",
+      .new_name = "*(reg(\"sp\") + <stack_offset>)",
+  },
+};
+
+void DeprecatedAnalyser::visit(Builtin &builtin)
+{
+  check(DEPRECATED_BUILTINS, builtin.ident, builtin);
+}
+
+static std::vector<DeprecatedName> DEPRECATED_CALLS = {};
+
+void DeprecatedAnalyser::visit(Call &call)
+{
+  check(DEPRECATED_CALLS, call.func, call);
+}
+
+Pass CreateDeprecatedPass()
+{
+  auto fn = [](ASTContext &ast) {
+    DeprecatedAnalyser deprecated;
+    deprecated.visit(ast.root);
+  };
+
+  return Pass::create("Deprecated", fn);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/deprecated.h
+++ b/src/ast/passes/deprecated.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateDeprecatedPass();
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -2,6 +2,7 @@
 
 #include "ast/attachpoint_parser.h"
 #include "ast/pass_manager.h"
+#include "ast/passes/deprecated.h"
 #include "ast/passes/field_analyser.h"
 #include "btf.h"
 #include "clang_parser.h"
@@ -17,6 +18,7 @@ inline std::vector<Pass> AllParsePasses(
 {
   std::vector<Pass> passes;
   passes.emplace_back(CreateParsePass());
+  passes.emplace_back(CreateDeprecatedPass());
   passes.emplace_back(CreateParseAttachpointsPass());
   passes.emplace_back(CreateParseBTFPass());
   passes.emplace_back(CreateParseTracepointFormatPass());


### PR DESCRIPTION
This provides an in-place error, and replace the nede to emit a warning from within the context of an AST constructor.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
