### PR TITLE
cleanup: simplify anonymous type plumbing

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -598,7 +598,7 @@ bool Probe::has_ap_of_probetype(ProbeType probe_type)
 
 SizedType ident_to_record(const std::string &ident, int pointer_level)
 {
-  SizedType result = CreateRecord(ident, std::weak_ptr<Struct>());
+  SizedType result = CreateRecord(ident);
   for (int i = 0; i < pointer_level; i++)
     result = CreatePointer(result);
   return result;

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -210,7 +210,7 @@ void FieldAnalyser::resolve_args(Probe &probe)
 {
   for (auto *ap : probe.attach_points) {
     // load probe arguments into a special record type "struct <probename>_args"
-    Struct probe_args;
+    std::shared_ptr<Struct> probe_args;
 
     auto probe_type = probetype(ap->provider);
     if (probe_type != ProbeType::fentry && probe_type != ProbeType::fexit &&
@@ -230,73 +230,70 @@ void FieldAnalyser::resolve_args(Probe &probe)
 
       // ... and check if they share same arguments.
 
-      Struct ap_args;
+      std::shared_ptr<Struct> ap_args;
       for (const auto &match : matches) {
         // Both uprobes and fentry have a target (binary for uprobes, kernel
         // module for fentry).
         std::string func = match;
         std::string target = util::erase_prefix(func);
-        std::optional<Struct> maybe_ap_args = std::nullopt;
         std::string err;
 
         // Trying to attach to multiple fentry. If some of them fails on
         // argument resolution, do not fail hard, just print a warning and
         // continue with other functions.
         if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit) {
-          maybe_ap_args = bpftrace_.btf_->resolve_args(
+          ap_args = bpftrace_.btf_->resolve_args(
               func, probe_type == ProbeType::fexit, true, false, err);
 
         } else if (probe_type == ProbeType::rawtracepoint) {
           for (const auto &prefix : RT_BTF_PREFIXES) {
-            maybe_ap_args = bpftrace_.btf_->resolve_args(
+            ap_args = bpftrace_.btf_->resolve_args(
                 prefix + ap->func, false, false, true, err);
-            if (maybe_ap_args.has_value()) {
+            if (ap_args != nullptr) {
               break;
             }
           }
         }
 
-        if (!maybe_ap_args.has_value()) {
+        if (!ap_args) {
           ap->addWarning() << probetypeName(probe_type) << ap->func << ": "
                            << err;
           continue;
         }
-        ap_args = std::move(*maybe_ap_args);
 
-        if (probe_args.size == -1)
+        if (!probe_args)
           probe_args = ap_args;
-        else if (ap_args != probe_args) {
+        else if (*ap_args != *probe_args) {
           ap->addError() << "Probe has attach points with mixed arguments";
           break;
         }
       }
     } else {
-      std::optional<Struct> maybe_probe_args = std::nullopt;
       std::string err;
       // Resolving args for an explicit function failed, print an error and fail
       if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit) {
-        maybe_probe_args = bpftrace_.btf_->resolve_args(
+        probe_args = bpftrace_.btf_->resolve_args(
             ap->func, probe_type == ProbeType::fexit, true, false, err);
+
       } else if (probe_type == ProbeType::rawtracepoint) {
         for (const auto &prefix : RT_BTF_PREFIXES) {
-          maybe_probe_args = bpftrace_.btf_->resolve_args(
+          probe_args = bpftrace_.btf_->resolve_args(
               prefix + ap->func, false, false, true, err);
-          if (maybe_probe_args.has_value()) {
+          if (probe_args != nullptr) {
             break;
           }
         }
       }
 
-      if (!maybe_probe_args.has_value()) {
+      if (!probe_args) {
         ap->addError() << probetypeName(probe_type) << ap->func << ": " << err;
         return;
       }
-      probe_args = std::move(*maybe_probe_args);
     }
 
     // check if we already stored arguments for this probe
     auto args = bpftrace_.structs.Lookup(probe.args_typename()).lock();
-    if (args && *args != probe_args) {
+    if (args && *args != *probe_args) {
       // we did, and it's different...trigger the error
       ap->addError() << "Probe has attach points with mixed arguments";
     } else {

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -416,28 +416,28 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
   return stype;
 }
 
-std::optional<Struct> BTF::resolve_args(const std::string &func,
-                                        bool ret,
-                                        bool check_traceable,
-                                        bool skip_first_arg,
-                                        std::string &err)
+std::shared_ptr<Struct> BTF::resolve_args(const std::string &func,
+                                          bool ret,
+                                          bool check_traceable,
+                                          bool skip_first_arg,
+                                          std::string &err)
 {
   if (!has_data()) {
     err = "BTF data not available";
-    return std::nullopt;
+    return nullptr;
   }
 
   auto func_id = find_id(func, BTF_KIND_FUNC);
   if (!func_id.btf) {
     err = "no BTF data for " + func;
-    return std::nullopt;
+    return nullptr;
   }
 
   const struct btf_type *t = btf__type_by_id(func_id.btf, func_id.id);
   t = btf__type_by_id(func_id.btf, t->type);
   if (!t || !btf_is_func_proto(t)) {
     err = func + " is not a function";
-    return std::nullopt;
+    return nullptr;
   }
 
   if (check_traceable) {
@@ -449,7 +449,7 @@ std::optional<Struct> BTF::resolve_args(const std::string &func,
         err = "function not traceable (probably it is "
               "inlined or marked as \"notrace\")";
       }
-      return std::nullopt;
+      return nullptr;
     }
   }
 
@@ -458,10 +458,10 @@ std::optional<Struct> BTF::resolve_args(const std::string &func,
   if (vlen > arch::max_arg() + 1) {
     err = "functions with more than 6 parameters are "
           "not supported.";
-    return std::nullopt;
+    return nullptr;
   }
 
-  Struct args(0, false);
+  auto args = std::make_shared<Struct>(0, false);
   int j = 0;
   int arg_idx = 0;
   __u32 type_size = 0;
@@ -473,18 +473,18 @@ std::optional<Struct> BTF::resolve_args(const std::string &func,
     const char *str = btf_str(func_id.btf, p->name_off);
     if (!str) {
       err = "failed to resolve arguments";
-      return std::nullopt;
+      return nullptr;
     }
 
     SizedType stype = get_stype(BTFId{ .btf = func_id.btf, .id = p->type });
     stype.funcarg_idx = arg_idx;
     stype.is_funcarg = true;
-    args.AddField(str, stype, args.size, std::nullopt, false);
+    args->AddField(str, stype, args->size, std::nullopt, false);
     // fentry args are stored in a u64 array.
     // Note that it's ok to represent them by a struct as we will use GEP with
     // funcarg_idx to access them in codegen.
     type_size = btf__resolve_size(func_id.btf, p->type);
-    args.size += type_size;
+    args->size += type_size;
     arg_idx += std::ceil(static_cast<float>(type_size) / static_cast<float>(8));
   }
 
@@ -492,9 +492,9 @@ std::optional<Struct> BTF::resolve_args(const std::string &func,
     SizedType stype = get_stype(BTFId{ .btf = func_id.btf, .id = t->type });
     stype.funcarg_idx = arg_idx;
     stype.is_funcarg = true;
-    args.AddField(RETVAL_FIELD_NAME, stype, args.size, std::nullopt, false);
+    args->AddField(RETVAL_FIELD_NAME, stype, args->size, std::nullopt, false);
     // fentry args (incl. retval) are stored in a u64 array
-    args.size += btf__resolve_size(func_id.btf, t->type);
+    args->size += btf__resolve_size(func_id.btf, t->type);
   }
   return args;
 }
@@ -823,7 +823,7 @@ void BTF::resolve_fields(SizedType &type)
   if (!type_id.btf)
     return;
 
-  resolve_fields(type_id, record.get(), 0);
+  resolve_fields(type_id, std::move(record), 0);
 }
 
 static std::optional<Bitfield> resolve_bitfield(
@@ -839,7 +839,7 @@ static std::optional<Bitfield> resolve_bitfield(
 }
 
 void BTF::resolve_fields(const BTFId &type_id,
-                         Struct *record,
+                         std::shared_ptr<Struct> record,
                          __u32 start_offset)
 {
   const auto *btf_type = btf__type_by_id(type_id.btf, type_id.id);

--- a/src/btf.h
+++ b/src/btf.h
@@ -92,11 +92,11 @@ public:
   std::map<std::string, std::vector<std::string>> get_params(
       const std::set<std::string>& funcs) const;
 
-  std::optional<Struct> resolve_args(const std::string& func,
-                                     bool ret,
-                                     bool check_traceable,
-                                     bool skip_first_arg,
-                                     std::string& err);
+  std::shared_ptr<Struct> resolve_args(const std::string& func,
+                                       bool ret,
+                                       bool check_traceable,
+                                       bool skip_first_arg,
+                                       std::string& err);
   void resolve_fields(SizedType& type);
 
   int get_btf_id(std::string_view func,
@@ -106,7 +106,9 @@ public:
 private:
   void load_kernel_btfs(const std::set<std::string>& modules);
   SizedType get_stype(const BTFId& btf_id, bool resolve_structs = true);
-  void resolve_fields(const BTFId& type_id, Struct* record, __u32 start_offset);
+  void resolve_fields(const BTFId& type_id,
+                      std::shared_ptr<Struct> record,
+                      __u32 start_offset);
   const struct btf_type* btf_type_skip_modifiers(const struct btf_type* t,
                                                  const struct btf* btf);
   BTF::BTFId find_id(const std::string& name,

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -536,8 +536,7 @@ bool ClangParser::visit_children(CXCursor &cursor, BPFtrace &bpftrace)
           // No need to worry about redefined types b/c we should have already
           // checked clang diagnostics. The diagnostics will tell us if we have
           // duplicated types.
-          structs.Lookup(ptypestr).lock()->AddField(
-              ident, sized_type, offset, bitfield, is_data_loc);
+          str->AddField(ident, sized_type, offset, bitfield, is_data_loc);
         }
 
         return CXChildVisit_Recurse;

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1040,8 +1040,8 @@ TEST(bpftrace, sort_by_key_int_int)
 {
   StrictMock<MockBPFtrace> bpftrace;
 
-  SizedType key = CreateTuple(bpftrace.structs.AddTuple(
-      { CreateInt64(), CreateInt64(), CreateInt64() }));
+  SizedType key = CreateTuple(
+      Struct::CreateTuple({ CreateInt64(), CreateInt64(), CreateInt64() }));
 
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
       values_by_key = {
@@ -1091,9 +1091,9 @@ TEST(bpftrace, sort_by_key_str_str)
   StrictMock<MockBPFtrace> bpftrace;
 
   SizedType key = CreateTuple(
-      bpftrace.structs.AddTuple({ CreateString(STRING_SIZE),
-                                  CreateString(STRING_SIZE),
-                                  CreateString(STRING_SIZE) }));
+      Struct::CreateTuple({ CreateString(STRING_SIZE),
+                            CreateString(STRING_SIZE),
+                            CreateString(STRING_SIZE) }));
 
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
       values_by_key = {
@@ -1124,7 +1124,7 @@ TEST(bpftrace, sort_by_key_int_str)
   StrictMock<MockBPFtrace> bpftrace;
 
   SizedType key = CreateTuple(
-      bpftrace.structs.AddTuple({ CreateUInt64(), CreateString(STRING_SIZE) }));
+      Struct::CreateTuple({ CreateUInt64(), CreateString(STRING_SIZE) }));
 
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
       values_by_key = {

--- a/tests/function_registry.cpp
+++ b/tests/function_registry.cpp
@@ -79,7 +79,7 @@ protected:
         CreateNone(),
         {
             Param{ "a",
-                   CreateTuple(structs_.AddTuple(
+                   CreateTuple(Struct::CreateTuple(
                        { CreateInt32(), CreateString(64) })) },
         });
 
@@ -267,11 +267,11 @@ TEST_F(TestFunctionRegistryPopulated, unique_string)
 TEST_F(TestFunctionRegistryPopulated, unique_tuple)
 {
   auto tuple1 = CreateTuple(
-      structs_.AddTuple({ CreateInt16(), CreateString(64) }));
+      Struct::CreateTuple({ CreateInt16(), CreateString(64) }));
   auto tuple2 = CreateTuple(
-      structs_.AddTuple({ CreateInt32(), CreateString(64) }));
+      Struct::CreateTuple({ CreateInt32(), CreateString(64) }));
   auto tuple3 = CreateTuple(
-      structs_.AddTuple({ CreateInt64(), CreateString(64) }));
+      Struct::CreateTuple({ CreateInt64(), CreateString(64) }));
 
   test("unique_tuple", { tuple1 }, unique_tuple_);
   test("unique_tuple", { tuple2 }, unique_tuple_);
@@ -292,7 +292,7 @@ HINT: Candidate function:
 
 TEST_F(TestFunctionRegistryPopulated, unique_struct)
 {
-  auto exact_struct = structs_.Lookup("unique_struct_arg");
+  auto exact_struct = structs_.Lookup("unique_struct_arg").lock();
 
   auto compatible_struct =
       structs_.Add("same_layout_as_unique_struct_arg", 8).lock();

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3638,7 +3638,7 @@ TEST(semantic_analyser, tuple_assign_var)
 {
   BPFtrace bpftrace;
   SizedType ty = CreateTuple(
-      bpftrace.structs.AddTuple({ CreateInt64(), CreateString(6) }));
+      Struct::CreateTuple({ CreateInt64(), CreateString(6) }));
   auto ast = test(
       bpftrace, true, R"_(BEGIN { $t = (1, "str"); $t = (4, "other"); })_", 0);
 
@@ -3665,13 +3665,13 @@ TEST(semantic_analyser, tuple_assign_map)
 
   // $t = (1, 3, 3, 7);
   auto *assignment = static_cast<ast::AssignMapStatement *>(stmts.at(0));
-  ty = CreateTuple(bpftrace.structs.AddTuple(
+  ty = CreateTuple(Struct::CreateTuple(
       { CreateInt64(), CreateInt64(), CreateInt64(), CreateInt64() }));
   EXPECT_EQ(ty, assignment->map->type);
 
   // $t = (0, 0, 0, 0);
   assignment = static_cast<ast::AssignMapStatement *>(stmts.at(1));
-  ty = CreateTuple(bpftrace.structs.AddTuple(
+  ty = CreateTuple(Struct::CreateTuple(
       { CreateInt64(), CreateInt64(), CreateInt64(), CreateInt64() }));
   EXPECT_EQ(ty, assignment->map->type);
 }
@@ -3681,9 +3681,8 @@ TEST(semantic_analyser, tuple_nested)
 {
   BPFtrace bpftrace;
   SizedType ty_inner = CreateTuple(
-      bpftrace.structs.AddTuple({ CreateInt64(), CreateInt64() }));
-  SizedType ty = CreateTuple(
-      bpftrace.structs.AddTuple({ CreateInt64(), ty_inner }));
+      Struct::CreateTuple({ CreateInt64(), CreateInt64() }));
+  SizedType ty = CreateTuple(Struct::CreateTuple({ CreateInt64(), ty_inner }));
   auto ast = test(bpftrace, true, R"_(BEGIN { $t = (1,(1,2)); })_", 0);
 
   auto &stmts = ast.root->probes.at(0)->block->stmts;
@@ -3691,14 +3690,6 @@ TEST(semantic_analyser, tuple_nested)
   // $t = (1, "str");
   auto *assignment = static_cast<ast::AssignVarStatement *>(stmts.at(0));
   EXPECT_EQ(ty, assignment->var->type);
-}
-
-TEST(semantic_analyser, tuple_types_unique)
-{
-  auto bpftrace = get_mock_bpftrace();
-  test(*bpftrace, R"_(BEGIN { $t = (1, "hello"); $t = (4, "other"); })_");
-
-  EXPECT_EQ(bpftrace->structs.GetTuplesCnt(), 1UL);
 }
 
 TEST(semantic_analyser, multi_pass_type_inference_zero_size_int)

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -34,12 +34,11 @@ TEST(types, to_str)
 
   EXPECT_EQ(to_str(CreateArray(2, CreateInt8())), "int8[2]");
 
-  auto record = std::weak_ptr<Struct>();
-  EXPECT_EQ(to_str(CreateRecord("hello", record)), "hello");
+  EXPECT_EQ(to_str(CreateRecord("hello")), "hello");
 
   std::shared_ptr<Struct> tuple = Struct::CreateTuple(
       { CreateInt8(), CreateString(10) });
-  EXPECT_EQ(to_str(CreateTuple(tuple)), "(int8,string[10])");
+  EXPECT_EQ(to_str(CreateTuple(std::move(tuple))), "(int8,string[10])");
 
   EXPECT_EQ(to_str(CreateSum(true)), "sum_t");
   EXPECT_EQ(to_str(CreateSum(false)), "usum_t");


### PR DESCRIPTION
Stacked PRs:
 * #3962
 * #3960
 * #3959
 * #3958
 * __->__#3957
 * #3961


--- --- ---

### cleanup: simplify anonymous type plumbing


Currently, a `weak_ptr` is used for type references internally. The
canonical ownership rests with the `StructManager`. This works well
enough for types that may be recursively-defined, e.g. those that
include pointers to themselves.

For anonymous types, this adds additional complexity without much
benefit. Primarily, there are two issues this commit aims to address:

* The anonymous types must be dedupped and stored centrally, even though
  they are not addressable. Although this may seem useful, in order to
  do this dedupping the objects need to be fully allocated and
  constructed anyways (and then compared against the others in the set),
  so there is actually *extra* work. A small amout of memory may be
  saved, but unreferenced anonymous types can also pile up in the
  central registry (because these tend to go through adjustment, based
  on string sizes, etc.).

* The ambiguity around the validity of `weak_ptr` leaks out from the
  SizedType and into other code.

For simplicity, the `StructManager` will continue to return `weak_ptr`
objects, but hide the details of ownership inside the `SizedType`.
Anonymous types are owned directly and will be freed directly, with the
pointers owned by `SizedType`. The methods on `SizedType` return
`std::shared_ptr` for clarity and convenience. There is no possibility
of cycles, because there is no way to look up a reference to an
anonymous type.

Signed-off-by: Adin Scannell <amscanne@meta.com>
