### PR TITLE
refactor: drop `is_literal` and add folding pass

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(ast STATIC
   passes/config_analyser.cpp
   passes/deprecated.cpp
   passes/field_analyser.cpp
+  passes/fold_literals.cpp
   passes/link.cpp
   passes/portability_analyser.cpp
   passes/printer.cpp

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -20,16 +20,19 @@ Diagnostic &Node::addWarning() const
 
 static constexpr std::string_view ENUM = "enum ";
 
-Integer::Integer(ASTContext &ctx, int64_t n, Location &&loc, bool is_negative)
-    : Expression(ctx, std::move(loc)), n(n), is_negative(is_negative)
+Integer::Integer(ASTContext &ctx, int64_t n, Location &&loc)
+    : Expression(ctx, std::move(loc)), value(n)
 {
-  is_literal = true;
+}
+
+NegativeInteger::NegativeInteger(ASTContext &ctx, int64_t n, Location &&loc)
+    : Expression(ctx, std::move(loc)), value(n)
+{
 }
 
 String::String(ASTContext &ctx, std::string str, Location &&loc)
-    : Expression(ctx, std::move(loc)), str(std::move(str))
+    : Expression(ctx, std::move(loc)), value(std::move(str))
 {
-  is_literal = true;
 }
 
 Builtin::Builtin(ASTContext &ctx, std::string ident, Location &&loc)
@@ -47,14 +50,12 @@ PositionalParameter::PositionalParameter(ASTContext &ctx,
                                          Location &&loc)
     : Expression(ctx, std::move(loc)), n(n)
 {
-  is_literal = true;
 }
 
 PositionalParameterCount::PositionalParameterCount(ASTContext &ctx,
                                                    Location &&loc)
     : Expression(ctx, std::move(loc))
 {
-  is_literal = true;
 }
 
 Call::Call(ASTContext &ctx, std::string func, Location &&loc)

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -97,27 +97,25 @@ public:
   Map *key_for_map = nullptr;
   Map *map = nullptr;      // Only set when this expression is assigned to a map
   Variable *var = nullptr; // Set when this expression is assigned to a variable
-  bool is_literal = false;
 };
 using ExpressionList = std::vector<Expression *>;
 
 class Integer : public Expression {
 public:
-  explicit Integer(ASTContext &ctx,
-                   int64_t n,
-                   Location &&loc,
-                   bool is_negative = true);
+  explicit Integer(ASTContext &ctx, int64_t n, Location &&loc);
+  const uint64_t value;
+};
 
-  int64_t n;
-  bool is_negative;
+class NegativeInteger : public Expression {
+public:
+  explicit NegativeInteger(ASTContext &ctx, int64_t n, Location &&loc);
+  const int64_t value;
 };
 
 class PositionalParameter : public Expression {
 public:
   explicit PositionalParameter(ASTContext &ctx, long n, Location &&loc);
-
-  long n;
-  bool is_in_str = false;
+  const long n;
 };
 
 class PositionalParameterCount : public Expression {
@@ -128,8 +126,7 @@ public:
 class String : public Expression {
 public:
   explicit String(ASTContext &ctx, std::string str, Location &&loc);
-
-  std::string str;
+  const std::string value;
 };
 
 class Identifier : public Expression {
@@ -280,7 +277,7 @@ public:
   TupleAccess(ASTContext &ctx, Expression *expr, ssize_t index, Location &&loc);
 
   Expression *expr = nullptr;
-  ssize_t index;
+  size_t index;
 };
 
 class Cast : public Expression {
@@ -399,7 +396,6 @@ class Unroll : public Statement {
 public:
   Unroll(ASTContext &ctx, Expression *expr, Block *block, Location &&loc);
 
-  long int var = 0;
   Expression *expr = nullptr;
   Block *block = nullptr;
 };

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -273,8 +273,7 @@ AttachPointParser::State AttachPointParser::lex_attachpoint(
 
       // Expand the positional param in-place and decrement idx so that the next
       // iteration takes the first char of the expansion
-      raw = raw.substr(0, idx) + bpftrace_.get_param(param_idx, true) +
-            raw.substr(i);
+      raw = raw.substr(0, idx) + bpftrace_.get_param(param_idx) + raw.substr(i);
       idx--;
     } else
       argument += raw[idx];

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -186,8 +186,7 @@ public:
 
   using Visitor<CodegenLLVM, ScopedExpr>::visit;
   ScopedExpr visit(Integer &integer);
-  ScopedExpr visit(PositionalParameter &param);
-  ScopedExpr visit(PositionalParameterCount &param);
+  ScopedExpr visit(NegativeInteger &integer);
   ScopedExpr visit(String &string);
   ScopedExpr visit(Identifier &identifier);
   ScopedExpr visit(Builtin &builtin);
@@ -463,40 +462,22 @@ CodegenLLVM::CodegenLLVM(ASTContext &ast,
 
 ScopedExpr CodegenLLVM::visit(Integer &integer)
 {
-  return ScopedExpr(b_.getInt64(integer.n));
+  return ScopedExpr(b_.getInt64(integer.value));
 }
 
-ScopedExpr CodegenLLVM::visit(PositionalParameter &param)
+ScopedExpr CodegenLLVM::visit(NegativeInteger &integer)
 {
-  std::string pstr = bpftrace_.get_param(param.n, param.is_in_str);
-  if (!param.is_in_str) {
-    if (param.type.IsSigned()) {
-      return ScopedExpr(b_.getInt64(std::stoll(pstr, nullptr, 0)));
-    } else {
-      return ScopedExpr(b_.getInt64(std::stoull(pstr, nullptr, 0)));
-    }
-  } else {
-    auto *string_param = llvm::dyn_cast<GlobalVariable>(
-        module_->getOrInsertGlobal(
-            pstr, ArrayType::get(b_.getInt8Ty(), pstr.length() + 1)));
-    string_param->setInitializer(
-        ConstantDataArray::getString(module_->getContext(), pstr));
-    return ScopedExpr(b_.CreatePtrToInt(string_param, b_.getInt64Ty()));
-  }
-}
-
-ScopedExpr CodegenLLVM::visit([[maybe_unused]] PositionalParameterCount &param)
-{
-  return ScopedExpr(b_.getInt64(bpftrace_.num_params()));
+  return ScopedExpr(b_.getInt64(integer.value));
 }
 
 ScopedExpr CodegenLLVM::visit(String &string)
 {
-  string.str.resize(string.type.GetSize() - 1);
+  std::string s(string.value);
+  s.resize(string.type.GetSize() - 1);
   auto *string_var = llvm::dyn_cast<GlobalVariable>(module_->getOrInsertGlobal(
-      string.str, ArrayType::get(b_.getInt8Ty(), string.type.GetSize())));
+      s, ArrayType::get(b_.getInt8Ty(), string.type.GetSize())));
   string_var->setInitializer(
-      ConstantDataArray::getString(module_->getContext(), string.str));
+      ConstantDataArray::getString(module_->getContext(), s));
   return ScopedExpr(string_var);
 }
 
@@ -1150,9 +1131,9 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       length = b_.CreateSelect(
           cmp, proposed_length, max_length, "length.select");
 
-      auto literal_length = bpftrace_.get_int_literal(&arg);
+      auto *literal_length = dynamic_cast<Integer *>(&arg);
       if (literal_length)
-        fixed_buffer_length = *literal_length;
+        fixed_buffer_length = literal_length->value;
     } else {
       auto &arg = *call.vargs.at(0);
       fixed_buffer_length = arg.type.GetNumElements() *
@@ -1226,13 +1207,13 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     return ScopedExpr(buf);
   } else if (call.func == "kaddr") {
     uint64_t addr;
-    auto name = bpftrace_.get_string_literal(call.vargs.at(0));
+    auto name = dynamic_cast<String *>(call.vargs.at(0))->value;
     addr = bpftrace_.resolve_kname(name);
     if (!addr)
       call.addError() << "Failed to resolve kernel symbol: " << name;
     return ScopedExpr(b_.getInt64(addr));
   } else if (call.func == "percpu_kaddr") {
-    auto name = bpftrace_.get_string_literal(call.vargs.at(0));
+    auto name = dynamic_cast<String *>(call.vargs.at(0))->value;
     auto *var = DeclareKernelVar(name);
     Value *percpu_ptr;
     if (call.vargs.size() == 1) {
@@ -1243,7 +1224,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     }
     return ScopedExpr(b_.CreatePtrToInt(percpu_ptr, b_.getInt64Ty()));
   } else if (call.func == "uaddr") {
-    auto name = bpftrace_.get_string_literal(call.vargs.at(0));
+    auto name = dynamic_cast<String *>(call.vargs.at(0))->value;
     struct symbol sym = {};
     int err = bpftrace_.resolve_uname(name,
                                       &sym,
@@ -1254,7 +1235,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     return ScopedExpr(b_.getInt64(sym.address));
   } else if (call.func == "cgroupid") {
     uint64_t cgroupid;
-    auto path = bpftrace_.get_string_literal(call.vargs.at(0));
+    auto path = dynamic_cast<String *>(call.vargs.at(0))->value;
     cgroupid = util::resolve_cgroupid(path);
     return ScopedExpr(b_.getInt64(cgroupid));
   } else if (call.func == "join") {
@@ -1380,7 +1361,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
   } else if (call.func == "pton") {
     auto af_type = AF_INET;
     int addr_size = 4;
-    std::string addr = bpftrace_.get_string_literal(call.vargs.at(0));
+    std::string addr = dynamic_cast<String *>(call.vargs.at(0))->value;
     if (addr.find(":") != std::string::npos) {
       af_type = AF_INET6;
       addr_size = 16;
@@ -1409,7 +1390,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
 
     return ScopedExpr(buf, [this, buf]() { b_.CreateLifetimeEnd(buf); });
   } else if (call.func == "reg") {
-    auto reg_name = bpftrace_.get_string_literal(call.vargs.at(0));
+    auto reg_name = dynamic_cast<String *>(call.vargs.at(0))->value;
     int offset = arch::offset(reg_name);
     if (offset == -1) {
       call.addError() << "negative offset on reg() call";
@@ -1692,7 +1673,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     // long bpf_send_signal(u32 sig)
     auto &arg = *call.vargs.at(0);
     if (arg.type.IsStringTy()) {
-      auto signame = bpftrace_.get_string_literal(&arg);
+      auto signame = dynamic_cast<String *>(&arg)->value;
       int sigid = signal_name_to_num(signame);
       // Should be caught in semantic analyser
       if (sigid < 1) {
@@ -1712,11 +1693,11 @@ ScopedExpr CodegenLLVM::visit(Call &call)
   } else if (call.func == "strncmp") {
     auto &left_arg = *call.vargs.at(0);
     auto &right_arg = *call.vargs.at(1);
-    auto size_opt = bpftrace_.get_int_literal(call.vargs.at(2));
-    if (!size_opt.has_value())
+    auto *size_opt = dynamic_cast<Integer *>(call.vargs.at(2));
+    if (!size_opt)
       LOG(BUG) << "Int literal should have been checked in semantic analysis";
     uint64_t size = std::min(
-        { static_cast<uint64_t>(*size_opt),
+        { static_cast<uint64_t>(size_opt->value),
           static_cast<uint64_t>(left_arg.type.GetSize()),
           static_cast<uint64_t>(right_arg.type.GetSize()) });
 
@@ -2877,13 +2858,14 @@ ScopedExpr CodegenLLVM::visit(If &if_node)
 
 ScopedExpr CodegenLLVM::visit(Unroll &unroll)
 {
-  for (int i = 0; i < unroll.var; i++) {
+  auto n = dynamic_cast<Integer *>(unroll.expr)->value;
+  for (uint64_t i = 0; i < n; i++) {
     // Make sure to save/restore async ID state b/c we could be processing
     // the same async calls multiple times.
     auto reset_ids = async_ids_.create_reset_ids();
     auto scoped_del = visit(unroll.block);
 
-    if (i != unroll.var - 1)
+    if (i != n - 1)
       reset_ids();
   }
   return ScopedExpr();

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -1,0 +1,452 @@
+#include "ast/passes/fold_literals.h"
+#include "ast/ast.h"
+#include "ast/visitor.h"
+#include "bpftrace.h"
+#include "log.h"
+#include "util/int_parser.h"
+
+namespace bpftrace::ast {
+
+namespace {
+
+class LiteralFolder : public Visitor<LiteralFolder, Expression *> {
+public:
+  LiteralFolder(ASTContext &ast, BPFtrace &bpftrace)
+      : ast_(ast), bpftrace_(bpftrace) {};
+
+  using Visitor<LiteralFolder, Expression *>::visit;
+
+  template <typename T>
+  T *replace(T *node, [[maybe_unused]] Expression **result)
+  {
+    if constexpr (std::is_same_v<T, Expression>) {
+      if (*result != nullptr && *result != node) {
+        return *result;
+      }
+    }
+    return node;
+  }
+
+  Expression *visit(Cast &cast);
+  Expression *visit(Unop &op);
+  Expression *visit(Binop &op);
+  Expression *visit(PositionalParameterCount &param);
+  Expression *visit(PositionalParameter &param);
+  Expression *visit(Call &call);
+
+private:
+  ASTContext &ast_;
+  BPFtrace &bpftrace_;
+};
+
+} // namespace
+
+template <typename T>
+static std::optional<std::variant<uint64_t, int64_t>> eval_binop(T left,
+                                                                 T right,
+                                                                 Operator op)
+{
+  auto clamp = [](auto v) -> std::variant<uint64_t, int64_t> {
+    if constexpr (std::is_same_v<T, int64_t>) {
+      if (v >= 0) {
+        return static_cast<uint64_t>(v);
+      }
+    }
+    return v;
+  };
+
+  switch (op) {
+    case Operator::EQ:
+      return static_cast<uint64_t>(left == right);
+    case Operator::NE:
+      return static_cast<uint64_t>(left != right);
+    case Operator::LE:
+      return static_cast<uint64_t>(left <= right);
+    case Operator::GE:
+      return static_cast<uint64_t>(left >= right);
+    case Operator::LT:
+      return static_cast<uint64_t>(left < right);
+    case Operator::GT:
+      return static_cast<uint64_t>(left > right);
+    case Operator::PLUS:
+      if (left == 0 || right == 0) {
+        return clamp(left + right);
+      }
+      if (left > 0 && right > 0) {
+        auto res = static_cast<uint64_t>(left) + static_cast<uint64_t>(right);
+        if (res > static_cast<uint64_t>(left) &&
+            res > static_cast<uint64_t>(right)) {
+          return res;
+        }
+      }
+      if constexpr (std::is_same_v<T, int64_t>) {
+        if ((left > 0 && right < 0) || (left < 0 && right > 0)) {
+          return clamp(left + right);
+        }
+        if (left < 0 && right < 0) {
+          auto res = left + right;
+          if (res < left && res < right) {
+            return res;
+          }
+          return std::nullopt;
+        }
+      }
+      return std::nullopt;
+    case Operator::MINUS:
+      if constexpr (std::is_same_v<T, uint64_t>) {
+        if (left >= right) {
+          return left - right;
+        } else {
+          // Ensure that this is representable during conversion. We know that
+          // right > left, therefore the delta here is guaranteed to be greater
+          // than zero.
+          uint64_t delta = right - left - 1;
+          auto max = static_cast<uint64_t>(std::numeric_limits<int64_t>::max());
+          if (delta > max) {
+            return std::nullopt;
+          } else {
+            return -static_cast<int64_t>(delta) - 1;
+          }
+        }
+      } else {
+        if (right == 0) {
+          return clamp(left);
+        } else if (right < 0) {
+          auto res = left - right;
+          if (res < left) {
+            return std::nullopt;
+          }
+          return clamp(res);
+        } else {
+          auto res = left - right;
+          if (res > left) {
+            return std::nullopt;
+          }
+          return clamp(res);
+        }
+      }
+    case Operator::MUL:
+      if (left == 0 || right == 0) {
+        return static_cast<uint64_t>(0);
+      } else {
+        if constexpr (std::is_same_v<T, int64_t>) {
+          // Spill into unsigned.
+          if (left < 0 && right < 0) {
+            return eval_binop(static_cast<uint64_t>(-(left + 1)) + 1,
+                              static_cast<uint64_t>(-(right + 1)) + 1,
+                              op);
+          }
+        }
+        auto result = left * right;
+        if (result / left != right) {
+          return std::nullopt; // Overflow.
+        }
+        return clamp(result);
+      }
+    case Operator::DIV:
+      if (right == 0) {
+        return std::nullopt;
+      }
+      return clamp(left / right);
+    case Operator::MOD:
+      if (right == 0) {
+        return std::nullopt;
+      }
+      return clamp(left % right);
+    case Operator::BAND:
+      return clamp(left & right);
+    case Operator::BOR:
+      return clamp(left | right);
+    case Operator::BXOR:
+      return clamp(left ^ right);
+    case Operator::LEFT:
+      return clamp(left << right);
+    case Operator::RIGHT:
+      return clamp(left >> right);
+    case Operator::LAND:
+      return static_cast<uint64_t>(left && right);
+    case Operator::LOR:
+      return static_cast<uint64_t>(left || right);
+    case Operator::INVALID:
+    case Operator::ASSIGN:
+    case Operator::INCREMENT:
+    case Operator::DECREMENT:
+    case Operator::LNOT:
+    case Operator::BNOT:
+      break;
+  }
+  LOG(BUG) << "Unexpected binary operator: " << static_cast<int>(op);
+  __builtin_unreachable();
+}
+
+Expression *LiteralFolder::visit(Cast &cast)
+{
+  visitAndReplace(&cast.expr);
+  return nullptr;
+}
+
+Expression *LiteralFolder::visit(Unop &op)
+{
+  visitAndReplace(&op.expr);
+
+  if (auto *integer = dynamic_cast<Integer *>(op.expr)) {
+    if (op.op == Operator::BNOT) {
+      // Still positive.
+      return ast_.make_node<Integer>(~integer->value, Location(op.loc));
+    } else if (op.op == Operator::LNOT) {
+      // Still positive.
+      return ast_.make_node<Integer>(!integer->value, Location(op.loc));
+    } else if (op.op == Operator::MINUS) {
+      // Ensure that it is representable as a negative value.
+      if (integer->value >
+          static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1) {
+        op.addError() << "negative value will underflow";
+        return nullptr;
+      }
+      // Carefully make the conversion. We need to ensure that this does not
+      // overflow/underflow while doing the math.
+      if (integer->value == 0) {
+        return integer; // Drop the operation.
+      } else if (integer->value <= 1) {
+        return ast_.make_node<NegativeInteger>(
+            -static_cast<int64_t>(integer->value), Location(op.loc));
+      } else {
+        int64_t value = -1;
+        value -= static_cast<int64_t>(integer->value - 1);
+        return ast_.make_node<NegativeInteger>(value, Location(op.loc));
+      }
+    }
+  } else if (auto *integer = dynamic_cast<NegativeInteger *>(op.expr)) {
+    if (op.op == Operator::BNOT) {
+      // Always positive.
+      return ast_.make_node<Integer>(static_cast<uint64_t>(~integer->value),
+                                     Location(op.loc));
+    } else if (op.op == Operator::LNOT) {
+      // Always positive.
+      return ast_.make_node<Integer>(static_cast<uint64_t>(!integer->value),
+                                     Location(op.loc));
+    } else if (op.op == Operator::MINUS) {
+      // Ensure that it doesn't overflow. We do this by ensuring that is
+      // representable as a positive number, casting, and then adding 1 to
+      // the unsigned form.
+      int64_t value = integer->value + 1;
+      value = -value;
+      return ast_.make_node<Integer>(static_cast<uint64_t>(value) + 1,
+                                     Location(op.loc));
+    }
+  }
+  return nullptr;
+}
+
+Expression *LiteralFolder::visit(Binop &op)
+{
+  visitAndReplace(&op.left);
+  visitAndReplace(&op.right);
+
+  // Check for string cases.
+  auto *str = dynamic_cast<String *>(op.left);
+  auto *other = op.right;
+  if (str == nullptr) {
+    str = dynamic_cast<String *>(op.right);
+    other = op.left;
+  }
+  if (str) {
+    // For whatever reason you are allowed to fold "foo"+3.
+    auto *integer = dynamic_cast<Integer *>(other);
+    if (op.op == Operator::PLUS && integer) {
+      if (integer->value >= static_cast<uint64_t>(str->value.size())) {
+        op.addWarning() << "literal string will always be empty";
+        return ast_.make_node<String>("", Location(op.loc));
+      }
+      return ast_.make_node<String>(str->value.substr(integer->value),
+                                    Location(op.loc));
+    }
+
+    // Check for another string.
+    auto *rs = dynamic_cast<String *>(other);
+    if (!rs) {
+      // Let's just make sure it's not a negative literal.
+      if (dynamic_cast<NegativeInteger *>(other)) {
+        op.addError() << "illegal literal operation with strings";
+      }
+      // This is a mix of a string and something else. This may be a runtime
+      // type, and we need to leave it up to the semantic analysis.
+      return nullptr;
+    }
+
+    switch (op.op) {
+      case Operator::EQ:
+        return ast_.make_node<Integer>(str->value == rs->value,
+                                       Location(op.loc));
+      case Operator::NE:
+        return ast_.make_node<Integer>(str->value != rs->value,
+                                       Location(op.loc));
+      case Operator::LE:
+        return ast_.make_node<Integer>(str->value <= rs->value,
+                                       Location(op.loc));
+      case Operator::GE:
+        return ast_.make_node<Integer>(str->value >= rs->value,
+                                       Location(op.loc));
+      case Operator::LT:
+        return ast_.make_node<Integer>(str->value < rs->value,
+                                       Location(op.loc));
+      case Operator::GT:
+        return ast_.make_node<Integer>(str->value > rs->value,
+                                       Location(op.loc));
+      case Operator::LAND:
+        return ast_.make_node<Integer>(!str->value.empty() && rs->value.empty(),
+                                       Location(op.loc));
+      case Operator::LOR:
+        return ast_.make_node<Integer>(!str->value.empty() || rs->value.empty(),
+                                       Location(op.loc));
+      case Operator::PLUS:
+        return ast_.make_node<String>(str->value + rs->value, Location(op.loc));
+      default:
+        // What are they tring to do?
+        op.addError() << "illegal literal operation with strings";
+        return nullptr;
+    }
+  }
+
+  // Handle all integer cases.
+  std::optional<std::variant<uint64_t, int64_t>> result;
+  auto *lu = dynamic_cast<Integer *>(op.left);
+  auto *ls = dynamic_cast<NegativeInteger *>(op.left);
+  auto *ru = dynamic_cast<Integer *>(op.right);
+  auto *rs = dynamic_cast<NegativeInteger *>(op.right);
+
+  // Only allow operations when we can safely marshall to two of the same type.
+  // Then `eval_binop` effectively handles all overflow/underflow calculations.
+  if (lu && ru) {
+    result = eval_binop(lu->value, ru->value, op.op);
+  } else if (ls && rs) {
+    result = eval_binop(ls->value, rs->value, op.op);
+  } else if (lu && rs) {
+    if (lu->value <= std::numeric_limits<int64_t>::max()) {
+      result = eval_binop(static_cast<int64_t>(lu->value), rs->value, op.op);
+    }
+  } else if (ls && ru) {
+    if (ru->value <= std::numeric_limits<int64_t>::max()) {
+      result = eval_binop(ls->value, static_cast<int64_t>(ru->value), op.op);
+    }
+  } else {
+    // This is not an integer expression at all.
+    return nullptr;
+  }
+
+  if (!result) {
+    // This is not a valid expression.
+    op.addError() << "unable to fold literals due to overflow or underflow";
+    return nullptr;
+  }
+
+  return std::visit(
+      [&](const auto &v) -> Expression * {
+        if constexpr (std::is_same_v<std::decay_t<decltype(v)>, uint64_t>) {
+          return ast_.make_node<Integer>(v, Location(op.loc));
+        } else {
+          return ast_.make_node<NegativeInteger>(v, Location(op.loc));
+        }
+      },
+      result.value());
+}
+
+Expression *LiteralFolder::visit(PositionalParameterCount &param)
+{
+  // This is always an unsigned integer value.
+  return ast_.make_node<Integer>(bpftrace_.num_params(), Location(param.loc));
+}
+
+Expression *LiteralFolder::visit(PositionalParameter &param)
+{
+  // By default, we treat parameters as integer literals if we can, and
+  // rely on the user to have an explicit `str` cast.
+  const std::string &val = bpftrace_.get_param(param.n);
+  // If empty, treat as zero. This is the documented behavior.
+  if (val.empty()) {
+    return ast_.make_node<Integer>(static_cast<uint64_t>(0),
+                                   Location(param.loc));
+  }
+  try {
+    if (val[0] == '-') {
+      auto v = util::to_int(val, 0);
+      return ast_.make_node<NegativeInteger>(v, Location(param.loc));
+    } else {
+      auto v = util::to_uint(val, 0);
+      return ast_.make_node<Integer>(v, Location(param.loc));
+    }
+  } catch (const std::exception &e) {
+    // Treat this as the original string.
+    return ast_.make_node<String>(val, Location(param.loc));
+  }
+}
+
+Expression *LiteralFolder::visit(Call &call)
+{
+  // If this is the string function, then we can evaluate the given literal
+  // as a string (e.g. this covers str(0) and str($3)).
+  if (call.func == "str" && !call.vargs.empty()) {
+    std::string s;
+
+    // First, we need to check if this directly wraps a positional parameter.
+    // If yes, then we prevent it from expanding to zero as is the default.
+    if (auto *param = dynamic_cast<PositionalParameter *>(call.vargs.at(0))) {
+      call.vargs[0] = ast_.make_node<String>(bpftrace_.get_param(param->n),
+                                             Location(param->loc));
+    } else if (auto *binop = dynamic_cast<Binop *>(call.vargs.at(0))) {
+      auto *param = dynamic_cast<PositionalParameter *>(binop->left);
+      if (param && binop->op == Operator::PLUS) {
+        binop->left = ast_.make_node<String>(bpftrace_.get_param(param->n),
+                                             Location(param->loc));
+      }
+    }
+
+    // Now we can expand normally.
+    Visitor<LiteralFolder, Expression *>::visit(call);
+
+    // If this is an integer of some kind, then fold it into a string.
+    if (auto *n = dynamic_cast<Integer *>(call.vargs.at(0))) {
+      std::stringstream ss;
+      ss << n->value;
+      s = ss.str();
+    } else if (auto *n = dynamic_cast<NegativeInteger *>(call.vargs.at(0))) {
+      std::stringstream ss;
+      ss << n->value;
+      s = ss.str();
+    } else if (auto *str = dynamic_cast<String *>(call.vargs.at(0))) {
+      s = str->value;
+    } else {
+      return nullptr;
+    }
+
+    // Handle optional truncation.
+    if (call.vargs.size() >= 2) {
+      if (auto *n = dynamic_cast<Integer *>(call.vargs.at(1))) {
+        // Truncate the string.
+        if (s.size() >= n->value) {
+          s = s.substr(0, n->value);
+        }
+      } else {
+        return nullptr;
+      }
+    }
+    return ast_.make_node<String>(s, Location(call.loc));
+  } else {
+    // Visit normally.
+    Visitor<LiteralFolder, Expression *>::visit(call);
+  }
+
+  return nullptr;
+}
+
+Pass CreateFoldLiteralsPass()
+{
+  auto fn = [](ASTContext &ast, BPFtrace &b) {
+    LiteralFolder folder(ast, b);
+    folder.visit(ast.root);
+  };
+
+  return Pass::create("FoldLiterals", fn);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/fold_literals.h
+++ b/src/ast/passes/fold_literals.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateFoldLiteralsPass();
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -26,7 +26,14 @@ std::string Printer::type(const SizedType &ty)
 void Printer::visit(Integer &integer)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "int: " << integer.n << type(integer.type) << std::endl;
+  out_ << indent << "int: " << integer.value << type(integer.type) << std::endl;
+}
+
+void Printer::visit(NegativeInteger &integer)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "signed int: " << integer.value << type(integer.type)
+       << std::endl;
 }
 
 void Printer::visit(PositionalParameter &param)
@@ -46,7 +53,7 @@ void Printer::visit(String &string)
   std::string indent(depth_, ' ');
   std::stringstream ss;
 
-  for (char c : string.str) {
+  for (char c : string.value) {
     // the argument of isprint() must be an unsigned char or EOF
     int code = static_cast<unsigned char>(c);
     if (std::isprint(code)) {

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -14,6 +14,7 @@ public:
 
   using Visitor<Printer>::visit;
   void visit(Integer &integer);
+  void visit(NegativeInteger &integer);
   void visit(PositionalParameter &param);
   void visit(PositionalParameterCount &param);
   void visit(String &string);

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -40,6 +40,10 @@ public:
   {
     return default_value();
   }
+  R visit(NegativeInteger &integer __attribute__((__unused__)))
+  {
+    return default_value();
+  }
   R visit(PositionalParameter &param __attribute__((__unused__)))
   {
     return default_value();
@@ -311,7 +315,9 @@ public:
   {
     if (auto *t = dynamic_cast<T>(*node)) {
       if constexpr (!std::is_void_v<R>) {
+        // NOLINTBEGIN(readability-qualified-auto)
         auto rval = visitAndReplace(&t);
+        // NOLINTEND(readability-qualified-auto)
         *node = static_cast<Orig *>(t); // Copy the modification.
         return rval;
       } else {
@@ -333,7 +339,9 @@ public:
     // `Expression*` can be swapped for another `Expression*`.
     Impl *impl = static_cast<Impl *>(this);
     if constexpr (!std::is_void_v<R>) {
+      // NOLINTBEGIN(readability-qualified-auto)
       auto rval = tryVisitAndReplaceOne<Orig, T, Ts...>(node);
+      // NOLINTEND(readability-qualified-auto)
       *node = impl->replace(*node, &rval);
       return rval;
     } else {
@@ -346,6 +354,7 @@ public:
   {
     return tryVisitAndReplace<Expression,
                               Integer *,
+                              NegativeInteger *,
                               PositionalParameter *,
                               PositionalParameterCount *,
                               String *,

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -622,10 +622,10 @@ void BPFtrace::add_param(const std::string &param)
   params_.emplace_back(param);
 }
 
-std::string BPFtrace::get_param(size_t i, bool is_str) const
+std::string BPFtrace::get_param(size_t i) const
 {
   if (params_.size() < i) {
-    return is_str ? "" : "0";
+    return "";
   }
   return params_.at(i - 1);
 }
@@ -1852,54 +1852,6 @@ void BPFtrace::sort_by_key(
                      key.GetSize()) < 0;
     });
   }
-}
-
-std::string BPFtrace::get_string_literal(const ast::Expression *expr) const
-{
-  if (expr->is_literal) {
-    if (const auto *string = dynamic_cast<const ast::String *>(expr))
-      return string->str;
-    else if (const auto *str_call = dynamic_cast<const ast::Call *>(expr)) {
-      // Positional parameters in the form str($1) can be used as literals
-      if (str_call->func == "str") {
-        if (const auto *pos_param =
-                dynamic_cast<const ast::PositionalParameter *>(
-                    str_call->vargs.at(0)))
-          return get_param(pos_param->n, true);
-      }
-    }
-  }
-
-  LOG(ERROR) << "Expected string literal, got " << expr->type;
-  return "";
-}
-
-std::optional<int64_t> BPFtrace::get_int_literal(
-    const ast::Expression *expr) const
-{
-  if (expr->is_literal) {
-    if (const auto *integer = dynamic_cast<const ast::Integer *>(expr))
-      return integer->n;
-    else if (const auto *pos_param =
-                 dynamic_cast<const ast::PositionalParameter *>(expr)) {
-      auto param_str = get_param(pos_param->n, false);
-      auto param_int = util::get_int_from_str(param_str);
-      if (!param_int.has_value()) {
-        // This case has to be handled at a higher layer, and it is also
-        // duplicated exactly in the semantic analyzer.
-        return std::nullopt;
-      }
-      if (std::holds_alternative<int64_t>(*param_int)) {
-        return std::get<int64_t>(*param_int);
-      } else {
-        return static_cast<int64_t>(std::get<uint64_t>(*param_int));
-      }
-    } else {
-      return static_cast<int64_t>(num_params());
-    }
-  }
-
-  return std::nullopt;
 }
 
 const util::FuncsModulesMap &BPFtrace::get_traceable_funcs() const

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -161,11 +161,9 @@ public:
       const std::vector<Field> &args,
       uint8_t *arg_data);
   void add_param(const std::string &param);
-  std::string get_param(size_t index, bool is_str) const;
+  std::string get_param(size_t index) const;
   size_t num_params() const;
   void request_finalize();
-  std::string get_string_literal(const ast::Expression *expr) const;
-  std::optional<int64_t> get_int_literal(const ast::Expression *expr) const;
   std::optional<std::string> get_watchpoint_binary_path() const;
   virtual bool is_traceable_func(const std::string &func_name) const;
   virtual std::unordered_set<std::string> get_func_modules(

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -89,8 +89,10 @@ oct_esc  [0-7]{1,3}
 {int}|{hex}|{exponent}  {
                           try
                           {
+                            // Note that we have no unsigned integers in the lexer, these
+                            // are purely derived as a result of folding constants.
                             auto res = util::to_uint(yytext, 0);
-                            return Parser::make_INT(res, driver.loc);
+                            return Parser::make_UNSIGNED_INT(res, driver.loc);
                           }
                           catch (const std::exception &e)
                           {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "ast/pass_manager.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/config_analyser.h"
+#include "ast/passes/fold_literals.h"
 #include "ast/passes/parser.h"
 #include "ast/passes/pid_filter_pass.h"
 #include "ast/passes/portability_analyser.h"
@@ -292,6 +293,7 @@ std::vector<std::string> extra_flags(
 
 void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
 {
+  add(ast::CreateFoldLiteralsPass());
   add(ast::CreateConfigPass());
   add(ast::CreateResolveImportsPass({}));
   add(ast::CreatePidFilterPass());
@@ -304,9 +306,10 @@ void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
 
 void CreateAotPasses(std::function<void(ast::Pass&& pass)> add)
 {
+  add(ast::CreatePortabilityPass());
+  add(ast::CreateFoldLiteralsPass());
   add(ast::CreateConfigPass());
   add(ast::CreateSemanticPass());
-  add(ast::CreatePortabilityPass());
   add(ast::CreateResourcePass());
   add(ast::CreateRecursionCheckPass());
   add(ast::CreateReturnPathPass());

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -10,7 +10,7 @@
 %define define_location_comparison
 %define parse.assert
 %define parse.trace
-%expect 4
+%expect 3
 
 %define parse.error verbose
 
@@ -117,7 +117,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> MAP "map"
 %token <std::string> VAR "variable"
 %token <std::string> PARAM "positional parameter"
-%token <int64_t> INT "integer"
+%token <uint64_t> UNSIGNED_INT "integer"
 %token <std::string> STACK_MODE "stack_mode"
 %token <std::string> CONFIG "config"
 %token <std::string> UNROLL "unroll"
@@ -132,7 +132,6 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> OFFSETOF "offsetof"
 %token <std::string> LET "let"
 %token <std::string> IMPORT "import"
-
 
 %type <ast::Operator> unary_op compound_op
 %type <std::string> attach_point_def c_definitions ident keyword external_name
@@ -150,7 +149,6 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::Subprog *> subprog
 %type <ast::SubprogArg *> subprog_arg
 %type <ast::SubprogArgList> subprog_args
-%type <ast::Integer *> int
 %type <ast::Map *> map
 %type <ast::MapDeclStatement *> map_decl_stmt
 %type <ast::PositionalParameter *> param
@@ -247,7 +245,7 @@ type:
                         $$ = CreateBuffer(0);
                     }
                 }
-        |       SIZED_TYPE "[" INT "]" {
+        |       SIZED_TYPE "[" UNSIGNED_INT "]" {
                     if ($1 == "string") {
                         $$ = CreateString($3);
                     } else if ($1 == "inet") {
@@ -256,10 +254,10 @@ type:
                         $$ = CreateBuffer($3);
                     }
                 }
-        |       int_type "[" INT "]" {
+        |       int_type "[" UNSIGNED_INT "]" {
                   $$ = CreateArray($3, $1);
                 }
-        |       struct_type "[" INT "]" {
+        |       struct_type "[" UNSIGNED_INT "]" {
                   $$ = CreateArray($3, $1);
                 }
         |       int_type "[" "]" {
@@ -311,9 +309,9 @@ config_assign_stmt_list:
                 ;
 
 config_assign_stmt:
-                IDENT ASSIGN STRING { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
-        |       IDENT ASSIGN IDENT  { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
-        |       IDENT ASSIGN INT    { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
+                IDENT ASSIGN UNSIGNED_INT { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
+        |       IDENT ASSIGN IDENT        { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
+        |       IDENT ASSIGN STRING       { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
                 ;
 
 subprog:
@@ -361,16 +359,19 @@ attach_point_def:
                 attach_point_def ident    { $$ = $1 + $2; }
                 // Since we're double quoting the STRING for the benefit of the
                 // AttachPointParser, we have to make sure we re-escape any double
-                // quotes.
-        |       attach_point_def STRING   { $$ = $1 + "\"" + std::regex_replace($2, std::regex("\""), "\\\"") + "\""; }
-        |       attach_point_def PATH     { $$ = $1 + $2; }
-        |       attach_point_def INT      { $$ = $1 + std::to_string($2); }
-        |       attach_point_def COLON    { $$ = $1 + ":"; }
-        |       attach_point_def DOT      { $$ = $1 + "."; }
-        |       attach_point_def PLUS     { $$ = $1 + "+"; }
-        |       attach_point_def MUL      { $$ = $1 + "*"; }
-        |       attach_point_def LBRACKET { $$ = $1 + "["; }
-        |       attach_point_def RBRACKET { $$ = $1 + "]"; }
+                // quotes. Note that this is a general escape hatch for many cases,
+                // since we can't handle the general parsing and unparsing of e.g.
+                // integer types that use `_` separators, or exponential notation,
+                // or hex vs. non-hex representation etc.
+        |       attach_point_def STRING       { $$ = $1 + "\"" + std::regex_replace($2, std::regex("\""), "\\\"") + "\""; }
+        |       attach_point_def UNSIGNED_INT { $$ = $1 + std::to_string($2); }
+        |       attach_point_def PATH         { $$ = $1 + $2; }
+        |       attach_point_def COLON        { $$ = $1 + ":"; }
+        |       attach_point_def DOT          { $$ = $1 + "."; }
+        |       attach_point_def PLUS         { $$ = $1 + "+"; }
+        |       attach_point_def MUL          { $$ = $1 + "*"; }
+        |       attach_point_def LBRACKET     { $$ = $1 + "["; }
+        |       attach_point_def RBRACKET     { $$ = $1 + "]"; }
         |       attach_point_def param
                 {
                   // "Un-parse" the positional parameter back into text so
@@ -444,10 +445,8 @@ jump_stmt:
                 ;
 
 loop_stmt:
-                UNROLL "(" int ")" block             { $$ = driver.ctx.make_node<ast::Unroll>($3, driver.ctx.make_node<ast::Block>(std::move($5), @5), @1 + @4); }
-        |       UNROLL "(" param ")" block           { $$ = driver.ctx.make_node<ast::Unroll>($3, driver.ctx.make_node<ast::Block>(std::move($5), @5), @1 + @4); }
-        |       UNROLL "(" param_count ")" block     { $$ = driver.ctx.make_node<ast::Unroll>($3, driver.ctx.make_node<ast::Block>(std::move($5), @5), @1 + @4); }
-        |       WHILE  "(" expr ")" block            { $$ = driver.ctx.make_node<ast::While>($3, driver.ctx.make_node<ast::Block>(std::move($5), @5), @1); }
+                UNROLL "(" expr ")" block { $$ = driver.ctx.make_node<ast::Unroll>($3, driver.ctx.make_node<ast::Block>(std::move($5), @5), @1 + @4); }
+        |       WHILE  "(" expr ")" block { $$ = driver.ctx.make_node<ast::While>($3, driver.ctx.make_node<ast::Block>(std::move($5), @5), @1); }
                 ;
 
 for_stmt:
@@ -491,7 +490,7 @@ map_decl_list:
         ;
 
 map_decl_stmt:
-                LET MAP ASSIGN IDENT LPAREN INT RPAREN { $$ = driver.ctx.make_node<ast::MapDeclStatement>($2, $4, $6, @$); }
+                LET MAP ASSIGN IDENT LPAREN UNSIGNED_INT RPAREN { $$ = driver.ctx.make_node<ast::MapDeclStatement>($2, $4, $6, @$); }
         ;
 
 var_decl_stmt:
@@ -501,7 +500,7 @@ var_decl_stmt:
 
 primary_expr:
                 raw_ident          { $$ = $1; }
-        |       int                { $$ = $1; }
+        |       UNSIGNED_INT       { $$ = driver.ctx.make_node<ast::Integer>($1, @$); }
         |       STRING             { $$ = driver.ctx.make_node<ast::String>($1, @$); }
         |       BUILTIN            { $$ = driver.ctx.make_node<ast::Builtin>($1, @$); }
         |       CALL_BUILTIN       { $$ = driver.ctx.make_node<ast::Builtin>($1, @$); }
@@ -538,7 +537,7 @@ postfix_expr:
 
 /* Tuple factored out so we can use it in the tuple field assignment error */
 tuple_access_expr:
-                postfix_expr DOT INT      { $$ = driver.ctx.make_node<ast::TupleAccess>($1, $3, @3); }
+                postfix_expr DOT UNSIGNED_INT { $$ = driver.ctx.make_node<ast::TupleAccess>($1, $3, @3); }
                 ;
 
 block_expr:
@@ -649,11 +648,6 @@ offsetof_expr:
                 OFFSETOF "(" struct_type "," struct_field ")"      { $$ = driver.ctx.make_node<ast::Offsetof>($3, $5, @$); }
                 /* For example: offsetof(*curtask, comm) */
         |       OFFSETOF "(" expr "," struct_field ")"             { $$ = driver.ctx.make_node<ast::Offsetof>($3, $5, @$); }
-                ;
-
-int:
-                MINUS INT    { $$ = driver.ctx.make_node<ast::Integer>((int64_t)(~(uint64_t)($2) + 1), @$, true); }
-        |       INT          { $$ = driver.ctx.make_node<ast::Integer>($1, @$, false); }
                 ;
 
 keyword:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(bpftrace_test
   cstring_view.cpp
   deprecated.cpp
   field_analyser.cpp
+  fold_literals.cpp
   function_registry.cpp
   location.cpp
   log.cpp

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -7,6 +7,7 @@
 #include "ast/attachpoint_parser.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/field_analyser.h"
+#include "ast/passes/fold_literals.h"
 #include "ast/passes/parser.h"
 #include "ast/passes/pid_filter_pass.h"
 #include "ast/passes/probe_analyser.h"
@@ -63,6 +64,7 @@ static void test(BPFtrace &bpftrace,
                 .add(CreateClangPass())
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateFoldLiteralsPass())
                 .add(ast::CreateSemanticPass())
                 .add(ast::CreatePidFilterPass())
                 .add(ast::CreateRecursionCheckPass())

--- a/tests/codegen/llvm/for_map_variables_multiple_loops.ll
+++ b/tests/codegen/llvm/for_map_variables_multiple_loops.ll
@@ -12,13 +12,13 @@ target triple = "bpf-pc-linux"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
-@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !40
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !51 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !56 {
 entry:
   %ctx1 = alloca %ctx_t.2, align 8
   %ctx = alloca %ctx_t, align 8
@@ -64,7 +64,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
 declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
 
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !57 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !62 {
   %"$_" = alloca %int64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
@@ -85,7 +85,7 @@ define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) section ".t
 ; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
-define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !65 {
+define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) section ".text" !dbg !70 {
   %"$_" = alloca %int64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
   %val = load i64, ptr %2, align 8
@@ -113,8 +113,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!48}
-!llvm.module.flags = !{!50}
+!llvm.dbg.cu = !{!53}
+!llvm.module.flags = !{!55}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -126,64 +126,69 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !18, !21}
+!10 = !{!11, !17, !22, !25}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
 !14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 !15 = !{!16}
 !16 = !DISubrange(count: 1, lowerBound: 0)
-!17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
-!18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
-!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
-!20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
-!39 = !{!40, !17, !45, !21}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 64, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 2, lowerBound: 0)
-!45 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !46, size: 64, offset: 128)
-!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
-!47 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!48 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !49)
-!49 = !{!0, !7, !22, !36}
-!50 = !{i32 2, !"Debug Info Version", i32 3}
-!51 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !48, retainedNodes: !55)
-!52 = !DISubroutineType(types: !53)
-!53 = !{!20, !54}
-!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!55 = !{!56}
-!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)
-!57 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !48, retainedNodes: !60)
-!58 = !DISubroutineType(types: !59)
-!59 = !{!20, !54, !54, !54, !54}
-!60 = !{!61, !62, !63, !64}
-!61 = !DILocalVariable(name: "map", arg: 1, scope: !57, file: !2, type: !54)
-!62 = !DILocalVariable(name: "key", arg: 2, scope: !57, file: !2, type: !54)
-!63 = !DILocalVariable(name: "value", arg: 3, scope: !57, file: !2, type: !54)
-!64 = !DILocalVariable(name: "ctx", arg: 4, scope: !57, file: !2, type: !54)
-!65 = distinct !DISubprogram(name: "map_for_each_cb_1", linkageName: "map_for_each_cb_1", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !48, retainedNodes: !66)
-!66 = !{!67, !68, !69, !70}
-!67 = !DILocalVariable(name: "map", arg: 1, scope: !65, file: !2, type: !54)
-!68 = !DILocalVariable(name: "key", arg: 2, scope: !65, file: !2, type: !54)
-!69 = !DILocalVariable(name: "value", arg: 3, scope: !65, file: !2, type: !54)
-!70 = !DILocalVariable(name: "ctx", arg: 4, scope: !65, file: !2, type: !54)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !18, size: 64, offset: 64)
+!18 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 131072, elements: !20)
+!20 = !{!21}
+!21 = !DISubrange(count: 4096, lowerBound: 0)
+!22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
+!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !43)
+!43 = !{!44, !49, !50, !25}
+!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 2, lowerBound: 0)
+!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !51, size: 64, offset: 128)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!52 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!53 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !54)
+!54 = !{!0, !7, !26, !40}
+!55 = !{i32 2, !"Debug Info Version", i32 3}
+!56 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !53, retainedNodes: !60)
+!57 = !DISubroutineType(types: !58)
+!58 = !{!24, !59}
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!60 = !{!61}
+!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!62 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !53, retainedNodes: !65)
+!63 = !DISubroutineType(types: !64)
+!64 = !{!24, !59, !59, !59, !59}
+!65 = !{!66, !67, !68, !69}
+!66 = !DILocalVariable(name: "map", arg: 1, scope: !62, file: !2, type: !59)
+!67 = !DILocalVariable(name: "key", arg: 2, scope: !62, file: !2, type: !59)
+!68 = !DILocalVariable(name: "value", arg: 3, scope: !62, file: !2, type: !59)
+!69 = !DILocalVariable(name: "ctx", arg: 4, scope: !62, file: !2, type: !59)
+!70 = distinct !DISubprogram(name: "map_for_each_cb_1", linkageName: "map_for_each_cb_1", scope: !2, file: !2, type: !63, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !53, retainedNodes: !71)
+!71 = !{!72, !73, !74, !75}
+!72 = !DILocalVariable(name: "map", arg: 1, scope: !70, file: !2, type: !59)
+!73 = !DILocalVariable(name: "key", arg: 2, scope: !70, file: !2, type: !59)
+!74 = !DILocalVariable(name: "value", arg: 3, scope: !70, file: !2, type: !59)
+!75 = !DILocalVariable(name: "ctx", arg: 4, scope: !70, file: !2, type: !59)

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -11,16 +11,14 @@ target triple = "bpf-pc-linux"
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
 @AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !31
-@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !45
-@max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !57
-@get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !59
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !29
+@event_loss_counter = dso_local global %"struct map_t.2" zeroinitializer, section ".maps", !dbg !43
 @0 = global [1 x i8] zeroinitializer
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !66 {
+define i64 @BEGIN_1(ptr %0) section "s_BEGIN_1" !dbg !58 {
 entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
@@ -32,15 +30,9 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
-  %1 = load i64, ptr @max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 1024, i64 ptrtoint (ptr @0 to i64))
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
-  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %2, i64 0)
+  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr @0, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
   ret i64 0
 }
@@ -54,8 +46,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!63}
-!llvm.module.flags = !{!65}
+!llvm.dbg.cu = !{!55}
+!llvm.module.flags = !{!57}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -85,47 +77,39 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !25 = !{!11, !17, !18, !26}
 !26 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !27, size: 64, offset: 192)
 !27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 8192, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 1024, lowerBound: 0)
-!31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
-!32 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
-!33 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !34)
-!34 = !{!35, !40}
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !36, size: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 27, lowerBound: 0)
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !41, size: 64, offset: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 262144, lowerBound: 0)
-!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
-!46 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
-!47 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !48)
-!48 = !{!49, !17, !54, !21}
-!49 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !50, size: 64)
-!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
-!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 64, elements: !52)
-!52 = !{!53}
-!53 = !DISubrange(count: 2, lowerBound: 0)
-!54 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !55, size: 64, offset: 128)
-!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !56, size: 64)
-!56 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
-!60 = distinct !DIGlobalVariable(name: "get_str_buf", linkageName: "global", scope: !2, file: !2, type: !61, isLocal: false, isDefinition: true)
-!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !62, size: 8192, elements: !15)
-!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !28, size: 8192, elements: !15)
-!63 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !64)
-!64 = !{!0, !7, !22, !31, !45, !57, !59}
-!65 = !{i32 2, !"Debug Info Version", i32 3}
-!66 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !63, retainedNodes: !70)
-!67 = !DISubroutineType(types: !68)
-!68 = !{!20, !69}
-!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!70 = !{!71}
-!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)
+!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 8, elements: !15)
+!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
+!30 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
+!31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !32)
+!32 = !{!33, !38}
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !34, size: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 27, lowerBound: 0)
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !39, size: 64, offset: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 262144, lowerBound: 0)
+!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
+!44 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!45 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !46)
+!46 = !{!47, !17, !52, !21}
+!47 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !48, size: 64)
+!48 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !49, size: 64)
+!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 64, elements: !50)
+!50 = !{!51}
+!51 = !DISubrange(count: 2, lowerBound: 0)
+!52 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !53, size: 64, offset: 128)
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
+!54 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
+!56 = !{!0, !7, !22, !29, !43}
+!57 = !{i32 2, !"Debug Info Version", i32 3}
+!58 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
+!59 = !DISubroutineType(types: !60)
+!60 = !{!20, !61}
+!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)

--- a/tests/fold_literals.cpp
+++ b/tests/fold_literals.cpp
@@ -1,0 +1,388 @@
+#include "ast/passes/fold_literals.h"
+#include "ast/passes/parser.h"
+#include "ast/passes/printer.h"
+#include "mocks.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::fold_literals {
+
+using ::testing::HasSubstr;
+
+void test(const std::string& input,
+          const std::string& output,
+          const std::string& error = "",
+          const std::string& warn = "")
+{
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace& bpftrace = *mock_bpftrace;
+
+  // The input provided here is embedded into an expression.
+  ast::ASTContext ast("stdin", "BEGIN { " + input + " }");
+  std::stringstream msg;
+  msg << "\nInput:\n" << input << "\n\nOutput:\n";
+
+  // N.B. No macro or tracepoint expansion.
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put(bpftrace)
+                .add(ast::AllParsePasses())
+                .add(ast::CreateFoldLiteralsPass())
+                .run();
+
+  std::ostringstream out;
+  ast::Printer printer(out);
+  printer.visit(ast.root);
+  ast.diagnostics().emit(out);
+
+  if (!output.empty() || !warn.empty()) {
+    ASSERT_TRUE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+    if (!output.empty()) {
+      EXPECT_THAT(out.str(), HasSubstr("BEGIN\n  " + output + "\n"))
+          << msg.str() << out.str();
+    }
+    if (!warn.empty()) {
+      EXPECT_THAT(out.str(), HasSubstr(warn)) << msg.str() << out.str();
+    }
+  }
+  if (!error.empty()) {
+    ASSERT_FALSE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+    EXPECT_THAT(out.str(), HasSubstr(error)) << msg.str() << out.str();
+  }
+}
+
+void test_error(const std::string& input, const std::string& error)
+{
+  test(input, "", error);
+}
+
+void test_warning(const std::string& input, const std::string& warn)
+{
+  test(input, "", "", warn);
+}
+
+TEST(fold_literals, equals)
+{
+  test("0 == 0", "int: 1");
+  test("0 == 1", "int: 0");
+  test("-1 == 1", "int: 0");
+  test("-1 == -1", "int: 1");
+  test(R"("foo" == "bar")", "int: 0");
+  test(R"("foo" == "foo")", "int: 1");
+  test("\"foo\" == 1", "=="); // Left as is
+  test("str($1) == \"\"", "int: 1");
+  test("str($1) == \"foo\"", "int: 0");
+  test("$1 == 0", "int: 1");
+  test("$1 == 1", "int: 0");
+}
+
+TEST(fold_literals, not_equals)
+{
+  test("0 != 0", "int: 0");
+  test("0 != 1", "int: 1");
+  test("-1 != 1", "int: 1");
+  test("-1 != -1", "int: 0");
+  test(R"("foo" != "bar")", "int: 1");
+  test(R"("foo" != "foo")", "int: 0");
+  test(R"("foo" != 1)", "!="); // Left as is
+  test(R"(str($1) != "")", "int: 0");
+  test(R"(str($1) != "foo")", "int: 1");
+  test("$1 != 0", "int: 0");
+  test("$1 != 1", "int: 1");
+}
+
+TEST(fold_literals, comparison)
+{
+  test("0 < 1", "int: 1");
+  test("1 < 0", "int: 0");
+  test("0 < 0", "int: 0");
+  test("-1 < 0", "int: 1");
+  test("-1 < -2", "int: 0");
+  test("0x7fffffffffffffff < 0x8000000000000000", "int: 1");
+  test("0xffffffffffffffff < 0", "int: 0");
+  test(R"("a" < "b")", "int: 1");
+  test(R"("b" < "a")", "int: 0");
+  test(R"("a" < "a")", "int: 0");
+  test(R"("" < "a")", "int: 1");
+  test(R"("abc" < "abd")", "int: 1");
+
+  test("0 > 1", "int: 0");
+  test("1 > 0", "int: 1");
+  test("0 > 0", "int: 0");
+  test("-1 > 0", "int: 0");
+  test("-1 > -2", "int: 1");
+  test("0x7fffffffffffffff > 0x8000000000000000", "int: 0");
+  test("0xffffffffffffffff > 0", "int: 1");
+  test(R"("a" > "b")", "int: 0");
+  test(R"("b" > "a")", "int: 1");
+  test(R"("a" > "a")", "int: 0");
+  test(R"("" > "a")", "int: 0");
+  test(R"("abc" > "abd")", "int: 0");
+
+  test("0 <= 1", "int: 1");
+  test("1 <= 0", "int: 0");
+  test("0 <= 0", "int: 1");
+  test("-1 <= 0", "int: 1");
+  test("-1 <= -1", "int: 1");
+  test("0x7fffffffffffffff <= 0x8000000000000000", "int: 1");
+  test("0xffffffffffffffff <= 0", "int: 0");
+  test(R"("a" <= "b")", "int: 1");
+  test(R"("b" <= "a")", "int: 0");
+  test(R"("a" <= "a")", "int: 1");
+  test(R"("" <= "a")", "int: 1");
+  test(R"("abc" <= "abd")", "int: 1");
+
+  test("0 >= 1", "int: 0");
+  test("1 >= 0", "int: 1");
+  test("0 >= 0", "int: 1");
+  test("-1 >= 0", "int: 0");
+  test("-1 >= -1", "int: 1");
+  test("0x7fffffffffffffff >= 0x8000000000000000", "int: 0");
+  test("0xffffffffffffffff >= 0", "int: 1");
+  test(R"("a" >= "b")", "int: 0");
+  test(R"("b" >= "a")", "int: 1");
+  test(R"("a" >= "a")", "int: 1");
+  test(R"("" >= "a")", "int: 0");
+  test(R"("abc" >= "abd")", "int: 0");
+}
+
+TEST(fold_literals, plus)
+{
+  test("0 + 0", "int: 0");
+  test("0 + 1", "int: 1");
+  test("1 + 2", "int: 3");
+  test("5 + 10", "int: 15");
+  test("-5 + 10", "int: 5");
+  test("-10 + -5", "signed int: -15");
+  test("9223372036854775807 + 1", "int: 9223372036854775808");
+  test("9223372036854775808 + 1", "int: 9223372036854775809");
+  test("0 + (-1)", "signed int: -1");
+  test("1 + (-2)", "signed int: -1");
+  test("-5 + 5", "int: 0");
+  test("0xffffffffffffffff + 0", "int: 18446744073709551615");
+  test("0x7fffffffffffffff + (-1)", "int: 9223372036854775806");
+  test_error("0xffffffffffffffff + 1", "overflow");
+  test_error("0x8000000000000000 + (-1)", "overflow"); // Coerced to signed
+
+  test(R"("foo" + "bar")", "string: foobar");
+  test(R"("" + "test")", "string: test");
+  test(R"("hello" + 3)", "string: lo");
+  test_warning(R"("hello" + 8)", "literal string will always be empty");
+}
+
+TEST(fold_literals, minus)
+{
+  test("0 - 1", "signed int: -1");
+  test("1 - 2", "signed int: -1");
+  test("0 - 0", "int: 0");
+  test("1 - 1", "int: 0");
+  test("2 - 1", "int: 1");
+  test("0xffffffffffffffff - 1", "int: 18446744073709551614");
+  test("0xffffffffffffffff - 0xffffffffffffffff", "int: 0");
+  test("0x8000000000000000 - 1", "int: 9223372036854775807");
+  test("0x7fffffffffffffff - 0x7fffffffffffffff", "int: 0");
+  test("0x7fffffffffffffff - 0x8000000000000000", "signed int: -1");
+  test("0x8000000000000000 - 0x8000000000000001", "signed int: -1");
+  test("0 - 0x8000000000000000", "signed int: -9223372036854775808");
+  test("0x7fffffffffffffff - 0xffffffffffffffff",
+       "signed int: -9223372036854775808",
+       "");
+  test("0-9223372036854775808", "signed int: -9223372036854775808");
+  test("0x8000000000000000-0xffffffffffffffff",
+       "signed int: -9223372036854775807",
+       "");
+  test("0x8000000000000000-0x7fffffffffffffff", "int: 1");
+  test("0-0x8000000000000000", "signed int: -9223372036854775808");
+  test("9223372036854775807-9223372036854775808", "signed int: -1");
+  test_error("0 - 0x8000000000000001", "underflow");
+  test_error("1 - 0xffffffffffffffff", "underflow");
+  test_error("0-9223372036854775809", "underflow");
+  test_error("10-9223372036854775819", "underflow");
+  test_error("0x7fffffffffffffff - (-1)", "overflow"); // Coerced to signed
+  test_error("0xffffffffffffffff - (-1)", "overflow");
+  test_error("0 - 0xffffffffffffffff", "underflow");
+}
+
+TEST(fold_literals, multiply)
+{
+  test("0 * 0", "int: 0");
+  test("0 * 1", "int: 0");
+  test("1 * 0", "int: 0");
+  test("1 * 1", "int: 1");
+  test("2 * 3", "int: 6");
+  test("10 * 20", "int: 200");
+  test("-1 * 1", "signed int: -1");
+  test("1 * -1", "signed int: -1");
+  test("-1 * -1", "int: 1");
+  test("-10 * 5", "signed int: -50");
+  test("5 * -10", "signed int: -50");
+  test("-5 * -10", "int: 50");
+  test("0xffffffffffffffff * 0x1", "int: 18446744073709551615");
+  test("0x7fffffffffffffff * 0x2", "int: 18446744073709551614");
+  test("0xffffffffffffffff * 0x0", "int: 0");
+  test("9223372036854775807 * 1", "int: 9223372036854775807");
+  test("9223372036854775808 * 1", "int: 9223372036854775808");
+  test_error("0x8000000000000000 * 0x2", "overflow");
+  test_error("0xffffffffffffffff * 0xffffffffffffffff", "overflow");
+}
+
+TEST(fold_literals, divide)
+{
+  test("10 / 2", "int: 5");
+  test("15 / 3", "int: 5");
+  test("100 / 10", "int: 10");
+  test("0 / 5", "int: 0");
+  test("-10 / 2", "signed int: -5");
+  test("10 / -2", "signed int: -5");
+  test("-10 / -2", "int: 5");
+  test("0xffffffffffffffff / 0x10", "int: 1152921504606846975");
+  test("0x7fffffffffffffff / 0xff", "int: 36170086419038336");
+  test("0x8000000000000000 / 0xff", "int: 36170086419038336");
+  test("9223372036854775807 / 1", "int: 9223372036854775807");
+  test("9223372036854775808 / 2", "int: 4611686018427387904");
+  test("0xffffffffffffffff / 1", "int: 18446744073709551615");
+  test_error("123 / 0", "unable to fold");
+  test_error("-123 / 0", "unable to fold");
+}
+
+TEST(fold_literals, mod)
+{
+  test("10 % 3", "int: 1");
+  test("15 % 4", "int: 3");
+  test("0 % 5", "int: 0");
+  test("100 % 10", "int: 0");
+  test("-10 % 3", "signed int: -1");
+  test("10 % -3", "int: 1");
+  test("-10 % -3", "signed int: -1");
+  test("0xffffffffffffffff % 0x10", "int: 15");
+  test("0x7fffffffffffffff % 0xff", "int: 127");
+  test("0x8000000000000000 % 0xff", "int: 128");
+  test_error("123 % 0", "unable to fold");
+  test_error("-123 % 0", "unable to fold");
+}
+
+TEST(fold_literals, binary)
+{
+  test("1 & 1", "int: 1");
+  test("1 & 0", "int: 0");
+  test("0 & 0", "int: 0");
+  test("0xffffffffffffffff & 0x1", "int: 1");
+  test("0xffffffffffffffff & 0x0", "int: 0");
+  test("0xffffffffffffffff & 0xffffffffffffffff",
+       "int: 18446744073709551615",
+       "");
+  test("0x7fffffffffffffff & 0x1", "int: 1");
+  test("0x7fffffffffffffff & 0x0", "int: 0");
+  test("0x7fffffffffffffff & 0x7fffffffffffffff",
+       "int: 9223372036854775807",
+       "");
+  test("-1 & 1", "int: 1");
+  test("-1 & 0", "int: 0");
+  test("-1 & -1", "signed int: -1");
+  test("0x8000000000000000 & 0x1", "int: 0");
+  test("0x8000000000000000 & 0x8000000000000000",
+       "int: 9223372036854775808",
+       "");
+  test_error("-1 & 0xffffffffffffffff", "overflow");
+
+  test("1 | 1", "int: 1");
+  test("1 | 0", "int: 1");
+  test("0 | 0", "int: 0");
+  test("0xffffffffffffffff | 0x1", "int: 18446744073709551615");
+  test("0xffffffffffffffff | 0x0", "int: 18446744073709551615");
+  test("0x7fffffffffffffff | 0x1", "int: 9223372036854775807");
+  test("0x7fffffffffffffff | 0x0", "int: 9223372036854775807");
+  test("-1 | 1", "signed int: -1");
+  test("-1 | 0", "signed int: -1");
+  test("-1 | -1", "signed int: -1");
+  test("0x8000000000000000 | 0x1", "int: 9223372036854775809");
+  test("0x8000000000000000 | 0x8000000000000000",
+       "int: 9223372036854775808",
+       "");
+  test("0xff | 0x0f", "int: 255");
+  test("0xff | 0xf0", "int: 255");
+  test("-10 | 0x0f", "signed int: -1");
+  test("0x7fffffffffffffff | -1", "signed int: -1");
+  test("0xffffffff | -0xf", "signed int: -1");
+  test("-0xff | -0x0f", "signed int: -15");
+
+  test("1 ^ 1", "int: 0");
+  test("1 ^ 0", "int: 1");
+  test("0 ^ 0", "int: 0");
+  test("0xffffffffffffffff ^ 0x1", "int: 18446744073709551614");
+  test("0xffffffffffffffff ^ 0x0", "int: 18446744073709551615");
+  test("0xffffffffffffffff ^ 0xffffffffffffffff", "int: 0");
+  test("0x7fffffffffffffff ^ 0x1", "int: 9223372036854775806");
+  test("0x7fffffffffffffff ^ 0x0", "int: 9223372036854775807");
+  test("0x7fffffffffffffff ^ 0x7fffffffffffffff", "int: 0");
+  test("-1 ^ 1", "signed int: -2");
+  test("-1 ^ 0", "signed int: -1");
+  test("-1 ^ -1", "int: 0");
+  test("0x8000000000000000 ^ 0x1", "int: 9223372036854775809");
+  test("0x8000000000000000 ^ 0x8000000000000000", "int: 0");
+  test("0xff ^ 0x0f", "int: 240");
+  test("0xff ^ 0xf0", "int: 15");
+  test("-10 ^ 0x0f", "signed int: -7");
+  test("0x7fffffffffffffff ^ -1", "signed int: -9223372036854775808");
+  test("0xffffffff ^ -0xf", "signed int: -4294967282");
+  test("-0xff ^ -0x0f", "int: 240");
+
+  test("1 << 0", "int: 1");
+  test("1 << 1", "int: 2");
+  test("1 << 2", "int: 4");
+  test("1 << 63", "int: 9223372036854775808");
+  test("1 << 64", "int: 1"); // Wraps around
+  test("0xff << 8", "int: 65280");
+  test("0xff << 56", "int: 18374686479671623680");
+  test("-1 << 1", "signed int: -2");
+  test("-1 << 63", "signed int: -9223372036854775808");
+  test("0x7fffffffffffffff << 1", "int: 18446744073709551614");
+  test("0x8000000000000000 << 1", "int: 0"); // Legal overflow
+
+  test("8 >> 1", "int: 4");
+  test("8 >> 2", "int: 2");
+  test("8 >> 3", "int: 1");
+  test("8 >> 4", "int: 0");
+  test("0xff >> 4", "int: 15");
+  test("0xffffffffffffffff >> 32", "int: 4294967295");
+  test("-1 >> 1", "signed int: -1"); // Sign extension
+  test("-8 >> 2", "signed int: -2"); // Sign extension
+  test("0x8000000000000000 >> 1", "int: 4611686018427387904");
+  test("0x8000000000000000 >> 63", "int: 1");
+}
+
+TEST(fold_literals, logical)
+{
+  test("1 && 1", "int: 1");
+  test("0 && 1", "int: 0");
+  test("0 && 0", "int: 0");
+  test("-1 && 0", "int: 0");
+  test("1 && -1", "int: 1");
+  test("\"foo\" && 1", "&&"); // Left as is
+
+  test("1 || 1", "int: 1");
+  test("0 || 1", "int: 1");
+  test("0 || 0", "int: 0");
+  test("-1 || 0", "int: 1");
+  test("1 || -1", "int: 1");
+  test("\"foo\" || 1", "||"); // Left as is
+}
+
+TEST(fold_literals, unary)
+{
+  test("~(-1)", "int: 0");
+  test("~0xfffffffffffffffe", "int: 1");
+  test("~0", "int: 18446744073709551615");
+
+  test("!0", "int: 1");
+  test("!1", "int: 0");
+  test("!-1", "int: 0");
+
+  test("-1", "signed int: -1");
+  test("-0", "int: 0");
+  test("-0x7fffffffffffffff", "signed int: -9223372036854775807");
+  test("-0x8000000000000000", "signed int: -9223372036854775808");
+  test("-(-0x8000000000000000)", "int: 9223372036854775808");
+  test_error("-0x8000000000000001", "underflow");
+}
+
+} // namespace bpftrace::test::fold_literals

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -469,7 +469,8 @@ TEST(Parser, variable_assign)
        " kprobe:sys_open\n"
        "  =\n"
        "   variable: $x\n"
-       "   int: -1\n");
+       "   -\n"
+       "    int: 1\n");
 
   char in_cstr[128];
   char out_cstr[128];
@@ -481,8 +482,9 @@ TEST(Parser, variable_assign)
            " kprobe:sys_open\n"
            "  =\n"
            "   variable: $x\n"
-           "   int: %ld\n",
-           LONG_MIN);
+           "   -\n"
+           "    int: %lu\n",
+           static_cast<unsigned long>(LONG_MAX) + 1);
   test(std::string(in_cstr), std::string(out_cstr));
 }
 

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -157,7 +157,7 @@ EXPECT ERROR: failed to open file '/does/not/exist/file': No such file or direct
 
 NAME sizeof
 PROG struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x)); exit(); }
-EXPECT 8 4 1 8 8
+EXPECT 8 4 1 1 8
 
 NAME sizeof_ints
 PROG BEGIN { printf("%d %d %d %d %d %d\n", sizeof(uint8), sizeof(int8), sizeof(uint16), sizeof(int16), sizeof(uint32), sizeof(int32)); exit(); }


### PR DESCRIPTION
Stacked PRs:
 * #3998
 * #3997
 * #3996
 * #3988
 * __->__#3984


--- --- ---

### refactor: drop `is_literal` and add folding pass


In order to reduce the complexity inside the more complex passes (the
semantic analyser and code generation), add a folding pass for literals
and constants. Note that this is not intended to do the work that LLVM
will do in the backend, rather it is merely folding constants that must
be interpreted by semantic analysis.

A classic example is `str($1)`, which can be folded into a suitable
`String` node. This eliminates the need for special cases in semantic
analysis and the `is_in_str` field within the AST.

Note that many tests are updated mostly to allow these new literal
cases, but there are a few noteworthy cases:

* `buf(arg0, arg1)` remains legal, because the code for this check is
  broken. The buffer will always be sized at the maximum size.

Signed-off-by: Adin Scannell <amscanne@meta.com>
