### PR TITLE
config: Remove vestigial probe_inline config

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -681,11 +681,6 @@ void SemanticAnalyser::visit(Builtin &builtin)
     AddrSpace addrspace = find_addrspace(pt);
     for (auto *attach_point : probe->attach_points) {
       ProbeType type = probetype(attach_point->provider);
-      if (type == ProbeType::uprobe &&
-          bpftrace_.config_->get(ConfigKeyBool::probe_inline))
-        builtin.addError() << "The " + builtin.ident +
-                                  " builtin can only be used when "
-                           << "the probe_inline config is disabled.";
       if (type != ProbeType::kprobe && type != ProbeType::uprobe &&
           type != ProbeType::usdt && type != ProbeType::rawtracepoint)
         builtin.addError() << "The " << builtin.ident
@@ -712,11 +707,6 @@ void SemanticAnalyser::visit(Builtin &builtin)
         builtin.addError()
             << "The " + builtin.ident
             << " builtin can only be used with 'kprobes' and 'uprobes' probes";
-      if (type == ProbeType::uprobe &&
-          bpftrace_.config_->get(ConfigKeyBool::probe_inline))
-        builtin.addError() << "The " + builtin.ident +
-                                  " builtin can only be used when "
-                           << "the probe_inline config is disabled.";
       if (is_final_pass() &&
           (attach_point->address != 0 || attach_point->func_offset != 0)) {
         // If sargX values are needed when using an offset, they can be stored
@@ -778,11 +768,6 @@ void SemanticAnalyser::visit(Builtin &builtin)
              "\"probe1,probe2 {args}\" is not.";
     } else if (type == ProbeType::fentry || type == ProbeType::fexit ||
                type == ProbeType::uprobe || type == ProbeType::rawtracepoint) {
-      if (type == ProbeType::uprobe &&
-          bpftrace_.config_->get(ConfigKeyBool::probe_inline))
-        builtin.addError() << "The args builtin can only be used when "
-                           << "the probe_inline config is disabled.";
-
       auto type_name = probe->args_typename();
       builtin.type = CreateRecord(type_name,
                                   bpftrace_.structs.Lookup(type_name));

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -13,7 +13,6 @@ Config::Config(bool has_cmd)
   config_map_ = {
     { ConfigKeyBool::cpp_demangle, { .value = true } },
     { ConfigKeyBool::lazy_symbolication, { .value = false } },
-    { ConfigKeyBool::probe_inline, { .value = false } },
     { ConfigKeyBool::print_maps_on_exit, { .value = true } },
     { ConfigKeyBool::unstable_map_decl, { .value = false } },
 #ifndef HAVE_BLAZESYM

--- a/src/config.h
+++ b/src/config.h
@@ -24,7 +24,6 @@ enum class ConfigSource {
 enum class ConfigKeyBool {
   cpp_demangle,
   lazy_symbolication,
-  probe_inline,
   print_maps_on_exit,
   use_blazesym,
   unstable_map_decl,
@@ -92,7 +91,6 @@ const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
   { "max_type_res_iterations", ConfigKeyInt::max_type_res_iterations },
   { "on_stack_limit", ConfigKeyInt::on_stack_limit },
   { "perf_rb_pages", ConfigKeyInt::perf_rb_pages },
-  { "probe_inline", ConfigKeyBool::probe_inline },
   { "stack_mode", ConfigKeyStackMode::default_ },
   { "str_trunc_trailer", ConfigKeyString::str_trunc_trailer },
   { "missing_probes", ConfigKeyMissingProbes::default_ },


### PR DESCRIPTION
The underlying functionality was removed along with LLDB. Inline probing will be handled in the future through a separate kernel-side effort.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
