### PR TITLE
fix: stats_t is not a multi-output map

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -459,15 +459,20 @@ public:
   }
   bool IsMapIterableTy() const
   {
-    return !IsMultiOutputMapTy();
+    if (IsMultiKeyMapTy()) {
+      return false;
+    }
+    if (NeedsPercpuMap() && !IsCastableMapTy()) {
+      return false;
+    }
+    return true;
   }
 
-  // These are special map value types that can't be reduced to a single value
-  // and output multiple lines when printed
-  bool IsMultiOutputMapTy() const
+  // These are special map value types that use multiple keys to store a single
+  // logical value (from the user perspective).
+  bool IsMultiKeyMapTy() const
   {
-    return type_ == Type::hist_t || type_ == Type::lhist_t ||
-           type_ == Type::stats_t;
+    return type_ == Type::hist_t || type_ == Type::lhist_t;
   }
 
   bool NeedsPercpuMap() const;

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2425,6 +2425,19 @@ kprobe:f { @y = avg(5); @x = @y; }
                         ~~~~~~~
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )");
+  test_error("kprobe:f { @y = stats(5); @x = @y; }", R"(
+stdin:1:27-34: ERROR: Map value 'stats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
+kprobe:f { @y = stats(5); @x = @y; }
+                          ~~~~~~~
+)");
+  test_error("kprobe:f { @x = 1; @y = stats(5); @x = @y; }", R"(
+stdin:1:35-42: ERROR: Map value 'stats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
+kprobe:f { @x = 1; @y = stats(5); @x = @y; }
+                                  ~~~~~~~
+stdin:1:35-37: ERROR: Type mismatch for @x: trying to assign value of type 'stats_t' when map already contains a value of type 'int64'
+kprobe:f { @x = 1; @y = stats(5); @x = @y; }
+                                  ~~
+)");
 
   test("kprobe:f { @ = count(); if (@ > 0) { print((1)); } }");
   test("kprobe:f { @ = sum(5); if (@ > 0) { print((1)); } }");


### PR DESCRIPTION
Stacked PRs:
 * #3988
 * #3984
 * #3983
 * #3982
 * #3981
 * #3980
 * #3979
 * __->__#3978


--- --- ---

### fix: stats_t is not a multi-output map

Stats do not require multiple keys. By request, they cannot be casted or
aggregated and must be kept in a map for printing.

Signed-off-by: Adin Scannell <amscanne@meta.com>
