### PR TITLE
fix: minor build fixups

### DIFF
--- a/cmake/BuildBPF.cmake
+++ b/cmake/BuildBPF.cmake
@@ -17,17 +17,14 @@ find_program(CLANG
   NAMES clang-${LLVM_VERSION_MAJOR}
   REQUIRED)
 
-function(btf_header NAME)
+function(btf_header NAME SOURCE)
   cmake_parse_arguments(
     ARG
     ""
-    "OUTPUT;SOURCE"
+    "OUTPUT"
     ""
     ${ARGN}
   )
-  if (NOT DEFINED ARG_SOURCE)
-    set(ARG_SOURCE "/sys/kernel/btf/vmlinux")
-  endif ()
   if (NOT DEFINED ARG_OUTPUT)
     set(ARG_OUTPUT "${NAME}.h")
   endif ()

--- a/src/ast/passes/recursion_check.cpp
+++ b/src/ast/passes/recursion_check.cpp
@@ -28,8 +28,7 @@ bool is_recursive_func(const std::string &func_name)
 
 class RecursionCheck : public Visitor<RecursionCheck> {
 public:
-  explicit RecursionCheck(ASTContext &ast, BPFtrace &bpftrace)
-      : ast_(ast), bpftrace_(bpftrace)
+  explicit RecursionCheck(BPFtrace &bpftrace) : bpftrace_(bpftrace)
   {
   }
 
@@ -37,7 +36,6 @@ public:
   void visit(Program &program);
 
 private:
-  ASTContext &ast_;
   BPFtrace &bpftrace_;
 };
 
@@ -80,7 +78,7 @@ void RecursionCheck::visit(Program &program)
 Pass CreateRecursionCheckPass()
 {
   return Pass::create("RecursionCheck", [](ASTContext &ast, BPFtrace &b) {
-    auto recursion_check = RecursionCheck(ast, b);
+    auto recursion_check = RecursionCheck(b);
     recursion_check.visit(ast.root);
   });
 };

--- a/src/ast/passes/resolve_imports.cpp
+++ b/src/ast/passes/resolve_imports.cpp
@@ -1,18 +1,14 @@
-#include <iostream>
-#include <sstream>
-#include <unordered_set>
-
 #include "ast/passes/resolve_imports.h"
 #include "ast/visitor.h"
 #include "bpftrace.h"
-#include "log.h"
 
 namespace bpftrace::ast {
 
 class ResolveImports : public Visitor<ResolveImports> {
 public:
-  ResolveImports(BPFtrace &bpftrace, const std::vector<std::string> &paths)
-      : bpftrace_(bpftrace), paths_(paths) {};
+  ResolveImports(BPFtrace &bpftrace,
+                 [[maybe_unused]] const std::vector<std::string> &paths)
+      : bpftrace_(bpftrace) {};
 
   using Visitor<ResolveImports>::visit;
   void visit(Import &imp);
@@ -25,7 +21,6 @@ public:
 
 private:
   BPFtrace &bpftrace_;
-  const std::vector<std::string> &paths_;
   Imports imports_;
 };
 

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -74,7 +74,6 @@ public:
       : no_feature_(no_feature), btf_(btf)
   {
   }
-  BPFfeature() = default;
   virtual ~BPFfeature() = default;
 
   // Due to the unique_ptr usage the generated copy constructor & assignment

--- a/src/stdlib/CMakeLists.txt
+++ b/src/stdlib/CMakeLists.txt
@@ -1,16 +1,11 @@
 include(BuildBPF)
 include(Embed)
 
-btf_header(vmlinux
-  OUTPUT vmlinux.h
-)
-
 bpf(base
   SOURCE  base.c
   BITCODE base.bc
   OBJECT  base.o
   BTF     base.btf
-  DEPENDS vmlinux
 )
 
 embed(

--- a/src/stdlib/base.c
+++ b/src/stdlib/base.c
@@ -1,5 +1,3 @@
-#include "vmlinux.h"
-
 int always_true()
 {
   return 1;

--- a/tests/data/data_source_cxx.cpp
+++ b/tests/data/data_source_cxx.cpp
@@ -1,6 +1,6 @@
 class Parent {
 private:
-  int a;
+  [[maybe_unused]] int a;
 
 protected:
   int b;


### PR DESCRIPTION
* Adds `[[maybe_unused]]` to some private unused variables in test files.
* Mounts BTF (for stdlib build processes) in Docker build containers.
* Removes unused variables from `resolve_imports` and 
* Drop the impossible constructor from BPFFeature (due to reference member)
