### PR TITLE
clang-tidy: Turn on readability-const-return-type

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,7 @@ Checks:
   - -modernize-use-nodiscard
   - -modernize-use-trailing-return-type
   - performance-unnecessary-copy-initialization
+  - readability-const-return-type
   - readability-container-contains
 
 WarningsAsErrors: "*"

--- a/src/ast/diagnostic.h
+++ b/src/ast/diagnostic.h
@@ -22,11 +22,11 @@ public:
     Error,
   };
   Diagnostic(const Location loc) : loc_(loc) {};
-  const std::string msg() const
+  std::string msg() const
   {
     return msg_.str();
   }
-  const std::string hint() const
+  std::string hint() const
   {
     return hint_.str();
   }

--- a/src/printf.h
+++ b/src/printf.h
@@ -9,7 +9,7 @@
 
 namespace bpftrace {
 
-static const std::string generate_pattern_string()
+static std::string generate_pattern_string()
 {
   std::string pattern = "%-?[0-9]*(\\.[0-9]+)?(";
   for (const auto& e : printf_format_types) {

--- a/src/types.h
+++ b/src/types.h
@@ -297,7 +297,7 @@ public:
     return num_elements_;
   };
 
-  const std::string GetName() const
+  std::string GetName() const
   {
     assert(IsRecordTy() || IsEnumTy());
     return name_;

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -27,9 +27,9 @@ static const int STRING_SIZE = 64;
 
 static const std::optional<int> no_pid = std::nullopt;
 
-static const std::string kprobe_name(const std::string &attach_point,
-                                     const std::string &target,
-                                     uint64_t func_offset)
+static std::string kprobe_name(const std::string &attach_point,
+                               const std::string &target,
+                               uint64_t func_offset)
 {
   auto str = func_offset ? "+" + std::to_string(func_offset) : "";
   if (!target.empty()) {


### PR DESCRIPTION
According to C++ core guidelines [0], returning a `const T` is usually not useful. So turn this check on.

[0]: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#f49-dont-return-const-t

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
