### PR TITLE
Add hygienic macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
   - [#3944](https://github.com/bpftrace/bpftrace/pull/3944)
 - Add 'show_debug_info' config for blazesym
   - [#3999](https://github.com/bpftrace/bpftrace/pull/3999)
+- Add hygienic macros (behind an "unstable" config flag)
+  - [#4037](https://github.com/bpftrace/bpftrace/pull/4037)
 #### Changed
 - `-p` CLI flag now applies to all probes (except BEGIN/END)
   - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -978,6 +978,91 @@ The following snippets create a map with key signature `(int64, string[16])` and
 @[(pid, comm)]++
 ----
 
+==== Macros
+
+bpftrace macros (as opposed to C macros) provide a way for you to structure your script.
+They can be useful when you want to factor out code into smaller, more understandable parts.
+Or if you want to share code between probes.
+
+At a high level, macros can be thought of as semantic aware text replacement.
+They accept (optional) variable, map, and some expression arguments.
+The body of the macro may only access maps and external variables passed in through the arguments, which is why these are often referred to as "hygienic macros".
+The body of the macro is exactly one block expression.
+
+For example, these are valid usages of macros:
+
+----
+config = {
+  unstable_macro=1;
+}
+
+macro one() {
+  1
+}
+
+macro add_one($other_name) {
+  $other_name + 1
+}
+
+macro add_one_to_each($a, @b) {
+  $a += 1;
+  @b += 1;
+  $a + @b
+}
+
+macro side_effect($x) {
+  print($x)
+}
+
+macro add_two($x) {
+  add_one($x) + 1
+}
+
+BEGIN {
+  print(one());                   // prints 1
+
+  $a = 42;
+  print(add_one($a));             // prints 43
+
+  @b = 3;
+  print(add_one_to_each($a, @b)); // prints 47
+
+  side_effect(5)                  // prints 5
+
+  print(add_two(1));              // prints 3
+}
+----
+
+Some examples of invalid macro usage:
+
+----
+config = {
+  unstable_macro=1;
+}
+
+macro not_expression() {
+  $var = 1;                    // BAD: Not an expression
+}
+
+macro unhygienic_access() {
+  @x++                         // BAD: @x not passed in
+}
+
+macro wrong_parameter_type($x) {
+  $x++
+}
+
+BEGIN {
+  @x = 1;
+  unhygienic_access();
+
+  wrong_parameter_type(@x);    // BAD: macro expects a scratch variable
+}
+----
+
+**Warning** this feature is experimental and may be subject to changes.
+It also requires the 'unstable_macro' config being set to 1.
+
 ==== Per-Thread Variables
 
 These can be implemented as a map keyed on the thread ID. For example, `@start[tid]`:

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(ast STATIC
   passes/fold_literals.cpp
   passes/link.cpp
   passes/map_sugar.cpp
+  passes/macro_expansion.cpp
   passes/portability_analyser.cpp
   passes/printer.cpp
   passes/probe_analyser.cpp

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1175,6 +1175,29 @@ public:
 };
 using ImportList = std::vector<Import *>;
 
+class Macro : public Node {
+public:
+  Macro(ASTContext &ctx,
+        std::string name,
+        ExpressionList &&vargs,
+        Block *block,
+        Location &&loc)
+      : Node(ctx, std::move(loc)),
+        name(std::move(name)),
+        vargs(std::move(vargs)),
+        block(block) {};
+  explicit Macro(ASTContext &ctx, const Macro &other, const Location &loc)
+      : Node(ctx, loc + other.loc),
+        name(other.name),
+        vargs(clone(ctx, other.vargs, loc)),
+        block(clone(ctx, other.block, loc)) {};
+
+  std::string name;
+  ExpressionList vargs;
+  Block *block;
+};
+using MacroList = std::vector<Macro *>;
+
 class Program : public Node {
 public:
   explicit Program(ASTContext &ctx,
@@ -1182,6 +1205,7 @@ public:
                    Config *config,
                    ImportList &&imports,
                    MapDeclList &&map_decls,
+                   MacroList &&macros,
                    SubprogList &&functions,
                    ProbeList &&probes,
                    Location &&loc)
@@ -1190,6 +1214,7 @@ public:
         config(config),
         imports(std::move(imports)),
         map_decls(std::move(map_decls)),
+        macros(std::move(macros)),
         functions(std::move(functions)),
         probes(std::move(probes)) {};
   explicit Program(ASTContext &ctx, const Program &other, const Location &loc)
@@ -1198,6 +1223,7 @@ public:
         config(clone(ctx, other.config, loc)),
         imports(clone(ctx, other.imports, loc)),
         map_decls(clone(ctx, other.map_decls, loc)),
+        macros(clone(ctx, other.macros, loc)),
         functions(clone(ctx, other.functions, loc)),
         probes(clone(ctx, other.probes, loc)) {};
 
@@ -1205,6 +1231,7 @@ public:
   Config *config = nullptr;
   ImportList imports;
   MapDeclList map_decls;
+  MacroList macros;
   SubprogList functions;
   ProbeList probes;
 };

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -1,0 +1,318 @@
+#include <format>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "ast/ast.h"
+#include "ast/context.h"
+#include "ast/passes/macro_expansion.h"
+#include "ast/visitor.h"
+#include "bpftrace.h"
+
+#include "log.h"
+
+namespace bpftrace::ast {
+
+class MacroExpander : public Visitor<MacroExpander> {
+public:
+  MacroExpander(ASTContext &ast,
+                std::string macro_name,
+                const std::unordered_map<std::string, Macro *> &macros,
+                std::vector<std::string> &&macro_stack);
+
+  using Visitor<MacroExpander>::visit;
+
+  void visit(AssignVarStatement &assignment);
+  void visit(Variable &var);
+  void visit(Map &map);
+  void visit(Expression &expr);
+
+  std::optional<Block *> expand(Macro &macro, const Call &call);
+  bool check_recursive_call(const std::string &macro_name, const Call &call);
+
+private:
+  ASTContext &ast_;
+  const std::string macro_name_;
+  const std::unordered_map<std::string, Macro *> &macros_;
+
+  std::string get_new_var_ident(std::string original_ident);
+
+  // Maps of macro map/var names -> callsite map/var names
+  std::unordered_map<std::string, std::string> maps_;
+  std::unordered_map<std::string, std::string> vars_;
+  std::unordered_set<Variable *> temp_vars_;
+  const std::vector<std::string> macro_stack_;
+};
+
+class MacroCollection : public Visitor<MacroCollection> {
+public:
+  MacroCollection(ASTContext &ast, BPFtrace &b);
+  void collect_macros();
+
+  using Visitor<MacroCollection>::visit;
+
+  void visit(Expression &expr);
+
+private:
+  ASTContext &ast_;
+  BPFtrace &bpftrace_;
+  std::unordered_map<std::string, Macro *> macros_;
+};
+
+MacroExpander::MacroExpander(
+    ASTContext &ast,
+    std::string macro_name,
+    const std::unordered_map<std::string, Macro *> &macros,
+    std::vector<std::string> &&macro_stack)
+    : ast_(ast),
+      macro_name_(std::move(macro_name)),
+      macros_(macros),
+      macro_stack_(std::move(macro_stack))
+{
+  assert(!macro_stack_.empty());
+}
+
+void MacroExpander::visit(AssignVarStatement &assignment)
+{
+  auto *var = assignment.var();
+  if (temp_vars_.contains(var)) {
+    // Don't change variable names if this is a variable assignment
+    // that we created to represent the passed in expression e.g.
+    // macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one($a + 1)); }
+    // will become
+    // BEGIN { $a = 1; print({let $$add_one_$a = $a + 1; $$add_one_$a + 1}); }
+    return;
+  }
+  if (std::holds_alternative<VarDeclStatement *>(assignment.var_decl)) {
+    visit(std::get<VarDeclStatement *>(assignment.var_decl));
+  } else {
+    visit(std::get<Variable *>(assignment.var_decl));
+  }
+  visit(assignment.expr);
+}
+
+void MacroExpander::visit(Variable &var)
+{
+  if (auto it = vars_.find(var.ident); it != vars_.end()) {
+    var.ident = it->second;
+  } else if (!temp_vars_.contains(&var)) {
+    var.ident = get_new_var_ident(var.ident);
+  }
+}
+
+void MacroExpander::visit(Map &map)
+{
+  if (auto it = maps_.find(map.ident); it != maps_.end()) {
+    map.ident = it->second;
+  } else {
+    map.addError() << "Unhygienic access to map: " << map.ident
+                   << ". Maps must be passed into the macro as arguments.";
+  }
+}
+
+bool MacroExpander::check_recursive_call(const std::string &macro_name,
+                                         const Call &call)
+{
+  for (size_t i = 0; i < macro_stack_.size(); ++i) {
+    if (macro_stack_.at(i) == macro_name) {
+      auto &err = call.addError();
+      err << "Recursive macro call detected. Call chain: ";
+      for (; i < macro_stack_.size(); ++i) {
+        err << macro_stack_.at(i) << " > ";
+      }
+      err << macro_name;
+      return true;
+    }
+  }
+  return false;
+}
+
+void MacroExpander::visit(Expression &expr)
+{
+  auto *call = expr.as<Call>();
+  if (!call) {
+    // Recursively expand the new expression, which may again contain macros...
+    Visitor<MacroExpander>::visit(expr);
+    return;
+  }
+
+  for (auto &varg : call->vargs) {
+    visit(varg);
+  }
+
+  if (auto it = macros_.find(call->func); it != macros_.end()) {
+    Macro *macro = it->second;
+
+    if (check_recursive_call(macro->name, *call)) {
+      return;
+    }
+
+    auto next_macro_stack = macro_stack_;
+    next_macro_stack.push_back(macro->name);
+
+    auto r = MacroExpander(
+                 ast_, macro->name, macros_, std::move(next_macro_stack))
+                 .expand(*macro, *call);
+    if (r) {
+      expr.value = *r;
+    }
+  }
+}
+
+std::string MacroExpander::get_new_var_ident(std::string original_ident)
+{
+  return std::format("$${}_{}", macro_name_, original_ident);
+}
+
+std::optional<Block *> MacroExpander::expand(Macro &macro, const Call &call)
+{
+  if (macro.vargs.size() != call.vargs.size()) {
+    call.addError() << "Call to macro has wrong number arguments. Expected: "
+                    << macro.vargs.size() << " but got " << call.vargs.size();
+    return std::nullopt;
+  }
+
+  StatementList stmt_list;
+
+  for (size_t i = 0; i < call.vargs.size(); i++) {
+    if (auto *cvar = call.vargs.at(i).as<Variable>()) {
+      if (auto *mvar = macro.vargs.at(i).as<Variable>()) {
+        vars_[mvar->ident] = cvar->ident;
+      } else {
+        call.addError()
+            << "Mismatched arg to macro call. Macro expects a map for arg "
+            << macro.vargs.at(i).as<Map>()->ident << " but got a variable.";
+      }
+    } else if (auto *cmap = call.vargs.at(i).as<Map>()) {
+      if (auto *mmap = macro.vargs.at(i).as<Map>()) {
+        maps_[mmap->ident] = cmap->ident;
+      } else {
+        call.addError()
+            << "Mismatched arg to macro call. Macro expects a variable for arg "
+            << macro.vargs.at(i).as<Variable>()->ident << " but got a map.";
+      }
+    } else {
+      if (auto *mvar = macro.vargs.at(i).as<Variable>()) {
+        stmt_list.emplace_back(ast_.make_node<AssignVarStatement>(
+            ast_.make_node<Variable>(get_new_var_ident(mvar->ident),
+                                     Location(call.loc)),
+            clone(ast_, call.vargs.at(i), call.vargs.at(i).loc()),
+            Location(call.loc)));
+        temp_vars_.insert(stmt_list.back().as<AssignVarStatement>()->var());
+      } else if (auto *mmap = macro.vargs.at(i).as<Map>()) {
+        call.addError()
+            << "Mismatched arg to macro call. Macro expects a map for arg "
+            << mmap->ident << " but got an expression.";
+      }
+    }
+  }
+
+  for (auto expr : macro.block->stmts) {
+    stmt_list.push_back(clone(ast_, expr, expr.loc()));
+  }
+
+  auto *cloned_block =
+      macro.block->expr.has_value()
+          ? ast_.make_node<Block>(
+                std::move(stmt_list),
+                clone(ast_, *macro.block->expr, macro.block->expr->loc()),
+                Location(macro.loc))
+          : ast_.make_node<Block>(std::move(stmt_list), Location(macro.loc));
+
+  visit(cloned_block);
+
+  if (ast_.diagnostics().ok()) {
+    return cloned_block;
+  }
+
+  return std::nullopt;
+}
+
+MacroCollection::MacroCollection(ASTContext &ast, BPFtrace &b)
+    : ast_(ast), bpftrace_(b)
+{
+}
+
+// This is similar to MacroExpander::visit(Expression &expr) but doesn't have
+// to check for macro recursion because we're at the top level of the AST
+// and avoids the need to keep some state in MacroExpander indicating if we're
+// at the top level of the AST (e.g. where we don't want to rename variables)
+void MacroCollection::visit(Expression &expr)
+{
+  auto *call = expr.as<Call>();
+  if (!call) {
+    Visitor<MacroCollection>::visit(expr);
+    return;
+  }
+
+  for (auto &varg : call->vargs) {
+    visit(varg);
+  }
+
+  if (auto it = macros_.find(call->func); it != macros_.end()) {
+    Macro *macro = it->second;
+    auto r = MacroExpander(ast_, macro->name, macros_, { macro->name })
+                 .expand(*macro, *call);
+    if (r) {
+      expr.value = *r;
+    }
+  }
+}
+
+void MacroCollection::collect_macros()
+{
+  bool unstable_macro = bpftrace_.config_->unstable_macro;
+
+  for (Macro *macro : ast_.root->macros) {
+    if (!unstable_macro) {
+      macro->addError()
+          << "Hygienic macros are not enabled by default. To enable "
+             "this unstable feature, set the 'unstable_macro' config flag to 1 "
+             "e.g. unstable_macro=1";
+      return;
+    }
+
+    if (macros_.contains(macro->name)) {
+      macro->addError() << "Redifinition of macro: " << macro->name;
+      return;
+    }
+
+    std::unordered_set<std::string> seen_mvars;
+    std::unordered_set<std::string> seen_mmaps;
+    for (const auto &arg : macro->vargs) {
+      if (auto *mvar = arg.as<Variable>()) {
+        auto inserted = seen_mvars.insert(mvar->ident);
+        if (!inserted.second) {
+          mvar->addError()
+              << "Variable for macro argument has already been used: "
+              << mvar->ident;
+          return;
+        }
+      } else if (auto *mmap = arg.as<Map>()) {
+        auto inserted = seen_mmaps.insert(mmap->ident);
+        if (!inserted.second) {
+          mmap->addError() << "Map for macro argument has already been used: "
+                           << mmap->ident;
+          return;
+        }
+      }
+    }
+
+    macros_[macro->name] = macro;
+  }
+}
+
+Pass CreateMacroExpansionPass()
+{
+  auto fn = [](ASTContext &ast, BPFtrace &b) {
+    MacroCollection collector(ast, b);
+    collector.collect_macros();
+    if (ast.diagnostics().ok()) {
+      collector.visit(ast.root);
+    }
+  };
+
+  return Pass::create("MacroExpansion", fn);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/macro_expansion.h
+++ b/src/ast/passes/macro_expansion.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateMacroExpansionPass();
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -5,6 +5,7 @@
 #include "ast/passes/config_analyser.h"
 #include "ast/passes/deprecated.h"
 #include "ast/passes/field_analyser.h"
+#include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
 #include "btf.h"
 #include "clang_parser.h"
@@ -21,6 +22,7 @@ inline std::vector<Pass> AllParsePasses(
   std::vector<Pass> passes;
   passes.emplace_back(CreateParsePass());
   passes.emplace_back(CreateConfigPass());
+  passes.emplace_back(CreateMacroExpansionPass());
   passes.emplace_back(CreateDeprecatedPass());
   passes.emplace_back(CreateParseAttachpointsPass());
   passes.emplace_back(CreateParseBTFPass());
@@ -30,6 +32,7 @@ inline std::vector<Pass> AllParsePasses(
   // The source and syntax is reparsed because it uses the `macros_` which are
   // set during the clang parse to expand identifiers within the lexer.
   passes.emplace_back(CreateParsePass());
+  passes.emplace_back(CreateMacroExpansionPass());
   passes.emplace_back(CreateParseAttachpointsPass());
   passes.emplace_back(CreateMapSugarPass());
   return passes;

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -209,6 +209,13 @@ public:
     visitImpl(block.expr);
     return default_value();
   }
+  R visit([[maybe_unused]] Macro &macro)
+  {
+    // In general because macros are expanded in an early pass (macro_expansion)
+    // later passes shouldn't visit any macros; visitation should be specially
+    // handled by the macro_expansion pass.
+    return default_value();
+  }
   R visit(Subprog &subprog)
   {
     visitImpl(subprog.args);
@@ -224,6 +231,7 @@ public:
     // This order is important.
     visitImpl(program.config);
     visitImpl(program.imports);
+    visitImpl(program.macros);
     visitImpl(program.functions);
     visitImpl(program.map_decls);
     visitImpl(program.probes);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -253,6 +253,7 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { "use_blazesym", CONFIG_FIELD_PARSER(use_blazesym) },
   { "show_debug_info", CONFIG_FIELD_PARSER(show_debug_info) },
   { "unstable_import", CONFIG_FIELD_PARSER(unstable_import) },
+  { "unstable_macro", CONFIG_FIELD_PARSER(unstable_macro) },
   { "unstable_map_decl", CONFIG_FIELD_PARSER(unstable_map_decl) },
 };
 

--- a/src/config.h
+++ b/src/config.h
@@ -32,6 +32,7 @@ public:
   bool cpp_demangle = true;
   bool lazy_symbolication = true;
   bool print_maps_on_exit = true;
+  bool unstable_macro = false;
   bool unstable_map_decl = false;
   bool unstable_import = false;
 #ifdef HAVE_BLAZESYM

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -15,8 +15,8 @@
 
 using namespace bpftrace;
 
-// Since `YY_INPUT` cannot access the `driver` variable, `source` and `curr` 
-// are defined as global variables. They are marked as thread_local to 
+// Since `YY_INPUT` cannot access the `driver` variable, `source` and `curr`
+// are defined as global variables. They are marked as thread_local to
 // ensure thread safety during lexical analysis.
 static thread_local const std::string *source;
 static thread_local size_t curr;
@@ -50,6 +50,7 @@ int_type        bool|(u)?int(8|16|32|64)
 builtin_type    void|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|strerror_t|kstack_t|ustack_t
 sized_type      string|inet|buffer
 subprog         fn
+macro           macro
 
 /* escape sequences in strings */
 hex_esc  (x|X)[0-9a-fA-F]{1,2}
@@ -80,6 +81,7 @@ oct_esc  [0-7]{1,3}
 
 {builtin}               { return Parser::make_BUILTIN(yytext, driver.loc); }
 {subprog}               { return Parser::make_SUBPROG(yytext, driver.loc); }
+{macro}                 { return Parser::make_MACRO(yytext, driver.loc); }
 {int}|{hex}|{exponent}  {
                           try
                           {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -664,6 +664,7 @@ static ast::ASTContext buildListProgram(const std::string& search)
                                          nullptr,
                                          ast::ImportList(),
                                          ast::MapDeclList(),
+                                         ast::MacroList(),
                                          ast::SubprogList(),
                                          ast::ProbeList({ probe }),
                                          location());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ add_executable(bpftrace_test
   function_registry.cpp
   location.cpp
   log.cpp
+  macro_expansion.cpp
   main.cpp
   mocks.cpp
   output.cpp

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -1,0 +1,115 @@
+#include "ast/passes/macro_expansion.h"
+#include "ast/passes/parser.h"
+#include "ast/passes/printer.h"
+#include "mocks.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::macro_expansion {
+
+using ::testing::HasSubstr;
+
+void test(const std::string& input,
+          const std::string& error = "",
+          const std::string& warn = "")
+{
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace& bpftrace = *mock_bpftrace;
+  bpftrace.config_->unstable_macro = true;
+
+  // The input provided here is embedded into an expression.
+  ast::ASTContext ast("stdin", input);
+  std::stringstream msg;
+  msg << "\nInput:\n" << input << "\n\nOutput:\n";
+
+  // N.B. No C macro or tracepoint expansion.
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put(bpftrace)
+                .add(CreateParsePass())
+                .add(ast::CreateMacroExpansionPass())
+                .run();
+
+  std::ostringstream out;
+  ast::Printer printer(out);
+  printer.visit(ast.root);
+  ast.diagnostics().emit(out);
+
+  if (error.empty()) {
+    ASSERT_TRUE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+    if (!warn.empty()) {
+      EXPECT_THAT(out.str(), HasSubstr(warn)) << msg.str() << out.str();
+    }
+  } else {
+    ASSERT_FALSE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+    EXPECT_THAT(out.str(), HasSubstr(error)) << msg.str() << out.str();
+  }
+}
+
+void test_error(const std::string& input, const std::string& error)
+{
+  test(input, error);
+}
+
+void test_warning(const std::string& input, const std::string& warn)
+{
+  test(input, "", warn);
+}
+
+TEST(macro_expansion, basic_checks)
+{
+  test_error("macro set($x) { $x += 1; $x } BEGIN { $a = 1; set($a, 1); }",
+             "Call to macro has wrong number arguments. Expected: 1 but got 2");
+  test_error("macro set($x, $x) { $x += 1; $x } BEGIN { $a = 1; set($a, 1); }",
+             "Variable for macro argument has already been used: $x");
+  test_error("macro set($x) { $x += 1; $x } macro set($x) { $x } BEGIN { $a = "
+             "1; set($a, 1); }",
+             "Redifinition of macro: set");
+  test("macro add1($x) { $x + 1 } macro add2($x) { $x + add1($x) } macro "
+       "add3($x) { $x + add2($x) } BEGIN { print(add3(1)); }");
+
+  test_error(
+      "macro add1($x) { $x + add3($x) } macro add2($x) { $x + add1($x) } macro "
+      "add3($x) { $x + add2($x) } BEGIN { print(add3(1)); }",
+      "Recursive macro call detected. Call chain: add3 > add2 > add1 > add3");
+}
+
+TEST(macro_expansion, variables)
+{
+  test("macro set($x) { $x += 1; $x } BEGIN { $a = 1; set($a); }");
+  test("macro set($x) { $x += 1; $x } BEGIN { $a = 1; set(1); }");
+  test("macro set($x, $y) { $x + $y } BEGIN { $a = 1; set($a, 1); }");
+  test("macro set($x) { $b = $x + 1; $b } BEGIN { $a = 1; set($a); }");
+  test("macro set($x) { let $b = $x + 1; $b } BEGIN { $a = 1; set($a); }");
+
+  test_error(
+      "macro set($x) { $x += 1; $x } BEGIN { @a = 1; set(@a); }",
+      "Mismatched arg to macro call. Macro expects a variable for arg $x "
+      "but got a map.");
+}
+
+TEST(macro_expansion, maps)
+{
+  test("macro set(@x) { @x[1] } BEGIN { @a[1] = 0; set(@a); }");
+  test("macro set(@x) { @x[1] = 1; @x[1] } BEGIN { @a[1] = 0; set(@a); }");
+
+  test_error("macro set(@x) { @x[1] = 1; @x[1] } BEGIN { $a = 0; set($a); }",
+             "Mismatched arg to macro call. Macro expects a map for arg @x but "
+             "got a variable.");
+  test_error("macro set(@x) { @x[1] = 1; @x[1] } BEGIN { $a = 0; set(1); }",
+             "Mismatched arg to macro call. Macro expects a map for arg @x but "
+             "got an expression.");
+  test_error("macro set() { @x[1] = 1; 1 } BEGIN { @x[0] = 0; set(); }",
+             "Unhygienic access to map: @x. Maps must be passed into the macro "
+             "as arguments");
+  test_error("macro set() { @x[1] } BEGIN { @x[0] = 0; set(); }",
+             "Unhygienic access to map: @x. Maps must be passed into the macro "
+             "as arguments");
+}
+
+TEST(macro_expansion, misc)
+{
+  // semantic_analyser will catch this undefined call/macro
+  test("macro add3($x) { $x + add5($x) } BEGIN { print(add3(1)); }");
+}
+
+} // namespace bpftrace::test::macro_expansion

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -1,0 +1,75 @@
+NAME it mutates the passed variable
+PROG config = { unstable_macro=1; } macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); print($a); exit(); }
+EXPECT 2
+
+NAME it does not mutate previously passed variable with literal
+PROG config = { unstable_macro=1; } macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); inc(1); print($a); exit(); }
+EXPECT 2
+
+NAME it mutates the passed non-scalar map
+PROG config = { unstable_macro=1; } macro set(@x) { @x[1] = 2; 1 } BEGIN { @a[1] = 1; set(@a); exit(); }
+EXPECT @a[1]: 2
+
+NAME it mutates the passed scalar map
+PROG config = { unstable_macro=1; } macro set(@x) { @x = 2; 1 } BEGIN { @a = 1; set(@a); exit(); }
+EXPECT @a: 2
+
+NAME it reads the passed map
+PROG config = { unstable_macro=1; } macro get(@x) { 1 + @x[1] } BEGIN { @a[1] = 1; print(get(@a)); exit(); }
+EXPECT 2
+
+NAME it can have side effects
+PROG config = { unstable_macro=1; } macro print_me($x) { print(("me", $x)) } BEGIN { $a = 1; print_me($a); exit(); }
+EXPECT (me, 1)
+
+NAME it can exit early
+PROG config = { unstable_macro=1; } macro early() { exit() } BEGIN { early(); print(1); }
+EXPECT_NONE 1
+
+NAME it can call other macros
+PROG config = { unstable_macro=1; } macro add1($x) { $x + 1 } macro add2($y) { $y + add1($y) } macro add3($z) { $z + add2($z) } BEGIN { print(add3(1)); exit(); }
+EXPECT 4
+
+NAME macro definition order does not matter
+PROG config = { unstable_macro=1; } macro add2($x) { $x + add1($x) } macro add3($x) { $x + add2($x) } macro add1($x) { $x + 1 } BEGIN { print(add3(1)); exit(); }
+EXPECT 4
+
+NAME it accepts arbitrary expressions without variables or maps
+PROG config = { unstable_macro=1; } macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one(1 + 1)); exit(); }
+EXPECT 3
+
+NAME it accepts arbitrary expressions with variables
+PROG config = { unstable_macro=1; } macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one($a + 1)); exit(); }
+EXPECT 3
+
+NAME it accepts arbitrary expressions with variables nested
+PROG config = { unstable_macro=1; } macro add_two($x) { $x + 2 } macro add_one($x) { add_two($x + 1) + 1 } BEGIN { $a = 1; print(add_one($a + 1)); exit(); }
+EXPECT 6
+
+NAME it accepts arbitrary expressions with maps
+PROG config = { unstable_macro=1; } macro add_one($x) { $x + 1 } BEGIN { @a = 1; print(add_one(@a + 1)); exit(); }
+EXPECT 3
+
+NAME can call the same macro multiple times
+PROG config = { unstable_macro=1; } macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); inc($a); inc($a); print($a); exit(); }
+EXPECT 4
+
+NAME for loops can be in macros
+PROG config = { unstable_macro=1; } macro loop_map(@a) { let $x = 1; for ($kv : @a) { $x += $kv.1;} $x } BEGIN { @x[1] = 5; @x[2] = 10; print(loop_map(@x)); exit(); }
+EXPECT 16
+
+NAME it works in nested scopes
+PROG config = { unstable_macro=1; } macro add1($x) { $x + 1 } macro add2($x) { $x + 2 } BEGIN { $a = 1; if ($a == 1) { print(add2($a)); } else { print(add1($a)); } exit(); }
+EXPECT 3
+
+NAME it re-names variables to prevent collision
+PROG config = { unstable_macro=1; } macro inc($x) { $y = $x + 1; $y } BEGIN { $y = 2; $z = inc(5); print(($y, $z)); exit(); }
+EXPECT (2, 6)
+
+NAME it re-names decl variables to prevent collision
+PROG config = { unstable_macro=1; } macro inc($x) { let $y = $x + 1; $y } BEGIN { $y = 2; $z = inc(5); print(($y, $z)); exit(); }
+EXPECT (2, 6)
+
+NAME it can be part of an expression passed to a macro
+PROG config = { unstable_macro=1; } macro add_one($x) { $x + 1 } BEGIN { $a = add_one(add_one(1) + 1); print($a); exit(); }
+EXPECT 4


### PR DESCRIPTION
Hygienic macros (usually just "macros") provide
a way for you to structure your script. They
can be useful when you want to factor out code
into smaller, more understandable parts. Or if
you want to share code between probes.

At a high level, macros can be thought of as
semantic aware text replacement. They accept
(optional) variable, map, and some expression
arguments. The body of the macro may only
access maps and variables passed in through
the arguments (the hygiene). The body of the
macro is exactly one block expression.

Example:
```
macro set($x) { $x += 1; $x }

BEGIN { $a = 1; set($a); print($a); exit(); }
```

This will print "2";

This feature is gated behind a config flag:
"unstable_macro".

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
