### PR TITLE
Fix tools/runqlat.bt warnings

### DIFF
--- a/tools/runqlat.bt
+++ b/tools/runqlat.bt
@@ -42,8 +42,8 @@ tracepoint:sched:sched_switch
 	$ns = @qtime[args.next_pid];
 	if ($ns) {
 		@usecs = hist((nsecs - $ns) / 1000);
+		delete(@qtime, args.next_pid);
 	}
-	delete(@qtime, args.next_pid);
 }
 
 END


### PR DESCRIPTION
   The warning looks like:
#  sudo ./tools/runqlat.bt
Attaching 5 probes...
Tracing CPU scheduler... Hit Ctrl-C to end.
./tools/runqlat.bt:46:2-31: WARNING: Can't delete map element because it does not exist. Additional Info - helper: map_delete_elem, retcode: -2
    delete(@qtime, args.next_pid);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./tools/runqlat.bt:46:2-31: WARNING: Can't delete map element because it does not exist. Additional Info - helper: map_delete_elem, retcode: -2
    delete(@qtime, args.next_pid);
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
