### PR TITLE
Backport v0.23.0 release info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,36 @@ and this project adheres to
 ## Unreleased
 
 #### Breaking Changes
-- Remove '-kk' command line opt, surface some BPF errors by default, and make '-k' surface probe read errors
-  - [#3784](https://github.com/bpftrace/bpftrace/pull/3784)
 - Drop DWARF support (userspace and kernel)
   - [#3921](https://github.com/bpftrace/bpftrace/pull/3921)
 - Removed config option 'symbol_source' - it no longer has any effect
   - [#3925](https://github.com/bpftrace/bpftrace/pull/3925)
+#### Added
+- Use blazesym for user space address symbolization
+  - [#3884](https://github.com/bpftrace/bpftrace/pull/3884)
+- Add simple block expressions
+  - [#3780](https://github.com/bpftrace/bpftrace/pull/3780)
+- Add map declaration syntax (behind an "unstable" config flag)
+  - [#3863](https://github.com/bpftrace/bpftrace/pull/3863)
+- Add license config to specify BPF license
+  - [#3905](https://github.com/bpftrace/bpftrace/pull/3905)
+#### Changed
+- `-p` CLI flag now applies to all probes (except BEGIN/END)
+  - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)
+- Introduce automatic session probes
+  - [#3772](https://github.com/bpftrace/bpftrace/pull/3772)
+#### Deprecated
+#### Removed
+#### Fixed
+#### Security
+#### Docs
+#### Tools
+
+## [0.23.0] 2025-03-25
+
+#### Breaking Changes
+- Remove '-kk' command line opt, surface some BPF errors by default, and make '-k' surface probe read errors
+  - [#3784](https://github.com/bpftrace/bpftrace/pull/3784)
 #### Added
 - `offsetof()` now supports sub fields e.g. `offsetof(struct Foo, bar.a.b);`
   - [#3761](https://github.com/bpftrace/bpftrace/pull/3761)
@@ -25,7 +49,6 @@ and this project adheres to
 - `blazesym` will be used for address symbolication if found during build
   - [#3760](https://github.com/bpftrace/bpftrace/pull/3760)
   - [#3787](https://github.com/bpftrace/bpftrace/pull/3787)
-  - [#3884](https://github.com/bpftrace/bpftrace/pull/3884)
 - Published aarch64 appimage builds from master
   - [#3795](https://github.com/bpftrace/bpftrace/pull/3795)
 - Add ability to cast int to an enum
@@ -34,12 +57,6 @@ and this project adheres to
   - [#3811](https://github.com/bpftrace/bpftrace/pull/3811)
 - Add support for LLVM 20
   - [#3841](https://github.com/bpftrace/bpftrace/pull/3841)
-- Add simple block expressions
-  - [#3780](https://github.com/bpftrace/bpftrace/pull/3780)
-- Add map declaration syntax (behind an "unstable" config flag)
-  - [#3863](https://github.com/bpftrace/bpftrace/pull/3863)
-- Add license config to specify BPF license
-  - [#3905](https://github.com/bpftrace/bpftrace/pull/3905)
 #### Changed
 - `probe` builtin is now represented as a string type
   - [#3638](https://github.com/bpftrace/bpftrace/pull/3638)
@@ -51,12 +68,8 @@ and this project adheres to
   - [#3752](https://github.com/bpftrace/bpftrace/pull/3752)
 - Increase default values for max_bpf_progs and max_probes
   - [#3808](https://github.com/bpftrace/bpftrace/pull/3808)
-- `-p` CLI flag now applies to all probes (except BEGIN/END)
-  - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)
 - Allow use of variables before they are assigned
   - [#3832](https://github.com/bpftrace/bpftrace/pull/3832)
-- Introduce automatic session probes
-  - [#3772](https://github.com/bpftrace/bpftrace/pull/3772)
 #### Deprecated
 #### Removed
 - Drop support for LLVM 14 and 15

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(SET CMP0057 NEW)
 
 # bpftrace version number components.
 set(bpftrace_VERSION_MAJOR 0)
-set(bpftrace_VERSION_MINOR 22)
+set(bpftrace_VERSION_MINOR 23)
 set(bpftrace_VERSION_PATCH 0)
 
 include(GNUInstallDirs)


### PR DESCRIPTION
Backport CHANGELOG and CMakeLists.txt changes from the release branch.

In CHANGELOG, move released entries from the Unreleased section into the new release section. The entry for using blazesym for symbolication contained 3 PRs, however, only the first 2 were in the release. Hence, move the last PR (using blazesym for userspace symbolication) into a separate entry in the Unreleased section.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
