### PR TITLE
Remove Apache license from all tools scripts

### DIFF
--- a/tools/bashreadline.bt
+++ b/tools/bashreadline.bt
@@ -10,7 +10,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 06-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/biolatency-kp.bt
+++ b/tools/biolatency-kp.bt
@@ -6,7 +6,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * This version of the tool uses kprobes to attach to kernel events.
  * Note that these do not exist or are inlined on newer kernels

--- a/tools/biolatency.bt
+++ b/tools/biolatency.bt
@@ -6,7 +6,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 13-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/biostacks.bt
+++ b/tools/biostacks.bt
@@ -5,7 +5,6 @@
  * See BPF Performance Tools, Chapter 9, for an explanation of this tool.
  *
  * Copyright (c) 2019 Brendan Gregg.
- * Licensed under the Apache License, Version 2.0 (the "License").
  * This was originally created for the BPF Performance Tools book
  * published by Addison Wesley. ISBN-13: 9780136554820
  * When copying or porting, include this comment.

--- a/tools/bitesize.bt
+++ b/tools/bitesize.bt
@@ -8,7 +8,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 07-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/capable.bt
+++ b/tools/capable.bt
@@ -8,7 +8,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 08-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/cpuwalk.bt
+++ b/tools/cpuwalk.bt
@@ -8,7 +8,6 @@
  * This is a bpftrace version of the DTraceToolkit tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 08-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/dcsnoop.bt
+++ b/tools/dcsnoop.bt
@@ -10,7 +10,6 @@
  * USAGE: dcsnoop.bt
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 08-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/gethostlatency.bt
+++ b/tools/gethostlatency.bt
@@ -14,7 +14,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 08-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/killsnoop.bt
+++ b/tools/killsnoop.bt
@@ -10,7 +10,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 07-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/loads.bt
+++ b/tools/loads.bt
@@ -12,7 +12,6 @@
  * This is a bpftrace version of a DTraceToolkit tool.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 10-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/mdflush.bt
+++ b/tools/mdflush.bt
@@ -10,7 +10,6 @@
  * For Linux 5.12+ (see tools/old for script for lower versions).
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 08-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/naptime.bt
+++ b/tools/naptime.bt
@@ -5,7 +5,6 @@
  * See BPF Performance Tools, Chapter 13, for an explanation of this tool.
  *
  * Copyright (c) 2019 Brendan Gregg.
- * Licensed under the Apache License, Version 2.0 (the "License").
  * This was originally created for the BPF Performance Tools book
  * published by Addison Wesley. ISBN-13: 9780136554820
  * When copying or porting, include this comment.

--- a/tools/old/biostacks.bt
+++ b/tools/old/biostacks.bt
@@ -5,7 +5,6 @@
  * See BPF Performance Tools, Chapter 9, for an explanation of this tool.
  *
  * Copyright (c) 2019 Brendan Gregg.
- * Licensed under the Apache License, Version 2.0 (the "License").
  * This was originally created for the BPF Performance Tools book
  * published by Addison Wesley. ISBN-13: 9780136554820
  * When copying or porting, include this comment.

--- a/tools/old/mdflush.bt
+++ b/tools/old/mdflush.bt
@@ -10,7 +10,6 @@
  * For Linux <= 5.11.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 08-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/old/runqlen.bt
+++ b/tools/old/runqlen.bt
@@ -8,7 +8,6 @@
  * For Linux < 6.14.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 07-Oct-2018	Brendan Gregg	Created this.
  */

--- a/tools/old/tcpdrop.bt
+++ b/tools/old/tcpdrop.bt
@@ -18,7 +18,6 @@
  * For Linux <= 5.18.
  *
  * Copyright (c) 2018 Dale Hamel.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 23-Nov-2018	Dale Hamel	created this.
  */

--- a/tools/oomkill.bt
+++ b/tools/oomkill.bt
@@ -15,7 +15,6 @@
  * USAGE: oomkill.bt
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 07-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -10,7 +10,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 08-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/pidpersec.bt
+++ b/tools/pidpersec.bt
@@ -10,7 +10,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 06-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/runqlat.bt
+++ b/tools/runqlat.bt
@@ -6,7 +6,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 17-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/runqlen.bt
+++ b/tools/runqlen.bt
@@ -6,7 +6,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 07-Oct-2018	Brendan Gregg	Created this.
  */

--- a/tools/setuids.bt
+++ b/tools/setuids.bt
@@ -5,7 +5,6 @@
  * See BPF Performance Tools, Chapter 11, for an explanation of this tool.
  *
  * Copyright (c) 2019 Brendan Gregg.
- * Licensed under the Apache License, Version 2.0 (the "License").
  * This was originally created for the BPF Performance Tools book
  * published by Addison Wesley. ISBN-13: 9780136554820
  * When copying or porting, include this comment.

--- a/tools/ssllatency.bt
+++ b/tools/ssllatency.bt
@@ -6,7 +6,6 @@
  * ssllatency shows handshake latency stats and distribution.
  *
  * Copyright (c) 2021 Tao Xu.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 17-Dec-2021	Tao Xu	created this.
  */

--- a/tools/sslsnoop.bt
+++ b/tools/sslsnoop.bt
@@ -7,7 +7,6 @@
  * performance analysis.
  *
  * Copyright (c) 2021 Tao Xu.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 15-Dec-2021	Tao Xu	created this.
  */

--- a/tools/statsnoop.bt
+++ b/tools/statsnoop.bt
@@ -14,7 +14,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 08-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/swapin.bt
+++ b/tools/swapin.bt
@@ -5,7 +5,6 @@
  * See BPF Performance Tools, Chapter 7, for an explanation of this tool.
  *
  * Copyright (c) 2019 Brendan Gregg.
- * Licensed under the Apache License, Version 2.0 (the "License").
  * This was originally created for the BPF Performance Tools book
  * published by Addison Wesley. ISBN-13: 9780136554820
  * When copying or porting, include this comment.

--- a/tools/syncsnoop.bt
+++ b/tools/syncsnoop.bt
@@ -10,7 +10,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 06-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/syscount.bt
+++ b/tools/syscount.bt
@@ -8,7 +8,6 @@
  * currently does not. Syscall IDs can be listed by "ausyscall --dump".
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 13-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/tcpaccept.bt
+++ b/tools/tcpaccept.bt
@@ -11,7 +11,6 @@
  * (from tcp_prot.accept), and will need to be modified to match kernel changes.
 
  * Copyright (c) 2018 Dale Hamel.
- * Licensed under the Apache License, Version 2.0 (the "License")
 
  * 23-Nov-2018	Dale Hamel	created this.
  */

--- a/tools/tcpconnect.bt
+++ b/tools/tcpconnect.bt
@@ -13,7 +13,6 @@
  * to match kernel changes.
  *
  * Copyright (c) 2018 Dale Hamel.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 23-Nov-2018	Dale Hamel	created this.
  */

--- a/tools/tcpdrop.bt
+++ b/tools/tcpdrop.bt
@@ -14,7 +14,6 @@
  * For Linux 5.17+ (see tools/old for script for lower versions).
  *
  * Copyright (c) 2018 Dale Hamel.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 23-Nov-2018	Dale Hamel	created this.
  * 01-Oct-2022	Rong Tao	use tracepoint:skb:kfree_skb

--- a/tools/tcplife.bt
+++ b/tools/tcplife.bt
@@ -5,7 +5,6 @@
  * See BPF Performance Tools, Chapter 10, for an explanation of this tool.
  *
  * Copyright (c) 2019 Brendan Gregg.
- * Licensed under the Apache License, Version 2.0 (the "License").
  * This was originally created for the BPF Performance Tools book
  * published by Addison Wesley. ISBN-13: 9780136554820
  * When copying or porting, include this comment.

--- a/tools/tcpretrans.bt
+++ b/tools/tcpretrans.bt
@@ -12,7 +12,6 @@
  * to match kernel changes.
  *
  * Copyright (c) 2018 Dale Hamel.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 23-Nov-2018  Dale Hamel      created this.
  */

--- a/tools/tcpsynbl.bt
+++ b/tools/tcpsynbl.bt
@@ -5,7 +5,6 @@
  * See BPF Performance Tools, Chapter 10, for an explanation of this tool.
  *
  * Copyright (c) 2019 Brendan Gregg.
- * Licensed under the Apache License, Version 2.0 (the "License").
  * This was originally created for the BPF Performance Tools book
  * published by Addison Wesley. ISBN-13: 9780136554820
  * When copying or porting, include this comment.

--- a/tools/threadsnoop.bt
+++ b/tools/threadsnoop.bt
@@ -5,7 +5,6 @@
  * See BPF Performance Tools, Chapter 13, for an explanation of this tool.
  *
  * Copyright (c) 2019 Brendan Gregg.
- * Licensed under the Apache License, Version 2.0 (the "License").
  * This was originally created for the BPF Performance Tools book
  * published by Addison Wesley. ISBN-13: 9780136554820
  * When copying or porting, include this comment.

--- a/tools/undump.bt
+++ b/tools/undump.bt
@@ -10,7 +10,6 @@
  * USAGE: undump.bt
  *
  * Copyright 2022 CESTC, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 22-May-2022	Rong Tao	Created this.
  */

--- a/tools/vfscount.bt
+++ b/tools/vfscount.bt
@@ -10,7 +10,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 06-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/vfsstat.bt
+++ b/tools/vfsstat.bt
@@ -11,7 +11,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 06-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/writeback.bt
+++ b/tools/writeback.bt
@@ -14,7 +14,6 @@
  * USAGE: writeback.bt
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 14-Sep-2018	Brendan Gregg	Created this.
  */

--- a/tools/xfsdist.bt
+++ b/tools/xfsdist.bt
@@ -11,7 +11,6 @@
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * Copyright 2018 Netflix, Inc.
- * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 08-Sep-2018	Brendan Gregg	Created this.
  */


### PR DESCRIPTION
This license is in conflict with the license
that bpftrace actually passes to the kernel.
By removing the Apache license these scripts
will now default to "GPL" (specifically GPL v2)
as per our doc: https://github.com/bpftrace/bpftrace/blob/master/man/adoc/bpftrace.adoc#bpf-license

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
