### PR TITLE
Adapt to the renaming of nr_running to nr_queued in `struct cfs_rq`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,26 +41,33 @@ jobs:
         - NAME: LLVM 16
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm16
+          TOOLS_TEST_OLDVERSION: runqlen.bt
         - NAME: LLVM 17
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm17
+          TOOLS_TEST_OLDVERSION: runqlen.bt
         - NAME: LLVM 18
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm18
+          TOOLS_TEST_OLDVERSION: runqlen.bt
         - NAME: LLVM 19
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm19
+          TOOLS_TEST_OLDVERSION: runqlen.bt
         - NAME: LLVM 20 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm20
+          TOOLS_TEST_OLDVERSION: runqlen.bt
         - NAME: LLVM 20 Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm20
+          TOOLS_TEST_OLDVERSION: runqlen.bt
         - NAME: LLVM 20 Clang Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm20
           CC: clang
           CXX: clang++
+          TOOLS_TEST_OLDVERSION: runqlen.bt
         - NAME: Fuzzing
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-fuzz
@@ -70,6 +77,7 @@ jobs:
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm20
           NIX_TARGET_KERNEL: .#kernel-6_12
+          TOOLS_TEST_OLDVERSION: runqlen.bt # Need 6.14 kernel
         - NAME: AOT (LLVM 20 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm20

--- a/tools/old/runqlen.bt
+++ b/tools/old/runqlen.bt
@@ -5,6 +5,8 @@
  *
  * This is a bpftrace version of the bcc tool of the same name.
  *
+ * For Linux < 6.14.
+ *
  * Copyright 2018 Netflix, Inc.
  * Licensed under the Apache License, Version 2.0 (the "License")
  *
@@ -19,8 +21,8 @@
 // your kernel version. It is from kernel/sched/sched.h:
 struct cfs_rq {
 	struct load_weight load;
-	unsigned int nr_queued;
-	unsigned int h_nr_queued;
+	unsigned int nr_running;
+	unsigned int h_nr_running;
 };
 #endif
 
@@ -33,7 +35,7 @@ profile:hz:99
 {
 	$task = (struct task_struct *)curtask;
 	$my_q = (struct cfs_rq *)$task->se.cfs_rq;
-	$len = (uint64)$my_q->nr_queued;
+	$len = (uint64)$my_q->nr_running;
 	$len = $len > 0 ? $len - 1 : 0;	// subtract currently running task
 	@runqlen = lhist($len, 0, 100, 1);
 }


### PR DESCRIPTION
With ["sched/fair: Fix statistics with delayed dequeue" series](https://lore.kernel.org/all/20241202174606.4074512-1-vincent.guittot@linaro.org/) (more specifically torvalds/linux@736c55a02c47) several fields in "struct cfs_rq" is renamed, leading to runqlen.bt to fail at runtime with the following error:

```
  ERROR: Struct/union of type 'struct cfs_rq' does not contain a field named 'nr_running'
      $len = $my_q->nr_running;
```

Move existing runqlen script to tools/old/, and create a copy of the original with with nr_running changed to nr_queued in its place.

While at it, also touch up the comment regarding BTF.

This address issue report by @Avinesh in #3898.