### PR TITLE
chore: remove unused attributes of `usdt_sem_up` function

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -907,8 +907,8 @@ int AttachedProbe::usdt_sem_up_manual_addsem(int pid,
   return err;
 }
 
-int AttachedProbe::usdt_sem_up([[maybe_unused]] BPFfeature &feature,
-                               [[maybe_unused]] int pid,
+int AttachedProbe::usdt_sem_up(BPFfeature &feature,
+                               int pid,
                                const std::string &fn_name,
                                void *ctx)
 {


### PR DESCRIPTION
Remove the unused [[maybe_unused]] of `usdt_sem_up` function

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Remove unused [[maybe_unused]] attributes for `usdt_sem_up` function. 

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
