### PR TITLE
attached_probe: profile: Use libbpf attachment API

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1033,7 +1033,7 @@ int open_perf_event(uint32_t ev_type,
                     int group_fd)
 {
   if (sample_period > 0 && sample_freq > 0) {
-    LOG(WARNING) << "Exactly one of sample_period / sample_freq should be set";
+    LOG(BUG) << "Exactly one of sample_period / sample_freq should be set";
     return -1;
   }
 
@@ -1078,7 +1078,7 @@ AttachedProfileProbe::AttachedProfileProbe(const Probe &probe,
 
 AttachedProfileProbe::~AttachedProfileProbe()
 {
-  for (auto link : links_) {
+  for (struct bpf_link *link : links_) {
     if (bpf_link__destroy(link))
       LOG(WARNING) << "failed to destroy link for profile probe: "
                    << strerror(errno);
@@ -1137,7 +1137,7 @@ Result<std::unique_ptr<AttachedProfileProbe>> AttachedProfileProbe::make(
   }
 
   if (has_error) {
-    for (auto link : links) {
+    for (struct bpf_link *link : links) {
       if (bpf_link__destroy(link))
         LOG(WARNING) << "failed to destroy link for profile probe: "
                      << strerror(errno);

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1024,6 +1024,36 @@ Result<std::unique_ptr<AttachedTracepointProbe>> AttachedTracepointProbe::make(
       probe, prog.fd(), perf_event_fd, eventname(probe, 0), probe.path));
 }
 
+int open_perf_event(uint32_t ev_type,
+                    uint32_t ev_config,
+                    uint64_t sample_period,
+                    uint64_t sample_freq,
+                    pid_t pid,
+                    int cpu,
+                    int group_fd)
+{
+  if (sample_period > 0 && sample_freq > 0) {
+    LOG(WARNING) << "Exactly one of sample_period / sample_freq should be set";
+    return -1;
+  }
+
+  struct perf_event_attr attr = {};
+  attr.type = ev_type;
+  attr.size = sizeof(struct perf_event_attr);
+  attr.config = ev_config;
+  if (sample_freq > 0) {
+    attr.freq = 1;
+    attr.sample_freq = sample_freq;
+  } else {
+    attr.sample_period = sample_period;
+  }
+  if (pid > 0)
+    attr.inherit = 1;
+
+  return syscall(
+      __NR_perf_event_open, &attr, pid, cpu, group_fd, PERF_FLAG_FD_CLOEXEC);
+}
+
 class AttachedProfileProbe : public AttachedProbe {
 public:
   static Result<std::unique_ptr<AttachedProfileProbe>> make(
@@ -1035,22 +1065,23 @@ public:
 private:
   AttachedProfileProbe(const Probe &probe,
                        int progfd,
-                       std::vector<int> perf_event_fds);
-  std::vector<int> perf_event_fds_;
+                       std::vector<struct bpf_link *> links);
+  std::vector<struct bpf_link *> links_;
 };
 
 AttachedProfileProbe::AttachedProfileProbe(const Probe &probe,
                                            int progfd,
-                                           std::vector<int> perf_event_fds)
-    : AttachedProbe(probe, progfd), perf_event_fds_(std::move(perf_event_fds))
+                                           std::vector<struct bpf_link *> links)
+    : AttachedProbe(probe, progfd), links_(std::move(links))
 {
 }
 
 AttachedProfileProbe::~AttachedProfileProbe()
 {
-  for (int perf_event_fd : perf_event_fds_) {
-    if (bpf_close_perf_event_fd(perf_event_fd))
-      LOG(WARNING) << "failed to close perf event FD for profile probe";
+  for (auto link : links_) {
+    if (bpf_link__destroy(link))
+      LOG(WARNING) << "failed to destroy link for profile probe: "
+                   << strerror(errno);
   }
 }
 
@@ -1079,27 +1110,43 @@ Result<std::unique_ptr<AttachedProfileProbe>> AttachedProfileProbe::make(
                                    "\"");
   }
 
+  bool has_error = false;
+  std::vector<struct bpf_link *> links;
   std::vector<int> cpus = util::get_online_cpus();
-  std::vector<int> perf_event_fds;
   for (int cpu : cpus) {
-    int perf_event_fd = bpf_attach_perf_event(prog.fd(),
-                                              PERF_TYPE_SOFTWARE,
-                                              PERF_COUNT_SW_CPU_CLOCK,
-                                              period,
-                                              freq,
-                                              pid.has_value() ? *pid : -1,
-                                              cpu,
-                                              group_fd);
+    int perf_event_fd = open_perf_event(PERF_TYPE_SOFTWARE,
+                                        PERF_COUNT_SW_CPU_CLOCK,
+                                        period,
+                                        freq,
+                                        pid.has_value() ? *pid : -1,
+                                        cpu,
+                                        group_fd);
 
     if (perf_event_fd < 0) {
-      return make_error<AttachError>();
+      has_error = true;
+      break;
     }
 
-    perf_event_fds.push_back(perf_event_fd);
+    auto *link = bpf_program__attach_perf_event(prog.bpf_prog(), perf_event_fd);
+    if (!link) {
+      has_error = true;
+      break;
+    }
+
+    links.push_back(link);
+  }
+
+  if (has_error) {
+    for (auto link : links) {
+      if (bpf_link__destroy(link))
+        LOG(WARNING) << "failed to destroy link for profile probe: "
+                     << strerror(errno);
+    }
+    return make_error<AttachError>();
   }
 
   return std::unique_ptr<AttachedProfileProbe>(
-      new AttachedProfileProbe(probe, prog.fd(), perf_event_fds));
+      new AttachedProfileProbe(probe, prog.fd(), links));
 }
 
 class AttachedIntervalProbe : public AttachedProbe {


### PR DESCRIPTION
Use libbpf API instead of bcc.

This closes #4147.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
