### PR TITLE
nix: fix references to incorrect versions of clang

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -146,7 +146,7 @@
 
                 nativeBuildInputs = [
                   pkgs.bison
-                  pkgs.clang
+                  pkgs."llvmPackages_${toString llvmVersion}".clang
                   pkgs.cmake
                   pkgs.flex
                   pkgs.gcc
@@ -188,9 +188,12 @@
               };
 
           # Define lambda that returns a devShell derivation with extra test-required packages
-          # given the bpftrace package derivation as input
+          # given the bpftrace LLVM version as input
           mkBpftraceDevShell =
-            pkg:
+            llvmVersion:
+            let
+              pkg = self.packages.${system}."bpftrace-llvm${toString llvmVersion}";
+            in
               with pkgs;
               pkgs.mkShell {
                 buildInputs = [
@@ -198,7 +201,7 @@
                   binutils
                   bpftools
                   coreutils
-                  clang-tools  # Needed for the nix-aware "wrapped" clang-tidy
+                  pkgs."llvmPackages_${toString llvmVersion}".clang-tools # Needed for the nix-aware "wrapped" clang-tidy
                   gawk
                   git
                   gnugrep
@@ -206,7 +209,7 @@
                   iproute2
                   kmod
                   # For git-clang-format
-                  libclang.python
+                  pkgs."llvmPackages_${toString llvmVersion}".libclang.python
                   nftables
                   procps
                   python3
@@ -318,11 +321,11 @@
           devShells = rec {
             default = self.devShells.${system}."bpftrace-llvm${toString defaultLlvmVersion}";
 
-            bpftrace-llvm20 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm20;
-            bpftrace-llvm19 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm19;
-            bpftrace-llvm18 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm18;
-            bpftrace-llvm17 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm17;
-            bpftrace-llvm16 = mkBpftraceDevShell self.packages.${system}.bpftrace-llvm16;
+            bpftrace-llvm20 = mkBpftraceDevShell 20;
+            bpftrace-llvm19 = mkBpftraceDevShell 19;
+            bpftrace-llvm18 = mkBpftraceDevShell 18;
+            bpftrace-llvm17 = mkBpftraceDevShell 17;
+            bpftrace-llvm16 = mkBpftraceDevShell 16;
 
             # Note that we depend on LLVM 18 explicitly for the fuzz shell, and
             # this is managed separately. The version of LLVM used to build the

--- a/scripts/clang_tidy.sh
+++ b/scripts/clang_tidy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Runs clang-tidy against the codebase.
 # Requires nix.
@@ -16,7 +16,7 @@ SCRIPT_NAME=$0
 FIX=
 
 function run() {
-  nix develop --command "$@"
+  nix develop ".#bpftrace-llvm19" --command "$@"
 }
 
 usage() {


### PR DESCRIPTION
The Nix flake got updated a while ago and it seems the Nix develop
environments are now providing the wrong versions of clang and some of
the clang tools. Update to use the llvmVersion in more places.

v2: took clang tidy fixes with `./scripts/clang_tidy.sh -u` and fixed
them. It's selecting a different version of clang now.

v3: drop clang tidy fixes again. set the clang tidy script back to
llvm-19 which is what it was using accidentally before, and leave this
to be fixed properly in the future.

v4: remove duplicated version in mkBpftraceDevShell.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
