### PR TITLE
Add check for signal probes

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1230,7 +1230,7 @@ END {
 
 These are special built-in events provided by the bpftrace runtime.
 The trigger function is called by the bpftrace runtime when the bpftrace process receives specific events, such as a `SIGUSR1` signal.
-When multiple signal handlers are attached to the same signal, only the first one is used.
+Multiple signal probes for the same signal are not allowed.
 
 ----
 self:signal:SIGUSR1 {

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -252,6 +252,7 @@ private:
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
   bool has_child_ = false;
+  std::unordered_set<std::string> signal_probes_;
 };
 
 } // namespace
@@ -3530,6 +3531,12 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     if (ap.target == "signal") {
       if (!SIGNALS.contains(ap.func))
         ap.addError() << ap.func << " is not a supported signal";
+      if (is_final_pass()) {
+        if (signal_probes_.contains(ap.func))
+          ap.addError() << "More than one signal probe for signal: " << ap.func;
+
+        signal_probes_.insert(ap.func);
+      }
       return;
     }
     ap.addError() << ap.target << " is not a supported trigger";

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2231,6 +2231,12 @@ stdin:1:1-20: ERROR: keypress is not a supported trigger
 self:keypress:space { 1 }
 ~~~~~~~~~~~~~~~~~~~
 )");
+
+  test_error("self:signal:SIGUSR1 { 1 } self:signal:SIGUSR1 { 2 }", R"(
+stdin:1:26-46: ERROR: More than one signal probe for signal: SIGUSR1
+self:signal:SIGUSR1 { 1 } self:signal:SIGUSR1 { 2 }
+                         ~~~~~~~~~~~~~~~~~~~~
+)");
 }
 
 TEST(semantic_analyser, tracepoint)


### PR DESCRIPTION
Add a semantic analyser check for the
case when there are multiple signal
probes with the same signal.

Issue: https://github.com/bpftrace/bpftrace/issues/4110

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
