### PR TITLE
tests: config: Remove unnecessary headers

### DIFF
--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -1,6 +1,4 @@
 #include "ast/passes/config_analyser.h"
-#include "ast/passes/parser.h"
-#include "ast/passes/semantic_analyser.h"
 #include "driver.h"
 #include "mocks.h"
 #include "gtest/gtest.h"


### PR DESCRIPTION
Config analyser tests only use bare minimum passes now. So these headers are no longer used.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
