### PR TITLE
refactor: clean up print arm implementation in `perf_event_printer`

### DIFF
--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -77,6 +77,28 @@ void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data)
   out.value(bpftrace, ty, bytes);
 }
 
+void zero_map_handler(BPFtrace &bpftrace, void *data)
+{
+  auto *mapevent = static_cast<AsyncEvent::MapEvent *>(data);
+  const auto &map = bpftrace.bytecode_.getMap(mapevent->mapid);
+
+  auto err = bpftrace.zero_map(map);
+  if (err)
+    LOG(BUG) << "Could not zero map with ident \"" << map.name()
+             << "\", err=" << std::to_string(err);
+}
+
+void clear_map_handler(BPFtrace &bpftrace, void *data)
+{
+  auto *mapevent = static_cast<AsyncEvent::MapEvent *>(data);
+  const auto &map = bpftrace.bytecode_.getMap(mapevent->mapid);
+
+  auto err = bpftrace.clear_map(map);
+  if (err)
+    LOG(BUG) << "Could not clear map with ident \"" << map.name()
+             << "\", err=" << std::to_string(err);
+}
+
 void watchpoint_attach_handler(BPFtrace &bpftrace, Output &output, void *data)
 {
   auto *watchpoint = static_cast<AsyncEvent::Watchpoint *>(data);

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -11,21 +11,21 @@
 
 namespace bpftrace::async_action {
 
-void exit_handler(BPFtrace &bpftrace, void *data)
+void exit_handler(BPFtrace &bpftrace, const void *data)
 {
-  auto *exit = static_cast<AsyncEvent::Exit *>(data);
+  const auto *exit = static_cast<const AsyncEvent::Exit *>(data);
   BPFtrace::exit_code = exit->exit_code;
   bpftrace.request_finalize();
 }
 
-void join_handler(BPFtrace &bpftrace, Output &out, void *data)
+void join_handler(BPFtrace &bpftrace, Output &out, const void *data)
 {
-  auto *join = static_cast<AsyncEvent::Join *>(data);
+  const auto *join = static_cast<const AsyncEvent::Join *>(data);
   uint64_t join_id = join->join_id;
   const auto *delim = bpftrace.resources.join_args[join_id].c_str();
   std::stringstream joined;
   for (unsigned int i = 0; i < bpftrace.join_argnum_; i++) {
-    auto *arg = join->content + (i * bpftrace.join_argsize_);
+    const auto *arg = join->content + (i * bpftrace.join_argsize_);
     if (arg[0] == 0)
       break;
     if (i)
@@ -35,7 +35,7 @@ void join_handler(BPFtrace &bpftrace, Output &out, void *data)
   out.message(MessageType::join, joined.str());
 }
 
-void time_handler(BPFtrace &bpftrace, Output &out, void *data)
+void time_handler(BPFtrace &bpftrace, Output &out, const void *data)
 {
   // not respecting config_->get(ConfigKeyInt::max_strlen)
   char timestr[MAX_TIME_STR_LEN];
@@ -46,7 +46,7 @@ void time_handler(BPFtrace &bpftrace, Output &out, void *data)
     LOG(WARNING) << "localtime_r: " << strerror(errno);
     return;
   }
-  auto *time = static_cast<AsyncEvent::Time *>(data);
+  const auto *time = static_cast<const AsyncEvent::Time *>(data);
   const auto *fmt = bpftrace.resources.time_args[time->time_id].c_str();
   if (strftime(timestr, sizeof(timestr), fmt, &tmp) == 0) {
     LOG(WARNING) << "strftime returned 0";
@@ -55,18 +55,18 @@ void time_handler(BPFtrace &bpftrace, Output &out, void *data)
   out.message(MessageType::time, timestr, false);
 }
 
-void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data)
+void helper_error_handler(BPFtrace &bpftrace, Output &out, const void *data)
 {
-  auto *helper_error = static_cast<AsyncEvent::HelperError *>(data);
+  const auto *helper_error = static_cast<const AsyncEvent::HelperError *>(data);
   auto error_id = helper_error->error_id;
-  auto return_value = helper_error->return_value;
-  auto &info = bpftrace.resources.helper_error_info[error_id];
+  const auto return_value = helper_error->return_value;
+  const auto &info = bpftrace.resources.helper_error_info[error_id];
   out.helper_error(return_value, info);
 }
 
-void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data)
+void print_non_map_handler(BPFtrace &bpftrace, Output &out, const void *data)
 {
-  auto *print = static_cast<AsyncEvent::PrintNonMap *>(data);
+  const auto *print = static_cast<const AsyncEvent::PrintNonMap *>(data);
   const SizedType &ty = bpftrace.resources.non_map_print_args.at(
       print->print_id);
 
@@ -77,9 +77,21 @@ void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data)
   out.value(bpftrace, ty, bytes);
 }
 
-void zero_map_handler(BPFtrace &bpftrace, void *data)
+void print_map_handler(BPFtrace &bpftrace, Output &out, const void *data)
 {
-  auto *mapevent = static_cast<AsyncEvent::MapEvent *>(data);
+  const auto *print = static_cast<const AsyncEvent::Print *>(data);
+  const auto &map = bpftrace.bytecode_.getMap(print->mapid);
+
+  auto err = bpftrace.print_map(out, map, print->top, print->div);
+
+  if (err)
+    LOG(BUG) << "Could not print map with ident \"" << map.name()
+             << "\", err=" << std::to_string(err);
+}
+
+void zero_map_handler(BPFtrace &bpftrace, const void *data)
+{
+  const auto *mapevent = static_cast<const AsyncEvent::MapEvent *>(data);
   const auto &map = bpftrace.bytecode_.getMap(mapevent->mapid);
 
   auto err = bpftrace.zero_map(map);
@@ -88,9 +100,9 @@ void zero_map_handler(BPFtrace &bpftrace, void *data)
              << "\", err=" << std::to_string(err);
 }
 
-void clear_map_handler(BPFtrace &bpftrace, void *data)
+void clear_map_handler(BPFtrace &bpftrace, const void *data)
 {
-  auto *mapevent = static_cast<AsyncEvent::MapEvent *>(data);
+  const auto *mapevent = static_cast<const AsyncEvent::MapEvent *>(data);
   const auto &map = bpftrace.bytecode_.getMap(mapevent->mapid);
 
   auto err = bpftrace.clear_map(map);
@@ -99,9 +111,11 @@ void clear_map_handler(BPFtrace &bpftrace, void *data)
              << "\", err=" << std::to_string(err);
 }
 
-void watchpoint_attach_handler(BPFtrace &bpftrace, Output &output, void *data)
+void watchpoint_attach_handler(BPFtrace &bpftrace,
+                               Output &output,
+                               const void *data)
 {
-  auto *watchpoint = static_cast<AsyncEvent::Watchpoint *>(data);
+  const auto *watchpoint = static_cast<const AsyncEvent::Watchpoint *>(data);
   uint64_t probe_idx = watchpoint->watchpoint_idx;
   uint64_t addr = watchpoint->addr;
 
@@ -157,9 +171,10 @@ out:
   }
 }
 
-void watchpoint_detach_handler(BPFtrace &bpftrace, void *data)
+void watchpoint_detach_handler(BPFtrace &bpftrace, const void *data)
 {
-  auto *unwatch = static_cast<AsyncEvent::WatchpointUnwatch *>(data);
+  const auto *unwatch = static_cast<const AsyncEvent::WatchpointUnwatch *>(
+      data);
   uint64_t addr = unwatch->addr;
 
   // Remove all probes watching `addr`. Note how we fail silently here

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -6,15 +6,18 @@
 namespace bpftrace::async_action {
 
 const static size_t MAX_TIME_STR_LEN = 64;
-void exit_handler(BPFtrace &bpftrace, void *data);
-void join_handler(BPFtrace &bpftrace, Output &out, void *data);
-void time_handler(BPFtrace &bpftrace, Output &out, void *data);
-void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data);
-void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data);
-void zero_map_handler(BPFtrace &bpftrace, void *data);
-void clear_map_handler(BPFtrace &bpftrace, void *data);
-void watchpoint_attach_handler(BPFtrace &bpftrace, Output &out, void *data);
-void watchpoint_detach_handler(BPFtrace &bpftrace, void *data);
+void exit_handler(BPFtrace &bpftrace, const void *data);
+void join_handler(BPFtrace &bpftrace, Output &out, const void *data);
+void time_handler(BPFtrace &bpftrace, Output &out, const void *data);
+void helper_error_handler(BPFtrace &bpftrace, Output &out, const void *data);
+void print_non_map_handler(BPFtrace &bpftrace, Output &out, const void *data);
+void print_map_handler(BPFtrace &bpftrace, Output &out, const void *data);
+void zero_map_handler(BPFtrace &bpftrace, const void *data);
+void clear_map_handler(BPFtrace &bpftrace, const void *data);
+void watchpoint_attach_handler(BPFtrace &bpftrace,
+                               Output &out,
+                               const void *data);
+void watchpoint_detach_handler(BPFtrace &bpftrace, const void *data);
 void skboutput_handler(BPFtrace &bpftrace, void *data, int size);
 void syscall_handler(BPFtrace &bpftrace,
                      Output &out,

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -11,6 +11,8 @@ void join_handler(BPFtrace &bpftrace, Output &out, void *data);
 void time_handler(BPFtrace &bpftrace, Output &out, void *data);
 void helper_error_handler(BPFtrace &bpftrace, Output &out, void *data);
 void print_non_map_handler(BPFtrace &bpftrace, Output &out, void *data);
+void zero_map_handler(BPFtrace &bpftrace, void *data);
+void clear_map_handler(BPFtrace &bpftrace, void *data);
 void watchpoint_attach_handler(BPFtrace &bpftrace, Output &out, void *data);
 void watchpoint_detach_handler(BPFtrace &bpftrace, void *data);
 void skboutput_handler(BPFtrace &bpftrace, void *data, int size);

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -2,6 +2,9 @@
 #include <unordered_map>
 
 #include "bpfmap.h"
+#include "log.h"
+#include "util/exceptions.h"
+#include "util/stats.h"
 
 namespace bpftrace {
 
@@ -33,16 +36,6 @@ std::string BpfMap::name() const
   return bpftrace_map_name(bpf_name());
 }
 
-uint32_t BpfMap::key_size() const
-{
-  return key_size_;
-}
-
-uint32_t BpfMap::value_size() const
-{
-  return value_size_;
-}
-
 uint32_t BpfMap::max_entries() const
 {
   return max_entries_;
@@ -69,6 +62,136 @@ bool BpfMap::is_printable() const
 {
   // Internal maps are not printable
   return bpf_name().starts_with("AT_");
+}
+
+KeyVec BpfMap::collect_keys() const
+{
+  uint8_t *old_key = nullptr;
+  auto key = KeyType(key_size_);
+
+  // snapshot keys, then operate on them
+  KeyVec keys;
+  while (bpf_map_get_next_key(fd(), old_key, key.data()) == 0) {
+    keys.push_back(key);
+    old_key = key.data();
+  }
+  return keys;
+}
+
+void BpfMap::zero_out(KeyVec &keys, int nvalues) const
+{
+  auto value_size = static_cast<size_t>(value_size_) *
+                    static_cast<size_t>(nvalues);
+  ValueType zero(value_size, 0);
+  for (auto &k : keys) {
+    int err = bpf_map_update_elem(fd(), k.data(), zero.data(), BPF_EXIST);
+
+    if (err && err != -ENOENT) {
+      throw util::BpfMapElemException(
+          "failed to look up elem: " + std::to_string(err) + " (" +
+          std::strerror(-err) + ")");
+    }
+  }
+}
+
+void BpfMap::delete_by_keys(KeyVec &keys) const
+{
+  for (auto &k : keys) {
+    int err = bpf_map_delete_elem(fd(), k.data());
+    if (err && err != -ENOENT) {
+      throw util::BpfMapElemException(
+          "failed to look up elem: " + std::to_string(err) + " (" +
+          std::strerror(-err) + ")");
+    }
+  }
+}
+
+void BpfMap::update_elem(const void *key, const void *value) const
+{
+  auto err = bpf_map_update_elem(fd(), key, value, BPF_ANY);
+  if (err != 0)
+    throw util::BpfMapElemException(
+        "failed to update elem: " + std::to_string(err) + " (" +
+        std::strerror(-err) + ")");
+}
+
+void BpfMap::lookup_elem(const void *key, void *value) const
+{
+  auto err = bpf_map_lookup_elem(fd(), key, value);
+  if (err != 0)
+    throw util::BpfMapElemException(
+        "failed to lookup elem: " + std::to_string(err) + " (" +
+        std::strerror(-err) + ")");
+}
+
+KVPairVec BpfMap::collect_kvs(int nvalues) const
+{
+  uint8_t *old_key = nullptr;
+  auto key = KeyType(key_size_);
+  KVPairVec values_by_key;
+
+  while (bpf_map_get_next_key(fd(), old_key, key.data()) == 0) {
+    auto value = ValueType(value_size_ * nvalues);
+    int err = bpf_map_lookup_elem(fd(), key.data(), value.data());
+    if (err == -ENOENT) {
+      // key was removed by the eBPF program during bpf_map_get_next_key() and
+      // bpf_map_lookup_elem(), let's skip this key
+      continue;
+    } else if (err) {
+      throw util::BpfMapElemException(
+          "failed to look up elem: " + std::to_string(err) + " (" +
+          std::strerror(-err) + ")");
+    }
+
+    values_by_key.emplace_back(key, value);
+
+    old_key = key.data();
+  }
+  return values_by_key;
+}
+
+HistogramMap BpfMap::collect_histogram_data(const MapInfo &map_info,
+                                            int nvalues) const
+{
+  uint8_t *old_key = nullptr;
+  auto key = KeyType(key_size_);
+
+  HistogramMap values_by_key;
+
+  while (bpf_map_get_next_key(fd(), old_key, key.data()) == 0) {
+    auto key_prefix = KeyType(map_info.key_type.GetSize());
+    auto bucket = util::read_data<BucketUnit>(key.data() +
+                                              map_info.key_type.GetSize());
+
+    std::ranges::copy(key.begin(),
+                      key.begin() + map_info.key_type.GetSize(),
+                      key_prefix.begin());
+
+    auto value = ValueType(value_size_ * nvalues);
+    int err = bpf_map_lookup_elem(fd(), key.data(), value.data());
+    if (err == -ENOENT) {
+      // key was removed by the eBPF program during bpf_map_get_next_key() and
+      // bpf_map_lookup_elem(), let's skip this key
+      continue;
+    } else if (err) {
+      throw util::BpfMapElemException(
+          "failed to look up elem: " + std::to_string(err) + " (" +
+          std::strerror(-err) + ")");
+    }
+
+    if (!values_by_key.contains(key_prefix)) {
+      // New key - create a list of buckets for it
+      if (map_info.value_type.IsHistTy())
+        values_by_key[key_prefix] = BucketType(65 * 32);
+      else
+        values_by_key[key_prefix] = BucketType(1002);
+    }
+    values_by_key[key_prefix].at(
+        bucket) = util::reduce_value<BucketUnit>(value, nvalues);
+
+    old_key = key.data();
+  }
+  return values_by_key;
 }
 
 std::string to_string(MapType t)

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -131,7 +131,8 @@ KVPairVec BpfMap::collect_kvs(int nvalues) const
   KVPairVec values_by_key;
 
   while (bpf_map_get_next_key(fd(), old_key, key.data()) == 0) {
-    auto value = ValueType(value_size_ * nvalues);
+    auto value = ValueType(static_cast<size_t>(value_size_) *
+                           static_cast<size_t>(nvalues));
     int err = bpf_map_lookup_elem(fd(), key.data(), value.data());
     if (err == -ENOENT) {
       // key was removed by the eBPF program during bpf_map_get_next_key() and
@@ -167,7 +168,8 @@ HistogramMap BpfMap::collect_histogram_data(const MapInfo &map_info,
                       key.begin() + map_info.key_type.GetSize(),
                       key_prefix.begin());
 
-    auto value = ValueType(value_size_ * nvalues);
+    auto value = ValueType(static_cast<size_t>(value_size_) *
+                           static_cast<size_t>(nvalues));
     int err = bpf_map_lookup_elem(fd(), key.data(), value.data());
     if (err == -ENOENT) {
       // key was removed by the eBPF program during bpf_map_get_next_key() and

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -59,9 +59,9 @@ public:
   bool is_printable() const;
 
   KeyVec collect_keys() const;
-  KVPairVec collect_kvs(int nvalues) const;
-  HistogramMap collect_histogram_data(const MapInfo &map_info,
-                                      int nvalues) const;
+  virtual KVPairVec collect_kvs(int nvalues) const;
+  virtual HistogramMap collect_histogram_data(const MapInfo &map_info,
+                                              int nvalues) const;
   void zero_out(KeyVec &keys, int nvalues) const;
   void delete_by_keys(KeyVec &keys) const;
   void update_elem(const void *key, const void *value) const;

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -5,15 +5,22 @@
 #include <string_view>
 
 #include <bpf/libbpf.h>
-#include <linux/bpf.h>
 
-#include "types.h"
+#include "map_info.h"
 
 namespace libbpf {
 #include "libbpf/bpf.h"
 } // namespace libbpf
 
 namespace bpftrace {
+
+using KeyType = std::vector<uint8_t>;
+using KeyVec = std::vector<KeyType>;
+using ValueType = std::vector<uint8_t>;
+using KVPairVec = std::vector<std::pair<KeyType, ValueType>>;
+using BucketUnit = uint64_t;
+using BucketType = std::vector<BucketUnit>;
+using HistogramMap = std::map<KeyType, BucketType>;
 
 class BpfMap {
 public:
@@ -44,14 +51,21 @@ public:
   libbpf::bpf_map_type type() const;
   const std::string &bpf_name() const;
   std::string name() const;
-  uint32_t key_size() const;
-  uint32_t value_size() const;
   uint32_t max_entries() const;
 
   bool is_stack_map() const;
   bool is_per_cpu_type() const;
   bool is_clearable() const;
   bool is_printable() const;
+
+  KeyVec collect_keys() const;
+  KVPairVec collect_kvs(int nvalues) const;
+  HistogramMap collect_histogram_data(const MapInfo &map_info,
+                                      int nvalues) const;
+  void zero_out(KeyVec &keys, int nvalues) const;
+  void delete_by_keys(KeyVec &keys) const;
+  void update_elem(const void *key, const void *value) const;
+  void lookup_elem(const void *key, void *value) const;
 
 private:
   struct bpf_map *bpf_map_;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -246,22 +246,10 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     async_action::print_non_map_handler(ctx->bpftrace, ctx->output, data);
     return;
   } else if (printf_id == AsyncAction::clear) {
-    auto *mapevent = static_cast<AsyncEvent::MapEvent *>(data);
-    const auto &map = ctx->bpftrace.bytecode_.getMap(mapevent->mapid);
-
-    err = ctx->bpftrace.clear_map(map);
-    if (err)
-      LOG(BUG) << "Could not clear map with ident \"" << map.name()
-               << "\", err=" << std::to_string(err);
+    async_action::clear_map_handler(ctx->bpftrace, data);
     return;
   } else if (printf_id == AsyncAction::zero) {
-    auto *mapevent = static_cast<AsyncEvent::MapEvent *>(data);
-    const auto &map = ctx->bpftrace.bytecode_.getMap(mapevent->mapid);
-
-    err = ctx->bpftrace.zero_map(map);
-    if (err)
-      LOG(BUG) << "Could not zero map with ident \"" << map.name()
-               << "\", err=" << std::to_string(err);
+    async_action::zero_map_handler(ctx->bpftrace, data);
     return;
   } else if (printf_id == AsyncAction::time) {
     async_action::time_handler(ctx->bpftrace, ctx->output, data);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -216,8 +216,6 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
 
   auto printf_id = AsyncAction(*reinterpret_cast<uint64_t *>(arg_data));
 
-  int err;
-
   // Ignore the remaining events if perf_event_printer is called during
   // finalization stage (exit() builtin has been called)
   if (ctx->bpftrace.finalize_)
@@ -233,14 +231,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     async_action::exit_handler(ctx->bpftrace, data);
     return;
   } else if (printf_id == AsyncAction::print) {
-    auto *print = static_cast<AsyncEvent::Print *>(data);
-    const auto &map = ctx->bpftrace.bytecode_.getMap(print->mapid);
-
-    err = ctx->bpftrace.print_map(ctx->output, map, print->top, print->div);
-
-    if (err)
-      LOG(BUG) << "Could not print map with ident \"" << map.name()
-               << "\", err=" << std::to_string(err);
+    async_action::print_map_handler(ctx->bpftrace, ctx->output, data);
     return;
   } else if (printf_id == AsyncAction::print_non_map) {
     async_action::print_non_map_handler(ctx->bpftrace, ctx->output, data);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -125,8 +125,6 @@ public:
       const BpfBytecode &bytecode);
   int run_iter();
   int print_maps(Output &out);
-  int clear_map(const BpfMap &map);
-  int zero_map(const BpfMap &map);
   int print_map(Output &out, const BpfMap &map, uint32_t top, uint32_t div);
   std::string get_stack(int64_t stackid,
                         uint32_t nr_stack_frames,

--- a/src/map_info.h
+++ b/src/map_info.h
@@ -1,0 +1,77 @@
+#pragma once
+#include "types.h"
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
+
+namespace libbpf {
+#include "libbpf/bpf.h"
+} // namespace libbpf
+
+namespace bpftrace {
+
+struct HistogramArgs {
+  long bits = -1;
+  bool scalar = true;
+
+  bool operator==(const HistogramArgs &other)
+  {
+    return bits == other.bits && scalar == other.scalar;
+  }
+  bool operator!=(const HistogramArgs &other)
+  {
+    return !(*this == other);
+  }
+
+private:
+  friend class cereal::access;
+  template <typename Archive>
+  void serialize(Archive &archive)
+  {
+    archive(bits, scalar);
+  }
+};
+
+struct LinearHistogramArgs {
+  long min = -1;
+  long max = -1;
+  long step = -1;
+  bool scalar = true;
+
+  bool operator==(const LinearHistogramArgs &other)
+  {
+    return min == other.min && max == other.max && step == other.step &&
+           scalar == other.scalar;
+  }
+  bool operator!=(const LinearHistogramArgs &other)
+  {
+    return !(*this == other);
+  }
+
+private:
+  friend class cereal::access;
+  template <typename Archive>
+  void serialize(Archive &archive)
+  {
+    archive(min, max, step, scalar);
+  }
+};
+
+struct MapInfo {
+  SizedType key_type;
+  SizedType value_type;
+  std::variant<std::monostate, HistogramArgs, LinearHistogramArgs> detail;
+  int id = -1;
+  int max_entries = -1;
+  libbpf::bpf_map_type bpf_type = libbpf::BPF_MAP_TYPE_HASH;
+  bool is_scalar = false;
+
+private:
+  friend class cereal::access;
+  template <typename Archive>
+  void serialize(Archive &archive)
+  {
+    archive(key_type, value_type, detail, id, max_entries, bpf_type, is_scalar);
+  }
+};
+
+} // namespace bpftrace

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <bpf/libbpf.h>
 #include <cstdint>
 #include <istream>
 #include <ostream>
@@ -15,12 +14,9 @@
 #include "ast/location.h"
 #include "format_string.h"
 #include "globalvars.h"
+#include "map_info.h"
 #include "struct.h"
 #include "types.h"
-
-namespace libbpf {
-#include "libbpf/bpf.h"
-} // namespace libbpf
 
 namespace bpftrace {
 
@@ -58,71 +54,6 @@ private:
   void serialize(Archive &archive)
   {
     archive(func_id, filename, line, column, source_location, source_context);
-  }
-};
-
-struct HistogramArgs {
-  long bits = -1;
-  bool scalar = true;
-
-  bool operator==(const HistogramArgs &other)
-  {
-    return bits == other.bits && scalar == other.scalar;
-  }
-  bool operator!=(const HistogramArgs &other)
-  {
-    return !(*this == other);
-  }
-
-private:
-  friend class cereal::access;
-  template <typename Archive>
-  void serialize(Archive &archive)
-  {
-    archive(bits, scalar);
-  }
-};
-
-struct LinearHistogramArgs {
-  long min = -1;
-  long max = -1;
-  long step = -1;
-  bool scalar = true;
-
-  bool operator==(const LinearHistogramArgs &other)
-  {
-    return min == other.min && max == other.max && step == other.step &&
-           scalar == other.scalar;
-  }
-  bool operator!=(const LinearHistogramArgs &other)
-  {
-    return !(*this == other);
-  }
-
-private:
-  friend class cereal::access;
-  template <typename Archive>
-  void serialize(Archive &archive)
-  {
-    archive(min, max, step, scalar);
-  }
-};
-
-struct MapInfo {
-  SizedType key_type;
-  SizedType value_type;
-  std::variant<std::monostate, HistogramArgs, LinearHistogramArgs> detail;
-  int id = -1;
-  int max_entries = -1;
-  libbpf::bpf_map_type bpf_type = libbpf::BPF_MAP_TYPE_HASH;
-  bool is_scalar = false;
-
-private:
-  friend class cereal::access;
-  template <typename Archive>
-  void serialize(Archive &archive)
-  {
-    archive(key_type, value_type, detail, id, max_entries, bpf_type, is_scalar);
   }
 };
 

--- a/src/util/exceptions.h
+++ b/src/util/exceptions.h
@@ -30,4 +30,11 @@ public:
   using std::runtime_error::runtime_error;
 };
 
+class BpfMapElemException : public std::runtime_error {
+public:
+  // C++11 feature: bring base class constructor into scope to automatically
+  // forward constructor calls to base class
+  using std::runtime_error::runtime_error;
+};
+
 } // namespace bpftrace::util

--- a/src/util/exceptions.h
+++ b/src/util/exceptions.h
@@ -30,11 +30,4 @@ public:
   using std::runtime_error::runtime_error;
 };
 
-class BpfMapElemException : public std::runtime_error {
-public:
-  // C++11 feature: bring base class constructor into scope to automatically
-  // forward constructor calls to base class
-  using std::runtime_error::runtime_error;
-};
-
 } // namespace bpftrace::util

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -29,10 +29,10 @@ static const int STRING_SIZE = 64;
 static const std::optional<int> no_pid = std::nullopt;
 
 template <typename K, typename V>
-KVPairVec generate_kv_pairs(const std::vector<K> &keys,
-                            const std::vector<V> &values)
+MapElements generate_kv_pairs(const std::vector<K> &keys,
+                              const std::vector<V> &values)
 {
-  KVPairVec kv_pairs;
+  MapElements kv_pairs;
   for (size_t i = 0; i < keys.size() && i < values.size(); ++i) {
     std::vector<uint8_t> key_bytes(sizeof(K));
     std::vector<uint8_t> value_bytes(sizeof(V));
@@ -44,10 +44,10 @@ KVPairVec generate_kv_pairs(const std::vector<K> &keys,
 }
 
 template <typename K>
-KVPairVec generate_kv_pairs(const std::vector<K> &keys,
-                            const std::vector<std::string> &values)
+MapElements generate_kv_pairs(const std::vector<K> &keys,
+                              const std::vector<std::string> &values)
 {
-  KVPairVec kv_pairs;
+  MapElements kv_pairs;
   for (size_t i = 0; i < keys.size() && i < values.size(); ++i) {
     std::vector<uint8_t> key_bytes(sizeof(K));
     memcpy(key_bytes.data(), &keys[i], sizeof(K));
@@ -60,10 +60,10 @@ KVPairVec generate_kv_pairs(const std::vector<K> &keys,
 }
 
 template <typename K>
-KVPairVec generate_kv_pairs(const std::vector<K> &keys,
-                            const std::vector<std::vector<uint8_t>> &values)
+MapElements generate_kv_pairs(const std::vector<K> &keys,
+                              const std::vector<std::vector<uint8_t>> &values)
 {
-  KVPairVec kv_pairs;
+  MapElements kv_pairs;
   for (size_t i = 0; i < keys.size() && i < values.size(); ++i) {
     std::vector<uint8_t> key_bytes(sizeof(K));
     memcpy(key_bytes.data(), &keys[i], sizeof(K));
@@ -1493,7 +1493,7 @@ basic_map_4[7]: 5
     auto bpftrace = get_mock_bpftrace();
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,
                                                  tc.name);
-    EXPECT_CALL(*mock_map, collect_kvs(testing::_))
+    EXPECT_CALL(*mock_map, collect_elements(testing::_))
         .WillOnce(testing::Return(returned_kvs));
 
     bpftrace->resources.maps_info[tc.name] = map_info;
@@ -1562,7 +1562,7 @@ max_map_4[3]: 10
     bpftrace->ncpus_ = 3;
     auto mock_map = std::make_unique<MockBpfMap>(
         libbpf::BPF_MAP_TYPE_PERCPU_HASH, tc.name);
-    EXPECT_CALL(*mock_map, collect_kvs(testing::_))
+    EXPECT_CALL(*mock_map, collect_elements(testing::_))
         .WillOnce(testing::Return(returned_kvs));
 
     bpftrace->resources.maps_info[tc.name] = map_info;
@@ -1635,7 +1635,7 @@ avg_map_4[3]: 100
     bpftrace->ncpus_ = 3;
     auto mock_map = std::make_unique<MockBpfMap>(
         libbpf::BPF_MAP_TYPE_PERCPU_HASH, tc.name);
-    EXPECT_CALL(*mock_map, collect_kvs(testing::_))
+    EXPECT_CALL(*mock_map, collect_elements(testing::_))
         .WillOnce(testing::Return(returned_kvs));
 
     bpftrace->resources.maps_info[tc.name] = map_info;
@@ -1699,7 +1699,7 @@ string_map_4[3]: hello
 
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,
                                                  tc.name);
-    EXPECT_CALL(*mock_map, collect_kvs(testing::_))
+    EXPECT_CALL(*mock_map, collect_elements(testing::_))
         .WillOnce(testing::Return(returned_kvs));
 
     bpftrace->resources.maps_info[tc.name] = map_info;

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -47,9 +47,10 @@ public:
       : BpfMap(type, name, key_size, value_size, max_entries)
   {
   }
-  MOCK_CONST_METHOD1(collect_kvs, KVPairVec(int nvalues));
+  MOCK_CONST_METHOD1(collect_elements, Result<MapElements>(int nvalues));
   MOCK_CONST_METHOD2(collect_histogram_data,
-                     HistogramMap(const MapInfo &map_info, int nvalues));
+                     Result<HistogramMap>(const MapInfo &map_info,
+                                          int nvalues));
 };
 
 class MockBPFtrace : public BPFtrace {

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -37,6 +37,21 @@ public:
 #pragma GCC diagnostic pop
 };
 
+class MockBpfMap : public BpfMap {
+public:
+  MockBpfMap(libbpf::bpf_map_type type = libbpf::BPF_MAP_TYPE_HASH,
+             std::string name = "mock_map",
+             uint32_t key_size = sizeof(uint64_t),
+             uint32_t value_size = sizeof(uint64_t),
+             uint32_t max_entries = 10)
+      : BpfMap(type, name, key_size, value_size, max_entries)
+  {
+  }
+  MOCK_CONST_METHOD1(collect_kvs, KVPairVec(int nvalues));
+  MOCK_CONST_METHOD2(collect_histogram_data,
+                     HistogramMap(const MapInfo &map_info, int nvalues));
+};
+
 class MockBPFtrace : public BPFtrace {
 public:
   MOCK_METHOD2(


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

This is the last pr of issue #3712. 


## Key changes
### Refactored BpfMap

* move some map relevant operations from `Bpftrace` to `BpfMap`

### Extracted handler functions and added comprehensive tests

* Moved `clear_map`, `zero_map`, and `print_map` handling from `perf_event_printer` to a dedicated handler function
* Created tests for `print_map` with various map types (`avg`, `max`, `lhist`, `hist`)
* Added tests for key sorting, `top` parameter, and `div` parameter behavior

## Not covered
The `clear_map` and `zero_map` handlers weren't specifically tested due to their simple logic.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
