### PR TITLE
Have bpffeature use bpftrace's BTF object

### DIFF
--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -70,7 +70,8 @@ protected:
 
 class BPFfeature {
 public:
-  BPFfeature(BPFnofeature& no_feature) : no_feature_(no_feature)
+  BPFfeature(BPFnofeature& no_feature, BTF& btf)
+      : no_feature_(no_feature), btf_(btf)
   {
   }
   BPFfeature() = default;
@@ -95,13 +96,13 @@ public:
   bool has_kprobe_multi();
   bool has_kprobe_session();
   bool has_uprobe_multi();
-  bool has_fentry();
   bool has_skb_output();
   bool has_prog_fentry();
   bool has_module_btf();
   bool has_iter(std::string name);
-
-  bool has_kernel_func(Kfunc kfunc);
+  // These are virtual so they can be overridden in tests by the mock
+  virtual bool has_fentry();
+  virtual bool has_kernel_func(Kfunc kfunc);
 
   std::string report();
 
@@ -165,9 +166,8 @@ private:
       int* outfd = nullptr);
   bool try_load_btf(const void* btf_data, size_t btf_size);
 
-  BTF btf_ = BTF({ "vmlinux" });
-
   BPFnofeature no_feature_;
+  BTF& btf_;
 };
 
 #undef DEFINE_PROG_TEST

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2018,14 +2018,14 @@ bool BPFtrace::write_pcaps(uint64_t id,
   return writer->write(ns, pkt, size);
 }
 
-void BPFtrace::parse_btf(const std::set<std::string> &modules)
+void BPFtrace::parse_module_btf(const std::set<std::string> &modules)
 {
-  btf_ = std::make_unique<BTF>(this, modules);
+  btf_->load_module_btfs(modules);
 }
 
 bool BPFtrace::has_btf_data() const
 {
-  return btf_ && btf_->has_data();
+  return btf_->has_data();
 }
 
 // Retrieves the list of kernel modules for all attachpoints. Will be used to

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -103,7 +103,8 @@ public:
            BPFnofeature no_feature = BPFnofeature(),
            std::unique_ptr<Config> config = std::make_unique<Config>())
       : out_(std::move(o)),
-        feature_(std::make_unique<BPFfeature>(no_feature)),
+        btf_(std::make_unique<BTF>(this)),
+        feature_(std::make_unique<BPFfeature>(no_feature, *btf_)),
         probe_matcher_(std::make_unique<ProbeMatcher>(this)),
         ncpus_(util::get_possible_cpus().size()),
         max_cpu_id_(util::get_max_cpu_id()),
@@ -176,7 +177,7 @@ public:
 
   bool write_pcaps(uint64_t id, uint64_t ns, uint8_t *pkt, unsigned int size);
 
-  void parse_btf(const std::set<std::string> &modules);
+  void parse_module_btf(const std::set<std::string> &modules);
   bool has_btf_data() const;
   Dwarf *get_dwarf(const std::string &filename);
   Dwarf *get_dwarf(const ast::AttachPoint &attachpoint);
@@ -209,6 +210,7 @@ public:
   unsigned int join_argnum_ = 16;
   unsigned int join_argsize_ = 1024;
   std::unique_ptr<Output> out_;
+  std::unique_ptr<BTF> btf_;
   std::unique_ptr<BPFfeature> feature_;
 
   bool resolve_user_symbols_ = true;
@@ -231,7 +233,6 @@ public:
 
   std::unique_ptr<ProbeMatcher> probe_matcher_;
 
-  std::unique_ptr<BTF> btf_;
   std::unordered_set<std::string> btf_set_;
   std::unique_ptr<ChildProcBase> child_;
   std::unique_ptr<ProcMonBase> procmon_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -177,6 +177,8 @@ static void info(BPFnofeature no_feature)
   struct utsname utsname;
   uname(&utsname);
 
+  auto btf = bpftrace::BTF();
+
   std::cout << "System" << std::endl
             << "  OS: " << utsname.sysname << " " << utsname.release << " "
             << utsname.version << std::endl
@@ -186,7 +188,7 @@ static void info(BPFnofeature no_feature)
   std::cout << BuildInfo::report();
 
   std::cout << std::endl;
-  std::cout << BPFfeature(no_feature).report();
+  std::cout << BPFfeature(no_feature, btf).report();
 }
 
 static std::optional<struct timespec> get_delta_with_boottime(int clock_type)
@@ -848,7 +850,6 @@ int main(int argc, char* argv[])
 
     if (is_type_name(args.search)) {
       // Print structure definitions
-      bpftrace.parse_btf({});
       bpftrace.probe_matcher_->list_structs(args.search);
       return 0;
     }

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -97,8 +97,8 @@ private:
       const std::string &target) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_list(
       const std::vector<ProbeListItem> &probes_list) const;
-  virtual std::unique_ptr<std::istream> get_symbols_from_raw_tracepoints()
-      const;
+  virtual std::unique_ptr<std::istream> get_fentry_symbols() const;
+  virtual std::unique_ptr<std::istream> get_raw_tracepoint_symbols() const;
 
   std::unique_ptr<std::istream> get_iter_symbols() const;
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1244,13 +1244,12 @@ class bpftrace_bad_btf : public test_bad_btf {};
 TEST_F(bpftrace_bad_btf, parse_invalid_btf)
 {
   BPFtrace bpftrace;
-  bpftrace.parse_btf({});
   EXPECT_FALSE(bpftrace.has_btf_data());
 }
 
 TEST_F(bpftrace_btf, add_probes_rawtracepoint)
 {
-  auto bpftrace = get_strict_mock_bpftrace();
+  auto bpftrace = get_mock_bpftrace();
   parse_probe("rawtracepoint:event_rt {}", *bpftrace);
 
   ASSERT_EQ(1U, bpftrace->get_probes().size());
@@ -1261,12 +1260,12 @@ TEST_F(bpftrace_btf, add_probes_rawtracepoint)
   EXPECT_EQ(ProbeType::rawtracepoint, probe.type);
   EXPECT_EQ("event_rt", probe.attach_point);
   EXPECT_EQ("rawtracepoint:*:event_rt", probe.orig_name);
-  EXPECT_EQ("rawtracepoint:event_rt", probe.name);
+  EXPECT_EQ("rawtracepoint:vmlinux:event_rt", probe.name);
 }
 
 TEST_F(bpftrace_btf, add_probes_rawtracepoint_wildcard)
 {
-  auto bpftrace = get_strict_mock_bpftrace();
+  auto bpftrace = get_mock_bpftrace();
   parse_probe(("rawtracepoint:event_* {}"), *bpftrace);
 
   ASSERT_EQ(1U, bpftrace->get_probes().size());
@@ -1275,7 +1274,7 @@ TEST_F(bpftrace_btf, add_probes_rawtracepoint_wildcard)
 
 TEST_F(bpftrace_btf, add_probes_rawtracepoint_wildcard_no_matches)
 {
-  auto bpftrace = get_strict_mock_bpftrace();
+  auto bpftrace = get_mock_bpftrace();
   parse_probe("rawtracepoint:typo_* {}", *bpftrace);
 
   ASSERT_EQ(0U, bpftrace->get_probes().size());

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -5,6 +5,7 @@
 #include "bpftrace.h"
 #include "clang_parser.h"
 #include "driver.h"
+#include "mocks.h"
 #include "struct.h"
 #include "gtest/gtest.h"
 
@@ -624,24 +625,23 @@ class clang_parser_btf : public test_btf {};
 
 TEST_F(clang_parser_btf, btf)
 {
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
+  auto bpftrace = get_mock_bpftrace();
   parse("struct Foo { "
         "  struct Foo1 f1;"
         "  struct Foo2 f2;"
         "  struct Foo3 f3;"
         "  struct Foo4 f4;"
         "}",
-        bpftrace);
+        *bpftrace);
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo1"));
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo2"));
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo3"));
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo4"));
-  auto foo1 = bpftrace.structs.Lookup("struct Foo1").lock();
-  auto foo2 = bpftrace.structs.Lookup("struct Foo2").lock();
-  auto foo3 = bpftrace.structs.Lookup("struct Foo3").lock();
-  auto foo4 = bpftrace.structs.Lookup("struct Foo4").lock();
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo1"));
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo2"));
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo3"));
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo4"));
+  auto foo1 = bpftrace->structs.Lookup("struct Foo1").lock();
+  auto foo2 = bpftrace->structs.Lookup("struct Foo2").lock();
+  auto foo3 = bpftrace->structs.Lookup("struct Foo3").lock();
+  auto foo4 = bpftrace->structs.Lookup("struct Foo4").lock();
 
   EXPECT_EQ(foo1->size, 16);
   ASSERT_EQ(foo1->fields.size(), 3U);
@@ -707,12 +707,11 @@ TEST_F(clang_parser_btf, btf)
 // Disabled because BTF flattens multi-dimensional arrays #3082.
 TEST_F(clang_parser_btf, DISABLED_btf_arrays_multi_dim)
 {
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
-  parse("struct Foo { struct Arrays a; };", bpftrace);
+  auto bpftrace = get_mock_bpftrace();
+  parse("struct Foo { struct Arrays a; };", *bpftrace);
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct Arrays"));
-  auto arrs = bpftrace.structs.Lookup("struct Arrays").lock();
+  ASSERT_TRUE(bpftrace->structs.Has("struct Arrays"));
+  auto arrs = bpftrace->structs.Lookup("struct Arrays").lock();
 
   ASSERT_TRUE(arrs->HasField("multi_dim"));
   EXPECT_TRUE(arrs->GetField("multi_dim").type.IsArrayTy());
@@ -740,15 +739,14 @@ TEST(clang_parser, btf_unresolved_typedef)
 {
   // size_t is defined in stddef.h, but if we have BTF, it should be possible to
   // extract it from there
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
-  if (!bpftrace.has_btf_data())
+  auto bpftrace = get_mock_bpftrace();
+  if (!bpftrace->has_btf_data())
     GTEST_SKIP();
 
-  parse("struct Foo { size_t x; };", bpftrace);
+  parse("struct Foo { size_t x; };", *bpftrace);
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo"));
+  auto foo = bpftrace->structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 8);
   ASSERT_EQ(foo->fields.size(), 1U);
@@ -762,31 +760,30 @@ TEST(clang_parser, btf_unresolved_typedef)
 TEST_F(clang_parser_btf, btf_type_override)
 {
   // It should be possible to override types from BTF, ...
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
+  auto bpftrace = get_mock_bpftrace();
   parse("struct Foo1 { int a; };\n",
-        bpftrace,
+        *bpftrace,
         true,
         "kprobe:sys_read { @x = ((struct Foo1 *)curtask); }");
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo1"));
-  auto foo1 = bpftrace.structs.Lookup("struct Foo1").lock();
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo1"));
+  auto foo1 = bpftrace->structs.Lookup("struct Foo1").lock();
   ASSERT_EQ(foo1->fields.size(), 1U);
   ASSERT_TRUE(foo1->HasField("a"));
 
   // ... however, in such case, no other types are taken from BTF and the
   // following will fail since Foo2 will be undefined
-  bpftrace.btf_set_.clear();
+  bpftrace->btf_set_.clear();
   parse("struct Foo1 { struct Foo2 foo2; };\n",
-        bpftrace,
+        *bpftrace,
         false,
         "kprobe:sys_read { @x = ((struct Foo1 *)curtask); }");
 
   // Here, Foo1 redefinition will take place when resolving incomplete types
   // (since Foo3 contains a pointer to Foo1)
-  bpftrace.btf_set_.clear();
+  bpftrace->btf_set_.clear();
   parse("struct Foo1 { struct Foo2 foo2; };\n",
-        bpftrace,
+        *bpftrace,
         false,
         "kprobe:sys_read { @x1 = ((struct Foo3 *)curtask); }");
 }

--- a/tests/codegen/call_len.cpp
+++ b/tests/codegen/call_len.cpp
@@ -11,15 +11,18 @@ TEST_F(codegen_btf, call_len_for_each_map_elem)
 {
   auto bpftrace = get_mock_bpftrace();
   auto feature = std::make_unique<MockBPFfeature>();
-  feature->mock_missing_kernel_func(Kfunc::bpf_map_sum_elem_count);
+  feature->add_to_available_kernel_funcs(Kfunc::bpf_map_sum_elem_count, false);
   bpftrace->feature_ = std::move(feature);
-
   test(*bpftrace, PROG, NAME);
 }
 
 TEST_F(codegen_btf, call_len_map_sum_elem_count)
 {
-  test(PROG, NAME);
+  auto bpftrace = get_mock_bpftrace();
+  auto feature = std::make_unique<MockBPFfeature>();
+  feature->add_to_available_kernel_funcs(Kfunc::bpf_map_sum_elem_count, true);
+  bpftrace->feature_ = std::move(feature);
+  test(*bpftrace, PROG, NAME);
 }
 
 TEST_F(codegen_btf, call_len_ustack_kstack)

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -62,9 +62,8 @@ TEST_F(field_analyser_btf, fentry_args)
 
 TEST_F(field_analyser_btf, btf_types)
 {
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
-  test(bpftrace,
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace,
        "kprobe:sys_read {\n"
        "  @x1 = (struct Foo1 *) curtask;\n"
        "  @x2 = (struct Foo2 *) curtask;\n"
@@ -72,12 +71,12 @@ TEST_F(field_analyser_btf, btf_types)
        "}",
        true);
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo1"));
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo2"));
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo3"));
-  auto foo1 = bpftrace.structs.Lookup("struct Foo1").lock();
-  auto foo2 = bpftrace.structs.Lookup("struct Foo2").lock();
-  auto foo3 = bpftrace.structs.Lookup("struct Foo3").lock();
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo1"));
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo2"));
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo3"));
+  auto foo1 = bpftrace->structs.Lookup("struct Foo1").lock();
+  auto foo2 = bpftrace->structs.Lookup("struct Foo2").lock();
+  auto foo3 = bpftrace->structs.Lookup("struct Foo3").lock();
 
   EXPECT_EQ(foo1->size, 16);
   ASSERT_EQ(foo1->fields.size(), 3U);
@@ -133,16 +132,15 @@ TEST_F(field_analyser_btf, btf_types)
 
 TEST_F(field_analyser_btf, btf_arrays)
 {
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
-  test(bpftrace,
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace,
        "BEGIN {\n"
        "  @ = (struct Arrays *) 0;\n"
        "}",
        true);
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct Arrays"));
-  auto arrs = bpftrace.structs.Lookup("struct Arrays").lock();
+  ASSERT_TRUE(bpftrace->structs.Has("struct Arrays"));
+  auto arrs = bpftrace->structs.Lookup("struct Arrays").lock();
 
   EXPECT_EQ(arrs->size, 64);
   ASSERT_EQ(arrs->fields.size(), 6U);
@@ -194,16 +192,15 @@ TEST_F(field_analyser_btf, btf_arrays)
 // Disabled because BTF flattens multi-dimensional arrays #3082.
 TEST_F(field_analyser_btf, DISABLED_btf_arrays_multi_dim)
 {
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
-  test(bpftrace,
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace,
        "BEGIN {\n"
        "  @ = (struct Arrays *) 0;\n"
        "}",
        true);
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct Arrays"));
-  auto arrs = bpftrace.structs.Lookup("struct Arrays").lock();
+  ASSERT_TRUE(bpftrace->structs.Has("struct Arrays"));
+  auto arrs = bpftrace->structs.Lookup("struct Arrays").lock();
 
   ASSERT_TRUE(arrs->HasField("multi_dim"));
   EXPECT_TRUE(arrs->GetField("multi_dim").type.IsArrayTy());
@@ -260,22 +257,20 @@ void test_arrays_compound_data(BPFtrace &bpftrace)
 
 TEST_F(field_analyser_btf, arrays_compound_data)
 {
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
-  test(bpftrace,
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace,
        "BEGIN {\n"
        "  $x = (struct ArrayWithCompoundData *) 0;\n"
        "  $x->data[0]->foo1->a\n"
        "}",
        true);
-  test_arrays_compound_data(bpftrace);
+  test_arrays_compound_data(*bpftrace);
 }
 
 TEST_F(field_analyser_btf, btf_types_struct_ptr)
 {
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
-  test(bpftrace,
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace,
        "kprobe:sys_read {\n"
        "  @x1 = ((struct Foo3 *) curtask);\n"
        "  @x3 = @x1->foo2;\n"
@@ -286,10 +281,10 @@ TEST_F(field_analyser_btf, btf_types_struct_ptr)
   // - add struct Foo2 (without resolving its fields)
   // - resolve fields of struct Foo3
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo2"));
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo3"));
-  auto foo2 = bpftrace.structs.Lookup("struct Foo2").lock();
-  auto foo3 = bpftrace.structs.Lookup("struct Foo3").lock();
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo2"));
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo3"));
+  auto foo2 = bpftrace->structs.Lookup("struct Foo2").lock();
+  auto foo3 = bpftrace->structs.Lookup("struct Foo3").lock();
 
   EXPECT_EQ(foo2->size, 24);
   ASSERT_EQ(foo2->fields.size(), 0U); // fields are not resolved
@@ -299,9 +294,8 @@ TEST_F(field_analyser_btf, btf_types_struct_ptr)
 
 TEST_F(field_analyser_btf, btf_types_arr_access)
 {
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
-  test(bpftrace,
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace,
        "fentry:func_1 {\n"
        "  @foo2 = args.foo3[0].foo2;\n"
        "}",
@@ -311,10 +305,10 @@ TEST_F(field_analyser_btf, btf_types_arr_access)
   // - add struct Foo2 (without resolving its fields)
   // - resolve fields of struct Foo3
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo2"));
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo3"));
-  auto foo2 = bpftrace.structs.Lookup("struct Foo2").lock();
-  auto foo3 = bpftrace.structs.Lookup("struct Foo3").lock();
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo2"));
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo3"));
+  auto foo2 = bpftrace->structs.Lookup("struct Foo2").lock();
+  auto foo3 = bpftrace->structs.Lookup("struct Foo3").lock();
 
   EXPECT_EQ(foo2->size, 24);
   ASSERT_EQ(foo2->fields.size(), 0U); // fields are not resolved
@@ -324,12 +318,11 @@ TEST_F(field_analyser_btf, btf_types_arr_access)
 
 TEST_F(field_analyser_btf, btf_types_bitfields)
 {
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
-  test(bpftrace, "fentry:func_1 { @ = ((struct Foo4 *)args.foo4)->pid; }");
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace, "fentry:func_1 { @ = ((struct Foo4 *)args.foo4)->pid; }");
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct Foo4"));
-  auto foo4 = bpftrace.structs.Lookup("struct Foo4").lock();
+  ASSERT_TRUE(bpftrace->structs.Has("struct Foo4"));
+  auto foo4 = bpftrace->structs.Lookup("struct Foo4").lock();
 
   // clang-tidy doesn't seem to acknowledge that ASSERT_*() will
   // return from function so that these are in fact checked accesses.
@@ -375,13 +368,12 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
 
 TEST_F(field_analyser_btf, btf_anon_union_first_in_struct)
 {
-  BPFtrace bpftrace;
-  bpftrace.parse_btf({});
-  test(bpftrace, "BEGIN { @ = (struct FirstFieldsAreAnonUnion *)0; }");
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace, "BEGIN { @ = (struct FirstFieldsAreAnonUnion *)0; }");
 
-  ASSERT_TRUE(bpftrace.structs.Has("struct FirstFieldsAreAnonUnion"));
+  ASSERT_TRUE(bpftrace->structs.Has("struct FirstFieldsAreAnonUnion"));
   auto record =
-      bpftrace.structs.Lookup("struct FirstFieldsAreAnonUnion").lock();
+      bpftrace->structs.Lookup("struct FirstFieldsAreAnonUnion").lock();
 
   ASSERT_TRUE(record->HasField("a"));
   EXPECT_TRUE(record->GetField("a").type.IsIntTy());

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -45,6 +45,21 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
             new std::istringstream(tracepoints));
       });
 
+  ON_CALL(matcher, get_raw_tracepoint_symbols()).WillByDefault([]() {
+    std::string rawtracepoints = "vmlinux:event_rt\n"
+                                 "vmlinux:sched_switch\n";
+    return std::unique_ptr<std::istream>(
+        new std::istringstream(rawtracepoints));
+  });
+
+  ON_CALL(matcher, get_fentry_symbols()).WillByDefault([]() {
+    std::string funcs = "vmlinux:func_1\n"
+                        "vmlinux:func_2\n"
+                        "vmlinux:func_3\n"
+                        "vmlinux:queued_spin_lock_slowpath\n";
+    return std::unique_ptr<std::istream>(new std::istringstream(funcs));
+  });
+
   std::string sh_usyms = "/bin/sh:first_open\n"
                          "/bin/sh:second_open\n"
                          "/bin/sh:open_as_well\n"
@@ -87,8 +102,6 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
 void setup_mock_bpftrace(MockBPFtrace &bpftrace)
 {
   bpftrace.delta_taitime_ = timespec{};
-
-  bpftrace.parse_btf({ "vmlinux" });
   // Fill in some default tracepoint struct definitions
   bpftrace.structs.Add("struct _tracepoint_sched_sched_one", 8);
   bpftrace.structs.Lookup("struct _tracepoint_sched_sched_one")

--- a/tests/recursion_check.cpp
+++ b/tests/recursion_check.cpp
@@ -10,7 +10,6 @@ void test(const std::string& input, bool has_recursion_check)
 {
   auto mock_bpftrace = get_mock_bpftrace();
   BPFtrace& bpftrace = *mock_bpftrace;
-  bpftrace.btf_ = nullptr;
 
   ast::ASTContext ast("stdin", input);
 


### PR DESCRIPTION
Instead of having bpffeature create it's own
BTF object and parsing vmlinux BTF again,
just pass bpftrace's BTF object when the bpftrace
object is created so vmlinux BTF is parsed
one less time.

This also separate BTF module loading
from the initial vmlinux BTF parsing
as that depends on the program probes.

There is also a commit to search all modules when listing types;
this is a drive-by fix I noticed when refactoring BTF.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
