### PR TITLE
Add ncpus builtin to get the number of CPUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 - Ustack and kstack symbols are automatically enhanced with debug info if available
   - [#3999](https://github.com/bpftrace/bpftrace/pull/3999)
 #### Added
+- Add ncpus builtin to get the number of CPUs.
+  - [#4105](https://github.com/bpftrace/bpftrace/pull/4105)
 - Use blazesym for user space address symbolization
   - [#3884](https://github.com/bpftrace/bpftrace/pull/3884)
 - Add simple block expressions

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1916,6 +1916,12 @@ For string arguments in an action block use the `str()` call to retrieve the val
 | raw_smp_processor_id
 | ID of the processor executing the BPF program
 
+| ncpus
+| uint64
+| n/a
+| n/a
+| Number of CPUs
+
 | curtask
 | uint64
 | 4.8

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -654,6 +654,12 @@ ScopedExpr CodegenLLVM::visit(Builtin &builtin)
   } else if (builtin.ident == "cpu") {
     Value *cpu = b_.CreateGetCpuId(builtin.loc);
     return ScopedExpr(b_.CreateZExt(cpu, b_.getInt64Ty()));
+  } else if (builtin.ident == "ncpus") {
+    return ScopedExpr(
+        b_.CreateLoad(b_.getInt64Ty(),
+                      module_->getGlobalVariable(
+                          to_string(bpftrace::globalvars::GlobalVar::NUM_CPUS)),
+                      "num_cpu.cmp"));
   } else if (builtin.ident == "curtask") {
     return ScopedExpr(b_.CreateGetCurrentTask(builtin.loc));
   } else if (builtin.ident == "rand") {

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -171,6 +171,9 @@ void ResourceAnalyser::visit(Builtin &builtin)
     // mark probe as using usym, so that the symbol table can be pre-loaded
     // and symbols resolved even when unavailable at resolution time
     resources_.probes_using_usym.insert(probe_);
+  } else if (builtin.ident == "ncpus") {
+    resources_.needed_global_vars.insert(
+        bpftrace::globalvars::GlobalVar::NUM_CPUS);
   }
 }
 

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -857,7 +857,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
              builtin.ident == "cgroup" || builtin.ident == "uid" ||
              builtin.ident == "gid" || builtin.ident == "cpu" ||
              builtin.ident == "rand" || builtin.ident == "numaid" ||
-             builtin.ident == "jiffies") {
+             builtin.ident == "jiffies" || builtin.ident == "ncpus") {
     builtin.builtin_type = CreateUInt64();
     if (builtin.ident == "cgroup" &&
         !bpftrace_.feature_->has_helper_get_current_cgroup_id()) {

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -44,7 +44,7 @@ hspace   [ \t]
 vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#$+\*])+
-builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies|nsecs|kstack|ustack
+builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ncpus|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies|nsecs|kstack|ustack
 
 int_type        bool|(u)?int(8|16|32|64)
 builtin_type    void|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|strerror_t|kstack_t|ustack_t

--- a/tests/codegen/builtin_ncpus.cpp
+++ b/tests/codegen/builtin_ncpus.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, builtin_ncpus)
+{
+  test("BEGIN { @x = ncpus; exit(); }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/builtin_ncpus.ll
+++ b/tests/codegen/llvm/builtin_ncpus.ll
@@ -1,0 +1,141 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr, ptr, ptr }
+%"struct map_t.0" = type { ptr, ptr }
+%"struct map_t.1" = type { ptr, ptr, ptr, ptr }
+%exit_t = type <{ i64, i8 }>
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
+@AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
+@event_loss_counter = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !36
+@num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !48
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+; Function Attrs: nounwind
+define i64 @BEGIN_1(ptr %0) #0 section "s_BEGIN_1" !dbg !54 {
+entry:
+  %key = alloca i32, align 4
+  %exit = alloca %exit_t, align 8
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %num_cpu.cmp = load i64, ptr @num_cpus, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
+  store i64 0, ptr %"@x_key", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
+  store i64 %num_cpu.cmp, ptr %"@x_val", align 8
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
+  %1 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
+  store i64 30000, ptr %1, align 8
+  %2 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
+  store i8 0, ptr %2, align 1
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %key)
+  store i32 0, ptr %key, align 4
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @event_loss_counter, ptr %key)
+  %map_lookup_cond = icmp ne ptr %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %exit)
+  ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %3 = atomicrmw add ptr %lookup_elem, i64 1 seq_cst, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %key)
+  br label %counter_merge
+
+deadcode:                                         ; No predecessors!
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!50}
+!llvm.module.flags = !{!52, !53}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 32, elements: !5)
+!4 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!5 = !{!6}
+!6 = !DISubrange(count: 4, lowerBound: 0)
+!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
+!8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
+!10 = !{!11, !17, !18, !21}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !{!16}
+!16 = !DISubrange(count: 1, lowerBound: 0)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
+!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
+!20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
+!25 = !{!26, !31}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
+!29 = !{!30}
+!30 = !DISubrange(count: 27, lowerBound: 0)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 262144, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !39)
+!39 = !{!40, !17, !45, !21}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 64, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 2, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !46, size: 64, offset: 128)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
+!49 = distinct !DIGlobalVariable(name: "num_cpus", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!50 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !51)
+!51 = !{!0, !7, !22, !36, !48}
+!52 = !{i32 2, !"Debug Info Version", i32 3}
+!53 = !{i32 7, !"uwtable", i32 0}
+!54 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !58)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!20, !57}
+!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!58 = !{!59}
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -30,6 +30,10 @@ NAME cpu
 PROG i:ms:1 { printf("SUCCESS %lu\n", cpu); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
 
+NAME ncpus
+PROG BEGIN { printf("%ld\n", ncpus); exit(); }
+EXPECT_REGEX ^[1-9][0-9]*$
+
 NAME comm
 PROG BEGIN { printf("SUCCESS %s\n", comm); exit(); }
 EXPECT SUCCESS bpftrace

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -254,6 +254,7 @@ TEST(semantic_analyser, builtin_variables)
   test("kprobe:f { elapsed }");
   test("kprobe:f { numaid }");
   test("kprobe:f { cpu }");
+  test("kprobe:f { ncpus }");
   test("kprobe:f { curtask }");
   test("kprobe:f { rand }");
   test("kprobe:f { ctx }");


### PR DESCRIPTION
If we want to count data indexed by CPU, we cannot print out the statistics of the number of CPUs now. To use unroll() to iterate over all CPUs, we can only pass in the $[0-9] parameter or use a constant.

For example, to get the softirqs information of all CPUs:

    tracepoint:irq:softirq_entry {
            @vec_count[cpu, args->vec] += 1;
    }
    interval:s:1 {
            system("clear");
            $i = 0;
            unroll($1) {
                    /* Do the print */
                    printf("cpu %d\n", $i);
                    $i += 1;
            }
    }

If running without pass parameter:
    $ sudo bpftrace --unsafe script.bt
    10:13-23: ERROR: unroll minimum value is 1
            unroll($1) {
            ~~~~~~~~~~

We need pass number of cpus:
    $ sudo bpftrace --unsafe script.bt $(nproc)
    # works fine

This submit introduce 'nproc' to provide the number of processing units online.

    $i = 0;
    unroll(nproc) {
            /* Do something */
            $i += 1;
    }

Whole script:

```
#!/usr/bin/bpftrace --unsafe
/**
 * Display softirqs statistic on CPUs.
 */

#include <linux/interrupt.h>

BEGIN
{
	@softirqname[HI_SOFTIRQ] = "HI";
	@softirqname[TIMER_SOFTIRQ] = "TIMER";
	@softirqname[NET_TX_SOFTIRQ] = "NET_TX";
	@softirqname[NET_RX_SOFTIRQ] = "NET_RX";
	@softirqname[BLOCK_SOFTIRQ] = "BLOCK";
	@softirqname[IRQ_POLL_SOFTIRQ] = "IRQ_POLL";
	@softirqname[TASKLET_SOFTIRQ] = "TASKLET";
	@softirqname[SCHED_SOFTIRQ] = "SCHED";
	@softirqname[HRTIMER_SOFTIRQ] = "HRTIMER";
	@softirqname[RCU_SOFTIRQ] = "RCU";

	$nr_cpu = *kaddr("nr_cpu_ids");

	if ($# < 1) {
		printf("Must specify CPU number, max %d.\n", $nr_cpu);
		exit();
	}

	if ($1 > $nr_cpu) {
		printf("ERROR: too much CPU %d, max %d\n", $1, $nr_cpu);
		exit(1);
	}

	printf("Tracing softirq_entry, hit ctrl+c to end.\n");
}

tracepoint:irq:softirq_entry
{
	$vec_nr = args->vec;

	@vec_count[cpu, @softirqname[$vec_nr]] += 1;
}

interval:s:1
{
	$nr_cpu = *kaddr("nr_cpu_ids");

	system("clear");

	printf("Statistic Softirq... %d out of %d\n", $1, $nr_cpu);
	printf("\033[1;32m%-4s\033[m\033[1;33m %-10s %-10s %-10s %-10s %-10s ",
		"CPU", "HI", "TIMER", "NET_TX", "NET_RX", "BLOCK");
	printf("%-10s %-10s %-10s %-10s %-10s\033[m\n",
		"IRQ_POLL", "TASKLET", "SCHED", "HRTIMER", "RCU");

	$i = 0;
	unroll($1) {
	printf("%-4d %-10ld %-10d %-10d %-10d %-10d ",
		$i,
		@vec_count[$i, "HI"],
		@vec_count[$i, "TIMER"],
		@vec_count[$i, "NET_TX"],
		@vec_count[$i, "NET_RX"],
		@vec_count[$i, "BLOCK"]);
	printf("%-10d %-10d %-10d %-10d %-10d\n",
		@vec_count[$i, "IRQ_POLL"],
		@vec_count[$i, "TASKLET"],
		@vec_count[$i, "SCHED"],
		@vec_count[$i, "HRTIMER"],
		@vec_count[$i, "RCU"]);

		$i = $i + 1;
	}
}

END
{
	clear(@softirqname);
	clear(@vec_count);
	printf("Bye.\n");
}
```

$ sudo ./softirq_entry.bt $(nproc)

```
Statistic Softirq... 12 out of 12
CPU  HI         TIMER      NET_TX     NET_RX     BLOCK      IRQ_POLL   TASKLET    SCHED      HRTIMER    RCU       
0    8          667        0          0          0          0          0          6299       0          1710      
1    193        485        0          0          0          0          0          1050       0          981       
2    358        1067       0          0          0          0          0          1057       0          1409      
3    5          225        0          0          0          0          0          445        0          757       
4    404        2319       0          0          0          0          0          1944       0          2374      
5    164        1634       0          0          0          0          0          1220       0          1643      
6    521        134        0          0          0          0          0          874        0          1293      
7    50         378        0          0          0          0          0          586        0          1006      
8    53         262        0          0          0          0          0          369        0          892       
9    5178       1179       0          0          0          0          0          1850       0          2411      
10   216        442        0          0          28         0          0          831        0          1137      
11   427        864        0          83         0          0          0          997        0          1360
```