### PR TITLE
Always fail if probes can't be attached

### DIFF
--- a/.github/include/aot_allow.txt
+++ b/.github/include/aot_allow.txt
@@ -191,7 +191,6 @@ aot.probe.uprobe_address_fail_resolve
 aot.probe.uprobe_offset
 aot.probe.uprobe_offset
 aot.probe.uprobe_offset_fail_size
-aot.probe.uprobe_warn_missing_probes
 aot.probe.uprobe_zero_size
 aot.probe.uretprobe
 aot.regression.access ctx struct field twice

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
   - [#3944](https://github.com/bpftrace/bpftrace/pull/3944)
 - Ustack and kstack symbols are automatically enhanced with debug info if available
   - [#3999](https://github.com/bpftrace/bpftrace/pull/3999)
+- Error by default if any probe fails to attach
+  - [#4097](https://github.com/bpftrace/bpftrace/pull/4097)
 #### Added
 - Add ncpus builtin to get the number of CPUs.
   - [#4105](https://github.com/bpftrace/bpftrace/pull/4105)

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -7,6 +7,23 @@ compatibility in some way. Each entry should contain:
 - an example of an error message
 - a simple guide to fix existing scripts
 
+## Versions 0.23.x (or earlier) to 0.24.x (or later)
+
+### Probe Attachment Failure Exits the Program
+
+Previously, if a probe with multiple attach points or a wildcard failed to attach,
+a warning would be printed and the program would continue to run. Now, if there
+are any attachment failures, the program will exit with an error.
+
+If it's expected that some probes will fail to attach, you can use the config
+variable 'missing_probes' to either `warn` or `ignore` these failures e.g.
+
+```
+config = {
+    missing_probes = "warn"
+}
+```
+
 ## Versions 0.21.x (or earlier) to 0.22.x (or later)
 
 ### Added block scoping for scratch variables
@@ -165,4 +182,3 @@ manually include the print statements in your signal handler probe:
 ```
 # bpftrace -e 'BEGIN { @b[1] = 2; } self:signal:SIGUSR1 { print(@b); }' & kill -s USR1 $(pidof bpftrace)
 ```
-

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1125,6 +1125,8 @@ kprobe:tcp_reset,kprobe:*socket* {
 }
 ----
 
+By default, bpftrace requires all probes to attach successfully or else an error is returned. However this can be changed using the `missing_probes` config variable.
+
 Most providers also support a short name which can be used instead of the full name, e.g. `kprobe:f` and `k:f` are identical.
 
 [cols="~,~,~,~"]
@@ -3785,11 +3787,9 @@ There is no artificial limit on what you can tune this to. But you may be wastin
 
 ==== missing_probes
 
-Default: `warn`
+Default: `error`
 
-Controls handling of probes with multiple kprobe or uprobe attach points which
-cannot be attached to some functions because they do not exist in the kernel or
-in the traced binary.
+Controls handling of probes which cannot be attached because they do not exist (in the kernel or in the traced binary) or there was an issue during attachment.
 
 The possible options are:
 - `error` - always fail on missing probes

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -14,9 +14,7 @@ void print_non_map_handler(BPFtrace &bpftrace, Output &out, const void *data);
 void print_map_handler(BPFtrace &bpftrace, Output &out, const void *data);
 void zero_map_handler(BPFtrace &bpftrace, const void *data);
 void clear_map_handler(BPFtrace &bpftrace, const void *data);
-void watchpoint_attach_handler(BPFtrace &bpftrace,
-                               Output &out,
-                               const void *data);
+void watchpoint_attach_handler(BPFtrace &bpftrace, const void *data);
 void watchpoint_detach_handler(BPFtrace &bpftrace, const void *data);
 void skboutput_handler(BPFtrace &bpftrace, void *data, int size);
 void syscall_handler(BPFtrace &bpftrace,

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -35,6 +35,13 @@
 
 namespace bpftrace {
 
+char AttachError::ID;
+
+void AttachError::log(llvm::raw_ostream &OS) const
+{
+  OS << msg_;
+}
+
 bpf_probe_attach_type attachtype(ProbeType t)
 {
   // clang-format off
@@ -95,15 +102,16 @@ std::string progtypeName(libbpf::bpf_prog_type t)
   }
 }
 
-void AttachedProbe::attach_fentry()
+Result<> AttachedProbe::attach_fentry()
 {
   if (progfd_ < 0)
-    return;
+    return make_error<AttachError>();
 
   tracing_fd_ = bpf_raw_tracepoint_open(nullptr, progfd_);
   if (tracing_fd_ < 0) {
-    throw util::FatalUserException("Error attaching probe: " + probe_.name);
+    return make_error<AttachError>();
   }
+  return OK();
 }
 
 int AttachedProbe::detach_fentry()
@@ -112,9 +120,9 @@ int AttachedProbe::detach_fentry()
   return 0;
 }
 
-void AttachedProbe::attach_iter(std::optional<int> pid)
+Result<> AttachedProbe::attach_iter()
 {
-  if (!pid.has_value()) {
+  if (!pid_.has_value()) {
     linkfd_ = bpf_link_create(progfd_,
                               0,
                               static_cast<enum ::bpf_attach_type>(
@@ -124,7 +132,7 @@ void AttachedProbe::attach_iter(std::optional<int> pid)
     BPFTRACE_LIBBPF_OPTS(bpf_link_create_opts, opts);
     union bpf_iter_link_info linfo;
     memset(&linfo, 0, sizeof(linfo));
-    linfo.task.pid = *pid;
+    linfo.task.pid = *pid_;
     opts.iter_info = &linfo;
     opts.iter_info_len = sizeof(linfo);
     linkfd_ = bpf_link_create(progfd_,
@@ -135,8 +143,9 @@ void AttachedProbe::attach_iter(std::optional<int> pid)
   }
 
   if (linkfd_ < 0) {
-    throw util::FatalUserException("Error attaching probe: " + probe_.name);
+    return make_error<AttachError>();
   }
+  return OK();
 }
 
 int AttachedProbe::detach_iter()
@@ -145,20 +154,20 @@ int AttachedProbe::detach_iter()
   return 0;
 }
 
-void AttachedProbe::attach_raw_tracepoint()
+Result<> AttachedProbe::attach_raw_tracepoint()
 {
   tracing_fd_ = bpf_raw_tracepoint_open(nullptr, progfd_);
   if (tracing_fd_ < 0) {
-    if (tracing_fd_ == -ENOENT)
-      throw util::FatalUserException("Probe does not exist: " + probe_.name);
-    else if (tracing_fd_ == -EINVAL)
-      throw util::FatalUserException(
-          "Error attaching probe: " + probe_.name +
-          ", maybe trying to access arguments beyond "
-          "what's available in this tracepoint");
-    else
-      throw util::FatalUserException("Error attaching probe: " + probe_.name);
+    if (tracing_fd_ == -ENOENT) {
+      return make_error<AttachError>("Probe does not exist: " + probe_.name);
+    } else if (tracing_fd_ == -EINVAL) {
+      return make_error<AttachError>(
+          "Maybe trying to access arguments beyond what's available in "
+          "this tracepoint");
+    }
+    return make_error<AttachError>();
   }
+  return OK();
 }
 
 int AttachedProbe::detach_raw_tracepoint()
@@ -167,60 +176,36 @@ int AttachedProbe::detach_raw_tracepoint()
   return 0;
 }
 
+Result<std::unique_ptr<AttachedProbe>> AttachedProbe::make(
+    Probe &probe,
+    const BpfProgram &prog,
+    std::optional<int> pid,
+    BPFtrace &bpftrace,
+    bool safe_mode)
+{
+  // Cannot use std::make_unique here b/c it won't have access to
+  // private constructor.
+  auto attached = std::unique_ptr<AttachedProbe>(
+      new AttachedProbe(probe, prog, pid, bpftrace, safe_mode));
+
+  auto result = attached->attach();
+  if (!result)
+    return result.takeError();
+
+  return attached;
+}
+
 AttachedProbe::AttachedProbe(Probe &probe,
                              const BpfProgram &prog,
                              std::optional<int> pid,
                              BPFtrace &bpftrace,
                              bool safe_mode)
-    : probe_(probe), progfd_(prog.fd()), bpftrace_(bpftrace)
+    : probe_(probe),
+      progfd_(prog.fd()),
+      bpftrace_(bpftrace),
+      pid_(pid),
+      safe_mode_(safe_mode)
 {
-  LOG(V1) << "Attaching " << probe_.orig_name;
-  switch (probe_.type) {
-    case ProbeType::kprobe:
-      attach_kprobe();
-      break;
-    case ProbeType::kretprobe:
-      attach_kprobe();
-      break;
-    case ProbeType::tracepoint:
-      attach_tracepoint();
-      break;
-    case ProbeType::profile:
-      attach_profile(pid);
-      break;
-    case ProbeType::interval:
-      attach_interval(pid);
-      break;
-    case ProbeType::software:
-      attach_software(pid);
-      break;
-    case ProbeType::hardware:
-      attach_hardware(pid);
-      break;
-    case ProbeType::fentry:
-    case ProbeType::fexit:
-      attach_fentry();
-      break;
-    case ProbeType::iter:
-      attach_iter(pid);
-      break;
-    case ProbeType::rawtracepoint:
-      attach_raw_tracepoint();
-      break;
-    case ProbeType::usdt:
-      attach_usdt(pid, *bpftrace_.feature_);
-      break;
-    case ProbeType::watchpoint:
-    case ProbeType::asyncwatchpoint:
-      attach_watchpoint(pid, probe.mode);
-      break;
-    case ProbeType::uprobe:
-    case ProbeType::uretprobe:
-      attach_uprobe(pid, safe_mode);
-      break;
-    default:
-      LOG(BUG) << "invalid attached probe type \"" << probe_.type << "\"";
-  }
 }
 
 AttachedProbe::~AttachedProbe()
@@ -282,6 +267,44 @@ AttachedProbe::~AttachedProbe()
     close(progfd_);
 }
 
+Result<> AttachedProbe::attach()
+{
+  LOG(V1) << "Trying to attach probe: " << probe_.orig_name;
+  switch (probe_.type) {
+    case ProbeType::kprobe:
+    case ProbeType::kretprobe:
+      return attach_kprobe();
+    case ProbeType::tracepoint:
+      return attach_tracepoint();
+    case ProbeType::profile:
+      return attach_profile();
+    case ProbeType::interval:
+      return attach_interval();
+    case ProbeType::software:
+      return attach_software();
+    case ProbeType::hardware:
+      return attach_hardware();
+    case ProbeType::fentry:
+    case ProbeType::fexit:
+      return attach_fentry();
+    case ProbeType::iter:
+      return attach_iter();
+    case ProbeType::rawtracepoint:
+      return attach_raw_tracepoint();
+    case ProbeType::usdt:
+      return attach_usdt(*bpftrace_.feature_);
+    case ProbeType::watchpoint:
+    case ProbeType::asyncwatchpoint:
+      return attach_watchpoint(probe_.mode);
+    case ProbeType::uprobe:
+    case ProbeType::uretprobe:
+      return attach_uprobe(safe_mode_);
+    default:
+      LOG(BUG) << "invalid attached probe type \"" << probe_.type << "\"";
+  }
+  return OK();
+}
+
 const Probe &AttachedProbe::probe() const
 {
   return probe_;
@@ -329,16 +352,17 @@ std::string AttachedProbe::eventname() const
   }
 }
 
-static uint64_t resolve_offset(const std::string &path,
-                               const std::string &symbol,
-                               uint64_t loc)
+Result<uint64_t> AttachedProbe::resolve_offset(const std::string &path,
+                                               const std::string &symbol,
+                                               uint64_t loc)
 {
   bcc_symbol bcc_sym;
 
   if (bcc_resolve_symname(
-          path.c_str(), symbol.c_str(), loc, 0, nullptr, &bcc_sym))
-    throw util::FatalUserException("Could not resolve symbol: " + path + ":" +
+          path.c_str(), symbol.c_str(), loc, 0, nullptr, &bcc_sym)) {
+    return make_error<AttachError>("Could not resolve symbol: " + path + ":" +
                                    symbol);
+  }
 
   // Have to free sym.module, see:
   // https://github.com/iovisor/bcc/blob/ba73657cb8c4dab83dfb89eed4a8b3866255569a/src/cc/bcc_syms.h#L98-L99
@@ -352,12 +376,12 @@ static constexpr std::string_view hint_unsafe =
     "\nUse --unsafe to force attachment. WARNING: This option could lead to "
     "data corruption in the target process.";
 
-static void check_alignment(std::string &path,
-                            std::string &symbol,
-                            uint64_t sym_offset,
-                            uint64_t func_offset,
-                            bool safe_mode,
-                            ProbeType type)
+Result<> AttachedProbe::check_alignment(std::string &path,
+                                        std::string &symbol,
+                                        uint64_t sym_offset,
+                                        uint64_t func_offset,
+                                        bool safe_mode,
+                                        ProbeType type)
 {
   Disasm dasm(path);
   AlignState aligned = dasm.is_aligned(sym_offset, func_offset);
@@ -366,42 +390,42 @@ static void check_alignment(std::string &path,
 
   switch (aligned) {
     case AlignState::Ok:
-      return;
+      return OK();
     case AlignState::NotAlign:
       if (safe_mode) {
-        auto msg = "Could not add " + probetypeName(type) +
-                   " into middle of instruction: " + tmp +
-                   std::string{ hint_unsafe };
-        throw util::FatalUserException(std::move(msg));
+        return make_error<AttachError>("Could not add " + probetypeName(type) +
+                                       " into middle of instruction: " + tmp +
+                                       std::string{ hint_unsafe });
       } else {
         std::string_view hint;
         LOG(WARNING) << "Unsafe " << type
                      << " in the middle of the instruction: " << tmp << hint;
+        return OK();
       }
-      break;
-
     case AlignState::Fail:
-      if (safe_mode)
-        throw util::FatalUserException(
+      if (safe_mode) {
+        return make_error<AttachError>(
             "Failed to check if " + probetypeName(type) +
             " is in proper place: " + tmp + std::string{ hint_unsafe });
-      else
+      } else {
         LOG(WARNING) << "Unchecked " << type << ": " << tmp;
-      break;
-
+        return OK();
+      }
     case AlignState::NotSupp:
-      if (safe_mode)
-        throw util::FatalUserException("Can't check if " + probetypeName(type) +
+      if (safe_mode) {
+        return make_error<AttachError>("Can't check if " + probetypeName(type) +
                                        " is in proper place (compiled without "
                                        "(k|u)probe offset support): " +
                                        tmp + std::string{ hint_unsafe });
-      else
-        LOG(WARNING) << "Unchecked " << type << " : " << tmp;
-      break;
+      } else {
+        LOG(WARNING) << "Unchecked " << type << ": " << tmp;
+        return OK();
+      }
   }
+  return OK();
 }
 
-bool AttachedProbe::resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps)
+Result<> AttachedProbe::resolve_offset_uprobe(bool safe_mode)
 {
   struct bcc_symbol_option option = {};
   struct symbol sym = {};
@@ -421,7 +445,7 @@ bool AttachedProbe::resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps)
       if (safe_mode) {
         std::stringstream ss;
         ss << "0x" << std::hex << probe_.address;
-        throw util::FatalUserException(
+        return make_error<AttachError>(
             "Could not resolve address: " + probe_.path + ":" + ss.str());
       } else {
         LOG(WARNING) << "Could not determine instruction boundary for "
@@ -429,7 +453,7 @@ bool AttachedProbe::resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps)
                      << " (binary appears stripped). Misaligned probes "
                         "can lead to tracee crashes!";
         offset_ = probe_.address;
-        return true;
+        return OK();
       }
     }
 
@@ -440,21 +464,13 @@ bool AttachedProbe::resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps)
     bcc_elf_foreach_sym(probe_.path.c_str(), util::sym_name_cb, &option, &sym);
 
     if (!sym.start) {
-      const std::string msg = "Could not resolve symbol: " + probe_.path + ":" +
-                              symbol;
-      const auto missing_probes = bpftrace_.config_->missing_probes;
-      if (!has_multiple_aps || missing_probes == ConfigMissingProbes::error) {
-        throw util::FatalUserException(msg + ", cannot attach probe.");
-      } else {
-        if (missing_probes == ConfigMissingProbes::warn)
-          LOG(WARNING) << msg << ", skipping probe.";
-        return false;
-      }
+      return make_error<AttachError>(
+          "Could not resolve symbol: " + probe_.path + ":" + symbol);
     }
   }
 
   if (probe_.type == ProbeType::uretprobe && func_offset != 0) {
-    throw util::FatalUserException("uretprobes cannot be attached at function "
+    return make_error<AttachError>("uretprobes cannot be attached at function "
                                    "offset. (address resolved to: " +
                                    symbol + "+" + std::to_string(func_offset) +
                                    ")");
@@ -467,41 +483,44 @@ bool AttachedProbe::resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps)
           << " (symbol has size 0).";
       if (probe_.orig_name == probe_.name) {
         msg << hint_unsafe;
-        throw util::FatalUserException(msg.str());
+        return make_error<AttachError>(msg.str());
       } else {
         LOG(WARNING) << msg.str() << " Skipping attachment." << hint_unsafe;
       }
-      return false;
+      return make_error<AttachError>();
     }
   } else if (func_offset >= sym.size) {
-    throw util::FatalUserException("Offset outside the function bounds ('" +
+    return make_error<AttachError>("Offset outside the function bounds ('" +
                                    symbol + "' size is " +
                                    std::to_string(sym.size) + ")");
   }
 
-  uint64_t sym_offset = resolve_offset(probe_.path,
-                                       probe_.attach_point,
-                                       probe_.loc);
-  offset_ = sym_offset + func_offset;
+  auto sym_offset = resolve_offset(probe_.path,
+                                   probe_.attach_point,
+                                   probe_.loc);
+  if (!sym_offset) {
+    return sym_offset.takeError();
+  }
+
+  offset_ = *sym_offset + func_offset;
 
   // If we are not aligned to the start of the symbol,
   // check if we are on the instruction boundary.
   if (func_offset == 0)
-    return true;
+    return OK();
 
-  check_alignment(
-      probe_.path, symbol, sym_offset, func_offset, safe_mode, probe_.type);
-  return true;
+  return check_alignment(
+      probe_.path, symbol, *sym_offset, func_offset, safe_mode, probe_.type);
 }
 
-void AttachedProbe::resolve_offset_kprobe()
+Result<> AttachedProbe::resolve_offset_kprobe()
 {
   offset_ = probe_.func_offset;
 
   // If we are using only the symbol, we don't need to check the offset.
   bool is_symbol_kprobe = !probe_.attach_point.empty();
   if (is_symbol_kprobe && probe_.func_offset == 0)
-    return;
+    return OK();
 
   // Setup the symbol to resolve, either using the address or the name.
   struct symbol sym = {};
@@ -512,15 +531,16 @@ void AttachedProbe::resolve_offset_kprobe()
 
   auto path = find_vmlinux(&sym);
   if (!path.has_value()) {
-    if (!is_symbol_kprobe)
-      throw util::FatalUserException("Could not resolve address: " +
+    if (!is_symbol_kprobe) {
+      return make_error<AttachError>("Could not resolve address: " +
                                      std::to_string(probe_.address));
+    }
 
     LOG(V1) << "Could not resolve symbol " << probe_.attach_point
             << ". Skipping usermode offset checking.";
     LOG(V1) << "The kernel will verify the safety of the location but "
                "will also allow the offset to be in a different symbol.";
-    return;
+    return OK();
   }
 
   // Populate probe_ fields according to the resolved symbol.
@@ -538,13 +558,15 @@ void AttachedProbe::resolve_offset_kprobe()
                   std::to_string(probe_.func_offset);
   }
 
-  if (probe_.func_offset >= sym.size)
-    throw util::FatalUserException("Offset outside the function bounds ('" +
+  if (probe_.func_offset >= sym.size) {
+    return make_error<AttachError>("Offset outside the function bounds ('" +
                                    probe_.attach_point + "' size is " +
                                    std::to_string(sym.size) + ")");
+  }
+  return OK();
 }
 
-void AttachedProbe::attach_multi_kprobe()
+Result<> AttachedProbe::attach_multi_kprobe()
 {
   BPFTRACE_LIBBPF_OPTS(bpf_link_create_opts, opts);
   std::vector<const char *> syms;
@@ -573,54 +595,44 @@ void AttachedProbe::attach_multi_kprobe()
   linkfd_ = bpf_link_create(
       progfd_, 0, static_cast<enum ::bpf_attach_type>(attach_type), &opts);
   if (linkfd_ < 0) {
-    throw util::FatalUserException("Error attaching probe: " + probe_.name);
+    return make_error<AttachError>();
   }
+
+  return OK();
 }
 
-void AttachedProbe::attach_kprobe()
+Result<> AttachedProbe::attach_kprobe()
 {
   if (!probe_.funcs.empty()) {
-    attach_multi_kprobe();
-    return;
+    return attach_multi_kprobe();
   }
 
+  if ((!probe_.attach_point.empty() || probe_.address != 0) &&
+      !bpftrace_.is_traceable_func(probe_.attach_point))
+    return make_error<AttachError>();
+
   // Construct a string containing "module:function."
-  // Also log a warning or throw an error if the module doesn't exist,
-  // before attempting to attach.
   // Note that we do not pass vmlinux, if it is specified.
   std::string funcname = probe_.attach_point;
   const std::string &modname = probe_.path;
   if ((!modname.empty()) && modname != "vmlinux") {
     if (!util::is_module_loaded(modname)) {
-      std::string message = "specified module " + modname + " in probe " +
-                            probe_.name + " is not loaded.";
-      if (probe_.orig_name != probe_.name) {
-        // Wildcard usage just gets a warning
-        LOG(WARNING) << message;
-      } else {
-        // Explicitly specified modules should fail
-        throw util::FatalUserException("Error attaching probe: " + probe_.name +
-                                       ": " + message);
-      }
+      return make_error<AttachError>("specified module " + modname +
+                                     " in probe " + probe_.name +
+                                     " is not loaded.");
     }
     funcname = modname + ":" + funcname;
   }
-
-  // If the user requested to ignore warnings on non-existing probes and the
-  // function is not traceable, do not even try to attach as that would yield
-  // warnings from BCC which we don't want to see.
-  if (bpftrace_.config_->missing_probes == ConfigMissingProbes::ignore &&
-      probe_.name != probe_.orig_name &&
-      (!funcname.empty() || probe_.address != 0) &&
-      !bpftrace_.is_traceable_func(funcname))
-    return;
 
   // The kprobe can either be defined by a symbol+offset or an address:
   // For symbol+offset kprobe, we need to check the validity of the offset.
   // For address kprobe, we need to resolve into the symbol+offset and
   // populate `funcname` with the results stored back in the probe_.
   bool is_symbol_kprobe = !probe_.attach_point.empty();
-  resolve_offset_kprobe();
+  auto offset_res = resolve_offset_kprobe();
+  if (!offset_res) {
+    return offset_res.takeError();
+  }
   if (!is_symbol_kprobe)
     funcname += probe_.attach_point;
 
@@ -634,21 +646,15 @@ void AttachedProbe::attach_kprobe()
                                         0);
 
   if (perf_event_fd < 0) {
-    if (probe_.orig_name != probe_.name &&
-        bpftrace_.config_->missing_probes == ConfigMissingProbes::warn) {
-      // a wildcard expansion couldn't probe something, just print a warning
-      // as this is normal for some kernel functions (eg, do_debug())
-      LOG(WARNING) << "could not attach probe " << probe_.name << ", skipping.";
-    } else {
-      if (errno == EILSEQ)
-        LOG(ERROR) << "Possible attachment attempt in the middle of an "
-                      "instruction, try a different offset.";
-      // an explicit match failed, so fail as the user must have wanted it
-      throw util::FatalUserException("Error attaching probe: " + probe_.name);
-    }
+    if (errno == EILSEQ)
+      return make_error<AttachError>(
+          "Possible attachment attempt in the middle of an instruction, "
+          "try a different offset.");
+    return make_error<AttachError>();
   }
 
   perf_event_fds_.push_back(perf_event_fd);
+  return OK();
 }
 
 #ifdef HAVE_LIBBPF_UPROBE_MULTI
@@ -693,11 +699,12 @@ static int bcc_load_cb(uint64_t v_addr,
   return 0;
 }
 
-static void resolve_offset_uprobe_multi(const std::string &path,
-                                        const std::string &probe_name,
-                                        const std::vector<std::string> &funcs,
-                                        std::vector<std::string> &syms,
-                                        std::vector<unsigned long> &offsets)
+Result<> AttachedProbe::resolve_offset_uprobe_multi(
+    const std::string &path,
+    const std::string &probe_name,
+    const std::vector<std::string> &funcs,
+    std::vector<std::string> &syms,
+    std::vector<unsigned long> &offsets)
 {
   struct bcc_symbol_option option = {};
   int err;
@@ -707,7 +714,7 @@ static void resolve_offset_uprobe_multi(const std::string &path,
     auto pos = func.find(':');
 
     if (pos == std::string::npos) {
-      throw util::FatalUserException("Error resolving probe: " + probe_name);
+      return make_error<AttachError>("Error resolving probe: " + probe_name);
     }
 
     syms.push_back(func.substr(pos + 1));
@@ -728,7 +735,7 @@ static void resolve_offset_uprobe_multi(const std::string &path,
   // Resolve symbols into addresses
   err = bcc_elf_foreach_sym(path.c_str(), bcc_sym_cb, &option, &data);
   if (err) {
-    throw util::FatalUserException("Failed to list symbols for probe: " +
+    return make_error<AttachError>("Failed to list symbols for probe: " +
                                    probe_name);
   }
 
@@ -744,24 +751,28 @@ static void resolve_offset_uprobe_multi(const std::string &path,
   // Translate addresses into offsets
   err = bcc_elf_foreach_load_section(path.c_str(), bcc_load_cb, &addrs);
   if (err) {
-    throw util::FatalUserException(
+    return make_error<AttachError>(
         "Failed to resolve symbols offsets for probe: " + probe_name);
   }
 
   for (auto a : addrs) {
     offsets.push_back(a.offset);
   }
+  return OK();
 }
 
-void AttachedProbe::attach_multi_uprobe(std::optional<int> pid)
+Result<> AttachedProbe::attach_multi_uprobe()
 {
   std::vector<std::string> syms;
   std::vector<unsigned long> offsets;
   unsigned int i;
 
   // Resolve probe_.funcs into offsets and syms vector
-  resolve_offset_uprobe_multi(
+  auto offset_res = resolve_offset_uprobe_multi(
       probe_.path, probe_.name, probe_.funcs, syms, offsets);
+  if (!offset_res) {
+    return offset_res.takeError();
+  }
 
   // Attach uprobe through uprobe_multi link
   BPFTRACE_LIBBPF_OPTS(bpf_link_create_opts, opts);
@@ -772,8 +783,8 @@ void AttachedProbe::attach_multi_uprobe(std::optional<int> pid)
   opts.uprobe_multi.flags = probe_.type == ProbeType::uretprobe
                                 ? BPF_F_UPROBE_MULTI_RETURN
                                 : 0;
-  if (pid.has_value()) {
-    opts.uprobe_multi.pid = *pid;
+  if (pid_.has_value()) {
+    opts.uprobe_multi.pid = *pid_;
   }
 
   if (bt_verbose) {
@@ -788,39 +799,44 @@ void AttachedProbe::attach_multi_uprobe(std::optional<int> pid)
                             static_cast<enum ::bpf_attach_type>(
                                 libbpf::BPF_TRACE_UPROBE_MULTI),
                             &opts);
+
   if (linkfd_ < 0) {
-    throw util::FatalUserException("Error attaching probe: " + probe_.name);
+    return make_error<AttachError>();
   }
+
+  return OK();
 }
 #else
-void AttachedProbe::attach_multi_uprobe([[maybe_unused]] std::optional<int> pid)
+void AttachedProbe::attach_multi_uprobe()
 {
 }
 #endif // HAVE_LIBBPF_UPROBE_MULTI
 
-void AttachedProbe::attach_uprobe(std::optional<int> pid, bool safe_mode)
+Result<> AttachedProbe::attach_uprobe(bool safe_mode)
 {
   if (!probe_.funcs.empty()) {
-    attach_multi_uprobe(pid);
-    return;
+    return attach_multi_uprobe();
   }
 
-  if (!resolve_offset_uprobe(safe_mode, probe_.orig_name != probe_.name))
-    return;
+  auto offset_res = resolve_offset_uprobe(safe_mode);
+  if (!offset_res) {
+    return offset_res.takeError();
+  }
 
   int perf_event_fd = bpf_attach_uprobe(progfd_,
                                         attachtype(probe_.type),
                                         eventname().c_str(),
                                         probe_.path.c_str(),
                                         offset_,
-                                        pid.has_value() ? *pid : -1,
+                                        pid_.has_value() ? *pid_ : -1,
                                         0);
 
   if (perf_event_fd < 0) {
-    throw util::FatalUserException("Error attaching probe: " + probe_.name);
+    return make_error<AttachError>();
   }
 
   perf_event_fds_.push_back(perf_event_fd);
+  return OK();
 }
 
 int AttachedProbe::usdt_sem_up_manual(const std::string &fn_name, void *ctx)
@@ -907,7 +923,7 @@ int AttachedProbe::usdt_sem_up([[maybe_unused]] BPFfeature &feature,
   return usdt_sem_up_manual_addsem(pid, fn_name, ctx);
 }
 
-void AttachedProbe::attach_usdt(std::optional<int> pid, BPFfeature &feature)
+Result<> AttachedProbe::attach_usdt(BPFfeature &feature)
 {
   struct bcc_usdt_location loc = {};
   int err;
@@ -916,24 +932,27 @@ void AttachedProbe::attach_usdt(std::optional<int> pid, BPFfeature &feature)
   // probe:
   std::string fn_name = "probe_" + probe_.attach_point + "_1";
 
-  if (pid.has_value()) {
+  if (pid_.has_value()) {
     // FIXME when iovisor/bcc#2064 is merged, optionally pass probe_.path
-    ctx = bcc_usdt_new_frompid(*pid, nullptr);
-    if (!ctx)
-      throw util::FatalUserException(
+    ctx = bcc_usdt_new_frompid(*pid_, nullptr);
+    if (!ctx) {
+      return make_error<AttachError>(
           "Error initializing context for probe: " + probe_.name +
-          ", for PID: " + std::to_string(*pid));
+          ", for PID: " + std::to_string(*pid_));
+    }
   } else {
     ctx = bcc_usdt_new_frompath(probe_.path.c_str());
-    if (!ctx)
-      throw util::FatalUserException("Error initializing context for probe: " +
+    if (!ctx) {
+      return make_error<AttachError>("Error initializing context for probe: " +
                                      probe_.name);
+    }
   }
 
   // Resolve location of usdt probe
-  auto u = usdt_helper.find(pid, probe_.path, probe_.ns, probe_.attach_point);
-  if (!u.has_value())
-    throw util::FatalUserException("Failed to find usdt probe: " + eventname());
+  auto u = usdt_helper.find(pid_, probe_.path, probe_.ns, probe_.attach_point);
+  if (!u.has_value()) {
+    return make_error<AttachError>("Failed to find usdt probe: " + eventname());
+  }
   probe_.path = u->path;
 
   err = bcc_usdt_get_location(ctx,
@@ -941,27 +960,32 @@ void AttachedProbe::attach_usdt(std::optional<int> pid, BPFfeature &feature)
                               probe_.attach_point.c_str(),
                               probe_.usdt_location_idx,
                               &loc);
-  if (err)
-    throw util::FatalUserException("Error finding location for probe: " +
+  if (err) {
+    return make_error<AttachError>("Error finding location for probe: " +
                                    probe_.name);
+  }
   probe_.loc = loc.address;
 
-  offset_ = resolve_offset(probe_.path, probe_.attach_point, probe_.loc);
+  auto offset = resolve_offset(probe_.path, probe_.attach_point, probe_.loc);
+
+  if (!offset) {
+    return offset.takeError();
+  }
+
+  offset_ = *offset;
 
   // Should be 0 if there's no semaphore
-  //
   // Cast to 32 bits b/c kernel API only takes 32 bit offset
   [[maybe_unused]] auto semaphore_offset = static_cast<uint32_t>(
       u->semaphore_offset);
 
   // Increment the semaphore count (will noop if no semaphore)
-  //
   // NB: Do *not* use `ctx` after this call. It may either be open or closed,
   // depending on which path was taken.
-  err = usdt_sem_up(feature, pid.value_or(0), fn_name, ctx);
+  err = usdt_sem_up(feature, pid_.value_or(0), fn_name, ctx);
 
   if (err) {
-    throw util::FatalUserException(
+    return make_error<AttachError>(
         "Error finding or enabling probe: " + probe_.name +
         "\n Try using -p or --usdt-file-activation if there's USDT semaphores");
   }
@@ -971,34 +995,36 @@ void AttachedProbe::attach_usdt(std::optional<int> pid, BPFfeature &feature)
                                         eventname().c_str(),
                                         probe_.path.c_str(),
                                         offset_,
-                                        pid.has_value() ? *pid : -1,
+                                        pid_.has_value() ? *pid_ : -1,
                                         semaphore_offset);
 
   if (perf_event_fd < 0) {
-    if (pid.has_value())
-      throw util::FatalUserException("Error attaching probe: " + probe_.name +
-                                     ", to PID: " + std::to_string(*pid));
-    else
-      throw util::FatalUserException("Error attaching probe: " + probe_.name);
+    if (pid_.has_value())
+      return make_error<AttachError>("Does PID exist? PID: " +
+                                     std::to_string(*pid_));
+
+    return make_error<AttachError>();
   }
 
   perf_event_fds_.push_back(perf_event_fd);
+  return OK();
 }
 
-void AttachedProbe::attach_tracepoint()
+Result<> AttachedProbe::attach_tracepoint()
 {
   int perf_event_fd = bpf_attach_tracepoint(progfd_,
                                             probe_.path.c_str(),
                                             eventname().c_str());
 
   if (perf_event_fd < 0 && probe_.name == probe_.orig_name) {
-    throw util::FatalUserException("Error attaching probe: " + probe_.name);
+    return make_error<AttachError>();
   }
 
   perf_event_fds_.push_back(perf_event_fd);
+  return OK();
 }
 
-void AttachedProbe::attach_profile(std::optional<int> pid)
+Result<> AttachedProbe::attach_profile()
 {
   int group_fd = -1;
 
@@ -1016,7 +1042,7 @@ void AttachedProbe::attach_profile(std::optional<int> pid)
     period = probe_.freq * 1e3;
     freq = 0;
   } else {
-    throw util::FatalUserException("invalid profile path \"" + probe_.path +
+    return make_error<AttachError>("invalid profile path \"" + probe_.path +
                                    "\"");
   }
 
@@ -1027,19 +1053,20 @@ void AttachedProbe::attach_profile(std::optional<int> pid)
                                               PERF_COUNT_SW_CPU_CLOCK,
                                               period,
                                               freq,
-                                              pid.has_value() ? *pid : -1,
+                                              pid_.has_value() ? *pid_ : -1,
                                               cpu,
                                               group_fd);
 
     if (perf_event_fd < 0) {
-      throw util::FatalUserException("Error attaching probe: " + probe_.name);
+      return make_error<AttachError>();
     }
 
     perf_event_fds_.push_back(perf_event_fd);
   }
+  return OK();
 }
 
-void AttachedProbe::attach_interval(std::optional<int> pid)
+Result<> AttachedProbe::attach_interval()
 {
   int group_fd = -1;
   int cpu = 0;
@@ -1054,7 +1081,7 @@ void AttachedProbe::attach_interval(std::optional<int> pid)
   } else if (probe_.path == "hz") {
     freq = probe_.freq;
   } else {
-    throw util::FatalUserException("invalid interval path \"" + probe_.path +
+    return make_error<AttachError>("invalid interval path \"" + probe_.path +
                                    "\"");
   }
 
@@ -1063,18 +1090,19 @@ void AttachedProbe::attach_interval(std::optional<int> pid)
                                             PERF_COUNT_SW_CPU_CLOCK,
                                             period,
                                             freq,
-                                            pid.has_value() ? *pid : -1,
+                                            pid_.has_value() ? *pid_ : -1,
                                             cpu,
                                             group_fd);
 
   if (perf_event_fd < 0) {
-    throw util::FatalUserException("Error attaching probe: " + probe_.name);
+    return make_error<AttachError>();
   }
 
   perf_event_fds_.push_back(perf_event_fd);
+  return OK();
 }
 
-void AttachedProbe::attach_software(std::optional<int> pid)
+Result<> AttachedProbe::attach_software()
 {
   int group_fd = -1;
 
@@ -1101,19 +1129,20 @@ void AttachedProbe::attach_software(std::optional<int> pid)
                                               type,
                                               period,
                                               0,
-                                              pid.has_value() ? *pid : -1,
+                                              pid_.has_value() ? *pid_ : -1,
                                               cpu,
                                               group_fd);
 
     if (perf_event_fd < 0) {
-      throw util::FatalUserException("Error attaching probe: " + probe_.name);
+      return make_error<AttachError>();
     }
 
     perf_event_fds_.push_back(perf_event_fd);
   }
+  return OK();
 }
 
-void AttachedProbe::attach_hardware(std::optional<int> pid)
+Result<> AttachedProbe::attach_hardware()
 {
   int group_fd = -1;
 
@@ -1140,20 +1169,20 @@ void AttachedProbe::attach_hardware(std::optional<int> pid)
                                               type,
                                               period,
                                               0,
-                                              pid.has_value() ? *pid : -1,
+                                              pid_.has_value() ? *pid_ : -1,
                                               cpu,
                                               group_fd);
 
     if (perf_event_fd < 0) {
-      throw util::FatalUserException("Error attaching probe: " + probe_.name);
+      return make_error<AttachError>();
     }
 
     perf_event_fds_.push_back(perf_event_fd);
   }
+  return OK();
 }
 
-void AttachedProbe::attach_watchpoint(std::optional<int> pid,
-                                      const std::string &mode)
+Result<> AttachedProbe::attach_watchpoint(const std::string &mode)
 {
   struct perf_event_attr attr = {};
   attr.type = PERF_TYPE_BREAKPOINT;
@@ -1177,7 +1206,7 @@ void AttachedProbe::attach_watchpoint(std::optional<int> pid,
   attr.sample_period = 1;
 
   std::vector<int> cpus;
-  if (pid.has_value()) {
+  if (pid_.has_value()) {
     cpus = { -1 };
   } else {
     cpus = util::get_online_cpus();
@@ -1189,33 +1218,31 @@ void AttachedProbe::attach_watchpoint(std::optional<int> pid,
     // want bcc's noisy error messages).
     int perf_event_fd = syscall(__NR_perf_event_open,
                                 &attr,
-                                pid.has_value() ? *pid : -1,
+                                pid_.has_value() ? *pid_ : -1,
                                 cpu,
                                 -1,
                                 PERF_FLAG_FD_CLOEXEC);
     if (perf_event_fd < 0) {
+      std::string err_msg;
       if (errno == ENOSPC)
-        throw util::EnospcException("No more HW registers left");
-      else
-        throw std::system_error(errno,
-                                std::generic_category(),
-                                "Error attaching probe: " + probe_.name);
+        err_msg = "No more HW registers left";
+
+      return make_error<AttachError>(std::move(err_msg));
     }
     if (ioctl(perf_event_fd, PERF_EVENT_IOC_SET_BPF, progfd_) != 0) {
       close(perf_event_fd);
-      throw std::system_error(errno,
-                              std::generic_category(),
-                              "Error attaching probe: " + probe_.name);
+      return make_error<AttachError>(
+          std::system_error(errno, std::generic_category(), "").what());
     }
     if (ioctl(perf_event_fd, PERF_EVENT_IOC_ENABLE, 0) != 0) {
       close(perf_event_fd);
-      throw std::system_error(errno,
-                              std::generic_category(),
-                              "Error attaching probe: " + probe_.name);
+      return make_error<AttachError>(
+          std::system_error(errno, std::generic_category(), "").what());
     }
 
     perf_event_fds_.push_back(perf_event_fd);
   }
+  return OK();
 }
 
 } // namespace bpftrace

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -10,6 +10,7 @@
 #include "btf.h"
 #include "probe_types.h"
 #include "usdt.h"
+#include "util/result.h"
 
 namespace bpftrace {
 
@@ -17,13 +18,29 @@ bpf_probe_attach_type attachtype(ProbeType t);
 libbpf::bpf_prog_type progtype(ProbeType t);
 std::string progtypeName(libbpf::bpf_prog_type t);
 
+class AttachError : public ErrorInfo<AttachError> {
+public:
+  AttachError(std::string &&msg) : msg_(std::move(msg)) {};
+  AttachError() = default;
+  static char ID;
+  void log(llvm::raw_ostream &OS) const override;
+  const std::string &msg() const
+  {
+    return msg_;
+  }
+
+private:
+  std::string msg_;
+};
+
 class AttachedProbe {
 public:
-  AttachedProbe(Probe &probe,
-                const BpfProgram &prog,
-                std::optional<int> pid,
-                BPFtrace &bpftrace,
-                bool safe_mode = true);
+  static Result<std::unique_ptr<AttachedProbe>> make(Probe &probe,
+                                                     const BpfProgram &prog,
+                                                     std::optional<int> pid,
+                                                     BPFtrace &bpftrace,
+                                                     bool safe_mode = true);
+
   ~AttachedProbe();
   AttachedProbe(const AttachedProbe &) = delete;
   AttachedProbe &operator=(const AttachedProbe &) = delete;
@@ -33,14 +50,28 @@ public:
   int linkfd_ = -1;
 
 private:
+  AttachedProbe(Probe &probe,
+                const BpfProgram &prog,
+                std::optional<int> pid,
+                BPFtrace &bpftrace,
+                bool safe_mode);
+  Result<> attach();
   std::string eventprefix() const;
   std::string eventname() const;
-  void resolve_offset_kprobe();
-  bool resolve_offset_uprobe(bool safe_mode, bool has_multiple_aps);
-  void attach_multi_kprobe();
-  void attach_multi_uprobe(std::optional<int> pid);
-  void attach_kprobe();
-  void attach_uprobe(std::optional<int> pid, bool safe_mode);
+  Result<uint64_t> resolve_offset(const std::string &path,
+                                  const std::string &symbol,
+                                  uint64_t loc);
+  Result<> resolve_offset_kprobe();
+  Result<> resolve_offset_uprobe(bool safe_mode);
+  Result<> resolve_offset_uprobe_multi(const std::string &path,
+                                       const std::string &probe_name,
+                                       const std::vector<std::string> &funcs,
+                                       std::vector<std::string> &syms,
+                                       std::vector<unsigned long> &offsets);
+  Result<> attach_multi_kprobe();
+  Result<> attach_multi_uprobe();
+  Result<> attach_kprobe();
+  Result<> attach_uprobe(bool safe_mode);
 
   // Note: the following usdt attachment functions will only activate a
   // semaphore if one exists.
@@ -54,24 +85,30 @@ private:
                   int pid,
                   const std::string &fn_name,
                   void *ctx);
-  void attach_usdt(std::optional<int> pid, BPFfeature &feature);
+  Result<> attach_usdt(BPFfeature &feature);
 
-  void attach_tracepoint();
-  void attach_profile(std::optional<int> pid);
-  void attach_interval(std::optional<int> pid);
-  void attach_software(std::optional<int> pid);
-  void attach_hardware(std::optional<int> pid);
-  void attach_watchpoint(std::optional<int> pid, const std::string &mode);
-  void attach_fentry();
+  Result<> attach_tracepoint();
+  Result<> attach_profile();
+  Result<> attach_interval();
+  Result<> attach_software();
+  Result<> attach_hardware();
+  Result<> attach_watchpoint(const std::string &mode);
+  Result<> attach_fentry();
   int detach_fentry();
-  void attach_iter(std::optional<int> pid);
+  Result<> attach_iter();
   int detach_iter();
-  void attach_raw_tracepoint();
+  Result<> attach_raw_tracepoint();
   int detach_raw_tracepoint();
 
   static std::map<std::string, int> cached_prog_fds_;
   bool use_cached_progfd(BPFfeature &feature);
   void cache_progfd();
+  Result<> check_alignment(std::string &path,
+                           std::string &symbol,
+                           uint64_t sym_offset,
+                           uint64_t func_offset,
+                           bool safe_mode,
+                           ProbeType type);
 
   Probe &probe_;
   std::vector<int> perf_event_fds_;
@@ -83,6 +120,8 @@ private:
   USDTHelper usdt_helper;
 
   BPFtrace &bpftrace_;
+  std::optional<int> pid_;
+  bool safe_mode_;
 };
 
 class HelperVerifierError : public std::runtime_error {

--- a/src/bpfprogram.cpp
+++ b/src/bpfprogram.cpp
@@ -82,20 +82,13 @@ void BpfProgram::set_attach_target(const Probe &probe,
   }
 
   if (btf.get_btf_id(btf_fun, mod, btf_kind) < 0) {
-    const std::string msg = "No BTF found for " + attach_target;
-    if (probe.orig_name != probe.name &&
-        config.missing_probes != ConfigMissingProbes::error) {
-      // One attach point in a multi-attachpoint probe failed and the user
-      // requested not to error out. Show a warning (if requested) and continue
-      // but disable auto-loading of the program as it would make the entire BPF
-      // object loading fail.
-      if (config.missing_probes == ConfigMissingProbes::warn)
-        LOG(WARNING) << msg << ", skipping.";
-      bpf_program__set_autoload(bpf_prog_, false);
-    } else {
-      // explicit match failed, fail hard
-      throw util::FatalUserException(msg);
+    const std::string msg = "No BTF found for " + attach_target + ".";
+    if (config.missing_probes == ConfigMissingProbes::error) {
+      LOG(ERROR) << msg;
+    } else if (config.missing_probes == ConfigMissingProbes::warn) {
+      LOG(WARNING) << msg;
     }
+    bpf_program__set_autoload(bpf_prog_, false);
   }
 
   bpf_program__set_attach_target(bpf_prog_, 0, attach_target.c_str());

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -37,6 +37,7 @@
 #include "usyms.h"
 #include "util/cpus.h"
 #include "util/kernel.h"
+#include "util/result.h"
 
 namespace bpftrace {
 
@@ -118,9 +119,9 @@ public:
   Probe generateWatchpointSetupProbe(const ast::AttachPoint &ap,
                                      const ast::Probe &probe);
   int num_probes() const;
-  int prerun(Output &out) const;
+  int prerun() const;
   int run(Output &out, BpfBytecode bytecode);
-  virtual std::vector<std::unique_ptr<AttachedProbe>> attach_probe(
+  virtual Result<std::vector<std::unique_ptr<AttachedProbe>>> attach_probe(
       Probe &probe,
       const BpfBytecode &bytecode);
   int run_iter();
@@ -241,7 +242,7 @@ private:
   std::vector<std::unique_ptr<void, void (*)(void *)>> open_perf_buffers_;
   std::map<std::string, std::unique_ptr<PCAPwriter>> pcap_writers_;
 
-  std::vector<std::unique_ptr<AttachedProbe>> attach_usdt_probe(
+  Result<std::vector<std::unique_ptr<AttachedProbe>>> attach_usdt_probe(
       Probe &probe,
       const BpfProgram &program,
       std::optional<int> pid,

--- a/src/config.h
+++ b/src/config.h
@@ -62,7 +62,7 @@ public:
   uint64_t perf_rb_pages = 64;
   std::string license = "GPL";
   std::string str_trunc_trailer = "..";
-  ConfigMissingProbes missing_probes = ConfigMissingProbes::warn;
+  ConfigMissingProbes missing_probes = ConfigMissingProbes::error;
   StackMode stack_mode = StackMode::bpftrace;
 
   // Initialized in the constructor.

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -47,10 +47,10 @@ TEST(Config, set)
   EXPECT_TRUE(bool(config.set("cache_user_symbols", "NONE")));
   EXPECT_EQ(config.user_symbol_cache_type, UserSymbolCacheType::none);
 
-  EXPECT_EQ(config.missing_probes, ConfigMissingProbes::warn);
-  EXPECT_FALSE(bool(config.set("missing_probes", "invalid")));
-  EXPECT_TRUE(bool(config.set("missing_probes", "error")));
   EXPECT_EQ(config.missing_probes, ConfigMissingProbes::error);
+  EXPECT_FALSE(bool(config.set("missing_probes", "invalid")));
+  EXPECT_TRUE(bool(config.set("missing_probes", "warn")));
+  EXPECT_EQ(config.missing_probes, ConfigMissingProbes::warn);
 }
 
 TEST(Config, key_finding)

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -6,6 +6,7 @@
 #include "probe_matcher.h"
 #include "procmon.h"
 #include "util/format.h"
+#include "util/result.h"
 #include "gmock/gmock-function-mocker.h"
 
 namespace bpftrace::test {
@@ -55,10 +56,10 @@ public:
 
 class MockBPFtrace : public BPFtrace {
 public:
-  MOCK_METHOD2(
-      attach_probe,
-      std::vector<std::unique_ptr<AttachedProbe>>(Probe &probe,
-                                                  const BpfBytecode &bytecode));
+  MOCK_METHOD2(attach_probe,
+               Result<std::vector<std::unique_ptr<AttachedProbe>>>(
+                   Probe &probe,
+                   const BpfBytecode &bytecode));
 
   MOCK_METHOD1(resume_tracee, int(pid_t tracee_pid));
   std::vector<Probe> get_probes()

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -68,18 +68,18 @@ REQUIRES_FEATURE fentry
 REQUIRES_FEATURE btf
 AFTER ./testprogs/fentry_args 1111 2222
 
-NAME fentry_warn_missing_probes
+NAME fentry_missing_probes
 PROG fentry:vfs_read,fentry:nonsense { exit(); }
-EXPECT WARNING: No BTF found for nonsense, skipping.
+EXPECT ERROR: No BTF found for nonsense.
+WILL_FAIL
+
+NAME fentry_warn_missing_probes
+PROG config = { missing_probes = "warn" } fentry:vfs_read,fentry:nonsense { exit(); }
+EXPECT WARNING: No BTF found for nonsense.
 
 NAME fentry_ignore_missing_probes
 PROG config = { missing_probes = "ignore" } fentry:vfs_read,fentry:nonsense { exit(); }
-EXPECT_NONE WARNING: No BTF found for nonsense, skipping.
-
-NAME fentry_error_missing_probes
-PROG config = { missing_probes = "error" } fentry:vfs_read,fentry:nonsense { exit(); }
-EXPECT ERROR: No BTF found for nonsense
-WILL_FAIL
+EXPECT_NONE WARNING: No BTF found for nonsense.
 
 # Sanity check for kfunc/kretfunc alias
 NAME kfunc
@@ -137,7 +137,7 @@ AFTER ./testprogs/syscall read
 
 NAME kprobe_module_missing
 PROG kprobe:nonsense:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT ERROR: Error attaching probe: kprobe:nonsense:vfs_read: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
+EXPECT ERROR: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
 WILL_FAIL
 
 NAME kprobe_wildcard_all_leading_underscore
@@ -157,7 +157,7 @@ EXPECT 0
 
 NAME kprobe_func_missing
 PROG kprobe:vmlinux:nonsense { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT ERROR: Error attaching probe: kprobe:vmlinux:nonsense
+EXPECT ERROR: Unable to attach probe: kprobe:vmlinux:nonsense. If this is expected, set the 'missing_probes' config variable to 'warn'.
 WILL_FAIL
 
 NAME kprobe_multi_wildcard
@@ -214,22 +214,9 @@ WILL_FAIL
 
 NAME kprobe_offset_module_error
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
-EXPECT cannot attach kprobe, Invalid argument
+EXPECT ERROR: Unable to attach probe: kprobe:nft_trans_alloc_gfp+0x1. If this is expected, set the 'missing_probes' config variable to 'warn'.
 ARCH aarch64|ppc64le|ppc64
 REQUIRES lsmod | grep '^nf_tables'
-WILL_FAIL
-
-NAME kprobe_warn_missing_probes
-PROG kprobe:vfs_read,kprobe:nonsense { exit(); }
-EXPECT WARNING: could not attach probe kprobe:nonsense, skipping.
-
-NAME kprobe_ignore_missing_probes
-PROG config = { missing_probes = "ignore" } kprobe:vfs_read,kprobe:nonsense { exit(); }
-EXPECT_NONE WARNING: could not attach probe kprobe:nonsense, skipping.
-
-NAME kprobe_error_missing_probes
-PROG config = { missing_probes = "error" } kprobe:vfs_read,kprobe:nonsense { exit(); }
-EXPECT ERROR: Error attaching probe: kprobe:nonsense
 WILL_FAIL
 
 NAME kretprobe
@@ -341,21 +328,21 @@ RUN {{BPFTRACE}} --unsafe -e 'uprobe:./testprogs/uprobe_test:_init { printf("arg
 EXPECT_REGEX arg0: [0-9]*
 AFTER ./testprogs/uprobe_test
 
-NAME uprobe_warn_missing_probes
+NAME uprobe_missing_probes
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
-EXPECT WARNING: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3, skipping probe.
+EXPECT ERROR: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3
+AFTER ./testprogs/uprobe_test
+WILL_FAIL
+
+NAME uprobe_warn_missing_probes
+PROG config = { missing_probes = "warn" } uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
+EXPECT WARNING: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3
 AFTER ./testprogs/uprobe_test
 
 NAME uprobe_ignore_missing_probes
 PROG config = { missing_probes = "ignore" } uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
 EXPECT_NONE WARNING: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3, skipping probe.
 AFTER ./testprogs/uprobe_test
-
-NAME uprobe_error_missing_probes
-PROG config = { missing_probes = "error" } uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
-EXPECT ERROR: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3, cannot attach probe.
-AFTER ./testprogs/uprobe_test
-WILL_FAIL
 
 NAME uretprobe
 PROG uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}
@@ -388,7 +375,8 @@ EXPECT hit
 
 NAME tracepoint_missing
 PROG t:syscalls:nonsense { print("hit"); exit(); }
-EXPECT stdin:1:1-20: ERROR: tracepoint not found: syscalls:nonsense
+EXPECT stdin:1:1-20: WARNING: tracepoint not found: syscalls:nonsense
+EXPECT ERROR: Unable to attach probe: tracepoint:syscalls:nonsense. If this is expected, set the 'missing_probes' config variable to 'warn'.
 WILL_FAIL
 
 NAME tracepoint_multiattach_missing
@@ -441,7 +429,7 @@ AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME rawtracepoint_module_missing
 PROG rawtracepoint:nonsense:sys_exit { printf("SUCCESS %d\n", gid); exit(); }
-EXPECT ERROR: No BTF found for nonsense:sys_exit
+EXPECT ERROR: No BTF found for nonsense:sys_exit.
 REQUIRES_FEATURE btf
 WILL_FAIL
 
@@ -596,3 +584,29 @@ NAME signal_order
 RUN {{BPFTRACE}} -e 'self:signal:SIGUSR1 { printf("first"); } self:signal:SIGUSR1 { printf(" second\n"); exit(); }'
 AFTER kill -s USR1 $(pidof bpftrace)
 EXPECT_REGEX (first)+ second
+
+NAME some_missing_probes_default_error
+PROG kprobe:vfs_read { exit(); } t:syscalls:nonsense { exit(); }
+EXPECT ERROR: Unable to attach probe: tracepoint:syscalls:nonsense. If this is expected, set the 'missing_probes' config variable to 'warn'.
+WILL_FAIL
+
+NAME missing_probes_multiple_attach_points_default_error
+PROG kprobe:vfs_read, kprobe:bad { exit(); }
+EXPECT ERROR: Unable to attach probe: kprobe:bad. If this is expected, set the 'missing_probes' config variable to 'warn'.
+WILL_FAIL
+
+NAME some_missing_probes_warn
+PROG config = { missing_probes=warn } kprobe:vfs_read { exit(); } t:syscalls:nonsense { exit(); }
+EXPECT WARNING: Unable to attach probe: tracepoint:syscalls:nonsense. Skipping.
+
+NAME some_missing_probes_ignore
+PROG config = { missing_probes=ignore } kprobe:vfs_read { exit(); } t:syscalls:nonsense { exit(); }
+EXPECT_NONE WARNING: Unable to attach probe: tracepoint:syscalls:nonsense. Skipping.
+
+NAME all_missing_probes_warn
+PROG config = { missing_probes=warn } kprobe:nonsense { exit(); } t:syscalls:nonsense { exit(); } uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
+EXPECT WARNING: Unable to attach probe: kprobe:nonsense. Skipping.
+EXPECT WARNING: Unable to attach probe: tracepoint:syscalls:nonsense. Skipping.
+EXPECT WARNING: Unable to attach probe: uprobe:./testprogs/uprobe_test:uprobeFunction3. Skipping.
+EXPECT ERROR: Attachment failed for all probes.
+WILL_FAIL

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -31,8 +31,9 @@ ARCH aarch64|x86_64
 REQUIRES_FEATURE signal
 
 NAME many_function_probes
-RUN {{BPFTRACE}} -e 'watchpoint:increment+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_many_probes
-EXPECT Failed to attach watchpoint probe. You are out of watchpoint registers.
+RUN {{BPFTRACE}} -e 'config = { missing_probes = "warn" } watchpoint:increment+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_many_probes
+EXPECT WARNING: No more HW registers left
+EXPECT WARNING: Unable to attach probe: watchpoint:./testprogs/watchpoint_func_many_probes:increment:4:w. Skipping.
 ARCH aarch64|x86_64
 REQUIRES_FEATURE signal
 
@@ -49,13 +50,14 @@ ARCH aarch64|x86_64
 REQUIRES_FEATURE signal
 
 NAME wildcarded_function
-RUN {{BPFTRACE}} -e 'watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
-EXPECT Failed to attach watchpoint probe. You are out of watchpoint registers.
+RUN {{BPFTRACE}} -e 'config = { missing_probes = "warn" } watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
+EXPECT WARNING: No more HW registers left
+EXPECT WARNING: Unable to attach probe: watchpoint:./testprogs/watchpoint_func_wildcard:increment_0:4:w. Skipping.
 ARCH aarch64|x86_64
 REQUIRES_FEATURE signal
 
 NAME unique_probe_bodies
-RUN {{BPFTRACE}} -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
+RUN {{BPFTRACE}} -e 'config = { missing_probes = "warn" } watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT_REGEX .*increment_0:4:w!
 ARCH aarch64|x86_64
 REQUIRES_FEATURE signal


### PR DESCRIPTION
This changes the default behavior for probes
that have multiple attach points or a wildcard.
Formerly we would just warn but this behavior
is inconsistent with single attach point probes,
which error. Now we error by default and users
have to explicity set the 'missing_probes'
config to 'warn'.

This also includes an improvement to the count
of actual probes being attached in the out message.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
