### PR TITLE
Use `blaze_sym::offset` attribute for reporting offsets

### DIFF
--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -19,8 +19,7 @@ std::string stringify_addr(uint64_t addr)
 #ifdef HAVE_BLAZESYM
 std::string stringify_ksym(const char *name,
                            const blaze_symbolize_code_info *code_info,
-                           uint64_t addr,
-                           uint64_t sym_addr,
+                           uint64_t offset,
                            bool show_offset,
                            bool perf_mode,
                            bool is_inlined)
@@ -34,7 +33,7 @@ std::string stringify_ksym(const char *name,
   symbol << name;
 
   if (show_offset) {
-    symbol << "+" << addr - sym_addr;
+    symbol << "+" << offset;
   }
 
   if (perf_mode) {
@@ -150,17 +149,12 @@ std::vector<std::string> Ksyms::resolve_blazesym_impl(uint64_t addr,
     inlined = &sym->inlined[j];
     if (inlined != nullptr) {
       str_syms.push_back(stringify_ksym(
-          inlined->name, &inlined->code_info, 0, 0, false, perf_mode, true));
+          inlined->name, &inlined->code_info, 0, false, perf_mode, true));
     }
   }
 
-  str_syms.push_back(stringify_ksym(sym->name,
-                                    &sym->code_info,
-                                    addr,
-                                    sym->addr,
-                                    show_offset,
-                                    perf_mode,
-                                    false));
+  str_syms.push_back(stringify_ksym(
+      sym->name, &sym->code_info, sym->offset, show_offset, perf_mode, false));
 
   return str_syms;
 }

--- a/src/usyms.cpp
+++ b/src/usyms.cpp
@@ -29,8 +29,7 @@ std::string stringify_addr(uint64_t addr, bool perf_mode)
 
 std::string stringify_sym(const char *name,
                           const blaze_symbolize_code_info *code_info,
-                          uint64_t addr,
-                          uint64_t sym_addr,
+                          uint64_t offset,
                           bool show_offset,
                           const char *sym_module,
                           bool perf_mode,
@@ -45,7 +44,7 @@ std::string stringify_sym(const char *name,
   symbol << name;
 
   if (show_offset) {
-    symbol << "+" << addr - sym_addr;
+    symbol << "+" << offset;
   }
 
   if (perf_mode) {
@@ -73,7 +72,6 @@ std::string stringify_sym(const char *name,
 }
 
 void add_symbols(const blaze_sym *sym,
-                 uint64_t addr,
                  bool show_offset,
                  bool perf_mode,
                  std::vector<std::string> &str_syms)
@@ -92,7 +90,6 @@ void add_symbols(const blaze_sym *sym,
       str_syms.push_back(stringify_sym(inlined->name,
                                        &inlined->code_info,
                                        0,
-                                       0,
                                        false,
                                        nullptr,
                                        perf_mode,
@@ -102,8 +99,7 @@ void add_symbols(const blaze_sym *sym,
 
   str_syms.push_back(stringify_sym(sym->name,
                                    &sym->code_info,
-                                   addr,
-                                   sym->addr,
+                                   sym->offset,
                                    show_offset,
                                    sym->module,
                                    perf_mode,
@@ -356,7 +352,7 @@ std::vector<std::string> Usyms::resolve_blazesym_impl(
 
       sym = &syms->syms[0];
 
-      add_symbols(sym, addr, show_offset, perf_mode, str_syms);
+      add_symbols(sym, show_offset, perf_mode, str_syms);
     }
     return str_syms;
   }
@@ -378,7 +374,7 @@ std::vector<std::string> Usyms::resolve_blazesym_impl(
   };
 
   sym = &syms->syms[0];
-  add_symbols(sym, addr, show_offset, perf_mode, str_syms);
+  add_symbols(sym, show_offset, perf_mode, str_syms);
 
   return str_syms;
 }


### PR DESCRIPTION
Use the blaze_sym::offset attribute for reporting function offsets instead of attempting to calculate the offset by subtracting the symbol address from the input address. The latter will only work when dealing with non-relocatable symbols, which at least in user space is the exception rather than the rule. Without this change, we could end up displaying unrealistically large offsets.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
