### PR TITLE
Fix bpftrace_test cmake

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,8 +66,7 @@ add_executable(bpftrace_test
 add_test(NAME bpftrace_test COMMAND bpftrace_test)
 
 add_subdirectory(data)
-add_dependencies(bpftrace_test data_source_btf data_source_funcs)
-add_dependencies(bpftrace data_source_dwarf)
+add_dependencies(bpftrace_test data_source_dwarf data_source_btf data_source_funcs)
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
Making bpftrace_test requires data_source
otherwise this error occurs when building:
```
[ 10%] Generating base_bc.h
/nix/store/y6d7nin0s3vkn2vs17klriwfrfyickvb-llvm-20.1.1/bin/llvm-objcopy: error: '/home/jordalgo/local/bpftrace/build/tests/data/data_source.o.btf': No such file or directory
btf_encoder__write_elf: failed to add .BTF section to '/home/jordalgo/local/bpftrace/build/tests/data/data_source.o': 2!
Failed to encode BTF
make[3]: *** [tests/data/CMakeFiles/data_source_btf.dir/build.make:89: tests/data/data_source.o] Error 1
make[3]: *** Deleting file 'tests/data/data_source.o'
make[2]: *** [CMakeFiles/Makefile2:2855: tests/data/CMakeFiles/data_source_btf.dir/all] Error 2
make[2]: *** Waiting for unfinished jobs....
[ 10%] Generating base.btf
[ 10%] Generating data_source.funcs
[ 10%] Built target base_bitcode
/nix/store/8v6k283dpbc0qkdq81nb6mrxrgcb10i1-gcc-wrapper-14-20241116/bin/nm: '/home/jordalgo/local/bpftrace/build/tests/data/data_source.o': No such file
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
