### PR TITLE
ast: remove need for macro expansion in the lexer

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(ast STATIC
   pass_manager.cpp
   signal.cpp
 
+  passes/c_macro_expansion.cpp
   passes/codegen_resources.cpp
   passes/config_analyser.cpp
   passes/deprecated.cpp

--- a/src/ast/passes/c_macro_expansion.cpp
+++ b/src/ast/passes/c_macro_expansion.cpp
@@ -1,0 +1,79 @@
+#include <algorithm>
+
+#include "ast/ast.h"
+#include "ast/context.h"
+#include "ast/passes/c_macro_expansion.h"
+#include "ast/visitor.h"
+#include "clang_parser.h"
+#include "driver.h"
+#include "util/format.h"
+
+namespace bpftrace::ast {
+
+class CMacroExpander : public Visitor<CMacroExpander> {
+public:
+  CMacroExpander(ASTContext &ast, CDefinitions &c_definitions)
+      : ast_(ast), c_definitions_(c_definitions) {};
+
+  using Visitor<CMacroExpander>::visit;
+  void visit(Expression &expr);
+
+private:
+  ASTContext &ast_;
+  CDefinitions &c_definitions_;
+  std::vector<std::string> active_;
+};
+
+void CMacroExpander::visit(Expression &expr)
+{
+  // N.B. We only support raw identifier macros. The way expansion works is
+  // that we see if an expression is a bare identifier, then attempt expansion
+  // recurisvely.
+  if (auto *ident = expr.as<Identifier>()) {
+    if (c_definitions_.macros.contains(ident->ident)) {
+      const auto &value = c_definitions_.macros[ident->ident];
+
+      // Check for recursion.
+      if (std::ranges::find(active_, ident->ident) != active_.end()) {
+        ident->addError() << "Macro recursion: "
+                          << util::str_join(active_, "->");
+        return;
+      }
+
+      // Parse just the macro as an expression.
+      ASTContext macro(ident->ident, value);
+      Driver driver(macro);
+      auto expanded = driver.parse_expr();
+      if (!expanded) {
+        ident->addError() << "unable to expand macro as an expression: "
+                          << value;
+        return;
+      }
+
+      // Expand the macro expression in place.
+      expr.value = clone(ast_, expanded->value, ident->loc);
+
+      // Recursively visit the potentially expanded expression, ensuring that
+      // we can catch recursive expansion, per above.
+      active_.emplace_back(ident->ident);
+      Visitor<CMacroExpander>::visit(expr);
+      active_.pop_back();
+      return;
+    }
+  }
+
+  // Expand normally.
+  Visitor<CMacroExpander>::visit(expr);
+}
+
+Pass CreateCMacroExpansionPass()
+{
+  auto fn = [](ASTContext &ast, CDefinitions &c_definitions) {
+    CMacroExpander expander(ast, c_definitions);
+    expander.visit(ast.root);
+  };
+
+  return Pass::create("CMacroExpansion", fn);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/c_macro_expansion.h
+++ b/src/ast/passes/c_macro_expansion.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateCMacroExpansionPass();
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -2,6 +2,7 @@
 
 #include "ast/attachpoint_parser.h"
 #include "ast/pass_manager.h"
+#include "ast/passes/c_macro_expansion.h"
 #include "ast/passes/config_analyser.h"
 #include "ast/passes/deprecated.h"
 #include "ast/passes/field_analyser.h"
@@ -31,11 +32,7 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateParseTracepointFormatPass());
   passes.emplace_back(CreateFieldAnalyserPass());
   passes.emplace_back(CreateClangPass(std::move(extra_flags)));
-  // The source and syntax is reparsed because it uses the `macros_` which are
-  // set during the clang parse to expand identifiers within the lexer.
-  passes.emplace_back(CreateParsePass());
-  passes.emplace_back(CreateMacroExpansionPass());
-  passes.emplace_back(CreateParseAttachpointsPass());
+  passes.emplace_back(CreateCMacroExpansionPass());
   passes.emplace_back(CreateMapSugarPass());
   return passes;
 }

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -1,34 +1,34 @@
+#include <memory>
+#include <string>
+
 #include "ast/async_event_types.h"
+#include "async_action.h"
 #include "bpftrace.h"
 #include "log.h"
 #include "util/exceptions.h"
 #include "util/io.h"
 #include "util/system.h"
-#include <memory>
-#include <string>
 
 namespace bpftrace::async_action {
 
-const static size_t MAX_TIME_STR_LEN = 64;
-
-void join_handler(BPFtrace *bpftrace, void *data)
+void join_handler(BPFtrace &bpftrace, Output &out, void *data)
 {
   auto *join = static_cast<AsyncEvent::Join *>(data);
   uint64_t join_id = join->join_id;
-  const auto *delim = bpftrace->resources.join_args[join_id].c_str();
+  const auto *delim = bpftrace.resources.join_args[join_id].c_str();
   std::stringstream joined;
-  for (unsigned int i = 0; i < bpftrace->join_argnum_; i++) {
-    auto *arg = join->content + (i * bpftrace->join_argsize_);
+  for (unsigned int i = 0; i < bpftrace.join_argnum_; i++) {
+    auto *arg = join->content + (i * bpftrace.join_argsize_);
     if (arg[0] == 0)
       break;
     if (i)
       joined << delim;
     joined << arg;
   }
-  bpftrace->out_->message(MessageType::join, joined.str());
+  out.message(MessageType::join, joined.str());
 }
 
-void time_handler(BPFtrace *bpftrace, void *data)
+void time_handler(BPFtrace &bpftrace, Output &out, void *data)
 {
   // not respecting config_->get(ConfigKeyInt::max_strlen)
   char timestr[MAX_TIME_STR_LEN];
@@ -40,70 +40,73 @@ void time_handler(BPFtrace *bpftrace, void *data)
     return;
   }
   auto *time = static_cast<AsyncEvent::Time *>(data);
-  const auto *fmt = bpftrace->resources.time_args[time->time_id].c_str();
+  const auto *fmt = bpftrace.resources.time_args[time->time_id].c_str();
   if (strftime(timestr, sizeof(timestr), fmt, &tmp) == 0) {
     LOG(WARNING) << "strftime returned 0";
     return;
   }
-  bpftrace->out_->message(MessageType::time, timestr, false);
+  out.message(MessageType::time, timestr, false);
 }
 
-void helper_error_handler(BPFtrace *bpftrace, void *data)
+void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data)
 {
   auto *helper_error = static_cast<AsyncEvent::HelperError *>(data);
   auto error_id = helper_error->error_id;
   auto return_value = helper_error->return_value;
-  auto &info = bpftrace->resources.helper_error_info[error_id];
-  bpftrace->out_->helper_error(return_value, info);
+  auto &info = bpftrace.resources.helper_error_info[error_id];
+  out.helper_error(return_value, info);
 }
 
-void syscall_handler(BPFtrace *bpftrace,
+void syscall_handler(BPFtrace &bpftrace,
+                     Output &out,
                      AsyncAction printf_id,
                      uint8_t *arg_data)
 {
-  if (bpftrace->safe_mode_) {
+  if (bpftrace.safe_mode_) {
     throw util::FatalUserException(
         "syscall() not allowed in safe mode. Use '--unsafe'.");
   }
 
   auto id = static_cast<uint64_t>(printf_id) -
             static_cast<uint64_t>(AsyncAction::syscall);
-  auto &fmt = std::get<0>(bpftrace->resources.system_args[id]);
-  auto &args = std::get<1>(bpftrace->resources.system_args[id]);
-  auto arg_values = bpftrace->get_arg_values(args, arg_data);
+  auto &fmt = std::get<0>(bpftrace.resources.system_args[id]);
+  auto &args = std::get<1>(bpftrace.resources.system_args[id]);
+  auto arg_values = bpftrace.get_arg_values(out, args, arg_data);
 
-  bpftrace->out_->message(MessageType::syscall,
-                          util::exec_system(fmt.format_str(arg_values).c_str()),
-                          false);
+  out.message(MessageType::syscall,
+              util::exec_system(fmt.format_str(arg_values).c_str()),
+              false);
 }
 
-void cat_handler(BPFtrace *bpftrace, AsyncAction printf_id, uint8_t *arg_data)
+void cat_handler(BPFtrace &bpftrace,
+                 Output &out,
+                 AsyncAction printf_id,
+                 uint8_t *arg_data)
 {
   auto id = static_cast<size_t>(printf_id) -
             static_cast<size_t>(AsyncAction::cat);
-  auto &fmt = std::get<0>(bpftrace->resources.cat_args[id]);
-  auto &args = std::get<1>(bpftrace->resources.cat_args[id]);
-  auto arg_values = bpftrace->get_arg_values(args, arg_data);
+  auto &fmt = std::get<0>(bpftrace.resources.cat_args[id]);
+  auto &args = std::get<1>(bpftrace.resources.cat_args[id]);
+  auto arg_values = bpftrace.get_arg_values(out, args, arg_data);
 
   std::stringstream buf;
   util::cat_file(fmt.format_str(arg_values).c_str(),
-                 bpftrace->config_->max_cat_bytes,
+                 bpftrace.config_->max_cat_bytes,
                  buf);
-  bpftrace->out_->message(MessageType::cat, buf.str(), false);
+  out.message(MessageType::cat, buf.str(), false);
 }
 
-void printf_handler(BPFtrace *bpftrace,
+void printf_handler(BPFtrace &bpftrace,
+                    Output &out,
                     AsyncAction printf_id,
                     uint8_t *arg_data)
 {
   auto id = static_cast<size_t>(printf_id) -
             static_cast<size_t>(AsyncAction::printf);
-  auto &fmt = std::get<0>(bpftrace->resources.printf_args[id]);
-  auto &args = std::get<1>(bpftrace->resources.printf_args[id]);
-  auto arg_values = bpftrace->get_arg_values(args, arg_data);
+  auto &fmt = std::get<0>(bpftrace.resources.printf_args[id]);
+  auto &args = std::get<1>(bpftrace.resources.printf_args[id]);
+  auto arg_values = bpftrace.get_arg_values(out, args, arg_data);
 
-  bpftrace->out_->message(MessageType::printf,
-                          fmt.format_str(arg_values),
-                          false);
+  out.message(MessageType::printf, fmt.format_str(arg_values), false);
 }
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -1,18 +1,24 @@
 #pragma once
 #include "ast/async_event_types.h"
 #include "bpftrace.h"
+#include "output.h"
 
 namespace bpftrace::async_action {
 
 const static size_t MAX_TIME_STR_LEN = 64;
-void join_handler(BPFtrace *bpftrace, void *data);
-void time_handler(BPFtrace *bpftrace, void *data);
-void helper_error_handler(BPFtrace *bpftrace, void *data);
-void syscall_handler(BPFtrace *bpftrace,
+void join_handler(BPFtrace &bpftrace, Output &out, void *data);
+void time_handler(BPFtrace &bpftrace, Output &out, void *data);
+void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data);
+void syscall_handler(BPFtrace &bpftrace,
+                     Output &out,
                      AsyncAction printf_id,
                      uint8_t *arg_data);
-void cat_handler(BPFtrace *bpftrace, AsyncAction printf_id, uint8_t *arg_data);
-void printf_handler(BPFtrace *bpftrace,
+void cat_handler(BPFtrace &bpftrace,
+                 Output &out,
+                 AsyncAction printf_id,
+                 uint8_t *arg_data);
+void printf_handler(BPFtrace &bpftrace,
+                    Output &out,
                     AsyncAction printf_id,
                     uint8_t *arg_data);
 

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -37,6 +37,9 @@ public:
              BPFtrace &bpftrace,
              std::vector<std::string> extra_flags = {});
 
+  // Moved out by the pass.
+  CDefinitions definitions;
+
 private:
   bool visit_children(CXCursor &cursor, BPFtrace &bpftrace);
   // The user might have written some struct definitions that rely on types
@@ -409,137 +412,138 @@ bool ClangParser::ClangParserHandler::has_unknown_type_error()
 }
 
 namespace {
+using visitFn = std::function<CXChildVisitResult(CXCursor, CXCursor)>;
+int visitChildren(CXCursor cursor, visitFn fn)
+{
+  return clang_visitChildren(
+      cursor,
+      [](CXCursor c, CXCursor parent, CXClientData data) {
+        auto *cb = static_cast<visitFn *>(data);
+        return (*cb)(c, parent);
+      },
+      static_cast<void *>(&fn));
+}
+
 // Get annotation associated with field declaration `c`
 std::optional<std::string> get_field_decl_annotation(CXCursor c)
 {
   assert(clang_getCursorKind(c) == CXCursor_FieldDecl);
 
   std::optional<std::string> annotation;
-  clang_visitChildren(
-      c,
-      [](CXCursor c,
-         CXCursor __attribute__((unused)) parent,
-         CXClientData data) {
-        // The header generation code can annotate some struct
-        // fields with additional information for us to parse
-        // here. The annotation looks like:
-        //
-        //    struct Foo {
-        //      __attribute__((annotate("tp_data_loc"))) int
-        //      name;
-        //    };
-        //
-        // Currently only the TracepointFormatParser does this.
-        if (clang_getCursorKind(c) == CXCursor_AnnotateAttr) {
-          auto &a = *static_cast<std::optional<std::string> *>(data);
-          a = get_clang_string(clang_getCursorSpelling(c));
-        }
+  visitChildren(c, [&](CXCursor c, CXCursor __attribute__((unused)) parent) {
+    // The header generation code can annotate some struct
+    // fields with additional information for us to parse
+    // here. The annotation looks like:
+    //
+    //    struct Foo {
+    //      __attribute__((annotate("tp_data_loc"))) int
+    //      name;
+    //    };
+    //
+    // Currently only the TracepointFormatParser does this.
+    if (clang_getCursorKind(c) == CXCursor_AnnotateAttr) {
+      annotation = get_clang_string(clang_getCursorSpelling(c));
+    }
 
-        return CXChildVisit_Recurse;
-      },
-      &annotation);
-
+    return CXChildVisit_Recurse;
+  });
   return annotation;
 }
 } // namespace
 
 bool ClangParser::visit_children(CXCursor &cursor, BPFtrace &bpftrace)
 {
-  int err = clang_visitChildren(
-      cursor,
-      [](CXCursor c, CXCursor parent, CXClientData client_data) {
-        if (clang_getCursorKind(c) == CXCursor_MacroDefinition) {
-          std::string macro_name;
-          std::string macro_value;
-          if (translateMacro(c, macro_name, macro_value)) {
-            auto &macros = static_cast<BPFtrace *>(client_data)->macros_;
-            macros[macro_name] = macro_value;
-          }
-          return CXChildVisit_Recurse;
+  int err = visitChildren(cursor, [&](CXCursor c, CXCursor parent) {
+    if (clang_getCursorKind(c) == CXCursor_MacroDefinition) {
+      std::string macro_name;
+      std::string macro_value;
+      if (translateMacro(c, macro_name, macro_value)) {
+        definitions.macros[macro_name] = macro_value;
+      }
+      return CXChildVisit_Recurse;
+    }
+
+    // Each anon enum must have a unique ID otherwise two variants
+    // with different names but same value will clobber each other
+    // in enum_defs.
+    static uint32_t anon_enum_count = 0;
+    if (clang_getCursorKind(c) == CXCursor_EnumDecl)
+      anon_enum_count++;
+
+    if (clang_getCursorKind(parent) == CXCursor_EnumDecl) {
+      // Store variant name to variant value
+      auto enum_name = get_clang_string(clang_getCursorSpelling(parent));
+      // Anonymous enums have empty string names in libclang <= 15
+      if (enum_name.empty()) {
+        std::ostringstream name;
+        name << "enum <anon_" << anon_enum_count << ">";
+        enum_name = name.str();
+      }
+      auto variant_name = get_clang_string(clang_getCursorSpelling(c));
+      auto variant_value = clang_getEnumConstantDeclValue(c);
+      definitions.enums[variant_name] = std::make_pair(variant_value,
+                                                       enum_name);
+
+      // Store enum name to variant value to variant name
+      definitions.enum_defs[enum_name][variant_value] = variant_name;
+
+      return CXChildVisit_Recurse;
+    }
+
+    if (clang_getCursorKind(parent) != CXCursor_StructDecl &&
+        clang_getCursorKind(parent) != CXCursor_UnionDecl)
+      return CXChildVisit_Recurse;
+
+    if (clang_getCursorKind(c) == CXCursor_FieldDecl) {
+      // N.B. In the future this may be moved into the C definitions, but
+      // currently this is rather tied in to a lot of other plumbing.
+      auto &structs = bpftrace.structs;
+
+      auto named_parent = get_named_parent(c);
+      auto ptype = clang_getCanonicalType(clang_getCursorType(named_parent));
+      auto ptypestr = get_unqualified_type_name(ptype);
+      auto ptypesize = clang_Type_getSizeOf(ptype);
+
+      auto ident = get_clang_string(clang_getCursorSpelling(c));
+      auto offset = clang_Type_getOffsetOf(ptype, ident.c_str()) / 8;
+      auto type = clang_getCanonicalType(clang_getCursorType(c));
+      auto sized_type = get_sized_type(type, structs);
+      auto bitfield = getBitfield(c);
+      bool is_data_loc = false;
+
+      // Process field annotations
+      auto annotation = get_field_decl_annotation(c);
+      if (annotation) {
+        if (*annotation == "tp_data_loc") {
+          // If the field is a tracepoint __data_loc, we need to rewrite the
+          // type as a u64. The reason is that the tracepoint infrastructure
+          // exports an encoded 32bit integer that tells us where to find
+          // the actual data and how wide it is. However, LLVM freaks out if
+          // you try to cast a pointer to a u32 (rightfully so) so we need
+          // this field to actually be 64 bits wide.
+          sized_type = CreateInt64();
+          is_data_loc = true;
         }
+      }
 
-        // Each anon enum must have a unique ID otherwise two variants
-        // with different names but same value will clobber each other
-        // in enum_defs_.
-        static uint32_t anon_enum_count = 0;
-        if (clang_getCursorKind(c) == CXCursor_EnumDecl)
-          anon_enum_count++;
+      // Initialize a new record type if needed
+      if (!structs.Has(ptypestr))
+        structs.Add(ptypestr, ptypesize, false);
 
-        if (clang_getCursorKind(parent) == CXCursor_EnumDecl) {
-          // Store variant name to variant value
-          auto &enums = static_cast<BPFtrace *>(client_data)->enums_;
-          auto enum_name = get_clang_string(clang_getCursorSpelling(parent));
-          // Anonymous enums have empty string names in libclang <= 15
-          if (enum_name.empty()) {
-            std::ostringstream name;
-            name << "enum <anon_" << anon_enum_count << ">";
-            enum_name = name.str();
-          }
-          auto variant_name = get_clang_string(clang_getCursorSpelling(c));
-          auto variant_value = clang_getEnumConstantDeclValue(c);
-          enums[variant_name] = std::make_pair(variant_value, enum_name);
+      auto str = structs.Lookup(ptypestr).lock();
+      if (str->allow_override) {
+        str->ClearFields();
+        str->allow_override = false;
+      }
 
-          // Store enum name to variant value to variant name
-          auto &enum_defs = static_cast<BPFtrace *>(client_data)->enum_defs_;
-          enum_defs[enum_name][variant_value] = variant_name;
+      // No need to worry about redefined types b/c we should have already
+      // checked clang diagnostics. The diagnostics will tell us if we have
+      // duplicated types.
+      str->AddField(ident, sized_type, offset, bitfield, is_data_loc);
+    }
 
-          return CXChildVisit_Recurse;
-        }
-
-        if (clang_getCursorKind(parent) != CXCursor_StructDecl &&
-            clang_getCursorKind(parent) != CXCursor_UnionDecl)
-          return CXChildVisit_Recurse;
-
-        if (clang_getCursorKind(c) == CXCursor_FieldDecl) {
-          auto &structs = static_cast<BPFtrace *>(client_data)->structs;
-
-          auto named_parent = get_named_parent(c);
-          auto ptype = clang_getCanonicalType(
-              clang_getCursorType(named_parent));
-          auto ptypestr = get_unqualified_type_name(ptype);
-          auto ptypesize = clang_Type_getSizeOf(ptype);
-
-          auto ident = get_clang_string(clang_getCursorSpelling(c));
-          auto offset = clang_Type_getOffsetOf(ptype, ident.c_str()) / 8;
-          auto type = clang_getCanonicalType(clang_getCursorType(c));
-          auto sized_type = get_sized_type(type, structs);
-          auto bitfield = getBitfield(c);
-          bool is_data_loc = false;
-
-          // Process field annotations
-          auto annotation = get_field_decl_annotation(c);
-          if (annotation) {
-            if (*annotation == "tp_data_loc") {
-              // If the field is a tracepoint __data_loc, we need to rewrite the
-              // type as a u64. The reason is that the tracepoint infrastructure
-              // exports an encoded 32bit integer that tells us where to find
-              // the actual data and how wide it is. However, LLVM freaks out if
-              // you try to cast a pointer to a u32 (rightfully so) so we need
-              // this field to actually be 64 bits wide.
-              sized_type = CreateInt64();
-              is_data_loc = true;
-            }
-          }
-
-          // Initialize a new record type if needed
-          if (!structs.Has(ptypestr))
-            structs.Add(ptypestr, ptypesize, false);
-
-          auto str = structs.Lookup(ptypestr).lock();
-          if (str->allow_override) {
-            str->ClearFields();
-            str->allow_override = false;
-          }
-
-          // No need to worry about redefined types b/c we should have already
-          // checked clang diagnostics. The diagnostics will tell us if we have
-          // duplicated types.
-          str->AddField(ident, sized_type, offset, bitfield, is_data_loc);
-        }
-
-        return CXChildVisit_Recurse;
-      },
-      &bpftrace);
+    return CXChildVisit_Recurse;
+  });
 
   // clang_visitChildren returns a non-zero value if the traversal
   // was terminated by the visitor returning CXChildVisit_Break.
@@ -563,40 +567,34 @@ std::unordered_set<std::string> ClangParser::get_incomplete_types()
   } type_data;
 
   CXCursor cursor = handler.get_translation_unit_cursor();
-  clang_visitChildren(
-      cursor,
-      [](CXCursor c, CXCursor parent, CXClientData client_data) {
-        auto &data = *static_cast<TypeData *>(client_data);
+  visitChildren(cursor, [&](CXCursor c, CXCursor parent) {
+    // We look for field declarations and store the parent
+    // as a fully defined type because we know we're looking at a
+    // type definition.
+    //
+    // Then look at the field declaration itself. If it's a record
+    // type (ie struct or union), check if we think it's a fully
+    // defined type. If not, add it to incomplete types set.
+    if (clang_getCursorKind(parent) == CXCursor_EnumDecl ||
+        (clang_getCursorKind(c) == CXCursor_FieldDecl &&
+         (clang_getCursorKind(parent) == CXCursor_UnionDecl ||
+          clang_getCursorKind(parent) == CXCursor_StructDecl))) {
+      auto parent_type = clang_getCanonicalType(clang_getCursorType(parent));
+      type_data.complete_types.emplace(get_unqualified_type_name(parent_type));
 
-        // We look for field declarations and store the parent
-        // as a fully defined type because we know we're looking at a
-        // type definition.
-        //
-        // Then look at the field declaration itself. If it's a record
-        // type (ie struct or union), check if we think it's a fully
-        // defined type. If not, add it to incomplete types set.
-        if (clang_getCursorKind(parent) == CXCursor_EnumDecl ||
-            (clang_getCursorKind(c) == CXCursor_FieldDecl &&
-             (clang_getCursorKind(parent) == CXCursor_UnionDecl ||
-              clang_getCursorKind(parent) == CXCursor_StructDecl))) {
-          auto parent_type = clang_getCanonicalType(
-              clang_getCursorType(parent));
-          data.complete_types.emplace(get_unqualified_type_name(parent_type));
+      auto cursor_type = clang_getCanonicalType(clang_getCursorType(c));
+      // We need layouts of pointee types because users could dereference
+      if (cursor_type.kind == CXType_Pointer)
+        cursor_type = clang_getPointeeType(cursor_type);
+      if (cursor_type.kind == CXType_Record) {
+        auto type_name = get_unqualified_type_name(cursor_type);
+        if (!type_data.complete_types.contains(type_name))
+          type_data.incomplete_types.emplace(std::move(type_name));
+      }
+    }
 
-          auto cursor_type = clang_getCanonicalType(clang_getCursorType(c));
-          // We need layouts of pointee types because users could dereference
-          if (cursor_type.kind == CXType_Pointer)
-            cursor_type = clang_getPointeeType(cursor_type);
-          if (cursor_type.kind == CXType_Record) {
-            auto type_name = get_unqualified_type_name(cursor_type);
-            if (!data.complete_types.contains(type_name))
-              data.incomplete_types.emplace(std::move(type_name));
-          }
-        }
-
-        return CXChildVisit_Recurse;
-      },
-      &type_data);
+    return CXChildVisit_Recurse;
+  });
 
   return type_data.incomplete_types;
 }
@@ -873,14 +871,14 @@ std::vector<std::string> ClangParser::system_include_paths()
 ast::Pass CreateClangPass(std::vector<std::string> &&extra_flags)
 {
   return ast::Pass::create("ClangParser",
-                           [extra_flags = std::move(
-                                extra_flags)](ast::ASTContext &ast,
-                                              BPFtrace &b) -> Result<OK> {
+                           [extra_flags = std::move(extra_flags)](
+                               ast::ASTContext &ast,
+                               BPFtrace &b) -> Result<CDefinitions> {
                              ClangParser parser;
                              if (!parser.parse(ast.root, b, extra_flags)) {
                                return make_error<ClangParseError>();
                              }
-                             return OK();
+                             return std::move(parser.definitions);
                            });
 }
 

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -1,8 +1,23 @@
 #pragma once
 
 #include "ast/pass_manager.h"
+#include <map>
 
 namespace bpftrace {
+
+// When the imported definitions are parsed with clang, relevant C definitions
+// are centralized here to be consumed by later passes.
+class CDefinitions : public ast::State<"C-definitions"> {
+public:
+  // Map of macro name to macro definition.
+  std::map<std::string, std::string> macros;
+
+  // Map of enum variant_name to (variant_value, enum_name).
+  std::map<std::string, std::tuple<uint64_t, std::string>> enums;
+
+  // Map of enum_name to map of variant_value to variant_name.
+  std::map<std::string, std::map<uint64_t, std::string>> enum_defs;
+};
 
 class ClangParseError : public ErrorInfo<ClangParseError> {
 public:

--- a/src/driver.h
+++ b/src/driver.h
@@ -3,6 +3,7 @@
 #include <optional>
 #include <utility>
 
+#include "ast/ast.h"
 #include "ast/context.h"
 #include "ast/pass_manager.h"
 #include "bpftrace.h"
@@ -18,15 +19,15 @@ namespace bpftrace {
 
 class Driver {
 public:
-  explicit Driver(ast::ASTContext &ctx, BPFtrace &bpftrace, bool debug = false)
-      : ctx(ctx), bpftrace(bpftrace), debug(debug) {};
-  void parse_program();
-  void parse_expr();
+  explicit Driver(ast::ASTContext &ctx, bool debug = false)
+      : ctx(ctx), debug(debug) {};
+  ast::Program *parse_program();
+  std::optional<ast::Expression> parse_expr();
+
   void error(const location &l, const std::string &m);
 
   // These are accessible to the parser and lexer, but are not mutable.
   ast::ASTContext &ctx;
-  BPFtrace &bpftrace;
   const bool debug;
 
   // These are mutable state that can be modified by the lexer.

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -262,41 +262,7 @@ struct|union|enum       {
   \n                    driver.buffer += '\n'; driver.loc.lines(1); driver.loc.step();
 }
 
-{ident}                 {
-                          static int unput_count = 0;
-                          if (driver.bpftrace.macros_.count(yytext) != 0)
-                          {
-                            const char *s = driver.bpftrace.macros_.find(yytext)->second.c_str();
-                            int z;
-                            // NOTE(mmarchini) workaround for simple recursive
-                            // macros. More complex recursive macros (for
-                            // example, with operators) will go into an
-                            // infinite loop. Yes, we should fix that in the
-                            // future.
-                            if (strcmp(s, yytext) == 0)
-                            {
-                              unput_count = 0;
-                              return Parser::make_IDENT(yytext, driver.loc);
-                            }
-                            else
-                            {
-                              std::string original_s(s);
-                              std::string original_yytext(yytext);
-                              for (z=strlen(s) - 1; z >= 0; z--) {
-                                if (unput_count >= 1000) {
-                                  driver.error(driver.loc, std::string("Macro recursion limit reached: ")
-                                                    + original_yytext + ", " + original_s);
-                                  yyterminate();
-                                }
-                                unput(s[z]);
-                                unput_count++;
-                              }
-                            }
-                          } else {
-                            unput_count = 0;
-                            return Parser::make_IDENT(yytext, driver.loc);
-                          }
-                        }
+{ident}                 { return Parser::make_IDENT(yytext, driver.loc); }
 
 .                       { driver.error(driver.loc, std::string("invalid character '") +
                                             std::string(yytext) + std::string("'")); }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -800,9 +800,9 @@ std::string TextOutput::value_to_str(BPFtrace &bpftrace,
             return {};
         }
 
-        if (bpftrace.enum_defs_.contains(enum_name) &&
-            bpftrace.enum_defs_[enum_name].contains(enum_val)) {
-          return bpftrace.enum_defs_[enum_name][enum_val];
+        if (c_definitions_.enum_defs.contains(enum_name) &&
+            c_definitions_.enum_defs[enum_name].contains(enum_val)) {
+          return c_definitions_.enum_defs[enum_name][enum_val];
         } else {
           // Fall back to something comprehensible in case user somehow
           // tricked the type system into accepting an invalid enum.

--- a/src/output.h
+++ b/src/output.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "bpfmap.h"
+#include "clang_parser.h"
 #include "required_resources.h"
 #include "types.h"
 
@@ -38,14 +39,20 @@ std::ostream &operator<<(std::ostream &out, MessageType type);
 // virtual methods.
 class Output {
 public:
-  explicit Output(std::ostream &out = std::cout, std::ostream &err = std::cerr)
-      : out_(out), err_(err)
+  explicit Output(CDefinitions &c_definitions,
+                  std::ostream &out = std::cout,
+                  std::ostream &err = std::cerr)
+      : c_definitions_(c_definitions), out_(out), err_(err)
   {
   }
   Output(const Output &) = delete;
   Output &operator=(const Output &) = delete;
   virtual ~Output() = default;
 
+  virtual const CDefinitions &c_definitions() const
+  {
+    return c_definitions_;
+  }
   virtual std::ostream &outputstream() const
   {
     return out_;
@@ -92,6 +99,7 @@ public:
   virtual void helper_error(int retcode, const HelperErrorInfo &info) const = 0;
 
 protected:
+  CDefinitions &c_definitions_;
   std::ostream &out_;
   std::ostream &err_;
   void hist_prepare(const std::vector<uint64_t> &values,
@@ -195,9 +203,10 @@ protected:
 
 class TextOutput : public Output {
 public:
-  explicit TextOutput(std::ostream &out = std::cout,
+  explicit TextOutput(CDefinitions &c_definitions,
+                      std::ostream &out = std::cout,
                       std::ostream &err = std::cerr)
-      : Output(out, err)
+      : Output(c_definitions, out, err)
   {
   }
 
@@ -268,9 +277,10 @@ protected:
 
 class JsonOutput : public Output {
 public:
-  explicit JsonOutput(std::ostream &out = std::cout,
+  explicit JsonOutput(CDefinitions &c_definitions,
+                      std::ostream &out = std::cout,
                       std::ostream &err = std::cerr)
-      : Output(out, err)
+      : Output(c_definitions, out, err)
   {
   }
 

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -34,7 +34,7 @@ void check_is_root()
   }
 }
 
-int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
+int run_bpftrace(BPFtrace &bpftrace, Output &output, BpfBytecode &bytecode)
 {
   int err;
 
@@ -48,7 +48,7 @@ int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
   act.sa_handler = [](int) { BPFtrace::sigusr1_recv = true; };
   sigaction(SIGUSR1, &act, nullptr);
 
-  err = bpftrace.run(std::move(bytecode));
+  err = bpftrace.run(output, std::move(bytecode));
   if (err)
     return err;
 
@@ -61,7 +61,7 @@ int run_bpftrace(BPFtrace &bpftrace, BpfBytecode &bytecode)
 
   // Print maps if needed (true by default).
   if (bpftrace.config_->print_maps_on_exit)
-    err = bpftrace.print_maps();
+    err = bpftrace.print_maps(output);
 
   if (bpftrace.child_) {
     auto val = 0;

--- a/src/run_bpftrace.h
+++ b/src/run_bpftrace.h
@@ -5,4 +5,6 @@
 int libbpf_print(enum libbpf_print_level level, const char *msg, va_list ap);
 void check_is_root();
 
-int run_bpftrace(bpftrace::BPFtrace &bpftrace, bpftrace::BpfBytecode &bytecode);
+int run_bpftrace(bpftrace::BPFtrace &bpftrace,
+                 bpftrace::Output &output,
+                 bpftrace::BpfBytecode &bytecode);

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -916,8 +916,7 @@ TEST(bpftrace, add_probes_hardware)
 TEST(bpftrace, trailing_comma)
 {
   ast::ASTContext ast("stdin", "kprobe:f1, {}");
-  auto bpftrace = get_strict_mock_bpftrace();
-  Driver driver(ast, *bpftrace);
+  Driver driver(ast);
 
   // Trailing comma is fine
   driver.parse_program();
@@ -927,15 +926,15 @@ TEST(bpftrace, trailing_comma)
 TEST(bpftrace, empty_attachpoint)
 {
   ast::ASTContext ast("stdin", "{}");
-  auto bpftrace = get_strict_mock_bpftrace();
-  Driver driver(ast, *bpftrace);
+  Driver driver(ast);
 
   // Empty attach point should fail...
-  driver.parse_program();
+  ast.root = driver.parse_program();
 
   // ... ah, but it doesn't really. What fails is the attachpoint parser. The
   // above is a valid program, it is just not a valid attachpoint.
-  ast::AttachPointParser ap_parser(ast, *bpftrace, false);
+  StrictMock<MockBPFtrace> bpftrace;
+  ast::AttachPointParser ap_parser(ast, bpftrace, false);
   ap_parser.parse();
   EXPECT_FALSE(ast.diagnostics().ok());
 }

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -5,6 +5,7 @@
 #include <regex>
 
 #include "ast/attachpoint_parser.h"
+#include "ast/passes/c_macro_expansion.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/fold_literals.h"
@@ -63,8 +64,7 @@ static void test(BPFtrace &bpftrace,
                 .add(ast::CreateParseAttachpointsPass())
                 .add(ast::CreateFieldAnalyserPass())
                 .add(CreateClangPass())
-                .add(CreateParsePass())
-                .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateCMacroExpansionPass())
                 .add(ast::CreateFoldLiteralsPass())
                 .add(ast::CreateMapSugarPass())
                 .add(ast::CreateSemanticPass())

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -14,10 +14,13 @@ TEST(codegen, regression_957)
   ast::ASTContext ast("stdin", "t:sched:sched_one* { cat(\"%s\", probe); }");
   auto bpftrace = get_mock_bpftrace();
 
+  CDefinitions no_c_defs; // Output from clang parser.
+
   // N.B. No macros or tracepoint expansion.
   auto ok = ast::PassManager()
                 .put(ast)
                 .put<BPFtrace>(*bpftrace)
+                .put(no_c_defs)
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
                 .add(ast::CreateFieldAnalyserPass())

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -157,10 +157,9 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
   bpftrace.helper_check_level_ = 0;
 }
 
-std::unique_ptr<MockBPFtrace> get_mock_bpftrace(std::ostream &os)
+std::unique_ptr<MockBPFtrace> get_mock_bpftrace()
 {
-  std::unique_ptr<Output> output = std::make_unique<TextOutput>(os);
-  auto bpftrace = std::make_unique<NiceMock<MockBPFtrace>>(std::move(output));
+  auto bpftrace = std::make_unique<NiceMock<MockBPFtrace>>();
   setup_mock_bpftrace(*bpftrace);
 
   auto probe_matcher = std::make_unique<NiceMock<MockProbeMatcher>>(
@@ -173,10 +172,9 @@ std::unique_ptr<MockBPFtrace> get_mock_bpftrace(std::ostream &os)
   return bpftrace;
 }
 
-std::unique_ptr<MockBPFtrace> get_strict_mock_bpftrace(std::ostream &os)
+std::unique_ptr<MockBPFtrace> get_strict_mock_bpftrace()
 {
-  std::unique_ptr<Output> output = std::make_unique<TextOutput>(os);
-  auto bpftrace = std::make_unique<StrictMock<MockBPFtrace>>(std::move(output));
+  auto bpftrace = std::make_unique<StrictMock<MockBPFtrace>>();
   setup_mock_bpftrace(*bpftrace);
 
   auto probe_matcher = std::make_unique<StrictMock<MockProbeMatcher>>(

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -39,9 +39,6 @@ public:
 
 class MockBPFtrace : public BPFtrace {
 public:
-  MockBPFtrace(std::unique_ptr<Output> o) : BPFtrace(std::move(o))
-  {
-  }
   std::vector<Probe> get_probes()
   {
     return resources.probes;
@@ -110,9 +107,8 @@ public:
   bool mock_in_init_pid_ns = true;
 };
 
-std::unique_ptr<MockBPFtrace> get_mock_bpftrace(std::ostream &os = std::cout);
-std::unique_ptr<MockBPFtrace> get_strict_mock_bpftrace(
-    std::ostream &os = std::cout);
+std::unique_ptr<MockBPFtrace> get_mock_bpftrace();
+std::unique_ptr<MockBPFtrace> get_strict_mock_bpftrace();
 
 static auto bpf_nofeature = BPFnofeature();
 static auto btf_obj = BTF(nullptr);

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -9,9 +9,10 @@ namespace bpftrace::test::output {
 
 TEST(TextOutput, lhist_no_suffix)
 {
+  CDefinitions c_definitions;
   std::stringstream out;
   std::stringstream err;
-  TextOutput output{ out, err };
+  TextOutput output{ c_definitions, out, err };
 
   auto bpftrace = get_mock_bpftrace();
   bpftrace->resources.maps_info["@mymap"] = MapInfo{
@@ -57,11 +58,12 @@ TEST(TextOutput, lhist_no_suffix)
 
 TEST(TextOutput, lhist_suffix)
 {
+  CDefinitions c_definitions;
   std::stringstream out;
   std::stringstream err;
-  TextOutput output{ out, err };
+  TextOutput output{ c_definitions, out, err };
 
-  auto bpftrace = get_mock_bpftrace(out);
+  auto bpftrace = get_mock_bpftrace();
   bpftrace->resources.maps_info["@mymap"] = MapInfo{
     .key_type = CreateInt64(),
     .value_type = SizedType{ Type::lhist_t, 8 },

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -19,10 +19,13 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
   std::stringstream msg;
   msg << "\nInput:\n" << input << "\n\nOutput:\n";
 
+  CDefinitions no_c_defs; // Output from clang parser.
+
   // N.B. No macro or tracepoint expansion.
   auto ok = ast::PassManager()
                 .put(ast)
                 .put(bpftrace)
+                .put(no_c_defs)
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
                 .add(ast::CreateMapSugarPass())

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -23,10 +23,13 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
   auto bpftrace = get_mock_bpftrace();
   ast::ASTContext ast("stdin", input);
 
+  CDefinitions no_c_defs; // Output from clang parser.
+
   // N.B. No macro or tracepoint expansion.
   auto ok = ast::PassManager()
                 .put(ast)
                 .put<BPFtrace>(*bpftrace)
+                .put(no_c_defs)
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
                 .add(CreateParseBTFPass())

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1,6 +1,7 @@
 #include "ast/passes/semantic_analyser.h"
 #include "ast/ast.h"
 #include "ast/attachpoint_parser.h"
+#include "ast/passes/c_macro_expansion.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/fold_literals.h"
 #include "ast/passes/macro_expansion.h"
@@ -38,8 +39,7 @@ ast::ASTContext test_for_warning(BPFtrace &bpftrace,
                 .add(ast::CreateParseAttachpointsPass())
                 .add(ast::CreateFieldAnalyserPass())
                 .add(CreateClangPass())
-                .add(CreateParsePass())
-                .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateCMacroExpansionPass())
                 .add(ast::CreateFoldLiteralsPass())
                 .add(ast::CreateMapSugarPass())
                 .add(ast::CreateSemanticPass())
@@ -96,9 +96,7 @@ ast::ASTContext test(BPFtrace &bpftrace,
                 .add(ast::CreateParseAttachpointsPass())
                 .add(ast::CreateFieldAnalyserPass())
                 .add(CreateClangPass())
-                .add(CreateParsePass())
-                .add(ast::CreateMacroExpansionPass())
-                .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateCMacroExpansionPass())
                 .add(ast::CreateFoldLiteralsPass())
                 .add(ast::CreateMapSugarPass())
                 .add(ast::CreateSemanticPass())


### PR DESCRIPTION
Stacked PRs:
 * __->__#4089


--- --- ---

### ast: remove need for macro expansion in the lexer


This change has a few tightly coupled parts.

First, we add `CDefinitions` as state produced by `ClangParse` instead
of having this generation in the `BPFtrace` object.

Next, the `Output` needs to be decoupled from `BPFtrace` also, because
the `CDefinitions` will only be available after `ClangParse`, but it is
needed by the output in order to pretty-print enum values.  The `Output`
is now plumbed explicitly when required. This is a general good anyways,
since untangling things from `BPFtrace` is an overall improvement.

Finally, we add a `CMacroExpansion` pass that expands the macros in
place, without the need for reparsing the full source.

Signed-off-by: Adin Scannell <amscanne@meta.com>
