### PR TITLE
Fix double arg listing for rawtracepoints

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -656,7 +656,7 @@ std::map<std::string, std::vector<std::string>> BTF::get_params_from_btf(
       func_name = btf_obj.name + ":" + str;
     }
 
-    if (!funcs.contains(func_name))
+    if (!funcs.contains(func_name) || params.contains(func_name))
       continue;
 
     t = btf__type_by_id(btf_obj.btf, t->type);
@@ -684,7 +684,7 @@ std::map<std::string, std::vector<std::string>> BTF::get_params_from_btf(
       params[func_name].push_back(type + " " + arg_name);
     }
 
-    if (!t->type)
+    if (!t->type || is_raw_tracepoint)
       continue;
 
     // set by dump_printf callback

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -443,8 +443,6 @@ FuncParamLists ProbeMatcher::get_rawtracepoint_params(
 {
   FuncParamLists params = bpftrace_->btf_->get_params(raw_tps, true);
   for (auto rt : raw_tps) {
-    // delete `int retval`
-    params[rt].pop_back();
     // delete `void *`
     params[rt].erase(params[rt].begin());
   }

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -63,6 +63,16 @@ EXPECT_REGEX [ ]+[a-zA-Z_\*\s]+
 REQUIRES_FEATURE btf
 TIMEOUT 1
 
+# The BTF FUNC_PROTOs for rawtracepoint params have an unnecessary initial
+# void * and a retval that can't be used so make sure they are not
+# included in the listing output
+NAME it doesn't list the first rawtracepoint param or retval
+RUN {{BPFTRACE}} -lv "rawtracepoint:consume_skb"
+EXPECT_NONE void * __data
+EXPECT_NONE int retval
+REQUIRES_FEATURE btf
+TIMEOUT 1
+
 NAME it lists fentry params
 RUN {{BPFTRACE}} -lv "fentry:*"
 EXPECT_REGEX [ ]+[a-zA-Z_\*\s]+


### PR DESCRIPTION
Because we're checking two FUNC_PROTO prefixes
for rawtracepoints, we need to make sure we only
use one. So check for duplicates when getting BTF
params.

Before:
```
rawtracepoint:vmlinux:consume_skb
  struct sk_buff * skb
  void * location
  void * __data
  struct sk_buff * skb
  void * location
  int retval
```

After:
```
rawtracepoint:vmlinux:consume_skb
  struct sk_buff * skb
  void * location
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
