### PR TITLE
cleanup: simplify AST by introducing `PositionalParameterCount`

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -40,11 +40,15 @@ Identifier::Identifier(Diagnostics &d, std::string ident, Location &&loc)
 {
 }
 
-PositionalParameter::PositionalParameter(Diagnostics &d,
-                                         PositionalParameterType ptype,
-                                         long n,
-                                         Location &&loc)
-    : Expression(d, std::move(loc)), ptype(ptype), n(n)
+PositionalParameter::PositionalParameter(Diagnostics &d, long n, Location &&loc)
+    : Expression(d, std::move(loc)), n(n)
+{
+  is_literal = true;
+}
+
+PositionalParameterCount::PositionalParameterCount(Diagnostics &d,
+                                                   Location &&loc)
+    : Expression(d, std::move(loc))
 {
   is_literal = true;
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -131,14 +131,15 @@ public:
 
 class PositionalParameter : public Expression {
 public:
-  explicit PositionalParameter(Diagnostics &d,
-                               PositionalParameterType ptype,
-                               long n,
-                               Location &&loc);
+  explicit PositionalParameter(Diagnostics &d, long n, Location &&loc);
 
-  PositionalParameterType ptype;
   long n;
   bool is_in_str = false;
+};
+
+class PositionalParameterCount : public Expression {
+public:
+  explicit PositionalParameterCount(Diagnostics &d, Location &&loc);
 };
 
 class String : public Expression {

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -32,17 +32,13 @@ void Printer::visit(Integer &integer)
 void Printer::visit(PositionalParameter &param)
 {
   std::string indent(depth_, ' ');
+  out_ << indent << "param: $" << param.n << type(param.type) << std::endl;
+}
 
-  switch (param.ptype) {
-    case PositionalParameterType::positional:
-      out_ << indent << "param: $" << param.n << type(param.type) << std::endl;
-      break;
-    case PositionalParameterType::count:
-      out_ << indent << "param: $#" << type(param.type) << std::endl;
-      break;
-    default:
-      break;
-  }
+void Printer::visit(PositionalParameterCount &param)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "param: $#" << type(param.type) << std::endl;
 }
 
 void Printer::visit(String &string)

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -15,6 +15,7 @@ public:
   using Visitor<Printer>::visit;
   void visit(Integer &integer);
   void visit(PositionalParameter &param);
+  void visit(PositionalParameterCount &param);
   void visit(String &string);
   void visit(StackMode &mode);
   void visit(Identifier &identifier);

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -40,7 +40,11 @@ public:
   {
     return default_value();
   }
-  R visit(PositionalParameter &integer __attribute__((__unused__)))
+  R visit(PositionalParameter &param __attribute__((__unused__)))
+  {
+    return default_value();
+  }
+  R visit(PositionalParameterCount &param __attribute__((__unused__)))
   {
     return default_value();
   }
@@ -324,6 +328,7 @@ public:
     return tryVisitAndReplace<Expression,
                               Integer *,
                               PositionalParameter *,
+                              PositionalParameterCount *,
                               String *,
                               StackMode *,
                               Identifier *,

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1885,21 +1885,20 @@ std::optional<int64_t> BPFtrace::get_int_literal(
       return integer->n;
     else if (const auto *pos_param =
                  dynamic_cast<const ast::PositionalParameter *>(expr)) {
-      if (pos_param->ptype == PositionalParameterType::positional) {
-        auto param_str = get_param(pos_param->n, false);
-        auto param_int = util::get_int_from_str(param_str);
-        if (!param_int.has_value()) {
-          // This case has to be handled at a higher layer, and it is also
-          // duplicated exactly in the semantic analyzer.
-          return std::nullopt;
-        }
-        if (std::holds_alternative<int64_t>(*param_int)) {
-          return std::get<int64_t>(*param_int);
-        } else {
-          return static_cast<int64_t>(std::get<uint64_t>(*param_int));
-        }
-      } else
-        return static_cast<int64_t>(num_params());
+      auto param_str = get_param(pos_param->n, false);
+      auto param_int = util::get_int_from_str(param_str);
+      if (!param_int.has_value()) {
+        // This case has to be handled at a higher layer, and it is also
+        // duplicated exactly in the semantic analyzer.
+        return std::nullopt;
+      }
+      if (std::holds_alternative<int64_t>(*param_int)) {
+        return std::get<int64_t>(*param_int);
+      } else {
+        return static_cast<int64_t>(std::get<uint64_t>(*param_int));
+      }
+    } else {
+      return static_cast<int64_t>(num_params());
     }
   }
 

--- a/src/types.h
+++ b/src/types.h
@@ -698,8 +698,6 @@ enum class AsyncAction {
 
 uint64_t asyncactionint(AsyncAction a);
 
-enum class PositionalParameterType { positional, count };
-
 namespace globalvars {
 
 enum class GlobalVar {


### PR DESCRIPTION
Stacked PRs:
 * #3962
 * #3960
 * #3959
 * #3958
 * #3964
 * __->__#3961


--- --- ---

### cleanup: simplify AST by introducing `PositionalParameterCount`


The current class is essentially a switch on the type, which fails to
capture the value of having different types and a structured visitor.
The code structure is simplified by using a proper type for this case.

Signed-off-by: Adin Scannell <amscanne@meta.com>
