### PR TITLE
Ut/skboutput and exit

### DIFF
--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -11,6 +11,13 @@
 
 namespace bpftrace::async_action {
 
+void exit_handler(BPFtrace &bpftrace, void *data)
+{
+  auto *exit = static_cast<AsyncEvent::Exit *>(data);
+  BPFtrace::exit_code = exit->exit_code;
+  bpftrace.request_finalize();
+}
+
 void join_handler(BPFtrace &bpftrace, Output &out, void *data)
 {
   auto *join = static_cast<AsyncEvent::Join *>(data);

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -70,6 +70,23 @@ void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data)
   out.value(bpftrace, ty, bytes);
 }
 
+void skboutput_handler(BPFtrace &bpftrace, void *data, int size)
+{
+  struct hdr_t {
+    uint64_t aid;
+    uint64_t id;
+    uint64_t ns;
+    uint8_t pkt[];
+  } __attribute__((packed)) * hdr;
+
+  hdr = static_cast<struct hdr_t *>(data);
+
+  int offset = std::get<1>(bpftrace.resources.skboutput_args_.at(hdr->id));
+
+  bpftrace.write_pcaps(
+      hdr->id, hdr->ns, hdr->pkt + offset, size - sizeof(*hdr));
+}
+
 void syscall_handler(BPFtrace &bpftrace,
                      Output &out,
                      AsyncAction printf_id,

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -10,6 +10,7 @@ void join_handler(BPFtrace &bpftrace, Output &out, void *data);
 void time_handler(BPFtrace &bpftrace, Output &out, void *data);
 void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data);
 void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data);
+void skboutput_handler(BPFtrace &bpftrace, void *data, int size);
 void syscall_handler(BPFtrace &bpftrace,
                      Output &out,
                      AsyncAction printf_id,

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -11,6 +11,7 @@ void join_handler(BPFtrace &bpftrace, Output &out, void *data);
 void time_handler(BPFtrace &bpftrace, Output &out, void *data);
 void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data);
 void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data);
+void watchpoint_detach_handler(BPFtrace &bpftrace, void *data);
 void skboutput_handler(BPFtrace &bpftrace, void *data, int size);
 void syscall_handler(BPFtrace &bpftrace,
                      Output &out,

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -6,6 +6,7 @@
 namespace bpftrace::async_action {
 
 const static size_t MAX_TIME_STR_LEN = 64;
+void exit_handler(BPFtrace &bpftrace, void *data);
 void join_handler(BPFtrace &bpftrace, Output &out, void *data);
 void time_handler(BPFtrace &bpftrace, Output &out, void *data);
 void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -230,9 +230,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
 
   // async actions
   if (printf_id == AsyncAction::exit) {
-    auto *exit = static_cast<AsyncEvent::Exit *>(data);
-    BPFtrace::exit_code = exit->exit_code;
-    ctx->bpftrace.request_finalize();
+    async_action::exit_handler(ctx->bpftrace, data);
     return;
   } else if (printf_id == AsyncAction::print) {
     auto *print = static_cast<AsyncEvent::Print *>(data);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -339,19 +339,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
 
     return;
   } else if (printf_id == AsyncAction::watchpoint_detach) {
-    auto *unwatch = static_cast<AsyncEvent::WatchpointUnwatch *>(data);
-    uint64_t addr = unwatch->addr;
-
-    // Remove all probes watching `addr`. Note how we fail silently here
-    // (ie invalid addr). This lets script writers be a bit more aggressive
-    // when unwatch'ing addresses, especially if they're sampling a portion
-    // of addresses they're interested in watching.
-    auto it = std::ranges::remove_if(ctx->bpftrace.attached_probes_,
-                                     [&](const auto &ap) {
-                                       return ap->probe().address == addr;
-                                     });
-    ctx->bpftrace.attached_probes_.erase(it.begin(), it.end());
-
+    async_action::watchpoint_detach_handler(ctx->bpftrace, data);
     return;
   } else if (printf_id == AsyncAction::skboutput) {
     async_action::skboutput_handler(ctx->bpftrace, data, size);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -356,20 +356,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
 
     return;
   } else if (printf_id == AsyncAction::skboutput) {
-    struct hdr_t {
-      uint64_t aid;
-      uint64_t id;
-      uint64_t ns;
-      uint8_t pkt[];
-    } __attribute__((packed)) * hdr;
-
-    hdr = static_cast<struct hdr_t *>(data);
-
-    int offset = std::get<1>(
-        ctx->bpftrace.resources.skboutput_args_.at(hdr->id));
-
-    ctx->bpftrace.write_pcaps(
-        hdr->id, hdr->ns, hdr->pkt + offset, size - sizeof(*hdr));
+    async_action::skboutput_handler(ctx->bpftrace, data, size);
     return;
   } else if (printf_id >= AsyncAction::syscall &&
              printf_id <= AsyncAction::syscall_end) {


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

This pr extracts `watchpoint_detach`, `exit`, and `skboutput` arm implementation in `perf_event_printer`.

Unit tests don't cover these three functions on the following grounds:
1. The `watchpoint_detach` is very simple. It just removes some elements in `bpftrace.attached_probes_`
2. The only test point in `exit` is the `request_finalize` method, whose test point has already been covered by `childproc.terminate`
3. The only test point of `skboutput` is the `write_pcaps` function and it's a simple wrapper of a third library function `pcap_dump` 


##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
