### PR TITLE
Revert "enhancement: suppress extraneous output in bpftrace_test when tests pass"

### DIFF
--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,11 +1,7 @@
 #include "gtest/gtest.h"
-#include <cstdlib>
-#include <string>
-#include <sys/mman.h>
-#include <unistd.h>
 
 class ThrowListener : public testing::EmptyTestEventListener {
-  void OnTestPartResult(const testing::TestPartResult& result) override
+  void OnTestPartResult(const testing::TestPartResult &result) override
   {
     if (result.type() == testing::TestPartResult::kFatalFailure) {
       throw testing::AssertionException(result);
@@ -13,76 +9,9 @@ class ThrowListener : public testing::EmptyTestEventListener {
   }
 };
 
-class OutputSuppressorListener : public testing::EmptyTestEventListener {
-public:
-  void OnTestStart(const testing::TestInfo& /*test_info*/) override
-  {
-    // stash original stderr
-    original_stderr_ = dup(STDERR_FILENO);
-    if (original_stderr_ == -1) {
-      return;
-    }
-
-    // create a temp file
-    constexpr unsigned int NO_FLAGS = 0;
-    memfd_ = memfd_create("stderr_capture", NO_FLAGS);
-    if (memfd_ == -1) {
-      close(original_stderr_);
-      original_stderr_ = -1;
-      return;
-    }
-
-    // redirect stderr to temp file
-    dup2(memfd_, STDERR_FILENO);
-  }
-
-  void OnTestEnd(const testing::TestInfo& test_info) override
-  {
-    if (original_stderr_ != -1) {
-      // restore output if test failed
-      if (test_info.result()->Failed()) {
-        restore_output();
-      }
-
-      if (original_stderr_ != -1) {
-        dup2(original_stderr_, STDERR_FILENO);
-        close(original_stderr_);
-        original_stderr_ = -1;
-      }
-    }
-  }
-
-private:
-  void restore_output()
-  {
-    if (memfd_ && original_stderr_ != -1) {
-      // temporarily switch back to original stderr
-      int old = dup(STDERR_FILENO);
-      dup2(original_stderr_, STDERR_FILENO);
-
-      // reset file pointer and output content
-      lseek(memfd_, 0, SEEK_SET);
-      char buffer[1024];
-      ssize_t n;
-      while ((n = read(memfd_, buffer, sizeof(buffer))) > 0) {
-        std::cerr << buffer;
-      }
-
-      // restore to temp file
-      dup2(old, STDERR_FILENO);
-      close(old);
-    }
-  }
-
-  int memfd_ = -1;
-  int original_stderr_ = -1;
-};
-
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::UnitTest::GetInstance()->listeners().Append(new ThrowListener);
-  ::testing::UnitTest::GetInstance()->listeners().Append(
-      new OutputSuppressorListener);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This reverts commit a30d61b56368ef33092fa261c168424168b1bcd3.

This is causing 2 issues:
1) Our test output supression is swallowing LOG(BUG) because this leads to an abort which the test listener is not catching

2) LOG(ERROR) no longer leads to a program termination so any places where this is called are also getting swallowed by output suppression because the tests don't fail

1 - This is probably address-able by adding a signal handler to OutputSuppressorListener.

2 - This is a larger problem with the codebase and needs to be addressed.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
