### PR TITLE
Allow statement lists in macro bodies

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -995,14 +995,13 @@ macro one() {
   1
 }
 
-macro add_one($other_name) {
+macro plus_one($other_name) {
   $other_name + 1
 }
 
 macro add_one_to_each($a, @b) {
   $a += 1;
   @b += 1;
-  $a + @b
 }
 
 macro side_effect($x) {
@@ -1016,11 +1015,12 @@ macro add_two($x) {
 BEGIN {
   print(one());                   // prints 1
 
-  $a = 42;
-  print(add_one($a));             // prints 43
+  $a = 10;
+  print(plus_one($a));            // prints 11
 
-  @b = 3;
-  print(add_one_to_each($a, @b)); // prints 47
+  @b = 5;
+  add_one_to_each($a, @b);
+  print($a + @b)                  // prints 17
 
   side_effect(5)                  // prints 5
 
@@ -1031,10 +1031,6 @@ BEGIN {
 Some examples of invalid macro usage:
 
 ----
-macro not_expression() {
-  $var = 1;                    // BAD: Not an expression
-}
-
 macro unhygienic_access() {
   @x++                         // BAD: @x not passed in
 }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -363,6 +363,8 @@ macros:
 macro:
                 MACRO IDENT "(" macro_args ")" block_expr { $$ = driver.ctx.make_node<ast::Macro>($2, std::move($4), $6, @$); }
         |       MACRO IDENT "(" ")" block_expr { $$ = driver.ctx.make_node<ast::Macro>($2, ast::ExpressionList{}, $5, @$); }
+        |       MACRO IDENT "(" macro_args ")" "{" stmt_list "}" { $$ = driver.ctx.make_node<ast::Macro>($2, std::move($4), driver.ctx.make_node<ast::Block>(std::move($7), @$), @$); }
+        |       MACRO IDENT "(" ")" "{" stmt_list "}" { $$ = driver.ctx.make_node<ast::Macro>($2, ast::ExpressionList{}, driver.ctx.make_node<ast::Block>(std::move($6), @$), @$); }
 
 macro_args:
                 macro_args "," map { $$ = std::move($1); $$.push_back($3); }

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -57,6 +57,12 @@ void test_warning(const std::string& input, const std::string& warn)
 
 TEST(macro_expansion, basic_checks)
 {
+  test("macro add1($x) { $x + 1 } macro add2($x) { $x + add1($x) } macro "
+       "add3($x) { $x + add2($x) } BEGIN { print(add3(1)); }");
+  test("macro add1($x) { $x += 1; } BEGIN { $y = 1; add1($y); }");
+  test("macro add3($x) { $x += 1; $x += 1; $x += 1; } BEGIN { $y = 1; "
+       "add3($y); }");
+
   test_error("macro set($x) { $x += 1; $x } BEGIN { $a = 1; set($a, 1); }",
              "Call to macro has wrong number arguments. Expected: 1 but got 2");
   test_error("macro set($x, $x) { $x += 1; $x } BEGIN { $a = 1; set($a, 1); }",
@@ -64,9 +70,6 @@ TEST(macro_expansion, basic_checks)
   test_error("macro set($x) { $x += 1; $x } macro set($x) { $x } BEGIN { $a = "
              "1; set($a, 1); }",
              "Redifinition of macro: set");
-  test("macro add1($x) { $x + 1 } macro add2($x) { $x + add1($x) } macro "
-       "add3($x) { $x + add2($x) } BEGIN { print(add3(1)); }");
-
   test_error(
       "macro add1($x) { $x + add3($x) } macro add2($x) { $x + add1($x) } macro "
       "add3($x) { $x + add2($x) } BEGIN { print(add3(1)); }",

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -1,6 +1,10 @@
 NAME it mutates the passed variable
-PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); print($a); exit(); }
+PROG macro inc($x) { $x += 1; } BEGIN { $a = 1; inc($a); print($a); exit(); }
 EXPECT 2
+
+NAME it assigns to the last expression
+PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; $b = inc($a); print(($a, $b)); exit(); }
+EXPECT (2, 2)
 
 NAME it mutates the passed non-scalar map
 PROG macro set(@x) { @x[1] = 2; 1 } BEGIN { @a[1] = 1; set(@a); exit(); }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5015,6 +5015,14 @@ TEST(semantic_analyser, macros)
   bpftrace->config_->unstable_macro = ConfigUnstable::enable;
 
   test_error(*bpftrace,
+             "macro set($x) { $x = 1; } BEGIN { $a = 0; $b = set($a); }",
+             R"(
+stdin:1:43-55: ERROR: Value 'none' cannot be assigned to a scratch variable.
+macro set($x) { $x = 1; } BEGIN { $a = 0; $b = set($a); }
+                                          ~~~~~~~~~~~~
+)");
+
+  test_error(*bpftrace,
              "macro set($x) { $x = 1; $x } BEGIN { $a = \"string\"; set($a); }",
              R"(
 stdin:1:17-23: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable already contains a value of type 'string'


### PR DESCRIPTION
This is to help the awkward case when macros
just have side effects and don't "return"
anything like block expressions.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
