### PR TITLE
Parse implicit module BTF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to
   - [#4113](https://github.com/bpftrace/bpftrace/pull/4113)
 - Fix type mismatch error for map assignments
   - [#4130](https://github.com/bpftrace/bpftrace/pull/4130)
+- Parse BTF for implicit kernel modules in kprobe/kretprobe
+  - [#4137](https://github.com/bpftrace/bpftrace/pull/4137)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -717,7 +717,7 @@ AttachPointParser::State AttachPointParser::fentry_parser()
     ap_->func = parts_[2];
   } else {
     ap_->func = parts_[1];
-    if (ap_->func.find('*') == std::string::npos) {
+    if (!util::has_wildcard(ap_->func)) {
       auto func_modules = bpftrace_.get_func_modules(ap_->func);
       if (func_modules.size() == 1)
         ap_->target = *func_modules.begin();

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1342,4 +1342,31 @@ TEST(bpftrace, list_modules_kprobe_explicit)
   EXPECT_THAT(modules, Contains("kernel_mod"));
 }
 
+// Implicit fentry/fexit is not tested b/c the mocks are currently wired
+// up in a somewhat rigid way. The mocked data source uses "vmlinux" module
+// but another mock forces "mock_vmlinux" module. Anyone reading this comment
+// is welcome to try it out again (in case it's been fixed in interim) or do
+// a proper fix.
+
+TEST_F(bpftrace_btf, list_modules_fentry_explicit)
+{
+  auto modules = list_modules("fentry:vmlinux:func_1{},fexit:vmlinux:func_2{}");
+  EXPECT_EQ(modules.size(), 1);
+  EXPECT_THAT(modules, Contains("vmlinux"));
+}
+
+TEST_F(bpftrace_btf, list_modules_rawtracepoint_implicit)
+{
+  auto modules = list_modules("rawtracepoint:event_rt{}");
+  EXPECT_EQ(modules.size(), 1);
+  EXPECT_THAT(modules, Contains("vmlinux"));
+}
+
+TEST_F(bpftrace_btf, list_modules_rawtracepoint_explicit)
+{
+  auto modules = list_modules("rawtracepoint:vmlinux:event_rt{}");
+  EXPECT_EQ(modules.size(), 1);
+  EXPECT_THAT(modules, Contains("vmlinux"));
+}
+
 } // namespace bpftrace::test::bpftrace


### PR DESCRIPTION
If a kprobe did not have an explicit module in the attachpoint, we would fail to parse that module's BTF while at the same point allowing the attachment. This leads to user confusion, as they expect types defined in that module to be available.

For example:

    kprobe:tun_net_xmit {
        $dev = (struct net_device *)arg1;
        $tun = (struct tun_struct *)$dev->priv;
    }
does not parse b/c `struct tun_struct` is unrecognized. However, the same probe using fentry worked just fine:

    fentry:tun_net_xmit {
        $tun = (struct tun_struct *)args->dev->priv;
        print($tun->numqueues);
    }

That was b/c fentry/fexit attachpoint parsing normalized the attachpoint and always inserted module information.

Ideally we'd fix kprobe by doing the same thing in attachpoint parser, but that ends up being somewhat tricky as a bunch of code expects there to not be a module name for the default vmlinux module. It is also backwards incompatible in a risky way, as `probe` builtin will start returning a different string.

So fix by teach BPFtrace::list_modules() to always try to extract module name for any kprobe/kretprobe function. Note we delete the calls to get_raw_tracepoint_modules() and get_func_modules(). Those are extraneous - the probe matcher already takes care of that work for us when returning us the attachpoint with the modules baked in.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
