### PR TITLE
Add map "spec" for call validation

### DIFF
--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -789,9 +789,6 @@ kprobe:f { @[lhist()] = 1; }
 stdin:1:12-21: ERROR: lhist() requires 4 arguments (0 provided)
 kprobe:f { @[lhist()] = 1; }
            ~~~~~~~~~
-stdin:1:12-21: ERROR: lhist_t cannot be used as a map key
-kprobe:f { @[lhist()] = 1; }
-           ~~~~~~~~~
 )");
   test_error("kprobe:f { if(lhist()) { 123 } }", R"(
 stdin:1:12-22: ERROR: lhist() should be directly assigned to a map
@@ -1163,7 +1160,7 @@ TEST(semantic_analyser, call_has_key)
 
   test_error("kprobe:f { @x[1] = 1;  if (has_key(@x)) {} }",
              R"(
-stdin:1:27-39: ERROR: has_key() requires at least 2 arguments (1 provided)
+stdin:1:27-39: ERROR: has_key() requires 2 arguments (1 provided)
 kprobe:f { @x[1] = 1;  if (has_key(@x)) {} }
                           ~~~~~~~~~~~~
 )");


### PR DESCRIPTION
This creates a map that lays out a simple spec
for `Call` checks. It removes boilerplate calls
to `check_assignment`, `check_varargs`,
`check_nargs`, and `check_arg`.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- [x] The new behaviour is covered by tests
