### PR TITLE
Remove uprobe ref count feature check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
   - [#4097](https://github.com/bpftrace/bpftrace/pull/4097)
 - Require BPF_MAP_TYPE_RINGBUF to be available
   - [#3974](https://github.com/bpftrace/bpftrace/pull/3974)
+- Require kernel uprobe ref counting to be available for USDTs with semaphores
+  - [#4199](https://github.com/bpftrace/bpftrace/pull/4199)
 #### Added
 - Add ncpus builtin to get the number of CPUs.
   - [#4105](https://github.com/bpftrace/bpftrace/pull/4105)

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -140,15 +140,15 @@ void watchpoint_attach_handler(BPFtrace &bpftrace, const void *data)
     Probe &wp_probe = bpftrace.resources.watchpoint_probes[probe_idx];
     wp_probe.address = addr;
 
-    auto aps = bpftrace.attach_probe(wp_probe, bpftrace.bytecode_);
+    auto ap = bpftrace.attach_probe(wp_probe, bpftrace.bytecode_);
 
-    if (!aps &&
-        bpftrace.config_->missing_probes == ConfigMissingProbes::error) {
-      throw util::FatalUserException("Unable to attach real watchpoint probe");
-    }
-
-    for (auto &ap : *aps) {
-      bpftrace.attached_probes_.push_back(std::move(ap));
+    if (!ap) {
+      if (bpftrace.config_->missing_probes == ConfigMissingProbes::error) {
+        throw util::FatalUserException(
+            "Unable to attach real watchpoint probe");
+      }
+    } else {
+      bpftrace.attached_probes_.push_back(std::move(*ap));
     }
   }
 

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -466,69 +466,6 @@ Result<std::vector<unsigned long>> resolve_offsets_uprobe_multi(
 }
 #endif // HAVE_LIBBPF_UPROBE_MULTI
 
-Result<std::function<void()>> usdt_sem_up(Probe &probe,
-                                          BPFfeature &feature,
-                                          int pid,
-                                          const std::string &fn_name,
-                                          void *ctx)
-{
-  // If we have BCC and kernel support for uprobe refcnt API, then we don't
-  // need to do anything here. The kernel will increment the semaphore count
-  // for us when we provide the semaphore offset.
-  if (feature.has_uprobe_refcnt()) {
-    bcc_usdt_close(ctx);
-    return []() {};
-  }
-
-  // NB: we are careful to capture by value here everything that will not
-  // be available in AttachedProbe destructor.
-  auto addsem = [probe, fn_name](void *c, int16_t val) -> int {
-    if (probe.ns.empty())
-      return bcc_usdt_addsem_probe(
-          c, probe.attach_point.c_str(), fn_name.c_str(), val);
-    else
-      return bcc_usdt_addsem_fully_specified_probe(c,
-                                                   probe.ns.c_str(),
-                                                   probe.attach_point.c_str(),
-                                                   fn_name.c_str(),
-                                                   val);
-  };
-
-  // Use semaphore increment API to avoid having to hold onto the usdt context
-  // for the entire tracing session. Reason we do it this way instead of
-  // holding onto usdt context is b/c each usdt context can take lots of
-  // memory
-  // (~10MB). This, coupled with --usdt-file-activation and tracees that have
-  // a forking model can cause bpftrace to use huge amounts of memory if we
-  // hold onto the contexts.
-  int err = addsem(ctx, +1);
-  if (err) {
-    return make_error<AttachError>(
-        "Error finding or enabling probe: " + probe.name +
-        "\n Try using -p or --usdt-file-activation if there's USDT "
-        "semaphores");
-  }
-
-  // Now close the context to save some memory
-  bcc_usdt_close(ctx);
-
-  // Set destructor to decrement the semaphore count
-  return [pid, probe, addsem]() {
-    void *c = nullptr;
-    if (!probe.path.empty()) {
-      auto real_path = std::filesystem::absolute(probe.path).string();
-      c = bcc_usdt_new_frompid(pid, real_path.c_str());
-    } else {
-      c = bcc_usdt_new_frompid(pid, nullptr);
-    }
-    if (!c)
-      return;
-
-    addsem(c, -1);
-    bcc_usdt_close(c);
-  };
-}
-
 class AttachedKprobeProbe : public AttachedProbe {
 public:
   static Result<std::unique_ptr<AttachedKprobeProbe>> make(
@@ -840,28 +777,21 @@ Result<std::unique_ptr<AttachedMultiUprobeProbe>> AttachedMultiUprobeProbe::
 
 class AttachedUSDTProbe : public AttachedProbe {
 public:
-  static Result<std::unique_ptr<AttachedUSDTProbe>> make(Probe &probe,
-                                                         const BpfProgram &prog,
-                                                         std::optional<int> pid,
-                                                         BPFfeature &feature);
+  static Result<std::unique_ptr<AttachedUSDTProbe>> make(
+      Probe &probe,
+      const BpfProgram &prog,
+      std::optional<int> pid);
   ~AttachedUSDTProbe() override;
 
 private:
-  AttachedUSDTProbe(const Probe &probe,
-                    int progfd,
-                    int perf_event_fd,
-                    std::function<void()> cleanup);
+  AttachedUSDTProbe(const Probe &probe, int progfd, int perf_event_fd);
   int perf_event_fd_;
-  std::function<void()> usdt_sem_cleanup_;
 };
 
 AttachedUSDTProbe::AttachedUSDTProbe(const Probe &probe,
                                      int progfd,
-                                     int perf_event_fd,
-                                     std::function<void()> cleanup)
-    : AttachedProbe(probe, progfd),
-      perf_event_fd_(perf_event_fd),
-      usdt_sem_cleanup_(std::move(cleanup))
+                                     int perf_event_fd)
+    : AttachedProbe(probe, progfd), perf_event_fd_(perf_event_fd)
 {
 }
 
@@ -869,15 +799,12 @@ AttachedUSDTProbe::~AttachedUSDTProbe()
 {
   if (bpf_close_perf_event_fd(perf_event_fd_))
     LOG(WARNING) << "failed to close perf event FD for usdt probe";
-
-  usdt_sem_cleanup_();
 }
 
 Result<std::unique_ptr<AttachedUSDTProbe>> AttachedUSDTProbe::make(
     Probe &probe,
     const BpfProgram &prog,
-    std::optional<int> pid,
-    BPFfeature &feature)
+    std::optional<int> pid)
 {
   struct bcc_usdt_location loc = {};
   int err;
@@ -939,15 +866,7 @@ Result<std::unique_ptr<AttachedUSDTProbe>> AttachedUSDTProbe::make(
   [[maybe_unused]] auto semaphore_offset = static_cast<uint32_t>(
       u->semaphore_offset);
 
-  // Increment the semaphore count (will noop if no semaphore)
-  // NB: Do *not* use `ctx` after this call. It may either be open or closed,
-  // depending on which path was taken.
-  std::function<void()> usdt_sem_cleanup;
-  auto sem_up_res = usdt_sem_up(probe, feature, pid.value_or(0), fn_name, ctx);
-
-  if (!sem_up_res) {
-    return sem_up_res.takeError();
-  }
+  bcc_usdt_close(ctx);
 
   int perf_event_fd = bpf_attach_uprobe(prog.fd(),
                                         attachtype(probe.type),
@@ -966,7 +885,7 @@ Result<std::unique_ptr<AttachedUSDTProbe>> AttachedUSDTProbe::make(
   }
 
   return std::unique_ptr<AttachedUSDTProbe>(
-      new AttachedUSDTProbe(probe, prog.fd(), perf_event_fd, *sem_up_res));
+      new AttachedUSDTProbe(probe, prog.fd(), perf_event_fd));
 }
 
 class AttachedTracepointProbe : public AttachedProbe {
@@ -1624,7 +1543,7 @@ Result<std::unique_ptr<AttachedProbe>> AttachedProbe::make(
       return AttachedRawtracepointProbe::make(probe, prog);
     }
     case ProbeType::usdt: {
-      return AttachedUSDTProbe::make(probe, prog, pid, *bpftrace.feature_);
+      return AttachedUSDTProbe::make(probe, prog, pid);
     }
     case ProbeType::watchpoint:
     case ProbeType::asyncwatchpoint: {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -376,20 +376,6 @@ bool BPFfeature::has_d_path()
   return *has_d_path_;
 }
 
-bool BPFfeature::has_uprobe_refcnt()
-{
-  if (has_uprobe_refcnt_.has_value())
-    return *has_uprobe_refcnt_;
-
-  std::error_code ec;
-  std::filesystem::path path{
-    "/sys/bus/event_source/devices/uprobe/format/ref_ctr_offset"
-  };
-  has_uprobe_refcnt_ = std::filesystem::exists(path, ec);
-
-  return *has_uprobe_refcnt_;
-}
-
 bool try_create_link(libbpf::bpf_prog_type prog_type,
                      const std::string_view prog_name,
                      libbpf::bpf_attach_type expected_attach_type,
@@ -608,8 +594,6 @@ std::string BPFfeature::report()
     { "btf", to_str(has_btf()) },
     { "module btf", to_str(btf_.has_module_btf()) },
     { "map batch", to_str(has_map_batch()) },
-    // Depends on BCC's bpf_attach_uprobe refcount feature
-    { "uprobe refcount", to_str(has_uprobe_refcnt()) }
   };
 
   std::vector<std::pair<std::string, std::string>> map_types = {

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -91,7 +91,6 @@ public:
   bool has_btf_func_global();
   bool has_map_batch();
   bool has_d_path();
-  bool has_uprobe_refcnt();
   bool has_kprobe_multi();
   bool has_kprobe_session();
   bool has_uprobe_multi();
@@ -133,7 +132,6 @@ protected:
   std::optional<bool> has_d_path_;
   std::optional<int> insns_limit_;
   std::optional<bool> has_map_batch_;
-  std::optional<bool> has_uprobe_refcnt_;
   std::optional<bool> has_kprobe_multi_;
   std::optional<bool> has_kprobe_session_;
   std::optional<bool> has_uprobe_multi_;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -121,7 +121,7 @@ public:
   int num_probes() const;
   int prerun() const;
   int run(Output &out, BpfBytecode bytecode);
-  virtual Result<std::vector<std::unique_ptr<AttachedProbe>>> attach_probe(
+  virtual Result<std::unique_ptr<AttachedProbe>> attach_probe(
       Probe &probe,
       const BpfBytecode &bytecode);
   int run_iter();
@@ -240,11 +240,6 @@ private:
   std::vector<std::unique_ptr<void, void (*)(void *)>> open_perf_buffers_;
   std::map<std::string, std::unique_ptr<PCAPwriter>> pcap_writers_;
 
-  Result<std::vector<std::unique_ptr<AttachedProbe>>> attach_usdt_probe(
-      Probe &probe,
-      const BpfProgram &program,
-      std::optional<int> pid,
-      bool file_activation);
   int create_pcaps();
   void close_pcaps();
   int setup_output(void *ctx);

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -56,10 +56,10 @@ public:
 
 class MockBPFtrace : public BPFtrace {
 public:
-  MOCK_METHOD2(attach_probe,
-               Result<std::vector<std::unique_ptr<AttachedProbe>>>(
-                   Probe &probe,
-                   const BpfBytecode &bytecode));
+  MOCK_METHOD2(
+      attach_probe,
+      Result<std::unique_ptr<AttachedProbe>>(Probe &probe,
+                                             const BpfBytecode &bytecode));
 
   MOCK_METHOD1(resume_tracee, int(pid_t tracee_pid));
   std::vector<Probe> get_probes()

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -151,7 +151,6 @@ class Runner(object):
         bpffeature["btf"] = output.find("btf: yes") != -1
         bpffeature["fentry"] = output.find("fentry: yes") != -1
         bpffeature["dpath"] = output.find("dpath: yes") != -1
-        bpffeature["uprobe_refcount"] = output.find("uprobe refcount") != -1
         bpffeature["signal"] = output.find("send_signal: yes") != -1
         bpffeature["iter"] = output.find("iter: yes") != -1
         bpffeature["libpath_resolv"] = output.find("bcc library path resolution: yes") != -1

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -196,29 +196,16 @@ EXPECT tracetest_testprobe_semaphore: 1
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
 
-NAME usdt probes - file based semaphore activation no process
-RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
-EXPECT Failed to find processes running
-REQUIRES ./testprogs/systemtap_sys_sdt_check
-REQUIRES_FEATURE !uprobe_refcount
-WILL_FAIL
-
-# We should be able to attach a probe even without any running processes
-# if the kernel handles the semaphore
 NAME usdt probes - file based semaphore activation no process, kernel usdt semaphore
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
 EXPECT Attached 1 probe
 REQUIRES ./testprogs/systemtap_sys_sdt_check
-REQUIRES_FEATURE uprobe_refcount
 
-# We should be able to activate a semaphore without specifying a PID or
-# --usdt-file-activation if the kernel handles the semaphore
 NAME usdt probes - file based semaphore activation
 PROG usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }
 EXPECT tracetest_testprobe_semaphore: 1
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/systemtap_sys_sdt_check
-REQUIRES_FEATURE uprobe_refcount
 
 NAME usdt probes - file based semaphore activation multi process
 RUN {{BPFTRACE}} runtime/scripts/usdt_file_activation_multiprocess.bt --usdt-file-activation


### PR DESCRIPTION
From what I can tell this was added back
in kernel version 4.20, whic his very old.
We no longer need to have forking logic for this.

https://github.com/torvalds/linux/commit/1cc33161a83d20b5462b1e93f95d3ce6388079ee

@danobi Added checks for this back in 2020
https://github.com/bpftrace/bpftrace/commit/344826c9b5b70a4346b53203ad48e2d553cb7f5f

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
