### PR TITLE
Require BPF_MAP_TYPE_RINGBUF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
   - [#3999](https://github.com/bpftrace/bpftrace/pull/3999)
 - Error by default if any probe fails to attach
   - [#4097](https://github.com/bpftrace/bpftrace/pull/4097)
+- Require BPF_MAP_TYPE_RINGBUF to be available
+  - [#3974](https://github.com/bpftrace/bpftrace/pull/3974)
 #### Added
 - Add ncpus builtin to get the number of CPUs.
   - [#4105](https://github.com/bpftrace/bpftrace/pull/4105)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -41,37 +41,26 @@ public:
   CallInst *CreateMapLookup(Map &map,
                             Value *key,
                             const std::string &name = "lookup_elem");
-  Value *CreateMapLookupElem(Value *ctx,
-                             Map &map,
-                             Value *key,
-                             const Location &loc);
-  Value *CreateMapLookupElem(Value *ctx,
-                             const std::string &map_name,
+  Value *CreateMapLookupElem(Map &map, Value *key, const Location &loc);
+  Value *CreateMapLookupElem(const std::string &map_name,
                              Value *key,
                              SizedType &type,
                              const Location &loc);
-  Value *CreatePerCpuMapAggElems(Value *ctx,
-                                 Map &map,
+  Value *CreatePerCpuMapAggElems(Map &map,
                                  Value *key,
                                  const SizedType &type,
                                  const Location &loc);
-  void CreateMapUpdateElem(Value *ctx,
-                           const std::string &map_ident,
+  void CreateMapUpdateElem(const std::string &map_ident,
                            Value *key,
                            Value *val,
                            const Location &loc,
                            int64_t flags = 0);
-  void CreateMapDeleteElem(Value *ctx,
-                           Map &map,
-                           Value *key,
-                           const Location &loc);
-  Value *CreateForEachMapElem(Value *ctx,
-                              Map &map,
+  void CreateMapDeleteElem(Map &map, Value *key, const Location &loc);
+  Value *CreateForEachMapElem(Map &map,
                               Value *callback,
                               Value *callback_ctx,
                               const Location &loc);
-  void CreateProbeRead(Value *ctx,
-                       Value *dst,
+  void CreateProbeRead(Value *dst,
                        llvm::Value *size,
                        Value *src,
                        AddrSpace as,
@@ -81,8 +70,7 @@ public:
   // size depends on the host system as well as the probe type.
   // If provided, the optional AddrSpace argument is used instead of the type's
   // address space (which may not always be set).
-  void CreateProbeRead(Value *ctx,
-                       Value *dst,
+  void CreateProbeRead(Value *dst,
                        const SizedType &type,
                        Value *src,
                        const Location &loc,
@@ -96,14 +84,12 @@ public:
       llvm::Value *ptr,
       bool isVolatile = false,
       std::optional<AddrSpace> addrSpace = std::nullopt);
-  CallInst *CreateProbeReadStr(Value *ctx,
-                               Value *dst,
+  CallInst *CreateProbeReadStr(Value *dst,
                                llvm::Value *size,
                                Value *src,
                                AddrSpace as,
                                const Location &loc);
-  CallInst *CreateProbeReadStr(Value *ctx,
-                               Value *dst,
+  CallInst *CreateProbeReadStr(Value *dst,
                                size_t size,
                                Value *src,
                                AddrSpace as,
@@ -121,8 +107,7 @@ public:
                            uint64_t haystack_sz,
                            Value *needle,
                            uint64_t needle_sz);
-  Value *CreateIntegerArrayCmp(Value *ctx,
-                               Value *val1,
+  Value *CreateIntegerArrayCmp(Value *val1,
                                Value *val2,
                                const SizedType &val1_type,
                                const SizedType &val2_type,
@@ -176,19 +161,14 @@ public:
                        Value *callee,
                        ArrayRef<Value *> args,
                        const Twine &Name);
-  void CreateGetCurrentComm(Value *ctx,
-                            AllocaInst *buf,
-                            size_t size,
-                            const Location &loc);
-  void CreateOutput(Value *ctx, Value *data, size_t size, const Location &loc);
+  void CreateGetCurrentComm(AllocaInst *buf, size_t size, const Location &loc);
+  void CreateOutput(Value *data, size_t size, const Location &loc);
   void CreateAtomicIncCounter(const std::string &map_name, uint32_t idx);
-  void CreatePerCpuMapElemInit(Value *ctx,
-                               Map &map,
+  void CreatePerCpuMapElemInit(Map &map,
                                Value *key,
                                Value *val,
                                const Location &loc);
-  void CreatePerCpuMapElemAdd(Value *ctx,
-                              Map &map,
+  void CreatePerCpuMapElemAdd(Map &map,
                               Value *key,
                               Value *val,
                               const Location &loc);
@@ -199,14 +179,12 @@ public:
                          Value *fmt_size,
                          const std::vector<Value *> &values,
                          const Location &loc);
-  void CreateSignal(Value *ctx, Value *sig, const Location &loc);
+  void CreateSignal(Value *sig, const Location &loc);
   void CreateOverrideReturn(Value *ctx, Value *rc);
-  void CreateHelperError(Value *ctx,
-                         Value *return_value,
+  void CreateHelperError(Value *return_value,
                          libbpf::bpf_func_id func_id,
                          const Location &loc);
-  void CreateHelperErrorCond(Value *ctx,
-                             Value *return_value,
+  void CreateHelperErrorCond(Value *return_value,
                              libbpf::bpf_func_id func_id,
                              const Location &loc,
                              bool compare_zero = false);
@@ -216,12 +194,7 @@ public:
                             bool packed = false);
   Value *CreateGetPid(const Location &loc);
   Value *CreateGetTid(const Location &loc);
-  Value *CreateGetPid(Value *ctx, const Location &loc);
-  Value *CreateGetTid(Value *ctx, const Location &loc);
-  AllocaInst *CreateUSym(Value *ctx,
-                         Value *val,
-                         int probe_id,
-                         const Location &loc);
+  AllocaInst *CreateUSym(Value *val, int probe_id, const Location &loc);
   Value *CreateRegisterRead(Value *ctx, const std::string &builtin);
   Value *CreateRegisterRead(Value *ctx, int offset, const std::string &name);
   Value *CreateKFuncArg(Value *ctx, SizedType &type, std::string &name);
@@ -232,11 +205,7 @@ public:
                             Value *len,
                             AllocaInst *data,
                             size_t size);
-  void CreatePath(Value *ctx,
-                  Value *buf,
-                  Value *path,
-                  Value *sz,
-                  const Location &loc);
+  void CreatePath(Value *buf, Value *path, Value *sz, const Location &loc);
   void CreateSeqPrintf(Value *ctx,
                        Value *fmt,
                        Value *fmt_size,
@@ -284,8 +253,7 @@ private:
   AsyncIds &async_ids_;
 
   CallInst *CreateGetPidTgid(const Location &loc);
-  void CreateGetNsPidTgid(Value *ctx,
-                          Value *dev,
+  void CreateGetNsPidTgid(Value *dev,
                           Value *ino,
                           AllocaInst *ret,
                           const Location &loc);
@@ -332,10 +300,6 @@ private:
   llvm::Type *getKernelPointerStorageTy();
   llvm::Type *getUserPointerStorageTy();
   void CreateRingbufOutput(Value *data, size_t size, const Location &loc);
-  void CreatePerfEventOutput(Value *ctx,
-                             Value *data,
-                             size_t size,
-                             const Location &loc);
 
   void createPerCpuSum(AllocaInst *ret, CallInst *call, const SizedType &type);
   void createPerCpuMinMax(AllocaInst *ret,

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -314,7 +314,7 @@ void ResourceAnalyser::visit(Call &call)
     const auto &offset = call.vargs.at(3).as<Integer>()->value;
 
     resources_.skboutput_args_.emplace_back(file, offset);
-    resources_.needs_perf_event_map = true;
+    resources_.using_skboutput = true;
   } else if (call.func == "delete") {
     auto &arg0 = call.vargs.at(0);
     auto &map = *arg0.as<Map>();

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -617,7 +617,6 @@ std::string BPFfeature::report()
     { "array", to_str(has_map_array()) },
     { "percpu array", to_str(has_map_percpu_array()) },
     { "stack_trace", to_str(has_map_stack_trace()) },
-    { "perf_event_array", to_str(has_map_perf_event_array()) },
     { "ringbuf", to_str(has_map_ringbuf()) }
   };
 

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -108,7 +108,6 @@ public:
   DEFINE_MAP_TEST(hash, libbpf::BPF_MAP_TYPE_HASH);
   DEFINE_MAP_TEST(percpu_array, libbpf::BPF_MAP_TYPE_PERCPU_ARRAY);
   DEFINE_MAP_TEST(stack_trace, libbpf::BPF_MAP_TYPE_STACK_TRACE);
-  DEFINE_MAP_TEST(perf_event_array, libbpf::BPF_MAP_TYPE_PERF_EVENT_ARRAY);
   DEFINE_MAP_TEST(ringbuf, libbpf::BPF_MAP_TYPE_RINGBUF);
   DEFINE_HELPER_TEST(send_signal, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(override_return, libbpf::BPF_PROG_TYPE_KPROBE);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -250,21 +250,9 @@ private:
   int create_pcaps();
   void close_pcaps();
   int setup_output(void *ctx);
-  int setup_perf_events(void *ctx);
+  int setup_skboutput_perf_buffer(void *ctx);
   void setup_ringbuf(void *ctx);
   int setup_event_loss();
-  // when the ringbuf feature is available, enable ringbuf for built-ins like
-  // printf, cat.
-  bool is_ringbuf_enabled() const
-  {
-    return feature_->has_map_ringbuf();
-  }
-  // when the ringbuf feature is unavailable or built-in skboutput is used,
-  // enable perf_event
-  bool is_perf_event_enabled() const
-  {
-    return !feature_->has_map_ringbuf() || resources.needs_perf_event_map;
-  }
   std::vector<std::string> resolve_ksym_stack(uint64_t addr,
                                               bool show_offset,
                                               bool perf_mode,
@@ -277,7 +265,7 @@ private:
                                               bool show_debug_info);
   void teardown_output();
   void poll_output(Output &out, bool drain = false);
-  int poll_perf_events();
+  int poll_skboutput_events();
   void handle_event_loss(Output &out);
   int print_map_hist(Output &out,
                      const BpfMap &map,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1001,6 +1001,12 @@ int main(int argc, char* argv[])
     exit(1);
   }
 
+  if (!bpftrace.feature_->has_map_ringbuf()) {
+    LOG(ERROR) << "Your kernel is too old and is missing the "
+                  "BPF_MAP_TYPE_RINGBUF, which bpftrace requires.";
+    return 1;
+  }
+
   auto& bytecode = pmresult->get<BpfBytecode>();
   return run_bpftrace(bpftrace, *output, bytecode);
 }

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -127,7 +127,7 @@ public:
   // Map metadata
   std::map<std::string, MapInfo> maps_info;
   std::unordered_set<bpftrace::globalvars::GlobalVar> needed_global_vars;
-  bool needs_perf_event_map = false;
+  bool using_skboutput = false;
 
   // Probe metadata
   //
@@ -159,7 +159,7 @@ private:
             probe_ids,
             maps_info,
             needed_global_vars,
-            needs_perf_event_map,
+            using_skboutput,
             probes,
             signal_probes,
             special_probes);

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -287,7 +287,7 @@ TIMEOUT 3
 
 NAME info flag
 RUN {{BPFTRACE}} --info
-EXPECT_REGEX perf_event_array: yes
+EXPECT_REGEX ringbuf: yes
 TIMEOUT 1
 
 NAME basic while loop


### PR DESCRIPTION
This gets rid of a little bit of forking
code by requiring BPF_MAP_TYPE_RINGBUF to
be available, which was added at kernel version
5.8.

However, we still have to keep logic for
BPF_MAP_TYPE_PERF_EVENT_ARRAY because
bpf_skb_output requires this map type.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
