### PR TITLE
ast: add basic `clone` plumbing

### DIFF
--- a/src/ast/clone.h
+++ b/src/ast/clone.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <variant>
+
+#include "ast/ast.h"
+#include "ast/context.h"
+
+namespace bpftrace::ast {
+
+class Expression;
+class Statement;
+
+template <typename T>
+struct Cloner {
+  T operator()([[maybe_unused]] ASTContext &ctx,
+               const T &v,
+               [[maybe_unused]] const Location &loc)
+  {
+    return v;
+  }
+};
+
+template <typename T>
+  requires(std::is_same_v<T, Expression> || std::is_same_v<T, Statement>)
+struct Cloner<T> {
+  T operator()(ASTContext &ctx, const T &v, const Location &loc)
+  {
+    return std::visit([&](const auto &v) -> T { return clone(ctx, v, loc); },
+                      v.value);
+  }
+};
+
+template <typename T>
+struct Cloner<std::vector<T>> {
+  std::vector<T> operator()(ASTContext &ctx,
+                            const std::vector<T> &obj,
+                            const Location &loc)
+  {
+    std::vector<T> ret;
+    for (const auto &v : obj) {
+      ret.emplace_back(clone(ctx, v, loc));
+    }
+    return ret;
+  }
+};
+
+template <typename... Ts>
+struct Cloner<std::variant<Ts...>> {
+  std::variant<Ts...> operator()(ASTContext &ctx,
+                                 const std::variant<Ts...> &obj,
+                                 const Location &loc)
+  {
+    return std::visit([&](const auto &v)
+                          -> std::variant<Ts...> { return clone(ctx, v, loc); },
+                      obj);
+  }
+};
+
+template <typename T>
+struct Cloner<std::optional<T>> {
+  std::optional<T> operator()(ASTContext &ctx,
+                              const std::optional<T> &obj,
+                              const Location &loc)
+  {
+    if (!obj.has_value()) {
+      return std::nullopt;
+    }
+    return clone(ctx, obj.value(), std::move(loc));
+  }
+};
+
+template <typename T>
+  requires std::derived_from<T, Node>
+struct Cloner<T> {
+  T *operator()(ASTContext &ctx, const T *obj, const Location &loc)
+  {
+    return ctx.clone_node<T>(obj, loc);
+  }
+};
+
+template <typename T>
+T clone(ASTContext &ctx, const T &t, const Location &loc)
+{
+  using V = std::remove_const_t<std::decay_t<std::remove_pointer_t<T>>>;
+  return Cloner<V>()(ctx, t, loc);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -60,6 +60,18 @@ public:
     return raw_ptr;
   }
 
+  template <NodeType T>
+  constexpr T *clone_node(const T *other, const Location &loc)
+  {
+    if (other == nullptr) {
+      return nullptr;
+    }
+    auto uniq_ptr = std::make_unique<T>(*this, *other, loc);
+    auto *raw_ptr = uniq_ptr.get();
+    nodes_.push_back(std::move(uniq_ptr));
+    return raw_ptr;
+  }
+
   unsigned int node_count()
   {
     return nodes_.size();

--- a/src/ast/location.cpp
+++ b/src/ast/location.cpp
@@ -84,4 +84,15 @@ std::vector<std::string> SourceLocation::source_context() const
   return result;
 }
 
+Location operator+(const Location &orig, const Location &expansion)
+{
+  if (expansion == nullptr) {
+    return orig;
+  }
+  auto nlink = std::make_shared<LocationChain>(expansion->current);
+  nlink->parent.emplace(LocationChain::Parent(Location(orig)));
+  nlink->parent->msg << "expanded from";
+  return nlink;
+}
+
 } // namespace bpftrace::ast

--- a/src/ast/location.h
+++ b/src/ast/location.h
@@ -113,4 +113,6 @@ public:
   const SourceLocation current;
 };
 
+Location operator+(const Location &orig, const Location &expansion);
+
 } // namespace bpftrace::ast


### PR DESCRIPTION
Stacked PRs:
 * #3998
 * __->__#3997


--- --- ---

### ast: add basic `clone` plumbing


By using `clone(<target-ast>, <node>, <Location>)` you are able to
recursively clone a full sub-tree from the AST.

Signed-off-by: Adin Scannell <amscanne@meta.com>
