### PR TITLE
Fix build error on Alpine 32-bit arches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to
 #### Fixed
 - Fix build failures due to missing location.hh
   - [#3987](https://github.com/bpftrace/bpftrace/pull/3987)
+- Fix 32-bit build failures due to missing cast
+  - [#4006](https://github.com/bpftrace/bpftrace/pull/4006)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1715,9 +1715,10 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     auto size_opt = bpftrace_.get_int_literal(call.vargs.at(2));
     if (!size_opt.has_value())
       LOG(BUG) << "Int literal should have been checked in semantic analysis";
-    uint64_t size = std::min({ static_cast<uint64_t>(*size_opt),
-                               left_arg.type.GetSize(),
-                               right_arg.type.GetSize() });
+    uint64_t size = std::min(
+        { static_cast<uint64_t>(*size_opt),
+          static_cast<uint64_t>(left_arg.type.GetSize()),
+          static_cast<uint64_t>(right_arg.type.GetSize()) });
 
     auto left_string = visit(&left_arg);
     auto right_string = visit(&right_arg);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Following #3986, which addressed a build error for x86_64, I'm also seeing errors on Alpine for armhf and armv7 architectures:

```
src/ast/passes/codegen_llvm.cpp: In member function 'bpftrace::ast::ScopedExpr bpftrace::ast::CodegenLLVM::visit(bpftrace::ast::Call&)':
src/ast/passes/codegen_llvm.cpp:1373:29: error: no matching function for call to 'min(<brace-enclosed initializer list>)'
 1373 |     uint64_t size = std::min({ static_cast<uint64_t>(*size_opt),
      |                     ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 1374 |                                left_arg.type.GetSize(),
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~
 1375 |                                right_arg.type.GetSize() });
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This PR adds a couple of casts to make sure all the args have the same type, which then satisfies the template function. My C++ fu is fairly weak these days, so please let me know if there's a different type of cast I should be using.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
