### PR TITLE
Run CI with hardened stdlib

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -165,6 +165,7 @@ def configure():
         f"-DBUILD_TESTING=1",
         f"-DENABLE_SKB_OUTPUT=1",
         f"-DBUILD_ASAN=1",
+        f"-DHARDENED_STDLIB=1",
     ]
     # fmt: on
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(bpftrace_VERSION_PATCH 0)
 include(GNUInstallDirs)
 
 set(WARNINGS_AS_ERRORS OFF CACHE BOOL "Build with -Werror")
+set(HARDENED_STDLIB OFF CACHE BOOL "Enable hardened definitions for standard library (for development use only)")
 set(STATIC_LINKING OFF CACHE BOOL "Build bpftrace as a statically linked executable")
 
 set(BUILD_ASAN OFF CACHE BOOL "Build bpftrace with -fsanitize=address")
@@ -41,6 +42,12 @@ add_compile_options("-Wcast-qual")
 add_compile_options("-Wunreachable-code")
 #add_compile_options("-Wformat=2")
 add_compile_options("-Wdisabled-optimization")
+
+if (HARDENED_STDLIB)
+  add_compile_definitions("-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG")
+  add_compile_definitions("-D_GLIBCXX_ASSERTIONS")
+  add_compile_definitions("-D_FORTIFY_SOURCE=1")
+endif()
 
 if (WARNINGS_AS_ERRORS)
   add_compile_options("-Werror")


### PR DESCRIPTION
Enable hardened-mode for the standard libraries, both C and C++:
- [glibc](https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#fortify-sources-for-unsafe-libc-usage-and-buffer-overflows)
- [libstdc++](https://best.openssf.org/Compiler-Hardening-Guides/Compiler-Options-Hardening-Guide-for-C-and-C++.html#precondition-checks-for-c-standard-library-calls)
- [libcxx](https://libcxx.llvm.org/Hardening.html)
