### PR TITLE
Make strings unsized from a user's point of view

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -967,7 +967,7 @@ tuple above:
 Just like with any variable the type is determined on first use and cannot be modified afterwards.
 This applies to both the key(s) and the value type.
 
-The following snippets create a map with key signature `(int64, string[16])` and a value type of `int64`:
+The following snippets create a map with key signature `(int64, string)` and a value type of `int64`:
 
 ----
 @[pid, comm]++
@@ -1886,7 +1886,7 @@ For string arguments in an action block use the `str()` call to retrieve the val
 | ID of the cgroup the current process belongs to. Only works with cgroupv2.
 
 | comm
-| string[16]
+| string
 | 4.2
 | get_current_comm
 | Name of the current thread

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -2,7 +2,6 @@
 
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/Module.h>
-#include <sstream>
 
 #include "arch/arch.h"
 #include "ast/async_event_types.h"
@@ -170,7 +169,7 @@ StructType *IRBuilderBPF::GetStackStructType(bool is_ustack)
 }
 
 StructType *IRBuilderBPF::GetStructType(
-    std::string name,
+    const std::string &name,
     const std::vector<llvm::Type *> &elements,
     bool packed)
 {
@@ -376,16 +375,16 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype,
     ty = ArrayType::get(GetType(*stype.GetElementTy()), stype.GetNumElements());
   } else if (stype.IsTupleTy()) {
     std::vector<llvm::Type *> llvm_elems;
-    std::ostringstream ty_name;
+    std::string ty_name;
 
     for (const auto &elem : stype.GetFields()) {
       const auto &elemtype = elem.type;
       llvm_elems.emplace_back(GetType(elemtype));
-      ty_name << elemtype << "_";
+      ty_name += typestr(elemtype, true) + "_";
     }
-    ty_name << "_tuple_t";
+    ty_name += "_tuple_t";
 
-    ty = GetStructType(ty_name.str(), llvm_elems, false);
+    ty = GetStructType(ty_name, llvm_elems, false);
   } else if (stype.IsStack()) {
     ty = GetStackStructType(stype.IsUstackTy());
   } else if (stype.IsPtrTy()) {

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -211,7 +211,7 @@ public:
                              const Location &loc,
                              bool compare_zero = false);
   StructType *GetStackStructType(bool is_ustack);
-  StructType *GetStructType(std::string name,
+  StructType *GetStructType(const std::string &name,
                             const std::vector<llvm::Type *> &elements,
                             bool packed = false);
   Value *CreateGetPid(const Location &loc);

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -14,7 +14,7 @@ std::string Printer::type(const SizedType &ty)
   if (ty.IsNoneTy())
     return "";
   std::stringstream buf;
-  buf << " :: [" << ty;
+  buf << " :: [" << typestr(ty, true);
   if (ty.IsCtxAccess())
     buf << ", ctx: 1";
   if (ty.GetAS() != AddrSpace::none)
@@ -151,14 +151,14 @@ void Printer::visit(Map &map)
   // going to be marked as `is_ctx` or have an associated address space.
   std::string indent(depth_, ' ');
   out_ << indent << "map: " << map.ident;
-  if (!map.key_type.IsNoneTy() || !map.key_type.IsNoneTy()) {
+  if (!map.key_type.IsNoneTy() || !map.value_type.IsNoneTy()) {
     out_ << " :: ";
   }
   if (!map.key_type.IsNoneTy()) {
-    out_ << "[" << map.key_type << "]";
+    out_ << "[" << typestr(map.key_type, true) << "]";
   }
   if (!map.value_type.IsNoneTy()) {
-    out_ << map.value_type;
+    out_ << typestr(map.value_type, true);
   }
   out_ << std::endl;
 }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -47,8 +47,8 @@ path     :(\\.|[_\-\./a-zA-Z0-9#$+\*])+
 builtin  arg[0-9]+|args|cgroup|comm|cpid|numaid|cpu|ncpus|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies|nsecs|kstack|ustack
 
 int_type        bool|(u)?int(8|16|32|64)
-builtin_type    void|(u)?(min|max|sum|avg|stats)_t|count_t|probe_t|username|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|strerror_t|kstack_t|ustack_t
-sized_type      string|inet|buffer
+builtin_type    void|(u)?(min|max|sum|avg|stats)_t|count_t|probe_t|username|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|strerror_t|kstack_t|ustack_t|string
+sized_type      inet|buffer
 subprog         fn
 macro           macro
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -260,22 +260,19 @@ type:
                         {"macaddr_t", CreateMacAddress()},
                         {"cgroup_path_t", CreateCgroupPath()},
                         {"strerror_t", CreateStrerror()},
+                        {"string", CreateString(0)},
                     };
                     $$ = type_map[$1];
                 }
         |       SIZED_TYPE {
-                    if ($1 == "string") {
-                        $$ = CreateString(0);
-                    } else if ($1 == "inet") {
+                    if ($1 == "inet") {
                         $$ = CreateInet(0);
                     } else if ($1 == "buffer") {
                         $$ = CreateBuffer(0);
                     }
                 }
         |       SIZED_TYPE "[" UNSIGNED_INT "]" {
-                    if ($1 == "string") {
-                        $$ = CreateString($3);
-                    } else if ($1 == "inet") {
+                    if ($1 == "inet") {
                         $$ = CreateInet($3);
                     } else if ($1 == "buffer") {
                         $$ = CreateBuffer($3);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -27,7 +27,7 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   return os;
 }
 
-std::string typestr(const SizedType &type)
+std::string typestr(const SizedType &type, bool debug)
 {
   switch (type.GetTy()) {
     case Type::integer:
@@ -36,18 +36,22 @@ std::string typestr(const SizedType &type)
       }
       return (type.is_signed_ ? "int" : "uint") +
              std::to_string(8 * type.GetSize());
-    case Type::inet:
     case Type::string:
+      if (debug)
+        return typestr(type.GetTy()) + "[" + std::to_string(type.GetSize()) +
+               "]";
+      return typestr(type.GetTy());
+    case Type::inet:
     case Type::buffer:
       return typestr(type.GetTy()) + "[" + std::to_string(type.GetSize()) + "]";
     case Type::pointer: {
       std::string prefix;
       if (type.IsCtxAccess())
         prefix = "(ctx) ";
-      return prefix + typestr(*type.GetPointeeTy()) + " *";
+      return prefix + typestr(*type.GetPointeeTy(), debug) + " *";
     }
     case Type::array:
-      return typestr(*type.GetElementTy()) + "[" +
+      return typestr(*type.GetElementTy(), debug) + "[" +
              std::to_string(type.GetNumElements()) + "]";
     case Type::record:
       return type.GetName();
@@ -55,7 +59,7 @@ std::string typestr(const SizedType &type)
       std::string res = "(";
       size_t n = type.GetFieldCount();
       for (size_t i = 0; i < n; ++i) {
-        res += typestr(type.GetField(i).type);
+        res += typestr(type.GetField(i).type, debug);
         if (i != n - 1)
           res += ",";
       }

--- a/src/types.h
+++ b/src/types.h
@@ -503,7 +503,7 @@ public:
 
   bool NeedsPercpuMap() const;
 
-  friend std::string typestr(const SizedType &type);
+  friend std::string typestr(const SizedType &type, bool debug);
 
   // Factories
 
@@ -572,7 +572,7 @@ SizedType CreateTimestampMode();
 
 std::string addrspacestr(AddrSpace as);
 std::string typestr(Type t);
-std::string typestr(const SizedType &type);
+std::string typestr(const SizedType &type, bool debug = false);
 std::ostream &operator<<(std::ostream &os, const SizedType &type);
 
 } // namespace bpftrace

--- a/tests/function_registry.cpp
+++ b/tests/function_registry.cpp
@@ -177,7 +177,7 @@ ERROR: Function not found: 'does_not_exist'
 TEST_F(TestFunctionRegistryPopulated, unique_wrong_args)
 {
   test("unique_int32", { CreateString(32) }, R"(
-ERROR: Cannot call function 'unique_int32' using argument types: (string[32])
+ERROR: Cannot call function 'unique_int32' using argument types: (string)
 HINT: Candidate function:
   unique_int32(int32)
 )");
@@ -277,16 +277,16 @@ TEST_F(TestFunctionRegistryPopulated, unique_tuple)
   test("unique_tuple", { tuple2 }, unique_tuple_);
 
   test("unique_tuple", { tuple3 }, R"(
-ERROR: Cannot call function 'unique_tuple' using argument types: ((int64,string[64]))
+ERROR: Cannot call function 'unique_tuple' using argument types: ((int64,string))
 HINT: Candidate function:
-  unique_tuple((int32,string[64]))
+  unique_tuple((int32,string))
 )");
 
   // Can't pass deconstructed tuple fields as multiple arguments
   test("unique_tuple", { CreateInt32(), CreateString(64) }, R"(
-ERROR: Cannot call function 'unique_tuple' using argument types: (int32, string[64])
+ERROR: Cannot call function 'unique_tuple' using argument types: (int32, string)
 HINT: Candidate function:
-  unique_tuple((int32,string[64]))
+  unique_tuple((int32,string))
 )");
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1878,7 +1878,7 @@ TEST(Parser, cast_sized_type)
   test("kprobe:sys_read { (string)arg0; }",
        "Program\n"
        " kprobe:sys_read\n"
-       "  (string[0])\n"
+       "  (string)\n"
        "   builtin: arg0\n");
 }
 
@@ -1887,7 +1887,7 @@ TEST(Parser, cast_sized_type_pointer)
   test("kprobe:sys_read { (string *)arg0; }",
        "Program\n"
        " kprobe:sys_read\n"
-       "  (string[0] *)\n"
+       "  (string *)\n"
        "   builtin: arg0\n");
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1893,10 +1893,10 @@ TEST(Parser, cast_sized_type_pointer)
 
 TEST(Parser, cast_sized_type_pointer_with_size)
 {
-  test("kprobe:sys_read { (string[1] *)arg0; }",
+  test("kprobe:sys_read { (inet[1] *)arg0; }",
        "Program\n"
        " kprobe:sys_read\n"
-       "  (string[1] *)\n"
+       "  (inet[1] *)\n"
        "   builtin: arg0\n");
 }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4011,10 +4011,10 @@ TEST(semantic_analyser, subprog_arguments)
 {
   test("fn f($a : int64): int64 { return $a; }");
   // Error location is incorrect: #3063
-  test_error("fn f($a : int64): string[16] { return $a; }", R"(
-stdin:1:34-43: ERROR: Function f is of type string[16], cannot return int64
-fn f($a : int64): string[16] { return $a; }
-                                 ~~~~~~~~~
+  test_error("fn f($a : int64): string { return $a; }", R"(
+stdin:1:30-39: ERROR: Function f is of type string[0], cannot return int64
+fn f($a : int64): string { return $a; }
+                             ~~~~~~~~~
 )");
 }
 
@@ -4648,12 +4648,8 @@ TEST(semantic_analyser, variable_declarations)
   test("BEGIN { let $a = 1; }");
   test("BEGIN { let $a: int16 = 1; }");
   test(R"(BEGIN { let $a: string; $a = "hiya"; })");
-  test(R"(BEGIN { let $a: string[5] = "hiya"; })");
   test("BEGIN { let $a: int16; print($a); }");
   test("BEGIN { let $a; print($a); $a = 1; }");
-  // If the type is specified it's strict in that future assignments
-  // need to fit into that type
-  test(R"(BEGIN { let $a: string[5] = "hiya"; $a = "bye"; })");
   test(R"(BEGIN { let $a = "hiya"; $a = "longerstr"; })");
   test("BEGIN { let $a: int16 = 1; $a = (int8)2; }");
   // Test more types
@@ -4705,12 +4701,6 @@ BEGIN { $a = -1; let $a; }
 stdin:1:9-29: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable already has a type 'uint16'
 BEGIN { let $a: uint16 = -1; }
         ~~~~~~~~~~~~~~~~~~~~
-)");
-
-  test_error(R"(BEGIN { let $a: string[5] = "hiya"; $a = "longerstr"; })", R"(
-stdin:1:38-54: ERROR: Type mismatch for $a: trying to assign value of type 'string[10]' when variable already contains a value of type 'string[5]'
-BEGIN { let $a: string[5] = "hiya"; $a = "longerstr"; }
-                                     ~~~~~~~~~~~~~~~~
 )");
 
   test_error(R"(BEGIN { let $a: sum_t; })", R"(

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -22,8 +22,9 @@ TEST(types, to_str)
   EXPECT_EQ(to_str(CreateUInt32()), "uint32");
   EXPECT_EQ(to_str(CreateUInt64()), "uint64");
 
+  EXPECT_EQ(to_str(CreateString(10)), "string");
+
   EXPECT_EQ(to_str(CreateInet(10)), "inet[10]");
-  EXPECT_EQ(to_str(CreateString(10)), "string[10]");
   EXPECT_EQ(to_str(CreateBuffer(10)), "buffer[14]"); // metadata headroom
 
   EXPECT_EQ(to_str(CreatePointer(CreateInt8(), AddrSpace::kernel)), "int8 *");
@@ -38,7 +39,7 @@ TEST(types, to_str)
 
   std::shared_ptr<Struct> tuple = Struct::CreateTuple(
       { CreateInt8(), CreateString(10) });
-  EXPECT_EQ(to_str(CreateTuple(std::move(tuple))), "(int8,string[10])");
+  EXPECT_EQ(to_str(CreateTuple(std::move(tuple))), "(int8,string)");
 
   EXPECT_EQ(to_str(CreateSum(true)), "sum_t");
   EXPECT_EQ(to_str(CreateSum(false)), "usum_t");


### PR DESCRIPTION
Fixes #4120

1. Don't allow users to specify string sizes for variables or subprogs
2. Hide string sizes from user-facing error messages

Sized-string output is kept in developer-facing messages, e.g. `-d ast`


##### Checklist

- ~[ ]~ Language changes are updated in `man/adoc/bpftrace.adoc`
- ~[ ]~ User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
