### PR TITLE
refactor:  clean up `print_non_map` arm implementation in `perf_event…

### DIFF
--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -57,6 +57,19 @@ void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data)
   out.helper_error(return_value, info);
 }
 
+void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data)
+{
+  auto *print = static_cast<AsyncEvent::PrintNonMap *>(data);
+  const SizedType &ty = bpftrace.resources.non_map_print_args.at(
+      print->print_id);
+
+  std::vector<uint8_t> bytes;
+  for (size_t i = 0; i < ty.GetSize(); ++i)
+    bytes.emplace_back(print->content[i]);
+
+  out.value(bpftrace, ty, bytes);
+}
+
 void syscall_handler(BPFtrace &bpftrace,
                      Output &out,
                      AsyncAction printf_id,
@@ -109,4 +122,5 @@ void printf_handler(BPFtrace &bpftrace,
 
   out.message(MessageType::printf, fmt.format_str(arg_values), false);
 }
+
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -9,6 +9,7 @@ const static size_t MAX_TIME_STR_LEN = 64;
 void join_handler(BPFtrace &bpftrace, Output &out, void *data);
 void time_handler(BPFtrace &bpftrace, Output &out, void *data);
 void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data);
+void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data);
 void syscall_handler(BPFtrace &bpftrace,
                      Output &out,
                      AsyncAction printf_id,

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -240,16 +240,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
                << "\", err=" << std::to_string(err);
     return;
   } else if (printf_id == AsyncAction::print_non_map) {
-    auto *print = static_cast<AsyncEvent::PrintNonMap *>(data);
-    const SizedType &ty = ctx->bpftrace.resources.non_map_print_args.at(
-        print->print_id);
-
-    std::vector<uint8_t> bytes;
-    for (size_t i = 0; i < ty.GetSize(); ++i)
-      bytes.emplace_back(print->content[i]);
-
-    ctx->output.value(ctx->bpftrace, ty, bytes);
-
+    async_action::print_non_map_handler(ctx->bpftrace, ctx->output, data);
     return;
   } else if (printf_id == AsyncAction::clear) {
     auto *mapevent = static_cast<AsyncEvent::MapEvent *>(data);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

refactor:  clean up `print_non_map` arm implementation in `perf_event_printer`

* extract the `print_non_map` logic into a seperate function
* add unit tests to cover the `async_action::print_non_map_handler`

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
