### PR TITLE
ast: Split `TupleAccess` into its own node

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -156,19 +156,19 @@ FieldAccess::FieldAccess(Diagnostics &d,
 {
 }
 
-FieldAccess::FieldAccess(Diagnostics &d,
-                         Expression *expr,
-                         ssize_t index,
-                         Location &&loc)
-    : Expression(d, std::move(loc)), expr(expr), index(index)
-{
-}
-
 ArrayAccess::ArrayAccess(Diagnostics &d,
                          Expression *expr,
                          Expression *indexpr,
                          Location &&loc)
     : Expression(d, std::move(loc)), expr(expr), indexpr(indexpr)
+{
+}
+
+TupleAccess::TupleAccess(Diagnostics &d,
+                         Expression *expr,
+                         ssize_t index,
+                         Location &&loc)
+    : Expression(d, std::move(loc)), expr(expr), index(index)
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -276,16 +276,13 @@ public:
 
 class FieldAccess : public Expression {
 public:
-  FieldAccess(Diagnostics &d, Expression *expr, const std::string &field);
   FieldAccess(Diagnostics &d,
               Expression *expr,
               std::string field,
               Location &&loc);
-  FieldAccess(Diagnostics &d, Expression *expr, ssize_t index, Location &&loc);
 
   Expression *expr = nullptr;
   std::string field;
-  ssize_t index = -1;
 };
 
 class ArrayAccess : public Expression {
@@ -298,6 +295,14 @@ public:
 
   Expression *expr = nullptr;
   Expression *indexpr = nullptr;
+};
+
+class TupleAccess : public Expression {
+public:
+  TupleAccess(Diagnostics &d, Expression *expr, ssize_t index, Location &&loc);
+
+  Expression *expr = nullptr;
+  ssize_t index;
 };
 
 class Cast : public Expression {

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -206,10 +206,7 @@ void Printer::visit(FieldAccess &acc)
   visit(acc.expr);
   --depth_;
 
-  if (!acc.field.empty())
-    out_ << indent << " " << acc.field << std::endl;
-  else
-    out_ << indent << " " << acc.index << std::endl;
+  out_ << indent << " " << acc.field << std::endl;
 }
 
 void Printer::visit(ArrayAccess &arr)
@@ -221,6 +218,18 @@ void Printer::visit(ArrayAccess &arr)
   visit(arr.expr);
   visit(arr.indexpr);
   --depth_;
+}
+
+void Printer::visit(TupleAccess &acc)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "." << type(acc.type) << std::endl;
+
+  ++depth_;
+  visit(acc.expr);
+  --depth_;
+
+  out_ << indent << " " << acc.index << std::endl;
 }
 
 void Printer::visit(Cast &cast)

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -30,6 +30,7 @@ public:
   void visit(Ternary &ternary);
   void visit(FieldAccess &acc);
   void visit(ArrayAccess &arr);
+  void visit(TupleAccess &acc);
   void visit(Cast &cast);
   void visit(Tuple &tuple);
   void visit(ExprStatement &expr);

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -119,6 +119,10 @@ public:
     visitAndReplace(&arr.indexpr);
     return default_value();
   }
+  R visit(TupleAccess &acc)
+  {
+    return visitAndReplace(&acc.expr);
+  }
   R visit(Cast &cast)
   {
     return visitAndReplace(&cast.expr);
@@ -333,6 +337,7 @@ public:
                               Unop *,
                               FieldAccess *,
                               ArrayAccess *,
+                              TupleAccess *,
                               Cast *,
                               Tuple *,
                               Ternary *,

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -521,7 +521,7 @@ postfix_expr:
 
 /* Tuple factored out so we can use it in the tuple field assignment error */
 tuple_access_expr:
-                postfix_expr DOT INT      { $$ = driver.ctx.make_node<ast::FieldAccess>($1, $3, @3); }
+                postfix_expr DOT INT      { $$ = driver.ctx.make_node<ast::TupleAccess>($1, $3, @3); }
                 ;
 
 block_expr:


### PR DESCRIPTION
Since this is unamibiguously parseable (`$x.0` vs `$x.arg`), there is no need for the `FieldAccess` node to be doing double duty. This reduces the complexity of the resulting code.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
