### PR TITLE
fix: colorized LogStreamBug output

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,6 +53,7 @@ IndentCaseLabels: true
 IndentPPDirectives: None
 IndentWidth: 2
 IndentWrappedFunctionNames: false
+InsertNewlineAtEOF: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 MacroBlockBegin: ''
 MacroBlockEnd: ''

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -51,6 +51,7 @@ void Log::take_input(LogType type,
   if (is_colorize_) {
     switch (type) {
       case LogType::ERROR:
+      case LogType::BUG:
         color_begin = LogColor::RED;
         color_end = LogColor::RESET;
         break;

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -120,7 +120,7 @@ TEST(Log, disable_log_type)
   ss.str({});
 }
 
-TEST(LogBugStream, log_bug_should_be_aborted)
+TEST(LogStreamBug, log_stream_bug_should_be_aborted)
 {
   const std::string content = "I'm gonna die";
 
@@ -130,6 +130,23 @@ TEST(LogBugStream, log_bug_should_be_aborted)
            content;
   };
   EXPECT_DEATH(LOG(BUG) << content, output(__LINE__));
+}
+
+TEST(LogStreamBug, log_stream_bug_colorized)
+{
+  Log::get().set_colorize(true);
+  const std::string content = "I'm gonna die";
+
+  auto output = [&content](int line) {
+    // Escape [ to avoid being captured by regex
+    const std::string bug_color = "\033\\[31m";
+    const std::string default_color = "\033\\[0m";
+    const std::string filename = __FILE__;
+    return bug_color + "BUG: \\[" + filename + ":" + std::to_string(line) +
+           "\\] " + content + default_color;
+  };
+  EXPECT_DEATH(LOG(BUG) << content, output(__LINE__));
+  Log::get().set_colorize(false);
 }
 
 } // namespace bpftrace::test::log


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

This pr enable colorized feature for LogStreamBug.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
