### PR TITLE
Fix unused parameter warning

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -352,8 +352,7 @@ static constexpr std::string_view hint_unsafe =
     "\nUse --unsafe to force attachment. WARNING: This option could lead to "
     "data corruption in the target process.";
 
-static void check_alignment(std::string &orig_name,
-                            std::string &path,
+static void check_alignment(std::string &path,
                             std::string &symbol,
                             uint64_t sym_offset,
                             uint64_t func_offset,
@@ -491,13 +490,8 @@ bool AttachedProbe::resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps)
   if (func_offset == 0)
     return true;
 
-  check_alignment(probe_.orig_name,
-                  probe_.path,
-                  symbol,
-                  sym_offset,
-                  func_offset,
-                  safe_mode,
-                  probe_.type);
+  check_alignment(
+      probe_.path, symbol, sym_offset, func_offset, safe_mode, probe_.type);
   return true;
 }
 


### PR DESCRIPTION
Fixes this warning:

```
/home/dxu/dev/bpftrace/src/attached_probe.cpp: In function ‘void
bpftrace::check_alignment(std::string&, std::string&, std::string&,
uint64_t, uint64_t, bool, ProbeType)’:
/home/dxu/dev/bpftrace/src/attached_probe.cpp:355:42: warning: unused
parameter ‘orig_name’ [-Wunused-parameter]
  355 | static void check_alignment(std::string &orig_name,
      |                             ~~~~~~~~~~~~~^~~~~~~~~
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
