### PR TITLE
util: add `TempDir` to create temporary directories

### DIFF
--- a/src/ast/passes/link.cpp
+++ b/src/ast/passes/link.cpp
@@ -29,8 +29,14 @@ Pass CreateLinkPass()
           return BpfBytecode{ obj.data };
         }
 
+        // Create a working directory.
+        auto dir = util::TempDir::create();
+        if (!dir) {
+          return dir.takeError();
+        }
+
         // Otherwise, dump the intermediate object.
-        auto object = util::TempFile::create();
+        auto object = dir->create_file();
         if (!object) {
           return object.takeError();
         }
@@ -41,7 +47,7 @@ Pass CreateLinkPass()
 
         // Create an output file on disk. In the future, we may want to accept
         // some flags that allow this file to persist.
-        auto output = util::TempFile::create();
+        auto output = dir->create_file();
         if (!output) {
           return output.takeError();
         }

--- a/src/util/temp.h
+++ b/src/util/temp.h
@@ -23,9 +23,11 @@ private:
 // TempFile provide a convenient RAII wrapper for temporary files. The use of
 // temporary files should be generally discouraged, unless they are necessary
 // to interacting with other libraries or tools.
+//
+// Using `pattern = false` should only be done from `TempDir`.
 class TempFile {
 public:
-  static Result<TempFile> create(std::string pattern = "");
+  static Result<TempFile> create(std::string name = "", bool pattern = true);
   ~TempFile();
 
   TempFile(const TempFile &other) = delete;
@@ -58,6 +60,43 @@ private:
 
   std::filesystem::path path_;
   int fd_;
+};
+
+// TempDir provides a wrapper for temporary directories.
+//
+// There is no way to create directories with a fixed name.
+class TempDir {
+public:
+  static Result<TempDir> create(std::string pattern = "");
+  ~TempDir();
+
+  TempDir(const TempDir &other) = delete;
+  TempDir &operator=(const TempDir &other) = delete;
+
+  TempDir(TempDir &&other)
+  {
+    path_ = std::move(other.path_);
+  }
+  TempDir &operator=(TempDir &&other)
+  {
+    path_ = std::move(other.path_);
+    return *this;
+  }
+
+  const std::filesystem::path &path()
+  {
+    return path_;
+  }
+
+  // Creates a temporary file in this directory. Note that `name` need not
+  // contain any `X` characters if `pattern` is true, as these will be appended
+  // as a suffix. The `name` provided should also not have any path components.
+  Result<TempFile> create_file(std::string name = "", bool pattern = true);
+
+private:
+  TempDir(std::filesystem::path &&path) : path_(std::move(path)) {};
+
+  std::filesystem::path path_;
 };
 
 } // namespace bpftrace::util

--- a/tests/temp.cpp
+++ b/tests/temp.cpp
@@ -6,6 +6,7 @@
 
 namespace bpftrace::test::types {
 
+using util::TempDir;
 using util::TempFile;
 
 TEST(util, tempfile_no_pattern)
@@ -35,6 +36,33 @@ TEST(util, tempfile_good_pattern)
   ASSERT_TRUE(bool(f2));
   EXPECT_TRUE(f1->path().filename().string().starts_with("testing."));
   EXPECT_TRUE(f2->path().filename().string().starts_with("testing."));
+}
+
+TEST(util, tempdir)
+{
+  auto d = TempDir::create();
+  ASSERT_TRUE(bool(d));
+  auto f1 = d->create_file("foo");
+  auto f2 = d->create_file("bar");
+  auto f3 = d->create_file();
+  ASSERT_TRUE(bool(f1));
+  ASSERT_TRUE(bool(f2));
+  ASSERT_TRUE(bool(f3));
+  EXPECT_TRUE(f1->path().filename().string().starts_with("foo."));
+  EXPECT_TRUE(f2->path().filename().string().starts_with("bar."));
+}
+
+TEST(util, tempdir_no_pattern)
+{
+  auto d = TempDir::create();
+  ASSERT_TRUE(bool(d));
+  auto f1 = d->create_file("foo", false);
+  auto f2 = d->create_file("bar", false);
+  ASSERT_TRUE(bool(f1));
+  ASSERT_TRUE(bool(f2));
+  EXPECT_EQ(f1->path().filename().string(), "foo");
+  EXPECT_EQ(f2->path().filename().string(), "bar");
+  EXPECT_FALSE(bool(d->create_file("foo", false)));
 }
 
 } // namespace bpftrace::test::types


### PR DESCRIPTION
In order to add a common working directory, add a `TempDir` utility which can collect a common set of temporary files.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- [x] The new behaviour is covered by tests
