### PR TITLE
BTF cleanup

### DIFF
--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -28,7 +28,6 @@ inline std::vector<Pass> AllParsePasses(
   // set during the clang parse to expand identifiers within the lexer.
   passes.emplace_back(CreateParsePass());
   passes.emplace_back(CreateParseAttachpointsPass());
-  passes.emplace_back(CreateParseBTFPass());
   return passes;
 }
 

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -48,8 +48,7 @@ BTF::BTF(const std::set<std::string> &modules)
   // Try to get BTF file from BPFTRACE_BTF env
   char *path = std::getenv("BPFTRACE_BTF");
   if (path) {
-    btf_objects.push_back(
-        BTFObj{ .btf = btf__parse_raw(path), .id = 0, .name = "" });
+    btf_objects.push_back(BTFObj{ .btf = btf__parse_raw(path), .name = "" });
     vmlinux_btf = btf_objects.back().btf;
     if (!vmlinux_btf) {
       LOG(WARNING) << "BTF: failed to parse BTF from " << path;
@@ -81,8 +80,7 @@ void BTF::load_kernel_btfs(const std::set<std::string> &modules)
     LOG(V1) << "BTF: failed to find BTF data for vmlinux: " << strerror(errno);
     return;
   }
-  btf_objects.push_back(
-      BTFObj{ .btf = vmlinux_btf, .id = 0, .name = "vmlinux" });
+  btf_objects.push_back(BTFObj{ .btf = vmlinux_btf, .name = "vmlinux" });
 
   if (bpftrace_ && !bpftrace_->feature_->has_module_btf())
     return;
@@ -124,12 +122,9 @@ void BTF::load_kernel_btfs(const std::set<std::string> &modules)
     if (!info.kernel_btf)
       continue;
 
-    if (mod_name == "vmlinux") {
-      btf_objects.front().id = id;
-    } else if (modules.contains(mod_name)) {
+    if (modules.contains(mod_name)) {
       btf_objects.push_back(
           BTFObj{ .btf = btf__load_from_kernel_by_id_split(id, vmlinux_btf),
-                  .id = id,
                   .name = mod_name });
     }
   }

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -611,7 +611,7 @@ std::unique_ptr<std::istream> BTF::get_all_raw_tracepoints() const
   return funcs;
 }
 
-std::map<std::string, std::vector<std::string>> BTF::get_params_from_btf(
+FuncParamLists BTF::get_params_from_btf(
     const BTFObj &btf_obj,
     const std::set<std::string> &funcs) const
 {
@@ -629,7 +629,7 @@ std::map<std::string, std::vector<std::string>> BTF::get_params_from_btf(
     return {};
   }
 
-  std::map<std::string, std::vector<std::string>> params;
+  FuncParamLists params;
   for (id = start_id(btf_obj.btf); id <= max; id++) {
     const struct btf_type *t = btf__type_by_id(btf_obj.btf, id);
 
@@ -693,10 +693,9 @@ std::map<std::string, std::vector<std::string>> BTF::get_params_from_btf(
   return params;
 }
 
-std::map<std::string, std::vector<std::string>> BTF::
-    get_raw_tracepoints_params_from_btf(
-        const BTFObj &btf_obj,
-        const std::set<std::string> &rawtracepoints) const
+FuncParamLists BTF::get_raw_tracepoints_params_from_btf(
+    const BTFObj &btf_obj,
+    const std::set<std::string> &rawtracepoints) const
 {
   __s32 id, max = static_cast<__s32>(type_cnt(btf_obj.btf));
   std::string type = std::string("");
@@ -712,7 +711,7 @@ std::map<std::string, std::vector<std::string>> BTF::
     return {};
   }
 
-  std::map<std::string, std::vector<std::string>> params;
+  FuncParamLists params;
   for (id = start_id(btf_obj.btf); id <= max; id++) {
     const struct btf_type *t = btf__type_by_id(btf_obj.btf, id);
 
@@ -775,11 +774,10 @@ std::map<std::string, std::vector<std::string>> BTF::
   return params;
 }
 
-std::map<std::string, std::vector<std::string>> BTF::get_params_impl(
-    const std::set<std::string> &funcs,
-    bool is_rawtracepoints) const
+FuncParamLists BTF::get_params_impl(const std::set<std::string> &funcs,
+                                    bool is_rawtracepoints) const
 {
-  std::map<std::string, std::vector<std::string>> params;
+  FuncParamLists params;
   auto all_resolved = [&params](const std::string &f) {
     return params.contains(f);
   };
@@ -797,13 +795,12 @@ std::map<std::string, std::vector<std::string>> BTF::get_params_impl(
   return params;
 }
 
-std::map<std::string, std::vector<std::string>> BTF::get_params(
-    const std::set<std::string> &funcs) const
+FuncParamLists BTF::get_params(const std::set<std::string> &funcs) const
 {
   return get_params_impl(funcs, false);
 }
 
-std::map<std::string, std::vector<std::string>> BTF::get_rawtracepoint_params(
+FuncParamLists BTF::get_rawtracepoint_params(
     const std::set<std::string> &rawtracepoints) const
 {
   return get_params_impl(rawtracepoints, true);

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -546,12 +546,14 @@ std::string BTF::get_all_funcs_from_btf(const BTFObj &btf_obj) const
   return funcs;
 }
 
-std::unique_ptr<std::istream> BTF::get_all_funcs() const
+std::unique_ptr<std::istream> BTF::get_all_funcs()
 {
-  auto funcs = std::make_unique<std::stringstream>();
+  if (!all_funcs_.empty()) {
+    return std::make_unique<std::stringstream>(all_funcs_);
+  }
   for (const auto &btf_obj : btf_objects)
-    *funcs << get_all_funcs_from_btf(btf_obj);
-  return funcs;
+    all_funcs_ += get_all_funcs_from_btf(btf_obj);
+  return std::make_unique<std::stringstream>(all_funcs_);
 }
 
 std::string BTF::get_all_raw_tracepoints_from_btf(const BTFObj &btf_obj) const
@@ -603,12 +605,14 @@ std::string BTF::get_all_raw_tracepoints_from_btf(const BTFObj &btf_obj) const
   return funcs;
 }
 
-std::unique_ptr<std::istream> BTF::get_all_raw_tracepoints() const
+std::unique_ptr<std::istream> BTF::get_all_raw_tracepoints()
 {
-  auto funcs = std::make_unique<std::stringstream>();
+  if (!all_rawtracepoints_.empty()) {
+    return std::make_unique<std::stringstream>(all_rawtracepoints_);
+  }
   for (const auto &btf_obj : btf_objects)
-    *funcs << get_all_raw_tracepoints_from_btf(btf_obj);
-  return funcs;
+    all_rawtracepoints_ += get_all_raw_tracepoints_from_btf(btf_obj);
+  return std::make_unique<std::stringstream>(all_rawtracepoints_);
 }
 
 FuncParamLists BTF::get_params_from_btf(

--- a/src/btf.h
+++ b/src/btf.h
@@ -47,6 +47,8 @@ static const std::vector<std::string> RT_BTF_PREFIXES = { "__probestub_",
 
 class BPFtrace;
 
+using FuncParamLists = std::map<std::string, std::vector<std::string>>;
+
 class BTF {
   enum state {
     NODATA,
@@ -91,9 +93,8 @@ public:
   std::unique_ptr<std::istream> get_all_funcs() const;
   std::unordered_set<std::string> get_all_iters() const;
   std::unique_ptr<std::istream> get_all_raw_tracepoints() const;
-  std::map<std::string, std::vector<std::string>> get_params(
-      const std::set<std::string>& funcs) const;
-  std::map<std::string, std::vector<std::string>> get_rawtracepoint_params(
+  FuncParamLists get_params(const std::set<std::string>& funcs) const;
+  FuncParamLists get_rawtracepoint_params(
       const std::set<std::string>& rawtracepoints) const;
 
   std::optional<Struct> resolve_args(const std::string& func,
@@ -125,13 +126,11 @@ private:
                                  std::unordered_set<std::string>& types) const;
   std::string get_all_funcs_from_btf(const BTFObj& btf_obj) const;
   std::string get_all_raw_tracepoints_from_btf(const BTFObj& btf_obj) const;
-  std::map<std::string, std::vector<std::string>> get_params_impl(
-      const std::set<std::string>& funcs,
-      bool is_rawtracepoints) const;
-  std::map<std::string, std::vector<std::string>> get_params_from_btf(
-      const BTFObj& btf_obj,
-      const std::set<std::string>& funcs) const;
-  std::map<std::string, std::vector<std::string>> get_raw_tracepoints_params_from_btf(
+  FuncParamLists get_params_impl(const std::set<std::string>& funcs,
+                                 bool is_rawtracepoints) const;
+  FuncParamLists get_params_from_btf(const BTFObj& btf_obj,
+                                     const std::set<std::string>& funcs) const;
+  FuncParamLists get_raw_tracepoints_params_from_btf(
       const BTFObj& btf_obj,
       const std::set<std::string>& rawtracepoints) const;
   std::set<std::string> get_all_structs_from_btf(const struct btf* btf) const;

--- a/src/btf.h
+++ b/src/btf.h
@@ -90,9 +90,9 @@ public:
   SizedType get_var_type(const std::string& var_name);
 
   std::set<std::string> get_all_structs() const;
-  std::unique_ptr<std::istream> get_all_funcs() const;
+  std::unique_ptr<std::istream> get_all_funcs();
   std::unordered_set<std::string> get_all_iters() const;
-  std::unique_ptr<std::istream> get_all_raw_tracepoints() const;
+  std::unique_ptr<std::istream> get_all_raw_tracepoints();
   FuncParamLists get_params(const std::set<std::string>& funcs) const;
   FuncParamLists get_rawtracepoint_params(
       const std::set<std::string>& rawtracepoints) const;
@@ -150,6 +150,8 @@ private:
   std::vector<BTFObj> btf_objects;
   enum state state = NODATA;
   BPFtrace* bpftrace_ = nullptr;
+  std::string all_funcs_;
+  std::string all_rawtracepoints_;
 };
 
 inline bool BTF::has_data() const

--- a/src/btf.h
+++ b/src/btf.h
@@ -125,8 +125,11 @@ private:
                                  std::unordered_set<std::string>& types) const;
   std::string get_all_funcs_from_btf(const BTFObj& btf_obj) const;
   std::string get_all_raw_tracepoints_from_btf(const BTFObj& btf_obj) const;
-  FuncParamLists get_params_impl(const std::set<std::string>& funcs,
-                                 bool is_rawtracepoints) const;
+  FuncParamLists get_params_impl(
+      const std::set<std::string>& funcs,
+      std::function<FuncParamLists(const BTFObj& btf_obj,
+                                   const std::set<std::string>& funcs)>
+          get_param_btf_cb) const;
   FuncParamLists get_params_from_btf(const BTFObj& btf_obj,
                                      const std::set<std::string>& funcs) const;
   FuncParamLists get_raw_tracepoints_params_from_btf(

--- a/src/btf.h
+++ b/src/btf.h
@@ -92,8 +92,9 @@ public:
   std::unordered_set<std::string> get_all_iters() const;
   std::unique_ptr<std::istream> get_all_raw_tracepoints() const;
   std::map<std::string, std::vector<std::string>> get_params(
-      const std::set<std::string>& funcs,
-      bool is_raw_tracepoint = false) const;
+      const std::set<std::string>& funcs) const;
+  std::map<std::string, std::vector<std::string>> get_rawtracepoint_params(
+      const std::set<std::string>& rawtracepoints) const;
 
   std::optional<Struct> resolve_args(const std::string& func,
                                      bool ret,
@@ -124,10 +125,15 @@ private:
                                  std::unordered_set<std::string>& types) const;
   std::string get_all_funcs_from_btf(const BTFObj& btf_obj) const;
   std::string get_all_raw_tracepoints_from_btf(const BTFObj& btf_obj) const;
+  std::map<std::string, std::vector<std::string>> get_params_impl(
+      const std::set<std::string>& funcs,
+      bool is_rawtracepoints) const;
   std::map<std::string, std::vector<std::string>> get_params_from_btf(
       const BTFObj& btf_obj,
-      const std::set<std::string>& funcs,
-      bool is_raw_tracepoint) const;
+      const std::set<std::string>& funcs) const;
+  std::map<std::string, std::vector<std::string>> get_raw_tracepoints_params_from_btf(
+      const BTFObj& btf_obj,
+      const std::set<std::string>& rawtracepoints) const;
   std::set<std::string> get_all_structs_from_btf(const struct btf* btf) const;
   std::unordered_set<std::string> get_all_iters_from_btf(
       const struct btf* btf) const;

--- a/src/btf.h
+++ b/src/btf.h
@@ -59,7 +59,6 @@ class BTF {
   // We're currently storing its name and BTF id.
   struct BTFObj {
     struct btf* btf;
-    __u32 id;
     std::string name;
   };
 

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -438,17 +438,6 @@ FuncParamLists ProbeMatcher::get_iters_params(
   return params;
 }
 
-FuncParamLists ProbeMatcher::get_rawtracepoint_params(
-    const std::set<std::string>& raw_tps)
-{
-  FuncParamLists params = bpftrace_->btf_->get_params(raw_tps, true);
-  for (auto rt : raw_tps) {
-    // delete `void *`
-    params[rt].erase(params[rt].begin());
-  }
-  return params;
-}
-
 FuncParamLists ProbeMatcher::get_uprobe_params(
     const std::set<std::string>& uprobes)
 {
@@ -485,7 +474,7 @@ void ProbeMatcher::list_probes(ast::Program* prog)
                  probe_type == ProbeType::fexit)
           param_lists = bpftrace_->btf_->get_params(matches);
         else if (probe_type == ProbeType::rawtracepoint)
-          param_lists = get_rawtracepoint_params(matches);
+          param_lists = bpftrace_->btf_->get_rawtracepoint_params(matches);
         else if (probe_type == ProbeType::iter)
           param_lists = get_iters_params(matches);
         else if (probe_type == ProbeType::uprobe)

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -4,6 +4,7 @@
 #include <set>
 
 #include "ast/ast.h"
+#include "btf.h"
 
 namespace bpftrace {
 
@@ -48,8 +49,6 @@ const std::unordered_set<std::string> TIME_UNITS = { "s", "ms", "us", "hz" };
 const std::unordered_set<std::string> SIGNALS = { "SIGUSR1" };
 
 class BPFtrace;
-
-using FuncParamLists = std::map<std::string, std::vector<std::string>>;
 
 class ProbeMatcher {
 public:

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -111,6 +111,5 @@ private:
 
   FuncParamLists get_iters_params(const std::set<std::string> &iters);
   FuncParamLists get_uprobe_params(const std::set<std::string> &uprobes);
-  FuncParamLists get_rawtracepoint_params(const std::set<std::string> &raw_tps);
 };
 } // namespace bpftrace


### PR DESCRIPTION
Combination of 7 clean-up commits.

- [Clean up get_params APIs in BTF class](https://github.com/bpftrace/bpftrace/pull/3967/commits/0251759d3a9e5b8fa930214304dfa238a2327152)
- [Reuse FuncParamLists alias in BTF class](https://github.com/bpftrace/bpftrace/pull/3967/commits/81cde5475038d70c335d3a9584bba48a506f8145)
- [Add helpful comment in get_matches_for_probetype](https://github.com/bpftrace/bpftrace/pull/3967/commits/a78ecaf4fa24511af66ede73cc54f4607b8bc2d7)
- [[BTF] cache calls to get_all funcs](https://github.com/bpftrace/bpftrace/pull/3967/commits/50844e2cca81b39fa03bf63bea1419302508d98b)
- [Don't re-parse BTF](https://github.com/bpftrace/bpftrace/pull/3967/commits/0014d53a434a00bb206bd1fa7189ebc73129a8a0)
- [Remove unused 'id' field from BTFObj](https://github.com/bpftrace/bpftrace/pull/3967/commits/8d815ccb9126603f2814817aca4d801e237193e7)
- [Pass callback to get_params_impl instead of bool](https://github.com/bpftrace/bpftrace/pull/3967/commits/b410d089346748c54748ac9885fd60e853636fd3)

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
