### PR TITLE
Fix max_cat_bytes in adoc

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3761,7 +3761,7 @@ takes a lot of resources (and it should not happen often).
 
 ==== max_cat_bytes
 
-Default: 10000
+Default: 10240
 
 Maximum bytes read by cat builtin.
 


### PR DESCRIPTION
##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
