### PR TITLE
allow sized_type idents to be used in field access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to
   - [#4006](https://github.com/bpftrace/bpftrace/pull/4006)
 - Don't crash if kernel isn't built with PID namespaces
   - [#3976](https://github.com/bpftrace/bpftrace/pull/3976)
+- Allow sized_type idents to be used for field access
+  - [#4064](https://github.com/bpftrace/bpftrace/pull/4064)
 #### Security
 #### Docs
 #### Tools

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -683,6 +683,7 @@ ident:
                 IDENT         { $$ = $1; }
         |       BUILTIN       { $$ = $1; }
         |       BUILTIN_TYPE  { $$ = $1; }
+        |       SIZED_TYPE    { $$ = $1; }
                 ;
 
 raw_ident:

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2180,6 +2180,24 @@ TEST(Parser, field_access_builtin_type)
        "   timestamp\n");
 }
 
+TEST(Parser, field_access_sized_type)
+{
+  test("kprobe:sys_read { @x.buffer; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  .\n"
+       "   map: @x\n"
+       "   buffer\n");
+
+  test("kprobe:sys_read { @x->string; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  .\n"
+       "   dereference\n"
+       "    map: @x\n"
+       "   string\n");
+}
+
 TEST(Parser, array_access)
 {
   test("kprobe:sys_read { x[index]; }",


### PR DESCRIPTION
This includes: buffer, string, and inet

issue: https://github.com/bpftrace/bpftrace/issues/4063

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
