### PR TITLE
Macros: prevent mutation of temp variables

### DIFF
--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -76,7 +76,6 @@ TEST(macro_expansion, basic_checks)
 TEST(macro_expansion, variables)
 {
   test("macro set($x) { $x += 1; $x } BEGIN { $a = 1; set($a); }");
-  test("macro set($x) { $x += 1; $x } BEGIN { $a = 1; set(1); }");
   test("macro set($x, $y) { $x + $y } BEGIN { $a = 1; set($a, 1); }");
   test("macro set($x) { $b = $x + 1; $b } BEGIN { $a = 1; set($a); }");
   test("macro set($x) { let $b = $x + 1; $b } BEGIN { $a = 1; set($a); }");
@@ -85,6 +84,10 @@ TEST(macro_expansion, variables)
       "macro set($x) { $x += 1; $x } BEGIN { @a = 1; set(@a); }",
       "Mismatched arg to macro call. Macro expects a variable for arg $x "
       "but got a map.");
+
+  test_error("macro add1($x) { $x += 1; $x } BEGIN { add1(1 + 1); }",
+             "Macro 'add1' assigns to parameter '$x', meaning it expects a "
+             "variable, not an expression.");
 }
 
 TEST(macro_expansion, maps)

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -2,10 +2,6 @@ NAME it mutates the passed variable
 PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); print($a); exit(); }
 EXPECT 2
 
-NAME it does not mutate previously passed variable with literal
-PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); inc(1); print($a); exit(); }
-EXPECT 2
-
 NAME it mutates the passed non-scalar map
 PROG macro set(@x) { @x[1] = 2; 1 } BEGIN { @a[1] = 1; set(@a); exit(); }
 EXPECT @a[1]: 2


### PR DESCRIPTION
If a user passes an expression to a macro
prevent mutation of the temp variable we
create to prevent unexpected behavior.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
