### PR TITLE
Add config to enable debug info for blazesym

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,1 +1,2 @@
 tests/data/data_source.c
+tests/testprogs/usdt_inlined.c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
   - [#3925](https://github.com/bpftrace/bpftrace/pull/3925)
 - Rawtracepoints now require kernel BTF
   - [#3944](https://github.com/bpftrace/bpftrace/pull/3944)
+- Ustack and kstack symbols are automatically enhanced with debug info if available
+  - [#3999](https://github.com/bpftrace/bpftrace/pull/3999)
 #### Added
 - Use blazesym for user space address symbolization
   - [#3884](https://github.com/bpftrace/bpftrace/pull/3884)
@@ -29,6 +31,8 @@ and this project adheres to
   - [#3918](https://github.com/bpftrace/bpftrace/pull/3918)
 - Add ability to specify rawtracepoint modules
   - [#3944](https://github.com/bpftrace/bpftrace/pull/3944)
+- Add 'show_debug_info' config for blazesym
+  - [#3999](https://github.com/bpftrace/bpftrace/pull/3999)
 #### Changed
 - `-p` CLI flag now applies to all probes (except BEGIN/END)
   - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -138,12 +138,8 @@ public:
                         StackType stack_type,
                         int indent = 0);
   std::string resolve_buf(const char *buf, size_t size);
-  std::string resolve_ksym(uint64_t addr, bool show_offset = false);
-  std::string resolve_usym(uint64_t addr,
-                           int32_t pid,
-                           int32_t probe_id,
-                           bool show_offset = false,
-                           bool show_module = false);
+  std::string resolve_ksym(uint64_t addr);
+  std::string resolve_usym(uint64_t addr, int32_t pid, int32_t probe_id);
   std::string resolve_inet(int af, const uint8_t *inet) const;
   std::string resolve_uid(uint64_t addr) const;
   std::string resolve_timestamp(uint32_t mode,
@@ -212,7 +208,6 @@ public:
   std::unique_ptr<BTF> btf_;
   std::unique_ptr<BPFfeature> feature_;
 
-  bool resolve_user_symbols_ = true;
   bool safe_mode_ = true;
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
@@ -278,6 +273,16 @@ private:
   {
     return !feature_->has_map_ringbuf() || resources.needs_perf_event_map;
   }
+  std::vector<std::string> resolve_ksym_stack(uint64_t addr,
+                                              bool show_offset,
+                                              bool perf_mode,
+                                              bool show_debug_info);
+  std::vector<std::string> resolve_usym_stack(uint64_t addr,
+                                              int32_t pid,
+                                              int32_t probe_id,
+                                              bool show_offset,
+                                              bool perf_mode,
+                                              bool show_debug_info);
   void teardown_output();
   void poll_output(bool drain = false);
   int poll_perf_events();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -252,6 +252,7 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { "missing_probes", CONFIG_FIELD_PARSER(missing_probes) },
   { "print_maps_on_exit", CONFIG_FIELD_PARSER(print_maps_on_exit) },
   { "use_blazesym", CONFIG_FIELD_PARSER(use_blazesym) },
+  { "show_debug_info", CONFIG_FIELD_PARSER(show_debug_info) },
   { "unstable_import", CONFIG_FIELD_PARSER(unstable_import) },
   { "unstable_map_decl", CONFIG_FIELD_PARSER(unstable_map_decl) },
 };

--- a/src/config.h
+++ b/src/config.h
@@ -36,8 +36,10 @@ public:
   bool unstable_import = false;
 #ifdef HAVE_BLAZESYM
   bool use_blazesym = true;
+  bool show_debug_info = true;
 #else
   bool use_blazesym = false;
+  bool show_debug_info = false;
 #endif
   uint64_t log_size = 1000000;
   uint64_t max_bpf_progs = 1024;

--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -15,6 +15,49 @@ std::string stringify_addr(uint64_t addr)
   symbol << reinterpret_cast<void *>(addr);
   return symbol.str();
 }
+
+#ifdef HAVE_BLAZESYM
+std::string stringify_ksym(const char *name,
+                           const blaze_symbolize_code_info *code_info,
+                           uint64_t addr,
+                           uint64_t sym_addr,
+                           bool show_offset,
+                           bool perf_mode,
+                           bool is_inlined)
+{
+  std::ostringstream symbol;
+
+  if (is_inlined && !perf_mode) {
+    symbol << "[inlined] ";
+  }
+
+  symbol << name;
+
+  if (show_offset) {
+    symbol << "+" << addr - sym_addr;
+  }
+
+  if (perf_mode) {
+    if (is_inlined) {
+      symbol << " (inlined)";
+    }
+
+    return symbol.str();
+  }
+
+  if (code_info != nullptr) {
+    if (code_info->dir != nullptr && code_info->file != nullptr) {
+      symbol << "@" << code_info->dir << "/" << code_info->file << ":"
+             << code_info->line;
+    } else if (code_info->file != nullptr) {
+      symbol << "@" << code_info->file << ":" << code_info->line;
+    }
+  }
+
+  return symbol.str();
+}
+#endif
+
 } // namespace
 
 namespace bpftrace {
@@ -52,18 +95,27 @@ std::string Ksyms::resolve_bcc(uint64_t addr, bool show_offset)
 }
 
 #ifdef HAVE_BLAZESYM
-std::optional<std::string> Ksyms::resolve_blazesym_impl(uint64_t addr,
-                                                        bool show_offset)
+std::vector<std::string> Ksyms::resolve_blazesym_impl(uint64_t addr,
+                                                      bool show_offset,
+                                                      bool perf_mode,
+                                                      bool show_debug_info)
 {
-  if (symbolizer_ == nullptr) {
-    symbolizer_ = blaze_symbolizer_new();
-    if (symbolizer_ == nullptr)
-      return std::nullopt;
-  }
+  std::vector<std::string> str_syms;
 
-  std::ostringstream symbol;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+  if (symbolizer_ == nullptr) {
+    blaze_symbolizer_opts opts = {
+      .type_size = sizeof(opts),
+      // Use the config here because the symbolizer is created once
+      .code_info = config_.show_debug_info,
+      .inlined_fns = config_.show_debug_info,
+    };
+    symbolizer_ = blaze_symbolizer_new_opts(&opts);
+    if (symbolizer_ == nullptr)
+      return str_syms;
+  }
+
   blaze_symbolize_src_kernel src = {
     .type_size = sizeof(src),
     // Use default system-wide kallsyms file.
@@ -72,47 +124,72 @@ std::optional<std::string> Ksyms::resolve_blazesym_impl(uint64_t addr,
     // TODO: We should eventually support that, incorporating discovery logic
     //       from find_vmlinux().
     .vmlinux = "",
+    .debug_syms = show_debug_info,
   };
 #pragma GCC diagnostic pop
 
   const blaze_syms *syms = blaze_symbolize_kernel_abs_addrs(
       symbolizer_, &src, &addr, 1);
   if (syms == nullptr)
-    return std::nullopt;
+    return str_syms;
   SCOPE_EXIT
   {
     blaze_syms_free(syms);
   };
 
   const blaze_sym *sym = &syms->syms[0];
-  if (sym->name == nullptr) {
-    return std::nullopt;
+  const struct blaze_symbolize_inlined_fn *inlined;
+
+  if (sym == nullptr || sym->name == nullptr) {
+    return str_syms;
   }
 
-  symbol << sym->name;
-  if (show_offset) {
-    auto offset = addr - sym->addr;
-    symbol << "+" << offset;
+  // bpftrace prints stacks leaf first so the inlined functions
+  // need to come first in the list (and in reverse order)
+  for (int j = static_cast<int>(sym->inlined_cnt) - 1; j >= 0; j--) {
+    inlined = &sym->inlined[j];
+    if (inlined != nullptr) {
+      str_syms.push_back(stringify_ksym(
+          inlined->name, &inlined->code_info, 0, 0, false, perf_mode, true));
+    }
   }
-  return symbol.str();
+
+  str_syms.push_back(stringify_ksym(sym->name,
+                                    &sym->code_info,
+                                    addr,
+                                    sym->addr,
+                                    show_offset,
+                                    perf_mode,
+                                    false));
+
+  return str_syms;
 }
 
-std::string Ksyms::resolve_blazesym(uint64_t addr, bool show_offset)
+std::vector<std::string> Ksyms::resolve_blazesym(uint64_t addr,
+                                                 bool show_offset,
+                                                 bool perf_mode,
+                                                 bool show_debug_info)
 {
-  if (auto sym = resolve_blazesym_impl(addr, show_offset)) {
-    return *sym;
+  auto syms = resolve_blazesym_impl(
+      addr, show_offset, perf_mode, show_debug_info);
+  if (syms.empty()) {
+    syms.push_back(stringify_addr(addr));
   }
-  return stringify_addr(addr);
+
+  return syms;
 }
 #endif
 
-std::string Ksyms::resolve(uint64_t addr, bool show_offset)
+std::vector<std::string> Ksyms::resolve(uint64_t addr,
+                                        bool show_offset,
+                                        bool perf_mode,
+                                        bool show_debug_info)
 {
 #ifdef HAVE_BLAZESYM
   if (config_.use_blazesym)
-    return resolve_blazesym(addr, show_offset);
+    return resolve_blazesym(addr, show_offset, perf_mode, show_debug_info);
 #endif
-  return resolve_bcc(addr, show_offset);
+  return std::vector<std::string>{ resolve_bcc(addr, show_offset) };
 }
 
 } // namespace bpftrace

--- a/src/ksyms.h
+++ b/src/ksyms.h
@@ -16,7 +16,10 @@ public:
   Ksyms(Ksyms &) = delete;
   Ksyms &operator=(const Ksyms &) = delete;
 
-  std::string resolve(uint64_t addr, bool show_offset);
+  std::vector<std::string> resolve(uint64_t addr,
+                                   bool show_offset,
+                                   bool perf_mode,
+                                   bool show_debug_info);
 
 private:
   const Config &config_;
@@ -25,9 +28,14 @@ private:
 #ifdef HAVE_BLAZESYM
   struct blaze_symbolizer *symbolizer_{ nullptr };
 
-  std::optional<std::string> resolve_blazesym_impl(uint64_t addr,
-                                                   bool show_offset);
-  std::string resolve_blazesym(uint64_t addr, bool show_offset);
+  std::vector<std::string> resolve_blazesym_impl(uint64_t addr,
+                                                 bool show_offset,
+                                                 bool perf_mode,
+                                                 bool show_debug_info);
+  std::vector<std::string> resolve_blazesym(uint64_t addr,
+                                            bool show_offset,
+                                            bool perf_mode,
+                                            bool show_debug_info);
 #endif
 
   std::string resolve_bcc(uint64_t addr, bool show_offset);

--- a/src/usyms.cpp
+++ b/src/usyms.cpp
@@ -18,32 +18,98 @@
 
 namespace {
 #ifdef HAVE_BLAZESYM
-std::string stringify_addr(uint64_t addr, bool show_module)
+std::string stringify_addr(uint64_t addr, bool perf_mode)
 {
   std::ostringstream symbol;
   symbol << reinterpret_cast<void *>(addr);
-  if (show_module)
+  if (perf_mode)
     symbol << " ([unknown])";
   return symbol.str();
 }
 
-std::string stringify_sym(const blaze_sym *sym,
+std::string stringify_sym(const char *name,
+                          const blaze_symbolize_code_info *code_info,
                           uint64_t addr,
+                          uint64_t sym_addr,
                           bool show_offset,
-                          bool show_module)
+                          const char *sym_module,
+                          bool perf_mode,
+                          bool is_inlined)
 {
   std::ostringstream symbol;
-  symbol << sym->name;
-  if (show_offset)
-    symbol << "+" << addr - sym->addr;
-  if (show_module) {
-    if (sym->module != nullptr)
-      symbol << " (" << sym->module << ")";
+
+  if (is_inlined && !perf_mode) {
+    symbol << "[inlined] ";
+  }
+
+  symbol << name;
+
+  if (show_offset) {
+    symbol << "+" << addr - sym_addr;
+  }
+
+  if (perf_mode) {
+    if (sym_module != nullptr)
+      symbol << " (" << sym_module << ")";
+    else if (is_inlined)
+      symbol << " (inlined)";
     else
       symbol << " ([unknown])";
+
+    // Don't add the file/line if we're in perf mode
+    return symbol.str();
   }
+
+  if (code_info != nullptr) {
+    if (code_info->dir != nullptr && code_info->file != nullptr) {
+      symbol << "@" << code_info->dir << "/" << code_info->file << ":"
+             << code_info->line;
+    } else if (code_info->file != nullptr) {
+      symbol << "@" << code_info->file << ":" << code_info->line;
+    }
+  }
+
   return symbol.str();
 }
+
+void add_symbols(const blaze_sym *sym,
+                 uint64_t addr,
+                 bool show_offset,
+                 bool perf_mode,
+                 std::vector<std::string> &str_syms)
+{
+  if (sym == nullptr || sym->name == nullptr) {
+    return;
+  }
+
+  const struct blaze_symbolize_inlined_fn *inlined;
+
+  // bpftrace prints stacks leaf first so the inlined functions
+  // need to come first in the list (and in reverse order)
+  for (int j = static_cast<int>(sym->inlined_cnt) - 1; j >= 0; j--) {
+    inlined = &sym->inlined[j];
+    if (inlined != nullptr) {
+      str_syms.push_back(stringify_sym(inlined->name,
+                                       &inlined->code_info,
+                                       0,
+                                       0,
+                                       false,
+                                       nullptr,
+                                       perf_mode,
+                                       true));
+    }
+  }
+
+  str_syms.push_back(stringify_sym(sym->name,
+                                   &sym->code_info,
+                                   addr,
+                                   sym->addr,
+                                   show_offset,
+                                   sym->module,
+                                   perf_mode,
+                                   false));
+}
+
 #endif
 } // namespace
 
@@ -96,6 +162,8 @@ struct blaze_symbolizer *Usyms::create_symbolizer() const
 {
   blaze_symbolizer_opts opts = {
     .type_size = sizeof(opts),
+    .code_info = config_.show_debug_info,
+    .inlined_fns = config_.show_debug_info,
     .demangle = config_.cpp_demangle,
   };
   return blaze_symbolizer_new_opts(&opts);
@@ -155,7 +223,7 @@ std::string Usyms::resolve_bcc(uint64_t addr,
                                int32_t pid,
                                const std::string &pid_exe,
                                bool show_offset,
-                               bool show_module)
+                               bool perf_mode)
 {
   const auto cache_type = config_.user_symbol_cache_type;
   struct bcc_symbol usym;
@@ -181,7 +249,7 @@ std::string Usyms::resolve_bcc(uint64_t addr,
         symbol << sym->second.name;
         if (show_offset)
           symbol << "+" << addr - sym->second.start;
-        if (show_module)
+        if (perf_mode)
           symbol << " (" << pid_exe << ")";
         return symbol.str();
       }
@@ -227,11 +295,11 @@ std::string Usyms::resolve_bcc(uint64_t addr,
       symbol << usym.name;
     if (show_offset)
       symbol << "+" << usym.offset;
-    if (show_module)
+    if (perf_mode)
       symbol << " (" << usym.module << ")";
   } else {
     symbol << reinterpret_cast<void *>(addr);
-    if (show_module)
+    if (perf_mode)
       symbol << " ([unknown])";
   }
 
@@ -242,17 +310,21 @@ std::string Usyms::resolve_bcc(uint64_t addr,
 }
 
 #ifdef HAVE_BLAZESYM
-std::optional<std::string> Usyms::resolve_blazesym_impl(
+std::vector<std::string> Usyms::resolve_blazesym_impl(
     uint64_t addr,
     int32_t pid,
     const std::string &pid_exe,
     bool show_offset,
-    bool show_module)
+    bool perf_mode,
+    bool show_debug_info)
 {
+  std::vector<std::string> str_syms;
+  const blaze_sym *sym;
+
   if (symbolizer_ == nullptr) {
     symbolizer_ = create_symbolizer();
     if (symbolizer_ == nullptr)
-      return std::nullopt;
+      return str_syms;
   }
 
   auto cache_type = config_.user_symbol_cache_type;
@@ -269,73 +341,79 @@ std::optional<std::string> Usyms::resolve_blazesym_impl(
       blaze_symbolize_src_elf src = {
         .type_size = sizeof(src),
         .path = pid_exe.c_str(),
-        // TODO: Enable usage of debug symbols at some point.
-        .debug_syms = false,
+        .debug_syms = show_debug_info,
       };
       const blaze_syms *syms = blaze_symbolize_elf_virt_offsets(
           symbolizer_, &src, &addr, 1);
-      if (syms != nullptr) {
-        SCOPE_EXIT
-        {
-          blaze_syms_free(syms);
-        };
-
-        const blaze_sym *sym = &syms->syms[0];
-        if (sym->name != nullptr)
-          return stringify_sym(sym, addr, show_offset, show_module);
+      if (syms == nullptr) {
+        return str_syms;
       }
+
+      SCOPE_EXIT
+      {
+        blaze_syms_free(syms);
+      };
+
+      sym = &syms->syms[0];
+
+      add_symbols(sym, addr, show_offset, perf_mode, str_syms);
     }
+    return str_syms;
   }
 
   blaze_symbolize_src_process src = {
     .type_size = sizeof(src),
     .pid = static_cast<uint32_t>(pid),
-    // TODO: Enable usage of debug symbols at some point.
-    .debug_syms = false,
+    .debug_syms = show_debug_info,
     .perf_map = true,
   };
 
   const blaze_syms *syms = blaze_symbolize_process_abs_addrs(
       symbolizer_, &src, &addr, 1);
   if (syms == nullptr)
-    return std::nullopt;
+    return str_syms;
   SCOPE_EXIT
   {
     blaze_syms_free(syms);
   };
 
-  const blaze_sym *sym = &syms->syms[0];
-  if (sym->name == nullptr)
-    return std::nullopt;
+  sym = &syms->syms[0];
+  add_symbols(sym, addr, show_offset, perf_mode, str_syms);
 
-  return stringify_sym(sym, addr, show_offset, show_module);
+  return str_syms;
 }
 
-std::string Usyms::resolve_blazesym(uint64_t addr,
-                                    int32_t pid,
-                                    const std::string &pid_exe,
-                                    bool show_offset,
-                                    bool show_module)
+std::vector<std::string> Usyms::resolve_blazesym(uint64_t addr,
+                                                 int32_t pid,
+                                                 const std::string &pid_exe,
+                                                 bool show_offset,
+                                                 bool perf_mode,
+                                                 bool show_debug_info)
 {
-  if (auto sym = resolve_blazesym_impl(
-          addr, pid, pid_exe, show_offset, show_module)) {
-    return *sym;
+  auto syms = resolve_blazesym_impl(
+      addr, pid, pid_exe, show_offset, perf_mode, show_debug_info);
+  if (syms.empty()) {
+    syms.push_back(stringify_addr(addr, perf_mode));
   }
-  return stringify_addr(addr, show_module);
+  return syms;
 }
 #endif
 
-std::string Usyms::resolve(uint64_t addr,
-                           int32_t pid,
-                           const std::string &pid_exe,
-                           bool show_offset,
-                           bool show_module)
+std::vector<std::string> Usyms::resolve(uint64_t addr,
+                                        int32_t pid,
+                                        const std::string &pid_exe,
+                                        bool show_offset,
+                                        bool perf_mode,
+                                        bool show_debug_info)
 {
 #ifdef HAVE_BLAZESYM
   if (config_.use_blazesym)
-    return resolve_blazesym(addr, pid, pid_exe, show_offset, show_module);
+    return resolve_blazesym(
+        addr, pid, pid_exe, show_offset, perf_mode, show_debug_info);
 #endif
-  return resolve_bcc(addr, pid, pid_exe, show_offset, show_module);
+  return std::vector<std::string>{
+    resolve_bcc(addr, pid, pid_exe, show_offset, perf_mode)
+  };
 }
 
 struct bcc_symbol_option &Usyms::get_symbol_opts()

--- a/src/usyms.h
+++ b/src/usyms.h
@@ -23,11 +23,12 @@ public:
   Usyms& operator=(const Usyms&) = delete;
 
   void cache(const std::string& elf_file);
-  std::string resolve(uint64_t addr,
-                      int32_t pid,
-                      const std::string& pid_exe,
-                      bool show_offset,
-                      bool show_module);
+  std::vector<std::string> resolve(uint64_t addr,
+                                   int32_t pid,
+                                   const std::string& pid_exe,
+                                   bool show_offset,
+                                   bool perf_mode,
+                                   bool show_debug_info);
 
 private:
   const Config& config_;
@@ -42,7 +43,7 @@ private:
                           int32_t pid,
                           const std::string& pid_exe,
                           bool show_offset,
-                          bool show_module);
+                          bool perf_mode);
   struct bcc_symbol_option& get_symbol_opts();
 
 #ifdef HAVE_BLAZESYM
@@ -50,16 +51,18 @@ private:
 
   struct blaze_symbolizer* create_symbolizer() const;
   void cache_blazesym(const std::string& elf_file);
-  std::optional<std::string> resolve_blazesym_impl(uint64_t addr,
-                                                   int32_t pid,
-                                                   const std::string& pid_exe,
-                                                   bool show_offset,
-                                                   bool show_module);
-  std::string resolve_blazesym(uint64_t addr,
-                               int32_t pid,
-                               const std::string& pid_exe,
-                               bool show_offset,
-                               bool show_module);
+  std::vector<std::string> resolve_blazesym_impl(uint64_t addr,
+                                                 int32_t pid,
+                                                 const std::string& pid_exe,
+                                                 bool show_offset,
+                                                 bool perf_mode,
+                                                 bool show_debug_info);
+  std::vector<std::string> resolve_blazesym(uint64_t addr,
+                                            int32_t pid,
+                                            const std::string& pid_exe,
+                                            bool show_offset,
+                                            bool perf_mode,
+                                            bool show_debug_info);
 #endif
 };
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -335,13 +335,20 @@ AFTER ./testprogs/uprobe_loop
 NAME ustack_stack_mode_env_bpftrace
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=bpftrace
-EXPECT_REGEX ^\s+uprobeFunction1\+[0-9]+$
+EXPECT_REGEX ^\s+uprobeFunction1\+[0-9]+@[\w\/]+.c:[0-9]+$
 AFTER ./testprogs/uprobe_loop
 
+# file and line are not available for perf stack mode
 NAME ustack_stack_mode_env_perf
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
 ENV BPFTRACE_STACK_MODE=perf
 EXPECT_REGEX ^\s+[0-9a-f]+ uprobeFunction1\+[0-9]+ \(.*/uprobe_loop\)$
+AFTER ./testprogs/uprobe_loop
+
+NAME ustack_with_no_file_and_line_env_bpftrace
+PROG config = { show_debug_info=0 } u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n", ustack(1)); exit(); }
+ENV BPFTRACE_STACK_MODE=bpftrace
+EXPECT_REGEX ^\s+uprobeFunction1\+[0-9]+$
 AFTER ./testprogs/uprobe_loop
 
 NAME ustack_stack_mode_env_raw
@@ -358,12 +365,31 @@ AFTER ./testprogs/uprobe_loop
 
 NAME ustack_elf_symtable
 ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM
-PROG uprobe:./testprogs/uprobe_symres_exited_process:test { print(ustack); exit(); }
+PROG config = { show_debug_info=0 } uprobe:./testprogs/uprobe_symres_exited_process:test { print(ustack); exit(); }
 EXPECT_REGEX ^\s+test\+[0-9]+\s+test2\+[0-9]+\s+main\+[0-9]+
 AFTER ./testprogs/disable_aslr ./testprogs/uprobe_symres_exited_process
 # The stack output expects prologue to be skipped on uprobes. See kernel:
 # cfa7f3d2c526 ("perf,x86: avoid missing caller address in stack traces captured in uprobe")
 MIN_KERNEL 6.12
+
+NAME ustack_with_inlined_funcs
+RUN {{BPFTRACE}} -e 'config = { show_debug_info=1 } usdt:./testprogs/usdt_inlined:tracetest:testprobe { if (arg1 == 100) { printf("%s\n", ustack()); exit(); } }' -c ./testprogs/usdt_inlined
+EXPECT_REGEX ^\s+\[inlined\] myclock@[\w\/]+.c:[0-9]+\s*\[inlined\] mywrapper_inlined@[\w\/]+.c:[0-9]+\s*mywrapper.*
+TIMEOUT 1
+REQUIRES ./testprogs/systemtap_sys_sdt_check
+
+NAME ustack_with_inlined_funcs_with_limit
+RUN {{BPFTRACE}} -e 'config = { show_debug_info=1 } usdt:./testprogs/usdt_inlined:tracetest:testprobe { if (arg1 == 100) { printf("%s\n", ustack(2)); exit(); } }' -c ./testprogs/usdt_inlined
+EXPECT_REGEX ^\s+\[inlined\] myclock@[\w\/]+.c:[0-9]+\s*\[inlined\] mywrapper_inlined@[\w\/]+.c:[0-9]+$
+TIMEOUT 1
+REQUIRES ./testprogs/systemtap_sys_sdt_check
+
+NAME ustack_with_inlined_funcs_env_perf
+RUN {{BPFTRACE}} -e 'config = { show_debug_info=1 } usdt:./testprogs/usdt_inlined:tracetest:testprobe { if (arg1 == 100) { printf("%s\n", ustack()); exit(); } }' -c ./testprogs/usdt_inlined
+ENV BPFTRACE_STACK_MODE=perf
+EXPECT_REGEX ^\s+[0-9a-f]+ myclock \(inlined\)\s*[0-9a-f]+ mywrapper_inlined \(inlined\)\s*[0-9a-f]+ mywrapper.*
+TIMEOUT 1
+REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME cat
 PROG i:ms:1 { cat("/proc/uptime"); exit();}

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -192,7 +192,7 @@ EXPECT SUCCESS
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME positional ustack
-RUN {{BPFTRACE}} -e 'u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack($1)); exit(); }' 1
+RUN {{BPFTRACE}} -e 'config = { show_debug_info=0 } u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack($1)); exit(); }' 1
 EXPECT_REGEX .*uprobeFunction1\+[0-9]+\n\s+spin\+[0-9]+\n\s+main\+[0-9]+\n(?s:.*)\n\n\n\s+uprobeFunction1\+[0-9]+
 # The stack output expects prologue to be skipped on uprobes. See kernel:
 # cfa7f3d2c526 ("perf,x86: avoid missing caller address in stack traces captured in uprobe")

--- a/tests/runtime/pid_namespace
+++ b/tests/runtime/pid_namespace
@@ -16,7 +16,7 @@ EXPECT_REGEX_NONE ^pid: 1, tid: 1$
 
 # Both bpftrace and target running inside a PID namespace
 NAME ustack_inside
-RUN unshare --fork --pid --mount-proc bash -c "(./testprogs/uprobe_loop &) && {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_loop:uprobeFunction1 { print(ustack); exit(); }'"
+RUN unshare --fork --pid --mount-proc bash -c "(./testprogs/uprobe_loop &) && {{BPFTRACE}} -e 'config = { show_debug_info=0 } uprobe:./testprogs/uprobe_loop:uprobeFunction1 { print(ustack); exit(); }'"
 EXPECT_REGEX         uprobeFunction1\+\d+$
                      spin\+\d+$
                      main\+\d+$
@@ -29,7 +29,7 @@ MIN_KERNEL 6.12
 # might not be true (e.g. on WSL2), so we skip it if that's not
 # the case.
 NAME ustack_outside
-RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_loop:uprobeFunction1 { print(ustack); exit(); }'
+RUN {{BPFTRACE}} -e 'config = { show_debug_info=0 } uprobe:./testprogs/uprobe_loop:uprobeFunction1 { print(ustack); exit(); }'
 AFTER unshare --fork --pid --mount-proc bash -c ./testprogs/uprobe_loop
 EXPECT_REGEX         uprobeFunction1\+\d+$
                      spin\+\d+$

--- a/tests/testprogs/usdt_inlined.c
+++ b/tests/testprogs/usdt_inlined.c
@@ -18,9 +18,13 @@ __attribute__((always_inline)) inline static void myclock(int probe_num)
   DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, on_stack);
 }
 
+__attribute__((always_inline)) inline static void mywrapper_inlined() {
+  myclock(100);
+}
+
 static void mywrapper()
 {
-  myclock(100);
+  mywrapper_inlined();
 }
 
 static void loop()


### PR DESCRIPTION
This adds information about dir, file, line
and inlined functions if debug info is available
and blazesym is being used.

This config defaults to true if blazesym exists.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
