### PR TITLE
Simplify hashing multiple fields

### DIFF
--- a/src/functions.h
+++ b/src/functions.h
@@ -9,6 +9,7 @@
 #include "ast/ast.h"
 #include "ast/location.h"
 #include "types.h"
+#include "util/hash.h"
 
 namespace bpftrace {
 
@@ -127,8 +128,10 @@ private:
   public:
     size_t operator()(const FqName &fq_name) const
     {
-      return std::hash<std::string>()(fq_name.ns) ^
-             std::hash<std::string>()(fq_name.name);
+      std::size_t seed = 0;
+      util::hash_combine(seed, fq_name.ns);
+      util::hash_combine(seed, fq_name.name);
+      return seed;
     }
   };
 

--- a/src/util/hash.h
+++ b/src/util/hash.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <functional>
 
 namespace bpftrace::util {


### PR DESCRIPTION
No need to manually swizzle hashes. Just use the existing util::hash_combine() we have.

Also fix hash.h to have the pragma once.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
