### PR TITLE
nix: Build with systemd support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -151,6 +151,7 @@
                   pkgs.flex
                   pkgs.gcc
                   pkgs.ninja
+                  pkgs.pkg-config
                 ];
 
                 buildInputs = [
@@ -166,6 +167,7 @@
                   pkgs.libffi
                   pkgs.libopcodes
                   pkgs.libpcap
+                  pkgs.systemdLibs
                   pkgs.libsystemtap
                   pkgs."llvmPackages_${toString llvmVersion}".libclang
                   pkgs."llvmPackages_${toString llvmVersion}".llvm
@@ -177,6 +179,7 @@
                 # Release flags
                 cmakeFlags = [
                   "-DCMAKE_BUILD_TYPE=Release"
+                  "-DENABLE_SYSTEMD=1"
                 ];
 
                 # Technically not needed cuz package name matches mainProgram, but

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -4153,7 +4153,8 @@ iscsid is sleeping.
 
 === Systemd support
 
-To run bpftrace in the background using systemd::
+If bpftrace has been built with `-DENABLE_SYSTEMD=1`, one can run bpftrace in
+the background using systemd::
 ----
 # systemd-run --unit=bpftrace --service-type=notify bpftrace -e 'kprobe:do_nanosleep { printf("%d sleeping\n", pid); }'
 ----


### PR DESCRIPTION
This builds the nix artifacts with systemd support. This allows to use the appimages with sd_notify when bpftrace is run as systemd service.

##### Checklist

- [n/a] Language changes are updated in `man/adoc/bpftrace.adoc`
- [n/a] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [n/a] The new behaviour is covered by tests
