### PR TITLE
bpftrace: fix compilation warnings

### DIFF
--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -182,8 +182,8 @@ std::vector<std::string> Ksyms::resolve_blazesym(uint64_t addr,
 
 std::vector<std::string> Ksyms::resolve(uint64_t addr,
                                         bool show_offset,
-                                        bool perf_mode,
-                                        bool show_debug_info)
+                                        [[maybe_unused]] bool perf_mode,
+                                        [[maybe_unused]] bool show_debug_info)
 {
 #ifdef HAVE_BLAZESYM
   if (config_.use_blazesym)

--- a/src/usyms.cpp
+++ b/src/usyms.cpp
@@ -404,7 +404,7 @@ std::vector<std::string> Usyms::resolve(uint64_t addr,
                                         const std::string &pid_exe,
                                         bool show_offset,
                                         bool perf_mode,
-                                        bool show_debug_info)
+                                        [[maybe_unused]] bool show_debug_info)
 {
 #ifdef HAVE_BLAZESYM
   if (config_.use_blazesym)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

The compiler generated unused parameter warnings during the bpftrace build process. The warning messages are pasted below::
```bash
[ 79%] Building CXX object src/ast/CMakeFiles/ast.dir/attachpoint_parser.cpp.o
/bpftrace/src/ksyms.cpp: In member function 'std::vector<std::__cxx11::basic_string<char> > bpftrace::Ksyms::resolve(uint64_t, bool, bool, bool)':
/bpftrace/src/ksyms.cpp:185:46: warning: unused parameter 'perf_mode' [-Wunused-parameter]
  185 |                                         bool perf_mode,
      |                                         ~~~~~^~~~~~~~~
/bpftrace/src/ksyms.cpp:186:46: warning: unused parameter 'show_debug_info' [-Wunused-parameter]
  186 |                                         bool show_debug_info)
      |                                         ~~~~~^~~~~~~~~~~~~~~
[ 79%] Building CXX object src/ast/CMakeFiles/ast.dir/codegen_helper.cpp.o
[ 80%] Building CXX object src/ast/CMakeFiles/ast.dir/diagnostic.cpp.o
/bpftrace/src/usyms.cpp: In member function 'std::vector<std::__cxx11::basic_string<char> > bpftrace::Usyms::resolve(uint64_t, int32_t, const std::string&, bool, bool, bool)':
/bpftrace/src/usyms.cpp:407:46: warning: unused parameter 'show_debug_info' [-Wunused-parameter]
  407 |                                         bool show_debug_info)
      |                                         ~~~~~^~~~~~~~~~~~~~~


##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
