### PR TITLE
Remove call and call_builtin from lexer/parser 

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -44,16 +44,12 @@ hspace   [ \t]
 vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#$+\*])+
-builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|len|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf|has_key|percpu_kaddr
+builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies|nsecs|kstack|ustack
 
 int_type        bool|(u)?int(8|16|32|64)
 builtin_type    void|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|strerror_t|kstack_t|ustack_t
 sized_type      string|inet|buffer
 subprog         fn
-
-/* Don't add to this! Use builtin OR call not both */
-call_and_builtin kstack|ustack|nsecs
 
 /* escape sequences in strings */
 hex_esc  (x|X)[0-9a-fA-F]{1,2}
@@ -83,8 +79,6 @@ oct_esc  [0-7]{1,3}
 }
 
 {builtin}               { return Parser::make_BUILTIN(yytext, driver.loc); }
-{call}                  { return Parser::make_CALL(yytext, driver.loc); }
-{call_and_builtin}      { return Parser::make_CALL_BUILTIN(yytext, driver.loc); }
 {subprog}               { return Parser::make_SUBPROG(yytext, driver.loc); }
 {int}|{hex}|{exponent}  {
                           try

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -118,7 +118,6 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> VAR "variable"
 %token <std::string> PARAM "positional parameter"
 %token <uint64_t> UNSIGNED_INT "integer"
-%token <std::string> STACK_MODE "stack_mode"
 %token <std::string> CONFIG "config"
 %token <std::string> UNROLL "unroll"
 %token <std::string> WHILE "while"
@@ -714,8 +713,6 @@ call:
         |       IDENT "(" vargs ")"          { error(@1, "Unknown function: " + $1); YYERROR;  }
         |       BUILTIN "(" ")"              { error(@1, "Unknown function: " + $1); YYERROR;  }
         |       BUILTIN "(" vargs ")"        { error(@1, "Unknown function: " + $1); YYERROR;  }
-        |       STACK_MODE "(" ")"           { error(@1, "Unknown function: " + $1); YYERROR;  }
-        |       STACK_MODE "(" vargs ")"     { error(@1, "Unknown function: " + $1); YYERROR;  }
                 ;
 
 map:

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -102,8 +102,6 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 ;
 
 %token <std::string> BUILTIN "builtin"
-%token <std::string> CALL "call"
-%token <std::string> CALL_BUILTIN "call_builtin"
 %token <std::string> INT_TYPE "integer type"
 %token <std::string> BUILTIN_TYPE "builtin type"
 %token <std::string> SUBPROG "subprog"
@@ -509,7 +507,6 @@ primary_expr:
         |       UNSIGNED_INT       { $$ = driver.ctx.make_node<ast::Integer>($1, @$); }
         |       STRING             { $$ = driver.ctx.make_node<ast::String>($1, @$); }
         |       BUILTIN            { $$ = driver.ctx.make_node<ast::Builtin>($1, @$); }
-        |       CALL_BUILTIN       { $$ = driver.ctx.make_node<ast::Builtin>($1, @$); }
         |       LPAREN expr RPAREN { $$ = $2; }
         |       param              { $$ = $1; }
         |       param_count        { $$ = $1; }
@@ -686,8 +683,6 @@ ident:
                 IDENT         { $$ = $1; }
         |       BUILTIN       { $$ = $1; }
         |       BUILTIN_TYPE  { $$ = $1; }
-        |       CALL          { $$ = $1; }
-        |       CALL_BUILTIN  { $$ = $1; }
                 ;
 
 raw_ident:
@@ -705,14 +700,10 @@ external_name:
         ;
 
 call:
-                CALL "(" ")"                 { $$ = driver.ctx.make_node<ast::Call>($1, @$); }
-        |       CALL "(" vargs ")"           { $$ = driver.ctx.make_node<ast::Call>($1, std::move($3), @$); }
-        |       CALL_BUILTIN  "(" ")"        { $$ = driver.ctx.make_node<ast::Call>($1, @$); }
-        |       CALL_BUILTIN "(" vargs ")"   { $$ = driver.ctx.make_node<ast::Call>($1, std::move($3), @$); }
-        |       IDENT "(" ")"                { error(@1, "Unknown function: " + $1); YYERROR;  }
-        |       IDENT "(" vargs ")"          { error(@1, "Unknown function: " + $1); YYERROR;  }
-        |       BUILTIN "(" ")"              { error(@1, "Unknown function: " + $1); YYERROR;  }
-        |       BUILTIN "(" vargs ")"        { error(@1, "Unknown function: " + $1); YYERROR;  }
+                IDENT "(" ")"                 { $$ = driver.ctx.make_node<ast::Call>($1, @$); }
+        |       BUILTIN "(" ")"               { $$ = driver.ctx.make_node<ast::Call>($1, @$); }
+        |       IDENT "(" vargs ")"           { $$ = driver.ctx.make_node<ast::Call>($1, std::move($3), @$); }
+        |       BUILTIN "(" vargs ")"         { $$ = driver.ctx.make_node<ast::Call>($1, std::move($3), @$); }
                 ;
 
 map:


### PR DESCRIPTION
Also remove STACK_MODE in parser which was unused

Semantic analyser already takes care of checking
if the ident of the `Call` is an expected name.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
