### PR TITLE
Fix attaching probe count and change attaching language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ and this project adheres to
   - [#4137](https://github.com/bpftrace/bpftrace/pull/4137)
 - Fix execution watchpoints
   - [#4139](https://github.com/bpftrace/bpftrace/pull/4139)
+- Fix incorrect reporting of attached count for multi probes
+  - [#4194](https://github.com/bpftrace/bpftrace/pull/4194)
 #### Security
 #### Docs
 #### Tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ and this project adheres to
   - [#4186](https://github.com/bpftrace/bpftrace/pull/4186)
 - if `delete` fails it will only print a warning if return value is not handled
   - [#4186](https://github.com/bpftrace/bpftrace/pull/4186)
+- Change "Attaching N probes..." to "Attached N probes"
+  - [#4194](https://github.com/bpftrace/bpftrace/pull/4194)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/docs/migration_guide.md
+++ b/docs/migration_guide.md
@@ -155,7 +155,7 @@ BEGIN { $x = pid; $x = cgroup; }
 To mitigate such an error, just typecast `pid` or `tid` to `uint64`:
 ```
 # bpftrace -e 'BEGIN { $x = (uint64)pid; $x = cgroup; }'
-Attaching 1 probe...
+Attached 1 probe
 ```
 
 ### default `SIGUSR1` handler removed

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -33,7 +33,7 @@ $ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 ```
 $ nix build
 $ sudo ./result/bin/bpftrace -e 'BEGIN { print("hello world!") }'
-Attaching 1 probe...
+Attached 1 probe
 hello world!
 ^C
 ```
@@ -53,7 +53,7 @@ $ nix build .#appimage
 $ ldd ./result
         not a dynamic executable
 $ sudo ./result -e 'BEGIN { print("static!"); exit() }'
-Attaching 1 probe...
+Attached 1 probe
 static!
 ```
 

--- a/docs/tutorial_one_liners.md
+++ b/docs/tutorial_one_liners.md
@@ -24,7 +24,7 @@ bpftrace -l 'tracepoint:syscalls:sys_enter_*'
 
 ```
 # bpftrace -e 'BEGIN { printf("hello world\n"); }'
-Attaching 1 probe...
+Attached 1 probe
 hello world
 ^C
 ```
@@ -38,7 +38,7 @@ This prints a welcome message. Run it, then hit Ctrl-C to end.
 
 ```
 # bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args.filename)); }'
-Attaching 1 probe...
+Attached 1 probe
 snmp-pass /proc/cpuinfo
 snmp-pass /proc/stat
 snmpd /proc/net/dev
@@ -61,7 +61,7 @@ members of this struct can be found with: `bpftrace -vl tracepoint:syscalls:sys_
 
 ```
 bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @[bpftrace]: 6
@@ -82,7 +82,7 @@ Maps are automatically printed when bpftrace ends (eg, via Ctrl-C).
 
 ```
 # bpftrace -e 'tracepoint:syscalls:sys_exit_read /pid == 18644/ { @bytes = hist(args.ret); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @bytes:
@@ -108,7 +108,7 @@ This summarizes the return value of the sys_read() kernel function for PID 18644
 
 ```
 # bpftrace -e 'kretprobe:vfs_read { @bytes = lhist(retval, 0, 2000, 200); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @bytes:
@@ -135,7 +135,7 @@ Summarize read() bytes as a linear histogram, and traced using kernel dynamic tr
 
 ```
 # bpftrace -e 'kprobe:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid]/ { @ns[comm] = hist(nsecs - @start[tid]); delete(@start, tid); }'
-Attaching 2 probes...
+Attached 2 probes
 
 [...]
 @ns[snmp-pass]:
@@ -174,7 +174,7 @@ Summarize the time spent in read(), in nanoseconds, as a histogram, by process n
 
 ```
 # bpftrace -e 'tracepoint:sched:sched* { @[probe] = count(); } interval:s:5 { exit(); }'
-Attaching 25 probes...
+Attached 25 probes
 @[tracepoint:sched:sched_wakeup_new]: 1
 @[tracepoint:sched:sched_process_fork]: 1
 @[tracepoint:sched:sched_process_exec]: 1
@@ -199,7 +199,7 @@ Count process-level events for five seconds, printing a summary.
 
 ```
 # bpftrace -e 'profile:hz:99 { @[kstack] = count(); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 [...]
@@ -263,7 +263,7 @@ This counts stack traces that led to context switching (off-CPU) events. The abo
 
 ```
 # bpftrace -e 'tracepoint:block:block_rq_issue { @ = hist(args.bytes); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @:
@@ -311,7 +311,7 @@ kprobe:vfs_open
 }
 
 # bpftrace path.bt
-Attaching 1 probe...
+Attached 1 probe
 open path: dev
 open path: if_inet6
 open path: retrans_time_ms

--- a/docs/tutorial_one_liners_chinese.md
+++ b/docs/tutorial_one_liners_chinese.md
@@ -20,7 +20,7 @@ bpftrace -l 'tracepoint:syscalls:sys_enter_*'
 
 ```
 # bpftrace -e 'BEGIN { printf("hello world\n"); }'
-Attaching 1 probe...
+Attached 1 probe
 hello world
 ^C
 ```
@@ -34,7 +34,7 @@ hello world
 
 ```
 # bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args.filename)); }'
-Attaching 1 probe...
+Attached 1 probe
 snmp-pass /proc/cpuinfo
 snmp-pass /proc/stat
 snmpd /proc/net/dev
@@ -54,7 +54,7 @@ snmpd /proc/net/if_inet6
 
 ```
 bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @[bpftrace]: 6
@@ -75,7 +75,7 @@ Maps会在bpftrace结束(如按Ctrl-C)时自动打印出来。
 
 ```
 # bpftrace -e 'tracepoint:syscalls:sys_exit_read /pid == 18644/ { @bytes = hist(args.ret); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @bytes:
@@ -100,7 +100,7 @@ Attaching 1 probe...
 
 ```
 # bpftrace -e 'kretprobe:vfs_read { @bytes = lhist(retval, 0, 2000, 200); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @bytes:
@@ -127,7 +127,7 @@ Attaching 1 probe...
 
 ```
 # bpftrace -e 'kprobe:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid]/ { @ns[comm] = hist(nsecs - @start[tid]); delete(@start, tid); }'
-Attaching 2 probes...
+Attached 2 probes
 
 [...]
 @ns[snmp-pass]:
@@ -165,7 +165,7 @@ Attaching 2 probes...
 
 ```
 # bpftrace -e 'tracepoint:sched:sched* { @[probe] = count(); } interval:s:5 { exit(); }'
-Attaching 25 probes...
+Attached 25 probes
 @[tracepoint:sched:sched_wakeup_new]: 1
 @[tracepoint:sched:sched_process_fork]: 1
 @[tracepoint:sched:sched_process_exec]: 1
@@ -190,7 +190,7 @@ Attaching 25 probes...
 
 ```
 # bpftrace -e 'profile:hz:99 { @[kstack] = count(); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 [...]
@@ -254,7 +254,7 @@ secondary_startup_64+165
 
 ```
 # bpftrace -e 'tracepoint:block:block_rq_issue { @ = hist(args.bytes); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @:
@@ -302,7 +302,7 @@ kprobe:vfs_open
 }
 
 # bpftrace path.bt
-Attaching 1 probe...
+Attached 1 probe
 open path: dev
 open path: if_inet6
 open path: retrans_time_ms

--- a/docs/tutorial_one_liners_japanese.md
+++ b/docs/tutorial_one_liners_japanese.md
@@ -21,7 +21,7 @@ bpftrace -l 'tracepoint:syscalls:sys_enter_*'
 
 ```
 # bpftrace -e 'BEGIN { printf("hello world\n"); }'
-Attaching 1 probe...
+Attached 1 probe
 hello world
 ^C
 ```
@@ -35,7 +35,7 @@ hello world
 
 ```
 # bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args.filename)); }'
-Attaching 1 probe...
+Attached 1 probe
 snmp-pass /proc/cpuinfo
 snmp-pass /proc/stat
 snmpd /proc/net/dev
@@ -58,7 +58,7 @@ snmpd /proc/net/if_inet6
 
 ```
 bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @[bpftrace]: 6
@@ -79,7 +79,7 @@ Attaching 1 probe...
 
 ```
 # bpftrace -e 'tracepoint:syscalls:sys_exit_read /pid == 18644/ { @bytes = hist(args.ret); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @bytes:
@@ -105,7 +105,7 @@ PID 18644 のプロセスによるカーネル関数 sys_read() の戻り値を�
 
 ```
 # bpftrace -e 'kretprobe:vfs_read { @bytes = lhist(retval, 0, 2000, 200); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @bytes:
@@ -132,7 +132,7 @@ read() のバイト数を線形スケールのヒストグラムとして集計�
 
 ```
 # bpftrace -e 'kprobe:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid]/ { @ns[comm] = hist(nsecs - @start[tid]); delete(@start, tid); }'
-Attaching 2 probes...
+Attached 2 probes
 
 [...]
 @ns[snmp-pass]:
@@ -171,7 +171,7 @@ read() の実行時間をナノ秒単位で計測し，プロセスごとにヒ�
 
 ```
 # bpftrace -e 'tracepoint:sched:sched* { @[probe] = count(); } interval:s:5 { exit(); }'
-Attaching 25 probes...
+Attached 25 probes
 @[tracepoint:sched:sched_wakeup_new]: 1
 @[tracepoint:sched:sched_process_fork]: 1
 @[tracepoint:sched:sched_process_exec]: 1
@@ -196,7 +196,7 @@ Attaching 25 probes...
 
 ```
 # bpftrace -e 'profile:hz:99 { @[kstack] = count(); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 [...]
@@ -260,7 +260,7 @@ secondary_startup_64+165
 
 ```
 # bpftrace -e 'tracepoint:block:block_rq_issue { @ = hist(args.bytes); }'
-Attaching 1 probe...
+Attached 1 probe
 ^C
 
 @:
@@ -308,7 +308,7 @@ kprobe:vfs_open
 }
 
 # bpftrace path.bt
-Attaching 1 probe...
+Attached 1 probe
 open path: dev
 open path: if_inet6
 open path: retrans_time_ms
@@ -325,4 +325,3 @@ open path: retrans_time_ms
 カーネル構造体のサポートは bcc と同様にカーネルヘッダを利用します．したがって多くの構造体が利用可能ですが，全てではありません．場合によっては手動で構造体を定義する必要があります．例えば [dcsnoop tool](../tools/dcsnoop.bt) では nameidata 構造体の一部を手動で定義しています．これはこの構造体がヘッダ内で定義されていないためです．LinuxカーネルのBTFデータがある場合，全ての構造体が利用可能です．
 
 ここまでで bpftrace の多くを理解し，強力なワンライナーを作成・利用することができます．bpftrace のその他の機能については [インストラクションマニュアル](../man/adoc/bpftrace.adoc) を参照して下さい．
-

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2070,7 +2070,7 @@ With no arguments, `$1` defaults to zero:
 
 ----
 # ./bsize.bt
-Attaching 2 probes...
+Attached 2 probes
 Tracing block I/O sizes > 0 bytes
 ^C
 
@@ -3101,7 +3101,7 @@ interval:s:30 {
 Note how the async `time` and `printf` first print every second until the `interval:s:10` probe hits, then they print every 10 seconds due to bpftrace blocking on `sleep`.
 
 ----
-Attaching 3 probes...
+Attached 3 probes
 08:50:37: 0
 08:50:38: 1
 08:50:39: 2
@@ -4246,7 +4246,7 @@ foo.h
 
 # bpftrace -I /tmp/include program.bt
 
-Attaching 1 probe...
+Attached 1 probe
 ----
 
 The `--include` option can be used to include headers by default.
@@ -4257,7 +4257,7 @@ Headers are included in the order they are defined, and they are included before
 # bpftrace --include linux/path.h --include linux/dcache.h \
     -e 'kprobe:vfs_open { printf("open path: %s\n", str(((struct path *)arg0)->dentry->d_name.name)); }'
 
-Attaching 1 probe...
+Attached 1 probe
 open path: .com.google.Chrome.ASsbu2
 open path: .com.google.Chrome.gimc10
 open path: .com.google.Chrome.R1234s
@@ -4270,7 +4270,7 @@ The `-v` option prints more information about the program as it is run:
 ----
 # bpftrace -v -e 'tracepoint:syscalls:sys_enter_nanosleep { printf("%s is sleeping.\n", comm); }'
 AST node count: 7
-Attaching 1 probe...
+Attached 1 probe
 
 load tracepoint:syscalls:sys_enter_nanosleep, with BTF, with func_infos: Success
 
@@ -4413,7 +4413,7 @@ And then calling it:
 ----
 # bpftrace sleepers.bt
 
-Attaching 1 probe...
+Attached 1 probe
 iscsid is sleeping.
 iscsid is sleeping.
 ----
@@ -4435,7 +4435,7 @@ Then make it executable:
 # chmod 755 sleepers.bt
 # ./sleepers.bt
 
-Attaching 1 probe...
+Attached 1 probe
 iscsid is sleeping.
 iscsid is sleeping.
 ----

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -630,6 +630,8 @@ public:
       const BpfProgram &prog);
   ~AttachedMultiKprobeProbe() override;
 
+  size_t probe_count() const override;
+
 private:
   AttachedMultiKprobeProbe(const Probe &probe, int progfd, int link_fd);
   int link_fd_;
@@ -645,6 +647,11 @@ AttachedMultiKprobeProbe::AttachedMultiKprobeProbe(const Probe &probe,
 AttachedMultiKprobeProbe::~AttachedMultiKprobeProbe()
 {
   close(link_fd_);
+}
+
+size_t AttachedMultiKprobeProbe::probe_count() const
+{
+  return probe_.funcs.size();
 }
 
 Result<std::unique_ptr<AttachedMultiKprobeProbe>> AttachedMultiKprobeProbe::
@@ -755,6 +762,8 @@ public:
       std::optional<int> pid);
   ~AttachedMultiUprobeProbe() override;
 
+  size_t probe_count() const override;
+
 private:
   AttachedMultiUprobeProbe(const Probe &probe, int progfd, int link_fd);
   int link_fd_;
@@ -770,6 +779,11 @@ AttachedMultiUprobeProbe::AttachedMultiUprobeProbe(const Probe &probe,
 AttachedMultiUprobeProbe::~AttachedMultiUprobeProbe()
 {
   close(link_fd_);
+}
+
+size_t AttachedMultiUprobeProbe::probe_count() const
+{
+  return probe_.funcs.size();
 }
 
 #ifdef HAVE_LIBBPF_UPROBE_MULTI

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -45,6 +45,10 @@ public:
   AttachedProbe &operator=(const AttachedProbe &) = delete;
 
   virtual int link_fd();
+  virtual size_t probe_count() const
+  {
+    return 1;
+  }
 
   const Probe &probe() const
   {
@@ -53,9 +57,9 @@ public:
 
 protected:
   AttachedProbe(const Probe &probe, int progfd);
+  const Probe &probe_;
 
 private:
-  const Probe &probe_;
   const int progfd_;
 };
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -876,7 +876,11 @@ int BPFtrace::run(Output &out, BpfBytecode bytecode)
     }
   }
 
-  size_t num_attached = attached_probes_.size();
+  size_t num_attached = 0;
+
+  for (auto &ap : attached_probes_) {
+    num_attached += ap->probe_count();
+  }
 
   auto total_attached = num_attached + num_special_attached;
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -835,9 +835,9 @@ void TextOutput::lost_events(uint64_t lost) const
 void TextOutput::attached_probes(uint64_t num_probes) const
 {
   if (num_probes == 1)
-    out_ << "Attaching " << num_probes << " probe..." << std::endl;
+    out_ << "Attached " << num_probes << " probe" << std::endl;
   else
-    out_ << "Attaching " << num_probes << " probes..." << std::endl;
+    out_ << "Attached " << num_probes << " probes" << std::endl;
 }
 
 void TextOutput::helper_error(int retcode, const HelperErrorInfo &info) const

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -1,16 +1,16 @@
 NAME user_supplied_c_def_using_btf
 PROG struct foo { struct task_struct t; } BEGIN { exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 REQUIRES_FEATURE btf
 
 NAME tracepoint_pointer_type_resolution
 PROG tracepoint:syscalls:sys_enter_nanosleep { args.rqtp->tv_sec; exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 REQUIRES_FEATURE btf
 
 NAME tracepoint_nested_pointer_type_resolution
 PROG tracepoint:napi:napi_poll { args.napi->dev->name; exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 REQUIRES_FEATURE btf
 
 NAME enum_value_reference
@@ -67,7 +67,7 @@ CLEANUP nft delete table bpftrace
 
 NAME kernel_module_tracepoint
 PROG tracepoint:xfs:xfs_setfilesize { print(args.offset) } i:ms:1 { exit(); }
-EXPECT Attaching 2 probes...
+EXPECT Attached 2 probes
 REQUIRES_FEATURE btf
 REQUIRES lsmod | grep "^xfs"
 
@@ -76,14 +76,14 @@ REQUIRES lsmod | grep "^xfs"
 # This tests checks that the correct BTF definition is pulled from 'kvm'.
 NAME kernel_module_type_fwd
 PROG fentry:kvm:x86_emulate_insn { printf("%d\n", args.ctxt->mode); exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 TIMEOUT 2
 REQUIRES_FEATURE fentry
 REQUIRES lsmod | grep '^kvm'
 
 NAME kprobe_kernel_module_type_fwd
 PROG kprobe:kvm:x86_emulate_insn { $ctxt = (struct x86_emulate_ctxt *) arg0; printf("%d\n", $ctxt->mode); exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 TIMEOUT 2
 REQUIRES lsmod | grep '^kvm'
 

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -40,11 +40,11 @@ EXPECT SUCCESS bpftrace
 
 NAME kstack
 PROG BEGIN { printf("%s\n", kstack); exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 
 NAME ustack
 PROG BEGIN { printf("%s\n", ustack); exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 
 NAME arg
 PROG k:vfs_read { printf("SUCCESS %p\n", arg0); exit(); }

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -320,17 +320,17 @@ EXPECT_FILE runtime/outputs/lhist.txt
 
 NAME kstack
 PROG k:do_nanosleep { printf("%s\n%s\n", kstack(), kstack(1)); exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME kstack perf mode
 PROG k:do_nanosleep { printf("%s\n", kstack(perf, 1)); exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack
 PROG u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack(1)); exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 AFTER ./testprogs/uprobe_loop
 
 NAME ustack_stack_mode_env_bpftrace
@@ -631,7 +631,7 @@ MIN_KERNEL 5.5
 # Just test that the verifier doesn't reject this
 NAME skboutput rawtracepoint
 RUN {{BPFTRACE}} -e 'rawtracepoint:consume_skb { $ret = skboutput("receive.pcap", (struct sk_buff *)arg0, 1, 0); printf("ret: %d\n", $ret); exit(); }'
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 REQUIRES_FEATURE skboutput
 MIN_KERNEL 5.5
 

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -157,7 +157,7 @@ TIMEOUT 1
 
 NAME positional as string literal
 RUN {{BPFTRACE}} -e 'BEGIN { @ = kaddr(str($1)); exit() }' vfs_read
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 
 NAME positional arg count
 RUN {{BPFTRACE}} -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); exit();}' "one" 2

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -127,7 +127,7 @@ REQUIRES_FEATURE kprobe_multi
 
 NAME kprobe_wildcard_multi_probe_count
 RUN {{BPFTRACE}} -e 'kprobe:vfs_* { exit(); }'
-EXPECT_REGEX Attaching [0-9][0-9]+ probes...
+EXPECT_REGEX Attached [0-9][0-9]+ probes
 REQUIRES_FEATURE kprobe_multi
 
 NAME kprobe_module

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -125,6 +125,11 @@ EXPECT progs: 1
 REQUIRES bpftool
 REQUIRES_FEATURE kprobe_multi
 
+NAME kprobe_wildcard_multi_probe_count
+RUN {{BPFTRACE}} -e 'kprobe:vfs_* { exit(); }'
+EXPECT_REGEX Attaching [0-9][0-9]+ probes...
+REQUIRES_FEATURE kprobe_multi
+
 NAME kprobe_module
 PROG kprobe:vmlinux:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT_REGEX SUCCESS [0-9][0-9]*

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -71,13 +71,13 @@ TIMEOUT 3
 # ctx+const is ok, but ctx+const+const is not ok.
 NAME access ctx struct field twice
 PROG tracepoint:sched:sched_wakeup { if (args.comm == "asdf") { print(args.comm) } exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 TIMEOUT 1
 
 # https://github.com/bpftrace/bpftrace/issues/2135
 NAME address_probe_invalid_expansion
 RUN {{BPFTRACE}} -e "uprobe:./testprogs/uprobe_test:0x$(nm ./testprogs/uprobe_test | awk '$3 == "uprobeFunction1" {print $1}') { @[probe] = count(); exit() }"
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 TIMEOUT 1
 
 # The verifier is not able to track BTF info for double pointer dereferences and
@@ -87,26 +87,26 @@ NAME fentry double pointer dereference
 PROG fentry:__module_get { print((*args.module->trace_events)->flags); exit(); }
 AFTER lsmod
 REQUIRES_FEATURE fentry
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 TIMEOUT 1
 
 NAME fentry double pointer array access
 PROG fentry:__module_get { print(args.module->trace_events[1]->flags); exit(); }
 AFTER lsmod
 REQUIRES_FEATURE fentry
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 TIMEOUT 1
 
 NAME fentry array access via pointer
 PROG fentry:__module_get { print(args.module->version[0]); exit(); }
 AFTER lsmod
 REQUIRES_FEATURE fentry
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 TIMEOUT 1
 
 NAME unaligned key with aligned value
 PROG BEGIN { @mapA["aaaabbb", 0] = 1; @mapA["ccccdddd", 0] = 1; }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 TIMEOUT 1
 
 # In some cases, LLVM can generate code that violates the BPF verifier
@@ -116,5 +116,5 @@ TIMEOUT 1
 # produced code that failed to verify.
 NAME preserve context pointer
 PROG BEGIN { @test[(uint64)1] = (uint64)1; } tracepoint:syscalls:sys_enter_kill { if (strcontains(comm, "test")) { @test[args.pid] = 1; } if (args.pid == @test[1]) { print((1)); } if (args.pid == @test[1]) { print((1)); exit(); } }
-EXPECT Attaching 2 probes...
+EXPECT Attached 2 probes
 TIMEOUT 1

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -116,8 +116,8 @@ AFTER ./testprogs/uprobe_test
 
 NAME ustack in tuple
 PROG BEGIN { print((ustack, "a")); exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 
 NAME kstack in tuple
 PROG BEGIN { print((kstack, "a")); exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -39,7 +39,7 @@ BEFORE ./testprogs/mountns_wrapper uprobe_test
 
 NAME uprobes - attach to probe for executable in separate mount namespace
 RUN {{BPFTRACE}} -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:uprobeFunction1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
 NAME uprobes - attach to probe for executable in a pivot_root'd mount namespace
@@ -49,7 +49,7 @@ BEFORE ./testprogs/mountns_pivot_wrapper uprobe_test
 
 NAME uprobes - attach to probe by pid with only wildcard
 RUN {{BPFTRACE}} -e 'uprobe:*:uprobeFunction1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - attach to multiple probes by pid with only wildcard
@@ -63,7 +63,7 @@ EXPECT uprobe:./testlibs/libsimple.so:fun
 
 NAME uprobes - probe function in non-executable library
 PROG uprobe:./testlibs/libsimple.so:fun {}
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 
 NAME uprobes - attach to single process with pid arg
 RUN {{BPFTRACE}} runtime/scripts/uprobe_pid_check.bt -p {{BEFORE_PID}} {{BEFORE_PID}}

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -87,13 +87,13 @@ REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - all probes by wildcard and file
 PROG usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }
-EXPECT Attaching 3 probes...
+EXPECT Attached 3 probes
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - all probes by wildcard and file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
-EXPECT Attaching 3 probes...
+EXPECT Attached 3 probes
 
 # TODO(mmarchini): re-enable this test
 # This test has two problems: it relies on the latest version of bcc and it
@@ -105,45 +105,45 @@ EXPECT Attaching 3 probes...
 #    and https://github.com/bpftrace/bpftrace/issues/688
 NAME usdt probes - all probes by wildcard and pid
 RUN {{BPFTRACE}} -e 'usdt:* { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
-EXPECT Attaching 3 probes...
+EXPECT Attached 3 probes
 BEFORE ./testprogs/usdt_test
 REQUIRES bash -c "exit 1"
 # REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - attach to probe by wildcard and file
 PROG usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }
-EXPECT Attaching 2 probes...
+EXPECT Attached 2 probes
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - attach to probe by wildcard and file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
-EXPECT Attaching 2 probes...
+EXPECT Attached 2 probes
 
 NAME usdt probes - attach to probes by wildcard file
 PROG usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }
-EXPECT Attaching 3 probes...
+EXPECT Attached 3 probes
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - attach to probes by wildcard file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
-EXPECT Attaching 3 probes...
+EXPECT Attached 3 probes
 
 NAME usdt probes - attach to probe on multiple files by wildcard
 PROG usdt:./testprogs/usdt*::* { printf("here\n" ); exit(); }
-EXPECT Attaching 49 probes...
+EXPECT Attached 49 probes
 
 NAME usdt probes - attach to probe on multiple providers by wildcard and pid
 RUN {{BPFTRACE}} -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
-EXPECT Attaching 2 probes...
+EXPECT Attached 2 probes
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes - attach to multiple probes with different number of locations by wildcard
 PROG usdt:./testprogs/usdt_multiple_locations:tracetest:testprobe* { printf("here\n" ); exit(); }
 BEFORE ./testprogs/usdt_multiple_locations
-EXPECT Attaching 6 probes...
+EXPECT Attached 6 probes
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 # TODO(mmarchini): re-enable this test
@@ -207,7 +207,7 @@ WILL_FAIL
 # if the kernel handles the semaphore
 NAME usdt probes - file based semaphore activation no process, kernel usdt semaphore
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 REQUIRES_FEATURE uprobe_refcount
 
@@ -284,7 +284,7 @@ REQUIRES ./testprogs/systemtap_sys_sdt_check
 
 NAME usdt probes in multiple modules
 RUN {{BPFTRACE}} runtime/scripts/usdt_multi_modules.bt
-EXPECT Attaching 2 probes...
+EXPECT Attached 2 probes
 TIMEOUT 1
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -116,7 +116,7 @@ EXPECT_REGEX [0-9]+
 
 NAME variable declaration with unresolved type
 PROG BEGIN { let $x: struct Foo[1]; exit(); }
-EXPECT Attaching 1 probe...
+EXPECT Attached 1 probe
 
 NAME variable declaration not initialized
 PROG BEGIN { let $a; if (false) { $a = 1; } @b = $a; exit();}

--- a/tools/bashreadline_example.txt
+++ b/tools/bashreadline_example.txt
@@ -5,7 +5,7 @@ This prints bash commands from all running bash shells on the system. For
 example:
 
 # ./bashreadline.bt
-Attaching 2 probes...
+Attached 2 probes
 Tracing bash commands... Hit Ctrl-C to end.
 TIME      PID    COMMAND
 06:40:06  5526   df -h

--- a/tools/biolatency_example.txt
+++ b/tools/biolatency_example.txt
@@ -4,7 +4,7 @@ Demonstrations of biolatency, the Linux BPF/bpftrace version.
 This traces block I/O, and shows latency as a power-of-2 histogram. For example:
 
 # ./biolatency-kp.bt
-Attaching 3 probes...
+Attached 3 probes
 Tracing block device I/O... Hit Ctrl-C to end.
 ^C
 

--- a/tools/biosnoop_example.txt
+++ b/tools/biosnoop_example.txt
@@ -5,7 +5,7 @@ This traces block I/O, and shows the issuing process (at least, the process
 that was on-CPU at the time of queue insert) and the latency of the I/O:
 
 # ./biosnoop.bt
-Attaching 4 probes...
+Attached 4 probes
 TIME(ms)     DISK ID        COMM             PID    LAT(ms)
              MAJOR MINOR
 611          259   0        bash             4179        10
@@ -37,7 +37,7 @@ program start.
 An example of some background flushing:
 
 # ./biosnoop.bt
-Attaching 4 probes...
+Attached 4 probes
 TIME(ms)     DISK ID        COMM             PID    LAT(ms)
              MAJOR MINOR
 2966         259   0        jbd2/nvme0n1-8   615          0

--- a/tools/biostacks_example.txt
+++ b/tools/biostacks_example.txt
@@ -7,7 +7,7 @@ requested by applications (eg, metadata reads on writes, resilvering, etc).
 For example:
 
 # ./biostacks.bt
-Attaching 5 probes...
+Attached 5 probes
 Tracing block I/O with init stacks. Hit Ctrl-C to end.
 ^C
 

--- a/tools/bitesize_example.txt
+++ b/tools/bitesize_example.txt
@@ -5,7 +5,7 @@ This traces disk I/O via the block I/O interface, and prints a summary of I/O
 sizes as histograms for each process name. For example:
 
 # ./bitesize.bt
-Attaching 3 probes...
+Attached 3 probes
 Tracing block device I/O... Hit Ctrl-C to end.
 ^C
 I/O size (bytes) histograms by process name:

--- a/tools/cpuwalk_example.txt
+++ b/tools/cpuwalk_example.txt
@@ -5,7 +5,7 @@ cpuwalk samples which CPUs processes are running on, and prints a summary
 histogram. For example, here is a Linux kernel build on a 36-CPU server:
 
 # ./cpuwalk.bt
-Attaching 2 probes...
+Attached 2 probes
 Sampling CPU at 99hz... Hit Ctrl-C to end.
 ^C
 
@@ -53,7 +53,7 @@ This shows that all 36 CPUs were active, with some busier than others.
 Compare that output to the following workload from an application:
 
 # ./cpuwalk.bt
-Attaching 2 probes...
+Attached 2 probes
 Sampling CPU at 99hz... Hit Ctrl-C to end.
 ^C
 

--- a/tools/dcsnoop_example.txt
+++ b/tools/dcsnoop_example.txt
@@ -6,7 +6,7 @@ further investigation beyond dcstat(8). The output is likely verbose, as
 dcache lookups are likely frequent. For example:
 
 # ./dcsnoop.bt
-Attaching 4 probes...
+Attached 4 probes
 Tracing dcache lookups... Hit Ctrl-C to end.
 TIME     PID    COMM             T FILE
 427      1518   irqbalance       R proc/interrupts

--- a/tools/execsnoop_example.txt
+++ b/tools/execsnoop_example.txt
@@ -4,7 +4,7 @@ Demonstrations of execsnoop, the Linux BPF/bpftrace version.
 Tracing all new process execution (via exec()):
 
 # ./execsnoop.bt
-Attaching 3 probes...
+Attached 3 probes
 TIME            PID     PPID    ARGS
 08:57:52.430193 3187374 1971701 ls --color --color=auto -lh execsnoop.bt execsnoop.bt.0 execsnoop.bt.1
 08:57:52.441868 3187378 3187375 man ls

--- a/tools/gethostlatency_example.txt
+++ b/tools/gethostlatency_example.txt
@@ -6,7 +6,7 @@ gethostbyname2()), and shows the PID and command performing the lookup, the
 latency (duration) of the call in milliseconds, and the host string:
 
 # ./gethostlatency.bt
-Attaching 7 probes...
+Attached 7 probes
 Tracing getaddr/gethost calls... Hit Ctrl-C to end.
 TIME      PID    COMM              LATms HOST
 02:52:05  19105  curl                 81 www.netflix.com

--- a/tools/killsnoop_example.txt
+++ b/tools/killsnoop_example.txt
@@ -5,7 +5,7 @@ Demonstrations of killsnoop, the Linux bpftrace/eBPF version.
 This traces signals sent via the kill() syscall. For example:
 
 # ./killsnoop.bt
-Attaching 3 probes...
+Attached 3 probes
 Tracing kill() signals... Hit Ctrl-C to end.
 TIME                PID COMM              SIG   TPID RESULT
 00:09:37.345938   22485 bash                2  23856      0

--- a/tools/loads_example.txt
+++ b/tools/loads_example.txt
@@ -6,7 +6,7 @@ places each (not that it really matters), as a demonstration of fetching
 kernel structures from bpftrace:
 
 # ./loads.bt
-Attaching 2 probes...
+Attached 2 probes
 Reading load averages... Hit Ctrl-C to end.
 21:29:17 load averages: 2.091 2.048 1.947
 21:29:18 load averages: 2.091 2.048 1.947

--- a/tools/naptime_example.txt
+++ b/tools/naptime_example.txt
@@ -4,7 +4,7 @@ Demonstrations of naptime, the Linux bpftrace/eBPF version.
 Tracing application sleeps via the nanosleep(2) syscall:
 
 # ./naptime.bt
-Attaching 2 probes...
+Attached 2 probes
 Tracing sleeps. Hit Ctrl-C to end.
 TIME     PCOMM  PPID             COMM   PID              SECONDS
 15:50:00 1      systemd          1319   mysqld           1.000

--- a/tools/opensnoop_example.txt
+++ b/tools/opensnoop_example.txt
@@ -5,7 +5,7 @@ opensnoop traces the open() syscall system-wide, and prints various details.
 Example output:
 
 # ./opensnoop.bt
-Attaching 3 probes...
+Attached 3 probes
 Tracing open syscalls... Hit Ctrl-C to end.
 PID    COMM               FD ERR PATH
 2440   snmp-pass           4   0 /proc/cpuinfo

--- a/tools/pidpersec_example.txt
+++ b/tools/pidpersec_example.txt
@@ -4,7 +4,7 @@ Demonstrations of pidpersec, the Linux bpftrace/eBPF version.
 Tracing new processes:
 
 # ./pidpersec.bt
-Attaching 4 probes...
+Attached 4 probes
 Tracing new processes... Hit Ctrl-C to end.
 22:29:50 PIDs/sec: @: 121
 22:29:51 PIDs/sec: @: 120
@@ -30,7 +30,7 @@ The following example shows a Linux build launched at 6:33:40, on a 36 CPU
 server, with make -j36:
 
 # ./pidpersec.bt
-Attaching 4 probes...
+Attached 4 probes
 Tracing new processes... Hit Ctrl-C to end.
 06:33:38 PIDs/sec:
 06:33:39 PIDs/sec:

--- a/tools/runqlat_example.txt
+++ b/tools/runqlat_example.txt
@@ -6,7 +6,7 @@ metric is often called run queue latency, or scheduler latency. This tool shows
 this latency as a power-of-2 histogram in nanoseconds. For example:
 
 # ./runqlat.bt
-Attaching 5 probes...
+Attached 5 probes
 Tracing CPU scheduler... Hit Ctrl-C to end.
 ^C
 
@@ -51,7 +51,7 @@ I'll now add a single-threaded CPU bound workload to this system, and bind
 it on one CPU:
 
 # ./runqlat.bt
-Attaching 5 probes...
+Attached 5 probes
 Tracing CPU scheduler... Hit Ctrl-C to end.
 ^C
 
@@ -87,7 +87,7 @@ Now I'll add a second single-threaded CPU workload, and bind it to the same
 CPU, causing contention:
 
 # ./runqlat.bt
-Attaching 5 probes...
+Attached 5 probes
 Tracing CPU scheduler... Hit Ctrl-C to end.
 ^C
 
@@ -122,7 +122,7 @@ wait its turn on the one CPU.
 Now I'll run 10 CPU-bound threads on one CPU:
 
 # ./runqlat.bt
-Attaching 5 probes...
+Attached 5 probes
 Tracing CPU scheduler... Hit Ctrl-C to end.
 ^C
 

--- a/tools/runqlen_example.txt
+++ b/tools/runqlen_example.txt
@@ -6,7 +6,7 @@ sampled lengths as a histogram. This can be used to characterize demand for
 CPU resources. For example:
 
 # ./runqlen.bt
-Attaching 2 probes...
+Attached 2 probes
 Sampling run queue length at 99 Hertz... Hit Ctrl-C to end.
 ^C
 

--- a/tools/setuids_example.txt
+++ b/tools/setuids_example.txt
@@ -6,7 +6,7 @@ setfsuid(2), retresuid(2)). For example, here are the setuid calls during an
 ssh login:
 
 # ./setuids.bt
-Attaching 7 probes...
+Attached 7 probes
 Tracing setuid(2) family syscalls. Hit Ctrl-C to end.
 TIME     PID    COMM             UID    SYSCALL   ARGS (RET)
 14:28:22 21785  ssh              1000   setresuid ruid=-1 euid=1000 suid=-1 (0)

--- a/tools/ssllatency_example.txt
+++ b/tools/ssllatency_example.txt
@@ -17,7 +17,7 @@ Requests/sec:   1272.97
 Transfer/sec:    376.67KB
 
 # ./ssllatency.bt
-Attaching 26 probes...
+Attached 26 probes
 Tracing SSL/TLS handshake... Hit Ctrl-C to end.
 ^C
 Latency distribution in microsecond:
@@ -64,7 +64,7 @@ Requests/sec:   2930.53
 Transfer/sec:    867.14KB
 
 # ./ssllatency.bt
-Attaching 26 probes...
+Attached 26 probes
 Tracing SSL/TLS handshake... Hit Ctrl-C to end.
 ^C
 Latency distribution in microsecond:

--- a/tools/sslsnoop_example.txt
+++ b/tools/sslsnoop_example.txt
@@ -4,7 +4,7 @@ sslsnoop shows OpenSSL handshake function latency and return value. This
 can be used to analyzea SSL/TLS performance. For example:
 
 # ./sslsnoop.bt
-Attaching 25 probes...
+Attached 25 probes
 Tracing SSL/TLS handshake... Hit Ctrl-C to end.
 TIME(us)   TID      COMM     LAT(us)   RET FUNC
 1623016    2834695  openssl       71     1 ossl_ecdh_compute_key
@@ -22,7 +22,7 @@ time. Local ECDH and RSA crypto calculation is fast at client side. Most
 time is spent at server side including crypto and network latency.
 
 # ./sslsnoop.bt
-Attaching 25 probes...
+Attached 25 probes
 Tracing SSL/TLS handshake... Hit Ctrl-C to end.
 TIME(us)   TID      COMM     LAT(us)   RET FUNC
 1133960    2826460  nginx         81    -1 SSL_do_handshake

--- a/tools/statsnoop_example.txt
+++ b/tools/statsnoop_example.txt
@@ -5,7 +5,7 @@ statsnoop traces different stat() syscalls system-wide, and prints details.
 Example output:
 
 # ./statsnoop.bt
-Attaching 9 probes...
+Attached 9 probes
 Tracing stat syscalls... Hit Ctrl-C to end.
 PID    COMM             ERR PATH
 27835  bash               0 .

--- a/tools/swapin_example.txt
+++ b/tools/swapin_example.txt
@@ -5,7 +5,7 @@ This tool counts swapins by process, to show which process is affected by
 swapping. For example:
 
 # ./swapin.bt
-Attaching 2 probes...
+Attached 2 probes
 13:36:59
 
 13:37:00

--- a/tools/syncsnoop_example.txt
+++ b/tools/syncsnoop_example.txt
@@ -4,7 +4,7 @@ Demonstrations of syncsnoop, the Linux bpftrace/eBPF version.
 Tracing file system sync events:
 
 # ./syncsnoop.bt
-Attaching 7 probes...
+Attached 7 probes
 Tracing sync syscalls... Hit Ctrl-C to end.
 TIME      PID    COMM             EVENT
 02:02:17  27933  sync             tracepoint:syscalls:sys_enter_sync

--- a/tools/syscount_example.txt
+++ b/tools/syscount_example.txt
@@ -5,7 +5,7 @@ syscount counts system calls, and prints summaries of the top ten syscall IDs,
 and the top ten process names making syscalls. For example:
 
 # ./syscount.bt
-Attaching 3 probes...
+Attached 3 probes
 Counting syscalls... Hit Ctrl-C to end.
 ^C
 Top 10 syscalls IDs:

--- a/tools/tcpsynbl_example.txt
+++ b/tools/tcpsynbl_example.txt
@@ -7,7 +7,7 @@ and dropping SYNs (causing performance issues with SYN retransmits). For
 example:
 
 # ./tcpsynbl.bt
-Attaching 4 probes...
+Attached 4 probes
 Tracing SYN backlog size. Ctrl-C to end.
 ^C
 @backlog[backlog limit]: histogram of backlog size

--- a/tools/threadsnoop_example.txt
+++ b/tools/threadsnoop_example.txt
@@ -4,7 +4,7 @@ Demonstrations of threadsnoop, the Linux bpftrace/eBPF version.
 Tracing new threads via phtread_create():
 
 # ./threadsnoop.bt
-Attaching 2 probes...
+Attached 2 probes
 TIME                PID COMM             FUNC
 10:20:31.938572   28549 dockerd          threadentry
 10:20:31.939213   28549 dockerd          threadentry

--- a/tools/undump_example.txt
+++ b/tools/undump_example.txt
@@ -25,11 +25,10 @@ Terminal 3, receive tracing:
 
 ```
 $ sudo ./undump.bt
-Attaching 3 probes...
+Attached 3 probes
 Dump UNIX socket packages RX. Ctrl-C to end
 TIME     COMM             PID      SIZE     DATA
 20:40:11 nc               139071   13       Hello, world\x0a
 20:40:14 nc               139071   7        123abc\x0a
 ^C
 ```
-

--- a/tools/vfscount_example.txt
+++ b/tools/vfscount_example.txt
@@ -4,7 +4,7 @@ Demonstrations of vfscount, the Linux bpftrace/eBPF version.
 Tracing all VFS calls:
 
 # ./vfscount.bt
-Attaching 54 probes...
+Attached 54 probes
 cannot attach kprobe, Invalid argument
 Warning: could not attach probe kprobe:vfs_dedupe_get_page.isra.21, skipping.
 Tracing VFS calls... Hit Ctrl-C to end.

--- a/tools/vfsstat_example.txt
+++ b/tools/vfsstat_example.txt
@@ -5,7 +5,7 @@ This traces some common VFS calls (see the script for the list) and prints
 per-second summaries.
 
 # ./vfsstat.bt
-Attaching 8 probes...
+Attached 8 probes
 Tracing key VFS calls... Hit Ctrl-C to end.
 21:30:38
 @[vfs_write]: 1274

--- a/tools/writeback_example.txt
+++ b/tools/writeback_example.txt
@@ -6,7 +6,7 @@ to disk, and shows details such as the time, device numbers, reason for the
 write back, and the duration. For example:
 
 # ./writeback.bt
-Attaching 4 probes...
+Attached 4 probes
 Tracing writeback... Hit Ctrl-C to end.
 TIME      DEVICE   PAGES    REASON           ms
 23:28:47  259:1    15791    periodic         0.005

--- a/tools/xfsdist_example.txt
+++ b/tools/xfsdist_example.txt
@@ -5,7 +5,7 @@ xfsdist traces XFS reads, writes, opens, and fsyncs, and summarizes their
 latency as a power-of-2 histogram. For example:
 
 # xfsdist.bt
-Attaching 9 probes...
+Attached 9 probes
 Tracing XFS operation latency... Hit Ctrl-C to end.
 ^C
 


### PR DESCRIPTION
Two commits:

## #1
Report correct number of probes attached

This is specific to kprobe-multi and uprobe-multi,
which are attaching to multiple functions under the
hood. This is transparent to users and we should
report the number of attached functions correctly.

Issue: https://github.com/bpftrace/bpftrace/issues/3180

## #2

Change "Attaching X probes..." to "Attached X probes"

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
