### PR TITLE
Add warning for use of unstable features

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -234,12 +234,10 @@ AssignVarStatement::AssignVarStatement(Diagnostics &d,
 }
 
 AssignConfigVarStatement::AssignConfigVarStatement(Diagnostics &d,
-                                                   std::string config_var,
+                                                   Identifier *config_var,
                                                    Expression *expr,
                                                    Location &&loc)
-    : Statement(d, std::move(loc)),
-      config_var(std::move(config_var)),
-      expr(expr)
+    : Statement(d, std::move(loc)), config_var(config_var), expr(expr)
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -377,11 +377,11 @@ public:
 class AssignConfigVarStatement : public Statement {
 public:
   AssignConfigVarStatement(Diagnostics &d,
-                           std::string config_var,
+                           Identifier *config_var,
                            Expression *expr,
                            Location &&loc);
 
-  std::string config_var;
+  Identifier *config_var = nullptr;
   Expression *expr = nullptr;
 };
 

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -185,6 +185,10 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
   auto configKey = maybeConfigKey.value();
 
   std::visit([&](auto key) { set_config(assignment, key); }, configKey);
+
+  if (bpftrace_.config_->is_unstable(configKey)) {
+    assignment.addWarning() << "Script is using an unstable feature: " << raw_ident;
+  }
 }
 
 Pass CreateConfigPass()

--- a/src/ast/passes/deprecated.cpp
+++ b/src/ast/passes/deprecated.cpp
@@ -88,7 +88,7 @@ static std::vector<DeprecatedName> DEPRECATED_CONFIGS = {
 
 void DeprecatedAnalyser::visit(AssignConfigVarStatement &assign)
 {
-  check(DEPRECATED_CONFIGS, assign.config_var, assign);
+  check(DEPRECATED_CONFIGS, assign.config_var->ident, assign);
 }
 
 Pass CreateDeprecatedPass()

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -294,7 +294,8 @@ void Printer::visit(AssignConfigVarStatement &assignment)
 
   ++depth_;
   std::string indentVar(depth_, ' ');
-  out_ << indentVar << "config var: " << assignment.config_var << std::endl;
+  out_ << indentVar << "config var: " << assignment.config_var->ident
+       << std::endl;
   visit(assignment.expr);
   --depth_;
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -120,6 +120,15 @@ std::optional<ConfigKey> Config::get_config_key(const std::string &str,
   return std::make_optional<ConfigKey>(found->second);
 }
 
+bool Config::is_unstable(ConfigKey key)
+{
+  static const std::string_view unstable_prefix = "unstable_";
+  static const std::map<ConfigKey, std::string> reversed_map =
+      reverse_config_map();
+  const std::string &config_str = reversed_map.at(key);
+  return config_str.starts_with(unstable_prefix);
+}
+
 bool ConfigSetter::set_stack_mode(const std::string &s)
 {
   auto stack_mode = Config::get_stack_mode(s);

--- a/src/config.h
+++ b/src/config.h
@@ -157,6 +157,16 @@ public:
   std::optional<ConfigKey> get_config_key(const std::string &str,
                                           std::string &err);
 
+  bool is_unstable(ConfigKey key);
+  std::map<ConfigKey, std::string> reverse_config_map()
+  {
+    std::map<ConfigKey, std::string> reversed_map;
+    for (const auto &[key, value] : CONFIG_KEY_MAP) {
+      reversed_map[value] = key;
+    }
+    return reversed_map;
+  }
+
   friend class ConfigSetter;
 
 private:

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -163,6 +163,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::StatementList> block block_or_if stmt_list config_block config_assign_stmt_list
 %type <SizedType> type int_type pointer_type struct_type
 %type <ast::Variable *> var
+%type <ast::Identifier *> raw_ident
 
 
 %left COMMA
@@ -295,7 +296,7 @@ config_assign_stmt_list:
                 ;
 
 config_assign_stmt:
-                IDENT ASSIGN expr   { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @2); }
+                raw_ident ASSIGN primary_expr   { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
                 ;
 
 subprog:
@@ -483,7 +484,7 @@ var_decl_stmt:
         ;
 
 primary_expr:
-                IDENT              { $$ = driver.ctx.make_node<ast::Identifier>($1, @$); }
+                raw_ident          { $$ = $1; }
         |       int                { $$ = $1; }
         |       STRING             { $$ = driver.ctx.make_node<ast::String>($1, @$); }
         |       STACK_MODE         { $$ = driver.ctx.make_node<ast::StackMode>($1, @$); }
@@ -662,6 +663,10 @@ ident:
         |       CALL          { $$ = $1; }
         |       CALL_BUILTIN  { $$ = $1; }
         |       STACK_MODE    { $$ = $1; }
+                ;
+
+raw_ident:
+                IDENT         { $$ = driver.ctx.make_node<ast::Identifier>($1, @$); }
                 ;
 
 struct_field:

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -118,23 +118,23 @@ TEST(config_analyser, config)
 TEST(config_analyser, config_error)
 {
   test("config = { BAD_CONFIG=1 } BEGIN { }",
-       R"(stdin:1:12-23: ERROR: Unrecognized config variable: BAD_CONFIG
+       R"(stdin:1:12-22: ERROR: Unrecognized config variable: BAD_CONFIG
 config = { BAD_CONFIG=1 } BEGIN { }
-           ~~~~~~~~~~~
+           ~~~~~~~~~~
 )",
        false);
   test(
-      "config = { BPFTRACE_MAX_PROBES=\"hello\" } BEGIN { }",
-      R"(stdin:1:12-32: ERROR: Invalid type for BPFTRACE_MAX_PROBES. Type: string. Expected Type: int
-config = { BPFTRACE_MAX_PROBES="hello" } BEGIN { }
-           ~~~~~~~~~~~~~~~~~~~~
+      "config = { BPFTRACE_MAX_PROBES = \"hello\" } BEGIN { }",
+      R"(stdin:1:34-41: ERROR: Invalid type for BPFTRACE_MAX_PROBES. Type: string. Expected Type: int
+config = { BPFTRACE_MAX_PROBES = "hello" } BEGIN { }
+                                 ~~~~~~~
 )",
       false);
   test(
       "config = { max_ast_nodes=1 } BEGIN { }",
-      R"(stdin:1:12-26: ERROR: max_ast_nodes can only be set as an environment variable
+      R"(stdin:1:12-25: ERROR: max_ast_nodes can only be set as an environment variable
 config = { max_ast_nodes=1 } BEGIN { }
-           ~~~~~~~~~~~~~~
+           ~~~~~~~~~~~~~
 )",
       false);
 }

--- a/tests/runtime/config
+++ b/tests/runtime/config
@@ -16,12 +16,12 @@ AFTER ./testprogs/uprobe_test
 
 NAME bad config
 RUN {{BPFTRACE}} -e 'config = { bad_config=raw } BEGIN {}'
-EXPECT stdin:1:12-23: ERROR: Unrecognized config variable: bad_config
+EXPECT stdin:1:12-22: ERROR: Unrecognized config variable: bad_config
 WILL_FAIL
 
 NAME env only config
 RUN {{BPFTRACE}} -e 'config = { debug_output=1 } BEGIN {}'
-EXPECT stdin:1:12-25: ERROR: debug_output can only be set as an environment variable
+EXPECT stdin:1:12-24: ERROR: debug_output can only be set as an environment variable
 WILL_FAIL
 
 NAME maps are printed by default


### PR DESCRIPTION
This is to notify users of a script using unstable features. Inspired by conversation here:
https://github.com/bpftrace/bpftrace/pull/3917#discussion_r2010025715

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
