### PR TITLE
biosnoop.bt: Print comm from block_io_start probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to
 #### Security
 #### Docs
 #### Tools
+- Fix biosnoop.bt to print comm from block_io_start probe
+  - [#4013](https://github.com/bpftrace/bpftrace/pull/4013)
 
 ## [0.23.0] 2025-03-25
 

--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -20,10 +20,13 @@ tracepoint:block:block_io_start
 	$key = (args.dev, args.sector);
 	@start[$key] = nsecs;
 	@iopid[$key] = pid;
+	@iocomm[$key] = comm;
 }
 
 tracepoint:block:block_io_done
-/@start[args.dev, args.sector] != 0 && @iopid[args.dev, args.sector] != 0 && args.comm != ""/
+/@start[args.dev, args.sector] != 0 &&
+ @iopid[args.dev, args.sector] != 0 &&
+ @iocomm[args.dev, args.sector] != ""/
 
 {
 	$key = (args.dev, args.sector);
@@ -31,15 +34,17 @@ tracepoint:block:block_io_done
 	$major = args.dev >> 20;
 	$minor = args.dev & ((1 << 20) - 1);
 	printf("%-12u %-5d %-8d %-16s %-6d %7d\n",
-	    elapsed / 1e6, $major, $minor, args.comm, @iopid[$key],
+	    elapsed / 1e6, $major, $minor, @iocomm[$key], @iopid[$key],
 	    ($now - @start[$key]) / 1e6);
 
 	delete(@start, $key);
 	delete(@iopid, $key);
+	delete(@iocomm, $key);
 }
 
 END
 {
 	clear(@start);
 	clear(@iopid);
+	clear(@iocomm);
 }


### PR DESCRIPTION
#3622 has changed biosnoop.bt to use tracepoints instead of unstable kprobes. However, it also changed the way process name (`comm`) is printed - instead of printing `comm` from the `block_io_start` probe, it prints the one from the `block_io_done` probe. Apparently, these two tracepoints can be called by different kernel threads and therefore the thread name can be different.

Return to printing `comm` from the `block_io_start` probe to keep consistent with the previous (documented) version as well as with the BCC and libbpf versions of the same tool.

Fixes #4010.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
