### PR TITLE
tools/killsnoop: support tkill() and tgkill()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ and this project adheres to
 #### Security
 #### Docs
 #### Tools
+- killsnoop.bt: support tkill() and tgkill()
+  - [#4190](https://github.com/bpftrace/bpftrace/pull/4190)
 - Remove tools example usage txt files and move info to comments
   - [#4187](https://github.com/bpftrace/bpftrace/pull/4187)
 - Fix biosnoop.bt to print comm from block_io_start probe

--- a/man/man8/killsnoop.bt.8
+++ b/man/man8/killsnoop.bt.8
@@ -1,21 +1,22 @@
 .TH killsnoop.bt 8  "2018-09-07" "USER COMMANDS"
 .SH NAME
-killsnoop.bt \- Trace signals issued by the kill() syscall. Uses bpftrace/eBPF.
+killsnoop.bt \- Trace signals issued by the kill(),tkill(),tgkill() syscall.
+Uses bpftrace/eBPF.
 .SH SYNOPSIS
 .B killsnoop.bt
 .SH DESCRIPTION
-killsnoop traces the kill() syscall, to show signals sent via this method. This
-may be useful to troubleshoot failing applications, where an unknown mechanism
-is sending signals.
+killsnoop traces the kill(),tkill(),tgkill() syscall, to show signals sent via
+this method. This may be useful to troubleshoot failing applications, where an
+unknown mechanism is sending signals.
 
-This works by tracing the kill() syscall tracepoints.
+This works by tracing the kill(),tkill(),tgkill() syscall tracepoints.
 
 Since this uses BPF, only the root user can use this tool.
 .SH REQUIREMENTS
 CONFIG_BPF and bpftrace.
 .SH EXAMPLES
 .TP
-Trace all kill() syscalls:
+Trace all kill(),tkill(),tgkill() syscalls:
 #
 .B killsnoop.bt
 .SH FIELDS
@@ -41,8 +42,8 @@ Result. 0 == success, a negative value (of the error code) for failure.
 This traces the kernel kill function and prints output for each event. As the
 rate of this is generally expected to be low (< 100/s), the overhead is also
 expected to be negligible. If you have an application that is calling a very
-high rate of kill()s for some reason, then test and understand overhead before
-use.
+high rate of kill()|tkill()|tgkill()s for some reason, then test and understand
+overhead before use.
 .SH SOURCE
 This is from bpftrace.
 .IP

--- a/tools/killsnoop.bt
+++ b/tools/killsnoop.bt
@@ -1,13 +1,13 @@
 #!/usr/bin/env bpftrace
 /*
- * killsnoop	Trace signals issued by the kill() syscall.
+ * killsnoop	Trace signals issued by the kill(),tkill(),tgkill() syscall.
  *		For Linux, uses bpftrace and eBPF.
  * 
  * Example of usage:
  * 
  * # ./killsnoop.bt
  * Attaching 3 probes...
- * Tracing kill() signals... Hit Ctrl-C to end.
+ * Tracing kill(),tkill(),tgkill() signals... Hit Ctrl-C to end.
  * TIME                PID COMM              SIG   TPID RESULT
  * 00:09:37.345938   22485 bash                2  23856      0
  * 00:09:40.838452   22485 bash                2  23856     -3
@@ -24,25 +24,30 @@
  * Copyright 2018 Netflix, Inc.
  *
  * 07-Sep-2018	Brendan Gregg	Created this.
+ * 27-May-2025	Rong Tao	Support tkill(), tgkill()
  */
 
 BEGIN
 {
-	printf("Tracing kill() signals... Hit Ctrl-C to end.\n");
-	printf("%-15s %7s %-16s %4s %6s %s\n",
+	printf("Tracing kill(),tkill(),tgkill() signals... Hit Ctrl-C to end.\n");
+	printf("%-15s %8s %-16s %4s %8s %s\n",
 		"TIME", "PID", "COMM", "SIG", "TPID", "RESULT");
 }
 
-tracepoint:syscalls:sys_enter_kill
+tracepoint:syscalls:sys_enter_kill,
+tracepoint:syscalls:sys_enter_tkill,
+tracepoint:syscalls:sys_enter_tgkill
 {
 	@tpid[tid] = args.pid;
 	@tsig[tid] = args.sig;
 }
 
-tracepoint:syscalls:sys_exit_kill
+tracepoint:syscalls:sys_exit_kill,
+tracepoint:syscalls:sys_exit_tkill,
+tracepoint:syscalls:sys_exit_tgkill
 /@tpid[tid]/
 {
-	printf("%-15s %7d %-16s %4d %6d %6d\n",
+	printf("%-15s %8d %-16s %4d %8d %6d\n",
 		strftime("%H:%M:%S.%f", nsecs),
 		pid, comm, @tsig[tid], @tpid[tid], args.ret);
 	delete(@tpid, tid);


### PR DESCRIPTION
Support tkill(2) and tgkill(2):

    $ sudo ./killsnoop.bt
    Attaching 7 probes...
    Tracing kill(),tkill(),tgkill() signals... Hit Ctrl-C to end.
    TIME                 PID COMM              SIG     TPID RESULT
    17:27:28.840289  1514550 kill                2  1514550      0
    17:27:31.344713  1514552 tkill              15  1514553      0
    17:27:33.773795  1514555 tgkill             15  1514556      0

At the same time, the output misalignment problem caused by excessive PID is eliminated.
