### PR TITLE
Don't crash if kernel is built without PID namespaces

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -76,11 +76,11 @@ constexpr uint32_t PROC_PID_INIT_INO = 0xeffffffc;
 Value *IRBuilderBPF::CreateGetPid(Value *ctx, const Location &loc)
 {
   const auto &pidns = bpftrace_.get_pidns_self_stat();
-  if (pidns.st_ino != PROC_PID_INIT_INO) {
+  if (pidns && pidns->st_ino != PROC_PID_INIT_INO) {
     // Get namespaced target PID when we're running in a namespace
     AllocaInst *res = CreateAllocaBPF(BpfPidnsInfoType(), "bpf_pidns_info");
     CreateGetNsPidTgid(
-        ctx, getInt64(pidns.st_dev), getInt64(pidns.st_ino), res, loc);
+        ctx, getInt64(pidns->st_dev), getInt64(pidns->st_ino), res, loc);
     Value *pid = CreateLoad(
         getInt32Ty(),
         CreateGEP(BpfPidnsInfoType(), res, { getInt32(0), getInt32(0) }));
@@ -97,11 +97,11 @@ Value *IRBuilderBPF::CreateGetPid(Value *ctx, const Location &loc)
 Value *IRBuilderBPF::CreateGetTid(Value *ctx, const Location &loc)
 {
   const auto &pidns = bpftrace_.get_pidns_self_stat();
-  if (pidns.st_ino != PROC_PID_INIT_INO) {
+  if (pidns && pidns->st_ino != PROC_PID_INIT_INO) {
     // Get namespaced target TID when we're running in a namespace
     AllocaInst *res = CreateAllocaBPF(BpfPidnsInfoType(), "bpf_pidns_info");
     CreateGetNsPidTgid(
-        ctx, getInt64(pidns.st_dev), getInt64(pidns.st_ino), res, loc);
+        ctx, getInt64(pidns->st_dev), getInt64(pidns->st_ino), res, loc);
     Value *tid = CreateLoad(
         getInt32Ty(),
         CreateGEP(BpfPidnsInfoType(), res, { getInt32(0), getInt32(1) }));

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1943,14 +1943,17 @@ std::unordered_set<std::string> BPFtrace::get_raw_tracepoint_modules(
   return mod != rts.end() ? mod->second : std::unordered_set<std::string>();
 }
 
-const struct stat &BPFtrace::get_pidns_self_stat() const
+const std::optional<struct stat> &BPFtrace::get_pidns_self_stat() const
 {
-  static struct stat pidns = []() -> auto {
+  static std::optional<struct stat> pidns = []() -> std::optional<struct stat> {
     struct stat s;
-    if (::stat("/proc/self/ns/pid", &s))
+    if (::stat("/proc/self/ns/pid", &s)) {
+      if (errno == ENOENT)
+        return std::nullopt;
       throw std::runtime_error(
           std::string("Failed to stat /proc/self/ns/pid: ") +
           std::strerror(errno));
+    }
     return s;
   }();
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -172,7 +172,7 @@ public:
       const std::string &func_name) const;
   virtual std::unordered_set<std::string> get_raw_tracepoint_modules(
       const std::string &name) const;
-  virtual const struct stat &get_pidns_self_stat() const;
+  virtual const std::optional<struct stat> &get_pidns_self_stat() const;
 
   bool write_pcaps(uint64_t id, uint64_t ns, uint8_t *pkt, unsigned int size);
 

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -74,17 +74,17 @@ public:
     return { "mock_vmlinux" };
   }
 
-  const struct stat &get_pidns_self_stat() const override
+  const std::optional<struct stat> &get_pidns_self_stat() const override
   {
-    static const struct stat init_pid_namespace = []() {
+    static const std::optional<struct stat> init_pid_namespace = []() {
       struct stat s {};
       s.st_ino = 0xeffffffc; // PROC_PID_INIT_INO
-      return s;
+      return std::optional{ s };
     }();
-    static const struct stat child_pid_namespace = []() {
+    static const std::optional<struct stat> child_pid_namespace = []() {
       struct stat s {};
       s.st_ino = 0xf0000011; // Arbitrary user namespace
-      return s;
+      return std::optional{ s };
     }();
 
     if (mock_in_init_pid_ns)


### PR DESCRIPTION
Like the android kernel.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests

Not sure how to test this?