### PR TITLE
Fix build failures due to missing location.hh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix build failures due to missing location.hh
+  - [#3987](https://github.com/bpftrace/bpftrace/pull/3987)
 #### Security
 #### Docs
 #### Tools

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(compiler_core STATIC
   struct.cpp
   types.cpp
 )
+add_dependencies(compiler_core parser)
 
 add_library(runtime STATIC
   attached_probe.cpp

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(ast STATIC
   passes/recursion_check.cpp
 )
 
+add_dependencies(ast parser)
 target_compile_definitions(ast PRIVATE ${BPFTRACE_FLAGS})
 target_link_libraries(ast PRIVATE debugfs tracefs util)
 target_link_libraries(ast PUBLIC ast_defs arch compiler_core parser)

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -15,7 +15,6 @@
 #include <vector>
 
 #include "ast/ast.h"
-#include "ast/location.h"
 #include "ast/pass_manager.h"
 #include "attached_probe.h"
 #include "bpfbytecode.h"

--- a/src/functions.h
+++ b/src/functions.h
@@ -7,7 +7,6 @@
 #include <vector>
 
 #include "ast/ast.h"
-#include "ast/location.h"
 #include "types.h"
 #include "util/hash.h"
 

--- a/src/log.h
+++ b/src/log.h
@@ -8,8 +8,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include "ast/location.h"
-
 namespace bpftrace {
 
 namespace LogColor {

--- a/src/output.h
+++ b/src/output.h
@@ -4,7 +4,6 @@
 #include <map>
 #include <vector>
 
-#include "ast/location.h"
 #include "bpfmap.h"
 #include "required_resources.h"
 #include "types.h"

--- a/src/util/io.cpp
+++ b/src/util/io.cpp
@@ -1,6 +1,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <fstream>
+#include <unistd.h>
 
 #include "log.h"
 #include "util/exceptions.h"

--- a/src/util/paths.cpp
+++ b/src/util/paths.cpp
@@ -6,6 +6,7 @@
 #include <glob.h>
 #include <iostream>
 #include <regex>
+#include <unistd.h>
 
 #include "log.h"
 #include "scopeguard.h"

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <climits>
 #include <filesystem>
 #include <fstream>
 #include <map>


### PR DESCRIPTION
ast/location.h does `#include "location.hh"` and location.hh is generated by the parser so any CMake target whose source includes ast/location.h needs to have a dependency on the `parser` target, otherwise the compilation may fail due to incorrect ordering of build targets.

compiler_core is an example of such a target, however, in this case, we can just drop the include of ast/location.h as it's not used.

Fixes #3986.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
