### PR TITLE
codegen: Remove unused AttachPoint visitor

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -213,7 +213,6 @@ public:
   ScopedExpr visit(For &f);
   ScopedExpr visit(Jump &jump);
   ScopedExpr visit(Predicate &pred);
-  ScopedExpr visit(AttachPoint &ap);
   ScopedExpr visit(Probe &probe);
   ScopedExpr visit(Subprog &subprog);
   ScopedExpr visit(Program &program);
@@ -3035,12 +3034,6 @@ ScopedExpr CodegenLLVM::visit(Predicate &pred)
   b_.SetInsertPoint(pred_true_block);
 
   return ScopedExpr(cmp_value);
-}
-
-ScopedExpr CodegenLLVM::visit(AttachPoint &)
-{
-  // Empty
-  return ScopedExpr();
 }
 
 ScopedExpr CodegenLLVM::visit(Block &block)


### PR DESCRIPTION
I'm getting this build warning:
```
[2/7] Building CXX object src/ast/CMakeFiles/ast.dir/passes/codegen_llvm.cpp.o /home/dxu/dev/bpftrace/src/ast/passes/codegen_llvm.cpp:3040:12: warning: ‘bpftrace::ast::{anonymous}::ScopedExpr
bpftrace::ast::{anonymous}::CodegenLLVM::visit(bpftrace::ast::AttachPoint&)’ defined but not used [-Wunused-function]
 3040 | ScopedExpr CodegenLLVM::visit(AttachPoint &ap)
      |            ^~~~~~~~~~~
```
Looks like the visitor is indeed unused. The Probe visitor directly looks at the attachpoints. So just delete.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
