### PR TITLE
Add runtime tests to validate the order of probe firing

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -567,3 +567,8 @@ AFTER ./testprogs/usdt_sized_args
 NAME interval_order
 RUN {{BPFTRACE}} runtime/scripts/interval_runtime_order.bt
 EXPECT_REGEX (first)+ second
+
+NAME hardware_order
+REQUIRES ls /sys/devices/cpu/events/cache-misses
+RUN {{BPFTRACE}} runtime/scripts/hardware_order.bt
+EXPECT_REGEX (first)+ second

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -563,3 +563,7 @@ NAME usdt_order
 RUN {{BPFTRACE}} runtime/scripts/usdt_order.bt
 EXPECT_REGEX (first)+ second
 AFTER ./testprogs/usdt_sized_args
+
+NAME interval_order
+RUN {{BPFTRACE}} runtime/scripts/interval_runtime_order.bt
+EXPECT_REGEX (first)+ second

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -572,3 +572,7 @@ NAME hardware_order
 REQUIRES ls /sys/devices/cpu/events/cache-misses
 RUN {{BPFTRACE}} runtime/scripts/hardware_order.bt
 EXPECT_REGEX (first)+ second
+
+NAME profile_order
+RUN {{BPFTRACE}} runtime/scripts/profile_order.bt
+EXPECT_REGEX (first)+ second

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -548,3 +548,8 @@ EXPECT_NONE bad
 BEFORE ./testprogs/nanosleep_loop
 BEFORE ./testprogs/nanosleep_loop
 TIMEOUT 2
+
+NAME fentry_order
+RUN {{BPFTRACE}} runtime/scripts/fentry_order.bt
+EXPECT_REGEX (first)+ second
+AFTER ./testprogs/syscall nanosleep 233;

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -558,3 +558,8 @@ NAME rawtracepoint_order
 RUN {{BPFTRACE}} runtime/scripts/rawtracepoint_order.bt
 EXPECT_REGEX (first)+ second
 AFTER ./testprogs/syscall nanosleep 233;
+
+NAME usdt_order
+RUN {{BPFTRACE}} runtime/scripts/usdt_order.bt
+EXPECT_REGEX (first)+ second
+AFTER ./testprogs/usdt_sized_args

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -576,3 +576,9 @@ EXPECT_REGEX (first)+ second
 NAME profile_order
 RUN {{BPFTRACE}} runtime/scripts/profile_order.bt
 EXPECT_REGEX (first)+ second
+
+NAME watchpoint_order
+RUN {{BPFTRACE}} -e 'watchpoint:increment+arg1:4:w { printf("first") } watchpoint:increment+arg1:4:w { printf(" second\n"); exit(); }' -c ./testprogs/watchpoint_func
+EXPECT_REGEX (first)+ second
+ARCH aarch64|x86_64
+REQUIRES_FEATURE signal

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -553,3 +553,8 @@ NAME fentry_order
 RUN {{BPFTRACE}} runtime/scripts/fentry_order.bt
 EXPECT_REGEX (first)+ second
 AFTER ./testprogs/syscall nanosleep 233;
+
+NAME rawtracepoint_order
+RUN {{BPFTRACE}} runtime/scripts/rawtracepoint_order.bt
+EXPECT_REGEX (first)+ second
+AFTER ./testprogs/syscall nanosleep 233;

--- a/tests/runtime/scripts/fentry_order.bt
+++ b/tests/runtime/scripts/fentry_order.bt
@@ -1,0 +1,14 @@
+// Check comm to make sure these are the nanosleeps we issued
+
+fentry:vmlinux:hrtimer_nanosleep
+/comm == "syscall"/
+{
+  printf("first");
+}
+
+fentry:vmlinux:hrtimer_nanosleep
+/comm == "syscall"/
+{
+  printf(" second\n");
+  exit();
+}

--- a/tests/runtime/scripts/hardware_order.bt
+++ b/tests/runtime/scripts/hardware_order.bt
@@ -1,0 +1,10 @@
+hardware:cache-misses:10
+{
+  printf("first");
+}
+
+hardware:cache-misses:10
+{
+  printf(" second\n");
+  exit();
+}

--- a/tests/runtime/scripts/interval_runtime_order.bt
+++ b/tests/runtime/scripts/interval_runtime_order.bt
@@ -1,0 +1,10 @@
+interval:ms:100
+{
+  printf("first");
+}
+
+interval:ms:100
+{
+  printf(" second\n");
+  exit();
+}

--- a/tests/runtime/scripts/profile_order.bt
+++ b/tests/runtime/scripts/profile_order.bt
@@ -1,0 +1,10 @@
+profile:ms:1000
+{
+  printf("first");
+}
+
+profile:ms:1000
+{
+  printf(" second\n");
+  exit();
+}

--- a/tests/runtime/scripts/rawtracepoint_order.bt
+++ b/tests/runtime/scripts/rawtracepoint_order.bt
@@ -1,0 +1,14 @@
+// Check comm and arg1(syscall_id) to make sure these are the nanosleeps we issued
+
+rawtracepoint:sys_enter
+/comm == "syscall" && arg1 == 0x23/
+{
+  printf("first");
+}
+
+rawtracepoint:sys_enter
+/comm == "syscall" && arg1 == 0x23/
+{
+  printf(" second\n");
+  exit();
+}

--- a/tests/runtime/scripts/usdt_order.bt
+++ b/tests/runtime/scripts/usdt_order.bt
@@ -1,0 +1,10 @@
+usdt:./testprogs/usdt_sized_args:probe1
+{
+  printf("first");
+}
+
+usdt:./testprogs/usdt_sized_args:probe1
+{
+  printf(" second\n");
+  exit();
+}


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

This PR covers probe firing order for fentry, rawtracepoint, usdt, interval, hardware, profile, and watchpoint. The other types of prog are either covered, or not applicable, or buggy.

| Probe Name  | Firing order test | 
| ------------- | ------------- |
|  BEGIN/END | not applicable: we don't allow more than one BEGIN probe defined  |
| self | bug: https://github.com/bpftrace/bpftrace/issues/4110 | 
| hareware | covered by this pr |
| interval | covered by this pr |
| iter | not applicable? It's not "event-triggered" |
| fentry | covered by this pr |
| fexit | bug: https://github.com/bpftrace/bpftrace/issues/4104 | 
| kprobe/kretprobe | covered by https://github.com/bpftrace/bpftrace/blob/master/tests/runtime/scripts/uretprobe_order.bt |
| profile | covered by this pr |
| rawtraceproint | covered by this pr |
| software | bug: https://github.com/bpftrace/bpftrace/issues/4111 |
| tracepoint | covered by https://github.com/bpftrace/bpftrace/blob/master/tests/runtime/scripts/tracepoint_order.bt | 
| uprobe/uretprobe | covered by https://github.com/bpftrace/bpftrace/blob/master/tests/runtime/scripts/uretprobe_order.bt | 
| usdt | covered by this pr |
| watchpoint | covered by this pr |

Fixes: https://github.com/bpftrace/bpftrace/issues/3170

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
