### PR TITLE
util: move `operator<<` for `llvm::Error` into llvm namespace

### DIFF
--- a/src/util/result.cpp
+++ b/src/util/result.cpp
@@ -2,7 +2,7 @@
 
 #include "util/result.h"
 
-namespace bpftrace {
+namespace llvm {
 
 std::ostream& operator<<(std::ostream& out, const llvm::Error& err)
 {
@@ -12,4 +12,4 @@ std::ostream& operator<<(std::ostream& out, const llvm::Error& err)
   return out;
 }
 
-} // namespace bpftrace
+} // namespace llvm

--- a/src/util/result.h
+++ b/src/util/result.h
@@ -60,10 +60,6 @@ public:
   }
 };
 
-// LLVM has its own set of stream classes and wrappers. Provide a simple
-// wrapper that supports `std::ostream` for convenience.
-std::ostream& operator<<(std::ostream& out, const llvm::Error& err);
-
 // All errors are constructed using `make_error<...>` with the error class.
 template <typename E, typename... Ts>
 auto make_error(Ts... args)
@@ -115,3 +111,11 @@ Result<> handleErrors(Result<T>&& ok, Ts&&... args)
 }
 
 }; // namespace bpftrace
+
+namespace llvm {
+
+// LLVM has its own set of stream classes and wrappers. Provide a simple
+// wrapper that supports `std::ostream` for convenience.
+std::ostream& operator<<(std::ostream& out, const Error& err);
+
+} // namespace llvm


### PR DESCRIPTION
The resolution rules for `operator<<` means that it needs to be either in the same namespace as the user or in the same namespace as the type in order to be found reliably. We can simply put this into the `llvm` namespace.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
