### PR TITLE
uninstall: use execute_process() instead of exec_program()

### DIFF
--- a/cmake/CmakeUninstall.cmake.in
+++ b/cmake/CmakeUninstall.cmake.in
@@ -12,10 +12,10 @@ string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
   if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
-    exec_program(
-      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+    execute_process(
+      COMMAND @CMAKE_COMMAND@ -E remove $ENV{DESTDIR}${file}
       OUTPUT_VARIABLE rm_out
-      RETURN_VALUE rm_retval
+      RESULT_VARIABLE rm_retval
       )
     if(NOT "${rm_retval}" STREQUAL 0)
       message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")


### PR DESCRIPTION
exec_program() is deprecated since 3.28, see: 'cmake --help-policy CMP0153', and cmake support execute_process() since CMake 2.6.0.

    $ sudo make uninstall
    ....
    -- Uninstalling /usr/share/man/man8/setuids.bt.8.gz
    CMake Warning (dev) at /home/rongtao/Git/bpftrace/bpftrace/build/CmakeUninstall.cmake:15 (exec_program):
      Policy CMP0153 is not set: The exec_program command should not be called.
      Run "cmake --help-policy CMP0153" for policy details.  Use the cmake_policy
      command to set the policy and suppress this warning.

      Use execute_process() instead.
    This warning is for project developers.  Use -Wno-dev to suppress it.

