### PR TITLE
Add return value to delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ and this project adheres to
   - [#4132](https://github.com/bpftrace/bpftrace/pull/4132)
 - Add signed type checking for map keys
   - [#4136](https://github.com/bpftrace/bpftrace/pull/4136)
+- `delete` now returns 1 if successful, 0 if not
+  - [#4186](https://github.com/bpftrace/bpftrace/pull/4186)
+- if `delete` fails it will only print a warning if return value is not handled
+  - [#4186](https://github.com/bpftrace/bpftrace/pull/4186)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3457,12 +3457,29 @@ interval:s:10 {
 === delete
 
 .variants
-* `void delete(map m, mapkey k)`
-* deprecated `void delete(mapkey k)`
+* `bool delete(map m, mapkey k)`
+* deprecated `bool delete(mapkey k)`
 
 Delete a single key from a map.
 For scalar maps (e.g. no explicit keys), the key is omitted and is equivalent to calling `clear`.
 For map keys that are composed of multiple values (e.g. `@mymap[3, "hello"] = 1` - remember these values are represented as a tuple) the syntax would be: `delete(@mymap, (3, "hello"));`
+
+If deletion fails (e.g. the key doesn't exist) the function returns false (0).
+Additionally, if the return value for `delete` is discarded, and deletion fails, you will get a warning.
+
+```
+@a[1] = 1;
+
+delete(@a, 1); // no warning (the key exists)
+
+if (delete(@a, 2)) { // no warning (return value is used)
+  ...
+}
+
+$did_delete = delete(@a, 2); // no warning (return value is used)
+
+delete(@a, 2); // warning (return value is discarded and the key doesn't exist)
+```
 
 The, now deprecated, API (supported in version <= 0.21.x) of passing map arguments with the key is still supported:
 e.g. `delete(@mymap[3, "hello"]);`.

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -404,6 +404,7 @@ public:
   // happens, this number is increased so that later error reporting can
   // correctly account for this.
   size_t injected_args = 0;
+  bool ret_val_discarded = false;
 };
 
 class Sizeof : public Node {

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -55,7 +55,10 @@ public:
                            Value *val,
                            const Location &loc,
                            int64_t flags = 0);
-  void CreateMapDeleteElem(Map &map, Value *key, const Location &loc);
+  CallInst *CreateMapDeleteElem(Map &map,
+                                Value *key,
+                                bool ret_val_discarded,
+                                const Location &loc);
   Value *CreateForEachMapElem(Map &map,
                               Value *callback,
                               Value *callback_ctx,
@@ -187,7 +190,7 @@ public:
   void CreateHelperErrorCond(Value *return_value,
                              libbpf::bpf_func_id func_id,
                              const Location &loc,
-                             bool compare_zero = false);
+                             bool suppress_error = false);
   StructType *GetStackStructType(bool is_ustack);
   StructType *GetStructType(const std::string &name,
                             const std::vector<llvm::Type *> &elements,

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1196,7 +1196,7 @@ void SemanticAnalyser::visit(Call &call)
   } else if (call.func == "stats") {
     call.return_type = CreateStats(true);
   } else if (call.func == "delete") {
-    // Leave as `none`.
+    call.return_type = CreateUInt8();
   } else if (call.func == "has_key") {
     // TODO: this should be a bool type but that type is currently broken
     // as a value for variables and maps
@@ -2935,6 +2935,16 @@ void SemanticAnalyser::visit(Tuple &tuple)
 
 void SemanticAnalyser::visit(ExprStatement &expr)
 {
+  if (auto *call = expr.expr.as<Call>()) {
+    // Calls from expression statements are bare, meaning they're not
+    // handling the return value e.g.
+    // delete(@a, 1); <- ExprStatement
+    // vs
+    // $x = delete(@a, 1) <- AssignVarStatement
+    // if (delete(@a, 1)) { <- If
+    call->ret_val_discarded = true;
+  }
+
   visit(expr.expr);
 }
 

--- a/tests/codegen/llvm/call_delete.ll
+++ b/tests/codegen/llvm/call_delete.ll
@@ -30,6 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 1, ptr %"@x_key1", align 8
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %"@x_key1")
+  %delete_ret = icmp eq i64 %delete_elem, 0
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   ret i64 0
 }

--- a/tests/codegen/llvm/call_delete_deprecated.ll
+++ b/tests/codegen/llvm/call_delete_deprecated.ll
@@ -30,6 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
   store i64 1, ptr %"@x_key1", align 8
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %"@x_key1")
+  %delete_ret = icmp eq i64 %delete_elem, 0
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   ret i64 0
 }

--- a/tests/codegen/llvm/call_map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/call_map_key_scratch_buf.ll
@@ -95,6 +95,7 @@ lookup_merge6:                                    ; preds = %lookup_failure5, %l
   %14 = getelementptr [1 x [3 x [16 x i8]]], ptr @map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
   store i64 1, ptr %14, align 8
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %14)
+  %delete_ret = icmp eq i64 %delete_elem, 0
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_map_key_stack.ll
+++ b/tests/codegen/llvm/call_map_key_stack.ll
@@ -86,6 +86,7 @@ lookup_merge4:                                    ; preds = %lookup_failure3, %l
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key11")
   store i64 1, ptr %"@x_key11", align 8
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %"@x_key11")
+  %delete_ret = icmp eq i64 %delete_elem, 0
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key11")
   ret i64 0
 }

--- a/tests/codegen/llvm/runtime_error_check_delete.ll
+++ b/tests/codegen/llvm/runtime_error_check_delete.ll
@@ -75,6 +75,7 @@ helper_failure2:                                  ; preds = %helper_merge
   br i1 %ringbuf_loss8, label %event_loss_counter6, label %counter_merge7
 
 helper_merge3:                                    ; preds = %counter_merge7, %helper_merge
+  %delete_ret = icmp eq i64 %delete_elem, 0
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   ret i64 0
 

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -250,8 +250,10 @@ EXPECT @: 0
 TIMEOUT 1
 
 NAME delete map
-PROG BEGIN { @ = 1; @a[1] = 1; @b[1, 2] = 2; delete(@); delete(@a, 1); delete(@b, (1, 2)); printf("ok\n"); exit(); }
-EXPECT ok
+PROG BEGIN { @ = 1; @a[1] = 1; @b[1, 2] = 2; if (delete(@)) { printf("ok1\n"); } delete(@a, 1); if (delete(@b, (1, 2))) { printf("ok2\n"); } if (!delete(@b, (5, 6))) { printf("ok3\n"); } exit(); }
+EXPECT ok1
+EXPECT ok2
+EXPECT ok3
 TIMEOUT 1
 
 NAME delete count-map
@@ -263,6 +265,16 @@ NAME delete deprecated
 PROG BEGIN { @a[1] = 1; @b[2, "hi"] = 2; delete(@a[1]); delete(@b[2, "hi"]); exit(); }
 EXPECT_NONE @a[1]: 1
 EXPECT_NONE @b[2, hi]: 2
+TIMEOUT 1
+
+NAME bad delete warning
+PROG BEGIN { @a[1] = 1; delete(@a, 2); exit(); }
+EXPECT stdin:1:20-33: WARNING: Can't delete map element because it does not exist.
+TIMEOUT 1
+
+NAME bad delete no warning
+PROG BEGIN { @a[1] = 1; $x = delete(@a, 2); if (1 && !delete(@a, 3)) {} exit(); }
+EXPECT_NONE stdin:1:20-33: WARNING: Can't delete map element because it does not exist.
 TIMEOUT 1
 
 NAME increment/decrement map

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -888,6 +888,11 @@ TEST(semantic_analyser, call_delete)
   test("kprobe:f { @y[(3, 4, 5)] = 5; delete(@y, (1, 2, 3)); }");
   test("kprobe:f { @y[((int8)3, 4, 5)] = 5; delete(@y, (1, 2, 3)); }");
   test("kprobe:f { @y[(3, 4, 5)] = 5; delete(@y, ((int8)1, 2, 3)); }");
+  test("kprobe:f { @y = delete(@x); }");
+  test("kprobe:f { $y = delete(@x); }");
+  test("kprobe:f { @[delete(@x)] = 1; }");
+  test("kprobe:f { @x = 1; if(delete(@x)) { 123 } }");
+  test("kprobe:f { @x = 1; delete(@x) ? 0 : 1; }");
   // The second arg gets treated like a map key, in terms of int type adjustment
   test("kprobe:f { @y[5] = 5; delete(@y, (int8)5); }");
   test("kprobe:f { @y[5, 4] = 5; delete(@y, ((int8)5, (int64)4)); }");
@@ -902,45 +907,6 @@ kprobe:f { delete(1); }
 stdin:1:12-20: ERROR: delete() expects a map argument
 kprobe:f { delete(1, 1); }
            ~~~~~~~~
-)");
-
-  test_error("kprobe:f { @y = delete(@x); }", R"(
-stdin:1:12-27: ERROR: Not a valid assignment: none
-kprobe:f { @y = delete(@x); }
-           ~~~~~~~~~~~~~~~
-stdin:1:12-14: ERROR: Undefined map: @y
-kprobe:f { @y = delete(@x); }
-           ~~
-)");
-
-  test_error("kprobe:f { $y = delete(@x); }", R"(
-stdin:1:12-27: ERROR: Value 'none' cannot be assigned to a scratch variable.
-kprobe:f { $y = delete(@x); }
-           ~~~~~~~~~~~~~~~
-)");
-
-  test_error("kprobe:f { @[delete(@x)] = 1; }", R"(
-stdin:1:12-24: ERROR: Invalid map key type: none
-kprobe:f { @[delete(@x)] = 1; }
-           ~~~~~~~~~~~~
-)");
-
-  test_error("kprobe:f { @x = 1; if(delete(@x)) { 123 } }", R"(
-stdin:1:20-42: ERROR: Invalid condition in if(): none
-kprobe:f { @x = 1; if(delete(@x)) { 123 } }
-                   ~~~~~~~~~~~~~~~~~~~~~~
-)");
-
-  test_error("kprobe:f { @x = 1; delete(@x) ? 0 : 1; }", R"(
-stdin:1:20-39: ERROR: Invalid condition in ternary: none
-kprobe:f { @x = 1; delete(@x) ? 0 : 1; }
-                   ~~~~~~~~~~~~~~~~~~~
-)");
-
-  test_error("kprobe:f { @y[5] = 5; delete(@y[5], 5); }", R"(
-stdin:1:23-35: ERROR: delete() expects a map argument
-kprobe:f { @y[5] = 5; delete(@y[5], 5); }
-                      ~~~~~~~~~~~~
 )");
 
   test_error("kprobe:f { @y[(3, 4, 5)] = 5; delete(@y, (1, 2)); }", R"(


### PR DESCRIPTION
Additionally, check if the return value
for delete is discarded. If it is discarded
issue a warning if there was an error deleting.
This allows users to handle deletion errors
and prevent expected warnings.

Issue: https://github.com/bpftrace/bpftrace/issues/4169

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
