### PR TITLE
Nix: Update blazesym to v0.1.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "blazesym": {
       "flake": false,
       "locked": {
-        "lastModified": 1741902957,
-        "narHash": "sha256-xbTweelSYcTqQJJeRiimZn06SDSm5WAIJ79cCTl4VfA=",
+        "lastModified": 1742330784,
+        "narHash": "sha256-bnXRy6Me+5bzUB/1i53qLCbAkvrAA/Ihxm24el/906Y=",
         "owner": "libbpf",
         "repo": "blazesym",
-        "rev": "7e1d9455db20a21c01d6a91b18457385f351d441",
+        "rev": "48014fdc07a18a084a3a4b7ef78239c8cee1afec",
         "type": "github"
       },
       "original": {

--- a/src/usyms.cpp
+++ b/src/usyms.cpp
@@ -290,7 +290,6 @@ std::optional<std::string> Usyms::resolve_blazesym_impl(
     // TODO: Enable usage of debug symbols at some point.
     .debug_syms = false,
     .perf_map = true,
-    .map_files = true,
   };
 
   const blaze_syms *syms = blaze_symbolize_process_abs_addrs(


### PR DESCRIPTION
Update the `blazesym` dependency to `v0.1.1` to get the latest and greatest and to rely on a more stable release.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
