### PR TITLE
ast: fix undefined behavior

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -347,7 +347,7 @@ public:
     if (ident.size() < 4 || ident.size() > 6 || !ident.starts_with("arg"))
       return false;
 
-    std::string_view num_part = ident.substr(3);
+    std::string num_part = ident.substr(3);
 
     // no leading zeros
     if (num_part.size() > 1 && num_part.front() == '0')


### PR DESCRIPTION
The `std::string.substr` method returns a new string object. Using this to construct a `string_view` and then destroyed the temporary object will result in undefined behavior. Since the number of characters here is quite small in practice, it will likely be stored inline within the `std::string` anyways, and the `string_view` is an unnecessary optimization. We can simply drop this and use a `std::string` to have well-defined semantics.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
