### PR TITLE
test: add an unit test to cover LogStreamBug

### DIFF
--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -120,4 +120,16 @@ TEST(Log, disable_log_type)
   ss.str({});
 }
 
+TEST(LogBugStream, log_bug_should_be_aborted)
+{
+  const std::string content = "I'm gonna die";
+
+  auto output = [&content](int line) {
+    const std::string filename = __FILE__;
+    return "BUG: \\[" + filename + ":" + std::to_string(line) + "\\] " +
+           content;
+  };
+  EXPECT_DEATH(LOG(BUG) << content, output(__LINE__));
+}
+
 } // namespace bpftrace::test::log


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

In this pr, I add a unit test `LogBugStream::log_bug_should_be_aborted` to cover the implementation of `LogStreamBug`. 


##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
