### PR TITLE
Parse implicit module BTF

### DIFF
--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -357,7 +357,9 @@ void FieldAnalyser::resolve_type(SizedType &type)
   if (sized_type_.IsNoneTy() && bpftrace_.has_btf_data())
     sized_type_ = bpftrace_.btf_->get_stype(name);
 
-  // Could not resolve destination type - let ClangParser do it
+  // Could not resolve destination type - let ClangParser do it.
+  // The type may have been provided through a #include or some C fragments
+  // inside the script.
   if (sized_type_.IsNoneTy())
     bpftrace_.btf_set_.insert(name);
 }

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -31,15 +31,15 @@ TEST(bpfbytecode, create_programs)
 
   Probe foo;
   foo.type = ProbeType::kprobe;
-  foo.name = "kprobe:foo";
+  foo.name = "kprobe:mock_vmlinux:foo";
   foo.index = 1;
 
   auto &program = bytecode.getProgramForProbe(foo);
 
   EXPECT_EQ(std::string_view{ bpf_program__name(program.bpf_prog()) },
-            "kprobe_foo_1");
+            "kprobe_mock_vmlinux_foo_1");
   EXPECT_EQ(std::string_view{ bpf_program__section_name(program.bpf_prog()) },
-            "s_kprobe_foo_1");
+            "s_kprobe_mock_vmlinux_foo_1");
 }
 
 } // namespace bpftrace::test::bpfbytecode

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -101,7 +101,7 @@ EXPECT_REGEX SUCCESS .*
 
 NAME probe
 PROG k:do_nanosleep { printf("SUCCESS %s\n", probe); exit(); }
-EXPECT SUCCESS kprobe:do_nanosleep
+EXPECT SUCCESS kprobe:vmlinux:do_nanosleep
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME begin probe


### PR DESCRIPTION
If a kprobe did not have an explicit module in the attachpoint, we would fail to parse that module's BTF while at the same point allowing the attachment. This leads to user confusion, as they expect types defined in that module to be available.

For example:

    kprobe:tun_net_xmit {
        $dev = (struct net_device *)arg1;
        $tun = (struct tun_struct *)$dev->priv;
    }
does not parse b/c `struct tun_struct` is unrecognized. However, the same probe using fentry worked just fine:

    fentry:tun_net_xmit {
        $tun = (struct tun_struct *)args->dev->priv;
        print($tun->numqueues);
    }

That was b/c fentry/fexit attachpoint parsing normalized the attachpoint and always inserted module information.

Fix kprobe by doing the same normalization. This fixes #4133.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
