### PR TITLE
Fix execution watchpoints

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,2 +1,3 @@
 tests/data/data_source.c
 tests/testprogs/usdt_inlined.c
+tests/testprogs/watchpoint_exec.c

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to
   - [#4130](https://github.com/bpftrace/bpftrace/pull/4130)
 - Parse BTF for implicit kernel modules in kprobe/kretprobe
   - [#4137](https://github.com/bpftrace/bpftrace/pull/4137)
+- Fix execution watchpoints
+  - [#4139](https://github.com/bpftrace/bpftrace/pull/4139)
 #### Security
 #### Docs
 #### Tools

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1171,7 +1171,8 @@ void AttachedProbe::attach_watchpoint(std::optional<int> pid,
   }
 
   attr.bp_addr = probe_.address;
-  attr.bp_len = probe_.len;
+  // https://man7.org/linux/man-pages/man2/perf_event_open.2.html
+  attr.bp_len = (attr.bp_type & HW_BREAKPOINT_X) ? sizeof(long) : probe_.len;
   // Generate a notification every 1 event; we care about every event
   attr.sample_period = 1;
 

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -59,3 +59,8 @@ RUN {{BPFTRACE}} -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }'
 EXPECT_REGEX .*increment_0:4:w!
 ARCH aarch64|x86_64
 REQUIRES_FEATURE signal
+
+NAME execution breakpoint
+RUN {{BPFTRACE}} -e 'watchpoint:0x10000000:1:x { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_exec
+EXPECT hit!
+ARCH aarch64|ppc64|ppc64le|x86_64

--- a/tests/testprogs/watchpoint_exec.c
+++ b/tests/testprogs/watchpoint_exec.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static uint8_t insns[] = {
+  0x90, // nop
+  0xc3  // retq
+};
+
+int main()
+{
+  size_t len = getpagesize();
+  void *addr = mmap((void *)0x10000000,
+                    len,
+                    PROT_READ | PROT_WRITE | PROT_EXEC,
+                    MAP_PRIVATE | MAP_ANONYMOUS,
+                    -1,
+                    0);
+  if (addr == MAP_FAILED) {
+    perror("mmap");
+    exit(EXIT_FAILURE);
+  }
+
+  memcpy(addr, insns, sizeof(insns));
+  void (*func)(void);
+  func = addr;
+  (*func)();
+
+  if (munmap(addr, len) == -1) {
+    perror("munmap");
+  }
+  return 0;
+}


### PR DESCRIPTION
As per the perf_event_open man page,
we should be setting bp_len to `sizeof(long)`
for execution breakpoints.

https://man7.org/linux/man-pages/man2/perf_event_open.2.html

Issue: https://github.com/bpftrace/bpftrace/issues/4131

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
