### PR TITLE
cleanup: drop dead declaration

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -288,7 +288,6 @@ public:
 
 class ArrayAccess : public Expression {
 public:
-  ArrayAccess(Diagnostics &d, Expression *expr, Expression *indexpr);
   ArrayAccess(Diagnostics &d,
               Expression *expr,
               Expression *indexpr,


### PR DESCRIPTION
This does not seem to have an associated implementation.
