### PR TITLE
ci: Fold output for configure() and build()

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -91,7 +91,10 @@ def sudo() -> Path:
 class FoldOutput:
     """
     GitHub Actions output folding context manager.
-    Will automatically fold output for successful operations and keep output unfolded for failures.
+
+    Will automatically fold output for all operations. In an ideal world we'd
+    like to leave the failed operations unfolded, but there's currently no way
+    to do this in GHA without buffering output.
     """
 
     def __init__(self, name: str):
@@ -107,9 +110,7 @@ class FoldOutput:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """By not returning a value in this function, we propagate exceptions up"""
-        if self.in_ci and exc_type is None:
-            # Only close the group if no exception occurred (success)
+        if self.in_ci:
             print("::endgroup::")
 
 


### PR DESCRIPTION
Extract the output folding code into a context manager. Then use said context manager on configure() and build().

Also fold all steps, even failed ones. See second commit for explanation.

Also run `black` over file, fixing small formatting inconsistencies.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
