### PR TITLE
stdlib: Add basic build harness for embedding files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         determinate: true
     - uses: DeterminateSystems/flakehub-cache-action@v1
     - name: clang-format
-      run: nix develop --command git clang-format --diff origin/master
+      run: nix develop --command git clang-format --diff origin/master --extensions cpp,h
 
   build_test:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${CMAKE_BINARY_DIR}/src)
 include_directories(${CMAKE_BINARY_DIR})
 
 # Ninja buffers output so gcc/clang think it's not an interactive session.

--- a/cmake/BuildBPF.cmake
+++ b/cmake/BuildBPF.cmake
@@ -1,0 +1,153 @@
+# Functions to build intermediate BPF modules.
+#
+# The `bpf` function will produce bitcode, an object as well as the BTF type
+# information for a given file. The `btf_header` function can be used to
+# produce a C header for a given BTF source file (often the kernel, but it
+# can be the output from any `bpf` rule, for example).
+
+find_program(GCC gcc REQUIRED)
+find_program(BPFTOOL bpftool REQUIRED)
+find_program(PAHOLE pahole REQUIRED)
+find_program(NM nm REQUIRED)
+find_program(AWK awk REQUIRED)
+find_program(LLVM_OBJCOPY
+  NAMES llvm-objcopy llvm-objcopy-${LLVM_VERSION_MAJOR} llvm${LLVM_VERSION_MAJOR}-objcopy
+  REQUIRED)
+find_program(CLANG
+  NAMES clang-${LLVM_VERSION_MAJOR}
+  REQUIRED)
+
+function(btf_header NAME)
+  cmake_parse_arguments(
+    ARG
+    ""
+    "OUTPUT;SOURCE"
+    ""
+    ${ARGN}
+  )
+  if (NOT DEFINED ARG_SOURCE)
+    set(ARG_SOURCE "/sys/kernel/btf/vmlinux")
+  endif ()
+  if (NOT DEFINED ARG_OUTPUT)
+    set(ARG_OUTPUT "${NAME}.h")
+  endif ()
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT}
+    COMMAND ${BPFTOOL} btf dump file "${ARG_SOURCE}" format c > ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT}
+    VERBATIM
+  )
+  add_custom_target(${NAME}
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT}
+  )
+endfunction()
+
+function(bpf NAME)
+  cmake_parse_arguments(
+    ARG
+    ""
+    "BITCODE;OBJECT;BINARY;BTF;SOURCE;BTF_BASE;FUNCTIONS"
+    "DEPENDS"
+    ${ARGN}
+  )
+  if (NOT DEFINED ARG_SOURCE)
+    set(ARG_SOURCE "${NAME}.c")
+  endif ()
+  if (NOT DEFINED ARG_OBJECT)
+    set(ARG_OBJECT "${NAME}.o")
+  endif ()
+  # The joys of BPF & debug tooling 101.
+  #
+  # The purpose for this function is to generate various types of output for a
+  # given source file, for testing and embedding purposes:
+  #  * LLVM bitcode file compatible with our major version of LLVM.
+  #  * A binary annotated with DWARF type information.
+  #  * Encoded BTF type information for this source unit.
+  #  * A list of functions defined in the file.
+  #
+  # Naturally, you'd assume that this could be implementated mostly as a chain
+  # of steps, save the intermediate results along the way. Wrong! Unfortunately,
+  # each of these steps has their own happy path.
+  #
+  # First, the bitcode. This is actually straight-forward! We need to ensure
+  # that this gets built with the correct version of LLVM (not whatever
+  # compiler CMAKE has selected) so that it is compatible with the LLVM
+  # libraries that we are linking against. We can even correctly select bpf as
+  # our target, to get the extent that there is any early specialization.
+  #
+  # Next, you might assume that taking this bitcode and turning it into a BPF
+  # object is the logical thing to do, in order to ensure that all the types
+  # are compatible and consistent. In fact, this even *seems* to work. But
+  # after banging your head on the keyboard for a while, you'll realize that
+  # something is broken. As you contort clang, and try building from scratch,
+  # you'll realize that clang seems to generate proper annotations and
+  # relocations for loadable programs (the happy path for that!), but fails to
+  # generate the same types for base types. In fact, in doesn't even generate
+  # named arguments without an explicit `-O2`.  Oh well, I suppose that the
+  # common path for the kernel is to build with `gcc` and then rely on the
+  # `pahole` conversion. Let's do that.
+  #
+  # But hold on a second, we said that we wanted to build a BPF target? Turns
+  # out that `gcc` can't do that very well. So `clang` can't build our BPF
+  # target because of incorrect BTF, and `gcc` can't build the BPF target. So
+  # we need to build the source natively, use `pahole` to generate the BTF
+  # data, and then extract that separately. This makes some sense, as it is the
+  # kernel happy path.
+  #
+  # But at least what we built above has the DWARF data, right? Wrong! If we
+  # were to link the full binary, too much gets stripped out to generate the
+  # full set of BTF information. So we need to generate just the object, add
+  # BTF information, and separately link that single object into a binary to
+  # have the DWARF data in a ELF binary that we're looking for.
+  #
+  # Finally, we can breath a sight of relief and generate our list of
+  # functions. Like the bitcode, this works as expected.
+  if (DEFINED ARG_BITCODE)
+    add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BITCODE}
+      DEPENDS ${ARG_SOURCE} ${ARG_DEPENDS}
+      COMMAND ${CLANG} -emit-llvm -g -target bpf -D__TARGET_ARCH_x86 -I ${CMAKE_CURRENT_BINARY_DIR} -c ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_SOURCE} -o ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BITCODE}
+      VERBATIM
+    )
+    list(APPEND ALL_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BITCODE})
+  endif()
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT}
+    DEPENDS ${ARG_SOURCE} ${ARG_DEPENDS}
+    # See above: fresh compilation and the use of `gcc`.
+    COMMAND ${GCC} -Wno-attributes -g -I ${CMAKE_CURRENT_BINARY_DIR} -c ${CMAKE_CURRENT_SOURCE_DIR}/${ARG_SOURCE} -o ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT}
+    COMMAND cmake -E env LLVM_OBJCOPY=${LLVM_OBJCOPY} ${PAHOLE} -J ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT}
+    VERBATIM
+  )
+  list(APPEND ALL_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT})
+  if (DEFINED ARG_BINARY)
+    add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BINARY}
+      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT}
+      COMMAND ${GCC} -g -o ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BINARY} ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT}
+      COMMAND cmake -E env LLVM_OBJCOPY=${LLVM_OBJCOPY} ${PAHOLE} -J ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BINARY}
+      VERBATIM
+    )
+    list(APPEND ALL_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BINARY})
+  endif()
+  list(APPEND ALL_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT})
+  if (DEFINED ARG_BTF)
+    add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BTF}
+      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT}
+      # See above re: the use of the `gcc`-compiled object, ignoring the binary.
+      COMMAND ${LLVM_OBJCOPY} --dump-section .BTF=${CMAKE_CURRENT_BINARY_DIR}/${ARG_BTF} ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT}
+      VERBATIM
+    )
+    list(APPEND ALL_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_BTF})
+  endif ()
+  if (DEFINED ARG_FUNCTIONS)
+    add_custom_command(
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ARG_FUNCTIONS}
+      DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT}
+      COMMAND ${NM} ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OBJECT} | ${AWK} -v ORS=\\\\n "$2 == \"T\" { print $3 }" > ${CMAKE_CURRENT_BINARY_DIR}/${ARG_FUNCTIONS}
+      VERBATIM
+    )
+    list(APPEND ALL_TARGETS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_FUNCTIONS})
+  endif ()
+  add_custom_target(${NAME} DEPENDS ${ALL_TARGETS})
+endfunction()

--- a/cmake/Embed.cmake
+++ b/cmake/Embed.cmake
@@ -1,0 +1,48 @@
+# Functions to embed source files.
+
+find_program(XXD xxd REQUIRED)
+
+function(embed NAME SOURCE)
+  cmake_parse_arguments(
+    ARG
+    ""
+    "OUTPUT;HEX;VAR"
+    ""
+    ${ARGN}
+  )
+  if (NOT DEFINED ARG_HEX)
+    set(ARG_HEX "${NAME}.hex")
+  endif ()
+  if (NOT DEFINED ARG_VAR)
+    set(ARG_VAR "${NAME}")
+  endif ()
+  if (NOT DEFINED ARG_OUTPUT)
+    set(ARG_OUTPUT "${NAME}.h")
+  endif ()
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ARG_HEX}
+    COMMAND ${XXD} -i < ${SOURCE} > ${CMAKE_CURRENT_BINARY_DIR}/${ARG_HEX}
+    DEPENDS ${SOURCE}
+    VERBATIM
+  )
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT}
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_HEX}
+    COMMAND ${CMAKE_COMMAND}
+      -DSOURCE=${CMAKE_CURRENT_BINARY_DIR}/${ARG_HEX}
+      -DVAR=${ARG_VAR}
+      -DNAMESPACE=${ARG_NAMESPACE}
+      -DOUTPUT=${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT}
+      -DTEMPLATE=${CMAKE_SOURCE_DIR}/cmake/Embed.tmpl
+      -P ${CMAKE_SOURCE_DIR}/cmake/EmbedRun.cmake
+    DEPENDS
+      ${CMAKE_CURRENT_BINARY_DIR}/${ARG_HEX}
+      ${CMAKE_SOURCE_DIR}/cmake/EmbedRun.cmake
+      ${CMAKE_SOURCE_DIR}/cmake/Embed.tmpl
+    VERBATIM
+  )
+  add_custom_target(
+    ${NAME}
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT}
+  )
+endfunction()

--- a/cmake/Embed.tmpl
+++ b/cmake/Embed.tmpl
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace ${NAMESPACE} {
+
+constexpr unsigned char ${VAR}[] = {
+${DATA}
+};
+
+} // ${NAMESPACE}

--- a/cmake/EmbedRun.cmake
+++ b/cmake/EmbedRun.cmake
@@ -2,6 +2,5 @@
 # at cmake configuration stage and _not_ during build. So this script
 # is wrapped in a custom command so that it's only run when necessary.
 
-file(READ ${DWARF_DATA_HEX} DWARF_DATA)
-
-configure_file(${DWARF_DATA_H_IN} ${DWARF_DATA_H})
+file(READ ${SOURCE} DATA)
+configure_file(${TEMPLATE} ${OUTPUT})

--- a/docker/Dockerfile.static
+++ b/docker/Dockerfile.static
@@ -10,6 +10,7 @@ RUN apk add --update \
   bcc-static \
   binutils-dev \
   bison \
+  bpftool \
   bzip2-static \
   build-base \
   cereal \

--- a/flake.nix
+++ b/flake.nix
@@ -146,6 +146,7 @@
 
                 nativeBuildInputs = [
                   pkgs.bison
+                  pkgs.bpftools
                   pkgs."llvmPackages_${toString llvmVersion}".clang
                   pkgs.cmake
                   pkgs.flex

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(libbpftrace STATIC
   lockdown.cpp
   tracepoint_format_parser.cpp
 )
+add_dependencies(libbpftrace stdlib)
 # So it's not "liblibbpftrace"
 set_target_properties(libbpftrace PROPERTIES PREFIX "")
 
@@ -223,5 +224,6 @@ add_subdirectory(ast)
 add_subdirectory(cxxdemangler)
 add_subdirectory(debugfs)
 add_subdirectory(resources)
+add_subdirectory(stdlib)
 add_subdirectory(tracefs)
 add_subdirectory(util)

--- a/src/stdlib/CMakeLists.txt
+++ b/src/stdlib/CMakeLists.txt
@@ -1,0 +1,36 @@
+include(BuildBPF)
+include(Embed)
+
+btf_header(vmlinux
+  OUTPUT vmlinux.h
+)
+
+bpf(base
+  SOURCE  base.c
+  BITCODE base.bc
+  OBJECT  base.o
+  BTF     base.btf
+  DEPENDS vmlinux
+)
+
+embed(
+  base_btf
+  base.btf
+  OUTPUT base_btf.h
+  VAR    base_btf
+)
+
+embed(
+  base_bitcode
+  base.bc
+  OUTPUT base_bc.h
+  VAR    base_bc
+)
+
+# The standard library holds these definitions internally via the headers
+# above. This can be made more dynamic in the future (e.g. using dynamic
+# initializers and registration), but given the size and scope the simpler
+# solution is more desirable for now.
+
+add_library(stdlib STATIC stdlib.cpp)
+add_dependencies(stdlib base_bitcode base_btf)

--- a/src/stdlib/base.c
+++ b/src/stdlib/base.c
@@ -1,0 +1,6 @@
+#include "vmlinux.h"
+
+int always_true()
+{
+  return 1;
+}

--- a/src/stdlib/stdlib.cpp
+++ b/src/stdlib/stdlib.cpp
@@ -1,0 +1,20 @@
+#include "stdlib/stdlib.h"
+
+namespace bpftrace::stdlib {
+
+std::string make_view(const unsigned char* v)
+{
+  return reinterpret_cast<const char*>(v);
+}
+
+// Embedded file contents.
+#include "stdlib/base_bc.h"
+#include "stdlib/base_btf.h"
+
+// Files is the immutable index of embedded files.
+const std::map<std::string, std::string> Stdlib::files = {
+  { "stdlib/base.btf", make_view(base_btf) },
+  { "stdlib/base.bc", make_view(base_bc) },
+};
+
+} // namespace bpftrace::stdlib

--- a/src/stdlib/stdlib.h
+++ b/src/stdlib/stdlib.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+namespace bpftrace::stdlib {
+
+class Stdlib {
+  // files is the set of files embedded in the standard library.
+  static const std::map<std::string, std::string> files;
+};
+
+} // namespace bpftrace::stdlib

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,10 +66,8 @@ add_executable(bpftrace_test
 add_test(NAME bpftrace_test COMMAND bpftrace_test)
 
 add_subdirectory(data)
-if(${LIBDW_FOUND})
-  add_dependencies(bpftrace_test debuginfo_dwarf_data)
-endif()
-add_dependencies(bpftrace_test debuginfo_btf_data)
+add_dependencies(bpftrace_test data_source_btf data_source_funcs)
+add_dependencies(bpftrace data_source_dwarf)
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/tests/btf_common.h
+++ b/tests/btf_common.h
@@ -7,7 +7,8 @@
 #include "gtest/gtest.h"
 
 namespace {
-#include "data/btf_data.h"
+#include "data/data_source_btf.h"
+#include "data/data_source_funcs.h"
 
 constexpr std::array<uint8_t, 4> INVALID_BTF_DATA = { 0xDE, 0xAD, 0xBE, 0xEF };
 
@@ -41,14 +42,14 @@ protected:
   {
     // BTF data file
     char *btf_path = strdup("/tmp/btf_dataXXXXXX");
-    if (create_tmp_with_data(btf_path, btf_data, btf_data_len)) {
+    if (create_tmp_with_data(btf_path, btf_data, sizeof(btf_data))) {
       setenv("BPFTRACE_BTF", btf_path, true);
       btf_path_ = btf_path;
     }
 
     // available functions file
     char *funcs_path = strdup("/tmp/available_filter_functionsXXXXXX");
-    if (create_tmp_with_data(funcs_path, func_list, func_list_len)) {
+    if (create_tmp_with_data(funcs_path, func_list, sizeof(func_list))) {
       setenv("BPFTRACE_AVAILABLE_FUNCTIONS_TEST", funcs_path, true);
       funcs_path_ = funcs_path;
     }

--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -1,112 +1,36 @@
-# Generates header files that store debuginfo from data_source.c in the form
-# of byte arrays
+include(BuildBPF)
+include(Embed)
 
-find_program(XXD xxd REQUIRED)
-find_program(PAHOLE pahole REQUIRED)
-find_program(LLVM_OBJCOPY
-  NAMES llvm-objcopy llvm-objcopy-${LLVM_VERSION_MAJOR} llvm${LLVM_VERSION_MAJOR}-objcopy
-  REQUIRED)
-find_program(NM nm REQUIRED)
-find_program(AWK awk REQUIRED)
+bpf(
+  data_source
+  BTF       data_source.btf
+  FUNCTIONS data_source.funcs
+  BINARY    data_source.exe
+)
 
-# Build data_source.o and inject BTF into it
-set(DATA_SOURCE_C ${CMAKE_CURRENT_SOURCE_DIR}/data_source.c)
-set(DATA_SOURCE_O ${CMAKE_CURRENT_BINARY_DIR}/data_source.o)
-set(DATA_SOURCE ${CMAKE_CURRENT_BINARY_DIR}/data_source)
-add_custom_command(
-  OUTPUT ${DATA_SOURCE_O}
-  COMMAND gcc -g -c -o ${DATA_SOURCE_O} ${DATA_SOURCE_C}
-  # pahole uses LLVM_OBJCOPY env var.
-  # We must hack it like this b/c cmake does not support setting env vars at build time
-  COMMAND bash -c "LLVM_OBJCOPY=${LLVM_OBJCOPY} pahole -J ${DATA_SOURCE_O}"
-  DEPENDS ${DATA_SOURCE_C})
+embed(
+  data_source_btf
+  data_source.btf
+  OUTPUT data_source_btf.h
+  VAR btf_data
+)
 
-# We don't want to use just ${DATA_SOURCE_O} as the dependency of the below
-# commands as that would make data_source.o be regenerated for every command
-# which is not only inefficient but also prone to race conditions.
-# So, we introduce a custom target data_source_o but unfortunately, it is not
-# sufficient to use solely that either as it just creates a target-ordering
-# dependency and not a file dependency, which causes the below commands not be
-# rerun when data_source.o changes.
-# The solution here is to use **both** data_source_o (to ensure correct target
-# ordering) and ${DATA_SOURCE_O} (to create file dependency) targets. We tie
-# them together in the ${DATA_SOURCE_DEPS} variable which should be used.
-add_custom_target(data_source_o DEPENDS ${DATA_SOURCE_O})
-set(DATA_SOURCE_DEPS data_source_o ${DATA_SOURCE_O})
+embed(
+  data_source_funcs
+  data_source.funcs
+  OUTPUT data_source_funcs.h
+  VAR func_list
+)
 
-# Generate btf_data from BTF in data_source.o
-set(BTF_DATA_FILE ${CMAKE_CURRENT_BINARY_DIR}/btf_data)
-add_custom_command(
-  OUTPUT ${BTF_DATA_FILE}
-  COMMAND ${LLVM_OBJCOPY} --dump-section .BTF=${BTF_DATA_FILE} ${DATA_SOURCE_O}
-  DEPENDS ${DATA_SOURCE_DEPS})
-
-# Generate btf_data.hex from btf_data
-set(BTF_DATA_HEX ${CMAKE_CURRENT_BINARY_DIR}/btf_data.hex)
-add_custom_command(
-  OUTPUT ${BTF_DATA_HEX}
-  COMMAND xxd -i < ${BTF_DATA_FILE} > ${BTF_DATA_HEX}
-  DEPENDS ${BTF_DATA_FILE})
-
-# Generate func_list.hex from data_source.o
-set(FUNC_LIST_HEX ${CMAKE_CURRENT_BINARY_DIR}/func_list.hex)
-add_custom_command(
-  OUTPUT ${FUNC_LIST_HEX}
-  COMMAND nm ${DATA_SOURCE_O} | awk -v ORS=\\\\n "$2 == \"T\" { print $3 }" > ${FUNC_LIST_HEX}
-  VERBATIM
-  DEPENDS ${DATA_SOURCE_DEPS})
-
-if(${LIBDW_FOUND})
-  # Generate dwarf_exe from data_source.o.
-  # We embed an executable to satisfy semantic analyser checks on executable || shared_object.
-  set(DWARF_DATA_EXE ${CMAKE_CURRENT_BINARY_DIR}/dwarf_data_exe)
-  add_custom_command(
-    OUTPUT ${DWARF_DATA_EXE}
-    COMMAND gcc -o ${DWARF_DATA_EXE} ${DATA_SOURCE_O}
-    DEPENDS data_source_o)
-
-  # Generate dwarf_data.hex from dwarf_exe
-  set(DWARF_DATA_HEX ${CMAKE_CURRENT_BINARY_DIR}/dwarf_data.hex)
-  add_custom_command(
-    OUTPUT ${DWARF_DATA_HEX}
-    COMMAND xxd -i < ${DWARF_DATA_EXE} > ${DWARF_DATA_HEX}
-    DEPENDS ${DWARF_DATA_EXE})
-
-  set(CONFIGURE_DWARF_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/configure_dwarf_headers.cmake)
-  set(DWARF_DATA_H_IN ${CMAKE_CURRENT_SOURCE_DIR}/dwarf_data.h.in)
-  set(DWARF_DATA_H ${CMAKE_CURRENT_BINARY_DIR}/dwarf_data.h)
-
-  add_custom_command(
-    OUTPUT ${DWARF_DATA_H}
-    COMMAND
-      ${CMAKE_COMMAND}
-      -DFUNC_LIST_HEX=${FUNC_LIST_HEX}
-      -DDWARF_DATA_HEX=${DWARF_DATA_HEX}
-      -DDWARF_DATA_H_IN=${DWARF_DATA_H_IN}
-      -DDWARF_DATA_H=${DWARF_DATA_H}
-      -P ${CONFIGURE_DWARF_HEADERS}
-    DEPENDS ${FUNC_LIST_HEX} ${DWARF_DATA_HEX} ${CONFIGURE_DWARF_HEADERS})
-
-  add_custom_target(debuginfo_dwarf_data DEPENDS ${DWARF_DATA_H})
-endif()
-
-set(CONFIGURE_BTF_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/configure_btf_headers.cmake)
-set(BTF_DATA_H_IN ${CMAKE_CURRENT_SOURCE_DIR}/btf_data.h.in)
-set(BTF_DATA_H ${CMAKE_CURRENT_BINARY_DIR}/btf_data.h)
-add_custom_command(
-  OUTPUT ${BTF_DATA_H}
-  COMMAND
-    ${CMAKE_COMMAND}
-    -DBTF_DATA_HEX=${BTF_DATA_HEX}
-    -DFUNC_LIST_HEX=${FUNC_LIST_HEX}
-    -DBTF_DATA_H_IN=${BTF_DATA_H_IN}
-    -DBTF_DATA_H=${BTF_DATA_H}
-    -P ${CONFIGURE_BTF_HEADERS}
-    DEPENDS ${BTF_DATA_H_IN} ${BTF_DATA_HEX} ${FUNC_LIST_HEX} ${CONFIGURE_BTF_HEADERS})
-
-add_custom_target(debuginfo_btf_data DEPENDS ${BTF_DATA_H})
+embed(
+  data_source_dwarf
+  ${CMAKE_CURRENT_BINARY_DIR}/data_source.exe
+  OUTPUT data_source_dwarf.h
+  VAR dwarf_data
+)
 
 # BTF doesn't support C++, so we only generate a data_source_cxx executable
 # to run the field_analyser tests on.
 add_executable(data_source_cxx data_source_cxx.cpp)
 target_compile_options(data_source_cxx PRIVATE -g)
+

--- a/tests/data/btf_data.h.in
+++ b/tests/data/btf_data.h.in
@@ -1,9 +1,0 @@
-#pragma once
-
-unsigned char btf_data[] = {
-${BTF_DATA}
-};
-unsigned int btf_data_len = sizeof(btf_data) / sizeof(btf_data[0]);
-
-unsigned char func_list[] = "${FUNC_LIST}";
-unsigned int func_list_len = sizeof(func_list) / sizeof(func_list[0]);

--- a/tests/data/configure_btf_headers.cmake
+++ b/tests/data/configure_btf_headers.cmake
@@ -1,8 +1,0 @@
-# This logic needs to be in a separate cmake script b/c file() runs
-# at cmake configuration stage and _not_ during build. So this script
-# is wrapped in a custom command so that it's only run when necessary.
-
-file(READ ${BTF_DATA_HEX} BTF_DATA)
-file(READ ${FUNC_LIST_HEX} FUNC_LIST)
-
-configure_file(${BTF_DATA_H_IN} ${BTF_DATA_H})

--- a/tests/data/dwarf_data.h.in
+++ b/tests/data/dwarf_data.h.in
@@ -1,8 +1,0 @@
-#pragma once
-
-constexpr inline unsigned char dwarf_data[] = {
-${DWARF_DATA}
-};
-constexpr inline unsigned int dwarf_data_len = sizeof(dwarf_data) / sizeof(dwarf_data[0]);
-
-constexpr inline const char *dwarf_data_cxx_path = "${DWARF_DATA_CXX_PATH}";

--- a/tests/dwarf_common.h
+++ b/tests/dwarf_common.h
@@ -8,7 +8,7 @@
 #include <stdexcept>
 
 namespace {
-#include "data/dwarf_data.h"
+#include "data/data_source_dwarf.h"
 } // namespace
 
 class test_dwarf : public ::testing::Test {
@@ -16,7 +16,7 @@ protected:
   static void SetUpTestSuite()
   {
     std::ofstream file(bin_, std::ios::trunc | std::ios::binary);
-    file.write(reinterpret_cast<const char *>(dwarf_data), dwarf_data_len);
+    file.write(reinterpret_cast<const char *>(dwarf_data), sizeof(dwarf_data));
     file.close();
     ASSERT_TRUE(file);
 


### PR DESCRIPTION
This will be used by to hold the standard library files in the future. For now, it is used in practice to generate test files.

The first case for this will be to support an `always_true` function with an import of `stdlib/base.bc`. This change will not be merged until there is considerable movement on some of the other pieces.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
