### PR TITLE
clang-tidy: Turn on most readability checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,7 @@ Checks:
   - -modernize-use-trailing-return-type
   - performance-unnecessary-copy-initialization
   - readability-const-return-type
+  - readability-container-size-empty
   - readability-container-contains
 
 WarningsAsErrors: "*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@ Checks:
   - readability-const-return-type
   - readability-container-size-empty
   - readability-container-contains
+  - readability-named-parameter
   - readability-qualified-auto
 
 WarningsAsErrors: "*"

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,11 +18,20 @@ Checks:
   - -modernize-use-nodiscard
   - -modernize-use-trailing-return-type
   - performance-unnecessary-copy-initialization
-  - readability-const-return-type
-  - readability-container-size-empty
-  - readability-container-contains
-  - readability-named-parameter
-  - readability-qualified-auto
+  - readability-*
+  - -readability-avoid-nested-conditional-operator
+  - -readability-braces-around-statements
+  - -readability-convert-member-functions-to-static
+  - -readability-else-after-return
+  - -readability-enum-initial-value
+  - -readability-function-cognitive-complexity
+  - -readability-function-size
+  - -readability-identifier-length
+  - -readability-implicit-bool-conversion
+  - -readability-isolate-declaration
+  - -readability-magic-numbers
+  - -readability-make-member-function-const
+  - -readability-suspicious-call-argument
 
 WarningsAsErrors: "*"
 UseColor: true

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,6 +21,7 @@ Checks:
   - readability-const-return-type
   - readability-container-size-empty
   - readability-container-contains
+  - readability-qualified-auto
 
 WarningsAsErrors: "*"
 UseColor: true

--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -143,7 +143,7 @@ int build_binary(const std::filesystem::path &shim,
 
   // Respect user provided BPFTRACE_OBJCOPY if present
   std::string_view objcopy = "objcopy";
-  if (auto c = std::getenv("BPFTRACE_OBJCOPY"))
+  if (auto *c = std::getenv("BPFTRACE_OBJCOPY"))
     objcopy = c;
 
   // Resolve objcopy binary to full path

--- a/src/aot/aot.h
+++ b/src/aot/aot.h
@@ -11,7 +11,7 @@ static constexpr std::string_view AOT_SHIM_NAME = "bpftrace-aotrt";
 
 int generate(const RequiredResources &resources,
              const std::string &out,
-             void *const elf,
+             void *elf,
              size_t elf_size);
 
 int load(BPFtrace &bpftrace, const std::string &in);

--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -29,7 +29,6 @@ void usage(std::ostream& out, std::string_view filename)
   out << "    -V, --version  bpftrace version" << std::endl;
   out << std::endl;
   // clang-format on
-  return;
 }
 
 std::unique_ptr<Output> prepare_output(const std::string& output_file,

--- a/src/arch/x86_64.cpp
+++ b/src/arch/x86_64.cpp
@@ -45,7 +45,7 @@ static std::array<std::string, 6> arg_registers = {
 
 int offset(std::string reg_name)
 {
-  auto it = std::ranges::find(registers, reg_name);
+  auto *it = std::ranges::find(registers, reg_name);
   if (it == registers.end())
     return -1;
   return distance(registers.begin(), it);

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -525,13 +525,13 @@ AttachPoint &AttachPoint::create_expansion_copy(ASTContext &ctx,
 std::string AttachPoint::name() const
 {
   std::string n = provider;
-  if (target != "")
+  if (!target.empty())
     n += ":" + target;
-  if (lang != "")
+  if (!lang.empty())
     n += ":" + lang;
-  if (ns != "")
+  if (!ns.empty())
     n += ":" + ns;
-  if (func != "") {
+  if (!func.empty()) {
     n += ":" + func;
     if (func_offset != 0)
       n += "+" + std::to_string(func_offset);
@@ -542,7 +542,7 @@ std::string AttachPoint::name() const
     n += ":" + std::to_string(freq);
   if (len != 0)
     n += ":" + std::to_string(len);
-  if (mode.size())
+  if (!mode.empty())
     n += ":" + mode;
   return n;
 }

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -589,11 +589,9 @@ std::string Subprog::name() const
 
 bool Probe::has_ap_of_probetype(ProbeType probe_type)
 {
-  for (auto *ap : attach_points) {
-    if (probetype(ap->provider) == probe_type)
-      return true;
-  }
-  return false;
+  return std::ranges::any_of(attach_points, [probe_type](auto *ap) {
+    return probetype(ap->provider) == probe_type;
+  });
 }
 
 SizedType ident_to_record(const std::string &ident, int pointer_level)

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -69,7 +69,7 @@ int AttachPointParser::parse()
   uint32_t failed = 0;
   for (Probe *probe : ctx_.root->probes) {
     for (size_t i = 0; i < probe->attach_points.size(); ++i) {
-      auto ap_ptr = probe->attach_points[i];
+      auto *ap_ptr = probe->attach_points[i];
       auto &ap = *ap_ptr;
       new_attach_points.clear();
 
@@ -402,8 +402,8 @@ AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
     // If the target has form "libXXX" then we use BCC to find the correct path
     // to the given library as it may differ across systems.
     auto libname = parts_[1].substr(3);
-    auto lib_path = bcc_procutils_which_so(libname.c_str(),
-                                           bpftrace_.pid().value_or(0));
+    auto *lib_path = bcc_procutils_which_so(libname.c_str(),
+                                            bpftrace_.pid().value_or(0));
     if (lib_path) {
       ap_->target = lib_path;
       ::free(lib_path);

--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -25,7 +25,7 @@ concept NodeType = std::derived_from<T, Node>;
 // single instance of this class should be created and referenced.
 class ASTSource {
 public:
-  ASTSource(std::string &&filename, std::string &&contents);
+  ASTSource(std::string &&filename, std::string &&input);
   ASTSource(const ASTSource &other) = delete;
   ASTSource &operator=(const ASTSource &other) = delete;
 
@@ -53,7 +53,7 @@ public:
   template <NodeType T, typename... Args>
   constexpr T *make_node(Args &&...args)
   {
-    auto uniq_ptr = std::make_unique<T>(*diagnostics_.get(),
+    auto uniq_ptr = std::make_unique<T>(*diagnostics_,
                                         wrap(std::forward<Args>(args))...);
     auto *raw_ptr = uniq_ptr.get();
     nodes_.push_back(std::move(uniq_ptr));
@@ -67,7 +67,7 @@ public:
 
   const Diagnostics &diagnostics() const
   {
-    return *diagnostics_.get();
+    return *diagnostics_;
   }
 
   Program *root = nullptr;

--- a/src/ast/diagnostic.cpp
+++ b/src/ast/diagnostic.cpp
@@ -18,7 +18,7 @@ void Diagnostics::emit(std::ostream& out, Severity s) const
 
 void Diagnostics::emit(std::ostream& out, Severity s, const Diagnostic& d) const
 {
-  auto& loc = d.loc();
+  const auto& loc = d.loc();
   switch (s) {
     case Severity::Warning:
       LOG(WARNING, loc.source_location(), loc.source_context(), out) << d.msg();

--- a/src/ast/diagnostic.cpp
+++ b/src/ast/diagnostic.cpp
@@ -22,13 +22,13 @@ void Diagnostics::emit(std::ostream& out, Severity s, const Diagnostic& d) const
   switch (s) {
     case Severity::Warning:
       LOG(WARNING, loc.source_location(), loc.source_context(), out) << d.msg();
-      if (auto msg = d.hint(); msg.size() > 0) {
+      if (auto msg = d.hint(); !msg.empty()) {
         LOG(HINT, out) << msg;
       }
       break;
     case Severity::Error:
       LOG(ERROR, loc.source_location(), loc.source_context(), out) << d.msg();
-      if (auto msg = d.hint(); msg.size() > 0) {
+      if (auto msg = d.hint(); !msg.empty()) {
         LOG(HINT, out) << msg;
       }
       break;

--- a/src/ast/diagnostic.h
+++ b/src/ast/diagnostic.h
@@ -84,7 +84,7 @@ public:
   bool has(Severity severity) const
   {
     auto index = static_cast<long unsigned int>(severity);
-    return diagnostics_.size() > index && diagnostics_[index].size() > 0;
+    return diagnostics_.size() > index && !diagnostics_[index].empty();
   }
   void clear()
   {

--- a/src/ast/diagnostic.h
+++ b/src/ast/diagnostic.h
@@ -116,7 +116,7 @@ private:
       return;
     }
     for (const auto& diag : diagnostics_[index]) {
-      fn(*diag.get());
+      fn(*diag);
     }
   }
 

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -36,7 +36,7 @@ void DIBuilderBPF::createFunctionDebugInfo(llvm::Function &func,
   DISubprogram::DISPFlags flags = DISubprogram::SPFlagZero;
   if (!is_declaration)
     flags |= DISubprogram::SPFlagDefinition;
-  if (func.isLocalLinkage(func.getLinkage()))
+  if (llvm::Function::isLocalLinkage(func.getLinkage()))
     flags |= DISubprogram::DISPFlags::SPFlagLocalToUnit;
 
   DISubprogram *subprog = createFunction(file,

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -25,7 +25,7 @@ void DIBuilderBPF::createFunctionDebugInfo(llvm::Function &func,
   SmallVector<Metadata *> types;
   types.reserve(args.fields.size() + 1);
   types.push_back(GetType(ret_type, false));
-  for (auto &arg : args.fields)
+  for (const auto &arg : args.fields)
     types.push_back(GetType(arg.type, false));
 
   DISubroutineType *ditype = createSubroutineType(getOrCreateTypeArray(types));
@@ -215,7 +215,7 @@ DIType *DIBuilderBPF::CreateMapStructType(const SizedType &stype)
 
 DIType *DIBuilderBPF::CreateByteArrayType(uint64_t num_bytes)
 {
-  auto subrange = getOrCreateSubrange(0, num_bytes);
+  auto *subrange = getOrCreateSubrange(0, num_bytes);
   return createArrayType(
       num_bytes * 8, 0, getInt8Ty(), getOrCreateArray({ subrange }));
 }
@@ -258,13 +258,13 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype, bool emit_codegen_types)
   }
 
   if (stype.IsByteArray() || stype.IsRecordTy() || stype.IsStack()) {
-    auto subrange = getOrCreateSubrange(0, stype.GetSize());
+    auto *subrange = getOrCreateSubrange(0, stype.GetSize());
     return createArrayType(
         stype.GetSize() * 8, 0, getInt8Ty(), getOrCreateArray({ subrange }));
   }
 
   if (stype.IsArrayTy()) {
-    auto subrange = getOrCreateSubrange(0, stype.GetNumElements());
+    auto *subrange = getOrCreateSubrange(0, stype.GetNumElements());
     return createArrayType(stype.GetSize() * 8,
                            0,
                            GetType(*stype.GetElementTy()),
@@ -328,8 +328,8 @@ DIType *DIBuilderBPF::GetMapFieldInt(int value)
 {
   // Integer fields of map entry are represented by 64-bit pointers to an array
   // of int, in which dimensionality of the array encodes the specified value.
-  auto subrange = getOrCreateSubrange(0, value);
-  auto array = createArrayType(
+  auto *subrange = getOrCreateSubrange(0, value);
+  auto *array = createArrayType(
       32 * value, 0, getIntTy(), getOrCreateArray({ subrange }));
   return createPointerType(array, 64);
 }

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -82,7 +82,7 @@ public:
   // If provided, the optional AddrSpace argument is used instead of the type's
   // address space (which may not always be set).
   void CreateProbeRead(Value *ctx,
-                       Value *dest,
+                       Value *dst,
                        const SizedType &type,
                        Value *src,
                        const Location &loc,
@@ -111,22 +111,22 @@ public:
   Value *CreateUSDTReadArgument(Value *ctx,
                                 AttachPoint *attach_point,
                                 int usdt_location_index,
-                                int arg_name,
+                                int arg_num,
                                 Builtin &builtin,
                                 std::optional<pid_t> pid,
                                 AddrSpace as,
                                 const Location &loc);
   Value *CreateStrncmp(Value *str1, Value *str2, uint64_t n, bool inverse);
-  Value *CreateStrcontains(Value *val1,
-                           uint64_t str1_size,
-                           Value *val2,
-                           uint64_t str2_size);
+  Value *CreateStrcontains(Value *haystack,
+                           uint64_t haystack_sz,
+                           Value *needle,
+                           uint64_t needle_sz);
   Value *CreateIntegerArrayCmp(Value *ctx,
                                Value *val1,
                                Value *val2,
                                const SizedType &val1_type,
                                const SizedType &val2_type,
-                               const bool inverse,
+                               bool inverse,
                                const Location &loc,
                                MDNode *metadata);
   CallInst *CreateGetNs(TimestampMode ts, const Location &loc);
@@ -262,7 +262,7 @@ public:
   // [1] https://reviews.llvm.org/D133361
   llvm::Value *CreateSafeGEP(llvm::Type *Ty,
                              llvm::Value *Ptr,
-                             llvm::ArrayRef<Value *> IdxList,
+                             llvm::ArrayRef<Value *> offsets,
                              const llvm::Twine &Name = "");
 
   StoreInst *createAlignedStore(Value *val, Value *ptr, unsigned align);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3117,7 +3117,7 @@ void CodegenLLVM::generateProbe(Probe &probe,
 
   auto pt = probetype(current_attach_point_->provider);
   if ((pt == ProbeType::watchpoint || pt == ProbeType::asyncwatchpoint) &&
-      current_attach_point_->func.size())
+      !current_attach_point_->func.empty())
     generateWatchpointSetupProbe(
         func_type, name, current_attach_point_->address, index, probe.loc);
 }

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -357,8 +357,8 @@ private:
   void maybeAllocVariable(const std::string &var_ident,
                           const SizedType &var_type,
                           const Location &loc);
-  VariableLLVM *maybeGetVariable(const std::string &);
-  VariableLLVM &getVariable(const std::string &);
+  VariableLLVM *maybeGetVariable(const std::string &var_ident);
+  VariableLLVM &getVariable(const std::string &var_ident);
 
   llvm::Function *DeclareKernelFunc(Kfunc kfunc, Node &call);
 

--- a/src/ast/passes/codegen_resources.h
+++ b/src/ast/passes/codegen_resources.h
@@ -24,7 +24,7 @@ public:
   CodegenResources analyse(Program &program);
 
   using Visitor<CodegenResourceAnalyser>::visit;
-  void visit(Builtin &map);
+  void visit(Builtin &builtin);
   void visit(Call &call);
 
 private:

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -102,7 +102,7 @@ void ConfigAnalyser::set_config(AssignConfigVarStatement &assignment,
 }
 
 void ConfigAnalyser::set_config(AssignConfigVarStatement &assignment,
-                                [[maybe_unused]] ConfigKeyStackMode)
+                                [[maybe_unused]] ConfigKeyStackMode key)
 {
   auto &assignTy = assignment.expr->type;
   if (!assignTy.IsStackModeTy()) {

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -303,7 +303,6 @@ void FieldAnalyser::resolve_args(Probe &probe)
       bpftrace_.structs.Add(probe.args_typename(), std::move(probe_args));
     }
   }
-  return;
 }
 
 void FieldAnalyser::resolve_fields(SizedType &type)

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -95,7 +95,7 @@ void FieldAnalyser::visit(Builtin &builtin)
       return;
     resolve_args(*probe_);
 
-    auto arg = bpftrace_.structs.GetProbeArg(*probe_, RETVAL_FIELD_NAME);
+    const auto *arg = bpftrace_.structs.GetProbeArg(*probe_, RETVAL_FIELD_NAME);
     if (arg)
       sized_type_ = arg->type;
     return;
@@ -128,7 +128,7 @@ void FieldAnalyser::visit(FieldAccess &acc)
   visit(acc.expr);
 
   if (has_builtin_args_) {
-    auto arg = bpftrace_.structs.GetProbeArg(*probe_, acc.field);
+    const auto *arg = bpftrace_.structs.GetProbeArg(*probe_, acc.field);
     if (arg)
       sized_type_ = arg->type;
 
@@ -232,7 +232,7 @@ void FieldAnalyser::resolve_args(Probe &probe)
       // ... and check if they share same arguments.
 
       Struct ap_args;
-      for (auto &match : matches) {
+      for (const auto &match : matches) {
         // Both uprobes and fentry have a target (binary for uprobes, kernel
         // module for fentry).
         std::string func = match;

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -206,7 +206,7 @@ void Printer::visit(FieldAccess &acc)
   visit(acc.expr);
   --depth_;
 
-  if (acc.field.size())
+  if (!acc.field.empty())
     out_ << indent << " " << acc.field << std::endl;
   else
     out_ << indent << " " << acc.index << std::endl;
@@ -448,7 +448,7 @@ void Printer::visit(Subprog &subprog)
 
 void Printer::visit(Program &program)
 {
-  if (program.c_definitions.size() > 0)
+  if (!program.c_definitions.empty())
     out_ << program.c_definitions << std::endl;
 
   std::string indent(depth_, ' ');

--- a/src/ast/passes/recursion_check.cpp
+++ b/src/ast/passes/recursion_check.cpp
@@ -10,7 +10,7 @@ namespace bpftrace::ast {
 
 namespace {
 
-static const std::unordered_set<std::string> RECURSIVE_KERNEL_FUNCS = {
+const std::unordered_set<std::string> RECURSIVE_KERNEL_FUNCS = {
   "vmlinux:_raw_spin_lock",
   "vmlinux:_raw_spin_lock_irqsave",
   "vmlinux:_raw_spin_unlock_irqrestore",

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -275,7 +275,7 @@ void ResourceAnalyser::visit(Call &call)
       map_info.lhist_args = args;
     }
   } else if (call.func == "time") {
-    if (call.vargs.size() > 0)
+    if (!call.vargs.empty())
       resources_.time_args.push_back(get_literal_string(*call.vargs.at(0)));
     else
       resources_.time_args.emplace_back("%H:%M:%S\n");

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -34,7 +34,7 @@ public:
   using Visitor<ResourceAnalyser>::visit;
   void visit(Probe &probe);
   void visit(Subprog &subprog);
-  void visit(Builtin &map);
+  void visit(Builtin &builtin);
   void visit(Call &call);
   void visit(Map &map);
   void visit(MapDeclStatement &decl);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -153,7 +153,7 @@ private:
 
   void check_stack_call(Call &call, bool kernel);
 
-  Probe *get_probe(Node &node, std::string = "");
+  Probe *get_probe(Node &node, std::string name = "");
 
   bool is_valid_assignment(const Expression *target, const Expression *expr);
   SizedType *get_map_type(const Map &map);

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -673,7 +673,10 @@ struct bcc_sym_cb_data {
   std::set<uint64_t> &offsets;
 };
 
-static int bcc_sym_cb(const char *symname, uint64_t start, uint64_t, void *p)
+static int bcc_sym_cb(const char *symname,
+                      uint64_t start,
+                      uint64_t /*unused*/,
+                      void *p)
 {
   auto *data = static_cast<struct bcc_sym_cb_data *>(p);
   std::vector<std::string> &syms = data->syms;

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1096,7 +1096,7 @@ void AttachedProbe::attach_software(std::optional<int> pid)
   uint32_t type = 0;
 
   // from linux/perf_event.h, with aliases from perf:
-  for (auto &probeListItem : SW_PROBE_LIST) {
+  for (const auto &probeListItem : SW_PROBE_LIST) {
     if (probe_.path == probeListItem.path ||
         probe_.path == probeListItem.alias) {
       type = probeListItem.type;
@@ -1135,7 +1135,7 @@ void AttachedProbe::attach_hardware(std::optional<int> pid)
   uint32_t type = 0;
 
   // from linux/perf_event.h, with aliases from perf:
-  for (auto &probeListItem : HW_PROBE_LIST) {
+  for (const auto &probeListItem : HW_PROBE_LIST) {
     if (probe_.path == probeListItem.path ||
         probe_.path == probeListItem.alias) {
       type = probeListItem.type;

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -604,7 +604,7 @@ void AttachedProbe::attach_kprobe()
   // Note that we do not pass vmlinux, if it is specified.
   std::string funcname = probe_.attach_point;
   const std::string &modname = probe_.path;
-  if ((modname.length() > 0) && modname != "vmlinux") {
+  if ((!modname.empty()) && modname != "vmlinux") {
     if (!util::is_module_loaded(modname)) {
       std::string message = "specified module " + modname + " in probe " +
                             probe_.name + " is not loaded.";
@@ -626,7 +626,7 @@ void AttachedProbe::attach_kprobe()
   if (bpftrace_.config_->get(ConfigKeyMissingProbes::default_) ==
           ConfigMissingProbes::ignore &&
       probe_.name != probe_.orig_name &&
-      (funcname != "" || probe_.address != 0) &&
+      (!funcname.empty() || probe_.address != 0) &&
       !bpftrace_.is_traceable_func(funcname))
     return;
 
@@ -841,7 +841,7 @@ int AttachedProbe::usdt_sem_up_manual(const std::string &fn_name, void *ctx)
   int err;
 
 #ifdef BCC_USDT_HAS_FULLY_SPECIFIED_PROBE
-  if (probe_.ns == "")
+  if (probe_.ns.empty())
     err = bcc_usdt_enable_probe(ctx,
                                 probe_.attach_point.c_str(),
                                 fn_name.c_str());
@@ -868,7 +868,7 @@ int AttachedProbe::usdt_sem_up_manual_addsem(int pid,
   // NB: we are careful to capture by value here everything that will not
   // be available in AttachedProbe destructor.
   auto addsem = [this, fn_name](void *c, int16_t val) -> int {
-    if (this->probe_.ns == "")
+    if (this->probe_.ns.empty())
       return bcc_usdt_addsem_probe(
           c, this->probe_.attach_point.c_str(), fn_name.c_str(), val);
     else

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -280,7 +280,7 @@ void BpfBytecode::prepare_progs(const std::vector<Probe> &probes,
                                 BPFfeature &feature,
                                 const Config &config)
 {
-  for (auto &probe : probes) {
+  for (const auto &probe : probes) {
     auto &program = getProgramForProbe(probe);
     program.set_prog_type(probe);
     program.set_expected_attach_type(probe, feature);
@@ -339,7 +339,7 @@ const std::map<std::string, BpfMap> &BpfBytecode::maps() const
 int BpfBytecode::countStackMaps() const
 {
   int n = 0;
-  for (auto &map : maps_) {
+  for (const auto &map : maps_) {
     if (map.second.is_stack_map())
       n++;
   }

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -59,7 +59,7 @@ class BPFfeature;
 class BPFnofeature {
 public:
   BPFnofeature() = default;
-  int parse(const char* optarg);
+  int parse(const char* str);
 
 protected:
   bool kprobe_multi_{ false };

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -125,7 +125,7 @@ int BPFtrace::add_probe(ast::ASTContext &ctx,
     resources.special_probes[name] = std::move(probe);
   } else if ((type == ProbeType::watchpoint ||
               type == ProbeType::asyncwatchpoint) &&
-             ap.func.size()) {
+             !ap.func.empty()) {
     // (async)watchpoint - generate also the setup probe
     resources.probes.emplace_back(generateWatchpointSetupProbe(ap, p));
     resources.watchpoint_probes.emplace_back(std::move(probe));
@@ -693,7 +693,7 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_usdt_probe(
   std::vector<std::unique_ptr<AttachedProbe>> ret;
 
   if (feature_->has_uprobe_refcnt() ||
-      !(file_activation && probe.path.size())) {
+      !(file_activation && !probe.path.empty())) {
     ret.emplace_back(
         std::make_unique<AttachedProbe>(probe, program, pid, *this));
     return ret;

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -291,7 +291,7 @@ std::string BTF::type_of(const BTFId &type_id, const std::string &field)
     std::string m_name = btf__name_by_offset(type_id.btf, m[i].name_off);
 
     // anonymous struct/union
-    if (m_name == "") {
+    if (m_name.empty()) {
       std::string type_name = type_of(
           BTFId{ .btf = type_id.btf, .id = m[i].type }, field);
       if (!type_name.empty())

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -852,7 +852,8 @@ void BTF::resolve_fields(const BTFId &type_id,
     std::string field_name = btf__name_by_offset(type_id.btf,
                                                  members[i].name_off);
 
-    __u32 field_offset = start_offset + btf_member_bit_offset(btf_type, i) / 8;
+    __u32 field_offset = start_offset +
+                         (btf_member_bit_offset(btf_type, i) / 8);
 
     if (btf_is_composite(field_type) &&
         (field_name.empty() || field_name == "(anon)")) {

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -533,7 +533,7 @@ std::string BTF::get_all_funcs_from_btf(const BTFObj &btf_obj) const
 std::unique_ptr<std::istream> BTF::get_all_funcs() const
 {
   auto funcs = std::make_unique<std::stringstream>();
-  for (auto &btf_obj : btf_objects)
+  for (const auto &btf_obj : btf_objects)
     *funcs << get_all_funcs_from_btf(btf_obj);
   return funcs;
 }
@@ -628,7 +628,7 @@ std::map<std::string, std::vector<std::string>> BTF::get_params(
     return params.contains(f);
   };
 
-  for (auto &btf_obj : btf_objects) {
+  for (const auto &btf_obj : btf_objects) {
     if (std::ranges::all_of(funcs, all_resolved))
       break;
 
@@ -707,7 +707,7 @@ std::set<std::string> BTF::get_all_structs_from_btf(const struct btf *btf) const
 std::set<std::string> BTF::get_all_structs() const
 {
   std::set<std::string> structs;
-  for (auto &btf_obj : btf_objects) {
+  for (const auto &btf_obj : btf_objects) {
     auto mod_structs = get_all_structs_from_btf(btf_obj.btf);
     structs.insert(mod_structs.begin(), mod_structs.end());
   }
@@ -746,7 +746,7 @@ std::unordered_set<std::string> BTF::get_all_iters_from_btf(
 std::unordered_set<std::string> BTF::get_all_iters() const
 {
   std::unordered_set<std::string> iters;
-  for (auto &btf_obj : btf_objects) {
+  for (const auto &btf_obj : btf_objects) {
     auto mod_iters = get_all_iters_from_btf(btf_obj.btf);
     iters.insert(mod_iters.begin(), mod_iters.end());
   }
@@ -755,7 +755,7 @@ std::unordered_set<std::string> BTF::get_all_iters() const
 
 int BTF::get_btf_id(std::string_view func, std::string_view mod) const
 {
-  for (auto &btf_obj : btf_objects) {
+  for (const auto &btf_obj : btf_objects) {
     if (!mod.empty() && mod != btf_obj.name)
       continue;
 
@@ -770,7 +770,7 @@ int BTF::get_btf_id(std::string_view func, std::string_view mod) const
 BTF::BTFId BTF::find_id(const std::string &name,
                         std::optional<__u32> kind) const
 {
-  for (auto &btf_obj : btf_objects) {
+  for (const auto &btf_obj : btf_objects) {
     __s32 id = kind ? btf__find_by_name_kind(btf_obj.btf, name.c_str(), *kind)
                     : btf__find_by_name(btf_obj.btf, name.c_str());
     if (id >= 0)
@@ -835,13 +835,13 @@ void BTF::resolve_fields(const BTFId &type_id,
                          Struct *record,
                          __u32 start_offset)
 {
-  auto btf_type = btf__type_by_id(type_id.btf, type_id.id);
+  const auto *btf_type = btf__type_by_id(type_id.btf, type_id.id);
   if (!btf_type)
     return;
-  auto members = btf_members(btf_type);
+  auto *members = btf_members(btf_type);
   for (__u32 i = 0; i < BTF_INFO_VLEN(btf_type->info); i++) {
     BTFId field_id{ .btf = type_id.btf, .id = members[i].type };
-    auto field_type = btf__type_by_id(field_id.btf, field_id.id);
+    const auto *field_type = btf__type_by_id(field_id.btf, field_id.id);
     if (!field_type) {
       LOG(ERROR) << "Inconsistent BTF data (no type found for id "
                  << members[i].type << ")";

--- a/src/btf.h
+++ b/src/btf.h
@@ -95,7 +95,7 @@ private:
                      std::optional<__u32> kind = std::nullopt) const;
   __s32 find_id_in_btf(struct btf* btf,
                        std::string_view name,
-                       std::optional<__u32> = std::nullopt) const;
+                       std::optional<__u32> kind = std::nullopt) const;
 
   std::string dump_defs_from_btf(const struct btf* btf,
                                  std::unordered_set<std::string>& types) const;

--- a/src/child.cpp
+++ b/src/child.cpp
@@ -18,8 +18,6 @@
 #include "util/format.h"
 #include "util/paths.h"
 
-extern char** environ;
-
 namespace bpftrace {
 
 constexpr unsigned int maxargs = 256;
@@ -97,7 +95,7 @@ static void validate_cmd(std::vector<std::string>& cmd)
       throw std::runtime_error("path '" + cmd[0] +
                                "' does not exist or is not executable");
     case 1:
-      cmd[0] = paths.front().c_str();
+      cmd[0] = paths.front();
       break;
     default:
       // /bin maybe is a symbolic link to /usr/bin (/bin -> /usr/bin), there
@@ -116,7 +114,7 @@ static void validate_cmd(std::vector<std::string>& cmd)
       }
 
       if (uniq_abs_path.size() == 1) {
-        cmd[0] = paths.front().c_str();
+        cmd[0] = paths.front();
         break;
       } else {
         throw std::runtime_error(

--- a/src/child.cpp
+++ b/src/child.cpp
@@ -211,7 +211,7 @@ void ChildProc::run(bool pause)
 
   assert(state_ == State::FORKED);
 
-  auto* data = pause ? &CHILD_PTRACE : &CHILD_GO;
+  const auto* data = pause ? &CHILD_PTRACE : &CHILD_GO;
   if (write(child_event_fd_, data, sizeof(*data)) < 0) {
     close(child_event_fd_);
     terminate(true);

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -232,7 +232,7 @@ static bool translateMacro(CXCursor cursor,
     clang_disposeString(tokenText);
   }
   clang_disposeTokens(transUnit, tokens, numTokens);
-  return value.length() != 0;
+  return !value.empty();
 }
 
 static std::string remove_qualifiers(std::string &&typestr)

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <clang-c/Index.h>
 #include <cstring>
 #include <iostream>
@@ -351,9 +352,7 @@ bool ClangParser::ClangParserHandler::check_diagnostics(bool bail_on_error)
     if ((bail_on_error && severity == CXDiagnostic_Error) ||
         severity == CXDiagnostic_Fatal) {
       // Do not fail on "too many errors"
-      if (!bail_on_error && msg == "too many errors emitted, stopping now")
-        return true;
-      return false;
+      return !bail_on_error && msg == "too many errors emitted, stopping now";
     }
   }
   return true;
@@ -399,20 +398,16 @@ const std::vector<std::string> &ClangParser::ClangParserHandler::
 
 bool ClangParser::ClangParserHandler::has_redefinition_error()
 {
-  for (auto &msg : error_msgs) {
-    if (msg.find("redefinition") != std::string::npos)
-      return true;
-  }
-  return false;
+  return std::ranges::any_of(error_msgs, [](const auto &msg) {
+    return msg.find("redefinition") != std::string::npos;
+  });
 }
 
 bool ClangParser::ClangParserHandler::has_unknown_type_error()
 {
-  for (auto &msg : error_msgs) {
-    if (ClangParser::get_unknown_type(msg).has_value())
-      return true;
-  }
-  return false;
+  return std::ranges::any_of(error_msgs, [](const auto &msg) {
+    return ClangParser::get_unknown_type(msg).has_value();
+  });
 }
 
 namespace {

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -619,7 +619,7 @@ void ClangParser::resolve_incomplete_types_from_btf(
   // The maximum number of iterations can be also controlled by the
   // BPFTRACE_MAX_TYPE_RES_ITERATIONS env variable (0 is unlimited).
   uint64_t field_lvl = 1;
-  for (auto &probe : probes)
+  for (const auto &probe : probes)
     if (probe->tp_args_structs_level > static_cast<int>(field_lvl))
       field_lvl = probe->tp_args_structs_level;
 
@@ -774,7 +774,7 @@ std::optional<std::string> ClangParser::ClangParser::get_unknown_type(
   const std::vector<std::string> unknown_type_msgs = {
     "unknown type name \'", "use of undeclared identifier \'"
   };
-  for (auto &unknown_type_msg : unknown_type_msgs) {
+  for (const auto &unknown_type_msg : unknown_type_msgs) {
     if (diagnostic_msg.starts_with(unknown_type_msg)) {
       return diagnostic_msg.substr(unknown_type_msg.length(),
                                    diagnostic_msg.length() -

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -55,11 +55,9 @@ Config::Config(bool has_cmd)
 
 bool Config::can_set(ConfigSource prevSource, ConfigSource source)
 {
-  if (prevSource == ConfigSource::default_ ||
-      (prevSource == ConfigSource::script && source == ConfigSource::env_var)) {
-    return true;
-  }
-  return false;
+  return prevSource == ConfigSource::default_ ||
+         (prevSource == ConfigSource::script &&
+          source == ConfigSource::env_var);
 }
 
 // /proc/sys/kernel/randomize_va_space >= 1

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -86,7 +86,7 @@ bool Config::is_aslr_enabled()
 std::map<std::string, StackMode> get_stack_mode_map()
 {
   std::map<std::string, StackMode> result;
-  for (auto &mode : STACK_MODE_NAME_MAP) {
+  for (const auto &mode : STACK_MODE_NAME_MAP) {
     result.emplace(mode.second, mode.first);
   }
   return result;

--- a/src/config.h
+++ b/src/config.h
@@ -203,7 +203,6 @@ private:
     }
   }
 
-private:
   bool can_set(ConfigSource prevSource, ConfigSource source);
   bool is_aslr_enabled();
 

--- a/src/config.h
+++ b/src/config.h
@@ -204,7 +204,7 @@ private:
   }
 
 private:
-  bool can_set(ConfigSource prevSource, ConfigSource);
+  bool can_set(ConfigSource prevSource, ConfigSource source);
   bool is_aslr_enabled();
 
   std::map<ConfigKey, ConfigValue> config_map_;

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -171,7 +171,7 @@ void FormatString::split()
 void FormatString::format(std::ostream &out,
                           std::vector<std::unique_ptr<IPrintable>> &args)
 {
-  if (parts_.size() < 1) {
+  if (parts_.empty()) {
     split();
 
     // figure out the argument type for each format specifier

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -204,7 +204,8 @@ void FormatString::format(std::ostream &out,
       std::string printf_fmt;
       if (fmt_string == "%r" || fmt_string == "%rx" || fmt_string == "%rh") {
         if (fmt_string == "%rx" || fmt_string == "%rh") {
-          auto printable_buffer = dynamic_cast<PrintableBuffer *>(&*args.at(i));
+          auto *printable_buffer = dynamic_cast<PrintableBuffer *>(
+              &*args.at(i));
           // this is checked by semantic analyzer
           assert(printable_buffer);
           printable_buffer->keep_ascii(false);

--- a/src/format_string.h
+++ b/src/format_string.h
@@ -13,7 +13,7 @@ namespace bpftrace {
 // validate_fmt makes sure that the type are valid for the format specifiers
 std::string validate_format_string(const std::string &fmt,
                                    std::vector<Field> args,
-                                   const std::string call_func);
+                                   std::string call_func);
 
 struct Field;
 
@@ -45,23 +45,23 @@ public:
   std::string format_str(std::vector<std::unique_ptr<IPrintable>> &args);
 
   // length returns the length of the format string
-  inline size_t length() const noexcept
+  size_t length() const noexcept
   {
     return fmt_.length();
   };
-  inline size_t size() const noexcept
+  size_t size() const noexcept
   {
     return length();
   };
 
   // str returns the format string as std::string
-  inline std::string str() const
+  std::string str() const
   {
     return fmt_;
   };
 
   // c_str returns the format string as c string
-  inline const char *c_str() const noexcept
+  const char *c_str() const noexcept
   {
     return fmt_.c_str();
   };

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -166,7 +166,7 @@ static void update_global_vars_custom_rw_section(
   auto global_var = *needed_global_vars.begin();
 
   size_t actual_size;
-  auto buf = bpf_map__initial_value(global_vars_map, &actual_size);
+  auto *buf = bpf_map__initial_value(global_vars_map, &actual_size);
   if (!buf) {
     LOG(BUG) << "Failed to get size for section " << section_name
              << " before resizing";

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -123,7 +123,7 @@ static void update_global_vars_rodata(
 
   size_t v_size;
   char *global_vars_buf = reinterpret_cast<char *>(
-      const_cast<void *>(bpf_map__initial_value(global_vars_map, &v_size)));
+      bpf_map__initial_value(global_vars_map, &v_size));
 
   if (!global_vars_buf) {
     LOG(BUG) << "Failed to get array buf for global variable map";

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -72,7 +72,7 @@ const std::unordered_map<GlobalVar, GlobalVarConfig> GLOBAL_VAR_CONFIGS = {
 };
 
 void update_global_vars(
-    const struct bpf_object *obj,
+    const struct bpf_object *bpf_object,
     const std::unordered_map<std::string, struct bpf_map *> &global_vars_map,
     const BPFtrace &bpftrace);
 

--- a/src/log.h
+++ b/src/log.h
@@ -118,7 +118,7 @@ class LogStreamBug : public LogStream {
 public:
   LogStreamBug(const std::string& file,
                int line,
-               __attribute__((unused)) LogType,
+               __attribute__((unused)) LogType /*unused*/,
                std::ostream& out = std::cerr)
       : LogStream(file, line, LogType::BUG, out) {};
   [[noreturn]] ~LogStreamBug() override;

--- a/src/log.h
+++ b/src/log.h
@@ -44,22 +44,22 @@ public:
                   std::optional<std::string>&& source_location,
                   std::optional<std::vector<std::string>>&& source_context,
                   std::ostream& out,
-                  std::string&& input);
+                  std::string&& msg);
 
-  inline void enable(LogType type)
+  void enable(LogType type)
   {
     enabled_map_[type] = true;
   }
-  inline void disable(LogType type)
+  void disable(LogType type)
   {
     assert(type != LogType::BUG && type != LogType::ERROR);
     enabled_map_[type] = false;
   }
-  inline bool is_enabled(LogType type)
+  bool is_enabled(LogType type)
   {
     return enabled_map_[type];
   }
-  inline void set_colorize(bool is_colorize)
+  void set_colorize(bool is_colorize)
   {
     is_colorize_ = is_colorize;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -744,8 +744,8 @@ bool is_colorize()
 static ast::ASTContext buildListProgram(const std::string& search)
 {
   ast::ASTContext ast("listing", search);
-  auto ap = ast.make_node<ast::AttachPoint>(search, true, location());
-  auto probe = ast.make_node<ast::Probe>(
+  auto* ap = ast.make_node<ast::AttachPoint>(search, true, location());
+  auto* probe = ast.make_node<ast::Probe>(
       ast::AttachPointList({ ap }), nullptr, nullptr, location());
   ast.root = ast.make_node<ast::Program>("",
                                          nullptr,

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -286,7 +286,7 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
           reinterpret_cast<const AsyncEvent::Buf *>(value.data())->length);
     }
     case Type::string: {
-      auto p = reinterpret_cast<const char *>(value.data());
+      const auto *p = reinterpret_cast<const char *>(value.data());
       return { p, strnlen(p, type.GetSize()) };
     }
     case Type::array: {
@@ -507,7 +507,7 @@ void Output::map_contents(
   const auto &map_type = bpftrace.resources.maps_info.at(map.name()).value_type;
 
   bool first = true;
-  for (auto &pair : values_by_key) {
+  for (const auto &pair : values_by_key) {
     auto key = pair.first;
     auto value = pair.second;
 
@@ -541,9 +541,9 @@ void Output::map_hist_contents(
   const auto &map_info = bpftrace.resources.maps_info.at(map.name());
   const auto &map_type = map_info.value_type;
   bool first = true;
-  for (auto &key_count : total_counts_by_key) {
-    auto &key = key_count.first;
-    auto &value = values_by_key.at(key);
+  for (const auto &key_count : total_counts_by_key) {
+    const auto &key = key_count.first;
+    const auto &value = values_by_key.at(key);
 
     if (top && values_by_key.size() > top && i++ < (values_by_key.size() - top))
       continue;
@@ -560,7 +560,7 @@ void Output::map_hist_contents(
         LOG(BUG) << "call to hist with missing \"bits\" argument";
       val_str = hist_to_str(value, div, *map_info.hist_bits_arg);
     } else {
-      auto &args = map_info.lhist_args;
+      const auto &args = map_info.lhist_args;
       if (!args.has_value())
         LOG(BUG) << "call to lhist with missing arguments";
       val_str = lhist_to_str(value, args->min, args->max, args->step);
@@ -582,7 +582,7 @@ void Output::map_stats_contents(
   size_t total = values_by_key.size();
   bool first = true;
 
-  for (auto &[key, value] : values_by_key) {
+  for (const auto &[key, value] : values_by_key) {
     if (top && map_type.IsAvgTy()) {
       if (total > top && i++ < (total - top))
         continue;
@@ -778,7 +778,7 @@ std::string TextOutput::value_to_str(BPFtrace &bpftrace,
       if (type.IsEnumTy() && div == 1) {
         assert(!is_per_cpu);
 
-        auto data = value.data();
+        const auto *data = value.data();
         auto enum_name = type.GetName();
         uint64_t enum_val;
         switch (type.GetIntBitWidth()) {

--- a/src/output.h
+++ b/src/output.h
@@ -242,7 +242,7 @@ protected:
                            bool is_per_cpu,
                            uint32_t div,
                            bool is_map_key = false) const override;
-  static std::string hist_index_label(uint32_t index, uint32_t bits);
+  static std::string hist_index_label(uint32_t index, uint32_t k);
   static std::string lhist_index_label(int number, int step);
   std::string hist_to_str(const std::vector<uint64_t> &values,
                           uint32_t div,

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -24,8 +24,8 @@ PrintableString::PrintableString(std::string value,
 int PrintableString::print(char *buf,
                            size_t size,
                            const char *fmt,
-                           Type,
-                           ArgumentType)
+                           Type /*token*/,
+                           ArgumentType /*expected_type*/)
 {
   return snprintf(buf, size, fmt, value_.c_str());
 }
@@ -33,8 +33,8 @@ int PrintableString::print(char *buf,
 int PrintableBuffer::print(char *buf,
                            size_t size,
                            const char *fmt,
-                           Type,
-                           ArgumentType)
+                           Type /*token*/,
+                           ArgumentType /*expected_type*/)
 {
   return snprintf(buf,
                   size,
@@ -57,8 +57,8 @@ void PrintableBuffer::escape_hex(bool value)
 int PrintableCString::print(char *buf,
                             size_t size,
                             const char *fmt,
-                            Type,
-                            ArgumentType)
+                            Type /*token*/,
+                            ArgumentType /*expected_type*/)
 {
   return snprintf(buf, size, fmt, value_);
 }
@@ -66,7 +66,7 @@ int PrintableCString::print(char *buf,
 int PrintableInt::print(char *buf,
                         size_t size,
                         const char *fmt,
-                        Type,
+                        Type /*token*/,
                         ArgumentType expected_type)
 {
   // Since the value is internally always stored as a 64-bit integer, a cast is
@@ -104,7 +104,7 @@ int PrintableInt::print(char *buf,
 int PrintableSInt::print(char *buf,
                          size_t size,
                          const char *fmt,
-                         Type,
+                         Type /*token*/,
                          ArgumentType expected_type)
 {
   switch (expected_type) {

--- a/src/printf.h
+++ b/src/printf.h
@@ -55,8 +55,8 @@ public:
   int print(char* buf,
             size_t size,
             const char* fmt,
-            Type,
-            ArgumentType) override;
+            Type /*token*/,
+            ArgumentType /*expected_type*/) override;
 
 private:
   std::string value_;
@@ -71,8 +71,8 @@ public:
   int print(char* buf,
             size_t size,
             const char* fmt,
-            Type,
-            ArgumentType) override;
+            Type /*token*/,
+            ArgumentType /*expected_type*/) override;
   void keep_ascii(bool value);
   void escape_hex(bool value);
 
@@ -90,8 +90,8 @@ public:
   int print(char* buf,
             size_t size,
             const char* fmt,
-            Type,
-            ArgumentType) override;
+            Type /*token*/,
+            ArgumentType /*expected_type*/) override;
 
 private:
   char* value_;

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -29,7 +29,7 @@ static int add_symbol(const char* symname,
                       uint64_t /*size*/,
                       void* payload)
 {
-  auto syms = static_cast<std::set<std::string>*>(payload);
+  auto* syms = static_cast<std::set<std::string>*>(payload);
   syms->insert(std::string(symname));
   return 0;
 }
@@ -165,7 +165,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
 
       std::string ret;
       auto iters = bpftrace_->btf_->get_all_iters();
-      for (auto& iter : iters) {
+      for (const auto& iter : iters) {
         // second check
         if (bpftrace_->feature_->has_iter(iter))
           ret += iter + "\n";
@@ -180,7 +180,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     case ProbeType::interval:
     case ProbeType::profile: {
       std::string ret;
-      for (auto& unit : TIME_UNITS)
+      for (const auto& unit : TIME_UNITS)
         ret += unit + ":\n";
       symbol_stream = std::make_unique<std::istringstream>(ret);
       break;
@@ -207,7 +207,7 @@ std::set<std::string> ProbeMatcher::get_matches_in_set(
   std::string stream_in;
   // Strings in the set may contain a newline character, so we use '$'
   // as a delimiter.
-  for (auto& str : set)
+  for (const auto& str : set)
     stream_in.append(str + "$");
 
   std::istringstream stream(stream_in);
@@ -231,9 +231,9 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_traceable_funcs(
     bool with_modules) const
 {
   std::string funcs;
-  for (auto& func_mod : bpftrace_->get_traceable_funcs()) {
+  for (const auto& func_mod : bpftrace_->get_traceable_funcs()) {
     if (with_modules) {
-      for (auto& mod : func_mod.second)
+      for (const auto& mod : func_mod.second)
         funcs += mod + ":" + func_mod.first + "\n";
     } else {
       funcs += func_mod.first + "\n";
@@ -277,7 +277,7 @@ std::unique_ptr<std::istream> ProbeMatcher::get_func_symbols_from_file(
     if (err) {
       LOG(WARNING) << "Could not list function symbols: " + real_path;
     }
-    for (auto& sym : syms)
+    for (const auto& sym : syms)
       result += real_path + ":" + sym + "\n";
   }
   return std::make_unique<std::istringstream>(result);
@@ -323,7 +323,7 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_list(
     const std::vector<ProbeListItem>& probes_list) const
 {
   std::string symbols;
-  for (auto& probe : probes_list) {
+  for (const auto& probe : probes_list) {
     symbols += probe.path + ":\n";
     if (!probe.alias.empty())
       symbols += probe.alias + ":\n";
@@ -336,7 +336,7 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_list(
 std::unique_ptr<std::istream> ProbeMatcher::kernel_probe_list()
 {
   std::string probes;
-  for (auto& p : PROBE_LIST) {
+  for (const auto& p : PROBE_LIST) {
     if (!p.show_in_kernel_list) {
       continue;
     }
@@ -357,7 +357,7 @@ std::unique_ptr<std::istream> ProbeMatcher::kernel_probe_list()
 std::unique_ptr<std::istream> ProbeMatcher::userspace_probe_list()
 {
   std::string probes;
-  for (auto& p : PROBE_LIST) {
+  for (const auto& p : PROBE_LIST) {
     if (p.show_in_userspace_list) {
       probes += p.name + "\n";
     }
@@ -370,7 +370,7 @@ FuncParamLists ProbeMatcher::get_tracepoints_params(
     const std::set<std::string>& tracepoints)
 {
   FuncParamLists params;
-  for (auto& tracepoint : tracepoints) {
+  for (const auto& tracepoint : tracepoints) {
     auto event = tracepoint;
     auto category = util::erase_prefix(event);
 
@@ -406,7 +406,7 @@ FuncParamLists ProbeMatcher::get_iters_params(
   FuncParamLists params;
   std::set<std::string> funcs;
 
-  for (auto& iter : iters)
+  for (const auto& iter : iters)
     funcs.insert(prefix + iter);
 
   params = bpftrace_->btf_->get_params(funcs);
@@ -429,7 +429,7 @@ FuncParamLists ProbeMatcher::get_uprobe_params(
   FuncParamLists params;
   static std::set<std::string> warned_paths;
 
-  for (auto& match : uprobes) {
+  for (const auto& match : uprobes) {
     std::string fun = match;
     std::string path = util::erase_prefix(fun);
     if (auto dwarf = Dwarf::GetFromBinary(nullptr, path)) {
@@ -469,7 +469,7 @@ void ProbeMatcher::list_probes(ast::Program* prog)
           param_lists = get_uprobe_params(matches);
       }
 
-      for (auto& match : matches) {
+      for (const auto& match : matches) {
         std::string match_print = match;
         if (ap->lang == "cpp") {
           std::string target = util::erase_prefix(match_print);
@@ -594,7 +594,7 @@ void ProbeMatcher::list_structs(const std::string& search)
   if (bt_verbose)
     search_input += " *{*}*";
 
-  for (auto& match : get_matches_in_set(search_input, structs))
+  for (const auto& match : get_matches_in_set(search_input, structs))
     std::cout << match << std::endl;
 }
 

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -386,7 +386,7 @@ FuncParamLists ProbeMatcher::get_tracepoints_params(
     // Skip lines until the first empty line
     do {
       getline(format_file, line);
-    } while (line.length() > 0);
+    } while (!line.empty());
 
     while (getline(format_file, line)) {
       if (line.starts_with("\tfield:")) {

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -77,7 +77,7 @@ private:
   std::set<std::string> get_matches_in_stream(const std::string &search_input,
                                               std::istream &symbol_stream,
                                               bool demangle_symbols = true,
-                                              const char delim = '\n');
+                                              char delim = '\n');
   std::set<std::string> get_matches_for_probetype(
       const ProbeType &probe_type,
       const std::string &target,

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -26,7 +26,7 @@ void RequiredResources::load_state(std::istream &in)
 
 void RequiredResources::load_state(const uint8_t *ptr, size_t len)
 {
-  auto addr = const_cast<uint8_t *>(ptr);
+  auto *addr = const_cast<uint8_t *>(ptr);
   util::Membuf mbuf(addr, addr + len);
   std::istream istream(&mbuf);
   cereal::BinaryInputArchive archive(istream);

--- a/src/scopeguard.h
+++ b/src/scopeguard.h
@@ -29,7 +29,7 @@ private:
   std::function<void()> fn_;
 };
 
-inline ScopeGuard operator+(ScopeGuardExit, std::function<void()> fn)
+inline ScopeGuard operator+(ScopeGuardExit /*unused*/, std::function<void()> fn)
 {
   return ScopeGuard(fn);
 }

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <iomanip>
 #include <limits>
 
@@ -131,11 +132,9 @@ void Struct::Dump(std::ostream &os)
 
 bool Struct::HasField(const std::string &name) const
 {
-  for (const auto &field : fields) {
-    if (field.name == name)
-      return true;
-  }
-  return false;
+  return std::ranges::any_of(fields, [name](const auto &field) {
+    return field.name == name;
+  });
 }
 
 const Field &Struct::GetField(const std::string &name) const

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -131,7 +131,7 @@ void Struct::Dump(std::ostream &os)
 
 bool Struct::HasField(const std::string &name) const
 {
-  for (auto &field : fields) {
+  for (const auto &field : fields) {
     if (field.name == name)
       return true;
   }
@@ -140,7 +140,7 @@ bool Struct::HasField(const std::string &name) const
 
 const Field &Struct::GetField(const std::string &name) const
 {
-  for (auto &field : fields) {
+  for (const auto &field : fields) {
     if (field.name == name)
       return field;
   }

--- a/src/struct.h
+++ b/src/struct.h
@@ -133,7 +133,7 @@ struct hash<bpftrace::Struct> {
   size_t operator()(const bpftrace::Struct &s) const
   {
     size_t hash = std::hash<int>()(s.size);
-    for (auto &field : s.fields)
+    for (const auto &field : s.fields)
       bpftrace::util::hash_combine(hash, field.type);
     return hash;
   }

--- a/src/struct.h
+++ b/src/struct.h
@@ -14,7 +14,7 @@ namespace bpftrace {
 static constexpr auto RETVAL_FIELD_NAME = "$retval";
 
 struct Bitfield {
-  Bitfield(size_t byte_offset, size_t bit_width);
+  Bitfield(size_t bit_offset, size_t bit_width);
   Bitfield(size_t read_bytes, size_t access_rshift, uint64_t mask)
       : read_bytes(read_bytes), access_rshift(access_rshift), mask(mask)
   {

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -158,7 +158,7 @@ std::string TracepointFormatParser::parse_field(const std::string &line,
                                                 int *last_offset,
                                                 BPFtrace &bpftrace)
 {
-  std::string extra = "";
+  std::string extra;
 
   auto field_pos = line.find("field:");
   if (field_pos == std::string::npos)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -580,7 +580,7 @@ void SizedType::DumpStructure(std::ostream &os)
     os << "tuple";
   else
     os << "struct";
-  return inner_struct_.lock()->Dump(os);
+  inner_struct_.lock()->Dump(os);
 }
 
 ssize_t SizedType::GetInTupleAlignment() const

--- a/src/types.h
+++ b/src/types.h
@@ -344,7 +344,7 @@ public:
   };
   bool IsEnumTy() const
   {
-    return IsIntTy() && name_.size();
+    return IsIntTy() && !name_.empty();
   }
   bool IsNoneTy() const
   {

--- a/src/usyms.cpp
+++ b/src/usyms.cpp
@@ -142,10 +142,12 @@ void Usyms::cache_blazesym(const std::string &elf_file)
 void Usyms::cache(const std::string &elf_file)
 {
 #ifdef HAVE_BLAZESYM
-  if (config_.get(ConfigKeyBool::use_blazesym))
-    return cache_blazesym(elf_file);
+  if (config_.get(ConfigKeyBool::use_blazesym)) {
+    cache_blazesym(elf_file);
+    return;
+  }
 #endif
-  return cache_bcc(elf_file);
+  cache_bcc(elf_file);
 }
 
 std::string Usyms::resolve_bcc(uint64_t addr,

--- a/src/util/cgroup.cpp
+++ b/src/util/cgroup.cpp
@@ -47,7 +47,7 @@ std::string get_cgroup_path_in_hierarchy(uint64_t cgroupid,
     return "/";
   }
 
-  for (auto &path_iter :
+  for (const auto &path_iter :
        std::filesystem::recursive_directory_iterator(base_path)) {
     if (stat(path_iter.path().c_str(), &path_st) < 0)
       return "";

--- a/src/util/env.cpp
+++ b/src/util/env.cpp
@@ -37,7 +37,6 @@ void get_bool_env_var(const ::std::string &str,
     }
     cb(dest);
   }
-  return;
 }
 
 } // namespace bpftrace::util

--- a/src/util/format.cpp
+++ b/src/util/format.cpp
@@ -74,7 +74,7 @@ std::string hex_format_buffer(const char *buf,
                               bool escape_hex)
 {
   // Allow enough space for every byte to be sanitized in the form "\x00"
-  std::string str(size * 4 + 1, '\0');
+  std::string str((size * 4) + 1, '\0');
   char *s = str.data();
 
   size_t offset = 0;

--- a/src/util/int_parser.cpp
+++ b/src/util/int_parser.cpp
@@ -146,7 +146,7 @@ uint64_t to_uint(const std::string &num, int base)
 std::optional<std::variant<int64_t, uint64_t>> get_int_from_str(
     const std::string &s)
 {
-  if (s.size() == 0) {
+  if (s.empty()) {
     return std::nullopt;
   }
 

--- a/src/util/io.h
+++ b/src/util/io.h
@@ -40,8 +40,8 @@ class Membuf : public std::streambuf {
 public:
   Membuf(uint8_t *begin, uint8_t *end)
   {
-    auto b = reinterpret_cast<char *>(begin);
-    auto e = reinterpret_cast<char *>(end);
+    auto *b = reinterpret_cast<char *>(begin);
+    auto *e = reinterpret_cast<char *>(end);
     this->setg(b, b, e);
   }
 };

--- a/src/util/io.h
+++ b/src/util/io.h
@@ -46,6 +46,6 @@ public:
   }
 };
 
-void cat_file(const char *filename, size_t, std::ostream &);
+void cat_file(const char *filename, size_t max_bytes, std::ostream &out);
 
 } // namespace bpftrace::util

--- a/src/util/kernel.cpp
+++ b/src/util/kernel.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <bcc/bcc_elf.h>
 #include <bcc/bcc_syms.h>
 #include <bcc/bcc_usdt.h>
@@ -227,12 +228,9 @@ static bool is_bad_func(std::string &func)
   if (bad_funcs.contains(func))
     return true;
 
-  for (const auto &s : bad_funcs_partial) {
-    if (!std::strncmp(func.c_str(), s.c_str(), s.length()))
-      return true;
-  }
-
-  return false;
+  return std::ranges::any_of(bad_funcs_partial, [func](const auto &s) {
+    return !std::strncmp(func.c_str(), s.c_str(), s.length());
+  });
 }
 
 FuncsModulesMap parse_traceable_funcs()

--- a/src/util/kernel.cpp
+++ b/src/util/kernel.cpp
@@ -30,24 +30,24 @@ namespace bpftrace::util {
 // Search for LINUX_VERSION_CODE in the vDSO, returning 0 if it can't be found.
 static uint32_t _find_version_note(unsigned long base)
 {
-  auto ehdr = reinterpret_cast<const ElfW(Ehdr) *>(base);
+  const auto *ehdr = reinterpret_cast<const ElfW(Ehdr) *>(base);
 
   for (int i = 0; i < ehdr->e_shnum; i++) {
-    auto shdr = reinterpret_cast<const ElfW(Shdr) *>(base + ehdr->e_shoff +
-                                                     (i * ehdr->e_shentsize));
+    const auto *shdr = reinterpret_cast<const ElfW(Shdr) *>(
+        base + ehdr->e_shoff + (i * ehdr->e_shentsize));
 
     if (shdr->sh_type == SHT_NOTE) {
-      auto ptr = reinterpret_cast<const char *>(base + shdr->sh_offset);
-      auto end = ptr + shdr->sh_size;
+      const auto *ptr = reinterpret_cast<const char *>(base + shdr->sh_offset);
+      const auto *end = ptr + shdr->sh_size;
 
       while (ptr < end) {
-        auto nhdr = reinterpret_cast<const ElfW(Nhdr) *>(ptr);
+        const auto *nhdr = reinterpret_cast<const ElfW(Nhdr) *>(ptr);
         ptr += sizeof *nhdr;
 
-        auto name = ptr;
+        const auto *name = ptr;
         ptr += (nhdr->n_namesz + sizeof(ElfW(Word)) - 1) & -sizeof(ElfW(Word));
 
-        auto desc = ptr;
+        const auto *desc = ptr;
         ptr += (nhdr->n_descsz + sizeof(ElfW(Word)) - 1) & -sizeof(ElfW(Word));
 
         if ((nhdr->n_namesz > 5 && !memcmp(name, "Linux", 5)) &&
@@ -161,7 +161,7 @@ std::optional<std::string> find_vmlinux(struct vmlinux_location const *locs,
                                         struct symbol *sym)
 {
   for (size_t i = 0; !locs[i].path.empty(); ++i) {
-    auto &loc = locs[i];
+    const auto &loc = locs[i];
     if (loc.raw)
       continue; // This file is for BTF. skip
 

--- a/src/util/kernel.h
+++ b/src/util/kernel.h
@@ -10,7 +10,7 @@
 namespace bpftrace::util {
 
 enum KernelVersionMethod { vDSO, UTS, File, None };
-uint32_t kernel_version(KernelVersionMethod);
+uint32_t kernel_version(KernelVersionMethod method);
 
 std::optional<std::string> find_vmlinux(struct symbol *sym = nullptr);
 

--- a/src/util/paths.cpp
+++ b/src/util/paths.cpp
@@ -183,7 +183,7 @@ static std::vector<std::string> resolve_binary_path(const std::string &cmd,
 std::vector<std::string> resolve_binary_path(const std::string &cmd,
                                              std::optional<int> pid)
 {
-  std::string env_paths = "";
+  std::string env_paths;
   std::ostringstream pid_environ_path;
 
   if (pid.has_value() && pid_in_different_mountns(*pid)) {

--- a/src/util/paths.cpp
+++ b/src/util/paths.cpp
@@ -286,7 +286,7 @@ std::string path_for_pid_mountns(int pid, const std::string &path)
   snprintf(pid_root, sizeof(pid_root), "/proc/%d/root", pid);
 
   if (!path.starts_with(pid_root)) {
-    std::string sep = (path.length() >= 1 && path.at(0) == '/') ? "" : "/";
+    std::string sep = (!path.empty() && path.at(0) == '/') ? "" : "/";
     pid_relative_path << pid_root << sep << path;
   } else {
     // The path is already relative to the pid's root

--- a/src/util/stats.h
+++ b/src/util/stats.h
@@ -21,7 +21,7 @@ T reduce_value(const std::vector<uint8_t> &value, int nvalues)
 {
   T sum = 0;
   for (int i = 0; i < nvalues; i++) {
-    sum += read_data<T>(value.data() + i * sizeof(T));
+    sum += read_data<T>(value.data() + (i * sizeof(T)));
   }
   return sum;
 }
@@ -32,9 +32,9 @@ T min_max_value(const std::vector<uint8_t> &value, int nvalues, bool is_max)
   T mm_val = 0;
   bool mm_set = false;
   for (int i = 0; i < nvalues; i++) {
-    T val = read_data<T>(value.data() + i * (sizeof(T) * 2));
+    T val = read_data<T>(value.data() + (i * (sizeof(T) * 2)));
     auto is_set = read_data<uint32_t>(value.data() + sizeof(T) +
-                                      i * (sizeof(T) * 2));
+                                      (i * (sizeof(T) * 2)));
     if (!is_set) {
       continue;
     }
@@ -62,8 +62,9 @@ stats<T> stats_value(const std::vector<uint8_t> &value, int nvalues)
 {
   stats<T> ret = { 0, 0, 0 };
   for (int i = 0; i < nvalues; i++) {
-    T val = read_data<T>(value.data() + i * (sizeof(T) * 2));
-    T cpu_count = read_data<T>(value.data() + sizeof(T) + i * (sizeof(T) * 2));
+    T val = read_data<T>(value.data() + (i * (sizeof(T) * 2)));
+    T cpu_count = read_data<T>(value.data() + sizeof(T) +
+                               (i * (sizeof(T) * 2)));
     ret.count += cpu_count;
     ret.total += val;
   }

--- a/src/util/symbols.cpp
+++ b/src/util/symbols.cpp
@@ -93,10 +93,7 @@ std::tuple<std::string, std::string, std::string> split_addrrange_symbol_module(
 
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name)
 {
-  if (!sym_name.rfind("_Z", 0) || !sym_name.rfind("____Z", 0))
-    return true;
-  else
-    return false;
+  return !sym_name.rfind("_Z", 0) || !sym_name.rfind("____Z", 0);
 }
 
 } // namespace bpftrace::util

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -169,7 +169,7 @@ std::vector<std::string> get_mapped_paths_for_running_pids()
     }
   }
   std::vector<std::string> paths;
-  for (auto &path : unique_paths) {
+  for (const auto &path : unique_paths) {
     paths.emplace_back(std::move(path));
   }
   return paths;

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -999,7 +999,7 @@ std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int(
 
   for (size_t i = 0; i < key.size(); i++) {
     uint64_t k = key.at(i);
-    std::memcpy(key_data + sizeof(uint64_t) * i, &k, sizeof(k));
+    std::memcpy(key_data + (sizeof(uint64_t) * i), &k, sizeof(k));
   }
   uint64_t v = val;
   std::memcpy(val_data, &v, sizeof(v));
@@ -1019,7 +1019,7 @@ std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_str(
   uint8_t *val_data = pair.second.data();
 
   for (size_t i = 0; i < key.size(); i++) {
-    strncpy(reinterpret_cast<char *>(key_data) + STRING_SIZE * i,
+    strncpy(reinterpret_cast<char *>(key_data) + (STRING_SIZE * i),
             key.at(i).c_str(),
             STRING_SIZE);
   }
@@ -1062,7 +1062,7 @@ TEST(bpftrace, sort_by_key_int)
         key_value_pair_int({ 3 }, 11),
         key_value_pair_int({ 1 }, 10),
       };
-  bpftrace.sort_by_key(key_arg, values_by_key);
+  StrictMock<MockBPFtrace>::sort_by_key(key_arg, values_by_key);
 
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
       expected_values = {
@@ -1087,7 +1087,7 @@ TEST(bpftrace, sort_by_key_int_int)
         key_value_pair_int({ 5, 1, 1 }, 3), key_value_pair_int({ 2, 2, 2 }, 4),
         key_value_pair_int({ 2, 3, 2 }, 5), key_value_pair_int({ 2, 1, 2 }, 6),
       };
-  bpftrace.sort_by_key(key, values_by_key);
+  StrictMock<MockBPFtrace>::sort_by_key(key, values_by_key);
 
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
       expected_values = {
@@ -1111,7 +1111,7 @@ TEST(bpftrace, sort_by_key_str)
         key_value_pair_str({ "x" }, 3),
         key_value_pair_str({ "d" }, 4),
       };
-  bpftrace.sort_by_key(key_arg, values_by_key);
+  StrictMock<MockBPFtrace>::sort_by_key(key_arg, values_by_key);
 
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
       expected_values = {
@@ -1142,7 +1142,7 @@ TEST(bpftrace, sort_by_key_str_str)
         key_value_pair_str({ "z", "b", "p" }, 5),
         key_value_pair_str({ "a", "b", "q" }, 6),
       };
-  bpftrace.sort_by_key(key, values_by_key);
+  StrictMock<MockBPFtrace>::sort_by_key(key, values_by_key);
 
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
       expected_values = {
@@ -1170,7 +1170,7 @@ TEST(bpftrace, sort_by_key_int_str)
         key_value_pair_int_str(3, "b", 3), key_value_pair_int_str(1, "a", 4),
         key_value_pair_int_str(2, "a", 5), key_value_pair_int_str(3, "a", 6),
       };
-  bpftrace.sort_by_key(key, values_by_key);
+  StrictMock<MockBPFtrace>::sort_by_key(key, values_by_key);
 
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
       expected_values = {

--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -252,7 +252,7 @@ TEST_F(childproc, multi_exec_match)
   }
 
   // Set ENV
-  auto old_path = ::getenv("PATH");
+  auto *old_path = ::getenv("PATH");
   auto new_path = usr_bin.native(); // copy
   new_path += ":";
   new_path += symlink_bin.c_str();

--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -149,7 +149,7 @@ TEST_F(childproc, stop_cont)
     FAIL() << "kill(SIGSTOP)";
 
   waitpid(child->pid(), &status, WUNTRACED);
-  if (!(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP))
+  if (!WIFSTOPPED(status) || WSTOPSIG(status) != SIGSTOP)
     FAIL() << "! WIFSTOPPED";
 
   EXPECT_TRUE(child->is_alive());
@@ -223,7 +223,7 @@ TEST_F(childproc, multi_exec_match)
 
   // Create directory for test
   std::string tmpdir = "/tmp/bpftrace-test-child-XXXXXX";
-  ASSERT_NE(::mkdtemp(&tmpdir[0]), nullptr);
+  ASSERT_NE(::mkdtemp(tmpdir.data()), nullptr);
 
   // Create fixture directories
   const auto path = std::filesystem::path(tmpdir);

--- a/tests/childhelper.h
+++ b/tests/childhelper.h
@@ -14,7 +14,7 @@ inline int msleep(int msec)
   struct timespec sleep = { .tv_sec = 0, .tv_nsec = msec * 1000000L };
   struct timespec rem = {};
   if (nanosleep(&sleep, &rem) < 0)
-    return 1000L * rem.tv_sec + 1000000L * rem.tv_nsec;
+    return (1000L * rem.tv_sec) + (1000000L * rem.tv_nsec);
   return 0;
 }
 

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -223,8 +223,8 @@ TEST(clang_parser, string_ptr)
   ASSERT_EQ(foo->fields.size(), 1U);
   ASSERT_TRUE(foo->HasField("str"));
 
-  auto &ty = foo->GetField("str").type;
-  auto *pointee = ty.GetPointeeTy();
+  const auto &ty = foo->GetField("str").type;
+  const auto *pointee = ty.GetPointeeTy();
   EXPECT_TRUE(pointee->IsIntTy());
   EXPECT_EQ(pointee->GetIntBitWidth(), 8 * sizeof(char));
   EXPECT_EQ(foo->GetField("str").offset, 0);
@@ -260,7 +260,7 @@ TEST(clang_parser, nested_struct_named)
   ASSERT_EQ(foo->fields.size(), 1U);
   ASSERT_TRUE(foo->HasField("bar"));
 
-  auto &bar = foo->GetField("bar");
+  const auto &bar = foo->GetField("bar");
   EXPECT_TRUE(bar.type.IsRecordTy());
   EXPECT_EQ(bar.type.GetName(), "struct Bar");
   EXPECT_EQ(bar.type.GetSize(), 4U);
@@ -280,7 +280,7 @@ TEST(clang_parser, nested_struct_ptr_named)
   ASSERT_EQ(foo->fields.size(), 1U);
   ASSERT_TRUE(foo->HasField("bar"));
 
-  auto &bar = foo->GetField("bar");
+  const auto &bar = foo->GetField("bar");
   EXPECT_TRUE(bar.type.IsPtrTy());
   EXPECT_TRUE(bar.type.GetPointeeTy()->IsRecordTy());
   EXPECT_EQ(bar.type.GetPointeeTy()->GetName(), "struct Bar");
@@ -328,12 +328,12 @@ TEST(clang_parser, nested_struct_no_type)
   EXPECT_EQ(baz->GetField("y").offset, 0);
 
   {
-    auto &bar_field = foo->GetField("bar");
+    const auto &bar_field = foo->GetField("bar");
     EXPECT_TRUE(bar_field.type.IsRecordTy());
     EXPECT_EQ(bar_field.type.GetSize(), sizeof(int));
     EXPECT_EQ(bar_field.offset, 0);
 
-    auto &baz_field = foo->GetField("baz");
+    const auto &baz_field = foo->GetField("baz");
     EXPECT_TRUE(baz_field.type.IsRecordTy());
     EXPECT_EQ(baz_field.type.GetSize(), sizeof(int));
     EXPECT_EQ(baz_field.offset, 4);

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -234,24 +234,24 @@ void test_arrays_compound_data(BPFtrace &bpftrace)
   ASSERT_EQ(arrs->fields.size(), 1U);
   ASSERT_TRUE(arrs->HasField("data"));
 
-  auto &data_type = arrs->GetField("data").type;
+  const auto &data_type = arrs->GetField("data").type;
   EXPECT_TRUE(data_type.IsArrayTy());
   EXPECT_EQ(data_type.GetNumElements(), 2);
   EXPECT_EQ(data_type.GetSize(), 2 * sizeof(uintptr_t));
 
   // Check that referenced types n-levels deep are all parsed from BTF
 
-  auto &foo3_ptr_type = *data_type.GetElementTy();
+  const auto &foo3_ptr_type = *data_type.GetElementTy();
   ASSERT_TRUE(foo3_ptr_type.IsPtrTy());
 
-  auto &foo3_type = *foo3_ptr_type.GetPointeeTy();
+  const auto &foo3_type = *foo3_ptr_type.GetPointeeTy();
   ASSERT_TRUE(foo3_type.IsRecordTy());
   ASSERT_TRUE(foo3_type.HasField("foo1"));
 
-  auto &foo1_ptr_type = foo3_type.GetField("foo1").type;
+  const auto &foo1_ptr_type = foo3_type.GetField("foo1").type;
   ASSERT_TRUE(foo1_ptr_type.IsPtrTy());
 
-  auto &foo1_type = *foo1_ptr_type.GetPointeeTy();
+  const auto &foo1_type = *foo1_ptr_type.GetPointeeTy();
   ASSERT_TRUE(foo1_type.IsRecordTy());
   ASSERT_TRUE(foo1_type.HasField("a"));
 }

--- a/tests/function_registry.cpp
+++ b/tests/function_registry.cpp
@@ -339,7 +339,8 @@ TEST_F(TestFunctionRegistryPopulated, overloaded_origin)
 TEST(TestFunctionRegistry, add_namespaced)
 {
   FunctionRegistry reg;
-  auto *foo = reg.add(Function::Origin::Script, "ns", "foo", CreateNone(), {});
+  const auto *foo = reg.add(
+      Function::Origin::Script, "ns", "foo", CreateNone(), {});
   ast::ASTContext ast;
   auto &call = *ast.make_node<ast::Call>("foo", ast::Location());
   EXPECT_EQ(nullptr, reg.get("", "foo", {}, call));

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -24,7 +24,7 @@ TEST(LogStream, basic)
 
   // test macro with 1 argument
   ENABLE_LOG(V1);
-  auto cerr_buf = std::cerr.rdbuf(ss.rdbuf());
+  auto *cerr_buf = std::cerr.rdbuf(ss.rdbuf());
   LOG(V1) << content_1 << content_2;
   EXPECT_EQ(ss.str(), content_1 + content_2 + "\n");
   std::cerr.rdbuf(cerr_buf);
@@ -62,7 +62,7 @@ TEST(LogStream, basic_colorized)
 
   // test macro with 1 argument
   ENABLE_LOG(V1);
-  auto cerr_buf = std::cerr.rdbuf(ss.rdbuf());
+  auto *cerr_buf = std::cerr.rdbuf(ss.rdbuf());
   LOG(V1) << content_1 << content_2;
   EXPECT_EQ(ss.str(), content_1 + content_2 + "\n");
   std::cerr.rdbuf(cerr_buf);

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -170,10 +170,7 @@ public:
 
   bool is_alive() override
   {
-    if (pid_ > 0)
-      return true;
-    else
-      return false;
+    return pid_ > 0;
   }
 };
 

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -63,13 +63,13 @@ public:
   }
 
   bool is_traceable_func(
-      const std::string &__attribute__((unused))) const override
+      const std::string &__attribute__((unused)) /*func_name*/) const override
   {
     return true;
   }
 
   std::unordered_set<std::string> get_func_modules(
-      const std::string &__attribute__((unused))) const override
+      const std::string &__attribute__((unused)) /*func_name*/) const override
   {
     return { "mock_vmlinux" };
   }

--- a/tests/pass_manager.cpp
+++ b/tests/pass_manager.cpp
@@ -11,7 +11,7 @@ namespace bpftrace::test::passes {
 class Error1 : public ErrorInfo<Error1> {
 public:
   static char ID;
-  void log(llvm::raw_ostream &) const override
+  void log(llvm::raw_ostream & /*OS*/) const override
   {
   }
 };
@@ -19,7 +19,7 @@ public:
 class Error2 : public ErrorInfo<Error2> {
 public:
   static char ID;
-  void log(llvm::raw_ostream &) const override
+  void log(llvm::raw_ostream & /*OS*/) const override
   {
   }
 };

--- a/tests/required_resources.cpp
+++ b/tests/required_resources.cpp
@@ -27,7 +27,7 @@ TEST(required_resources, round_trip_simple)
   {
     RequiredResources r;
     r.load_state(input);
-    ASSERT_EQ(r.probe_ids.size(), 1ul);
+    ASSERT_EQ(r.probe_ids.size(), 1UL);
     EXPECT_EQ(r.probe_ids[0], "itsastring");
   }
 }
@@ -52,22 +52,22 @@ TEST(required_resources, round_trip_field_sized_type)
     RequiredResources r;
     r.load_state(input);
 
-    ASSERT_EQ(r.system_args.size(), 1ul);
+    ASSERT_EQ(r.system_args.size(), 1UL);
     EXPECT_EQ(std::get<0>(r.system_args[0]).str(), "field0");
 
     auto &fields = std::get<1>(r.system_args[0]);
-    ASSERT_EQ(fields.size(), 1ul);
+    ASSERT_EQ(fields.size(), 1UL);
     auto &field = fields[0];
     EXPECT_EQ(field.name, "myfield");
     EXPECT_TRUE(field.type.IsIntTy());
-    EXPECT_EQ(field.type.GetSize(), 4ul);
+    EXPECT_EQ(field.type.GetSize(), 4UL);
     EXPECT_EQ(field.offset, 123);
     // clang-tidy does not recognize ASSERT_*() terminates testcase
     // NOLINTBEGIN(bugprone-unchecked-optional-access)
     ASSERT_TRUE(field.bitfield.has_value());
-    EXPECT_EQ(field.bitfield->read_bytes, 1ul);
-    EXPECT_EQ(field.bitfield->access_rshift, 2ul);
-    EXPECT_EQ(field.bitfield->mask, 0xFFul);
+    EXPECT_EQ(field.bitfield->read_bytes, 1UL);
+    EXPECT_EQ(field.bitfield->access_rshift, 2UL);
+    EXPECT_EQ(field.bitfield->mask, 0xFFUL);
     // NOLINTEND(bugprone-unchecked-optional-access)
   }
 }
@@ -98,11 +98,11 @@ TEST(required_resources, round_trip_map_info)
     RequiredResources r;
     r.load_state(input);
 
-    ASSERT_EQ(r.maps_info.count("mymap"), 1ul);
+    ASSERT_EQ(r.maps_info.count("mymap"), 1UL);
     const auto &map_info = r.maps_info["mymap"];
 
     EXPECT_TRUE(map_info.value_type.IsInetTy());
-    EXPECT_EQ(map_info.value_type.GetSize(), 3ul);
+    EXPECT_EQ(map_info.value_type.GetSize(), 3UL);
 
     EXPECT_TRUE(map_info.key_type.IsIntegerTy());
     EXPECT_EQ(map_info.key_type.GetSize(), 4);
@@ -140,7 +140,7 @@ TEST(required_resources, round_trip_probes)
     RequiredResources r;
     r.load_state(input);
 
-    ASSERT_EQ(r.special_probes.size(), 1ul);
+    ASSERT_EQ(r.special_probes.size(), 1UL);
     auto &probe = r.special_probes["test"];
     EXPECT_EQ(probe.type, ProbeType::hardware);
     EXPECT_EQ(probe.path, "mypath");
@@ -163,9 +163,9 @@ TEST(required_resources, round_trip_multiple_members)
     RequiredResources r;
     r.load_state(input);
 
-    ASSERT_EQ(r.join_args.size(), 1ul);
+    ASSERT_EQ(r.join_args.size(), 1UL);
     EXPECT_EQ(r.join_args[0], "joinarg0");
-    ASSERT_EQ(r.time_args.size(), 1ul);
+    ASSERT_EQ(r.time_args.size(), 1UL);
     EXPECT_EQ(r.time_args[0], "timearg0");
   }
 }

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -40,7 +40,7 @@ void test(const std::string &input,
   auto bpftrace = get_mock_bpftrace();
   auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
   configs.set(ConfigKeyInt::on_stack_limit, on_stack_limit.value_or(0));
-  return test(*bpftrace, input, expected_result, out);
+  test(*bpftrace, input, expected_result, out);
 }
 
 TEST(resource_analyser, multiple_hist_bits_in_single_map)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1296,7 +1296,7 @@ TEST(semantic_analyser, call_str_2_lit)
   BPFtrace bpftrace;
   auto ast = test("kprobe:f { $x = str(arg0, 3); }");
 
-  auto x = static_cast<ast::AssignVarStatement *>(
+  auto *x = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateString(3), x->var->type);
 }
@@ -1459,7 +1459,7 @@ TEST(semantic_analyser, call_uaddr)
   std::vector<int> sizes = { 8, 16, 32, 64, 64, 64 };
 
   for (size_t i = 0; i < sizes.size(); i++) {
-    auto v = static_cast<ast::AssignVarStatement *>(
+    auto *v = static_cast<ast::AssignVarStatement *>(
         ast.root->probes.at(0)->block->stmts.at(i));
     EXPECT_TRUE(v->var->type.IsPtrTy());
     EXPECT_TRUE(v->var->type.GetPointeeTy()->IsIntTy());
@@ -1746,26 +1746,26 @@ TEST(semantic_analyser, array_access)
   auto ast = test(
       "struct MyStruct { int y[4]; } kprobe:f { $s = (struct MyStruct *) "
       "arg0; @x = $s->y[0];}");
-  auto assignment = static_cast<ast::AssignMapStatement *>(
+  auto *assignment = static_cast<ast::AssignMapStatement *>(
       ast.root->probes.at(0)->block->stmts.at(1));
   EXPECT_EQ(CreateInt64(), assignment->map->type);
 
   ast = test(
       "struct MyStruct { int y[4]; } kprobe:f { $s = ((struct MyStruct *) "
       "arg0)->y; @x = $s[0];}");
-  auto array_var_assignment = static_cast<ast::AssignVarStatement *>(
+  auto *array_var_assignment = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateArray(4, CreateInt32()), array_var_assignment->var->type);
 
   ast = test(
       "struct MyStruct { int y[4]; } kprobe:f { @a[0] = ((struct MyStruct *) "
       "arg0)->y; @x = @a[0][0];}");
-  auto array_map_assignment = static_cast<ast::AssignMapStatement *>(
+  auto *array_map_assignment = static_cast<ast::AssignMapStatement *>(
       ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateArray(4, CreateInt32()), array_map_assignment->map->type);
 
   ast = test("kprobe:f { $s = (int32 *) arg0; $x = $s[0]; }");
-  auto var_assignment = static_cast<ast::AssignVarStatement *>(
+  auto *var_assignment = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(1));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
 
@@ -1869,7 +1869,7 @@ TEST(semantic_analyser, variable_type)
   BPFtrace bpftrace;
   auto ast = test("kprobe:f { $x = 1 }");
   auto st = CreateInt64();
-  auto assignment = static_cast<ast::AssignVarStatement *>(
+  auto *assignment = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(st, assignment->var->type);
 }
@@ -1900,9 +1900,9 @@ TEST(semantic_analyser, map_integer_sizes)
   BPFtrace bpftrace;
   auto ast = test("kprobe:f { $x = (int32) -1; @x = $x; }");
 
-  auto var_assignment = static_cast<ast::AssignVarStatement *>(
+  auto *var_assignment = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(0));
-  auto map_assignment = static_cast<ast::AssignMapStatement *>(
+  auto *map_assignment = static_cast<ast::AssignMapStatement *>(
       ast.root->probes.at(0)->block->stmts.at(1));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
   EXPECT_EQ(CreateInt64(), map_assignment->map->type);
@@ -1913,7 +1913,7 @@ TEST(semantic_analyser, binop_integer_promotion)
   BPFtrace bpftrace;
   auto ast = test("kprobe:f { $x = (int32)5 + (int16)6 }");
 
-  auto var_assignment = static_cast<ast::AssignVarStatement *>(
+  auto *var_assignment = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateInt32(), var_assignment->var->type);
 }
@@ -1923,7 +1923,7 @@ TEST(semantic_analyser, binop_integer_no_promotion)
   BPFtrace bpftrace;
   auto ast = test("kprobe:f { $x = (int8)5 + (int8)6 }");
 
-  auto var_assignment = static_cast<ast::AssignVarStatement *>(
+  auto *var_assignment = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(0));
   EXPECT_EQ(CreateInt8(), var_assignment->var->type);
 }
@@ -2680,7 +2680,7 @@ TEST(semantic_analyser, field_access_is_internal)
   {
     auto ast = test(structs + "kprobe:f { $x = (*(struct type1*)0).x }");
     auto &stmts = ast.root->probes.at(0)->block->stmts;
-    auto var_assignment1 = static_cast<ast::AssignVarStatement *>(stmts.at(0));
+    auto *var_assignment1 = static_cast<ast::AssignVarStatement *>(stmts.at(0));
     EXPECT_FALSE(var_assignment1->var->type.is_internal);
   }
 
@@ -2688,8 +2688,8 @@ TEST(semantic_analyser, field_access_is_internal)
     auto ast = test(structs +
                     "kprobe:f { @type1 = *(struct type1*)0; $x = @type1.x }");
     auto &stmts = ast.root->probes.at(0)->block->stmts;
-    auto map_assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
-    auto var_assignment2 = static_cast<ast::AssignVarStatement *>(stmts.at(1));
+    auto *map_assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
+    auto *var_assignment2 = static_cast<ast::AssignVarStatement *>(stmts.at(1));
     EXPECT_TRUE(map_assignment->map->type.is_internal);
     EXPECT_TRUE(var_assignment2->var->type.is_internal);
   }
@@ -2793,9 +2793,9 @@ TEST(semantic_analyser, positional_parameters)
   test(bpftrace, "kprobe:f { printf(\"%d\", cgroupid(str($2))); }");
 
   auto ast = test("k:f { $1 }");
-  auto stmt = static_cast<ast::ExprStatement *>(
+  auto *stmt = static_cast<ast::ExprStatement *>(
       ast.root->probes.at(0)->block->stmts.at(0));
-  auto pp = static_cast<ast::PositionalParameter *>(stmt->expr);
+  auto *pp = static_cast<ast::PositionalParameter *>(stmt->expr);
   EXPECT_EQ(CreateUInt64(), pp->type);
   EXPECT_TRUE(pp->is_literal);
 
@@ -2963,13 +2963,13 @@ TEST(semantic_analyser, cast_sign)
       "  $s = $t->s; $us = $t->us; $l = $t->l; $lu = $t->ul; }";
   auto ast = test(prog);
 
-  auto s = static_cast<ast::AssignVarStatement *>(
+  auto *s = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(1));
-  auto us = static_cast<ast::AssignVarStatement *>(
+  auto *us = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(2));
-  auto l = static_cast<ast::AssignVarStatement *>(
+  auto *l = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(3));
-  auto ul = static_cast<ast::AssignVarStatement *>(
+  auto *ul = static_cast<ast::AssignVarStatement *>(
       ast.root->probes.at(0)->block->stmts.at(4));
   EXPECT_EQ(CreateInt32(), s->var->type);
   EXPECT_EQ(CreateUInt32(), us->var->type);
@@ -2999,13 +2999,13 @@ TEST(semantic_analyser, binop_sign)
                        "}";
 
     auto ast = test(prog);
-    auto varA = static_cast<ast::AssignVarStatement *>(
+    auto *varA = static_cast<ast::AssignVarStatement *>(
         ast.root->probes.at(0)->block->stmts.at(1));
     EXPECT_EQ(CreateInt64(), varA->var->type);
-    auto varB = static_cast<ast::AssignVarStatement *>(
+    auto *varB = static_cast<ast::AssignVarStatement *>(
         ast.root->probes.at(0)->block->stmts.at(2));
     EXPECT_EQ(CreateUInt64(), varB->var->type);
-    auto varC = static_cast<ast::AssignVarStatement *>(
+    auto *varC = static_cast<ast::AssignVarStatement *>(
         ast.root->probes.at(0)->block->stmts.at(3));
     EXPECT_EQ(CreateUInt64(), varC->var->type);
   }
@@ -3408,23 +3408,23 @@ TEST(semantic_analyser, type_ctx)
   auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $x = (struct x*)ctx;
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
+  auto *assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   EXPECT_TRUE(assignment->var->type.IsPtrTy());
 
   // $a = $x->a;
   assignment = static_cast<ast::AssignVarStatement *>(stmts.at(1));
   EXPECT_EQ(CreateInt64(), assignment->var->type);
-  auto fieldaccess = static_cast<ast::FieldAccess *>(assignment->expr);
+  auto *fieldaccess = static_cast<ast::FieldAccess *>(assignment->expr);
   EXPECT_EQ(CreateInt64(), fieldaccess->type);
-  auto unop = static_cast<ast::Unop *>(fieldaccess->expr);
+  auto *unop = static_cast<ast::Unop *>(fieldaccess->expr);
   EXPECT_TRUE(unop->type.IsCtxAccess());
-  auto var = static_cast<ast::Variable *>(unop->expr);
+  auto *var = static_cast<ast::Variable *>(unop->expr);
   EXPECT_TRUE(var->type.IsPtrTy());
 
   // $b = $x->b[0];
   assignment = static_cast<ast::AssignVarStatement *>(stmts.at(2));
   EXPECT_EQ(CreateInt16(), assignment->var->type);
-  auto arrayaccess = static_cast<ast::ArrayAccess *>(assignment->expr);
+  auto *arrayaccess = static_cast<ast::ArrayAccess *>(assignment->expr);
   EXPECT_EQ(CreateInt16(), arrayaccess->type);
   fieldaccess = static_cast<ast::FieldAccess *>(arrayaccess->expr);
   EXPECT_TRUE(fieldaccess->type.IsCtxAccess());
@@ -3485,7 +3485,7 @@ TEST(semantic_analyser, double_pointer_int)
   auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $pp = (int8 **)1;
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
+  auto *assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   ASSERT_TRUE(assignment->var->type.IsPtrTy());
   ASSERT_TRUE(assignment->var->type.GetPointeeTy()->IsPtrTy());
   ASSERT_TRUE(assignment->var->type.GetPointeeTy()->GetPointeeTy()->IsIntTy());
@@ -3513,7 +3513,7 @@ TEST(semantic_analyser, double_pointer_struct)
   auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $pp = (struct Foo **)1;
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
+  auto *assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   ASSERT_TRUE(assignment->var->type.IsPtrTy());
   ASSERT_TRUE(assignment->var->type.GetPointeeTy()->IsPtrTy());
   ASSERT_TRUE(
@@ -3695,7 +3695,7 @@ TEST(semantic_analyser, tuple_assign_var)
   auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $t = (1, "str");
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
+  auto *assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   EXPECT_EQ(ty, assignment->var->type);
 
   // $t = (4, "other");
@@ -3714,7 +3714,7 @@ TEST(semantic_analyser, tuple_assign_map)
   auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $t = (1, 3, 3, 7);
-  auto assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
+  auto *assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
   ty = CreateTuple(bpftrace.structs.AddTuple(
       { CreateInt64(), CreateInt64(), CreateInt64(), CreateInt64() }));
   EXPECT_EQ(ty, assignment->map->type);
@@ -3739,7 +3739,7 @@ TEST(semantic_analyser, tuple_nested)
   auto &stmts = ast.root->probes.at(0)->block->stmts;
 
   // $t = (1, "str");
-  auto assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
+  auto *assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   EXPECT_EQ(ty, assignment->var->type);
 }
 
@@ -3877,14 +3877,14 @@ TEST(semantic_analyser, string_size)
   // Size of the variable should be the size of the larger string (incl. null)
   BPFtrace bpftrace;
   auto ast = test(bpftrace, true, R"_(BEGIN { $x = "hi"; $x = "hello"; })_", 0);
-  auto stmt = ast.root->probes.at(0)->block->stmts.at(0);
-  auto var_assign = dynamic_cast<ast::AssignVarStatement *>(stmt);
+  auto *stmt = ast.root->probes.at(0)->block->stmts.at(0);
+  auto *var_assign = dynamic_cast<ast::AssignVarStatement *>(stmt);
   ASSERT_TRUE(var_assign->var->type.IsStringTy());
   ASSERT_EQ(var_assign->var->type.GetSize(), 6UL);
 
   ast = test(bpftrace, true, R"_(k:f1 {@ = "hi";} k:f2 {@ = "hello";})_", 0);
   stmt = ast.root->probes.at(0)->block->stmts.at(0);
-  auto map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
+  auto *map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
   ASSERT_TRUE(map_assign->map->type.IsStringTy());
   ASSERT_EQ(map_assign->map->type.GetSize(), 6UL);
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3748,7 +3748,7 @@ TEST(semantic_analyser, tuple_types_unique)
   auto bpftrace = get_mock_bpftrace();
   test(*bpftrace, R"_(BEGIN { $t = (1, "hello"); $t = (4, "other"); })_");
 
-  EXPECT_EQ(bpftrace->structs.GetTuplesCnt(), 1ul);
+  EXPECT_EQ(bpftrace->structs.GetTuplesCnt(), 1UL);
 }
 
 TEST(semantic_analyser, multi_pass_type_inference_zero_size_int)

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -166,7 +166,7 @@ static std::string get_working_path()
 TEST(utils, resolve_binary_path)
 {
   std::string path = "/tmp/bpftrace-test-utils-XXXXXX";
-  if (::mkdtemp(&path[0]) == nullptr) {
+  if (::mkdtemp(path.data()) == nullptr) {
     throw std::runtime_error("creating temporary path for tests failed");
   }
 
@@ -201,7 +201,7 @@ TEST(utils, abs_path)
 {
   std::string path = "/tmp/bpftrace-test-utils-XXXXXX";
   std::string rel_file = "bpftrace-test-utils-abs-path";
-  if (::mkdtemp(&path[0]) == nullptr) {
+  if (::mkdtemp(path.data()) == nullptr) {
     throw std::runtime_error("creating temporary path for tests failed");
   }
 
@@ -246,7 +246,7 @@ TEST(utils, get_cgroup_path_in_hierarchy)
 {
   std::string tmpdir = "/tmp/bpftrace-test-utils-XXXXXX";
 
-  if (::mkdtemp(&tmpdir[0]) == nullptr) {
+  if (::mkdtemp(tmpdir.data()) == nullptr) {
     throw std::runtime_error("creating temporary path for tests failed");
   }
 
@@ -337,7 +337,7 @@ static void with_env(const std::string &key,
 TEST(utils, find_in_path)
 {
   std::string tmpdir = "/tmp/bpftrace-test-utils-XXXXXX";
-  ASSERT_TRUE(::mkdtemp(&tmpdir[0]));
+  ASSERT_TRUE(::mkdtemp(tmpdir.data()));
 
   // Create some directories
   const std::filesystem::path path(tmpdir);


### PR DESCRIPTION
Turns out most of them are pretty good.

Some of the bigger changes I pulled into separate commits. Final commit switches to deny-list, similar to modernize checks.

For the final commit, here's are the lints associated with most of the generated changes: https://gist.github.com/danobi/38197d1842a749a471754953c15f6351

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
