### PR TITLE
refactor: update join_id extraction logic in `perf_event_printer`

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -280,7 +280,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     bpftrace->out_->message(MessageType::time, timestr, false);
     return;
   } else if (printf_id == asyncactionint(AsyncAction::join)) {
-    uint64_t join_id = *(static_cast<uint64_t *>(data) + 1);
+    uint64_t join_id = static_cast<AsyncEvent::Join *>(data)->join_id;
     const auto *delim = bpftrace->resources.join_args[join_id].c_str();
     std::stringstream joined;
     for (unsigned int i = 0; i < bpftrace->join_argnum_; i++) {


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

This pr update the `join_id` extraction logic in the `perf_event_printer` function. 

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
