### PR TITLE
clang_tidy.sh: update to clang-tidy 20 and disable modernize-use-integer-sign-comparison

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks:
   - modernize-*
   - -modernize-avoid-c-arrays
   - -modernize-use-nodiscard
+  - -modernize-use-integer-sign-comparison
   - -modernize-use-trailing-return-type
   - performance-unnecessary-copy-initialization
   - readability-*

--- a/scripts/clang_tidy.sh
+++ b/scripts/clang_tidy.sh
@@ -16,7 +16,7 @@ SCRIPT_NAME=$0
 FIX=
 
 function run() {
-  nix develop ".#bpftrace-llvm19" --command "$@"
+  nix develop --command "$@"
 }
 
 usage() {

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -299,12 +299,12 @@ bool BpfBytecode::all_progs_loaded()
 
 bool BpfBytecode::hasMap(MapType internal_type) const
 {
-  return maps_.find(to_string(internal_type)) != maps_.end();
+  return maps_.contains(to_string(internal_type));
 }
 
 bool BpfBytecode::hasMap(const StackType &stack_type) const
 {
-  return maps_.find(stack_type.name()) != maps_.end();
+  return maps_.contains(stack_type.name());
 }
 
 const BpfMap &BpfBytecode::getMap(const std::string &name) const

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -169,9 +169,7 @@ int BPFtrace::add_probe(ast::ASTContext &ctx,
     has_iter_ = true;
 
   // Preload symbol tables if necessary
-  if (resources.probes_using_usym.find(&p) !=
-          resources.probes_using_usym.end() &&
-      util::is_exe(ap.target)) {
+  if (resources.probes_using_usym.contains(&p) && util::is_exe(ap.target)) {
     usyms_.cache(ap.target);
   }
 

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -957,8 +957,7 @@ std::unordered_set<std::string> BTF::get_all_iters_from_btf(
 
     // skip __safe_trusted suffix struct
     if (suffix___safe_trusted.length() < name.length() &&
-        name.rfind(suffix___safe_trusted) ==
-            (name.length() - suffix___safe_trusted.length()))
+        name.ends_with(suffix___safe_trusted))
       continue;
     if (name.size() > prefix.size() && name.starts_with(prefix)) {
       iter_set.insert(name.substr(prefix.size()));

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -590,8 +590,7 @@ std::unordered_set<std::string> ClangParser::get_incomplete_types()
             cursor_type = clang_getPointeeType(cursor_type);
           if (cursor_type.kind == CXType_Record) {
             auto type_name = get_unqualified_type_name(cursor_type);
-            if (data.complete_types.find(type_name) ==
-                data.complete_types.end())
+            if (!data.complete_types.contains(type_name))
               data.incomplete_types.emplace(std::move(type_name));
           }
         }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -246,8 +246,7 @@ ProbeType probetype(const std::string &probeName)
 
                                 [&probeName](const ProbeItem &p) {
                                   return (p.name == probeName ||
-                                          p.aliases.find(probeName) !=
-                                              p.aliases.end());
+                                          p.aliases.contains(probeName));
                                 });
 
   if (v != PROBE_LIST.end())
@@ -264,8 +263,7 @@ std::string expand_probe_name(const std::string &orig_name)
 
                                 [&orig_name](const ProbeItem &p) {
                                   return (p.name == orig_name ||
-                                          p.aliases.find(orig_name) !=
-                                              p.aliases.end());
+                                          p.aliases.contains(orig_name));
                                 });
 
   if (v != PROBE_LIST.end())

--- a/src/util/kernel.cpp
+++ b/src/util/kernel.cpp
@@ -265,7 +265,7 @@ FuncsModulesMap parse_traceable_funcs()
   std::ifstream kprobes_blacklist_funs(kprobes_blacklist_path);
   while (std::getline(kprobes_blacklist_funs, line)) {
     auto addr_func_mod = split_addrrange_symbol_module(line);
-    if (result.find(std::get<1>(addr_func_mod)) != result.end()) {
+    if (result.contains(std::get<1>(addr_func_mod))) {
       result.erase(std::get<1>(addr_func_mod));
     }
   }


### PR DESCRIPTION
The clang-tidy script was recently held back to LLVM-19 in #3968 because it provided some annoying lints. Disable `modernize-use-integer-sign-comparison` which is pretty noisy in the codebase and has non obvious fixes, and apply the rest (`.contains` and `.ends_with`).

Did start work on the `modernize-use-integer-sign-comparison`, but I really think we should leave it disabled. It would be good if the things it complains about weren't used in new code, but every change to the old code to make it happy seems unnecessarily risky, especially given most of the cases are perfectly valid (if ugly) static casts anyway.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
