### PR TITLE
lexer: add support for adjacent string literal concatenation (#2458)

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -56,6 +56,7 @@ hex_esc  (x|X)[0-9a-fA-F]{1,2}
 oct_esc  [0-7]{1,3}
 
 %x STR
+%x STR_CONCAT
 %x STRUCT
 %x ENUM
 %x BRACE
@@ -171,7 +172,10 @@ oct_esc  [0-7]{1,3}
 
 \"                      { yy_push_state(STR, yyscanner); driver.buffer.clear(); }
 <STR>{
-  \"                    { yy_pop_state(yyscanner); return Parser::make_STRING(driver.buffer, driver.loc); }
+  \"                    { 
+                          yy_pop_state(yyscanner); 
+                          yy_push_state(STR_CONCAT, yyscanner);
+                        }
   [^\\\n\"]+            driver.buffer += yytext;
   \\n                   driver.buffer += '\n';
   \\t                   driver.buffer += '\t';
@@ -191,6 +195,24 @@ oct_esc  [0-7]{1,3}
   \\.                   { driver.error(driver.loc, std::string("invalid escape character '") +
                                             yytext + "'"); }
   .                     driver.error(driver.loc, "invalid character"); yy_pop_state(yyscanner);
+}
+
+<STR_CONCAT>{
+  {hspace}+             { driver.loc.step(); }
+  {vspace}+             { driver.loc.lines(yyleng); driver.loc.step(); }
+  \"                    { 
+                          yy_pop_state(yyscanner);
+                          yy_push_state(STR, yyscanner);
+                        }
+  .                     { 
+                          unput(yytext[0]); /* Put the character back */
+                          yy_pop_state(yyscanner);
+                          return Parser::make_STRING(driver.buffer, driver.loc);
+                        }
+  <<EOF>>               { 
+                          yy_pop_state(yyscanner);
+                          return Parser::make_STRING(driver.buffer, driver.loc);
+                        }
 }
 
 struct|union|enum       {


### PR DESCRIPTION
**This change introduces a new lexer state, STR_CONCAT, to handle string concatenation more effectively. It modifies the STR state to transition to STR_CONCAT after encountering a closing quote ("), allowing additional handling for concatenated strings or whitespace. New rules in STR_CONCAT manage spaces, return to STR for further strings, or finalize the string token. This improves support for multi-line strings, location tracking, and error handling in the lexer.**

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
