### PR TITLE
util: add `TempDir` to create temporary directories

### DIFF
--- a/src/ast/passes/link.cpp
+++ b/src/ast/passes/link.cpp
@@ -29,8 +29,14 @@ Pass CreateLinkPass()
           return BpfBytecode{ obj.data };
         }
 
+        // Create a working directory.
+        auto dir = util::TempDir::create();
+        if (!dir) {
+          return dir.takeError();
+        }
+
         // Otherwise, dump the intermediate object.
-        auto object = util::TempFile::create();
+        auto object = dir->create_file();
         if (!object) {
           return object.takeError();
         }
@@ -41,7 +47,7 @@ Pass CreateLinkPass()
 
         // Create an output file on disk. In the future, we may want to accept
         // some flags that allow this file to persist.
-        auto output = util::TempFile::create();
+        auto output = dir->create_file();
         if (!output) {
           return output.takeError();
         }

--- a/src/util/temp.cpp
+++ b/src/util/temp.cpp
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "log.h"
 #include "util/result.h"
 #include "util/temp.h"
 
@@ -14,7 +15,11 @@ void TempFileError::log(llvm::raw_ostream &OS) const
   OS << "temporary file " << origin_ << ": " << strerror(err_);
 }
 
-Result<TempFile> TempFile::create(std::string pattern)
+// Generic helper for providing a default pattern and ensuring that it is
+// mutable, in order to call the standard `mktemp` et al. Note that the
+// function `fn` must return `-errno` in the case of failure.
+static Result<std::pair<std::string, int>> mktemp(std::string pattern,
+                                                  std::function<int(char *)> fn)
 {
   if (pattern.empty()) {
     // Attempt to extract the best temporary directory. If the environment
@@ -32,13 +37,34 @@ Result<TempFile> TempFile::create(std::string pattern)
   // hold this result. This is used below as the actual filename.
   std::vector<char> mutable_pattern(pattern.size() + 1);
   ::strncpy(mutable_pattern.data(), pattern.c_str(), mutable_pattern.size());
-  int fd = ::mkostemp(mutable_pattern.data(), O_CLOEXEC);
+  int fd = fn(mutable_pattern.data());
   if (fd < 0) {
-    int err = errno;
+    int err = -fd; // See doc above.
     return make_error<TempFileError>(pattern, err);
   }
-  std::filesystem::path final_path(mutable_pattern.data());
-  return TempFile(std::move(final_path), fd);
+  return std::pair<std::string, int>(std::string(mutable_pattern.data()), fd);
+}
+
+Result<TempFile> TempFile::create(std::string name, bool pattern)
+{
+  if (!pattern) {
+    int fd = ::open(name.c_str(), O_CREAT | O_EXCL | O_WRONLY | O_TRUNC, 0644);
+    if (fd < 0) {
+      return make_error<TempFileError>(name, errno);
+    }
+    return TempFile(std::move(name), fd);
+  }
+  auto res = mktemp(name, [](char *s) -> int {
+    int fd = ::mkostemp(s, O_CLOEXEC);
+    if (fd < 0) {
+      return -errno;
+    }
+    return fd;
+  });
+  if (!res) {
+    return res.takeError();
+  }
+  return TempFile(std::move(res->first), res->second);
 }
 
 TempFile::~TempFile()
@@ -67,6 +93,45 @@ Result<OK> TempFile::write_all(std::span<char> bytes)
     left -= rc;
   }
   return OK();
+}
+
+Result<TempDir> TempDir::create(std::string pattern)
+{
+  auto res = mktemp(pattern, [](char *s) -> int {
+    char *res = ::mkdtemp(s);
+    return res == nullptr ? -errno : 0;
+  });
+  if (!res) {
+    return res.takeError();
+  }
+  assert(res->second == 0);
+  return TempDir(std::move(res->first));
+}
+
+Result<TempFile> TempDir::create_file(std::string name, bool pattern)
+{
+  if (pattern) {
+    // Using a pattern.
+    if (name.empty()) {
+      return TempFile::create(path_ / "XXXXXX");
+    }
+    return TempFile::create(path_ / (name + ".XXXXXX"));
+  }
+
+  // Using a fixed name.
+  if (name.empty()) {
+    return make_error<TempFileError>(name, EINVAL);
+  }
+  return TempFile::create(path_ / name, false);
+}
+
+TempDir::~TempDir()
+{
+  std::error_code ec;
+  std::filesystem::remove_all(path_, ec);
+  if (ec) {
+    LOG(WARNING) << "unable to remove directory: " << path_;
+  }
 }
 
 } // namespace bpftrace::util

--- a/src/util/temp.h
+++ b/src/util/temp.h
@@ -14,6 +14,10 @@ public:
       : origin_(std::move(origin)), err_(err) {};
   static char ID;
   void log(llvm::raw_ostream &OS) const override;
+  int err() const
+  {
+    return err_;
+  }
 
 private:
   std::string origin_;
@@ -23,9 +27,11 @@ private:
 // TempFile provide a convenient RAII wrapper for temporary files. The use of
 // temporary files should be generally discouraged, unless they are necessary
 // to interacting with other libraries or tools.
+//
+// Using `pattern = false` should only be done from `TempDir`.
 class TempFile {
 public:
-  static Result<TempFile> create(std::string pattern = "");
+  static Result<TempFile> create(std::string name = "", bool pattern = true);
   ~TempFile();
 
   TempFile(const TempFile &other) = delete;
@@ -58,6 +64,45 @@ private:
 
   std::filesystem::path path_;
   int fd_;
+};
+
+// TempDir provides a wrapper for temporary directories.
+//
+// There is no way to create directories with a fixed name.
+class TempDir {
+public:
+  static Result<TempDir> create(std::string pattern = "");
+  ~TempDir();
+
+  TempDir(const TempDir &other) = delete;
+  TempDir &operator=(const TempDir &other) = delete;
+
+  TempDir(TempDir &&other)
+  {
+    path_ = std::move(other.path_);
+  }
+  TempDir &operator=(TempDir &&other)
+  {
+    path_ = std::move(other.path_);
+    return *this;
+  }
+
+  const std::filesystem::path &path()
+  {
+    return path_;
+  }
+
+  // Creates a temporary file in this directory. Note that `name` need not
+  // contain any `X` characters if `pattern` is true, as these will be appended
+  // as a suffix. The `name` provided may hae path components, but this
+  // function will do not anything with respect to creating intermediate
+  // directories.
+  Result<TempFile> create_file(std::string name = "", bool pattern = true);
+
+private:
+  TempDir(std::filesystem::path &&path) : path_(std::move(path)) {};
+
+  std::filesystem::path path_;
 };
 
 } // namespace bpftrace::util

--- a/tests/temp.cpp
+++ b/tests/temp.cpp
@@ -6,7 +6,9 @@
 
 namespace bpftrace::test::types {
 
+using util::TempDir;
 using util::TempFile;
+using util::TempFileError;
 
 TEST(util, tempfile_no_pattern)
 {
@@ -35,6 +37,38 @@ TEST(util, tempfile_good_pattern)
   ASSERT_TRUE(bool(f2));
   EXPECT_TRUE(f1->path().filename().string().starts_with("testing."));
   EXPECT_TRUE(f2->path().filename().string().starts_with("testing."));
+}
+
+TEST(util, tempdir)
+{
+  auto d = TempDir::create();
+  ASSERT_TRUE(bool(d));
+  auto f1 = d->create_file("foo");
+  auto f2 = d->create_file("bar");
+  auto f3 = d->create_file();
+  ASSERT_TRUE(bool(f1));
+  ASSERT_TRUE(bool(f2));
+  ASSERT_TRUE(bool(f3));
+  EXPECT_TRUE(f1->path().filename().string().starts_with("foo."));
+  EXPECT_TRUE(f2->path().filename().string().starts_with("bar."));
+}
+
+TEST(util, tempdir_no_pattern)
+{
+  auto d = TempDir::create();
+  ASSERT_TRUE(bool(d));
+  auto f1 = d->create_file("foo", false);
+  auto f2 = d->create_file("bar", false);
+  ASSERT_TRUE(bool(f1));
+  ASSERT_TRUE(bool(f2));
+  EXPECT_EQ(f1->path().filename().string(), "foo");
+  EXPECT_EQ(f2->path().filename().string(), "bar");
+  auto ok = d->create_file("foo", false);
+  EXPECT_FALSE(bool(ok));
+  auto nowOk = handleErrors(std::move(ok), [&](const TempFileError &err) {
+    EXPECT_EQ(err.err(), EEXIST);
+  });
+  EXPECT_TRUE(bool(nowOk));
 }
 
 } // namespace bpftrace::test::types


### PR DESCRIPTION
Stacked PRs:
 * #4051
 * #4050
 * #4049
 * #4034
 * __->__#4090


--- --- ---

### util: add `TempDir` to create temporary directories


In order to add a common working directory, add a `TempDir` utility
which can collect a common set of temporary files.

Signed-off-by: Adin Scannell <amscanne@meta.com>
