### PR TITLE
Warnings for empty positional parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to
   - [#3999](https://github.com/bpftrace/bpftrace/pull/3999)
 - Add hygienic macros (behind an "unstable" config flag)
   - [#4037](https://github.com/bpftrace/bpftrace/pull/4037)
+- Add warning when unset or empty positional parameters are used
+  - [#4095](https://github.com/bpftrace/bpftrace/pull/4095)
 #### Changed
 - `-p` CLI flag now applies to all probes (except BEGIN/END)
   - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -354,6 +354,8 @@ std::optional<Expression> LiteralFolder::visit(PositionalParameter &param)
   const std::string &val = bpftrace_.get_param(param.n);
   // If empty, treat as zero. This is the documented behavior.
   if (val.empty()) {
+    param.addWarning() << "Positional parameter $" << param.n
+                       << " is empty or not provided. ";
     return ast_.make_node<Integer>(static_cast<uint64_t>(0),
                                    Location(param.loc));
   }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4997,4 +4997,13 @@ macro add2($x) { $x + 1 } macro add1($x) { add2($x) } BEGIN { $a = "string"; add
 )");
 }
 
+TEST(semantic_analyser, warning_for_empty_positional_parameters)
+{
+  BPFtrace bpftrace;
+  bpftrace.add_param("1");
+  test_for_warning(bpftrace,
+                   "BEGIN { print(($1, $2)) }",
+                   "Positional parameter $2 is empty or not provided.");
+}
+
 } // namespace bpftrace::test::semantic_analyser


### PR DESCRIPTION
This patch adds warnings when positional parameters are empty or not
provided. Use --no-warnings to suppress.

```
$ sudo ./result/bin/bpftrace -e 'BEGIN { print(($1, $2, $3, $4)) }' 34 "" "2"
stdin:1:20-22: WARNING: Positional parameter $2 is empty or not provided.
BEGIN { print(($1, $2, $3, $4)) }
                 ~~
stdin:1:28-30: WARNING: Positional parameter $4 is empty or not provided.
BEGIN { print(($1, $2, $3, $4)) }
                         ~~
Attaching 1 probe...
(34, 0, 2, 0)

$ sudo ./result/bin/bpftrace --no-warnings -e 'BEGIN { print(($1, $2, $3, $4)) }' 34 "" "2"
Attaching 1 probe...
(34, 0, 2, 0)
```

Fixes: https://github.com/bpftrace/bpftrace/issues/3555



<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
