### PR TITLE
cleanup: simplify `For` nodes by only parsing maps

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -471,18 +471,18 @@ class For : public Statement {
 public:
   For(Diagnostics &d,
       Variable *decl,
-      Expression *expr,
+      Map *map,
       StatementList &&stmts,
       Location &&loc)
       : Statement(d, std::move(loc)),
         decl(decl),
-        expr(expr),
+        map(map),
         stmts(std::move(stmts))
   {
   }
 
   Variable *decl = nullptr;
-  Expression *expr = nullptr;
+  Map *map = nullptr;
   StatementList stmts;
   SizedType ctx_type;
 };

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -372,11 +372,7 @@ void Printer::visit(For &for_loop)
   out_ << indent << " decl\n";
   ++depth_;
   visit(for_loop.decl);
-  --depth_;
-
-  out_ << indent << " expr\n";
-  ++depth_;
-  visit(for_loop.expr);
+  visit(for_loop.map);
   --depth_;
 
   out_ << indent << " stmts\n";

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -185,7 +185,7 @@ public:
   R visit(For &for_loop)
   {
     visitAndReplace(&for_loop.decl);
-    visitAndReplace(&for_loop.expr);
+    visitAndReplace(&for_loop.map);
     visitImpl(for_loop.stmts);
     return default_value();
   }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -447,7 +447,7 @@ loop_stmt:
                 ;
 
 for_stmt:
-                FOR "(" var ":" expr ")" block       { $$ = driver.ctx.make_node<ast::For>($3, $5, std::move($7), @1); }
+                FOR "(" var ":" map ")" block        { $$ = driver.ctx.make_node<ast::For>($3, $5, std::move($7), @1); }
                 ;
 
 if_stmt:

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2903,7 +2903,6 @@ Program
   for
    decl
     variable: $kv
-   expr
     map: @map
    stmts
     call: print

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4146,7 +4146,6 @@ Program
   for
    decl
     variable: $kv :: [(int64,int64)]
-   expr
     map: @map :: [int64]
    stmts
     call: print
@@ -4168,7 +4167,6 @@ Program
   for
    decl
     variable: $kv :: [((int64,int64),int64)]
-   expr
     map: @map :: [int64]
    stmts
     call: print
@@ -4369,17 +4367,17 @@ TEST(semantic_analyser, for_loop_invalid_expr)
 {
   // Error location is incorrect: #3063
   test_error("BEGIN { for ($x : $var) { } }", R"(
-stdin:1:19-24: ERROR: Loop expression must be a map
+stdin:1:19-24: ERROR: syntax error, unexpected variable, expecting map
 BEGIN { for ($x : $var) { } }
                   ~~~~~
 )");
   test_error("BEGIN { for ($x : 1+2) { } }", R"(
-stdin:1:19-22: ERROR: Loop expression must be a map
+stdin:1:19-21: ERROR: syntax error, unexpected integer, expecting map
 BEGIN { for ($x : 1+2) { } }
-                  ~~~
+                  ~~
 )");
   test_error("BEGIN { for ($x : \"abc\") { } }", R"(
-stdin:1:19-25: ERROR: Loop expression must be a map
+stdin:1:19-25: ERROR: syntax error, unexpected string, expecting map
 BEGIN { for ($x : "abc") { } }
                   ~~~~~~
 )");
@@ -4392,15 +4390,12 @@ TEST(semantic_analyser, for_loop_multiple_errors)
     BEGIN {
       $kv = 1;
       @map[0] = 1;
-      for ($kv : 1) { }
+      for ($kv : @map) { }
     })",
              R"(
 stdin:4:11-15: ERROR: Loop declaration shadows existing variable: $kv
-      for ($kv : 1) { }
+      for ($kv : @map) { }
           ~~~~
-stdin:4:18-20: ERROR: Loop expression must be a map
-      for ($kv : 1) { }
-                 ~~
 )");
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #3988
 * #3984
 * #3983
 * #3982
 * #3981
 * #3980
 * __->__#3979


--- --- ---

### cleanup: simplify `For` nodes by only parsing maps


Currently we accept any expression here, but this is not a supported
feature. Simplify some of the internals by simplify having this be a
map. This can be relaxed in the future.

Signed-off-by: Adin Scannell <amscanne@meta.com>
