### PR TITLE
Allow positional parameters in path tokens in probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
   - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)
 - Introduce automatic session probes
   - [#3772](https://github.com/bpftrace/bpftrace/pull/3772)
+- Positional params can be used in any part of a probe string
+  - [#3956](https://github.com/bpftrace/bpftrace/pull/3956)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1774,8 +1774,8 @@ The 'Kernel' column indicates the minimum kernel version required and the 'BPF H
 | n/a
 | n/a
 | The nth positional parameter passed to the bpftrace program.
-If less than n parameters are passed this evaluates to `0`.
-For string arguments use the `str()` call to retrieve the value.
+If less than n parameters are passed this evaluates to `0` in an action block or an empty string in a probe.
+For string arguments in an action block use the `str()` call to retrieve the value.
 
 | `$#`
 | int64

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <bcc/bcc_proc.h>
+#include <cctype>
 #include <exception>
 #include <iostream>
 #include <string>
@@ -236,25 +237,37 @@ AttachPointParser::State AttachPointParser::lex_attachpoint(
       argument += raw[idx + 1];
       ++idx;
     } else if (!in_quotes && raw[idx] == '$') {
-      // There's an assumption that the positional parameter is well
-      // formed. ie we are not expecting a bare `$` or `$nonint`. The
-      // bison parser should have guaranteed this.
       size_t i = idx + 1;
       size_t len = 0;
-      while (i < raw.size() && (raw[i] != '"' && raw[i] != ':')) {
+      while (i < raw.size() && std::isdigit(raw[i])) {
+        if (len == 0 && raw[i] == '0') {
+          break;
+        }
         len++;
         i++;
       }
 
-      std::string param_idx_str = raw.substr(idx + 1, len);
-      size_t pos, param_idx;
-      param_idx = std::stoll(param_idx_str, &pos, 0);
+      std::string param_idx_str;
 
-      if (pos != param_idx_str.size()) {
+      if (len == 0 && (idx + 1) < raw.size()) {
+        param_idx_str = raw.substr(idx + 1, 1);
         errs_
-            << "Found trailing text '" << param_idx_str.substr(pos)
-            << "' in positional parameter index. Try quoting the trailing text."
-            << std::endl;
+            << "invalid trailing character for positional param: "
+            << param_idx_str
+            << ". Try quoting this entire part if this is intentional e.g. \"$"
+            << param_idx_str << "\".";
+        return State::INVALID;
+      }
+
+      param_idx_str = raw.substr(idx + 1, len);
+      size_t pos, param_idx;
+
+      try {
+        param_idx = std::stoll(param_idx_str, &pos, 0);
+      } catch (std::out_of_range const &ex) {
+        errs_ << "positional param index " << param_idx_str
+              << " is out of integer range. Max int: "
+              << std::to_string(std::numeric_limits<long>::max());
         return State::INVALID;
       }
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -43,7 +43,7 @@ var      ${ident}
 hspace   [ \t]
 vspace   [\n\r]
 space    {hspace}|{vspace}
-path     :(\\.|[_\-\./a-zA-Z0-9#+\*])+
+path     :(\\.|[_\-\./a-zA-Z0-9#$+\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies
 call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|len|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf|has_key|percpu_kaddr
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -246,6 +246,12 @@ stdin:1:12-14: ERROR: param $0 is out of integer range [1, 9223372036854775807]
 kprobe:f { $0 }
            ~~
 )");
+
+  test_parse_failure("kprobe:f { $999999999999999999999999 }", R"(
+stdin:1:12-37: ERROR: param $999999999999999999999999 is out of integer range [1, 9223372036854775807]
+kprobe:f { $999999999999999999999999 }
+           ~~~~~~~~~~~~~~~~~~~~~~~~~
+)");
 }
 
 TEST(Parser, positional_param_count)
@@ -286,6 +292,13 @@ TEST(Parser, positional_param_attachpoint)
 )PROG");
 
   test(bpftrace,
+       R"PROG(uprobe:/$1/bash:readline { 1 })PROG",
+       R"PROG(Program
+ uprobe:/foo/bash:readline
+  int: 1
+)PROG");
+
+  test(bpftrace,
        R"PROG(uprobe:$1:$2 { 1 })PROG",
        R"PROG(Program
  uprobe:foo:bar
@@ -321,41 +334,44 @@ TEST(Parser, positional_param_attachpoint)
 )PROG");
 
   test(bpftrace,
-       R"PROG(uprobe:aa$1:$2 { 1 })PROG",
+       R"PROG(uprobe:aa$1aa:$2 { 1 })PROG",
        R"PROG(Program
- uprobe:aafoo:bar
+ uprobe:aafooaa:bar
   int: 1
 )PROG");
 
-  // Error location is incorrect: #3063
-  test_parse_failure(bpftrace, R"(uprobe:$1a { 1 })", R"(
-stdin:1:1-12: ERROR: Found trailing text 'a' in positional parameter index. Try quoting the trailing text.
-uprobe:$1a { 1 }
-~~~~~~~~~~~
-stdin:1:1-18: ERROR: No attach points for probe
-uprobe:$1a { 1 }
-~~~~~~~~~~~~~~~~
+  test(bpftrace,
+       R"PROG(uprobe:$1:$2func$4 { 1 })PROG",
+       R"PROG(Program
+ uprobe:foo:barfunc
+  int: 1
+)PROG");
+
+  test_parse_failure(bpftrace, R"(uprobe:/bin/bash:$0 { 1 })", R"(
+stdin:1:1-20: ERROR: invalid trailing character for positional param: 0. Try quoting this entire part if this is intentional e.g. "$0".
+uprobe:/bin/bash:$0 { 1 }
+~~~~~~~~~~~~~~~~~~~
+stdin:1:1-26: ERROR: No attach points for probe
+uprobe:/bin/bash:$0 { 1 }
+~~~~~~~~~~~~~~~~~~~~~~~~~
 )");
 
-  test_parse_failure(bpftrace, R"(uprobe:$a { 1 })", R"(
-stdin:1:1-11: ERROR: syntax error, unexpected variable, expecting {
-uprobe:$a { 1 }
-~~~~~~~~~~
-)");
-
-  test_parse_failure(bpftrace, R"(uprobe:$-1 { 1 })", R"(
-stdin:1:1-10: ERROR: invalid character '$'
-uprobe:$-1 { 1 }
-~~~~~~~~~
-stdin:1:1-11: ERROR: syntax error, unexpected -, expecting {
-uprobe:$-1 { 1 }
-~~~~~~~~~~
+  test_parse_failure(bpftrace, R"(uprobe:/bin/bash:$a { 1 })", R"(
+stdin:1:1-20: ERROR: invalid trailing character for positional param: a. Try quoting this entire part if this is intentional e.g. "$a".
+uprobe:/bin/bash:$a { 1 }
+~~~~~~~~~~~~~~~~~~~
+stdin:1:1-26: ERROR: No attach points for probe
+uprobe:/bin/bash:$a { 1 }
+~~~~~~~~~~~~~~~~~~~~~~~~~
 )");
 
   test_parse_failure(bpftrace, R"(uprobe:$999999999999999999999999 { 1 })", R"(
-stdin:1:1-34: ERROR: param $999999999999999999999999 is out of integer range [1, 9223372036854775807]
+stdin:1:1-33: ERROR: positional param index 999999999999999999999999 is out of integer range. Max int: 9223372036854775807
 uprobe:$999999999999999999999999 { 1 }
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+stdin:1:1-39: ERROR: No attach points for probe
+uprobe:$999999999999999999999999 { 1 }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )");
 }
 


### PR DESCRIPTION
This is useful for variable targets e.g. /proc/$1/exe

Issue: https://github.com/bpftrace/bpftrace/issues/3559

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
