### PR TITLE
cmake: Only use _FORTIFY_SOURCE on optimized builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,10 +43,13 @@ add_compile_options("-Wunreachable-code")
 #add_compile_options("-Wformat=2")
 add_compile_options("-Wdisabled-optimization")
 
-if (HARDENED_STDLIB)
+if(HARDENED_STDLIB)
   add_compile_definitions("-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_DEBUG")
   add_compile_definitions("-D_GLIBCXX_ASSERTIONS")
-  add_compile_definitions("-D_FORTIFY_SOURCE=1")
+  if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    # _FORTIFY_SOURCE requires at least -O1
+    add_compile_definitions("-D_FORTIFY_SOURCE=3")
+  endif()
 endif()
 
 if (WARNINGS_AS_ERRORS)


### PR DESCRIPTION
We get these warnings on Debug builds:

  422 | #  warning _FORTIFY_SOURCE requires compiling with optimization (-O)
      |    ^~~~~~~

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
