### PR TITLE
parser: fix shift/reduce conflicts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,9 +112,9 @@ find_package(FLEX REQUIRED)
 # But `api.parser.class` is not supported in bison < 3.3. So we must inject
 # the %define based on the bison version here.
 if(${BISON_VERSION} VERSION_GREATER_EQUAL 3.3)
-  set(BISON_FLAGS "-Dapi.parser.class={Parser}")
+  set(BISON_FLAGS "-Dapi.parser.class={Parser} -Wcounterexamples")
 else()
-  set(BISON_FLAGS "-Dparser_class_name={Parser}")
+  set(BISON_FLAGS "-Dparser_class_name={Parser} -Wcounterexamples")
 endif()
 bison_target(bison_parser src/parser.yy ${CMAKE_BINARY_DIR}/parser.tab.cc COMPILE_FLAGS ${BISON_FLAGS} VERBOSE)
 flex_target(flex_lexer src/lexer.l ${CMAKE_BINARY_DIR}/lex.yy.cc)

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -10,7 +10,7 @@
 %define define_location_comparison
 %define parse.assert
 %define parse.trace
-%expect 4
+%expect 0
 
 %define parse.error verbose
 
@@ -99,6 +99,9 @@ void yyerror(bpftrace::Driver &driver, const char *s);
   PTR        "->"
   STRUCT     "struct"
   UNION      "union"
+
+  // Pseudo token; see below.
+  LOW "low-precedence"
 ;
 
 %token <std::string> BUILTIN "builtin"
@@ -169,9 +172,19 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::ConfigStatementList> config_assign_stmt_list config_block
 %type <SizedType> type int_type pointer_type struct_type
 %type <ast::Variable *> var
-%type <ast::Identifier *> raw_ident
 %type <ast::Program *> program
 
+
+// A pseudo token, which is the lowest precedence among all tokens.
+//
+// This helps us explicitly lower the precedence of a given rule to force shift
+// vs. reduce, and make the grammar explicit (still ambiguous, but explicitly
+// ambiguous). For example, consider the inherently ambiguous `@foo[..]`, which
+// could be interpreted as accessing the `@foo` non-scalar map, or indexing
+// into the value of the `@foo` scalar map, e.g. `(@foo)[...]`. We lower the
+// precedence of the associated rules to ensure that this is shifted, and the
+// longer `map_expr` rule will match over the `map` rule in this case.
+%left LOW
 
 %left COMMA
 %right ASSIGN LEFTASSIGN RIGHTASSIGN PLUSASSIGN MINUSASSIGN MULASSIGN DIVASSIGN MODASSIGN BANDASSIGN BORASSIGN BXORASSIGN
@@ -187,7 +200,9 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %left PLUS MINUS
 %left MUL DIV MOD
 %right LNOT BNOT
-%left LPAREN RPAREN LBRACKET RBRACKET DOT PTR
+%left DOT PTR
+%right PAREN RPAREN
+%right LBRACKET RBRACKET
 
 // In order to support the parsing of full programs and the parsing of just
 // expressions (used while expanding C macros, for example), use the trick
@@ -199,12 +214,12 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 
 %%
 
-start:          START_PROGRAM program { driver.result = $2; }
-        |       START_EXPR expr       { driver.result = $2; }
+start:          START_PROGRAM program END { driver.result = $2; }
+        |       START_EXPR expr END       { driver.result = $2; }
                 ;
 
 program:
-                c_definitions config imports map_decl_list macros body END {
+                c_definitions config imports map_decl_list macros body {
                     $$ = driver.ctx.make_node<ast::Program>($1, $2, std::move($3), std::move($4), std::move($5), std::move($6.second), std::move($6.first), @$);
                 }
                 ;
@@ -538,15 +553,13 @@ var_decl_stmt:
         ;
 
 primary_expr:
-                raw_ident          { $$ = $1; }
-        |       UNSIGNED_INT       { $$ = driver.ctx.make_node<ast::Integer>($1, @$); }
+                UNSIGNED_INT       { $$ = driver.ctx.make_node<ast::Integer>($1, @$); }
         |       STRING             { $$ = driver.ctx.make_node<ast::String>($1, @$); }
         |       BUILTIN            { $$ = driver.ctx.make_node<ast::Builtin>($1, @$); }
         |       LPAREN expr RPAREN { $$ = $2; }
         |       param              { $$ = $1; }
         |       param_count        { $$ = $1; }
         |       var                { $$ = $1; }
-        |       map                { $$ = $1; }
         |       map_expr           { $$ = $1; }
         |       "(" vargs "," expr ")"
                 {
@@ -554,6 +567,8 @@ primary_expr:
                   args.push_back($4);
                   $$ = driver.ctx.make_node<ast::Tuple>(std::move(args), @$);
                 }
+        |       map %prec LOW      { $$ = $1; }
+        |       IDENT %prec LOW    { $$ = driver.ctx.make_node<ast::Identifier>($1, @$); }
                 ;
 
 postfix_expr:
@@ -719,10 +734,6 @@ ident:
         |       BUILTIN       { $$ = $1; }
         |       BUILTIN_TYPE  { $$ = $1; }
         |       SIZED_TYPE    { $$ = $1; }
-                ;
-
-raw_ident:
-                IDENT         { $$ = driver.ctx.make_node<ast::Identifier>($1, @$); }
                 ;
 
 struct_field:


### PR DESCRIPTION
Stacked PRs:
 * #4126
 * #4125
 * __->__#4124


--- --- ---

### parser: fix shift/reduce conflicts


This eliminates all expected shift/reduce conflicts which should make it
easy to make changes in the parser without unexpected changes (e.g.
where the number of conflicts stays the same, but they move around).

To do this, we introduce a pseudo-token, which allows us to explicitly
lower the precedence of conflicting reduce rules. The shift variant is
already being used in these cases, so this should not change parsing.

Signed-off-by: Adin Scannell <amscanne@meta.com>
