### PR TITLE
ast: move config into early parsing

### DIFF
--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -2,6 +2,7 @@
 
 #include "ast/attachpoint_parser.h"
 #include "ast/pass_manager.h"
+#include "ast/passes/config_analyser.h"
 #include "ast/passes/deprecated.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/map_sugar.h"
@@ -19,6 +20,7 @@ inline std::vector<Pass> AllParsePasses(
 {
   std::vector<Pass> passes;
   passes.emplace_back(CreateParsePass());
+  passes.emplace_back(CreateConfigPass());
   passes.emplace_back(CreateDeprecatedPass());
   passes.emplace_back(CreateParseAttachpointsPass());
   passes.emplace_back(CreateParseBTFPass());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,7 +295,6 @@ std::vector<std::string> extra_flags(
 void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
 {
   add(ast::CreateFoldLiteralsPass());
-  add(ast::CreateConfigPass());
   add(ast::CreateResolveImportsPass({}));
   add(ast::CreatePidFilterPass());
   add(ast::CreateSemanticPass());
@@ -309,7 +308,6 @@ void CreateAotPasses(std::function<void(ast::Pass&& pass)> add)
 {
   add(ast::CreatePortabilityPass());
   add(ast::CreateFoldLiteralsPass());
-  add(ast::CreateConfigPass());
   add(ast::CreateSemanticPass());
   add(ast::CreateResourcePass());
   add(ast::CreateRecursionCheckPass());


### PR DESCRIPTION
ast: move config into early parsing

The configuration may be used to control how certain things are parsed
early on (e.g. for the import expansion). Therefore, make this trivial
pass very early.

Signed-off-by: Adin Scannell <amscanne@meta.com>