### PR TITLE
config: add `unstable_import` as option to enable imports

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(ast STATIC
   passes/resource_analyser.cpp
   passes/semantic_analyser.cpp
   passes/codegen_llvm.cpp
+  passes/resolve_imports.cpp
   passes/return_path_analyser.cpp
   passes/pid_filter_pass.cpp
   passes/recursion_check.cpp

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -342,9 +342,15 @@ Subprog::Subprog(Diagnostics &d,
 {
 }
 
+Import::Import(Diagnostics &d, std::string name, Location &&loc)
+    : Node(d, std::move(loc)), name_(std::move(name))
+{
+}
+
 Program::Program(Diagnostics &d,
                  std::string c_definitions,
                  Config *config,
+                 ImportList &&imports,
                  MapDeclList &&map_decls,
                  SubprogList &&functions,
                  ProbeList &&probes,
@@ -352,6 +358,7 @@ Program::Program(Diagnostics &d,
     : Node(d, std::move(loc)),
       c_definitions(std::move(c_definitions)),
       config(config),
+      imports(std::move(imports)),
       functions(std::move(functions)),
       probes(std::move(probes)),
       map_decls(std::move(map_decls))

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -608,11 +608,26 @@ private:
 };
 using SubprogList = std::vector<Subprog *>;
 
+class Import : public Node {
+public:
+  Import(Diagnostics &d, std::string name, Location &&loc);
+
+  const std::string &name() const
+  {
+    return name_;
+  }
+
+private:
+  std::string name_;
+};
+using ImportList = std::vector<Import *>;
+
 class Program : public Node {
 public:
   Program(Diagnostics &d,
           std::string c_definitions,
           Config *config,
+          ImportList &&imports,
           MapDeclList &&map_decls,
           SubprogList &&functions,
           ProbeList &&probes,
@@ -620,6 +635,7 @@ public:
 
   std::string c_definitions;
   Config *config = nullptr;
+  ImportList imports;
   SubprogList functions;
   ProbeList probes;
   MapDeclList map_decls;

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -456,6 +456,12 @@ void Printer::visit(Subprog &subprog)
   --depth_;
 }
 
+void Printer::visit(Import &imp)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "import " << imp.name() << std::endl;
+}
+
 void Printer::visit(Program &program)
 {
   if (!program.c_definitions.empty())
@@ -466,6 +472,10 @@ void Printer::visit(Program &program)
 
   ++depth_;
   visit(program.config);
+  --depth_;
+
+  ++depth_;
+  visit(program.imports);
   --depth_;
 
   ++depth_;

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -48,6 +48,7 @@ public:
   void visit(AttachPoint &ap);
   void visit(Probe &probe);
   void visit(Subprog &subprog);
+  void visit(Import &imp);
   void visit(Program &program);
 
 private:

--- a/src/ast/passes/resolve_imports.cpp
+++ b/src/ast/passes/resolve_imports.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <sstream>
+#include <unordered_set>
+
+#include "ast/passes/resolve_imports.h"
+#include "ast/visitor.h"
+#include "bpftrace.h"
+#include "log.h"
+
+namespace bpftrace::ast {
+
+class ResolveImports : public Visitor<ResolveImports> {
+public:
+  ResolveImports(BPFtrace &bpftrace, const std::vector<std::string> &paths)
+      : bpftrace_(bpftrace), paths_(paths) {};
+
+  using Visitor<ResolveImports>::visit;
+  void visit(Import &imp);
+
+  // Should be called after the visit, this will move the result.
+  Imports imports()
+  {
+    return std::move(imports_);
+  }
+
+private:
+  BPFtrace &bpftrace_;
+  const std::vector<std::string> &paths_;
+  Imports imports_;
+};
+
+void ResolveImports::visit(Import &imp)
+{
+  if (!bpftrace_.config_->get(ConfigKeyBool::unstable_import)) {
+    imp.addError() << "Imports are not enabled by default. To enable "
+                      "this unstable feature, set this config flag to 1 "
+                      "e.g. unstable_import=1";
+    return;
+  }
+
+  imp.addWarning() << "Imports are not yet implemented.";
+}
+
+Pass CreateResolveImportsPass(std::vector<std::string> &&import_paths)
+{
+  return Pass::create("ResolveImports",
+                      [import_paths](ASTContext &ast, BPFtrace &b) {
+                        ResolveImports analyser(b, import_paths);
+                        analyser.visit(ast.root);
+                      });
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/resolve_imports.h
+++ b/src/ast/passes/resolve_imports.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+// Imports holds the set of imported modules. This includes the parsed ASTs for
+// any source files, the loaded module for serialized modules, any dlhandles
+// for loaded dynamic plugins, and the BPF objects for any binary blobs.
+//
+// It is currently empty.
+class Imports : public ast::State<"imports"> {};
+
+Pass CreateResolveImportsPass(std::vector<std::string> &&import_paths);
+
+} // namespace bpftrace::ast

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -213,11 +213,16 @@ public:
     visitImpl(subprog.stmts);
     return default_value();
   }
+  R visit([[maybe_unused]] Import &imp)
+  {
+    return default_value();
+  }
   R visit(Program &program)
   {
-    // This order is important
-    visitImpl(program.functions);
+    // This order is important.
     visitAndReplace(&program.config);
+    visitImpl(program.imports);
+    visitImpl(program.functions);
     visitImpl(program.map_decls);
     visitImpl(program.probes);
     return default_value();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -14,6 +14,7 @@ Config::Config(bool has_cmd)
     { ConfigKeyBool::cpp_demangle, { .value = true } },
     { ConfigKeyBool::lazy_symbolication, { .value = false } },
     { ConfigKeyBool::print_maps_on_exit, { .value = true } },
+    { ConfigKeyBool::unstable_import, { .value = false } },
     { ConfigKeyBool::unstable_map_decl, { .value = false } },
 #ifndef HAVE_BLAZESYM
     { ConfigKeyBool::use_blazesym, { .value = false } },

--- a/src/config.h
+++ b/src/config.h
@@ -27,6 +27,7 @@ enum class ConfigKeyBool {
   print_maps_on_exit,
   use_blazesym,
   unstable_map_decl,
+  unstable_import,
 };
 
 enum class ConfigKeyInt {
@@ -96,6 +97,7 @@ const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
   { "missing_probes", ConfigKeyMissingProbes::default_ },
   { "print_maps_on_exit", ConfigKeyBool::print_maps_on_exit },
   { "use_blazesym", ConfigKeyBool::use_blazesym },
+  { "unstable_import", ConfigKeyBool::unstable_import },
   { "unstable_map_decl", ConfigKeyBool::unstable_map_decl },
 };
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -167,6 +167,7 @@ bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, driver.loc); }
 "sizeof"                { return Parser::make_SIZEOF(yytext, driver.loc); }
 "offsetof"              { return Parser::make_OFFSETOF(yytext, driver.loc); }
 "let"                   { return Parser::make_LET(yytext, driver.loc); }
+"import"                { return Parser::make_IMPORT(yytext, driver.loc); }
 
 {int_type}              { return Parser::make_INT_TYPE(yytext, driver.loc); }
 {builtin_type}          { return Parser::make_BUILTIN_TYPE(yytext, driver.loc); }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -26,6 +26,7 @@
 #include "ast/passes/printer.h"
 #include "ast/passes/probe_analyser.h"
 #include "ast/passes/recursion_check.h"
+#include "ast/passes/resolve_imports.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/return_path_analyser.h"
 #include "ast/passes/semantic_analyser.h"
@@ -386,6 +387,7 @@ std::vector<std::string> extra_flags(
 void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
 {
   add(ast::CreateConfigPass());
+  add(ast::CreateResolveImportsPass({}));
   add(ast::CreatePidFilterPass());
   add(ast::CreateSemanticPass());
   add(ast::CreateResourcePass());
@@ -749,6 +751,7 @@ static ast::ASTContext buildListProgram(const std::string& search)
       ast::AttachPointList({ ap }), nullptr, nullptr, location());
   ast.root = ast.make_node<ast::Program>("",
                                          nullptr,
+                                         ast::ImportList(),
                                          ast::MapDeclList(),
                                          ast::SubprogList(),
                                          ast::ProbeList({ probe }),

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -81,12 +81,13 @@ void test(BPFtrace &bpftrace,
   driver.parse();
   ast::AttachPointParser ap_parser(ast, bpftrace, false);
   ap_parser.parse();
-  ASSERT_TRUE(ast.diagnostics().ok());
+  std::ostringstream out;
+  ast.diagnostics().emit(out);
+  ASSERT_TRUE(ast.diagnostics().ok()) << out.str();
 
   if (expected[0] == '\n')
     expected.remove_prefix(1); // Remove initial '\n'
 
-  std::ostringstream out;
   Printer printer(out);
   printer.visit(ast.root);
   EXPECT_EQ(expected, out.str());
@@ -3054,6 +3055,40 @@ BEGIN { M; }
 stdin:2:9-343: ERROR: syntax error, unexpected end of file
 BEGIN { M; }
         ~~~~
+)");
+}
+
+TEST(Parser, imports)
+{
+  test(R"(import "foo"; BEGIN { })", R"(
+Program
+ import foo
+ BEGIN
+)");
+
+  test(R"(import "foo"; import "bar"; BEGIN { })", R"(
+Program
+ import foo
+ import bar
+ BEGIN
+)");
+
+  test_parse_failure(R"(BEGIN { }; import "foo";)", R"(
+stdin:1:9-11: ERROR: syntax error, unexpected ;, expecting {
+BEGIN { }; import "foo";
+        ~~
+)");
+
+  test_parse_failure("import 0; BEGIN { }", R"(
+stdin:1:8-9: ERROR: syntax error, unexpected integer, expecting string
+import 0; BEGIN { }
+       ~
+)");
+
+  test_parse_failure("import foo; BEGIN { }", R"(
+stdin:1:8-11: ERROR: syntax error, unexpected identifier, expecting string
+import foo; BEGIN { }
+       ~~~
 )");
 }
 


### PR DESCRIPTION
This adds the statement to the parser, the basic configuration and a dummy pass that checks that configuration and emits a warning.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests

Note: I have decided to leave this undocumented in the man page until the feature actually does something. This is just adding the basic plumbing for the nodes.