### PR TITLE
Fix type mismatch error for map assignments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to
   - [#4047](https://github.com/bpftrace/bpftrace/pull/4074)
 - Fix probe firing order for fexit and software
   - [#4113](https://github.com/bpftrace/bpftrace/pull/4113)
+- Fix type mismatch error for map assignments
+  - [#4130](https://github.com/bpftrace/bpftrace/pull/4130)
 #### Security
 #### Docs
 #### Tools

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -356,14 +356,14 @@ TEST(semantic_analyser, consistent_map_values)
   test(
       R"(BEGIN { $a = (3, "hello"); @m[1] = $a; $a = (1,"aaaaaaaaaa"); @m[2] = $a; })");
   test_error("kprobe:f { @x = 0; @x = \"a\"; }", R"(
-stdin:1:20-22: ERROR: Type mismatch for @x: trying to assign value of type 'string[2]' when map already contains a value of type 'int64'
+stdin:1:20-28: ERROR: Type mismatch for @x: trying to assign value of type 'string[2]' when map already contains a value of type 'int64'
 kprobe:f { @x = 0; @x = "a"; }
-                   ~~
+                   ~~~~~~~~
 )");
   test_error("kprobe:f { @x = 0; @x = *curtask; }", R"(
-stdin:1:20-22: ERROR: Type mismatch for @x: trying to assign value of type 'struct task_struct' when map already contains a value of type 'int64'
+stdin:1:20-33: ERROR: Type mismatch for @x: trying to assign value of type 'struct task_struct' when map already contains a value of type 'int64'
 kprobe:f { @x = 0; @x = *curtask; }
-                   ~~
+                   ~~~~~~~~~~~~~
 )");
 }
 
@@ -2459,9 +2459,9 @@ kprobe:f { @y = stats(5); @x = @y; }
 stdin:1:35-42: ERROR: Map value 'stats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
 kprobe:f { @x = 1; @y = stats(5); @x = @y; }
                                   ~~~~~~~
-stdin:1:35-37: ERROR: Type mismatch for @x: trying to assign value of type 'stats_t' when map already contains a value of type 'int64'
+stdin:1:35-42: ERROR: Type mismatch for @x: trying to assign value of type 'stats_t' when map already contains a value of type 'int64'
 kprobe:f { @x = 1; @y = stats(5); @x = @y; }
-                                  ~~
+                                  ~~~~~~~
 )");
 
   test("kprobe:f { @ = count(); if (@ > 0) { print((1)); } }");
@@ -2482,9 +2482,9 @@ kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
                                 ~
 )");
   test_error("kprobe:f { @ = count(); @ += 5 }", R"(
-stdin:1:25-26: ERROR: Type mismatch for @: trying to assign value of type 'int64' when map already contains a value of type 'count_t'
+stdin:1:25-31: ERROR: Type mismatch for @: trying to assign value of type 'int64' when map already contains a value of type 'count_t'
 kprobe:f { @ = count(); @ += 5 }
-                        ~
+                        ~~~~~~
 )");
 }
 


### PR DESCRIPTION
Type mismatch diagnostics for variables and maps now highlight the same underscore location.

```
$ ./result/bin/bpftrace -e 'BEGIN { $a = ""; $a = 1; }'
stdin:1:18-24: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable already contains a value of type 'string[1]'
BEGIN { $a = ""; $a = 1; }
                 ~~~~~~
$ ./result/bin/bpftrace -e 'BEGIN { @a = ""; @a = 1; }'
stdin:1:18-24: ERROR: Type mismatch for @a: trying to assign value of type 'int64' when map already contains a value of type 'string[1]'
BEGIN { @a = ""; @a = 1; }
                 ~~~~~~
```

Fixes: https://github.com/bpftrace/bpftrace/issues/3150

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
