### PR TITLE
test: suppress extraneous output in `bpftrace_test` when tests pass

### DIFF
--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,7 +1,11 @@
 #include "gtest/gtest.h"
+#include <cstdlib>
+#include <string>
+#include <sys/mman.h>
+#include <unistd.h>
 
 class ThrowListener : public testing::EmptyTestEventListener {
-  void OnTestPartResult(const testing::TestPartResult &result) override
+  void OnTestPartResult(const testing::TestPartResult& result) override
   {
     if (result.type() == testing::TestPartResult::kFatalFailure) {
       throw testing::AssertionException(result);
@@ -9,9 +13,76 @@ class ThrowListener : public testing::EmptyTestEventListener {
   }
 };
 
-int main(int argc, char *argv[])
+class OutputSuppressorListener : public testing::EmptyTestEventListener {
+public:
+  void OnTestStart(const testing::TestInfo& /*test_info*/) override
+  {
+    // stash original stderr
+    original_stderr_ = dup(STDERR_FILENO);
+    if (original_stderr_ == -1) {
+      return;
+    }
+
+    // create a temp file
+    constexpr unsigned int NO_FLAGS = 0;
+    memfd_ = memfd_create("stderr_capture", NO_FLAGS);
+    if (memfd_ == -1) {
+      close(original_stderr_);
+      original_stderr_ = -1;
+      return;
+    }
+
+    // redirect stderr to temp file
+    dup2(memfd_, STDERR_FILENO);
+  }
+
+  void OnTestEnd(const testing::TestInfo& test_info) override
+  {
+    if (original_stderr_ != -1) {
+      // restore output if test failed
+      if (test_info.result()->Failed()) {
+        restore_output();
+      }
+
+      if (original_stderr_ != -1) {
+        dup2(original_stderr_, STDERR_FILENO);
+        close(original_stderr_);
+        original_stderr_ = -1;
+      }
+    }
+  }
+
+private:
+  void restore_output()
+  {
+    if (memfd_ && original_stderr_ != -1) {
+      // temporarily switch back to original stderr
+      int old = dup(STDERR_FILENO);
+      dup2(original_stderr_, STDERR_FILENO);
+
+      // reset file pointer and output content
+      lseek(memfd_, 0, SEEK_SET);
+      char buffer[1024];
+      ssize_t n;
+      while ((n = read(memfd_, buffer, sizeof(buffer))) > 0) {
+        std::cerr << buffer;
+      }
+
+      // restore to temp file
+      dup2(old, STDERR_FILENO);
+      close(old);
+    }
+  }
+
+  int memfd_ = -1;
+  int original_stderr_ = -1;
+};
+
+int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::UnitTest::GetInstance()->listeners().Append(new ThrowListener);
+  ::testing::UnitTest::GetInstance()->listeners().Append(
+      new OutputSuppressorListener);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

This commit introduces the `BPFTRACE_SUPPRESS_TEST_SPEW` environment variable, which allows users to suppress expected error and warning outputs during bpftrace unit tests. When set to "1", it captures and hides these outputs, maintaining clean test output while still allowing relevant messages to be viewed if a test fails.

Additionally, a new OutputSuppressorListener class is implemented to manage the suppression of output during test execution.

Closes: #3711

Before Change:
```bash
$ bprtrace_test --gtest_filter=bpftrace_bad_btf.parse_invalid_btf:clang_parser.parse_fail:clang_parser.redefined_types:clang_parser_btf.btf_arrays_multi_dim:clang_parser_btf.btf_type_override:ConfigSetter.set_stack_mode:ConfigSetter.set_user_symbol_cache_type:ConfigSetter.set_missing_probes:field_analyser_btf.btf_arrays_multi_dim:field_analyser_dwarf.parse_struct_anonymous_fields:Parser.builtin_variables:semantic_analyser.call_lhist_posparam:semantic_analyser.call_buf_posparam:semantic_analyser.call_pton:semantic_analyser_btf.call_percpu_kaddr:semantic_analyser.call_stack:semantic_analyser.array_access:semantic_analyser.unroll:semantic_analyser.positional_parameters:semantic_analyser.signal:semantic_analyser.strncmp_posparam:probe.short_name

Note: Google Test filter = clang_parser.parse_fail:clang_parser.redefined_types:clang_parser_btf.btf_arrays_multi_dim:clang_parser_btf.btf_type_override:ConfigSetter.set_stack_mode:ConfigSetter.set_user_symbol_cache_type:ConfigSetter.set_missing_probes:field_analyser_btf.btf_arrays_multi_dim:field_analyser_dwarf.parse_struct_anonymous_fields:Parser.builtin_variables:semantic_analyser.call_lhist_posparam:semantic_analyser.call_buf_posparam:semantic_analyser.call_pton:semantic_analyser_btf.call_percpu_kaddr:semantic_analyser.call_stack:semantic_analyser.array_access:semantic_analyser.unroll:semantic_analyser.positional_parameters:semantic_analyser.signal:semantic_analyser.strncmp_posparam:probe.short_name
[==========] Running 19 tests from 8 test suites.
[----------] Global test environment set-up.
[----------] 1 test from bpftrace_bad_btf
[ RUN      ] bpftrace_bad_btf.parse_invalid_btf
WARNING: BTF: failed to parse BTF from /tmp/btf_datae42Vlv
WARNING: BTF: failed to parse BTF from /tmp/btf_datae42Vlv
[       OK ] bpftrace_bad_btf.parse_invalid_btf (0 ms)
[----------] 1 test from bpftrace_bad_btf (0 ms total)

[----------] 2 tests from clang_parser
[ RUN      ] clang_parser.parse_fail
definitions.h:2:28: error: field has incomplete type 'struct b'
definitions.h:2:26: note: forward declaration of 'struct b'
[       OK ] clang_parser.parse_fail (44 ms)
[ RUN      ] clang_parser.redefined_types
definitions.h:3:8: error: redefinition of 'a'
definitions.h:2:8: note: previous definition is here
WARNING: Cannot take type definitions from BTF since there is a redefinition conflict with user-defined types.
definitions.h:3:8: error: redefinition of 'a'
definitions.h:2:8: note: previous definition is here
WARNING: Cannot take type definitions from BTF since there is a redefinition conflict with user-defined types.
[       OK ] clang_parser.redefined_types (69 ms)
[----------] 2 tests from clang_parser (114 ms total)

[----------] 1 test from clang_parser_btf
[ RUN      ] clang_parser_btf.btf_type_override
definitions.h:2:27: error: field has incomplete type 'struct Foo2'
definitions.h:2:22: note: forward declaration of 'struct Foo2'
definitions.h:2:27: error: field has incomplete type 'struct Foo2'
definitions.h:2:22: note: forward declaration of 'struct Foo2'
[       OK ] clang_parser_btf.btf_type_override (118 ms)
[----------] 1 test from clang_parser_btf (118 ms total)

[----------] 3 tests from ConfigSetter
[ RUN      ] ConfigSetter.set_stack_mode
ERROR: invalid is not a valid StackMode
[       OK ] ConfigSetter.set_stack_mode (0 ms)
[ RUN      ] ConfigSetter.set_user_symbol_cache_type
ERROR: Invalid value for cache_user_symbols: valid values are PER_PID, PER_PROGRAM, and NONE.
[       OK ] ConfigSetter.set_user_symbol_cache_type (0 ms)
[ RUN      ] ConfigSetter.set_missing_probes
ERROR: Invalid value for missing_probes: valid values are "ignore", "warn", and "error".
[       OK ] ConfigSetter.set_missing_probes (0 ms)
[----------] 3 tests from ConfigSetter (0 ms total)

[----------] 1 test from Parser
[ RUN      ] Parser.builtin_variables
[       OK ] Parser.builtin_variables (252 ms)
[----------] 1 test from Parser (252 ms total)

[----------] 9 tests from semantic_analyser
[ RUN      ] semantic_analyser.call_lhist_posparam
[       OK ] semantic_analyser.call_lhist_posparam (95 ms)
[ RUN      ] semantic_analyser.call_buf_posparam
[       OK ] semantic_analyser.call_buf_posparam (95 ms)
[ RUN      ] semantic_analyser.call_pton
ERROR: Expected string literal, got int64
ERROR: Expected string literal, got uint8[4]
[       OK ] semantic_analyser.call_pton (1403 ms)
[ RUN      ] semantic_analyser.call_stack
[       OK ] semantic_analyser.call_stack (2980 ms)
[ RUN      ] semantic_analyser.array_access
[       OK ] semantic_analyser.array_access (1763 ms)
[ RUN      ] semantic_analyser.unroll
[       OK ] semantic_analyser.unroll (393 ms)
[ RUN      ] semantic_analyser.positional_parameters
[       OK ] semantic_analyser.positional_parameters (836 ms)
[ RUN      ] semantic_analyser.signal
[       OK ] semantic_analyser.signal (1728 ms)
[ RUN      ] semantic_analyser.strncmp_posparam
[       OK ] semantic_analyser.strncmp_posparam (83 ms)
[----------] 9 tests from semantic_analyser (9381 ms total)

[----------] 1 test from probe
[ RUN      ] probe.short_name
libbpf: elf: skipping unrecognized data section(14) .eh_frame
libbpf: elf: skipping relo section(15) .rel.eh_frame for section(14) .eh_frame
libbpf: elf: skipping unrecognized data section(14) .eh_frame
libbpf: elf: skipping relo section(15) .rel.eh_frame for section(14) .eh_frame
libbpf: elf: skipping unrecognized data section(14) .eh_frame
libbpf: elf: skipping relo section(15) .rel.eh_frame for section(14) .eh_frame
libbpf: elf: skipping unrecognized data section(14) .eh_frame
libbpf: elf: skipping relo section(15) .rel.eh_frame for section(14) .eh_frame
[       OK ] probe.short_name (392 ms)
[----------] 1 test from probe (392 ms total)

[----------] 1 test from semantic_analyser_btf
[ RUN      ] semantic_analyser_btf.call_percpu_kaddr
ERROR: Expected string literal, got int64
[       OK ] semantic_analyser_btf.call_percpu_kaddr (304 ms)
[----------] 1 test from semantic_analyser_btf (304 ms total)

[----------] Global test environment tear-down
[==========] 18 tests from 7 test suites ran. (10564 ms total)
[  PASSED  ] 18 tests.
```

After Change
```bash
$ BPFTRACE_SUPPRESS_TEST_SPEW=1 bpftrace_test --gtest_filter=clang_parser.parse_fail:clang_parser.redefined_types:clang_parser_btf.btf_arrays_multi_dim:clang_parser_btf.btf_type_override:ConfigSetter.set_stack_mode:ConfigSetter.set_user_symbol_cache_type:ConfigSetter.set_missing_probes:field_analyser_btf.btf_arrays_multi_dim:field_analyser_dwarf.parse_struct_anonymous_fields:Parser.builtin_variables:semantic_analyser.call_lhist_posparam:semantic_analyser.call_buf_posparam:semantic_analyser.call_pton:semantic_analyser_btf.call_percpu_kaddr:semantic_analyser.call_stack:semantic_analyser.array_access:semantic_analyser.unroll:semantic_analyser.positional_parameters:semantic_analyser.signal:semantic_analyser.strncmp_posparam:probe.short_name
Note: Google Test filter = clang_parser.parse_fail:clang_parser.redefined_types:clang_parser_btf.btf_arrays_multi_dim:clang_parser_btf.btf_type_override:ConfigSetter.set_stack_mode:ConfigSetter.set_user_symbol_cache_type:ConfigSetter.set_missing_probes:field_analyser_btf.btf_arrays_multi_dim:field_analyser_dwarf.parse_struct_anonymous_fields:Parser.builtin_variables:semantic_analyser.call_lhist_posparam:semantic_analyser.call_buf_posparam:semantic_analyser.call_pton:semantic_analyser_btf.call_percpu_kaddr:semantic_analyser.call_stack:semantic_analyser.array_access:semantic_analyser.unroll:semantic_analyser.positional_parameters:semantic_analyser.signal:semantic_analyser.strncmp_posparam:probe.short_name
[==========] Running 19 tests from 8 test suites.
[----------] Global test environment set-up.
[----------] 1 test from bpftrace_bad_btf
[ RUN      ] bpftrace_bad_btf.parse_invalid_btf
[       OK ] bpftrace_bad_btf.parse_invalid_btf (0 ms)
[----------] 1 test from bpftrace_bad_btf (0 ms total)

[----------] 2 tests from clang_parser
[ RUN      ] clang_parser.parse_fail
[       OK ] clang_parser.parse_fail (42 ms)
[ RUN      ] clang_parser.redefined_types
[       OK ] clang_parser.redefined_types (68 ms)
[----------] 2 tests from clang_parser (111 ms total)

[----------] 1 test from clang_parser_btf
[ RUN      ] clang_parser_btf.btf_type_override
[       OK ] clang_parser_btf.btf_type_override (110 ms)
[----------] 1 test from clang_parser_btf (110 ms total)

[----------] 3 tests from ConfigSetter
[ RUN      ] ConfigSetter.set_stack_mode
[       OK ] ConfigSetter.set_stack_mode (0 ms)
[ RUN      ] ConfigSetter.set_user_symbol_cache_type
[       OK ] ConfigSetter.set_user_symbol_cache_type (0 ms)
[ RUN      ] ConfigSetter.set_missing_probes
[       OK ] ConfigSetter.set_missing_probes (0 ms)
[----------] 3 tests from ConfigSetter (0 ms total)

[----------] 1 test from Parser
[ RUN      ] Parser.builtin_variables
[       OK ] Parser.builtin_variables (241 ms)
[----------] 1 test from Parser (241 ms total)

[----------] 9 tests from semantic_analyser
[ RUN      ] semantic_analyser.call_lhist_posparam
[       OK ] semantic_analyser.call_lhist_posparam (86 ms)
[ RUN      ] semantic_analyser.call_buf_posparam
[       OK ] semantic_analyser.call_buf_posparam (91 ms)
[ RUN      ] semantic_analyser.call_pton
[       OK ] semantic_analyser.call_pton (1368 ms)
[ RUN      ] semantic_analyser.call_stack
[       OK ] semantic_analyser.call_stack (2891 ms)
[ RUN      ] semantic_analyser.array_access
[       OK ] semantic_analyser.array_access (1757 ms)
[ RUN      ] semantic_analyser.unroll
[       OK ] semantic_analyser.unroll (403 ms)
[ RUN      ] semantic_analyser.positional_parameters
[       OK ] semantic_analyser.positional_parameters (863 ms)
[ RUN      ] semantic_analyser.signal
[       OK ] semantic_analyser.signal (1737 ms)
[ RUN      ] semantic_analyser.strncmp_posparam
[       OK ] semantic_analyser.strncmp_posparam (82 ms)
[----------] 9 tests from semantic_analyser (9284 ms total)

[----------] 1 test from probe
[ RUN      ] probe.short_name
[       OK ] probe.short_name (377 ms)
[----------] 1 test from probe (377 ms total)

[----------] 1 test from semantic_analyser_btf
[ RUN      ] semantic_analyser_btf.call_percpu_kaddr
[       OK ] semantic_analyser_btf.call_percpu_kaddr (295 ms)
[----------] 1 test from semantic_analyser_btf (295 ms total)

[----------] Global test environment tear-down
[==========] 19 tests from 8 test suites ran. (10422 ms total)
[  PASSED  ] 19 tests.
```

If a test failed, say `bpftrace_bad_btf.parse_invalid_btf`, the output will be like this:
```bash
$ BPFTRACE_SUPPRESS_TEST_SPEW=1 bpftrace_test --gtest_filter=bpftrace_bad_btf.parse_invalid_btf:clang_parser.parse_fail:clang_parser.redefined_types:clang_parser_btf.btf_arrays_multi_dim:clang_parser_btf.btf_type_override:ConfigSetter.set_stack_mode:ConfigSetter.set_user_symbol_cache_type:ConfigSetter.set_missing_probes:field_analyser_btf.btf_arrays_multi_dim:field_analyser_dwarf.parse_struct_anonymous_fields:Parser.builtin_variables:semantic_analyser.call_lhist_posparam:semantic_analyser.call_buf_posparam:semantic_analyser.call_pton:semantic_analyser_btf.call_percpu_kaddr:semantic_analyser.call_stack:semantic_analyser.array_access:semantic_analyser.unroll:semantic_analyser.positional_parameters:semantic_analyser.signal:semantic_analyser.strncmp_posparam:probe.short_name
Note: Google Test filter = bpftrace_bad_btf.parse_invalid_btf:clang_parser.parse_fail:clang_parser.redefined_types:clang_parser_btf.btf_arrays_multi_dim:clang_parser_btf.btf_type_override:ConfigSetter.set_stack_mode:ConfigSetter.set_user_symbol_cache_type:ConfigSetter.set_missing_probes:field_analyser_btf.btf_arrays_multi_dim:field_analyser_dwarf.parse_struct_anonymous_fields:Parser.builtin_variables:semantic_analyser.call_lhist_posparam:semantic_analyser.call_buf_posparam:semantic_analyser.call_pton:semantic_analyser_btf.call_percpu_kaddr:semantic_analyser.call_stack:semantic_analyser.array_access:semantic_analyser.unroll:semantic_analyser.positional_parameters:semantic_analyser.signal:semantic_analyser.strncmp_posparam:probe.short_name
[==========] Running 19 tests from 8 test suites.
[----------] Global test environment set-up.
[----------] 1 test from bpftrace_bad_btf
[ RUN      ] bpftrace_bad_btf.parse_invalid_btf
/bpftrace/tests/bpftrace.cpp:1248: Failure
Value of: !bpftrace.has_btf_data()
  Actual: true
Expected: false

WARNING: BTF: failed to parse BTF from /tmp/btf_datae42Vlv
WARNING: BTF: failed to parse BTF from /tmp/btf_datae42Vlv
[  FAILED  ] bpftrace_bad_btf.parse_invalid_btf (0 ms)
[----------] 1 test from bpftrace_bad_btf (0 ms total)

[----------] 2 tests from clang_parser
[ RUN      ] clang_parser.parse_fail
[       OK ] clang_parser.parse_fail (46 ms)
[ RUN      ] clang_parser.redefined_types
[       OK ] clang_parser.redefined_types (67 ms)
[----------] 2 tests from clang_parser (114 ms total)

[----------] 1 test from clang_parser_btf
[ RUN      ] clang_parser_btf.btf_type_override
[       OK ] clang_parser_btf.btf_type_override (112 ms)
[----------] 1 test from clang_parser_btf (112 ms total)

[----------] 3 tests from ConfigSetter
[ RUN      ] ConfigSetter.set_stack_mode
[       OK ] ConfigSetter.set_stack_mode (0 ms)
[ RUN      ] ConfigSetter.set_user_symbol_cache_type
[       OK ] ConfigSetter.set_user_symbol_cache_type (0 ms)
[ RUN      ] ConfigSetter.set_missing_probes
[       OK ] ConfigSetter.set_missing_probes (0 ms)
[----------] 3 tests from ConfigSetter (1 ms total)

[----------] 1 test from Parser
[ RUN      ] Parser.builtin_variables
[       OK ] Parser.builtin_variables (242 ms)
[----------] 1 test from Parser (242 ms total)

[----------] 9 tests from semantic_analyser
[ RUN      ] semantic_analyser.call_lhist_posparam
[       OK ] semantic_analyser.call_lhist_posparam (97 ms)
[ RUN      ] semantic_analyser.call_buf_posparam
[       OK ] semantic_analyser.call_buf_posparam (95 ms)
[ RUN      ] semantic_analyser.call_pton
[       OK ] semantic_analyser.call_pton (1447 ms)
[ RUN      ] semantic_analyser.call_stack
[       OK ] semantic_analyser.call_stack (2964 ms)
[ RUN      ] semantic_analyser.array_access
[       OK ] semantic_analyser.array_access (1790 ms)
[ RUN      ] semantic_analyser.unroll
[       OK ] semantic_analyser.unroll (409 ms)
[ RUN      ] semantic_analyser.positional_parameters
[       OK ] semantic_analyser.positional_parameters (816 ms)
[ RUN      ] semantic_analyser.signal
[       OK ] semantic_analyser.signal (1717 ms)
[ RUN      ] semantic_analyser.strncmp_posparam
[       OK ] semantic_analyser.strncmp_posparam (87 ms)
[----------] 9 tests from semantic_analyser (9427 ms total)

[----------] 1 test from probe
[ RUN      ] probe.short_name
[       OK ] probe.short_name (415 ms)
[----------] 1 test from probe (415 ms total)

[----------] 1 test from semantic_analyser_btf
[ RUN      ] semantic_analyser_btf.call_percpu_kaddr
[       OK ] semantic_analyser_btf.call_percpu_kaddr (313 ms)
[----------] 1 test from semantic_analyser_btf (313 ms total)

[----------] Global test environment tear-down
[==========] 19 tests from 8 test suites ran. (10628 ms total)
[  PASSED  ] 18 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] bpftrace_bad_btf.parse_invalid_btf

 1 FAILED TEST
```

##### Checklist

- [ x ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ x ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ x ] The new behaviour is covered by tests
