### PR TITLE
Fix build failures due to missing location.hh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+#### Fixed
+- Fix build failures due to missing location.hh
+  - [#4000](https://github.com/bpftrace/bpftrace/pull/4000)
+
 ## [0.23.0] 2025-03-25
 
 #### Breaking Changes

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(compiler_core STATIC
   struct.cpp
   types.cpp
 )
+add_dependencies(compiler_core parser)
 
 add_library(runtime STATIC
   attached_probe.cpp

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(ast STATIC
   passes/return_path_analyser.cpp
 )
 
+add_dependencies(ast parser)
 target_compile_definitions(ast PRIVATE ${BPFTRACE_FLAGS})
 target_link_libraries(ast PUBLIC ast_defs arch compiler_core parser)
 


### PR DESCRIPTION
location.hh is generated by the parser so any CMake target whose source includes it needs to have a dependency on the `parser` target, otherwise the compilation may fail due to incorrect ordering of build targets. This also applies to targets which include location.hh transitively via other headers.

To avoid such errors, add an explicit dependency on the `parser` target for all CMake targets including location.hh.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
