### PR TITLE
Enable some unstable features by default

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -907,14 +907,13 @@ All valid identifiers can be used as `name`.
 
 The data type of a variable is automatically determined during first assignment and cannot be changed afterwards.
 
-==== Maps Declarations
+==== Map Declarations
+
+**Warning** this feature is experimental and may be subject to changes.
+Stabilization is tracked in link:https://github.com/bpftrace/bpftrace/issues/4077[#4077].
 
 Maps can also be declared in the global scope, before probes and after the config e.g.
 ----
-config = {
-    unstable_map_decl=1;
-}
-
 let @a = hash(100);
 let @b = percpulruhash(20);
 
@@ -932,9 +931,6 @@ Currently these are available in bpftrace:
 Additionally, map declarations must supply a single argument: **max entries** e.g. `let @a = lruhash(100);`
 All maps that are not declared in the global scope utilize the default set in the config variable "max_map_keys".
 However, it's best practice to declare maps up front as using the default can lead to lost map update events (if the map is full) or over allocation of memory if the map is intended to only store a few entries.
-
-**Warning** this feature is experimental and may be subject to changes.
-It also requires the 'unstable_map_decl' config being set to 1. Stabilization is tracked in link:https://github.com/bpftrace/bpftrace/issues/4077[#4077].
 
 **Warning** The "lru" variants of hash and percpuhash evict the approximately least recently used elements. In other words, users should not rely on the accuracy on the part of the eviction algorithm. Adding a single new element may cause one or multiple elements to be deleted if the map is at capacity. link:https://docs.ebpf.io/linux/map-type/BPF_MAP_TYPE_LRU_HASH/[Read more about LRU internals].
 
@@ -980,6 +976,9 @@ The following snippets create a map with key signature `(int64, string[16])` and
 
 ==== Macros
 
+**Warning** this feature is experimental and may be subject to changes.
+Stabilization is tracked in link:https://github.com/bpftrace/bpftrace/issues/4079[#4079].
+
 bpftrace macros (as opposed to C macros) provide a way for you to structure your script.
 They can be useful when you want to factor out code into smaller, more understandable parts.
 Or if you want to share code between probes.
@@ -992,10 +991,6 @@ The body of the macro is exactly one block expression.
 For example, these are valid usages of macros:
 
 ----
-config = {
-  unstable_macro=1;
-}
-
 macro one() {
   1
 }
@@ -1036,10 +1031,6 @@ BEGIN {
 Some examples of invalid macro usage:
 
 ----
-config = {
-  unstable_macro=1;
-}
-
 macro not_expression() {
   $var = 1;                    // BAD: Not an expression
 }
@@ -1059,9 +1050,6 @@ BEGIN {
   wrong_parameter_type(@x);    // BAD: macro expects a scratch variable
 }
 ----
-
-**Warning** this feature is experimental and may be subject to changes.
-It also requires the 'unstable_macro' config being set to 1. Stabilization is tracked in link:https://github.com/bpftrace/bpftrace/issues/4079[#4079].
 
 ==== Per-Thread Variables
 
@@ -3852,6 +3840,28 @@ Default: 1
 
 Controls whether maps are printed on exit. Set to `0` in order to change the default behavior and not automatically print maps at program exit.
 
+==== unstable_macro
+
+Default: warn
+
+Feature flag for bpftrace macros.
+
+The possible options are:
+- `error` - fail if this feature is used
+- `warn` - enable feature but print a warning
+- `enable` - enable feature
+
+==== unstable_map_decl
+
+Default: warn
+
+Feature flag for map declarations.
+
+The possible options are:
+- `error` - fail if this feature is used
+- `warn` - enable feature but print a warning
+- `enable` - enable feature
+
 === Environment Variables
 
 These are not available as part of the standard set of <<Config Variables>> and can only be set as environment variables.
@@ -4290,6 +4300,26 @@ BEGIN {
   }
 }
 ----
+
+=== Unstable Features
+
+Some features added to bpftrace are not yet stable.
+They are enabled by default but come with a warning if used.
+If you explicitly add the config variable to your script the warning will not be shown e.g.
+```
+config = {
+    unstable_map_decl=enable;
+}
+```
+
+To opt-out of these unstable features (and ensure they are not used) add the config variable and set it to `error` e.g.
+```
+config = {
+    unstable_map_decl=error;
+}
+```
+
+Note: all unstable features are subject to change and/or removal.
 
 == Terminology
 

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(ast STATIC
   passes/return_path_analyser.cpp
   passes/pid_filter_pass.cpp
   passes/recursion_check.cpp
+  passes/unstable_feature.cpp
 )
 
 add_dependencies(ast parser)

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -62,12 +62,6 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
     assignment.addWarning()
         << assignment.var << " has been renamed, please use " << var;
   }
-
-  // If set successfully, see if we must warn.
-  if (bpftrace_.config_->is_unstable(assignment.var)) {
-    assignment.addWarning()
-        << "Script is using an unstable feature: " << assignment.var;
-  }
 }
 
 Pass CreateConfigPass()

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -260,17 +260,7 @@ void MacroCollection::visit(Expression &expr)
 
 void MacroCollection::collect_macros()
 {
-  bool unstable_macro = bpftrace_.config_->unstable_macro;
-
   for (Macro *macro : ast_.root->macros) {
-    if (!unstable_macro) {
-      macro->addError()
-          << "Hygienic macros are not enabled by default. To enable "
-             "this unstable feature, set the 'unstable_macro' config flag to 1 "
-             "e.g. unstable_macro=1";
-      return;
-    }
-
     if (macros_.contains(macro->name)) {
       macro->addError() << "Redifinition of macro: " << macro->name;
       return;

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -7,6 +7,7 @@
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
+#include "ast/passes/unstable_feature.h"
 #include "btf.h"
 #include "clang_parser.h"
 #include "driver.h"
@@ -22,6 +23,7 @@ inline std::vector<Pass> AllParsePasses(
   std::vector<Pass> passes;
   passes.emplace_back(CreateParsePass());
   passes.emplace_back(CreateConfigPass());
+  passes.emplace_back(CreateUnstableFeaturePass());
   passes.emplace_back(CreateMacroExpansionPass());
   passes.emplace_back(CreateDeprecatedPass());
   passes.emplace_back(CreateParseAttachpointsPass());

--- a/src/ast/passes/resolve_imports.cpp
+++ b/src/ast/passes/resolve_imports.cpp
@@ -26,13 +26,6 @@ private:
 
 void ResolveImports::visit(Import &imp)
 {
-  if (!bpftrace_.config_->unstable_import) {
-    imp.addError() << "Imports are not enabled by default. To enable "
-                      "this unstable feature, set this config flag to 1 "
-                      "e.g. unstable_import=1";
-    return;
-  }
-
   imp.addWarning() << "Imports are not yet implemented.";
 }
 

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1818,12 +1818,6 @@ void SemanticAnalyser::validate_map_key(const SizedType &key, Node &node)
 
 void SemanticAnalyser::visit(MapDeclStatement &decl)
 {
-  if (!bpftrace_.config_->unstable_map_decl) {
-    decl.addError() << "Map declarations are not enabled by default. To enable "
-                       "this unstable feature, set this config flag to 1 "
-                       "e.g. unstable_map_decl=1";
-  }
-
   const auto bpf_type = get_bpf_map_type(decl.bpf_type);
   if (!bpf_type) {
     auto &err = decl.addError();

--- a/src/ast/passes/unstable_feature.cpp
+++ b/src/ast/passes/unstable_feature.cpp
@@ -1,0 +1,96 @@
+#include <cstring>
+#include <format>
+#include <string>
+
+#include "ast/ast.h"
+#include "ast/passes/unstable_feature.h"
+#include "ast/visitor.h"
+#include "bpftrace.h"
+#include "config.h"
+
+namespace bpftrace::ast {
+
+namespace {
+
+std::string get_warning(const std::string &feature)
+{
+  return std::format("Script is using an unstable feature. To prevent this "
+                     "warning you must explicitly enable the unstable "
+                     "feature in the config e.g. {}=enable",
+                     feature);
+}
+
+std::string get_error(std::string &&feature)
+{
+  return std::format(
+      "Feature not enabled by default. To enable "
+      "this unstable feature, set the config flag to enable. {}=enable",
+      feature);
+}
+
+class UnstableFeature : public Visitor<UnstableFeature> {
+public:
+  explicit UnstableFeature(BPFtrace &bpftrace) : bpftrace_(bpftrace) {};
+
+  using Visitor<UnstableFeature>::visit;
+  void visit(MapDeclStatement &decl);
+  void visit(Import &imp);
+  void visit(Macro &macro);
+
+private:
+  BPFtrace &bpftrace_;
+  // This set is so we don't warn multiple times for the same feature.
+  std::unordered_set<std::string> warned_features;
+};
+
+} // namespace
+
+void UnstableFeature::visit(MapDeclStatement &decl)
+{
+  if (bpftrace_.config_->unstable_map_decl == ConfigUnstable::error) {
+    decl.addError() << get_error(UNSTABLE_MAP_DECL);
+    return;
+  }
+  if (bpftrace_.config_->unstable_map_decl == ConfigUnstable::warn &&
+      !warned_features.contains(UNSTABLE_MAP_DECL)) {
+    decl.addWarning() << get_warning(UNSTABLE_MAP_DECL);
+    warned_features.insert(UNSTABLE_MAP_DECL);
+  }
+}
+
+void UnstableFeature::visit(Import &imp)
+{
+  if (bpftrace_.config_->unstable_import == ConfigUnstable::error) {
+    imp.addError() << get_error(UNSTABLE_IMPORT);
+    return;
+  }
+
+  if (bpftrace_.config_->unstable_import == ConfigUnstable::warn &&
+      !warned_features.contains(UNSTABLE_IMPORT)) {
+    imp.addWarning() << get_warning(UNSTABLE_IMPORT);
+    warned_features.insert(UNSTABLE_IMPORT);
+  }
+}
+
+void UnstableFeature::visit(Macro &macro)
+{
+  if (bpftrace_.config_->unstable_macro == ConfigUnstable::error) {
+    macro.addError() << get_error(UNSTABLE_MACRO);
+    return;
+  }
+  if (bpftrace_.config_->unstable_macro == ConfigUnstable::warn &&
+      !warned_features.contains(UNSTABLE_MACRO)) {
+    macro.addWarning() << get_warning(UNSTABLE_MACRO);
+    warned_features.insert(UNSTABLE_MACRO);
+  }
+}
+
+Pass CreateUnstableFeaturePass()
+{
+  return Pass::create("UnstableFeature", [](ASTContext &ast, BPFtrace &b) {
+    auto configs = UnstableFeature(b);
+    configs.visit(ast.root);
+  });
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/unstable_feature.h
+++ b/src/ast/passes/unstable_feature.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateUnstableFeaturePass();
+
+} // namespace bpftrace::ast

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -205,6 +205,43 @@ struct ConfigParser<ConfigMissingProbes> {
   }
 };
 
+template <>
+struct ConfigParser<ConfigUnstable> {
+  Result<OK> parse(const std::string &key,
+                   ConfigUnstable *target,
+                   const std::string &original)
+  {
+    std::string s = tolower(original);
+    if (s == "enable" || s == "1" || s == "true" || s == "on" || s == "yes") {
+      *target = ConfigUnstable::enable;
+      return OK();
+    } else if (s == "warn") {
+      *target = ConfigUnstable::warn;
+      return OK();
+    } else if (s == "error" || s == "0" || s == "false" || s == "off" ||
+               s == "no") {
+      *target = ConfigUnstable::error;
+      return OK();
+    } else {
+      return make_error<ParseError>(key,
+                                    "Invalid value for unstable config: valid "
+                                    "values are enable, warn, and error.");
+    }
+  }
+  Result<OK> parse([[maybe_unused]] const std::string &key,
+                   [[maybe_unused]] ConfigUnstable *target,
+                   [[maybe_unused]] uint64_t v)
+  {
+    if (v != 0) {
+      *target = ConfigUnstable::enable;
+      return OK();
+    } else {
+      *target = ConfigUnstable::error;
+      return OK();
+    }
+  }
+};
+
 struct AnyParser {
   using KeyType = const std::string &;
   std::function<Result<OK>(KeyType, Config *, uint64_t)> integer;
@@ -252,9 +289,9 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { "print_maps_on_exit", CONFIG_FIELD_PARSER(print_maps_on_exit) },
   { "use_blazesym", CONFIG_FIELD_PARSER(use_blazesym) },
   { "show_debug_info", CONFIG_FIELD_PARSER(show_debug_info) },
-  { "unstable_import", CONFIG_FIELD_PARSER(unstable_import) },
-  { "unstable_macro", CONFIG_FIELD_PARSER(unstable_macro) },
-  { "unstable_map_decl", CONFIG_FIELD_PARSER(unstable_map_decl) },
+  { UNSTABLE_IMPORT, CONFIG_FIELD_PARSER(unstable_import) },
+  { UNSTABLE_MACRO, CONFIG_FIELD_PARSER(unstable_macro) },
+  { UNSTABLE_MAP_DECL, CONFIG_FIELD_PARSER(unstable_map_decl) },
 };
 
 // These symbols are deprecated, and have been remapped elsewhere.

--- a/src/config.h
+++ b/src/config.h
@@ -14,6 +14,16 @@ enum class ConfigMissingProbes {
   error,
 };
 
+enum class ConfigUnstable {
+  enable,
+  warn,
+  error,
+};
+
+static const auto UNSTABLE_MACRO = "unstable_macro";
+static const auto UNSTABLE_MAP_DECL = "unstable_map_decl";
+static const auto UNSTABLE_IMPORT = "unstable_import";
+
 class Config {
 public:
   Config(bool has_cmd = false);
@@ -32,9 +42,9 @@ public:
   bool cpp_demangle = true;
   bool lazy_symbolication = true;
   bool print_maps_on_exit = true;
-  bool unstable_macro = false;
-  bool unstable_map_decl = false;
-  bool unstable_import = false;
+  ConfigUnstable unstable_macro = ConfigUnstable::warn;
+  ConfigUnstable unstable_map_decl = ConfigUnstable::warn;
+  ConfigUnstable unstable_import = ConfigUnstable::error;
 #ifdef HAVE_BLAZESYM
   bool use_blazesym = true;
   bool show_debug_info = true;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ add_executable(bpftrace_test
   temp.cpp
   tracepoint_format_parser.cpp
   types.cpp
+  unstable_feature.cpp
   utils.cpp
 
   ${CODEGEN_SRC}

--- a/tests/codegen/map_declarations.cpp
+++ b/tests/codegen/map_declarations.cpp
@@ -5,24 +5,18 @@ namespace bpftrace::test::codegen {
 TEST(codegen, map_hash)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->unstable_map_decl = true;
-
   test(*bpftrace, R"(let @a = hash(10); BEGIN { @a[1] = 1; })", NAME);
 }
 
 TEST(codegen, map_lruhash)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->unstable_map_decl = true;
-
   test(*bpftrace, R"(let @a = lruhash(10); BEGIN { @a[1] = 1; })", NAME);
 }
 
 TEST(codegen, map_percpuhash)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->unstable_map_decl = true;
-
   test(*bpftrace,
        R"(let @a = percpuhash(10); BEGIN { @a[1] = count(); })",
        NAME);
@@ -31,8 +25,6 @@ TEST(codegen, map_percpuhash)
 TEST(codegen, map_percpulruhash)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->unstable_map_decl = true;
-
   test(*bpftrace,
        R"(let @a = percpulruhash(10); BEGIN { @a[1] = count(); })",
        NAME);
@@ -41,8 +33,6 @@ TEST(codegen, map_percpulruhash)
 TEST(codegen, map_percpuarray)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->unstable_map_decl = true;
-
   test(*bpftrace, R"(let @a = percpuarray(1); BEGIN { @a = count(); })", NAME);
 }
 
@@ -50,8 +40,6 @@ TEST(codegen, map_percpuarray)
 TEST(codegen, map_unused)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->unstable_map_decl = true;
-
   test(*bpftrace, R"(let @a = hash(1); BEGIN { 1 })", NAME);
 }
 

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -169,14 +169,4 @@ TEST(config_analyser, config_setting)
   EXPECT_EQ(bpftrace->config_->log_size, 150);
 }
 
-TEST(config_analyser, config_unstable)
-{
-  test_for_warning("config = { unstable_map_decl=1 } BEGIN { }",
-                   "Script is using an unstable feature: unstable_map_decl");
-  test_for_warning("config = { unstable_map_decl=0 } BEGIN { }",
-                   "Script is using an unstable feature: unstable_map_decl");
-  test_for_no_warning("config = { stack_mode=perf } BEGIN { }",
-                      "Script is using an unstable feature: unstable_map_decl");
-}
-
 } // namespace bpftrace::test::config_analyser

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -14,7 +14,7 @@ void test(const std::string& input,
 {
   auto mock_bpftrace = get_mock_bpftrace();
   BPFtrace& bpftrace = *mock_bpftrace;
-  bpftrace.config_->unstable_macro = true;
+  bpftrace.config_->unstable_macro = ConfigUnstable::enable;
 
   // The input provided here is embedded into an expression.
   ast::ASTContext ast("stdin", input);

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -1,75 +1,75 @@
 NAME it mutates the passed variable
-PROG config = { unstable_macro=1; } macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); print($a); exit(); }
+PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); print($a); exit(); }
 EXPECT 2
 
 NAME it does not mutate previously passed variable with literal
-PROG config = { unstable_macro=1; } macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); inc(1); print($a); exit(); }
+PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); inc(1); print($a); exit(); }
 EXPECT 2
 
 NAME it mutates the passed non-scalar map
-PROG config = { unstable_macro=1; } macro set(@x) { @x[1] = 2; 1 } BEGIN { @a[1] = 1; set(@a); exit(); }
+PROG macro set(@x) { @x[1] = 2; 1 } BEGIN { @a[1] = 1; set(@a); exit(); }
 EXPECT @a[1]: 2
 
 NAME it mutates the passed scalar map
-PROG config = { unstable_macro=1; } macro set(@x) { @x = 2; 1 } BEGIN { @a = 1; set(@a); exit(); }
+PROG macro set(@x) { @x = 2; 1 } BEGIN { @a = 1; set(@a); exit(); }
 EXPECT @a: 2
 
 NAME it reads the passed map
-PROG config = { unstable_macro=1; } macro get(@x) { 1 + @x[1] } BEGIN { @a[1] = 1; print(get(@a)); exit(); }
+PROG macro get(@x) { 1 + @x[1] } BEGIN { @a[1] = 1; print(get(@a)); exit(); }
 EXPECT 2
 
 NAME it can have side effects
-PROG config = { unstable_macro=1; } macro print_me($x) { print(("me", $x)) } BEGIN { $a = 1; print_me($a); exit(); }
+PROG macro print_me($x) { print(("me", $x)) } BEGIN { $a = 1; print_me($a); exit(); }
 EXPECT (me, 1)
 
 NAME it can exit early
-PROG config = { unstable_macro=1; } macro early() { exit() } BEGIN { early(); print(1); }
+PROG macro early() { exit() } BEGIN { early(); print(1); }
 EXPECT_NONE 1
 
 NAME it can call other macros
-PROG config = { unstable_macro=1; } macro add1($x) { $x + 1 } macro add2($y) { $y + add1($y) } macro add3($z) { $z + add2($z) } BEGIN { print(add3(1)); exit(); }
+PROG macro add1($x) { $x + 1 } macro add2($y) { $y + add1($y) } macro add3($z) { $z + add2($z) } BEGIN { print(add3(1)); exit(); }
 EXPECT 4
 
 NAME macro definition order does not matter
-PROG config = { unstable_macro=1; } macro add2($x) { $x + add1($x) } macro add3($x) { $x + add2($x) } macro add1($x) { $x + 1 } BEGIN { print(add3(1)); exit(); }
+PROG macro add2($x) { $x + add1($x) } macro add3($x) { $x + add2($x) } macro add1($x) { $x + 1 } BEGIN { print(add3(1)); exit(); }
 EXPECT 4
 
 NAME it accepts arbitrary expressions without variables or maps
-PROG config = { unstable_macro=1; } macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one(1 + 1)); exit(); }
+PROG macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one(1 + 1)); exit(); }
 EXPECT 3
 
 NAME it accepts arbitrary expressions with variables
-PROG config = { unstable_macro=1; } macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one($a + 1)); exit(); }
+PROG macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one($a + 1)); exit(); }
 EXPECT 3
 
 NAME it accepts arbitrary expressions with variables nested
-PROG config = { unstable_macro=1; } macro add_two($x) { $x + 2 } macro add_one($x) { add_two($x + 1) + 1 } BEGIN { $a = 1; print(add_one($a + 1)); exit(); }
+PROG macro add_two($x) { $x + 2 } macro add_one($x) { add_two($x + 1) + 1 } BEGIN { $a = 1; print(add_one($a + 1)); exit(); }
 EXPECT 6
 
 NAME it accepts arbitrary expressions with maps
-PROG config = { unstable_macro=1; } macro add_one($x) { $x + 1 } BEGIN { @a = 1; print(add_one(@a + 1)); exit(); }
+PROG macro add_one($x) { $x + 1 } BEGIN { @a = 1; print(add_one(@a + 1)); exit(); }
 EXPECT 3
 
 NAME can call the same macro multiple times
-PROG config = { unstable_macro=1; } macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); inc($a); inc($a); print($a); exit(); }
+PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); inc($a); inc($a); print($a); exit(); }
 EXPECT 4
 
 NAME for loops can be in macros
-PROG config = { unstable_macro=1; } macro loop_map(@a) { let $x = 1; for ($kv : @a) { $x += $kv.1;} $x } BEGIN { @x[1] = 5; @x[2] = 10; print(loop_map(@x)); exit(); }
+PROG macro loop_map(@a) { let $x = 1; for ($kv : @a) { $x += $kv.1;} $x } BEGIN { @x[1] = 5; @x[2] = 10; print(loop_map(@x)); exit(); }
 EXPECT 16
 
 NAME it works in nested scopes
-PROG config = { unstable_macro=1; } macro add1($x) { $x + 1 } macro add2($x) { $x + 2 } BEGIN { $a = 1; if ($a == 1) { print(add2($a)); } else { print(add1($a)); } exit(); }
+PROG macro add1($x) { $x + 1 } macro add2($x) { $x + 2 } BEGIN { $a = 1; if ($a == 1) { print(add2($a)); } else { print(add1($a)); } exit(); }
 EXPECT 3
 
 NAME it re-names variables to prevent collision
-PROG config = { unstable_macro=1; } macro inc($x) { $y = $x + 1; $y } BEGIN { $y = 2; $z = inc(5); print(($y, $z)); exit(); }
+PROG macro inc($x) { $y = $x + 1; $y } BEGIN { $y = 2; $z = inc(5); print(($y, $z)); exit(); }
 EXPECT (2, 6)
 
 NAME it re-names decl variables to prevent collision
-PROG config = { unstable_macro=1; } macro inc($x) { let $y = $x + 1; $y } BEGIN { $y = 2; $z = inc(5); print(($y, $z)); exit(); }
+PROG macro inc($x) { let $y = $x + 1; $y } BEGIN { $y = 2; $z = inc(5); print(($y, $z)); exit(); }
 EXPECT (2, 6)
 
 NAME it can be part of an expression passed to a macro
-PROG config = { unstable_macro=1; } macro add_one($x) { $x + 1 } BEGIN { $a = add_one(add_one(1) + 1); print($a); exit(); }
+PROG macro add_one($x) { $x + 1 } BEGIN { $a = add_one(add_one(1) + 1); print($a); exit(); }
 EXPECT 4

--- a/tests/runtime/map
+++ b/tests/runtime/map
@@ -16,46 +16,46 @@ PROG BEGIN { @a = 0; exit(); }
 EXPECT @a: 0
 
 NAME map indexed, scalar-like, with decl
-PROG config = { unstable_map_decl=1 } let @a = hash(1); BEGIN { @a[0] = 0; exit(); }
+PROG let @a = hash(1); BEGIN { @a[0] = 0; exit(); }
 EXPECT @a[0]: 0
 
 # Unfortunately there are some issues when evicting lruhash entries. We can't
 # know exactly which elements will be present. See #3992 for more information.
 NAME map declaration lruhash
-PROG config = { unstable_map_decl=1 } let @a = lruhash(2); BEGIN { @a[0] = 0; @a[1] = 1; @a[2] = 2; exit(); }
+PROG let @a = lruhash(2); BEGIN { @a[0] = 0; @a[1] = 1; @a[2] = 2; exit(); }
 EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
 EXPECT_REGEX @a\[.\]: .
 
 NAME map declaration lruhash
-PROG config = { unstable_map_decl=1 } let @a = lruhash(1); BEGIN { @a[1] = 1; exit(); }
+PROG let @a = lruhash(1); BEGIN { @a[1] = 1; exit(); }
 EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
 EXPECT @a[1]: 1
 
 NAME map declaration lruhash, scalar-like
-PROG config = { unstable_map_decl=1 } let @a = lruhash(1); BEGIN { @a[0] = 1; exit(); }
+PROG let @a = lruhash(1); BEGIN { @a[0] = 1; exit(); }
 EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
 EXPECT @a[0]: 1
 
 NAME map declaration hash
-PROG config = { unstable_map_decl=1 } let @a = hash(1); BEGIN { @a[1] = 1; @a[2] = 2; exit(); }
+PROG let @a = hash(1); BEGIN { @a[1] = 1; @a[2] = 2; exit(); }
 EXPECT_REGEX .*WARNING: Map full; can't update element.*
 EXPECT @a[1]: 1
 
 NAME map declaration hash, scalar-like
-PROG config = { unstable_map_decl=1 } let @a = hash(1); BEGIN { @a[0] = 0; @a[0] = 1; exit(); }
+PROG let @a = hash(1); BEGIN { @a[0] = 0; @a[0] = 1; exit(); }
 EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
 EXPECT @a[0]: 1
 
 NAME map declaration percpuhash
-PROG config = { unstable_map_decl=1 } let @a = percpuhash(1); BEGIN { @a[1] = count(); @a[2] = count(); exit(); }
+PROG let @a = percpuhash(1); BEGIN { @a[1] = count(); @a[2] = count(); exit(); }
 EXPECT_REGEX .*WARNING: Map full; can't update element.*
 EXPECT @a[1]: 1
 
 NAME map declaration percpulruhash
-PROG config = { unstable_map_decl=1 } let @a = percpulruhash(1); BEGIN { @a[1] = count(); @a[2] = count(); exit(); }
+PROG let @a = percpulruhash(1); BEGIN { @a[1] = count(); @a[2] = count(); exit(); }
 EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
 EXPECT @a[2]: 1
 
 NAME map declaration unused
-PROG config = { unstable_map_decl=1 } let @a = percpuhash(1); BEGIN { exit(); }
+PROG let @a = percpuhash(1); BEGIN { exit(); }
 EXPECT_REGEX .*WARNING: Unused map: @a.*

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4905,7 +4905,6 @@ Program
 TEST(semantic_analyser, map_declarations)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->unstable_map_decl = true;
 
   test(*bpftrace, "let @a = hash(2); BEGIN { @a = 1; }");
   test(*bpftrace, "let @a = lruhash(2); BEGIN { @a = 1; }");
@@ -4962,7 +4961,7 @@ let @a = percpuarray(10); BEGIN { @a = count(); }
 TEST(semantic_analyser, macros)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->unstable_macro = true;
+  bpftrace->config_->unstable_macro = ConfigUnstable::enable;
 
   test_error(*bpftrace,
              "macro set($x) { $x = 1; $x } BEGIN { $a = \"string\"; set($a); }",

--- a/tests/unstable_feature.cpp
+++ b/tests/unstable_feature.cpp
@@ -1,0 +1,116 @@
+#include "ast/passes/unstable_feature.h"
+#include "ast/passes/config_analyser.h"
+#include "ast/passes/parser.h"
+#include "ast/passes/printer.h"
+#include "mocks.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::unstable_feature {
+
+using ::testing::HasSubstr;
+
+void test(const std::string& input,
+          const std::string& error = "",
+          const std::string& warn = "",
+          bool invert = false)
+{
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace& bpftrace = *mock_bpftrace;
+
+  // The input provided here is embedded into an expression.
+  ast::ASTContext ast("stdin", input);
+  std::stringstream msg;
+  msg << "\nInput:\n" << input << "\n\nOutput:\n";
+
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put(bpftrace)
+                .add(CreateParsePass())
+                .add(ast::CreateConfigPass())
+                .add(ast::CreateUnstableFeaturePass())
+                .run();
+
+  std::ostringstream out;
+  ast::Printer printer(out);
+  printer.visit(ast.root);
+  ast.diagnostics().emit(out);
+
+  if (error.empty()) {
+    ASSERT_TRUE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+    if (!warn.empty()) {
+      if (invert) {
+        EXPECT_THAT(out.str(), Not(HasSubstr(warn))) << msg.str() << out.str();
+      } else {
+        EXPECT_THAT(out.str(), HasSubstr(warn)) << msg.str() << out.str();
+      }
+    }
+  } else {
+    ASSERT_FALSE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+    EXPECT_THAT(out.str(), HasSubstr(error)) << msg.str() << out.str();
+  }
+}
+
+void test_error(const std::string& input, const std::string& error)
+{
+  test(input, error);
+}
+
+void test_warning(const std::string& input, const std::string& warn)
+{
+  test(input, "", warn);
+}
+
+void test_no_warning(const std::string& input, const std::string& warn)
+{
+  test(input, "", warn, true);
+}
+
+TEST(unstable_feature, check_warnings)
+{
+  test_warning("let @a = lruhash(5); BEGIN { @a[0] = 0; }",
+               "Script is using an unstable feature. To prevent this "
+               "warning you must explicitly enable the unstable "
+               "feature in the config e.g. unstable_map_decl=enable");
+
+  test_warning("macro add_one($x) { $x } BEGIN { @a[0] = 0; }",
+               "Script is using an unstable feature. To prevent this "
+               "warning you must explicitly enable the unstable "
+               "feature in the config e.g. unstable_macro=enable");
+
+  test_warning("config = { unstable_map_decl=warn } macro add_one($x) { $x } "
+               "BEGIN { @a[0] = 0; }",
+               "Script is using an unstable feature. To prevent this "
+               "warning you must explicitly enable the unstable "
+               "feature in the config e.g. unstable_macro=enable");
+
+  test_no_warning(
+      "config = { unstable_map_decl=enable } let @a = lruhash(5); BEGIN "
+      "{ @a[0] = 0; }",
+      "Script is using an unstable feature");
+  test_no_warning("config = { unstable_map_decl=1 } let @a = lruhash(5); BEGIN "
+                  "{ @a[0] = 0; }",
+                  "Script is using an unstable feature");
+  test_no_warning(
+      "config = { unstable_macro=enable } macro add_one($x) { $x } BEGIN "
+      "{ @a[0] = 0; }",
+      "Script is using an unstable feature");
+}
+
+TEST(unstable_feature, check_error)
+{
+  test_error("config = { unstable_map_decl=0 } let @a = lruhash(5); BEGIN { "
+             "@a[0] = 0; }",
+             "Feature not enabled by default. To enable this unstable feature, "
+             "set the config flag to enable. unstable_map_decl=enable");
+  test_error("config = { unstable_macro=0 } macro add_one($x) { $x } BEGIN { "
+             "@a[0] = 0; }",
+             "Feature not enabled by default. To enable this unstable feature, "
+             "set the config flag to enable. unstable_macro=enable");
+  test_error(
+      "config = { unstable_macro=error } macro add_one($x) { $x } BEGIN { "
+      "@a[0] = 0; }",
+      "Feature not enabled by default. To enable this unstable feature, "
+      "set the config flag to enable. unstable_macro=enable");
+}
+
+} // namespace bpftrace::test::unstable_feature


### PR DESCRIPTION
 Enable some unstable features by default

Instead of having users explicitly opt-in to
most unstable features, enable them by default.
Obviously unstable features that are
half-baked or more risky should be disabled
by default but this can be on a case-by-case
basis. In general though we want to reduce
friction for users to use new, cool things.

This changes the config value type for unstable
features to an enum: enable, warn, and error.
For macros and map declarations it will be warn,
which means users get a warning they are using
an unstable feature. They can suppress this warning
by setting this config to 'enable'.

The import feature will stay as 'error'.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
