### PR TITLE
CI: Enable manual runs of "distros" workflow

### DIFF
--- a/.github/workflows/distros.yml
+++ b/.github/workflows/distros.yml
@@ -3,6 +3,7 @@ name: Distros
 on:
   push:
     branches: [ master, release/* ]
+  workflow_dispatch:
 
 # Cancel previous run if a new one is started
 concurrency:


### PR DESCRIPTION
This `workflow_dispatch` event enables a button in the GitHub Actions web interface to manually run the workflow.

More info at: https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow

Reason I want this: to check distro builds of #4115 before merging.