### PR TITLE
Fix macro location expansion

### DIFF
--- a/src/ast/location.cpp
+++ b/src/ast/location.cpp
@@ -90,7 +90,7 @@ Location operator+(const Location &orig, const Location &expansion)
     return orig;
   }
   auto nlink = std::make_shared<LocationChain>(expansion->current);
-  nlink->parent.emplace(LocationChain::Parent(Location(orig)));
+  nlink->parent.emplace(LocationChain::Context(Location(orig)));
   nlink->parent->msg << "expanded from";
   return nlink;
 }

--- a/src/ast/location.h
+++ b/src/ast/location.h
@@ -74,9 +74,8 @@ using Location = std::shared_ptr<LocationChain>;
 // `Location` alias should be the way that it is referred to broadly.
 class LocationChain {
 public:
-  // See the `parent` field below.
-  struct Parent {
-    Parent(Location &&loc) : loc(std::move(loc)) {};
+  struct Context {
+    Context(Location &&loc) : loc(std::move(loc)) {};
     std::stringstream msg;
     const Location loc;
   };
@@ -109,8 +108,9 @@ public:
   // copying a node you may automatically modify the location in order to
   // inject a parent that has "expanded from <...>". When these are displayed as
   // diagnostics, they are unpacked in reverse.
-  std::optional<Parent> parent;
+  std::optional<Context> parent;
   const SourceLocation current;
+  std::vector<Context> contexts;
 };
 
 Location operator+(const Location &orig, const Location &expansion);

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -208,16 +208,15 @@ std::optional<Block *> MacroExpander::expand(Macro &macro, const Call &call)
   }
 
   for (auto expr : macro.block->stmts) {
-    stmt_list.push_back(clone(ast_, expr, expr.loc()));
+    stmt_list.push_back(clone(ast_, expr, call.loc));
   }
 
   auto *cloned_block =
       macro.block->expr.has_value()
-          ? ast_.make_node<Block>(
-                std::move(stmt_list),
-                clone(ast_, *macro.block->expr, macro.block->expr->loc()),
-                Location(macro.loc))
-          : ast_.make_node<Block>(std::move(stmt_list), Location(macro.loc));
+          ? ast_.make_node<Block>(std::move(stmt_list),
+                                  clone(ast_, *macro.block->expr, call.loc),
+                                  Location(macro.loc))
+          : ast_.make_node<Block>(std::move(stmt_list), Location(call.loc));
 
   visit(cloned_block);
 


### PR DESCRIPTION
- Separate parent location chaining from added context. Now LocationChain has a vector of 'contexts' that can be added too in addition to a parent chain.
- Pass call location to cloned nodes in macro_expansion

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
