### PR TITLE
cmake: handle the target LLVM not available gracefully

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -100,9 +100,15 @@ if(STATIC_LINKING)
   target_link_libraries(ast PUBLIC ${clang_libs})
   target_link_libraries(ast PUBLIC ${llvm_libs})
 else()
-  # llvm_config macro comes from the LLVM toolchain and will auto-resolve component
-  # names to library names. USE_SHARED option will tell llvm_config macro to prefer
-  # shared library / DLL on the system over the static libraries
-  llvm_config(ast USE_SHARED bpfcodegen ipo irreader mcjit orcjit)
+  if (TARGET LLVM)
+    # llvm_config macro comes from the LLVM toolchain and will auto-resolve component
+    # names to library names. USE_SHARED option will tell llvm_config macro to prefer
+    # shared library / DLL on the system over the static libraries
+    llvm_config(ast USE_SHARED bpfcodegen ipo irreader mcjit orcjit)
+  else()
+    # some build environment(e.g facebookexperimental/ExtendedAndroidTools) doesn't
+    # have libLLVM.so, drop `USE_SHARED` to avoid forcing link to `-lLLVM`.
+    llvm_config(ast bpfcodegen ipo irreader mcjit orcjit)
+  endif()
   target_link_libraries(ast PUBLIC libclang)
 endif()


### PR DESCRIPTION
In PR #3580, it uses `llvm_config` to migrate the LLVM linking issue, but the `llvm_config` directly link the target LLVM[0], which break the bpftrace build in [facebookexperimental/ExtendedAndroidTools](https://github.com/facebookexperimental/ExtendedAndroidTools).

This PR falls back to original logic if LLVM target is not available.

[0] https://github.com/llvm/llvm-project/blob/7a8fe0f83c4ba03d07aef9243596d67af74a3b87/llvm/cmake/modules/LLVM-Config.cmake#L95