### PR TITLE
Update rawtracepoints to use correct types and utilize BTF

### DIFF
--- a/.github/include/aot_allow.txt
+++ b/.github/include/aot_allow.txt
@@ -175,10 +175,6 @@ aot.probe.probe_builtin_scratch_buf
 aot.probe.profile
 aot.probe.profile_probe_builtin
 aot.probe.profile_short_name
-aot.probe.rawtracepoint
-aot.probe.rawtracepoint_missing
-aot.probe.rawtracepoint_short_name
-aot.probe.rawtracepoint_wildcard
 aot.probe.sanitise probe name
 aot.probe.software
 aot.probe.software_alias_probe_builtin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
   - [#3863](https://github.com/bpftrace/bpftrace/pull/3863)
 - Add license config to specify BPF license
   - [#3905](https://github.com/bpftrace/bpftrace/pull/3905)
+- Rawtracepoints can now use `args` builtin and list params
+  - [#3918](https://github.com/bpftrace/bpftrace/pull/3918)
 #### Changed
 - `-p` CLI flag now applies to all probes (except BEGIN/END)
   - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1482,29 +1482,22 @@ profile:hz:99 { @[tid] = count(); }
 .short name
 * `rt`
 
-The hook point triggered by `tracepoint` and `rawtracepoint` is the same.
-`tracepoint` and `rawtracepoint` are nearly identical in terms of functionality.
-The only difference is in the program context.
-`rawtracepoint` offers raw arguments to the tracepoint while `tracepoint` applies further processing to the raw arguments.
-The additional processing is defined inside the kernel.
+Raw tracepoints are attached to the same tracepoints as normal tracepoint programs.
+The reason why you might want to use raw tracepoints over normal tracepoints is due to the performance improvement - https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_RAW_TRACEPOINT/[Read More].
+
+`rawtracepoint` arguments can be accessed via the `argN` builtins AND via the `args` builtin.
 
 ----
-rawtracepoint:block_rq_insert {
-  printf("%llx %llx\n", arg0, arg1);
+rawtracepoint:kfree_skb {
+  printf("%llx %llx\n", arg0, args.skb);
 }
 ----
+`arg0` and `args.skb` will print the same address.
 
-Tracepoint arguments are available via the `argN` builtins.
-Each arg is a 64-bit integer.
-The available arguments can be found in the relative path of the kernel source code `include/trace/events/`. For example:
-
-----
-include/trace/events/block.h
-DEFINE_EVENT(block_rq, block_rq_insert,
-	TP_PROTO(struct request_queue *q, struct request *rq),
-	TP_ARGS(q, rq)
-);
-----
+`rawtracepoint` probes make use of BTF type information to derive the type of function arguments at compile time.
+This removes the need for manual type casting and makes the code more resilient against small signature changes in the kernel.
+The arguments accessible by a `rawtracepoint` are different from the arguments you can access from the `tracepoint` of the same name.
+The function arguments are available in the `args` struct which can be inspected by doing verbose listing (see <<Listing Probes>>).
 
 [#probes-software]
 === software

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2342,7 +2342,8 @@ ScopedExpr CodegenLLVM::visit(FieldAccess &acc)
 
   if (type.is_funcarg) {
     auto probe_type = probetype(current_attach_point_->provider);
-    if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit)
+    if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit ||
+        probe_type == ProbeType::rawtracepoint)
       return ScopedExpr(b_.CreateKFuncArg(ctx_, acc.type, acc.field),
                         std::move(scoped_arg));
     else if (probe_type == ProbeType::uprobe) {
@@ -4782,7 +4783,7 @@ llvm::Function *CodegenLLVM::DeclareKernelFunc(Kfunc kfunc, Node &call)
 
   std::string err;
   auto maybe_func_type = bpftrace_.btf_->resolve_args(
-      func_name, true, false, err);
+      func_name, true, false, false, err);
   if (!maybe_func_type.has_value()) {
     call.addError() << "Unknown kernel function: " << func_name;
     return nullptr;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -777,7 +777,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
              "probe type, e.g. \"probe1 {args}\" is valid while "
              "\"probe1,probe2 {args}\" is not.";
     } else if (type == ProbeType::fentry || type == ProbeType::fexit ||
-               type == ProbeType::uprobe) {
+               type == ProbeType::uprobe || type == ProbeType::rawtracepoint) {
       if (type == ProbeType::uprobe &&
           bpftrace_.config_->get(ConfigKeyBool::probe_inline))
         builtin.addError() << "The args builtin can only be used when "

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -4007,6 +4007,8 @@ bool SemanticAnalyser::check_available(const Call &call, const AttachPoint &ap)
       case ProbeType::iter:
         return false;
     }
+  } else if (func == "skboutput") {
+    return progtype(type) == libbpf::BPF_PROG_TYPE_TRACING;
   }
 
   if (type == ProbeType::invalid)

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -72,7 +72,7 @@ libbpf::bpf_prog_type progtype(ProbeType t)
     case ProbeType::fentry:     return libbpf::BPF_PROG_TYPE_TRACING; break;
     case ProbeType::fexit:      return libbpf::BPF_PROG_TYPE_TRACING; break;
     case ProbeType::iter:       return libbpf::BPF_PROG_TYPE_TRACING; break;
-    case ProbeType::rawtracepoint: return libbpf::BPF_PROG_TYPE_RAW_TRACEPOINT; break;
+    case ProbeType::rawtracepoint: return libbpf::BPF_PROG_TYPE_TRACING; break;
     // clang-format on
     case ProbeType::invalid:
       LOG(BUG) << "program type invalid";
@@ -147,7 +147,7 @@ int AttachedProbe::detach_iter()
 
 void AttachedProbe::attach_raw_tracepoint()
 {
-  tracing_fd_ = bpf_raw_tracepoint_open(probe_.attach_point.c_str(), progfd_);
+  tracing_fd_ = bpf_raw_tracepoint_open(nullptr, progfd_);
   if (tracing_fd_ < 0) {
     if (tracing_fd_ == -ENOENT)
       throw util::FatalUserException("Probe does not exist: " + probe_.name);

--- a/src/bpfprogram.cpp
+++ b/src/bpfprogram.cpp
@@ -70,18 +70,18 @@ void BpfProgram::set_attach_target(const Probe &probe,
   const std::string attach_target = !mod.empty() ? mod + ":" + fun : fun;
 
   std::string btf_fun;
-  __u32 kind = BTF_KIND_FUNC;
+  __u32 btf_kind = BTF_KIND_FUNC;
 
   if (probe.type == ProbeType::iter) {
     btf_fun = "bpf_iter_" + fun;
   } else if (probe.type == ProbeType::rawtracepoint) {
     btf_fun = "btf_trace_" + fun;
-    kind = BTF_KIND_TYPEDEF;
+    btf_kind = BTF_KIND_TYPEDEF;
   } else {
     btf_fun = fun;
   }
 
-  if (btf.get_btf_id(btf_fun, mod, kind) < 0) {
+  if (btf.get_btf_id(btf_fun, mod, btf_kind) < 0) {
     const std::string msg = "No BTF found for " + attach_target;
     if (probe.orig_name != probe.name &&
         config.get(ConfigKeyMissingProbes::default_) !=

--- a/src/bpfprogram.cpp
+++ b/src/bpfprogram.cpp
@@ -35,6 +35,8 @@ void BpfProgram::set_expected_attach_type(const Probe &probe,
     attach_type = libbpf::BPF_TRACE_FEXIT;
   else if (probe.type == ProbeType::iter)
     attach_type = libbpf::BPF_TRACE_ITER;
+  else if (probe.type == ProbeType::rawtracepoint)
+    attach_type = libbpf::BPF_TRACE_RAW_TP;
 
   // We want to avoid kprobe_multi when a module is specified
   // because the BPF_TRACE_KPROBE_MULTI link type does not
@@ -60,16 +62,26 @@ void BpfProgram::set_attach_target(const Probe &probe,
                                    const Config &config)
 {
   if (probe.type != ProbeType::fentry && probe.type != ProbeType::fexit &&
-      probe.type != ProbeType::iter)
+      probe.type != ProbeType::iter && probe.type != ProbeType::rawtracepoint)
     return;
 
   const std::string &mod = probe.path;
   const std::string &fun = probe.attach_point;
   const std::string attach_target = !mod.empty() ? mod + ":" + fun : fun;
 
-  const std::string &btf_fun = probe.type == ProbeType::iter ? "bpf_iter_" + fun
-                                                             : fun;
-  if (btf.get_btf_id(btf_fun, mod) < 0) {
+  std::string btf_fun;
+  __u32 kind = BTF_KIND_FUNC;
+
+  if (probe.type == ProbeType::iter) {
+    btf_fun = "bpf_iter_" + fun;
+  } else if (probe.type == ProbeType::rawtracepoint) {
+    btf_fun = "btf_trace_" + fun;
+    kind = BTF_KIND_TYPEDEF;
+  } else {
+    btf_fun = fun;
+  }
+
+  if (btf.get_btf_id(btf_fun, mod, kind) < 0) {
     const std::string msg = "No BTF found for " + attach_target;
     if (probe.orig_name != probe.name &&
         config.get(ConfigKeyMissingProbes::default_) !=

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -753,13 +753,15 @@ std::unordered_set<std::string> BTF::get_all_iters() const
   return iters;
 }
 
-int BTF::get_btf_id(std::string_view func, std::string_view mod) const
+int BTF::get_btf_id(std::string_view func,
+                    std::string_view mod,
+                    __u32 kind) const
 {
   for (const auto &btf_obj : btf_objects) {
     if (!mod.empty() && mod != btf_obj.name)
       continue;
 
-    auto id = find_id_in_btf(btf_obj.btf, func, BTF_KIND_FUNC);
+    auto id = find_id_in_btf(btf_obj.btf, func, kind);
     if (id >= 0)
       return id;
   }

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -419,6 +419,7 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
 std::optional<Struct> BTF::resolve_args(const std::string &func,
                                         bool ret,
                                         bool check_traceable,
+                                        bool skip_first_arg,
                                         std::string &err)
 {
   if (!has_data()) {
@@ -465,6 +466,10 @@ std::optional<Struct> BTF::resolve_args(const std::string &func,
   int arg_idx = 0;
   __u32 type_size = 0;
   for (; j < vlen; j++, p++) {
+    if (j == 0 && skip_first_arg) {
+      continue;
+    }
+
     const char *str = btf_str(func_id.btf, p->name_off);
     if (!str) {
       err = "failed to resolve arguments";

--- a/src/btf.h
+++ b/src/btf.h
@@ -30,6 +30,20 @@ struct btf_type;
 
 namespace bpftrace {
 
+// Note: there are several prefixes for raw tracepoint BTF functions.
+// "__probestub_" seems to be the most accurate in terms of getting the params
+// but it wasn't added until May 2023 so older kernels might not have it,
+// which is why we also check "__traceiter_" (as needed).
+// "btf_trace_" prefix, which we use to validate if we can attach to this
+// tracepoint is a typedef that eventually resolves to a FUNC_PROTO
+// but the params for this do not have names, which is what we need.
+// "__probestub_" was added here:
+// https://lore.kernel.org/all/168507471874.913472.17214624519622959593.stgit@mhiramat.roam.corp.google.com/
+// "__traceiter_" was added here:
+// https://lore.kernel.org/all/20200908105743.GW2674@hirez.programming.kicks-ass.net/
+static const std::vector<std::string> RT_BTF_PREFIXES = { "__probestub_",
+                                                          "__traceiter_" };
+
 class BPFtrace;
 
 class BTF {
@@ -81,6 +95,7 @@ public:
   std::optional<Struct> resolve_args(const std::string& func,
                                      bool ret,
                                      bool check_traceable,
+                                     bool skip_first_arg,
                                      std::string& err);
   void resolve_fields(SizedType& type);
 

--- a/src/btf.h
+++ b/src/btf.h
@@ -3,6 +3,7 @@
 #include "types.h"
 
 #include <cstddef>
+#include <linux/btf.h>
 #include <linux/types.h>
 #include <map>
 #include <optional>
@@ -83,7 +84,9 @@ public:
                                      std::string& err);
   void resolve_fields(SizedType& type);
 
-  int get_btf_id(std::string_view func, std::string_view mod) const;
+  int get_btf_id(std::string_view func,
+                 std::string_view mod,
+                 __u32 kind = BTF_KIND_FUNC) const;
 
 private:
   void load_kernel_btfs(const std::set<std::string>& modules);

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -111,5 +111,6 @@ private:
       const std::set<std::string> &tracepoints);
 
   FuncParamLists get_iters_params(const std::set<std::string> &iters);
+  FuncParamLists get_rawtracepoint_params(const std::set<std::string> &raw_tps);
 };
 } // namespace bpftrace

--- a/tests/codegen/args_rawtracepoint.cpp
+++ b/tests/codegen/args_rawtracepoint.cpp
@@ -1,0 +1,16 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, args_rawtracepoint)
+{
+  test("rawtracepoint:sched_switch { @[args.preempt] = 1; }",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/args_rawtracepoint.ll
+++ b/tests/codegen/llvm/args_rawtracepoint.ll
@@ -1,0 +1,113 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
+@AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @rawtracepoint_sched_switch_1(ptr %0) section "s_rawtracepoint_sched_switch_1" !dbg !56 {
+entry:
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i64, ptr %1, i64 0
+  %preempt = load volatile i8, ptr %2, align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
+  %3 = zext i8 %preempt to i64
+  store i64 %3, ptr %"@_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
+  store i64 1, ptr %"@_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!55}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 32, elements: !5)
+!4 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!5 = !{!6}
+!6 = !DISubrange(count: 4, lowerBound: 0)
+!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
+!8 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
+!10 = !{!11, !17, !22, !25}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !{!16}
+!16 = !DISubrange(count: 1, lowerBound: 0)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !18, size: 64, offset: 64)
+!18 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 131072, elements: !20)
+!20 = !{!21}
+!21 = !DISubrange(count: 4096, lowerBound: 0)
+!22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !50, !25}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !51, size: 64, offset: 128)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!52 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
+!54 = !{!0, !7, !26, !40}
+!55 = !{i32 2, !"Debug Info Version", i32 3}
+!56 = distinct !DISubprogram(name: "rawtracepoint_sched_switch_1", linkageName: "rawtracepoint_sched_switch_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
+!57 = !DISubroutineType(types: !58)
+!58 = !{!24, !59}
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!60 = !{!61}
+!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -132,6 +132,11 @@ _Bool bpf_session_is_return()
   return 1;
 }
 
+long __probestub_event_rt(void *__data, long first_real_arg)
+{
+  return first_real_arg;
+}
+
 // kernel percpu variables
 __attribute__((section(".data..percpu"))) unsigned long process_counts;
 
@@ -150,5 +155,6 @@ int main(void)
   bpf_iter_task_file();
   bpf_iter_task_vma();
   bpf_map_sum_elem_count(&bpf_map);
+  __probestub_event_rt((void *)&bpf_map, 1);
   return 0;
 }

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -57,6 +57,12 @@ RUN {{BPFTRACE}} -l | grep rawtracepoint
 EXPECT_REGEX rawtracepoint:.*
 TIMEOUT 1
 
+NAME it lists rawtracepoint params
+RUN {{BPFTRACE}} -lv "rawtracepoint:*"
+EXPECT_REGEX [ ]+[a-zA-Z_\*\s]+
+REQUIRES_FEATURE btf
+TIMEOUT 1
+
 NAME it lists fentry params
 RUN {{BPFTRACE}} -lv "fentry:*"
 EXPECT_REGEX [ ]+[a-zA-Z_\*\s]+

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -601,6 +601,13 @@ REQUIRES_FEATURE fentry
 REQUIRES_FEATURE skboutput
 MIN_KERNEL 5.5
 
+# Just test that the verifier doesn't reject this
+NAME skboutput rawtracepoint
+RUN {{BPFTRACE}} -e 'rawtracepoint:consume_skb { $ret = skboutput("receive.pcap", (struct sk_buff *)arg0, 1, 0); printf("ret: %d\n", $ret); exit(); }'
+EXPECT Attaching 1 probe...
+REQUIRES_FEATURE skboutput
+MIN_KERNEL 5.5
+
 NAME debugf
 RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { debugf("debugf"); exit();}'; cat /sys/kernel/debug/tracing/trace
 EXPECT_REGEX bpf_trace_printk: debugf

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -433,6 +433,11 @@ PROG rawtracepoint:sys_* { printf("SUCCESS %d\n", gid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep
 
+# Test that we get at least two characters out
+NAME rawtracepoint args
+PROG rawtracepoint:irq_handler_entry { print(str(((struct irqaction*)args.action)->name)); exit(); }
+EXPECT_REGEX ..+
+
 NAME profile
 PROG profile:hz:599 { print("hit"); exit(); }
 EXPECT hit

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -425,7 +425,7 @@ AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME rawtracepoint_missing
 PROG rawtracepoint:nonsense { print("hit"); exit(); }
-EXPECT ERROR: Probe does not exist: rawtracepoint:nonsense
+EXPECT ERROR: No BTF found for nonsense
 WILL_FAIL
 
 NAME rawtracepoint_wildcard

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4035,6 +4035,12 @@ stdin:1:17-58: ERROR: skboutput() should be assigned to a variable
 fentry:func_1 { skboutput("one.pcap", args.foo1, 1500, 0); }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )");
+  test_error("kprobe:func_1 { $ret = skboutput(\"one.pcap\", arg1, 1500, 0); }",
+             R"(
+stdin:1:24-60: ERROR: skboutput can not be used with "kprobe" probes
+kprobe:func_1 { $ret = skboutput("one.pcap", arg1, 1500, 0); }
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+)");
 }
 
 TEST_F(semantic_analyser_btf, call_percpu_kaddr)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2230,7 +2230,7 @@ TEST(semantic_analyser, tracepoint)
 TEST(semantic_analyser, rawtracepoint)
 {
   test("rawtracepoint:event { 1 }");
-  test("rawtracepoint:event { args }", 1);
+  test("rawtracepoint:event { arg0 }");
 }
 
 #if defined(__x86_64__) || defined(__aarch64__)
@@ -4082,6 +4082,17 @@ iter:task,iter:task_file { 1 }
 stdin:1:1-10: ERROR: Only single iter attach point is allowed.
 iter:task,f:func_1 { 1 }
 ~~~~~~~~~
+)");
+}
+
+TEST_F(semantic_analyser_btf, rawtracepoint)
+{
+  test("rawtracepoint:event_rt { args.first_real_arg }");
+
+  test_error("rawtracepoint:event_rt { args.bad_arg }", R"(
+stdin:1:26-31: ERROR: Can't find function parameter bad_arg
+rawtracepoint:event_rt { args.bad_arg }
+                         ~~~~~
 )");
 }
 


### PR DESCRIPTION
This updates rawtracepoints to use the correct prog and attach types, which will give rawtracepoints access to functions
like 'skboutput' and others.

This also utilizes BTF to read rawtracepoint arguments to make the `args` builtin available to rawtracepoints and allows users to see their params when listing in verbose mode.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
