### PR TITLE
refactor: clean up `watchpoint_attach` arm implementation in `perf_ev…

### DIFF
--- a/src/async_action.h
+++ b/src/async_action.h
@@ -11,6 +11,7 @@ void join_handler(BPFtrace &bpftrace, Output &out, void *data);
 void time_handler(BPFtrace &bpftrace, Output &out, void *data);
 void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data);
 void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data);
+void watchpoint_attach_handler(BPFtrace &bpftrace, Output &out, void *data);
 void watchpoint_detach_handler(BPFtrace &bpftrace, void *data);
 void skboutput_handler(BPFtrace &bpftrace, void *data, int size);
 void syscall_handler(BPFtrace &bpftrace,

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -120,7 +120,7 @@ public:
   int num_probes() const;
   int prerun(Output &out) const;
   int run(Output &out, BpfBytecode bytecode);
-  std::vector<std::unique_ptr<AttachedProbe>> attach_probe(
+  virtual std::vector<std::unique_ptr<AttachedProbe>> attach_probe(
       Probe &probe,
       const BpfBytecode &bytecode);
   int run_iter();
@@ -161,6 +161,7 @@ public:
   void request_finalize();
   std::optional<std::string> get_watchpoint_binary_path() const;
   virtual bool is_traceable_func(const std::string &func_name) const;
+  virtual int resume_tracee(pid_t tracee_pid);
   virtual std::unordered_set<std::string> get_func_modules(
       const std::string &func_name) const;
   virtual std::unordered_set<std::string> get_raw_tracepoint_modules(

--- a/tests/async_action.cpp
+++ b/tests/async_action.cpp
@@ -463,4 +463,132 @@ TEST(async_action, print_non_map)
   }
 }
 
+TEST(async_action, watchpoint_attach_out_of_bound)
+{
+  CDefinitions no_c_defs;
+  std::stringstream out;
+  TextOutput output(no_c_defs, out);
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace &bpftrace = *mock_bpftrace;
+  bpftrace.procmon_ = std::make_unique<MockProcMon>(1234);
+  auto invalid_index = 10;
+  AsyncEvent::Watchpoint watch_event(
+      static_cast<int>(AsyncAction::watchpoint_attach), invalid_index, 0x1234);
+
+  // Combine the `EXPECT_CALL` with the `EXPECT_DEATH`
+  // FYI: https://github.com/google/googletest/issues/1004
+  auto watchpoint_attach_handler_op = [&] {
+    EXPECT_CALL(*mock_bpftrace, resume_tracee(testing::_)).Times(1);
+    watchpoint_attach_handler(bpftrace, output, &watch_event);
+  };
+
+  EXPECT_DEATH(watchpoint_attach_handler_op(),
+               "Invalid watchpoint probe idx=" + std::to_string(invalid_index));
+}
+
+TEST(async_action, watchpoint_attach_duplicated_address)
+{
+  CDefinitions no_c_defs;
+  std::stringstream out;
+  TextOutput output(no_c_defs, out);
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace &bpftrace = *mock_bpftrace;
+  bpftrace.procmon_ = std::make_unique<MockProcMon>(1234);
+  AsyncEvent::Watchpoint watch_event(
+      static_cast<int>(AsyncAction::watchpoint_attach), 0, 0x1234);
+  Probe probe;
+  probe.type = ProbeType::watchpoint;
+  probe.address = 0x1234;
+  bpftrace.resources.watchpoint_probes.push_back(std::move(probe));
+  EXPECT_CALL(*mock_bpftrace, attach_probe(testing::_, testing::_)).Times(0);
+  EXPECT_CALL(*mock_bpftrace, resume_tracee(testing::_)).Times(1);
+  watchpoint_attach_handler(bpftrace, output, &watch_event);
+}
+
+TEST(async_action, watchpoint_attach_enospc_exception)
+{
+  CDefinitions no_c_defs;
+  std::stringstream out;
+  TextOutput output(no_c_defs, out);
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace &bpftrace = *mock_bpftrace;
+  bpftrace.procmon_ = std::make_unique<MockProcMon>(1234);
+  AsyncEvent::Watchpoint watch_event(
+      static_cast<int>(AsyncAction::watchpoint_attach), 0, 0x1234);
+  Probe probe;
+  probe.type = ProbeType::watchpoint;
+  probe.address = 0x12345678;
+  bpftrace.resources.watchpoint_probes.push_back(std::move(probe));
+  const char *expected_substring = "Failed to attach watchpoint probe. You are "
+                                   "out of watchpoint registers.";
+  EXPECT_CALL(*mock_bpftrace, attach_probe(testing::_, testing::_))
+      .WillOnce(
+          testing::Throw(util::EnospcException("No more HW registers left")));
+  EXPECT_CALL(*mock_bpftrace, resume_tracee(testing::_)).Times(1);
+  watchpoint_attach_handler(bpftrace, output, &watch_event);
+  EXPECT_THAT(out.str(), testing::HasSubstr(expected_substring))
+      << "Watchpoint_attach output should contain the result of \""
+      << expected_substring << "\"";
+}
+
+TEST(async_action, watchpoint_attach_empty_probes)
+{
+  CDefinitions no_c_defs;
+  std::stringstream out;
+  TextOutput output(no_c_defs, out);
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace &bpftrace = *mock_bpftrace;
+  bpftrace.procmon_ = std::make_unique<MockProcMon>(1234);
+  AsyncEvent::Watchpoint watch_event(
+      static_cast<int>(AsyncAction::watchpoint_attach), 0, 0x1234);
+  Probe probe;
+  probe.type = ProbeType::watchpoint;
+  probe.address = 0x12345678;
+  bpftrace.resources.watchpoint_probes.push_back(std::move(probe));
+  EXPECT_CALL(*mock_bpftrace, attach_probe(testing::_, testing::_))
+      .WillOnce(testing::Return(std::vector<std::unique_ptr<AttachedProbe>>{}));
+  EXPECT_THROW(watchpoint_attach_handler(bpftrace, output, &watch_event),
+               util::FatalUserException);
+}
+
+TEST(async_action, watchpoint_attach_resume_tracee_failed)
+{
+  CDefinitions no_c_defs;
+  std::stringstream out;
+  TextOutput output(no_c_defs, out);
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace &bpftrace = *mock_bpftrace;
+  bpftrace.procmon_ = std::make_unique<MockProcMon>(1234);
+  AsyncEvent::Watchpoint watch_event(
+      static_cast<int>(AsyncAction::watchpoint_attach), 0, 0x1234);
+  Probe probe;
+  probe.type = ProbeType::watchpoint;
+  probe.address = 0x1234;
+  bpftrace.resources.watchpoint_probes.push_back(std::move(probe));
+  EXPECT_CALL(*mock_bpftrace, attach_probe(testing::_, testing::_)).Times(0);
+  EXPECT_CALL(*mock_bpftrace, resume_tracee(testing::_))
+      .WillOnce(testing::Return(-1));
+  EXPECT_THROW(watchpoint_attach_handler(bpftrace, output, &watch_event),
+               util::FatalUserException);
+}
+
+TEST(async_action, asyncwatchpoint_attach_ignore_duplicated_addr)
+{
+  CDefinitions no_c_defs;
+  std::stringstream out;
+  TextOutput output(no_c_defs, out);
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace &bpftrace = *mock_bpftrace;
+  bpftrace.procmon_ = std::make_unique<MockProcMon>(1234);
+  AsyncEvent::Watchpoint watch_event(
+      static_cast<int>(AsyncAction::watchpoint_attach), 0, 0x1234);
+  Probe probe;
+  probe.type = ProbeType::watchpoint;
+  probe.address = 0x1234;
+  probe.async = true;
+  bpftrace.resources.watchpoint_probes.push_back(std::move(probe));
+  EXPECT_CALL(*mock_bpftrace, attach_probe(testing::_, testing::_)).Times(0);
+  EXPECT_CALL(*mock_bpftrace, resume_tracee(testing::_)).Times(0);
+  watchpoint_attach_handler(bpftrace, output, &watch_event);
+}
 } // namespace bpftrace::test::async_action

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -39,6 +39,12 @@ public:
 
 class MockBPFtrace : public BPFtrace {
 public:
+  MOCK_METHOD2(
+      attach_probe,
+      std::vector<std::unique_ptr<AttachedProbe>>(Probe &probe,
+                                                  const BpfBytecode &bytecode));
+
+  MOCK_METHOD1(resume_tracee, int(pid_t tracee_pid));
   std::vector<Probe> get_probes()
   {
     return resources.probes;


### PR DESCRIPTION
…ent_printer`

* extract the `watchpoint_attach` logic into a seperate function `watchpoint_attach_handler`
* add unit tests to cover the `watchpoint_attach_handler` implementation

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Extract the watchpoint_attach logic into a separate function and add tests to cover it. This is the fifth pr of issue #3712 

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
