### PR TITLE
Add recursion_check pass

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ast_defs STATIC
   ast.cpp
   context.cpp
+  helpers.cpp
   location.cpp
 )
 add_dependencies(ast_defs parser)
@@ -12,7 +13,6 @@ add_library(ast STATIC
   codegen_helper.cpp
   diagnostic.cpp
   dibuilderbpf.cpp
-  helpers.cpp
   irbuilderbpf.cpp
   pass_manager.cpp
   signal.cpp
@@ -28,6 +28,7 @@ add_library(ast STATIC
   passes/codegen_llvm.cpp
   passes/return_path_analyser.cpp
   passes/pid_filter_pass.cpp
+  passes/recursion_check.cpp
 )
 
 target_compile_definitions(ast PRIVATE ${BPFTRACE_FLAGS})

--- a/src/ast/helpers.cpp
+++ b/src/ast/helpers.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <set>
 #include <vector>
 
 #include "ast/helpers.h"
@@ -41,13 +40,6 @@ static std::vector<std::string> UNSAFE_BUILTIN_FUNCS = {
 static std::vector<std::string> COMPILE_TIME_FUNCS = { "cgroupid" };
 
 static std::vector<std::string> UPROBE_LANGS = { "cpp" };
-
-static const std::set<std::string> RECURSIVE_KERNEL_FUNCS = {
-  "vmlinux:_raw_spin_lock",
-  "vmlinux:_raw_spin_lock_irqsave",
-  "vmlinux:_raw_spin_unlock_irqrestore",
-  "vmlinux:queued_spin_lock_slowpath",
-};
 
 const std::string &is_deprecated(const std::string &str)
 {
@@ -102,15 +94,6 @@ bool is_type_name(std::string_view str)
 {
   return str.starts_with("struct ") || str.starts_with("union ") ||
          str.starts_with("enum ");
-}
-
-// Attaching to these kernel functions with fentry/fexit (kfunc/kretfunc)
-// could lead to a recursive loop and kernel crash so we need additional
-// generated BPF code to protect against this if one of these are being
-// attached to.
-bool is_recursive_func(const std::string &func_name)
-{
-  return RECURSIVE_KERNEL_FUNCS.find(func_name) != RECURSIVE_KERNEL_FUNCS.end();
 }
 
 } // namespace bpftrace

--- a/src/ast/helpers.h
+++ b/src/ast/helpers.h
@@ -5,7 +5,6 @@
 namespace bpftrace {
 
 const std::string &is_deprecated(const std::string &str);
-bool is_recursive_func(const std::string &func_name);
 bool is_unsafe_func(const std::string &func_name);
 bool is_compile_time_func(const std::string &func_name);
 bool is_supported_lang(const std::string &lang);

--- a/src/ast/passes/recursion_check.cpp
+++ b/src/ast/passes/recursion_check.cpp
@@ -1,0 +1,88 @@
+#include <set>
+
+#include "ast/ast.h"
+#include "ast/passes/recursion_check.h"
+#include "ast/visitor.h"
+#include "bpftrace.h"
+#include "log.h"
+
+namespace bpftrace::ast {
+
+namespace {
+
+static const std::set<std::string> RECURSIVE_KERNEL_FUNCS = {
+  "vmlinux:_raw_spin_lock",
+  "vmlinux:_raw_spin_lock_irqsave",
+  "vmlinux:_raw_spin_unlock_irqrestore",
+  "vmlinux:queued_spin_lock_slowpath",
+};
+
+// Attaching to these kernel functions with fentry/fexit (kfunc/kretfunc)
+// could lead to a recursive loop and kernel crash so we need additional
+// generated BPF code to protect against this if one of these are being
+// attached to.
+bool is_recursive_func(const std::string &func_name)
+{
+  return RECURSIVE_KERNEL_FUNCS.find(func_name) != RECURSIVE_KERNEL_FUNCS.end();
+}
+
+class RecursionCheck : public Visitor<RecursionCheck> {
+public:
+  explicit RecursionCheck(ASTContext &ast, BPFtrace &bpftrace)
+      : ast_(ast), bpftrace_(bpftrace)
+  {
+  }
+
+  using Visitor<RecursionCheck>::visit;
+  void visit(Program &program);
+
+private:
+  ASTContext &ast_;
+  BPFtrace &bpftrace_;
+};
+
+} // namespace
+
+// This prevents an ABBA deadlock when attaching to spin lock internal
+// functions e.g. "fentry:queued_spin_lock_slowpath".
+//
+// Specifically, if there are two hash maps (non percpu) being accessed by
+// two different CPUs by two bpf progs then we can get in a situation where,
+// because there are progs attached to spin lock internals, a lock is taken for
+// one map while a different lock is trying to be acquired for the other map.
+// This is specific to fentry/fexit (kfunc/kretfunc) as kprobes have kernel
+// protections against this type of deadlock.
+//
+// Note: it would be better if this was in resource analyzer but we need
+// probe_matcher to get the list of functions for the attach point.
+void RecursionCheck::visit(Program &program)
+{
+  for (auto *probe : program.probes) {
+    for (auto *ap : probe->attach_points) {
+      auto probe_type = probetype(ap->provider);
+      if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit) {
+        auto matches = bpftrace_.probe_matcher_->get_matches_for_ap(*ap);
+        for (const auto &match : matches) {
+          if (is_recursive_func(match)) {
+            LOG(WARNING)
+                << "Attaching to dangerous function: " << match
+                << ". bpftrace has added mitigations to prevent a kernel "
+                   "deadlock but they may result in some lost events.";
+            bpftrace_.need_recursion_check_ = true;
+            return;
+          }
+        }
+      }
+    }
+  }
+}
+
+Pass CreateRecursionCheckPass()
+{
+  return Pass::create("RecursionCheck", [](ASTContext &ast, BPFtrace &b) {
+    auto recursion_check = RecursionCheck(ast, b);
+    recursion_check.visit(ast.root);
+  });
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/recursion_check.h
+++ b/src/ast/passes/recursion_check.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateRecursionCheckPass();
+
+} // namespace bpftrace::ast

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -182,7 +182,6 @@ public:
   {
     return !dwarves_.empty();
   }
-  void fentry_recursion_check(ast::Program *prog);
   std::set<std::string> list_modules(const ast::ASTContext &ctx);
 
   std::string cmd_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include "ast/passes/portability_analyser.h"
 #include "ast/passes/printer.h"
 #include "ast/passes/probe_analyser.h"
+#include "ast/passes/recursion_check.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/return_path_analyser.h"
 #include "ast/passes/semantic_analyser.h"
@@ -388,6 +389,7 @@ void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreatePidFilterPass());
   add(ast::CreateSemanticPass());
   add(ast::CreateResourcePass());
+  add(ast::CreateRecursionCheckPass());
   add(ast::CreateReturnPathPass());
   add(ast::CreateProbePass());
 }
@@ -397,6 +399,7 @@ void CreateAotPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateSemanticPass());
   add(ast::CreatePortabilityPass());
   add(ast::CreateResourcePass());
+  add(ast::CreateRecursionCheckPass());
   add(ast::CreateReturnPathPass());
   add(ast::CreateProbePass());
 }
@@ -960,12 +963,6 @@ int main(int argc, char* argv[])
     bpftrace.probe_matcher_->list_probes(ast.root);
     return 0;
   }
-
-  // This should be a standardized pass in the future.
-  addPass(ast::Pass::create("recursion-check",
-                            [](ast::ASTContext& ast, BPFtrace& b) {
-                              b.fentry_recursion_check(ast.root);
-                            }));
 
   switch (args.build_mode) {
     case BuildMode::DYNAMIC:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ add_executable(bpftrace_test
   config_analyser.cpp
   pass_manager.cpp
   pid_filter_pass.cpp
+  recursion_check.cpp
   resource_analyser.cpp
   result.cpp
   required_resources.cpp

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -10,6 +10,7 @@
 #include "ast/passes/parser.h"
 #include "ast/passes/pid_filter_pass.h"
 #include "ast/passes/probe_analyser.h"
+#include "ast/passes/recursion_check.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 #include "bpftrace.h"
@@ -64,6 +65,7 @@ static void test(BPFtrace &bpftrace,
                 .add(ast::CreateParseAttachpointsPass())
                 .add(ast::CreateSemanticPass())
                 .add(ast::CreatePidFilterPass())
+                .add(ast::CreateRecursionCheckPass())
                 .add(ast::CreateSemanticPass())
                 .add(ast::CreateResourcePass())
                 .add(ast::CreateProbePass())

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -24,7 +24,8 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
   ON_CALL(matcher, get_symbols_from_traceable_funcs(true)).WillByDefault([]() {
     std::string ksyms = "kernel_mod:func_in_mod\n"
                         "kernel_mod:other_func_in_mod\n"
-                        "other_kernel_mod:func_in_mod\n";
+                        "other_kernel_mod:func_in_mod\n"
+                        "vmlinux:queued_spin_lock_slowpath\n";
     auto myval = std::unique_ptr<std::istream>(new std::istringstream(ksyms));
     return myval;
   });

--- a/tests/recursion_check.cpp
+++ b/tests/recursion_check.cpp
@@ -1,0 +1,38 @@
+#include "ast/passes/recursion_check.h"
+#include "ast/attachpoint_parser.h"
+#include "driver.h"
+#include "mocks.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::recursion_check {
+
+void test(const std::string& input, bool has_recursion_check)
+{
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace& bpftrace = *mock_bpftrace;
+  bpftrace.btf_ = nullptr;
+
+  ast::ASTContext ast("stdin", input);
+
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put(bpftrace)
+                .add(CreateParsePass())
+                .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateRecursionCheckPass())
+                .run();
+  ASSERT_TRUE(ok && ast.diagnostics().ok());
+  EXPECT_EQ(bpftrace.need_recursion_check_, has_recursion_check);
+}
+
+TEST(recursion_check, has_check)
+{
+  test("fentry:vmlinux:queued_spin_lock_slowpath { 1 }", true);
+  test("fentry:otherfunc, fentry:vmlinux:queued_spin_lock_slowpath { 1 }",
+       true);
+  test("fentry:otherfunc { 1 } fentry:vmlinux:queued_spin_lock_slowpath { 1 }",
+       true);
+  test("fentry:otherfunc { 1 }", false);
+}
+
+} // namespace bpftrace::test::recursion_check


### PR DESCRIPTION
This moves the fentry recursion check
logic out of bpftrace and into it's own
pass.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
