### PR TITLE
Add support for rawtracepoint modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
   - [#3950](https://github.com/bpftrace/bpftrace/pull/3950)
 - Removed config option 'symbol_source' - it no longer has any effect
   - [#3925](https://github.com/bpftrace/bpftrace/pull/3925)
+- Rawtracepoints now require kernel BTF
+  - [#3944](https://github.com/bpftrace/bpftrace/pull/3944)
 #### Added
 - Use blazesym for user space address symbolization
   - [#3884](https://github.com/bpftrace/bpftrace/pull/3884)
@@ -25,6 +27,8 @@ and this project adheres to
   - [#3905](https://github.com/bpftrace/bpftrace/pull/3905)
 - Rawtracepoints can now use `args` builtin and list params
   - [#3918](https://github.com/bpftrace/bpftrace/pull/3918)
+- Add ability to specify rawtracepoint modules
+  - [#3944](https://github.com/bpftrace/bpftrace/pull/3944)
 #### Changed
 - `-p` CLI flag now applies to all probes (except BEGIN/END)
   - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1477,7 +1477,7 @@ profile:hz:99 { @[tid] = count(); }
 === rawtracepoint
 
 .variants
-* `rawtracepoint:event`
+* `rawtracepoint[:module]:event`
 
 .short name
 * `rt`
@@ -1488,7 +1488,7 @@ The reason why you might want to use raw tracepoints over normal tracepoints is 
 `rawtracepoint` arguments can be accessed via the `argN` builtins AND via the `args` builtin.
 
 ----
-rawtracepoint:kfree_skb {
+rawtracepoint:vmlinux:kfree_skb {
   printf("%llx %llx\n", arg0, args.skb);
 }
 ----

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -483,9 +483,10 @@ AttachPoint &AttachPoint::create_expansion_copy(ASTContext &ctx,
     case ProbeType::fentry:
     case ProbeType::fexit:
     case ProbeType::tracepoint:
-      // Tracepoint, uprobe, and fentry/fexit probes specify both a target
-      // (category for tracepoints, binary for uprobes, and kernel module
-      // for fentry/fexit and a function name.
+    case ProbeType::rawtracepoint:
+      // Tracepoint, raw tracepoint, uprobe, and fentry/fexit probes specify
+      // both a target (category for tracepoints, binary for uprobes, and
+      // kernel module for fentry/fexit and a function name.
       ap.func = match;
       ap.target = util::erase_prefix(ap.func);
       break;
@@ -502,9 +503,6 @@ AttachPoint &AttachPoint::create_expansion_copy(ASTContext &ctx,
       // function
       ap.func = match;
       util::erase_prefix(ap.func);
-      break;
-    case ProbeType::rawtracepoint:
-      ap.func = match;
       break;
     case ProbeType::software:
     case ProbeType::hardware:

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -765,16 +765,24 @@ AttachPointParser::State AttachPointParser::iter_parser()
 
 AttachPointParser::State AttachPointParser::raw_tracepoint_parser()
 {
-  if (parts_.size() != 2) {
+  if (parts_.size() != 2 && parts_.size() != 3) {
     if (ap_->ignore_invalid)
       return SKIP;
 
-    return argument_count_error(1);
+    return argument_count_error(2, 1);
   }
 
-  ap_->func = parts_[1];
+  if (parts_.size() == 3) {
+    ap_->target = parts_[1];
+    ap_->func = parts_[2];
+  } else {
+    // This is to maintain backwards compatibility with older scripts
+    // that couldn't include a target for a raw tracepoint.
+    ap_->target = "*";
+    ap_->func = parts_[1];
+  }
 
-  if (util::has_wildcard(ap_->func))
+  if (util::has_wildcard(ap_->func) || util::has_wildcard(ap_->target))
     ap_->expansion = ExpansionType::FULL;
 
   return OK;

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -249,13 +249,8 @@ void FieldAnalyser::resolve_args(Probe &probe)
               func, probe_type == ProbeType::fexit, true, false, err);
 
         } else if (probe_type == ProbeType::rawtracepoint) {
-          for (const auto &prefix : RT_BTF_PREFIXES) {
-            maybe_ap_args = bpftrace_.btf_->resolve_args(
-                prefix + ap->func, false, false, true, err);
-            if (maybe_ap_args.has_value()) {
-              break;
-            }
-          }
+          maybe_ap_args = bpftrace_.btf_->resolve_raw_tracepoint_args(func,
+                                                                      err);
         } else { // uprobe
           Dwarf *dwarf = bpftrace_.get_dwarf(target);
           if (dwarf)
@@ -286,13 +281,8 @@ void FieldAnalyser::resolve_args(Probe &probe)
         maybe_probe_args = bpftrace_.btf_->resolve_args(
             ap->func, probe_type == ProbeType::fexit, true, false, err);
       } else if (probe_type == ProbeType::rawtracepoint) {
-        for (const auto &prefix : RT_BTF_PREFIXES) {
-          maybe_probe_args = bpftrace_.btf_->resolve_args(
-              prefix + ap->func, false, false, true, err);
-          if (maybe_probe_args.has_value()) {
-            break;
-          }
-        }
+        maybe_probe_args = bpftrace_.btf_->resolve_raw_tracepoint_args(ap->func,
+                                                                       err);
       } else { // uprobe
         Dwarf *dwarf = bpftrace_.get_dwarf(ap->target);
         if (dwarf) {

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3520,10 +3520,14 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     if (ap.target.empty() || ap.func.empty())
       ap.addError() << "tracepoint probe must have a target";
   } else if (ap.provider == "rawtracepoint") {
-    if (!ap.target.empty())
-      ap.addError() << "rawtracepoint should not have a target";
     if (ap.func.empty())
       ap.addError() << "rawtracepoint should be attached to a function";
+
+    if (!listing_ && !bpftrace_.has_btf_data()) {
+      ap.addError() << "rawtracepoints require kernel BTF. Try using a "
+                       "'tracepoint' instead.";
+    }
+
   } else if (ap.provider == "profile") {
     if (ap.target.empty())
       ap.addError() << "profile probe must have unit of time";

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -170,6 +170,8 @@ public:
   virtual bool is_traceable_func(const std::string &func_name) const;
   virtual std::unordered_set<std::string> get_func_modules(
       const std::string &func_name) const;
+  virtual std::unordered_set<std::string> get_raw_tracepoint_modules(
+      const std::string &name) const;
   virtual const struct stat &get_pidns_self_stat() const;
 
   bool write_pcaps(uint64_t id, uint64_t ns, uint8_t *pkt, unsigned int size);
@@ -199,6 +201,7 @@ public:
   // For each helper, list of all generated call sites.
   std::map<libbpf::bpf_func_id, std::vector<HelperErrorInfo>> helper_use_loc_;
   const util::FuncsModulesMap &get_traceable_funcs() const;
+  const util::FuncsModulesMap &get_raw_tracepoints() const;
   util::KConfig kconfig;
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
   std::optional<int> sigusr1_prog_fd_;
@@ -294,7 +297,7 @@ private:
   // Needs to be mutable to allow lazy loading of the mapping from const lookup
   // functions.
   mutable util::FuncsModulesMap traceable_funcs_;
-
+  mutable util::FuncsModulesMap raw_tracepoints_;
   std::unordered_map<std::string, std::unique_ptr<Dwarf>> dwarves_;
 };
 

--- a/src/btf.h
+++ b/src/btf.h
@@ -34,9 +34,10 @@ namespace bpftrace {
 // "__probestub_" seems to be the most accurate in terms of getting the params
 // but it wasn't added until May 2023 so older kernels might not have it,
 // which is why we also check "__traceiter_" (as needed).
-// "btf_trace_" prefix, which we use to validate if we can attach to this
-// tracepoint is a typedef that eventually resolves to a FUNC_PROTO
-// but the params for this do not have names, which is what we need.
+// "btf_trace_" prefix, which is what the kernel uses for raw tracepoints, we
+// use in bpfprogram.cpp to validate if we can attach to this raw tracepoint.
+// The BTF for "btf_trace_" is a typedef that eventually resolves to a
+// FUNC_PROTO but the params for this do not have names, which is what we need.
 // "__probestub_" was added here:
 // https://lore.kernel.org/all/168507471874.913472.17214624519622959593.stgit@mhiramat.roam.corp.google.com/
 // "__traceiter_" was added here:
@@ -89,14 +90,18 @@ public:
   std::set<std::string> get_all_structs() const;
   std::unique_ptr<std::istream> get_all_funcs() const;
   std::unordered_set<std::string> get_all_iters() const;
+  std::unique_ptr<std::istream> get_all_raw_tracepoints() const;
   std::map<std::string, std::vector<std::string>> get_params(
-      const std::set<std::string>& funcs) const;
+      const std::set<std::string>& funcs,
+      bool is_raw_tracepoint = false) const;
 
   std::optional<Struct> resolve_args(const std::string& func,
                                      bool ret,
                                      bool check_traceable,
                                      bool skip_first_arg,
                                      std::string& err);
+  std::optional<Struct> resolve_raw_tracepoint_args(const std::string& func,
+                                                    std::string& err);
   void resolve_fields(SizedType& type);
 
   int get_btf_id(std::string_view func,
@@ -118,9 +123,11 @@ private:
   std::string dump_defs_from_btf(const struct btf* btf,
                                  std::unordered_set<std::string>& types) const;
   std::string get_all_funcs_from_btf(const BTFObj& btf_obj) const;
+  std::string get_all_raw_tracepoints_from_btf(const BTFObj& btf_obj) const;
   std::map<std::string, std::vector<std::string>> get_params_from_btf(
       const BTFObj& btf_obj,
-      const std::set<std::string>& funcs) const;
+      const std::set<std::string>& funcs,
+      bool is_raw_tracepoint) const;
   std::set<std::string> get_all_structs_from_btf(const struct btf* btf) const;
   std::unordered_set<std::string> get_all_iters_from_btf(
       const struct btf* btf) const;

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -98,9 +98,8 @@ private:
       const std::string &target) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_list(
       const std::vector<ProbeListItem> &probes_list) const;
-
-  virtual std::unique_ptr<std::istream> adjust_rawtracepoint(
-      std::istream &symbol_list) const;
+  virtual std::unique_ptr<std::istream> get_symbols_from_raw_tracepoints()
+      const;
 
   std::unique_ptr<std::istream> get_iter_symbols() const;
 

--- a/src/util/kernel.h
+++ b/src/util/kernel.h
@@ -18,6 +18,7 @@ using FuncsModulesMap =
     std::unordered_map<std::string, std::unordered_set<std::string>>;
 
 FuncsModulesMap parse_traceable_funcs();
+FuncsModulesMap parse_rawtracepoints();
 
 struct KConfig {
   KConfig();

--- a/tests/codegen/llvm/argN_rawtracepoint.ll
+++ b/tests/codegen/llvm/argN_rawtracepoint.ll
@@ -15,7 +15,7 @@ target triple = "bpf-pc-linux"
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @rawtracepoint_sched_switch_1(ptr %0) section "s_rawtracepoint_sched_switch_1" !dbg !56 {
+define i64 @rawtracepoint_vmlinux_sched_switch_1(ptr %0) section "s_rawtracepoint_vmlinux_sched_switch_1" !dbg !56 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
@@ -104,7 +104,7 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
 !54 = !{!0, !7, !26, !40}
 !55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "rawtracepoint_sched_switch_1", linkageName: "rawtracepoint_sched_switch_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
+!56 = distinct !DISubprogram(name: "rawtracepoint_vmlinux_sched_switch_1", linkageName: "rawtracepoint_vmlinux_sched_switch_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
 !57 = !DISubroutineType(types: !58)
 !58 = !{!24, !59}
 !59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)

--- a/tests/codegen/llvm/args_rawtracepoint.ll
+++ b/tests/codegen/llvm/args_rawtracepoint.ll
@@ -15,7 +15,7 @@ target triple = "bpf-pc-linux"
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @rawtracepoint_sched_switch_1(ptr %0) section "s_rawtracepoint_sched_switch_1" !dbg !56 {
+define i64 @rawtracepoint_vmlinux_sched_switch_1(ptr %0) section "s_rawtracepoint_vmlinux_sched_switch_1" !dbg !56 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
@@ -105,7 +105,7 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
 !54 = !{!0, !7, !26, !40}
 !55 = !{i32 2, !"Debug Info Version", i32 3}
-!56 = distinct !DISubprogram(name: "rawtracepoint_sched_switch_1", linkageName: "rawtracepoint_sched_switch_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
+!56 = distinct !DISubprogram(name: "rawtracepoint_vmlinux_sched_switch_1", linkageName: "rawtracepoint_vmlinux_sched_switch_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
 !57 = !DISubroutineType(types: !58)
 !58 = !{!24, !59}
 !59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -39,7 +39,8 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
                                   "notsched:bar\n"
                                   "file:filename\n"
                                   "tcp:some_tcp_tp\n"
-                                  "btf:tag\n";
+                                  "btf:tag\n"
+                                  "vmlinux:event_rt\n";
         return std::unique_ptr<std::istream>(
             new std::istringstream(tracepoints));
       });

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1402,6 +1402,28 @@ tracepoint { 1 }
 )");
 }
 
+TEST(Parser, rawtracepoint_probe)
+{
+  test("rawtracepoint:sched:sched_switch { 1 }",
+       "Program\n"
+       " rawtracepoint:sched:sched_switch\n"
+       "  int: 1\n");
+  test("rawtracepoint:* { 1 }",
+       "Program\n"
+       " rawtracepoint:*:*\n"
+       "  int: 1\n");
+  test("rawtracepoint:f { 1 }",
+       "Program\n"
+       " rawtracepoint:*:f\n"
+       "  int: 1\n");
+
+  test_parse_failure("rawtracepoint { 1 }", R"(
+stdin:1:1-14: ERROR: rawtracepoint probe type requires 2 or 1 arguments, found 0
+rawtracepoint { 1 }
+~~~~~~~~~~~~~
+)");
+}
+
 TEST(Parser, profile_probe)
 {
   test("profile:ms:997 { 1 }",

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -425,13 +425,25 @@ AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME rawtracepoint_missing
 PROG rawtracepoint:nonsense { print("hit"); exit(); }
-EXPECT ERROR: No BTF found for nonsense
+EXPECT No probes to attach
+REQUIRES_FEATURE btf
 WILL_FAIL
 
 NAME rawtracepoint_wildcard
 PROG rawtracepoint:sys_* { printf("SUCCESS %d\n", gid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep
+
+NAME rawtracepoint_module_wildcard
+PROG rawtracepoint:vmlinu*:sys_exit { printf("SUCCESS %d\n", gid); exit(); }
+EXPECT_REGEX SUCCESS [0-9][0-9]*
+AFTER ./testprogs/syscall nanosleep 1e8
+
+NAME rawtracepoint_module_missing
+PROG rawtracepoint:nonsense:sys_exit { printf("SUCCESS %d\n", gid); exit(); }
+EXPECT ERROR: No BTF found for nonsense:sys_exit
+REQUIRES_FEATURE btf
+WILL_FAIL
 
 # Test that we get at least two characters out
 NAME rawtracepoint args

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2231,6 +2231,7 @@ TEST(semantic_analyser, rawtracepoint)
 {
   test("rawtracepoint:event { 1 }");
   test("rawtracepoint:event { arg0 }");
+  test("rawtracepoint:mod:event { arg0 }");
 }
 
 #if defined(__x86_64__) || defined(__aarch64__)


### PR DESCRIPTION
This maintains backward compat with older
scripts where only two arguments were allowed
by assuming the module is "vmlinux".

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
