### PR TITLE
config: refactor and simplify configuration plumbing

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -32,12 +32,6 @@ String::String(ASTContext &ctx, std::string str, Location &&loc)
   is_literal = true;
 }
 
-StackMode::StackMode(ASTContext &ctx, std::string mode, Location &&loc)
-    : Expression(ctx, std::move(loc)), mode(std::move(mode))
-{
-  is_literal = true;
-}
-
 Builtin::Builtin(ASTContext &ctx, std::string ident, Location &&loc)
     : Expression(ctx, std::move(loc)), ident(std::move(ident))
 {
@@ -248,10 +242,18 @@ AssignVarStatement::AssignVarStatement(ASTContext &ctx,
 }
 
 AssignConfigVarStatement::AssignConfigVarStatement(ASTContext &ctx,
-                                                   Identifier *config_var,
-                                                   Expression *expr,
+                                                   std::string var,
+                                                   uint64_t value,
                                                    Location &&loc)
-    : Statement(ctx, std::move(loc)), config_var(config_var), expr(expr)
+    : Node(ctx, std::move(loc)), var(std::move(var)), value(std::move(value))
+{
+}
+
+AssignConfigVarStatement::AssignConfigVarStatement(ASTContext &ctx,
+                                                   std::string var,
+                                                   std::string value,
+                                                   Location &&loc)
+    : Node(ctx, std::move(loc)), var(std::move(var)), value(std::move(value))
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <string>
+#include <variant>
 #include <vector>
 
 #include "diagnostic.h"
@@ -129,13 +130,6 @@ public:
   explicit String(ASTContext &ctx, std::string str, Location &&loc);
 
   std::string str;
-};
-
-class StackMode : public Expression {
-public:
-  explicit StackMode(ASTContext &ctx, std::string mode, Location &&loc);
-
-  std::string mode;
 };
 
 class Identifier : public Expression {
@@ -356,16 +350,21 @@ public:
   Expression *expr = nullptr;
 };
 
-class AssignConfigVarStatement : public Statement {
+class AssignConfigVarStatement : public Node {
 public:
   AssignConfigVarStatement(ASTContext &ctx,
-                           Identifier *config_var,
-                           Expression *expr,
+                           std::string var,
+                           uint64_t value,
+                           Location &&loc);
+  AssignConfigVarStatement(ASTContext &ctx,
+                           std::string var,
+                           std::string value,
                            Location &&loc);
 
-  Identifier *config_var = nullptr;
-  Expression *expr = nullptr;
+  std::string var;
+  std::variant<uint64_t, std::string> value;
 };
+using ConfigStatementList = std::vector<AssignConfigVarStatement *>;
 
 class Block : public Expression {
 public:
@@ -472,14 +471,14 @@ public:
   SizedType ctx_type;
 };
 
-class Config : public Statement {
+class Config : public Node {
 public:
-  Config(ASTContext &ctx, StatementList &&stmts, Location &&loc)
-      : Statement(ctx, std::move(loc)), stmts(std::move(stmts))
+  Config(ASTContext &ctx, ConfigStatementList &&stmts, Location &&loc)
+      : Node(ctx, std::move(loc)), stmts(std::move(stmts))
   {
   }
 
-  StatementList stmts;
+  ConfigStatementList stmts;
 };
 
 class Probe;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -537,7 +537,7 @@ CallInst *IRBuilderBPF::CreateGetStackScratchMap(StackType stack_type,
 Value *IRBuilderBPF::CreateGetStrAllocation(const std::string &name,
                                             const Location &loc)
 {
-  const auto max_strlen = bpftrace_.config_->get(ConfigKeyInt::max_strlen);
+  const auto max_strlen = bpftrace_.config_->max_strlen;
   const auto str_type = CreateArray(max_strlen, CreateInt8());
   return createAllocation(bpftrace::globalvars::GlobalVar::GET_STR_BUFFER,
                           GetType(str_type),
@@ -635,8 +635,7 @@ Value *IRBuilderBPF::createAllocation(
     std::optional<std::function<size_t(AsyncIds &)>> gen_async_id_cb)
 {
   const auto obj_size = module_.getDataLayout().getTypeAllocSize(obj_type);
-  const auto on_stack_limit = bpftrace_.config_->get(
-      ConfigKeyInt::on_stack_limit);
+  const auto on_stack_limit = bpftrace_.config_->on_stack_limit;
   if (obj_size > on_stack_limit) {
     return createScratchBuffer(
         globalvar, loc, gen_async_id_cb ? (*gen_async_id_cb)(async_ids_) : 0);

--- a/src/ast/passes/codegen_resources.cpp
+++ b/src/ast/passes/codegen_resources.cpp
@@ -21,8 +21,7 @@ void CodegenResourceAnalyser::visit(Builtin &builtin)
   if (builtin.ident == "elapsed") {
     resources_.needs_elapsed_map = true;
   } else if (builtin.ident == "kstack" || builtin.ident == "ustack") {
-    resources_.stackid_maps.insert(
-        StackType{ .mode = config_.get(ConfigKeyStackMode::default_) });
+    resources_.stackid_maps.insert(StackType{ .mode = config_.stack_mode });
   }
 }
 

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -6,7 +6,6 @@
 #include "ast/visitor.h"
 #include "bpftrace.h"
 #include "config.h"
-#include "types.h"
 
 namespace bpftrace::ast {
 
@@ -14,191 +13,75 @@ namespace {
 
 class ConfigAnalyser : public Visitor<ConfigAnalyser> {
 public:
-  explicit ConfigAnalyser(BPFtrace &bpftrace)
-      : bpftrace_(bpftrace),
-        config_setter_(ConfigSetter(*bpftrace.config_, ConfigSource::script))
-  {
-  }
+  explicit ConfigAnalyser(BPFtrace &bpftrace) : bpftrace_(bpftrace) {};
 
   using Visitor<ConfigAnalyser>::visit;
-  void visit(Integer &integer);
-  void visit(String &string);
-  void visit(StackMode &mode);
   void visit(AssignConfigVarStatement &assignment);
 
 private:
   BPFtrace &bpftrace_;
-  ConfigSetter config_setter_;
-
-  void set_config(AssignConfigVarStatement &assignment, ConfigKeyInt key);
-  void set_config(AssignConfigVarStatement &assignment, ConfigKeyBool key);
-  void set_config(AssignConfigVarStatement &assignment, ConfigKeyString key);
-  void set_config(AssignConfigVarStatement &assignment,
-                  ConfigKeyUserSymbolCacheType key);
-  void set_config(AssignConfigVarStatement &assignment, ConfigKeyStackMode key);
-  void set_config(AssignConfigVarStatement &assignment,
-                  ConfigKeyMissingProbes key);
-
-  void log_type_error(SizedType &type,
-                      Type expected_type,
-                      AssignConfigVarStatement &assignment);
 };
 
 } // namespace
 
-void ConfigAnalyser::log_type_error(SizedType &type,
-                                    Type expected_type,
-                                    AssignConfigVarStatement &assignment)
-{
-  assignment.expr->addError()
-      << "Invalid type for " << assignment.config_var->ident
-      << ". Type: " << type.GetTy() << ". Expected Type: " << expected_type;
-}
-
-void ConfigAnalyser::set_config(AssignConfigVarStatement &assignment,
-                                ConfigKeyInt key)
-{
-  auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsIntegerTy()) {
-    log_type_error(assignTy, Type::integer, assignment);
-    return;
-  }
-
-  config_setter_.set(key, dynamic_cast<Integer *>(assignment.expr)->n);
-}
-
-void ConfigAnalyser::set_config(AssignConfigVarStatement &assignment,
-                                ConfigKeyBool key)
-{
-  auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsIntegerTy()) {
-    log_type_error(assignTy, Type::integer, assignment);
-    return;
-  }
-
-  auto val = dynamic_cast<Integer *>(assignment.expr)->n;
-  if (val == 0) {
-    config_setter_.set(key, false);
-  } else if (val == 1) {
-    config_setter_.set(key, true);
-  } else {
-    assignment.expr->addError()
-        << "Invalid value for " << assignment.config_var->ident
-        << ". Needs to be 0 or 1. Value: " << val;
-  }
-}
-
-void ConfigAnalyser::set_config(AssignConfigVarStatement &assignment,
-                                [[maybe_unused]] ConfigKeyString key)
-{
-  auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsStringTy()) {
-    log_type_error(assignTy, Type::string, assignment);
-    return;
-  }
-
-  config_setter_.set(key, dynamic_cast<String *>(assignment.expr)->str);
-}
-
-void ConfigAnalyser::set_config(AssignConfigVarStatement &assignment,
-                                [[maybe_unused]] ConfigKeyStackMode key)
-{
-  auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsStackModeTy()) {
-    log_type_error(assignTy, Type::stack_mode, assignment);
-    return;
-  }
-
-  config_setter_.set(assignTy.stack_type.mode);
-}
-
-void ConfigAnalyser::set_config(
-    AssignConfigVarStatement &assignment,
-    [[maybe_unused]] ConfigKeyUserSymbolCacheType key)
-{
-  auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsStringTy()) {
-    log_type_error(assignTy, Type::string, assignment);
-    return;
-  }
-
-  auto val = dynamic_cast<String *>(assignment.expr)->str;
-  if (!config_setter_.set_user_symbol_cache_type(val))
-    assignment.expr->addError();
-}
-
-void ConfigAnalyser::set_config(AssignConfigVarStatement &assignment,
-                                [[maybe_unused]] ConfigKeyMissingProbes key)
-{
-  auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsStringTy()) {
-    log_type_error(assignTy, Type::string, assignment);
-    return;
-  }
-
-  auto val = dynamic_cast<String *>(assignment.expr)->str;
-  if (!config_setter_.set_missing_probes_config(val))
-    assignment.expr->addError();
-}
-
-void ConfigAnalyser::visit(Integer &integer)
-{
-  integer.type = CreateInt64();
-}
-
-void ConfigAnalyser::visit(String &string)
-{
-  string.type = CreateString(string.str.size() + 1);
-}
-
-void ConfigAnalyser::visit(StackMode &mode)
-{
-  auto stack_mode = bpftrace::Config::get_stack_mode(mode.mode);
-  if (stack_mode.has_value()) {
-    mode.type = CreateStackMode();
-    mode.type.stack_type.mode = stack_mode.value();
-  } else {
-    mode.type = CreateNone();
-    mode.addError() << "Unknown stack mode: '" + mode.mode + "'";
-  }
-}
+static std::unordered_set<std::string> DEPRECATED_CONFIGS = {
+  "symbol_source",
+};
 
 void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
 {
-  Visitor<ConfigAnalyser>::visit(assignment);
-  std::string &raw_ident = assignment.config_var->ident;
-
-  std::string err_msg;
-  const auto maybeConfigKey = bpftrace_.config_->get_config_key(raw_ident,
-                                                                err_msg);
-
-  if (!maybeConfigKey.has_value()) {
-    assignment.config_var->addError() << err_msg;
-    return;
+  // If this is deprecated, just emit a warning and move on. This is done here
+  // because they are no longer understood by the actual config type.
+  if (DEPRECATED_CONFIGS.contains(assignment.var)) {
+    assignment.addWarning()
+        << assignment.var << " is deprecated and has no effect";
   }
 
-  if (!assignment.expr->is_literal) {
-    assignment.expr->addError()
-        << "Assignment for " << assignment.config_var->ident
-        << " must be literal.";
-    return;
+  std::string var(assignment.var);
+  while (true) {
+    // Set the variable.
+    auto ok = std::visit(
+        [&](const auto &v) { return bpftrace_.config_->set(var, v); },
+        assignment.value);
+
+    // Attempt to handle a rename error, and find the new name. This is done
+    // here rather than the config so that we can emit a suitable error.
+    if (!ok) {
+      ok = handleErrors(std::move(ok),
+                        [&](const RenameError &e) { var = e.new_name(); });
+      if (!ok) {
+        assignment.addError() << ok.takeError();
+        return;
+      }
+      continue;
+    }
+    break; // All set.
+  }
+  if (var != assignment.var) {
+    assignment.addWarning()
+        << assignment.var << " has been renamed, please use " << var;
   }
 
-  auto configKey = maybeConfigKey.value();
-
-  std::visit([&](auto key) { set_config(assignment, key); }, configKey);
-
-  if (bpftrace_.config_->is_unstable(configKey)) {
-    assignment.config_var->addWarning()
-        << "Script is using an unstable feature: " << raw_ident;
+  // If set successfully, see if we must warn.
+  if (bpftrace_.config_->is_unstable(assignment.var)) {
+    assignment.addWarning()
+        << "Script is using an unstable feature: " << assignment.var;
   }
 }
 
 Pass CreateConfigPass()
 {
-  auto fn = [](ASTContext &ast, BPFtrace &b) {
+  auto fn = [](ASTContext &ast, BPFtrace &b) -> Result<OK> {
     auto configs = ConfigAnalyser(b);
     configs.visit(ast.root);
+
+    // Reload any environment changes.
+    auto ok = b.config_->load_environment();
+    if (!ok) {
+      return ok.takeError();
+    }
+
+    return OK();
   };
 
   return Pass::create("ConfigAnalyser", fn);

--- a/src/ast/passes/deprecated.cpp
+++ b/src/ast/passes/deprecated.cpp
@@ -13,7 +13,6 @@ public:
   using Visitor<DeprecatedAnalyser>::visit;
   void visit(Builtin &builtin);
   void visit(Call &call);
-  void visit(AssignConfigVarStatement &assign);
 };
 
 struct DeprecatedName {
@@ -76,19 +75,6 @@ static std::vector<DeprecatedName> DEPRECATED_CALLS = {};
 void DeprecatedAnalyser::visit(Call &call)
 {
   check(DEPRECATED_CALLS, call.func, call);
-}
-
-static std::vector<DeprecatedName> DEPRECATED_CONFIGS = {
-  {
-      .old_name = "symbol_source",
-      .new_name = {},
-      .deleted = true,
-  },
-};
-
-void DeprecatedAnalyser::visit(AssignConfigVarStatement &assign)
-{
-  check(DEPRECATED_CONFIGS, assign.config_var->ident, assign);
 }
 
 Pass CreateDeprecatedPass()

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -71,12 +71,6 @@ void Printer::visit(String &string)
   out_ << indent << "string: " << ss.str() << type(string.type) << std::endl;
 }
 
-void Printer::visit(StackMode &mode)
-{
-  std::string indent(depth_, ' ');
-  out_ << indent << "stack_mode: " << mode.mode << type(mode.type) << std::endl;
-}
-
 void Printer::visit(Builtin &builtin)
 {
   std::string indent(depth_, ' ');
@@ -290,9 +284,16 @@ void Printer::visit(AssignConfigVarStatement &assignment)
 
   ++depth_;
   std::string indentVar(depth_, ' ');
-  out_ << indentVar << "config var: " << assignment.config_var->ident
-       << std::endl;
-  visit(assignment.expr);
+  out_ << indentVar << "var: " << assignment.var << std::endl;
+  std::visit(
+      [&](auto &v) {
+        if constexpr (std::is_same_v<std::decay_t<decltype(v)>, std::string>) {
+          out_ << indentVar << "string: " << v << std::endl;
+        } else {
+          out_ << indentVar << "int: " << v << std::endl;
+        }
+      },
+      assignment.value);
   --depth_;
 }
 

--- a/src/ast/passes/resolve_imports.cpp
+++ b/src/ast/passes/resolve_imports.cpp
@@ -31,7 +31,7 @@ private:
 
 void ResolveImports::visit(Import &imp)
 {
-  if (!bpftrace_.config_->get(ConfigKeyBool::unstable_import)) {
+  if (!bpftrace_.config_->unstable_import) {
     imp.addError() << "Imports are not enabled by default. To enable "
                       "this unstable feature, set this config flag to 1 "
                       "e.g. unstable_import=1";

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -339,7 +339,7 @@ void ResourceAnalyser::visit(Call &call)
   }
 
   if (call.func == "str" || call.func == "buf" || call.func == "path") {
-    const auto max_strlen = bpftrace_.config_->get(ConfigKeyInt::max_strlen);
+    const auto max_strlen = bpftrace_.config_->max_strlen;
     if (exceeds_stack_limit(max_strlen))
       resources_.str_buffers++;
   }
@@ -499,7 +499,7 @@ void ResourceAnalyser::visit(Ternary &ternary)
   // blow it up. So we need a scratch buffer for it.
 
   if (ternary.type.IsStringTy()) {
-    const auto max_strlen = bpftrace_.config_->get(ConfigKeyInt::max_strlen);
+    const auto max_strlen = bpftrace_.config_->max_strlen;
     if (exceeds_stack_limit(max_strlen))
       resources_.str_buffers++;
   }
@@ -535,7 +535,7 @@ void ResourceAnalyser::visit(VarDeclStatement &decl)
 
 bool ResourceAnalyser::exceeds_stack_limit(size_t size)
 {
-  return size > bpftrace_.config_->get(ConfigKeyInt::on_stack_limit);
+  return size > bpftrace_.config_->on_stack_limit;
 }
 
 bool ResourceAnalyser::uses_usym_table(const std::string &fun)
@@ -565,7 +565,7 @@ void ResourceAnalyser::update_map_info(Map &map)
   } else {
     map_info.bpf_type = get_bpf_map_type(map_info.value_type,
                                          map_info.key_type);
-    map_info.max_entries = bpftrace_.config_->get(ConfigKeyInt::max_map_keys);
+    map_info.max_entries = bpftrace_.config_->max_map_keys;
   }
 }
 

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -60,10 +60,6 @@ public:
   {
     return default_value();
   }
-  R visit(StackMode &mode __attribute__((__unused__)))
-  {
-    return default_value();
-  }
   R visit(Variable &var __attribute__((__unused__)))
   {
     return default_value();
@@ -151,9 +147,9 @@ public:
     visitAndReplace(&assignment.expr);
     return default_value();
   }
-  R visit(AssignConfigVarStatement &assignment)
+  R visit(AssignConfigVarStatement &assignment __attribute__((__unused__)))
   {
-    return visitAndReplace(&assignment.expr);
+    return default_value();
   }
   R visit(VarDeclStatement &decl)
   {
@@ -353,7 +349,6 @@ public:
                               PositionalParameter *,
                               PositionalParameterCount *,
                               String *,
-                              StackMode *,
                               Identifier *,
                               Builtin *,
                               Call *,
@@ -378,13 +373,11 @@ public:
                               VarDeclStatement *,
                               AssignMapStatement *,
                               AssignVarStatement *,
-                              AssignConfigVarStatement *,
                               If *,
                               Unroll *,
                               Jump *,
                               While *,
-                              For *,
-                              Config *>(stmt);
+                              For *>(stmt);
   }
 
 private:

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -442,8 +442,7 @@ bool AttachedProbe::resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps)
     if (!sym.start) {
       const std::string msg = "Could not resolve symbol: " + probe_.path + ":" +
                               symbol;
-      auto missing_probes = bpftrace_.config_->get(
-          ConfigKeyMissingProbes::default_);
+      const auto missing_probes = bpftrace_.config_->missing_probes;
       if (!has_multiple_aps || missing_probes == ConfigMissingProbes::error) {
         throw util::FatalUserException(msg + ", cannot attach probe.");
       } else {
@@ -610,8 +609,7 @@ void AttachedProbe::attach_kprobe()
   // If the user requested to ignore warnings on non-existing probes and the
   // function is not traceable, do not even try to attach as that would yield
   // warnings from BCC which we don't want to see.
-  if (bpftrace_.config_->get(ConfigKeyMissingProbes::default_) ==
-          ConfigMissingProbes::ignore &&
+  if (bpftrace_.config_->missing_probes == ConfigMissingProbes::ignore &&
       probe_.name != probe_.orig_name &&
       (!funcname.empty() || probe_.address != 0) &&
       !bpftrace_.is_traceable_func(funcname))
@@ -637,8 +635,7 @@ void AttachedProbe::attach_kprobe()
 
   if (perf_event_fd < 0) {
     if (probe_.orig_name != probe_.name &&
-        bpftrace_.config_->get(ConfigKeyMissingProbes::default_) ==
-            ConfigMissingProbes::warn) {
+        bpftrace_.config_->missing_probes == ConfigMissingProbes::warn) {
       // a wildcard expansion couldn't probe something, just print a warning
       // as this is normal for some kernel functions (eg, do_debug())
       LOG(WARNING) << "could not attach probe " << probe_.name << ", skipping.";

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -182,8 +182,7 @@ void BpfBytecode::load_progs(const RequiredResources &resources,
 {
   std::unordered_map<std::string_view, std::vector<char>> log_bufs;
   for (auto &[name, prog] : programs_) {
-    log_bufs[name] = std::vector<char>(config.get(ConfigKeyInt::log_size),
-                                       '\0');
+    log_bufs[name] = std::vector<char>(config.log_size, '\0');
     auto &log_buf = log_bufs[name];
     bpf_program__set_log_buf(prog.bpf_prog(), log_buf.data(), log_buf.size());
   }
@@ -236,7 +235,7 @@ void BpfBytecode::load_progs(const RequiredResources &resources,
       if (err_pos != std::string_view::npos) {
         LOG(ERROR) << "Your bpftrace program cannot load because you are using "
                       "a license that is non-GPL compatible. License: "
-                   << config.get(ConfigKeyString::license);
+                   << config.license;
         LOG(HINT)
             << "Read more about BPF programs and licensing: "
                "https://docs.kernel.org/bpf/"

--- a/src/bpfprogram.cpp
+++ b/src/bpfprogram.cpp
@@ -84,14 +84,12 @@ void BpfProgram::set_attach_target(const Probe &probe,
   if (btf.get_btf_id(btf_fun, mod, btf_kind) < 0) {
     const std::string msg = "No BTF found for " + attach_target;
     if (probe.orig_name != probe.name &&
-        config.get(ConfigKeyMissingProbes::default_) !=
-            ConfigMissingProbes::error) {
+        config.missing_probes != ConfigMissingProbes::error) {
       // One attach point in a multi-attachpoint probe failed and the user
       // requested not to error out. Show a warning (if requested) and continue
       // but disable auto-loading of the program as it would make the entire BPF
       // object loading fail.
-      if (config.get(ConfigKeyMissingProbes::default_) ==
-          ConfigMissingProbes::warn)
+      if (config.missing_probes == ConfigMissingProbes::warn)
         LOG(WARNING) << msg << ", skipping.";
       bpf_program__set_autoload(bpf_prog_, false);
     } else {

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -12,7 +12,6 @@
 
 #include "ast/ast.h"
 #include "ast/context.h"
-#include "ast/visitor.h"
 #include "bpftrace.h"
 #include "btf.h"
 #include "clang_parser.h"
@@ -617,8 +616,8 @@ void ClangParser::resolve_incomplete_types_from_btf(
     if (probe->tp_args_structs_level > static_cast<int>(field_lvl))
       field_lvl = probe->tp_args_structs_level;
 
-  unsigned max_iterations = std::max(
-      bpftrace.config_->get(ConfigKeyInt::max_type_res_iterations), field_lvl);
+  unsigned max_iterations = std::max(bpftrace.config_->max_type_res_iterations,
+                                     field_lvl);
 
   bool check_incomplete_types = true;
   for (unsigned i = 0; i < max_iterations && check_incomplete_types; i++) {

--- a/src/config_parser.h
+++ b/src/config_parser.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+#include "util/result.h"
+
+namespace bpftrace {
+
+// If you want to be able to parse custom configuration, then simply
+// provide a specialization of the `ConfigParser` class that specifies
+// the implementation of the operators to parse any string and integers.
+template <typename T>
+struct ConfigParser;
+
+// Generic parse error for a specific key. This should be returned by
+// the `ConfigParser` implementations if the value cannot be parsed.
+class ParseError : public ErrorInfo<ParseError> {
+public:
+  static char ID;
+  ParseError(std::string key, std::string &&detail)
+      : key_(std::move(key)), detail_(std::move(detail)) {};
+  void log(llvm::raw_ostream &OS) const override;
+
+private:
+  std::string key_;
+  std::string detail_;
+};
+
+} // namespace bpftrace

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -277,7 +277,7 @@ SizedType get_type(bpftrace::globalvars::GlobalVar global_var,
                           CreateArray(resources.max_tuple_size, CreateInt8()));
     case bpftrace::globalvars::GlobalVar::GET_STR_BUFFER: {
       assert(resources.str_buffers > 0);
-      const auto max_strlen = bpftrace_config.get(ConfigKeyInt::max_strlen);
+      const auto max_strlen = bpftrace_config.max_strlen;
       return make_rw_type(resources.str_buffers,
                           CreateArray(max_strlen, CreateInt8()));
     }

--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -109,7 +109,7 @@ std::string Ksyms::resolve_blazesym(uint64_t addr, bool show_offset)
 std::string Ksyms::resolve(uint64_t addr, bool show_offset)
 {
 #ifdef HAVE_BLAZESYM
-  if (config_.get(ConfigKeyBool::use_blazesym))
+  if (config_.use_blazesym)
     return resolve_blazesym(addr, show_offset);
 #endif
   return resolve_bcc(addr, show_offset);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -82,7 +82,6 @@ oct_esc  [0-7]{1,3}
   <<EOF>>               yy_pop_state(yyscanner); driver.error(driver.loc, "end of file during comment");
 }
 
-bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, driver.loc); }
 {builtin}               { return Parser::make_BUILTIN(yytext, driver.loc); }
 {call}                  { return Parser::make_CALL(yytext, driver.loc); }
 {call_and_builtin}      { return Parser::make_CALL_BUILTIN(yytext, driver.loc); }

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -60,7 +60,7 @@ int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
   std::cout << "\n\n";
 
   // Print maps if needed (true by default).
-  if (bpftrace.config_->get(ConfigKeyBool::print_maps_on_exit))
+  if (bpftrace.config_->print_maps_on_exit)
     err = bpftrace.print_maps();
 
   if (bpftrace.child_) {

--- a/tests/codegen/license.cpp
+++ b/tests/codegen/license.cpp
@@ -7,8 +7,7 @@ namespace codegen {
 TEST(codegen, license)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
-  configs.set(ConfigKeyString::license, "Dual BSD/GPL");
+  bpftrace->config_->license = "Dual BSD/GPL";
 
   test(*bpftrace, "kprobe:f { @x = 1; }", NAME);
 }

--- a/tests/codegen/map_declarations.cpp
+++ b/tests/codegen/map_declarations.cpp
@@ -5,8 +5,7 @@ namespace bpftrace::test::codegen {
 TEST(codegen, map_hash)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
-  configs.set(ConfigKeyBool::unstable_map_decl, true);
+  bpftrace->config_->unstable_map_decl = true;
 
   test(*bpftrace, R"(let @a = hash(10); BEGIN { @a[1] = 1; })", NAME);
 }
@@ -14,8 +13,7 @@ TEST(codegen, map_hash)
 TEST(codegen, map_lruhash)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
-  configs.set(ConfigKeyBool::unstable_map_decl, true);
+  bpftrace->config_->unstable_map_decl = true;
 
   test(*bpftrace, R"(let @a = lruhash(10); BEGIN { @a[1] = 1; })", NAME);
 }
@@ -23,8 +21,7 @@ TEST(codegen, map_lruhash)
 TEST(codegen, map_percpuhash)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
-  configs.set(ConfigKeyBool::unstable_map_decl, true);
+  bpftrace->config_->unstable_map_decl = true;
 
   test(*bpftrace,
        R"(let @a = percpuhash(10); BEGIN { @a[1] = count(); })",
@@ -34,8 +31,7 @@ TEST(codegen, map_percpuhash)
 TEST(codegen, map_percpulruhash)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
-  configs.set(ConfigKeyBool::unstable_map_decl, true);
+  bpftrace->config_->unstable_map_decl = true;
 
   test(*bpftrace,
        R"(let @a = percpulruhash(10); BEGIN { @a[1] = count(); })",
@@ -45,8 +41,7 @@ TEST(codegen, map_percpulruhash)
 TEST(codegen, map_percpuarray)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
-  configs.set(ConfigKeyBool::unstable_map_decl, true);
+  bpftrace->config_->unstable_map_decl = true;
 
   test(*bpftrace, R"(let @a = percpuarray(1); BEGIN { @a = count(); })", NAME);
 }
@@ -55,8 +50,7 @@ TEST(codegen, map_percpuarray)
 TEST(codegen, map_unused)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
-  configs.set(ConfigKeyBool::unstable_map_decl, true);
+  bpftrace->config_->unstable_map_decl = true;
 
   test(*bpftrace, R"(let @a = hash(1); BEGIN { 1 })", NAME);
 }

--- a/tests/codegen/scratch_buffer.cpp
+++ b/tests/codegen/scratch_buffer.cpp
@@ -13,10 +13,8 @@ static void test_stack_or_scratch_buffer(const std::string &input,
                                          uint64_t on_stack_limit)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
-  configs.set(ConfigKeyInt::on_stack_limit, on_stack_limit);
-  configs.set(ConfigKeyInt::max_strlen, MAX_STRLEN);
-
+  bpftrace->config_->on_stack_limit = on_stack_limit;
+  bpftrace->config_->max_strlen = MAX_STRLEN;
   bpftrace->safe_mode_ = true;
 
   test(*bpftrace, input, name);

--- a/tests/deprecated.cpp
+++ b/tests/deprecated.cpp
@@ -32,14 +32,6 @@ void test(const std::string &input, const std::string &output)
   test(*bpftrace, input, output);
 }
 
-TEST(deprecated, symbol_source)
-{
-  test("config = { symbol_source=\"symbol_table\" } BEGIN { }",
-       "symbol_source is deprecated and has no effect");
-  test("config = { symbol_source=\"zzz\" } BEGIN { }",
-       "symbol_source is deprecated and has no effect");
-}
-
 TEST(deprecated, sarg)
 {
   test("BEGIN { sarg0 }", "sarg* is deprecated");

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2662,7 +2662,7 @@ TEST(Parser, config)
 Program
  config
   =
-   config var: blah
+   var: blah
    int: 5
  BEGIN
 )");
@@ -2671,7 +2671,7 @@ Program
 Program
  config
   =
-   config var: blah
+   var: blah
    int: 5
  BEGIN
 )");
@@ -2680,10 +2680,10 @@ Program
 Program
  config
   =
-   config var: blah
+   var: blah
    int: 5
   =
-   config var: zoop
+   var: zoop
    string: a
  BEGIN
 )");

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -38,8 +38,8 @@ void test(const std::string &input,
           std::optional<uint64_t> on_stack_limit = std::nullopt)
 {
   auto bpftrace = get_mock_bpftrace();
-  auto configs = ConfigSetter(*bpftrace->config_, ConfigSource::script);
-  configs.set(ConfigKeyInt::on_stack_limit, on_stack_limit.value_or(0));
+  bpftrace->config_->on_stack_limit = on_stack_limit.value_or(0);
+
   test(*bpftrace, input, expected_result, out);
 }
 

--- a/tests/runtime/config
+++ b/tests/runtime/config
@@ -16,12 +16,12 @@ AFTER ./testprogs/uprobe_test
 
 NAME bad config
 RUN {{BPFTRACE}} -e 'config = { bad_config=raw } BEGIN {}'
-EXPECT stdin:1:12-22: ERROR: Unrecognized config variable: bad_config
+EXPECT stdin:1:12-26: ERROR: bad_config: not a known configuration option
 WILL_FAIL
 
 NAME env only config
 RUN {{BPFTRACE}} -e 'config = { debug_output=1 } BEGIN {}'
-EXPECT stdin:1:12-24: ERROR: debug_output can only be set as an environment variable
+EXPECT stdin:1:12-26: ERROR: debug_output: can only be set as an environment variable
 WILL_FAIL
 
 NAME maps are printed by default

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3236,8 +3236,8 @@ TEST(semantic_analyser, strcontains_large_warnings)
       /* invert= */ true);
 
   auto bpftrace = get_mock_bpftrace();
-  ConfigSetter configs{ *bpftrace->config_, ConfigSource::script };
-  configs.set(ConfigKeyInt::max_strlen, 16);
+  bpftrace->config_->max_strlen = 16;
+
   test_for_warning(
       *bpftrace,
       "k:f { $s1 = str(arg0); $s2 = str(arg1); strcontains($s1, $s2) }",
@@ -4544,8 +4544,7 @@ TEST_F(semantic_analyser_btf, binop_late_ptr_resolution)
 TEST(semantic_analyser, buf_strlen_too_large)
 {
   auto bpftrace = get_mock_bpftrace();
-  ConfigSetter configs{ *bpftrace->config_, ConfigSource::script };
-  configs.set(ConfigKeyInt::max_strlen, 9999999999);
+  bpftrace->config_->max_strlen = 9999999999;
 
   test_error(*bpftrace, "uprobe:/bin/sh:f { buf(arg0, 4) }", R"(
 stdin:1:20-32: ERROR: BPFTRACE_MAX_STRLEN too large to use on buffer (9999999999 > 4294967295)
@@ -4865,8 +4864,7 @@ Program
 TEST(semantic_analyser, map_declarations)
 {
   auto bpftrace = get_mock_bpftrace();
-  ConfigSetter configs{ *bpftrace->config_, ConfigSource::script };
-  configs.set(ConfigKeyBool::unstable_map_decl, true);
+  bpftrace->config_->unstable_map_decl = true;
 
   test(*bpftrace, "let @a = hash(2); BEGIN { @a = 1; }");
   test(*bpftrace, "let @a = lruhash(2); BEGIN { @a = 1; }");


### PR DESCRIPTION
Stacked PRs:
 * #3998
 * #3997
 * #3996
 * #3988
 * #3984
 * #3981
 * __->__#3982


--- --- ---

### config: refactor and simplify configuration plumbing


This change started as a way to remove the `StackMode` processing from
the lexer and parser, in order to simplify the literal mechanisms.
Unfortunately, it became quickly apparent that the AST types that these
gave rise to were somewhat tied in to the configuration itself. In order
to achieve this simpliciation, this change refactors and rewrites the
`Config` object.

Instead of a enum class of keys, the `Config` is changed to be a
plain-old C object. This allows us to more throughly document each
member, and reference the configuration is an easily understood and
type-checked way. This also makes the defaults incredibly obvious.

The parsing of different types is delegated to extensible `ConfigParser`
classes, that can be declared for any type that you wish to add to the
configuration. The mapping from configuration "keys" (human strings) is
owned by `config.cpp`, which automatically defines parsers for each of
the associated fields. Amazingly, this is the only place that some
amount of template magic occurs, in order to automatically construct the
appropriate parser based on the field type.

This change does drop some functionality:

* The "ConfigSource" parts are dropped, since they were never referenced
  beyond checking if a configuration could be overriden. There is a much
  simpler way to do this: load the environment variables and override
  configuration values *after* they have been parsed from the script.

* The potential to allow arbitrary expressions as configuration values
  is removed. Arguably, this could have been useful in the future for
  doing evaluation, but this was not done yet. This will be reintroduced
  with proper literal plumbing, coming shortly.

On of the upsides of this change is that parsing is unified for each
type, and we can accept a wider variety of options. For example, in the
configuration block we treat identifiers as strings, so quoting is
necessary only for values containing a space or other characters.
Similarly, values like `true` and `false` can be accepted for boolean
values, in addition to `0` and `1`.

Signed-off-by: Adin Scannell <amscanne@meta.com>
