### PR TITLE
refactor: move enum AsyncAction to async_action.h

### DIFF
--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -21,33 +21,7 @@ class IRBuilderBPF;
 //
 // If you update a type, remember to update the .cpp too!
 
-namespace bpftrace {
-
-// TODO: move this `AsyncAction` enum to `async_action.h`
-enum class AsyncAction {
-  // clang-format off
-  printf      = 0,     // printf reserves 0-9999 for printf_ids
-  printf_end  = 9999,
-  syscall     = 10000, // system reserves 10000-19999 for printf_ids
-  syscall_end = 19999,
-  cat         = 20000, // cat reserves 20000-29999 for printf_ids
-  cat_end     = 29999,
-  exit        = 30000,
-  print,
-  clear,
-  zero,
-  time,
-  join,
-  helper_error,
-  print_non_map,
-  strftime,
-  watchpoint_attach,
-  watchpoint_detach,
-  skboutput,
-  // clang-format on
-};
-
-namespace AsyncEvent {
+namespace bpftrace::AsyncEvent {
 
 struct Print {
   uint64_t action_id;
@@ -153,5 +127,4 @@ struct Join {
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, uint32_t length);
 } __attribute__((packed));
 
-} // namespace AsyncEvent
-} // namespace bpftrace
+} // namespace bpftrace::AsyncEvent

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -3,6 +3,7 @@
 #include "arch/arch.h"
 #include "ast/async_event_types.h"
 #include "ast/codegen_helper.h"
+#include "async_action.h"
 #include "bpfmap.h"
 #include "bpftrace.h"
 #include "globalvars.h"
@@ -2451,7 +2452,8 @@ void IRBuilderBPF::CreateHelperError(Value *return_value,
                                                   true);
   AllocaInst *buf = CreateAllocaBPF(helper_error_struct, "helper_error_t");
   CreateStore(
-      GetIntSameSize(static_cast<int64_t>(AsyncAction::helper_error),
+      GetIntSameSize(static_cast<int64_t>(
+                         async_action::AsyncAction::helper_error),
                      elements.at(0)),
       CreateGEP(helper_error_struct, buf, { getInt64(0), getInt32(0) }));
   CreateStore(

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -43,6 +43,7 @@
 #include "ast/passes/codegen_llvm.h"
 #include "ast/signal_bt.h"
 #include "ast/visitor.h"
+#include "async_action.h"
 #include "bpfmap.h"
 #include "bpftrace.h"
 #include "codegen_resources.h"
@@ -233,7 +234,7 @@ private:
                               int id,
                               const CallArgs &call_args,
                               const std::string &call_name,
-                              AsyncAction async_action);
+                              async_action::AsyncAction async_action);
 
   void createPrintMapCall(Call &call);
   void createPrintNonMapCall(Call &call, int id);
@@ -1420,7 +1421,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                              async_ids_.printf(),
                              bpftrace_.resources.printf_args,
                              "printf",
-                             AsyncAction::printf);
+                             async_action::AsyncAction::printf);
       return ScopedExpr();
     }
   } else if (call.func == "debugf") {
@@ -1447,14 +1448,14 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                            async_ids_.system(),
                            bpftrace_.resources.system_args,
                            "system",
-                           AsyncAction::syscall);
+                           async_action::AsyncAction::syscall);
     return ScopedExpr();
   } else if (call.func == "cat") {
     createFormatStringCall(call,
                            async_ids_.cat(),
                            bpftrace_.resources.cat_args,
                            "cat",
-                           AsyncAction::cat);
+                           async_action::AsyncAction::cat);
     return ScopedExpr();
   } else if (call.func == "exit") {
     auto elements = AsyncEvent::Exit().asLLVMType(b_);
@@ -1464,7 +1465,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
 
     // Fill in exit struct.
     b_.CreateStore(
-        b_.getInt64(static_cast<int64_t>(AsyncAction::exit)),
+        b_.getInt64(static_cast<int64_t>(async_action::AsyncAction::exit)),
         b_.CreateGEP(exit_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
 
     Value *code = b_.getInt8(0);
@@ -1535,11 +1536,13 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                                 buf,
                                 { b_.getInt64(0), b_.getInt32(0) });
     if (call.func == "clear")
-      b_.CreateStore(b_.GetIntSameSize(static_cast<int64_t>(AsyncAction::clear),
+      b_.CreateStore(b_.GetIntSameSize(static_cast<int64_t>(
+                                           async_action::AsyncAction::clear),
                                        elements.at(0)),
                      aa_ptr);
     else
-      b_.CreateStore(b_.GetIntSameSize(static_cast<int64_t>(AsyncAction::zero),
+      b_.CreateStore(b_.GetIntSameSize(static_cast<int64_t>(
+                                           async_action::AsyncAction::zero),
                                        elements.at(0)),
                      aa_ptr);
 
@@ -1594,7 +1597,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     AllocaInst *buf = b_.CreateAllocaBPF(time_struct, call.func + "_t");
 
     b_.CreateStore(
-        b_.GetIntSameSize(static_cast<int64_t>(AsyncAction::time),
+        b_.GetIntSameSize(static_cast<int64_t>(async_action::AsyncAction::time),
                           elements.at(0)),
         b_.CreateGEP(time_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
 
@@ -1704,7 +1707,8 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     size_t struct_size = datalayout().getTypeAllocSize(unwatch_struct);
 
     b_.CreateStore(
-        b_.getInt64(static_cast<int64_t>(AsyncAction::watchpoint_detach)),
+        b_.getInt64(
+            static_cast<int64_t>(async_action::AsyncAction::watchpoint_detach)),
         b_.CreateGEP(unwatch_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
     b_.CreateStore(
         b_.CreateIntCast(scoped_addr.value(),
@@ -1749,7 +1753,8 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                                     data,
                                     { b_.getInt64(0), b_.getInt32(2) });
 
-    b_.CreateStore(b_.getInt64(static_cast<int64_t>(AsyncAction::skboutput)),
+    b_.CreateStore(b_.getInt64(static_cast<int64_t>(
+                       async_action::AsyncAction::skboutput)),
                    aid_addr);
     b_.CreateStore(b_.getInt64(async_ids_.skb_output()), id_addr);
     b_.CreateStore(b_.CreateGetNs(TimestampMode::boot, call.loc), time_addr);
@@ -3794,7 +3799,7 @@ void CodegenLLVM::createFormatStringCall(Call &call,
                                          int id,
                                          const CallArgs &call_args,
                                          const std::string &call_name,
-                                         AsyncAction async_action)
+                                         async_action::AsyncAction async_action)
 {
   // perf event output has: uint64_t id, vargs
   // The id maps to bpftrace_.*_args_, and is a way to define the
@@ -3896,7 +3901,8 @@ void CodegenLLVM::generateWatchpointSetupProbe(
 
   // Fill in perf event struct
   b_.CreateStore(
-      b_.getInt64(static_cast<int64_t>(AsyncAction::watchpoint_attach)),
+      b_.getInt64(
+          static_cast<int64_t>(async_action::AsyncAction::watchpoint_attach)),
       b_.CreateGEP(watchpoint_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
   b_.CreateStore(
       b_.getInt64(async_ids_.watchpoint()),
@@ -3923,7 +3929,7 @@ void CodegenLLVM::createPrintMapCall(Call &call)
 
   // store asyncactionid:
   b_.CreateStore(
-      b_.getInt64(static_cast<int64_t>(AsyncAction::print)),
+      b_.getInt64(static_cast<int64_t>(async_action::AsyncAction::print)),
       b_.CreateGEP(print_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
 
   int id = bpftrace_.resources.maps_info.at(map.ident).id;
@@ -3981,7 +3987,7 @@ void CodegenLLVM::createJoinCall(Call &call, int id)
                                       PointerType::get(join_struct, 0));
 
   b_.CreateStore(
-      b_.getInt64(static_cast<int>(AsyncAction::join)),
+      b_.getInt64(static_cast<int>(async_action::AsyncAction::join)),
       b_.CreateGEP(join_struct, join_data, { b_.getInt64(0), b_.getInt32(0) }));
 
   b_.CreateStore(
@@ -4046,7 +4052,8 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int id)
 
   // Store asyncactionid:
   b_.CreateStore(
-      b_.getInt64(static_cast<int64_t>(AsyncAction::print_non_map)),
+      b_.getInt64(
+          static_cast<int64_t>(async_action::AsyncAction::print_non_map)),
       b_.CreateGEP(print_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
 
   // Store print id

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -5,6 +5,29 @@
 
 namespace bpftrace::async_action {
 
+enum class AsyncAction {
+  // clang-format off
+  printf      = 0,     // printf reserves 0-9999 for printf_ids
+  printf_end  = 9999,
+  syscall     = 10000, // system reserves 10000-19999 for printf_ids
+  syscall_end = 19999,
+  cat         = 20000, // cat reserves 20000-29999 for printf_ids
+  cat_end     = 29999,
+  exit        = 30000,
+  print,
+  clear,
+  zero,
+  time,
+  join,
+  helper_error,
+  print_non_map,
+  strftime,
+  watchpoint_attach,
+  watchpoint_detach,
+  skboutput,
+  // clang-format on
+};
+
 const static size_t MAX_TIME_STR_LEN = 64;
 void exit_handler(BPFtrace &bpftrace, const void *data);
 void join_handler(BPFtrace &bpftrace, Output &out, const void *data);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -234,7 +234,8 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
   auto *ctx = static_cast<PerfEventContext *>(cb_cookie);
   auto *arg_data = data_aligned.data();
 
-  auto printf_id = AsyncAction(*reinterpret_cast<uint64_t *>(arg_data));
+  auto printf_id = async_action::AsyncAction(
+      *reinterpret_cast<uint64_t *>(arg_data));
 
   // Ignore the remaining events if perf_event_printer is called during
   // finalization stage (exit() builtin has been called)
@@ -247,50 +248,50 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
   }
 
   // async actions
-  if (printf_id == AsyncAction::exit) {
+  if (printf_id == async_action::AsyncAction::exit) {
     async_action::exit_handler(ctx->bpftrace, data);
     return;
-  } else if (printf_id == AsyncAction::print) {
+  } else if (printf_id == async_action::AsyncAction::print) {
     async_action::print_map_handler(ctx->bpftrace, ctx->output, data);
     return;
-  } else if (printf_id == AsyncAction::print_non_map) {
+  } else if (printf_id == async_action::AsyncAction::print_non_map) {
     async_action::print_non_map_handler(ctx->bpftrace, ctx->output, data);
     return;
-  } else if (printf_id == AsyncAction::clear) {
+  } else if (printf_id == async_action::AsyncAction::clear) {
     async_action::clear_map_handler(ctx->bpftrace, data);
     return;
-  } else if (printf_id == AsyncAction::zero) {
+  } else if (printf_id == async_action::AsyncAction::zero) {
     async_action::zero_map_handler(ctx->bpftrace, data);
     return;
-  } else if (printf_id == AsyncAction::time) {
+  } else if (printf_id == async_action::AsyncAction::time) {
     async_action::time_handler(ctx->bpftrace, ctx->output, data);
     return;
-  } else if (printf_id == AsyncAction::join) {
+  } else if (printf_id == async_action::AsyncAction::join) {
     async_action::join_handler(ctx->bpftrace, ctx->output, data);
     return;
-  } else if (printf_id == AsyncAction::helper_error) {
+  } else if (printf_id == async_action::AsyncAction::helper_error) {
     async_action::helper_error_handler(ctx->bpftrace, ctx->output, data);
     return;
-  } else if (printf_id == AsyncAction::watchpoint_attach) {
+  } else if (printf_id == async_action::AsyncAction::watchpoint_attach) {
     async_action::watchpoint_attach_handler(ctx->bpftrace, data);
     return;
-  } else if (printf_id == AsyncAction::watchpoint_detach) {
+  } else if (printf_id == async_action::AsyncAction::watchpoint_detach) {
     async_action::watchpoint_detach_handler(ctx->bpftrace, data);
     return;
-  } else if (printf_id == AsyncAction::skboutput) {
+  } else if (printf_id == async_action::AsyncAction::skboutput) {
     async_action::skboutput_handler(ctx->bpftrace, data, size);
     return;
-  } else if (printf_id >= AsyncAction::syscall &&
-             printf_id <= AsyncAction::syscall_end) {
+  } else if (printf_id >= async_action::AsyncAction::syscall &&
+             printf_id <= async_action::AsyncAction::syscall_end) {
     async_action::syscall_handler(
         ctx->bpftrace, ctx->output, printf_id, arg_data);
     return;
-  } else if (printf_id >= AsyncAction::cat &&
-             printf_id <= AsyncAction::cat_end) {
+  } else if (printf_id >= async_action::AsyncAction::cat &&
+             printf_id <= async_action::AsyncAction::cat_end) {
     async_action::cat_handler(ctx->bpftrace, ctx->output, printf_id, arg_data);
     return;
-  } else if (printf_id >= AsyncAction::printf &&
-             printf_id <= AsyncAction::printf_end) {
+  } else if (printf_id >= async_action::AsyncAction::printf &&
+             printf_id <= async_action::AsyncAction::printf_end) {
     async_action::printf_handler(
         ctx->bpftrace, ctx->output, printf_id, arg_data);
     return;


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

This commit fulfills a previously promised refactoring task by moving the
AsyncAction enum from async_event_types.h to async_action.h. The change was
originally suggested by @jordalgo, and I had left a TODO comment to implement
this move after issue https://github.com/bpftrace/bpftrace/issues/3712 was completed. But I finally forgot it.

While reviewing the code, I noticed my own TODO comment and completed this
pending refactoring task. This improves code organization by placing the
AsyncAction enum in a more logical location alongside its related handler
implementations.
##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
