### PR TITLE
ast: allow chain of errors

### DIFF
--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -12,7 +12,7 @@ class Driver;
 
 namespace ast {
 
-class Location;
+class SourceLocation;
 class Node;
 class Program;
 
@@ -35,7 +35,7 @@ public:
 private:
   std::vector<std::string> lines_;
 
-  friend class Location;
+  friend class SourceLocation;
 };
 
 // Manages the lifetime of AST nodes.
@@ -53,7 +53,7 @@ public:
   template <NodeType T, typename... Args>
   constexpr T *make_node(Args &&...args)
   {
-    auto uniq_ptr = std::make_unique<T>(*diagnostics_,
+    auto uniq_ptr = std::make_unique<T>(*this,
                                         wrap(std::forward<Args>(args))...);
     auto *raw_ptr = uniq_ptr.get();
     nodes_.push_back(std::move(uniq_ptr));
@@ -83,7 +83,7 @@ private:
   }
   Location wrap(location loc)
   {
-    return { loc, source_ };
+    return std::make_shared<LocationChain>(SourceLocation(loc, source_));
   };
 
   std::vector<std::unique_ptr<Node>> nodes_;
@@ -91,6 +91,7 @@ private:
   std::shared_ptr<ASTSource> source_;
 
   friend class bpftrace::Driver;
+  friend class Node;
 };
 
 } // namespace ast

--- a/src/ast/diagnostic.cpp
+++ b/src/ast/diagnostic.cpp
@@ -1,8 +1,21 @@
-#include "diagnostic.h"
+#include <algorithm>
+#include <ranges>
 
+#include "diagnostic.h"
 #include "log.h"
 
 namespace bpftrace::ast {
+
+std::stringstream& Diagnostic::addContext(Location loc)
+{
+  // This must not modify the existing location, instead we add
+  // a new link to the location chain. We don't inject the full
+  // chain if one has been provided, but take only that node.
+  auto nloc = std::make_shared<LocationChain>(loc->current);
+  auto& nlink = nloc->parent.emplace(LocationChain::Parent(std::move(loc_)));
+  loc_ = std::move(nloc);
+  return nlink.msg;
+}
 
 void Diagnostics::emit(std::ostream& out) const
 {
@@ -18,16 +31,40 @@ void Diagnostics::emit(std::ostream& out, Severity s) const
 
 void Diagnostics::emit(std::ostream& out, Severity s, const Diagnostic& d) const
 {
-  const auto& loc = d.loc();
+  // Build our set of messages.
+  std::vector<std::pair<std::string, SourceLocation>> msgs;
+  auto loc = d.loc();
+  while (loc) {
+    auto& parent = loc->parent;
+    if (parent) {
+      msgs.emplace_back(parent->msg.str(), loc->current);
+      loc = parent->loc;
+    } else {
+      msgs.emplace_back(d.msg(), loc->current);
+      break;
+    }
+  }
+  std::ranges::reverse(msgs);
+
   switch (s) {
     case Severity::Warning:
-      LOG(WARNING, loc.source_location(), loc.source_context(), out) << d.msg();
+      if (msgs.empty()) {
+        LOG(WARNING, out) << d.msg();
+      }
+      for (const auto& [msg, loc] : msgs) {
+        LOG(WARNING, loc.source_location(), loc.source_context(), out) << msg;
+      }
       if (auto msg = d.hint(); !msg.empty()) {
         LOG(HINT, out) << msg;
       }
       break;
     case Severity::Error:
-      LOG(ERROR, loc.source_location(), loc.source_context(), out) << d.msg();
+      if (msgs.empty()) {
+        LOG(ERROR, out) << d.msg();
+      }
+      for (const auto& [msg, loc] : msgs) {
+        LOG(ERROR, loc.source_location(), loc.source_context(), out) << msg;
+      }
       if (auto msg = d.hint(); !msg.empty()) {
         LOG(HINT, out) << msg;
       }

--- a/src/ast/diagnostic.h
+++ b/src/ast/diagnostic.h
@@ -42,6 +42,9 @@ public:
     return hint_;
   }
 
+  // Add additional context for the error.
+  std::stringstream& addContext(Location loc);
+
   template <typename T>
   Diagnostic& operator<<(const T& t)
   {
@@ -52,7 +55,7 @@ public:
 private:
   std::stringstream msg_;
   std::stringstream hint_;
-  const Location loc_;
+  Location loc_;
 };
 
 class Diagnostics {

--- a/src/ast/location.cpp
+++ b/src/ast/location.cpp
@@ -6,14 +6,14 @@
 
 namespace bpftrace::ast {
 
-Location::Location(location loc, std::shared_ptr<ASTSource> source)
+SourceLocation::SourceLocation(location loc, std::shared_ptr<ASTSource> source)
     : line_range_(loc.begin.line, loc.end.line),
       column_range_(loc.begin.column, loc.end.column),
       source_(std::move(source))
 {
 }
 
-std::string Location::filename() const
+std::string SourceLocation::filename() const
 {
   if (source_) {
     return source_->filename;
@@ -21,7 +21,7 @@ std::string Location::filename() const
   return "";
 }
 
-std::string Location::source_location() const
+std::string SourceLocation::source_location() const
 {
   std::stringstream ss;
   if (source_) {
@@ -36,7 +36,7 @@ std::string Location::source_location() const
   return ss.str();
 }
 
-std::vector<std::string> Location::source_context() const
+std::vector<std::string> SourceLocation::source_context() const
 {
   std::vector<std::string> result;
 

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -31,11 +31,11 @@ public:
   // serialized and used by a separate runtime.
   HelperErrorInfo(int func_id, const ast::Location &loc)
       : func_id(func_id),
-        filename(loc.filename()),
-        line(loc.line()),
-        column(loc.column()),
-        source_location(loc.source_location()),
-        source_context(loc.source_context())
+        filename(loc->filename()),
+        line(loc->line()),
+        column(loc->column()),
+        source_location(loc->source_location()),
+        source_context(loc->source_context())
   {
   }
 

--- a/tests/location.cpp
+++ b/tests/location.cpp
@@ -23,8 +23,8 @@ TEST(Location, single_line)
   auto &call = *ast.make_node<ast::Call>("foo", loc);
   auto &err = call.addError();
 
-  EXPECT_EQ(err.loc().source_location(), "testfile:3:9-13");
-  EXPECT_EQ(err.loc().source_context(),
+  EXPECT_EQ(err.loc()->source_location(), "testfile:3:9-13");
+  EXPECT_EQ(err.loc()->source_context(),
             std::vector<std::string>({
                 "  print(1, 2);",
                 "        ~~~~",
@@ -40,8 +40,8 @@ TEST(Location, multi_line)
   auto &call = *ast.make_node<ast::Call>("foo", loc);
   auto &err = call.addError();
 
-  EXPECT_EQ(err.loc().source_location(), "testfile:3-4");
-  EXPECT_EQ(err.loc().source_context(),
+  EXPECT_EQ(err.loc()->source_location(), "testfile:3-4");
+  EXPECT_EQ(err.loc()->source_context(),
             std::vector<std::string>({
                 "  print(1, 2);",
                 "  print(1, 2, 3, 4);",

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2446,9 +2446,15 @@ kprobe:f { @x = 1; @y = stats(5); @x = @y; }
   test("kprobe:f { @ = avg(5); if (@ > 0) { print((1)); } }");
 
   test_error("kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }", R"(
-stdin:1:28-34: ERROR: Type mismatch for '>': comparing 'hist_t' with 'int64'
+stdin:1:31-32: ERROR: Type mismatch for '>': comparing hist_t with int64
 kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
-                           ~~~~~~
+                              ~
+stdin:1:28-30: ERROR: left (hist_t)
+kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
+                           ~~
+stdin:1:33-34: ERROR: right (int64)
+kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
+                                ~
 )");
   test_error("kprobe:f { @ = count(); @ += 5 }", R"(
 stdin:1:25-26: ERROR: Type mismatch for @: trying to assign value of type 'int64' when map already contains a value of type 'count_t'
@@ -3571,7 +3577,7 @@ TEST(semantic_analyser, pointer_compare)
   test(R"_(BEGIN { $t = (int32*) 32; $y = (int64*) 1024; @ = ($t == $y); })_");
 
   test_for_warning("k:f { $a = (int8*) 1; $b = (int16*) 2; $c = ($a == $b) }",
-                   "comparison of distinct pointer types ('int8, 'int16')");
+                   "comparison of distinct pointer types: int8, int16");
 }
 
 // Basic functionality test


### PR DESCRIPTION
This updates the diagnostic structure to support chain of locations (not an arbitrary graph, just a chain to eventually allow showing expansion sites). It is necessary to support a chain rather than a span because with macro expansion, the source locations will be able to (eventually) live across different source files. Even within a single file, it is not useful for a span to cover the entire file from the macro to the probe.

The plumbing to updated to remove the operator overloading, and move the implementation for `addError` out of the header, since it is no longer a template. We can also update the type passed through to be the `ASTContext` (since the implementation is in the header, this can be used), in order to lay the groundwork for the clone operation.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- [x] The new behaviour is covered by tests
