### PR TITLE
Refactor `helpererror` in `perf_event_printer`

### DIFF
--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -45,4 +45,13 @@ void time_handler(BPFtrace *bpftrace, void *data)
   bpftrace->out_->message(MessageType::time, timestr, false);
 }
 
+void helper_error_handler(BPFtrace *bpftrace, void *data)
+{
+  auto *helper_error = static_cast<AsyncEvent::HelperError *>(data);
+  auto error_id = helper_error->error_id;
+  auto return_value = helper_error->return_value;
+  auto &info = bpftrace->resources.helper_error_info[error_id];
+  bpftrace->out_->helper_error(return_value, info);
+}
+
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -6,5 +6,6 @@ namespace bpftrace::async_action {
 const static size_t MAX_TIME_STR_LEN = 64;
 void join_handler(BPFtrace *bpftrace, void *data);
 void time_handler(BPFtrace *bpftrace, void *data);
+void helper_error_handler(BPFtrace *bpftrace, void *data);
 
 } // namespace bpftrace::async_action

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -270,11 +270,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     async_action::join_handler(bpftrace, data);
     return;
   } else if (printf_id == AsyncAction::helper_error) {
-    auto *helpererror = static_cast<AsyncEvent::HelperError *>(data);
-    auto error_id = helpererror->error_id;
-    auto return_value = helpererror->return_value;
-    auto &info = bpftrace->resources.helper_error_info[error_id];
-    bpftrace->out_->helper_error(return_value, info);
+    async_action::helper_error_handler(bpftrace, data);
     return;
   } else if (printf_id == AsyncAction::watchpoint_attach) {
     bool abort = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,7 +68,7 @@ add_executable(bpftrace_test
 add_test(NAME bpftrace_test COMMAND bpftrace_test)
 
 add_subdirectory(data)
-add_dependencies(bpftrace_test data_source_dwarf data_source_btf data_source_funcs)
+add_dependencies(bpftrace_test data_source_dwarf data_source_btf data_source_funcs parser)
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->
Extract helpererror logic into a separate function and add a unit test to cover it. This is the second pr of issue #3712 

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
