### PR TITLE
cmake: simplify `BuildBPF`, eliminate race

### DIFF
--- a/cmake/Embed.cmake
+++ b/cmake/Embed.cmake
@@ -7,7 +7,7 @@ function(embed NAME SOURCE)
     ARG
     ""
     "OUTPUT;HEX;VAR"
-    ""
+    "DEPENDS"
     ${ARGN}
   )
   if (NOT DEFINED ARG_HEX)
@@ -20,14 +20,14 @@ function(embed NAME SOURCE)
     set(ARG_OUTPUT "${NAME}.h")
   endif ()
   add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ARG_HEX}
-    COMMAND ${XXD} -i < ${SOURCE} > ${CMAKE_CURRENT_BINARY_DIR}/${ARG_HEX}
-    DEPENDS ${SOURCE}
+    OUTPUT ${ARG_HEX}
+    COMMAND ${XXD} -i < ${SOURCE} > ${ARG_HEX}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${ARG_DEPENDS}
     VERBATIM
   )
   add_custom_command(
-    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT}
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_HEX}
+    OUTPUT ${ARG_OUTPUT}
     COMMAND ${CMAKE_COMMAND}
       -DSOURCE=${CMAKE_CURRENT_BINARY_DIR}/${ARG_HEX}
       -DVAR=${ARG_VAR}
@@ -36,13 +36,13 @@ function(embed NAME SOURCE)
       -DTEMPLATE=${CMAKE_SOURCE_DIR}/cmake/Embed.tmpl
       -P ${CMAKE_SOURCE_DIR}/cmake/EmbedRun.cmake
     DEPENDS
-      ${CMAKE_CURRENT_BINARY_DIR}/${ARG_HEX}
+      ${ARG_HEX}
       ${CMAKE_SOURCE_DIR}/cmake/EmbedRun.cmake
       ${CMAKE_SOURCE_DIR}/cmake/Embed.tmpl
     VERBATIM
   )
   add_custom_target(
     ${NAME}
-    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT}
+    DEPENDS ${ARG_OUTPUT}
   )
 endfunction()

--- a/src/stdlib/CMakeLists.txt
+++ b/src/stdlib/CMakeLists.txt
@@ -11,15 +11,17 @@ bpf(base
 embed(
   base_btf
   base.btf
-  OUTPUT base_btf.h
-  VAR    base_btf
+  OUTPUT  base_btf.h
+  VAR     base_btf
+  DEPENDS base
 )
 
 embed(
   base_bitcode
   base.bc
-  OUTPUT base_bc.h
-  VAR    base_bc
+  OUTPUT  base_bc.h
+  VAR     base_bc
+  DEPENDS base
 )
 
 # The standard library holds these definitions internally via the headers

--- a/tests/data/CMakeLists.txt
+++ b/tests/data/CMakeLists.txt
@@ -5,32 +5,34 @@ bpf(
   data_source
   BTF       data_source.btf
   FUNCTIONS data_source.funcs
-  BINARY    data_source.exe
+  BINARY    data_source_exe
 )
 
 embed(
   data_source_btf
   data_source.btf
-  OUTPUT data_source_btf.h
-  VAR btf_data
+  OUTPUT  data_source_btf.h
+  VAR     btf_data
+  DEPENDS data_source
 )
 
 embed(
   data_source_funcs
   data_source.funcs
-  OUTPUT data_source_funcs.h
-  VAR func_list
+  OUTPUT  data_source_funcs.h
+  VAR     func_list
+  DEPENDS data_source
 )
 
 embed(
   data_source_dwarf
-  ${CMAKE_CURRENT_BINARY_DIR}/data_source.exe
-  OUTPUT data_source_dwarf.h
-  VAR dwarf_data
+  data_source_exe
+  OUTPUT  data_source_dwarf.h
+  VAR     dwarf_data
+  DEPENDS data_source
 )
 
 # BTF doesn't support C++, so we only generate a data_source_cxx executable
 # to run the field_analyser tests on.
 add_executable(data_source_cxx data_source_cxx.cpp)
 target_compile_options(data_source_cxx PRIVATE -g)
-


### PR DESCRIPTION
Amazingly, `cmake` manages to generate Makefiles that execute the same
rule multiple times in parallel if the same `OUTPUT` is used in
multiple `DEPENDS` stanzas. See [1] for more information.
    
[1] https://discourse.cmake.org/t/how-to-avoid-parallel-build-race-conditions/727
    
This change simplifies some of the structure in `BuildBPF`, using
relative paths in the local rules, which should trigger the heuristics
internally:
    
```
If any dependency is an OUTPUT of another custom command in the same
directory (CMakeLists.txt file), CMake automatically brings the other
custom command into the target in which this command is built.
```

This does not fix this issue, but should make it easier to see.
    
For the actual fix, we group the cases where the same output is used
for multiple rules into a target. This should prevent the concurrent
execution of those rules.