### PR TITLE
Fix iter probe listing with a wildcard

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -780,10 +780,11 @@ AttachPointParser::State AttachPointParser::raw_tracepoint_parser()
   return OK;
 }
 
-Pass CreateParseAttachpointsPass()
+// Note: listing changes the parsing semantics for attach points
+Pass CreateParseAttachpointsPass(bool listing)
 {
-  return Pass::create("attachpoints", [](ASTContext &ast, BPFtrace &b) {
-    AttachPointParser ap_parser(ast, b, false);
+  return Pass::create("attachpoints", [listing](ASTContext &ast, BPFtrace &b) {
+    AttachPointParser ap_parser(ast, b, listing);
     ap_parser.parse();
   });
 }

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -63,6 +63,6 @@ private:
 };
 
 // The attachpoints are expanded in their own separate pass.
-Pass CreateParseAttachpointsPass();
+Pass CreateParseAttachpointsPass(bool listing = false);
 
 } // namespace bpftrace::ast

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -140,6 +140,11 @@ RUN {{BPFTRACE}} -l "rawtracepoint:*"
 EXPECT_REGEX rawtracepoint:.*
 TIMEOUT 1
 
+NAME it lists iter with regex filter
+RUN {{BPFTRACE}} -l "iter:*"
+EXPECT_REGEX iter:.*
+TIMEOUT 1
+
 NAME it only lists probes in the program
 RUN {{BPFTRACE}} -l -e 'fentry:vmlinux:vfs_read { exit(); }'
 EXPECT fentry:vmlinux:vfs_read


### PR DESCRIPTION
args.listing wasn't being passed to the
attachpoint parser.

Issue: https://github.com/bpftrace/bpftrace/issues/3942

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
