### PR TITLE
Add signed checks for map keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to
   - [#3956](https://github.com/bpftrace/bpftrace/pull/3956)
 - Add signed type checking for map assignments
   - [#4132](https://github.com/bpftrace/bpftrace/pull/4132)
+- Add signed type checking for map keys
+  - [#4136](https://github.com/bpftrace/bpftrace/pull/4136)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3342,7 +3342,7 @@ ScopedExpr CodegenLLVM::getMapKey(Map &map, Expression &key_expr)
     // Integers are always stored as 64-bit in map keys
     b_.CreateStore(b_.CreateIntCast(scoped_key_expr.value(),
                                     b_.getInt64Ty(),
-                                    key_expr.type().IsSigned()),
+                                    key_type.IsSigned()),
                    key);
   } else {
     if (key_expr.type().IsArrayTy() || key_expr.type().IsRecordTy()) {

--- a/tests/runtime/map
+++ b/tests/runtime/map
@@ -19,6 +19,10 @@ NAME map indexed, scalar-like, with decl
 PROG let @a = hash(1); BEGIN { @a[0] = 0; exit(); }
 EXPECT @a[0]: 0
 
+NAME uint64 key
+PROG BEGIN { @a[18446744073709551615] = 0; exit(); }
+EXPECT @a[18446744073709551615]: 0
+
 # Unfortunately there are some issues when evicting lruhash entries. We can't
 # know exactly which elements will be present. See #3992 for more information.
 NAME map declaration lruhash

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -115,6 +115,6 @@ TIMEOUT 1
 # doesn't happen, but this runtime test exercises a pattern that previously
 # produced code that failed to verify.
 NAME preserve context pointer
-PROG BEGIN { @test[1] = (uint64)1; } tracepoint:syscalls:sys_enter_kill { if (strcontains(comm, "test")) { @test[(uint64)args.pid] = 1; } if (args.pid == @test[1]) { print((1)); } if (args.pid == @test[1]) { print((1)); exit(); } }
+PROG BEGIN { @test[(uint64)1] = (uint64)1; } tracepoint:syscalls:sys_enter_kill { if (strcontains(comm, "test")) { @test[args.pid] = 1; } if (args.pid == @test[1]) { print((1)); } if (args.pid == @test[1]) { print((1)); exit(); } }
 EXPECT Attaching 2 probes...
 TIMEOUT 1

--- a/tools/capable.bt
+++ b/tools/capable.bt
@@ -17,7 +17,7 @@ BEGIN
 	printf("Tracing cap_capable syscalls... Hit Ctrl-C to end.\n");
 	printf("%-9s %-6s %-6s %-16s %-4s %-20s AUDIT\n", "TIME", "UID", "PID",
 	    "COMM", "CAP", "NAME");
-	@cap[0] = "CAP_CHOWN";
+	@cap[(uint64)0] = "CAP_CHOWN";
 	@cap[1] = "CAP_DAC_OVERRIDE";
 	@cap[2] = "CAP_DAC_READ_SEARCH";
 	@cap[3] = "CAP_FOWNER";

--- a/tools/old/tcpdrop.bt
+++ b/tools/old/tcpdrop.bt
@@ -35,7 +35,7 @@ BEGIN
   printf("%-8s %-8s %-16s %-21s %-21s %-8s\n", "TIME", "PID", "COMM", "SADDR:SPORT", "DADDR:DPORT", "STATE");
 
   // See https://github.com/torvalds/linux/blob/master/include/net/tcp_states.h
-  @tcp_states[1] = "ESTABLISHED";
+  @tcp_states[(uint64)1] = "ESTABLISHED";
   @tcp_states[2] = "SYN_SENT";
   @tcp_states[3] = "SYN_RECV";
   @tcp_states[4] = "FIN_WAIT1";

--- a/tools/tcpdrop.bt
+++ b/tools/tcpdrop.bt
@@ -38,7 +38,7 @@ BEGIN
   printf("%-8s %-8s %-16s %-21s %-21s %-8s\n", "TIME", "PID", "COMM", "SADDR:SPORT", "DADDR:DPORT", "STATE");
 
   // See https://github.com/torvalds/linux/blob/master/include/net/tcp_states.h
-  @tcp_states[1] = "ESTABLISHED";
+  @tcp_states[(uint64)1] = "ESTABLISHED";
   @tcp_states[2] = "SYN_SENT";
   @tcp_states[3] = "SYN_RECV";
   @tcp_states[4] = "FIN_WAIT1";

--- a/tools/tcpretrans.bt
+++ b/tools/tcpretrans.bt
@@ -36,7 +36,7 @@ BEGIN
 	    "RADDR:RPORT", "STATE");
 
 	// See include/net/tcp_states.h:
-	@tcp_states[1] = "ESTABLISHED";
+	@tcp_states[(uint64)1] = "ESTABLISHED";
 	@tcp_states[2] = "SYN_SENT";
 	@tcp_states[3] = "SYN_RECV";
 	@tcp_states[4] = "FIN_WAIT1";


### PR DESCRIPTION
This makes sure we can print all uint64
map keys and that there is signed check
if the key is a integer (similar to how
we handle map value types).

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
