### PR TITLE
Add new builtin argpid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to
   - [#4095](https://github.com/bpftrace/bpftrace/pull/4095)
 - Support accessing up to 255 USDT probe args
   - [#4118](https://github.com/bpftrace/bpftrace/pull/4118)
+- Add new builtin "argpid"
+  - [#4129](https://github.com/bpftrace/bpftrace/pull/4129)
 #### Changed
 - `-p` CLI flag now applies to all probes (except BEGIN/END)
   - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1879,6 +1879,12 @@ For string arguments in an action block use the `str()` call to retrieve the val
 | n/a
 | The struct of all arguments of the traced function. Available in `tracepoint`, `fentry`, `fexit`, and `uprobe` (with DWARF) probes. Use `args.x` to access argument `x` or `args` to get a record with all arguments.
 
+| `argpid`
+| uint32
+| n/a
+| n/a
+| The process id (or pid) passed to bpftrace via the `-p` CLI option.
+
 | cgroup
 | uint64
 | 4.18

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -642,6 +642,8 @@ ScopedExpr CodegenLLVM::visit(Builtin &builtin)
     return ScopedExpr(b_.CreateGetPid(ctx_, builtin.loc));
   } else if (builtin.ident == "tid") {
     return ScopedExpr(b_.CreateGetTid(ctx_, builtin.loc));
+  } else if (builtin.ident == "argpid") {
+    return ScopedExpr(b_.getInt32(bpftrace_.pid().value_or(0)));
   } else if (builtin.ident == "cgroup") {
     return ScopedExpr(b_.CreateGetCurrentCgroupId(builtin.loc));
   } else if (builtin.ident == "uid" || builtin.ident == "gid" ||

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -856,6 +856,12 @@ void SemanticAnalyser::visit(Builtin &builtin)
     }
   } else if (builtin.ident == "pid" || builtin.ident == "tid") {
     builtin.builtin_type = CreateUInt32();
+  } else if (builtin.ident == "argpid") {
+    if (!bpftrace_.pid()) {
+      builtin.addError() << "'argpid' builtin is available only if -p is set";
+      return;
+    }
+    builtin.builtin_type = CreateUInt32();
   } else if (builtin.ident == "nsecs" || builtin.ident == "elapsed" ||
              builtin.ident == "cgroup" || builtin.ident == "uid" ||
              builtin.ident == "gid" || builtin.ident == "cpu" ||

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -44,7 +44,7 @@ hspace   [ \t]
 vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#$+\*])+
-builtin  arg[0-9]+|args|cgroup|comm|cpid|numaid|cpu|ncpus|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies|nsecs|kstack|ustack
+builtin  arg[0-9]+|args|argpid|cgroup|comm|cpid|numaid|cpu|ncpus|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies|nsecs|kstack|ustack
 
 int_type        bool|(u)?int(8|16|32|64)
 builtin_type    void|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|strerror_t|kstack_t|ustack_t

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -357,3 +357,7 @@ TIMEOUT 1
 NAME block expression
 PROG BEGIN { let $a = { let $b = 1; $b }; print($a); exit(); }
 EXPECT 1
+
+NAME argpid_builtin
+RUN {{BPFTRACE}} -p 1 -e 'BEGIN {print(argpid); exit();}'
+EXPECT 1


### PR DESCRIPTION
The new builtin argpid is an uint32 set to the pid by command line option "-p".

```
  $ result/bin/bpftrace -p 233 -e 'BEGIN {print(argpid); exit();}'
  Attaching 1 probe...
  233
```

Fixes: #3552 

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
