### PR TITLE
Create wrapper for std::format

### DIFF
--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -1,4 +1,3 @@
-#include <format>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -8,6 +7,7 @@
 #include "ast/passes/macro_expansion.h"
 #include "ast/visitor.h"
 #include "bpftrace.h"
+#include "util/std_format.h"
 
 #include "log.h"
 
@@ -161,7 +161,7 @@ void MacroExpander::visit(Expression &expr)
 
 std::string MacroExpander::get_new_var_ident(std::string original_ident)
 {
-  return std::format("$${}_{}", macro_name_, original_ident);
+  return util::format("$${}_{}", macro_name_, original_ident);
 }
 
 std::optional<Block *> MacroExpander::expand(Macro &macro, const Call &call)

--- a/src/util/std_format.h
+++ b/src/util/std_format.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <format>
+#include <string>
+
+// This file/function is a hack to get around an internal Meta issue
+// whereby bpftrace is built without support for some C++20 features e.g.
+// std::format so we have this layer of indirection so this file can be replaced
+// with the `fmt` version of format.
+namespace bpftrace::util {
+
+template <typename... T>
+inline std::string format(std::format_string<T...> fmt, T &&...args)
+{
+  return std::format(fmt, std::forward<T &&>(args)...);
+}
+
+} // namespace bpftrace::util


### PR DESCRIPTION
Unfortunately bpftrace is built inside of Meta
infrastructure which doesn't yet support some C++20 features/functions including `std::format`.

This creates a wrapper around `std::format` that
Meta will replace internaly with `fmt::format`.

This is a hack that should be removed as soon
as `std::format` is supported at Meta.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
