### PR TITLE
info: Add blazesym to --info output

### DIFF
--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -33,6 +33,12 @@ std::string BuildInfo::report()
 #else
       << "no" << std::endl;
 #endif
+  buf << "  blazesym (advanced symbolization): "
+#ifdef HAVE_BLAZESYM
+      << "yes" << std::endl;
+#else
+      << "no" << std::endl;
+#endif
 
   return buf.str();
 }


### PR DESCRIPTION
It's useful to know if bpftrace was built with blazesym or not.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
