### PR TITLE
Lazy load btf

### DIFF
--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -98,7 +98,6 @@ public:
   bool has_uprobe_multi();
   bool has_skb_output();
   bool has_prog_fentry();
-  bool has_module_btf();
   bool has_iter(std::string name);
   // These are virtual so they can be overridden in tests by the mock
   virtual bool has_fentry();
@@ -142,7 +141,6 @@ protected:
   std::optional<bool> has_uprobe_multi_;
   std::optional<bool> has_skb_output_;
   std::optional<bool> has_prog_fentry_;
-  std::optional<bool> has_module_btf_;
   std::optional<bool> has_btf_func_global_;
   std::optional<bool> has_kernel_dwarf_;
 

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -93,11 +93,43 @@ void BTF::load_vmlinux_btf()
   state = VMLINUX_LOADED;
 }
 
+bool BTF::has_module_btf()
+{
+  if (has_module_btf_.has_value())
+    return *has_module_btf_;
+
+  char name[64];
+  struct bpf_btf_info info = {};
+  info.name = reinterpret_cast<uintptr_t>(name);
+  info.name_len = sizeof(name);
+  __u32 id = 0, info_len = sizeof(info);
+  int err = 0, fd = -1;
+
+  err = bpf_btf_get_next_id(id, &id);
+  if (err)
+    goto not_support;
+
+  fd = bpf_btf_get_fd_by_id(id);
+  if (fd < 0)
+    goto not_support;
+
+  err = bpf_obj_get_info_by_fd(fd, &info, &info_len);
+  close(fd);
+  if (err)
+    goto not_support;
+
+  has_module_btf_ = true;
+  return *has_module_btf_;
+
+not_support:
+  has_module_btf_ = false;
+  return *has_module_btf_;
+}
+
 void BTF::load_module_btfs(const std::set<std::string> &modules)
 {
   load_vmlinux_btf();
-  if ((bpftrace_ && !bpftrace_->feature_->has_module_btf()) ||
-      state != VMLINUX_LOADED)
+  if ((bpftrace_ && !has_module_btf()) || state != VMLINUX_LOADED)
     return;
 
   // Note that we cannot parse BTFs from /sys/kernel/btf/ as we need BTF object

--- a/src/btf.h
+++ b/src/btf.h
@@ -77,6 +77,7 @@ public:
   ~BTF();
 
   bool has_data();
+  bool has_module_btf();
   bool modules_loaded() const;
   size_t objects_cnt() const
   {
@@ -157,6 +158,7 @@ private:
   BPFtrace* bpftrace_ = nullptr;
   std::string all_funcs_;
   std::string all_rawtracepoints_;
+  std::optional<bool> has_module_btf_;
 };
 
 inline bool BTF::has_data()

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -4,6 +4,7 @@
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 #include "bpftrace.h"
+#include "btf.h"
 #include "driver.h"
 #include "mocks.h"
 #include "gtest/gtest.h"
@@ -27,6 +28,7 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
                 .put<BPFtrace>(*bpftrace)
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
+                .add(CreateParseBTFPass())
                 .add(ast::CreateFieldAnalyserPass())
                 .add(ast::CreateSemanticPass())
                 .add(ast::CreateResourcePass())


### PR DESCRIPTION
This is primarily for tests that don't
need vmlinux BTF loaded.

Number of times vmlinux is loaded when
running bpftrace_test.
Before: 2162
After: 1626

I'm sure this number can be futher reduced
by finding all tests where we don't
need to have vmlinux BTF loaded.

This PR also included a minor refactoring to
remove a circular depedency.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
