### PR TITLE
parser: add ability to parse bare expressions

### DIFF
--- a/src/driver.h
+++ b/src/driver.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <optional>
+#include <utility>
+
 #include "ast/context.h"
 #include "ast/pass_manager.h"
 #include "bpftrace.h"
+#include "parser.tab.hh"
 
 using yyscan_t = void *;
 
@@ -16,7 +20,8 @@ class Driver {
 public:
   explicit Driver(ast::ASTContext &ctx, BPFtrace &bpftrace, bool debug = false)
       : ctx(ctx), bpftrace(bpftrace), debug(debug) {};
-  void parse();
+  void parse_program();
+  void parse_expr();
   void error(const location &l, const std::string &m);
 
   // These are accessible to the parser and lexer, but are not mutable.
@@ -28,6 +33,15 @@ public:
   location loc;
   std::string struct_type;
   std::string buffer;
+
+  // This is the token injected into the lexer.
+  std::optional<Parser::symbol_type> token;
+
+  // The final result is available here.
+  std::variant<ast::Program *, ast::Expression> result;
+
+private:
+  void parse(Parser::symbol_type first_token);
 };
 
 ast::Pass CreateParsePass(bool debug = false);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -66,6 +66,14 @@ oct_esc  [0-7]{1,3}
 
 %%
 
+%{
+  if (driver.token) {
+    auto t = *driver.token;
+    driver.token.reset();
+    return t;
+  }
+%}
+
 {hspace}+               { driver.loc.step(); }
 {vspace}+               { driver.loc.lines(yyleng); driver.loc.step(); }
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -920,7 +920,7 @@ TEST(bpftrace, trailing_comma)
   Driver driver(ast, bpftrace);
 
   // Trailing comma is fine
-  driver.parse();
+  driver.parse_program();
   ASSERT_TRUE(ast.diagnostics().ok());
 }
 
@@ -931,7 +931,7 @@ TEST(bpftrace, empty_attachpoint)
   Driver driver(ast, bpftrace);
 
   // Empty attach point should fail...
-  driver.parse();
+  driver.parse_program();
 
   // ... ah, but it doesn't really. What fails is the attachpoint parser. The
   // above is a valid program, it is just not a valid attachpoint.


### PR DESCRIPTION
Stacked PRs:
 * #4089
 * __->__#4088


--- --- ---

### parser: add ability to parse bare expressions


Using a documented Bison trick, we can add the ability to parse some
source string as a full program or simply an expression. This will allow
us to add macro expansion as a later pass without needing a reparse.

Signed-off-by: Adin Scannell <amscanne@meta.com>
