### PR TITLE
ci: Fold output for successful test suites

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -183,9 +183,19 @@ def test_one(name: str, cond: Callable[[], bool], fn: Callable[[], None]) -> Tes
     status = TestStatus.PASSED
 
     if cond():
-        print(f"\n======= {name} ======")
+        in_ci = truthy(CI)
+        if in_ci:
+            # Start a collapsible section in GitHub Actions logs
+            # For failed tests, we'll omit the endgroup command to keep them expanded
+            print(f"::group::{name}")
+        else:
+            print(f"\n======= {name} ======")
+
         try:
             fn()
+            if in_ci:
+                # Only close the group if the test succeeded
+                print("::endgroup::")
         except subprocess.CalledProcessError as e:
             status = TestStatus.FAILED
     else:


### PR DESCRIPTION
Right now the CI logs have a lot of output, even if everything is successful. Nobody cares what the output is if the tests are successful - we only care about failures.

This commit adds magic GHA markers such that successful tests are folded (hidden) by default. You can always click to expand the folds if you want to see the successful output.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
