### PR TITLE
ast: don't bind nodes to `ASTContext&`

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -10,12 +10,12 @@ namespace bpftrace::ast {
 
 Diagnostic &Node::addError() const
 {
-  return ctx_.diagnostics_->addError(loc);
+  return state_.diagnostics_->addError(loc);
 }
 
 Diagnostic &Node::addWarning() const
 {
-  return ctx_.diagnostics_->addWarning(loc);
+  return state_.diagnostics_->addWarning(loc);
 }
 
 const SizedType &Expression::type() const

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -69,7 +69,7 @@ enum class ExpansionType {
 
 class Node {
 public:
-  Node(ASTContext &ctx, Location &&loc) : ctx_(ctx), loc(loc) {};
+  Node(ASTContext &ctx, Location &&loc) : state_(*ctx.state_), loc(loc) {};
   virtual ~Node() = default;
 
   Node(const Node &) = delete;
@@ -81,7 +81,12 @@ public:
   Diagnostic &addWarning() const;
 
 private:
-  ASTContext &ctx_;
+  // N.B. it is not legal to hold on to a long-term reference to `ASTContext&`,
+  // as this is generally movable. Therefore, we hold on to the internal state
+  // only, which will not be moving.
+  //
+  // See `ASTContext::State` for more information.
+  ASTContext::State &state_;
 
 public:
   // This is temporarily accessible by other classes because we don't have a

--- a/src/ast/context.cpp
+++ b/src/ast/context.cpp
@@ -16,7 +16,7 @@ ASTSource::ASTSource(std::string &&filename, std::string &&input)
 }
 
 ASTContext::ASTContext(std::string &&filename, std::string &&contents)
-    : diagnostics_(std::make_unique<Diagnostics>()),
+    : state_(std::make_unique<State>()),
       source_(
           std::make_shared<ASTSource>(std::move(filename), std::move(contents)))
 {
@@ -34,8 +34,12 @@ ASTContext::ASTContext() : ASTContext("", "")
 void ASTContext::clear()
 {
   root = nullptr;
-  nodes_.clear();
-  diagnostics_->clear();
+  state_->nodes_.clear();
+  state_->diagnostics_->clear();
+}
+
+ASTContext::State::State() : diagnostics_(std::make_unique<Diagnostics>())
+{
 }
 
 } // namespace bpftrace::ast

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -50,7 +50,7 @@ void Driver::error(const location &l, const std::string &m)
 {
   // This path is normally not allowed, however we don't yet have nodes
   // constructed. Therefore, we add diagnostics directly via the private field.
-  ctx.diagnostics_->addError(ctx.wrap(l)) << m;
+  ctx.state_->diagnostics_->addError(ctx.wrap(l)) << m;
 }
 
 ast::Pass CreateParsePass(bool debug)

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -30,6 +30,11 @@ RUN {{BPFTRACE}} -l | grep kprobes
 EXPECT_REGEX kprobe:.*
 TIMEOUT 1
 
+NAME it lists kprobes with glob matching
+RUN {{BPFTRACE}} -l 'kprobe*'
+EXPECT_REGEX kprobe:.*
+TIMEOUT 1
+
 NAME it lists tracepoints
 RUN {{BPFTRACE}} -l | grep tracepoint
 EXPECT_REGEX tracepoint:.*


### PR DESCRIPTION
Stacked PRs:
 * __->__#4163


--- --- ---

### ast: don't bind nodes to `ASTContext&`


The ASTContext may be moved, and is not guaranteed to be durable.
Instead, ensuring that the nodes themselves are bound to something
that will not be moving. This adds a small layer of indirection within
the `ASTContext` object.

Fixes #4162

Signed-off-by: Adin Scannell <amscanne@meta.com>