### PR TITLE
Refactor `syscall`, `cat` and `printf` in `perf_event_printer`

### DIFF
--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -92,4 +92,18 @@ void cat_handler(BPFtrace *bpftrace, AsyncAction printf_id, uint8_t *arg_data)
   bpftrace->out_->message(MessageType::cat, buf.str(), false);
 }
 
+void printf_handler(BPFtrace *bpftrace,
+                    AsyncAction printf_id,
+                    uint8_t *arg_data)
+{
+  auto id = static_cast<size_t>(printf_id) -
+            static_cast<size_t>(AsyncAction::printf);
+  auto &fmt = std::get<0>(bpftrace->resources.printf_args[id]);
+  auto &args = std::get<1>(bpftrace->resources.printf_args[id]);
+  auto arg_values = bpftrace->get_arg_values(args, arg_data);
+
+  bpftrace->out_->message(MessageType::printf,
+                          fmt.format_str(arg_values),
+                          false);
+}
 } // namespace bpftrace::async_action

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -45,4 +45,13 @@ void time_handler(BPFtrace *bpftrace, void *data)
   bpftrace->out_->message(MessageType::time, timestr, false);
 }
 
+void helper_error_handler(BPFtrace *bpftrace, void *data)
+{
+  auto *helper_error = static_cast<AsyncEvent::HelperError *>(data);
+  auto error_id = helper_error->error_id;
+  auto return_value = helper_error->return_value;
+  auto &info = bpftrace->resources.helper_error_info[error_id];
+  bpftrace->out_->helper_error(return_value, info);
+}
+
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "ast/async_event_types.h"
 #include "bpftrace.h"
 
 namespace bpftrace::async_action {
@@ -7,5 +8,8 @@ const static size_t MAX_TIME_STR_LEN = 64;
 void join_handler(BPFtrace *bpftrace, void *data);
 void time_handler(BPFtrace *bpftrace, void *data);
 void helper_error_handler(BPFtrace *bpftrace, void *data);
+void syscall_handler(BPFtrace *bpftrace,
+                     AsyncAction printf_id,
+                     uint8_t *arg_data);
 
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -6,5 +6,6 @@ namespace bpftrace::async_action {
 const static size_t MAX_TIME_STR_LEN = 64;
 void join_handler(BPFtrace *bpftrace, void *data);
 void time_handler(BPFtrace *bpftrace, void *data);
+void helper_error_handler(BPFtrace *bpftrace, void *data);
 
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -12,5 +12,8 @@ void syscall_handler(BPFtrace *bpftrace,
                      AsyncAction printf_id,
                      uint8_t *arg_data);
 void cat_handler(BPFtrace *bpftrace, AsyncAction printf_id, uint8_t *arg_data);
+void printf_handler(BPFtrace *bpftrace,
+                    AsyncAction printf_id,
+                    uint8_t *arg_data);
 
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -11,5 +11,6 @@ void helper_error_handler(BPFtrace *bpftrace, void *data);
 void syscall_handler(BPFtrace *bpftrace,
                      AsyncAction printf_id,
                      uint8_t *arg_data);
+void cat_handler(BPFtrace *bpftrace, AsyncAction printf_id, uint8_t *arg_data);
 
 } // namespace bpftrace::async_action

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -376,15 +376,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     return;
   } else if (printf_id >= AsyncAction::printf &&
              printf_id <= AsyncAction::printf_end) {
-    auto id = static_cast<size_t>(printf_id) -
-              static_cast<size_t>(AsyncAction::printf);
-    auto &fmt = std::get<0>(bpftrace->resources.printf_args[id]);
-    auto &args = std::get<1>(bpftrace->resources.printf_args[id]);
-    auto arg_values = bpftrace->get_arg_values(args, arg_data);
-
-    bpftrace->out_->message(MessageType::printf,
-                            fmt.format_str(arg_values),
-                            false);
+    async_action::printf_handler(bpftrace, printf_id, arg_data);
     return;
   } else {
     LOG(BUG) << "Unknown printf_id: " << static_cast<int64_t>(printf_id);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -369,21 +369,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     return;
   } else if (printf_id >= AsyncAction::syscall &&
              printf_id <= AsyncAction::syscall_end) {
-    if (bpftrace->safe_mode_) {
-      throw util::FatalUserException(
-          "syscall() not allowed in safe mode. Use '--unsafe'.");
-    }
-
-    auto id = static_cast<size_t>(printf_id) -
-              static_cast<size_t>(AsyncAction::syscall);
-    auto &fmt = std::get<0>(bpftrace->resources.system_args[id]);
-    auto &args = std::get<1>(bpftrace->resources.system_args[id]);
-    auto arg_values = bpftrace->get_arg_values(args, arg_data);
-
-    bpftrace->out_->message(MessageType::syscall,
-                            util::exec_system(
-                                fmt.format_str(arg_values).c_str()),
-                            false);
+    async_action::syscall_handler(bpftrace, printf_id, arg_data);
     return;
   } else if (printf_id >= AsyncAction::cat &&
              printf_id <= AsyncAction::cat_end) {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -270,11 +270,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     async_action::join_handler(bpftrace, data);
     return;
   } else if (printf_id == AsyncAction::helper_error) {
-    auto *helpererror = static_cast<AsyncEvent::HelperError *>(data);
-    auto error_id = helpererror->error_id;
-    auto return_value = helpererror->return_value;
-    auto &info = bpftrace->resources.helper_error_info[error_id];
-    bpftrace->out_->helper_error(return_value, info);
+    async_action::helper_error_handler(bpftrace, data);
     return;
   } else if (printf_id == AsyncAction::watchpoint_attach) {
     bool abort = false;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -47,7 +47,6 @@
 #include "util/exceptions.h"
 #include "util/format.h"
 #include "util/int_parser.h"
-#include "util/io.h"
 #include "util/kernel.h"
 #include "util/paths.h"
 #include "util/stats.h"
@@ -373,18 +372,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     return;
   } else if (printf_id >= AsyncAction::cat &&
              printf_id <= AsyncAction::cat_end) {
-    auto id = static_cast<size_t>(printf_id) -
-              static_cast<size_t>(AsyncAction::cat);
-    auto &fmt = std::get<0>(bpftrace->resources.cat_args[id]);
-    auto &args = std::get<1>(bpftrace->resources.cat_args[id]);
-    auto arg_values = bpftrace->get_arg_values(args, arg_data);
-
-    std::stringstream buf;
-    util::cat_file(fmt.format_str(arg_values).c_str(),
-                   bpftrace->config_->max_cat_bytes,
-                   buf);
-    bpftrace->out_->message(MessageType::cat, buf.str(), false);
-
+    async_action::cat_handler(bpftrace, printf_id, arg_data);
     return;
   } else if (printf_id >= AsyncAction::printf &&
              printf_id <= AsyncAction::printf_end) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,7 +68,7 @@ add_executable(bpftrace_test
 add_test(NAME bpftrace_test COMMAND bpftrace_test)
 
 add_subdirectory(data)
-add_dependencies(bpftrace_test data_source_dwarf data_source_btf data_source_funcs)
+add_dependencies(bpftrace_test data_source_dwarf data_source_btf data_source_funcs parser)
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(bpftrace_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -10,6 +10,7 @@
 #include "util/bpf_names.h"
 #include "util/cgroup.h"
 #include "util/format.h"
+#include "util/io.h"
 #include "util/kernel.h"
 #include "util/math.h"
 #include "util/paths.h"
@@ -433,6 +434,53 @@ TEST(utils, round_up_to_next_power_of_two)
   ASSERT_EQ(round_up_to_next_power_of_two(max_power_of_two - 1),
             max_power_of_two);
   ASSERT_EQ(round_up_to_next_power_of_two(max_power_of_two), max_power_of_two);
+}
+
+TEST(utils, cat_file_success)
+{
+  std::string test_content = "Hello, cat_file test!\nThis is line 2.\n";
+  char filename[] = "/tmp/bpftrace-test-cat-file-XXXXXX";
+  int fd = mkstemp(filename);
+  ASSERT_NE(fd, -1) << "Failed to create temporary file";
+  ASSERT_EQ(write(fd, test_content.c_str(), test_content.length()),
+            static_cast<ssize_t>(test_content.length()));
+  close(fd);
+
+  // Test cat_file with the temporary file
+  std::stringstream out;
+  cat_file(filename, 1024, out);
+
+  // Verify output matches the file content
+  EXPECT_EQ(test_content, out.str());
+
+  // Cleanup
+  unlink(filename);
+}
+
+TEST(utils, cat_file_nonexistent)
+{
+  // Path to a file that shouldn't exist
+  std::string nonexistent_file = "/tmp/bpftrace-nonexistent-file-test-XXXXXX";
+  int fd = mkstemp(const_cast<char *>(nonexistent_file.c_str()));
+  close(fd);
+  unlink(nonexistent_file.c_str()); // Ensure file doesn't exist
+
+  testing::internal::CaptureStderr();
+
+  // Test cat_file with nonexistent file
+  std::stringstream out;
+  cat_file(nonexistent_file.c_str(), 1024, out);
+
+  // Get captured stderr
+  std::string stderr_output = testing::internal::GetCapturedStderr();
+
+  // Verify no output was produced
+  EXPECT_TRUE(out.str().empty())
+      << "cat_file should not output anything for nonexistent files";
+
+  // Verify error message was logged
+  EXPECT_THAT(stderr_output, testing::HasSubstr("failed to open file"))
+      << "Error message should indicate file opening failure";
 }
 
 } // namespace bpftrace::test::utils


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Extract the `syscall`, the `cat`, and the `printf` logic into separate functions and add tests to cover them. 

This pr is the third pr of issue #3712  and it bases on pr #4098 

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
