### PR TITLE
ast: Introduce transforms for map functions

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(ast STATIC
   passes/config_analyser.cpp
   passes/deprecated.cpp
   passes/field_analyser.cpp
+  passes/map_assign_funcs.cpp
   passes/portability_analyser.cpp
   passes/printer.cpp
   passes/probe_analyser.cpp

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -195,22 +195,7 @@ AssignMapStatement::AssignMapStatement(Diagnostics &d,
                                        Map *map,
                                        Expression *expr,
                                        Location &&loc)
-    : Statement(d, std::move(loc)), map(map), expr(expr)
-{
-  // If this is a block expression, then we skip through that and actually set
-  // the map on the underlying expression. This is done recursively. It is only
-  // done to support functions that need to know the type of the map to which
-  // they are being assigned.
-  Expression *value = expr;
-  while (true) {
-    auto *block = dynamic_cast<Block *>(value);
-    if (block == nullptr) {
-      break;
-    }
-    value = block->expr; // Must be non-null if expression.
-  };
-  value->map = map;
-};
+    : Statement(d, std::move(loc)), map(map), expr(expr) {};
 
 AssignVarStatement::AssignVarStatement(Diagnostics &d,
                                        Variable *var,

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -110,7 +110,6 @@ public:
 
   SizedType type;
   Map *key_for_map = nullptr;
-  Map *map = nullptr;      // Only set when this expression is assigned to a map
   Variable *var = nullptr; // Set when this expression is assigned to a variable
   bool is_literal = false;
   bool is_variable = false;

--- a/src/ast/passes/map_assign_funcs.cpp
+++ b/src/ast/passes/map_assign_funcs.cpp
@@ -1,0 +1,92 @@
+#include <unordered_set>
+
+#include "ast/passes/map_assign_funcs.h"
+#include "ast/visitor.h"
+
+namespace bpftrace::ast {
+
+namespace {
+
+class MapAssignTransform : public Visitor<MapAssignTransform, Expression *> {
+public:
+  MapAssignTransform(ASTContext &ast) : ast_(ast) {};
+
+  using Visitor<MapAssignTransform, Expression *>::visit;
+  Expression *visit(Call &call);
+  Expression *visit(AssignMapStatement &map);
+  Expression *pushMap(Map *map, Expression *expr);
+
+  using Visitor<MapAssignTransform, Expression *>::replace;
+  Statement *replace(Statement *orig, Expression **result);
+
+private:
+  ASTContext &ast_;
+};
+
+} // namespace
+
+static std::unordered_set<std::string> rewrite = {
+  "count", "sum", "max", "min", "avg", "stats", "hist", "lhist",
+};
+
+Expression *MapAssignTransform::visit(Call &call)
+{
+  visit(call.vargs);
+
+  // This should be rewritten before getting walked.
+  if (rewrite.contains(call.func)) {
+    call.addError() << call.func << "() should be directly assigned to a map";
+    return nullptr;
+  }
+
+  return nullptr;
+}
+
+Expression *MapAssignTransform::pushMap(Map *map, Expression *expr)
+{
+  if (auto *call = dynamic_cast<Call *>(expr)) {
+    if (rewrite.contains(call->func)) {
+      ExpressionList new_args = { map };
+      ExpressionList old_args = std::move(call->vargs);
+      new_args.insert(new_args.end(), old_args.begin(), old_args.end());
+      call->vargs = std::move(new_args);
+      visit(call->vargs);
+      return call;
+    }
+  }
+  if (auto *block = dynamic_cast<Block *>(expr)) {
+    if (pushMap(map, block->expr) != nullptr) {
+      return block; // Replace with this block.
+    }
+  }
+  return nullptr;
+}
+
+Expression *MapAssignTransform::visit(AssignMapStatement &map)
+{
+  visit(map.map);
+  return pushMap(map.map, map.expr);
+}
+
+Statement *MapAssignTransform::replace(Statement *orig, Expression **result)
+{
+  if (*result != nullptr) {
+    // Replace the original statement with the expression, so
+    // that we don't confuse ourselves with any map assignment.
+    auto orig_loc = (*result)->loc;
+    return ast_.make_node<ExprStatement>(*result, std::move(orig_loc));
+  }
+  return orig;
+}
+
+Pass CreateMapAssignTransformPass()
+{
+  auto fn = [](ASTContext &ast) {
+    MapAssignTransform analyser(ast);
+    analyser.visit(ast.root);
+  };
+
+  return Pass::create("MapAssignTransform", fn);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/map_assign_funcs.h
+++ b/src/ast/passes/map_assign_funcs.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateMapAssignTransformPass();
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -4,6 +4,7 @@
 #include "ast/pass_manager.h"
 #include "ast/passes/deprecated.h"
 #include "ast/passes/field_analyser.h"
+#include "ast/passes/map_assign_funcs.h"
 #include "btf.h"
 #include "clang_parser.h"
 #include "driver.h"
@@ -29,6 +30,7 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateParsePass());
   passes.emplace_back(CreateParseAttachpointsPass());
   passes.emplace_back(CreateParseBTFPass());
+  passes.emplace_back(CreateMapAssignTransformPass());
   return passes;
 }
 

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -7,6 +7,7 @@
 #include "ast/attachpoint_parser.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/field_analyser.h"
+#include "ast/passes/map_assign_funcs.h"
 #include "ast/passes/parser.h"
 #include "ast/passes/pid_filter_pass.h"
 #include "ast/passes/probe_analyser.h"
@@ -63,6 +64,7 @@ static void test(BPFtrace &bpftrace,
                 .add(CreateClangPass())
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateMapAssignTransformPass())
                 .add(ast::CreateSemanticPass())
                 .add(ast::CreatePidFilterPass())
                 .add(ast::CreateRecursionCheckPass())

--- a/tests/codegen/llvm/call_map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/call_map_key_scratch_buf.ll
@@ -13,10 +13,10 @@ target triple = "bpf-pc-linux"
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
 @ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !28
 @event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !42
-@map_key_buf = dso_local externally_initialized global [1 x [7 x [8 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !59
+@map_key_buf = dso_local externally_initialized global [1 x [9 x [8 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !59
 @write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !68
 @max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !72
-@read_map_val_buf = dso_local externally_initialized global [1 x [2 x [8 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !74
+@read_map_val_buf = dso_local externally_initialized global [1 x [4 x [8 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !74
 @num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !78
 
 ; Function Attrs: nounwind
@@ -31,7 +31,7 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
   %1 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [7 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %2 = getelementptr [1 x [9 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   store i64 1, ptr %2, align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
@@ -57,7 +57,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
   %5 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
-  %6 = getelementptr [1 x [7 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
+  %6 = getelementptr [1 x [9 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
   store i64 %log2, ptr %6, align 8
   %lookup_elem3 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_y, ptr %6)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val7)
@@ -82,14 +82,14 @@ lookup_merge6:                                    ; preds = %lookup_failure5, %l
   %get_cpu_id11 = call i64 inttoptr (i64 8 to ptr)()
   %9 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded12 = and i64 %get_cpu_id11, %9
-  %10 = getelementptr [1 x [7 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded12, i64 2, i64 0
+  %10 = getelementptr [1 x [9 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded12, i64 2, i64 0
   store i64 1, ptr %10, align 8
   %lookup_elem13 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %10)
   %has_key = icmp ne ptr %lookup_elem13, null
   %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)()
   %11 = load i64, ptr @max_cpu_id, align 8
   %cpu.id.bounded15 = and i64 %get_cpu_id14, %11
-  %12 = getelementptr [1 x [7 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
+  %12 = getelementptr [1 x [9 x [8 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
   store i64 1, ptr %12, align 8
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %12)
   ret i64 0
@@ -238,13 +238,13 @@ attributes #2 = { alwaysinline }
 !58 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
 !60 = distinct !DIGlobalVariable(name: "map_key_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
-!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 448, elements: !54)
-!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 448, elements: !66)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 576, elements: !54)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 576, elements: !66)
 !63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 64, elements: !64)
 !64 = !{!65}
 !65 = !DISubrange(count: 8, lowerBound: 0)
 !66 = !{!67}
-!67 = !DISubrange(count: 7, lowerBound: 0)
+!67 = !DISubrange(count: 9, lowerBound: 0)
 !68 = !DIGlobalVariableExpression(var: !69, expr: !DIExpression())
 !69 = distinct !DIGlobalVariable(name: "write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !70, isLocal: false, isDefinition: true)
 !70 = !DICompositeType(tag: DW_TAG_array_type, baseType: !71, size: 64, elements: !54)
@@ -253,8 +253,8 @@ attributes #2 = { alwaysinline }
 !73 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
 !74 = !DIGlobalVariableExpression(var: !75, expr: !DIExpression())
 !75 = distinct !DIGlobalVariable(name: "read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !76, isLocal: false, isDefinition: true)
-!76 = !DICompositeType(tag: DW_TAG_array_type, baseType: !77, size: 128, elements: !54)
-!77 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 128, elements: !49)
+!76 = !DICompositeType(tag: DW_TAG_array_type, baseType: !77, size: 256, elements: !54)
+!77 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 256, elements: !5)
 !78 = !DIGlobalVariableExpression(var: !79, expr: !DIExpression())
 !79 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
 !80 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !81)

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -25,6 +25,7 @@ void test(BPFtrace &bpftrace,
                 .add(ast::CreateSemanticPass())
                 .add(ast::CreateResourcePass())
                 .run();
+  ast.diagnostics().emit(msg);
   ASSERT_TRUE(bool(ok)) << msg.str();
   EXPECT_EQ(ast.diagnostics().ok(), expected_result) << msg.str();
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1,6 +1,7 @@
 #include "ast/passes/semantic_analyser.h"
 #include "ast/attachpoint_parser.h"
 #include "ast/passes/field_analyser.h"
+#include "ast/passes/map_assign_funcs.h"
 #include "ast/passes/printer.h"
 #include "bpftrace.h"
 #include "clang_parser.h"
@@ -37,6 +38,7 @@ ast::ASTContext test_for_warning(BPFtrace &bpftrace,
                 .add(CreateClangPass())
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateMapAssignTransformPass())
                 .add(ast::CreateSemanticPass())
                 .run();
   EXPECT_TRUE(bool(ok));
@@ -92,6 +94,7 @@ ast::ASTContext test(BPFtrace &bpftrace,
                 .add(CreateClangPass())
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateMapAssignTransformPass())
                 .add(ast::CreateSemanticPass())
                 .run();
 


### PR DESCRIPTION
Rather than relying on look-aside information in the AST, use transformations for these map functions to pass the map as an argument.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
