### PR TITLE
ci: Upgrade flakehuh-cache-action

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -183,9 +183,19 @@ def test_one(name: str, cond: Callable[[], bool], fn: Callable[[], None]) -> Tes
     status = TestStatus.PASSED
 
     if cond():
-        print(f"\n======= {name} ======")
+        in_ci = truthy(CI)
+        if in_ci:
+            # Start a collapsible section in GitHub Actions logs
+            # For failed tests, we'll omit the endgroup command to keep them expanded
+            print(f"\n::group::{name}")
+        else:
+            print(f"\n======= {name} ======")
+
         try:
             fn()
+            if in_ci:
+                # Only close the group if the test succeeded
+                print("::endgroup::")
         except subprocess.CalledProcessError as e:
             status = TestStatus.FAILED
     else:

--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@v16
       with:
         determinate: true
-    - uses: DeterminateSystems/flakehub-cache-action@v1
+    - uses: DeterminateSystems/flakehub-cache-action@04eb56b73c2de9e098015ec61db998329962ed34
 
     - name: Build appimage
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@v16
       with:
         determinate: true
-    - uses: DeterminateSystems/flakehub-cache-action@v1
+    - uses: DeterminateSystems/flakehub-cache-action@04eb56b73c2de9e098015ec61db998329962ed34
     - name: clang-format
       run: nix develop --command git clang-format --diff origin/master --extensions cpp,h
 
@@ -89,7 +89,7 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@v16
       with:
         determinate: true
-    - uses: DeterminateSystems/flakehub-cache-action@v1
+    - uses: DeterminateSystems/flakehub-cache-action@04eb56b73c2de9e098015ec61db998329962ed34
     - uses: ./.github/actions/configure_kvm
     - name: Load kernel modules
       # nf_tables and xfs are necessary for testing kernel modules BTF support

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
         with:
           determinate: true
-      - uses: DeterminateSystems/flakehub-cache-action@v1
+      - uses: DeterminateSystems/flakehub-cache-action@04eb56b73c2de9e098015ec61db998329962ed34
 
       - name: Configure (cpp)
         if: ${{ matrix.language == 'cpp' }}

--- a/.github/workflows/flakehub.yml
+++ b/.github/workflows/flakehub.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
         with:
           determinate: true
-      - uses: DeterminateSystems/flakehub-cache-action@v1
+      - uses: DeterminateSystems/flakehub-cache-action@04eb56b73c2de9e098015ec61db998329962ed34
       - uses: DeterminateSystems/flakehub-push@v5
         with:
           visibility: public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: DeterminateSystems/nix-installer-action@v16
       with:
         determinate: true
-    - uses: DeterminateSystems/flakehub-cache-action@v1
+    - uses: DeterminateSystems/flakehub-cache-action@04eb56b73c2de9e098015ec61db998329962ed34
     - name: Build artifacts
       run: nix develop --command bash -c "OUT=./assets ./scripts/create-assets.sh"
 

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -23,6 +23,6 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@v16
         with:
           determinate: true
-      - uses: DeterminateSystems/flakehub-cache-action@v1
+      - uses: DeterminateSystems/flakehub-cache-action@04eb56b73c2de9e098015ec61db998329962ed34
       - name: Run clang-tidy
         run: ./scripts/clang_tidy.sh


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

I'm seeing this error in CI:

    FlakeHub Cache is disabled due to missing or invalid token

I'm guessing it's due to old action, so upgrade.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
