### PR TITLE
c++20: don't use std::format()

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -34,6 +34,12 @@ Checks:
   - -readability-make-member-function-const
   - -readability-suspicious-call-argument
 
+CheckOptions:
+  # gcc and llvm did not introduce <format> when supporting C++20, so using
+  # std::format is temporarily not allowed.
+  # see issue https://github.com/bpftrace/bpftrace/issues/4185
+  modernize-use-std-format.ReplacementFormat: "DISALLOW"
+
 WarningsAsErrors: "*"
 UseColor: true
 HeaderFilterRegex: ".*"

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -1,4 +1,3 @@
-#include <format>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -171,7 +170,7 @@ void MacroExpander::visit(Expression &expr)
 
 std::string MacroExpander::get_new_var_ident(std::string original_ident)
 {
-  return std::format("$${}_{}", macro_name_, original_ident);
+  return std::string("$$") + macro_name_ + std::string("_") + original_ident;
 }
 
 std::optional<Block *> MacroExpander::expand(Macro &macro, Call &call)

--- a/src/ast/passes/unstable_feature.cpp
+++ b/src/ast/passes/unstable_feature.cpp
@@ -1,5 +1,4 @@
 #include <cstring>
-#include <format>
 #include <string>
 
 #include "ast/ast.h"
@@ -14,18 +13,17 @@ namespace {
 
 std::string get_warning(const std::string &feature)
 {
-  return std::format("Script is using an unstable feature. To prevent this "
+  return std::string("Script is using an unstable feature. To prevent this "
                      "warning you must explicitly enable the unstable "
-                     "feature in the config e.g. {}=enable",
-                     feature);
+                     "feature in the config e.g. ") +
+         feature + std::string("=enable");
 }
 
 std::string get_error(std::string &&feature)
 {
-  return std::format(
-      "Feature not enabled by default. To enable "
-      "this unstable feature, set the config flag to enable. {}=enable",
-      feature);
+  return std::string("Feature not enabled by default. To enable "
+                     "this unstable feature, set the config flag to enable. ") +
+         feature + std::string("=enable");
 }
 
 class UnstableFeature : public Visitor<UnstableFeature> {


### PR DESCRIPTION
On debian12(gcc 12.2.0, llvm 19.1.14):

    ....
    [ 18%] Building CXX object src/ast/CMakeFiles/ast.dir/passes/macro_expansion.cpp.o
    /home/rongtao/Git/bpftrace/bpftrace/src/ast/passes/macro_expansion.cpp:1:10:
    fatal error: format: No such file or directory
        1 | #include <format>
          |          ^~~~~~~~
    compilation terminated.

    ....
    [ 82%] Building CXX object src/ast/CMakeFiles/ast.dir/passes/unstable_feature.cpp.o
    /home/rongtao/Git/bpftrace/bpftrace/src/ast/passes/unstable_feature.cpp:2:10:
    fatal error: format: No such file or directory
        2 | #include <format>
          |          ^~~~~~~~
    compilation terminated.

gcc-13-3936-g1d9454aba615 and llvmorg-13-init-172-g081c1db02dd2 introduce format header. Because the clang/gcc version judgment conditions are more complicated, it is a good solution to directly replace std::format with std::string concatenation.

Link: https://github.com/gcc-mirror/gcc/commit/1d9454aba615
Link: https://github.com/llvm/llvm-project/commit/081c1db02dd2
