### PR TITLE
editor:enable editor to format on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,7 @@
     "clangd.arguments": [
         "-background-index",
         "-compile-commands-dir=${workspaceFolder}/build-vscode"
-    ]
+    ],
+    "editor.formatOnSave": true,
+    "C_Cpp.clang_format_style": "file"
 }


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

This PR enables the `formatOnSave` feature of the editor. It goes a long way toward improving the developer efficiency, preventing the CI failures from forgetting to run clang-format manually. 

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
