### PR TITLE
Add support for bare block statements

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -986,7 +986,6 @@ Or if you want to share code between probes.
 At a high level, macros can be thought of as semantic aware text replacement.
 They accept (optional) variable, map, and some expression arguments.
 The body of the macro may only access maps and external variables passed in through the arguments, which is why these are often referred to as "hygienic macros".
-The body of the macro is exactly one block expression.
 
 For example, these are valid usages of macros:
 
@@ -995,14 +994,13 @@ macro one() {
   1
 }
 
-macro add_one($other_name) {
+macro plus_one($other_name) {
   $other_name + 1
 }
 
 macro add_one_to_each($a, @b) {
   $a += 1;
   @b += 1;
-  $a + @b
 }
 
 macro side_effect($x) {
@@ -1016,11 +1014,12 @@ macro add_two($x) {
 BEGIN {
   print(one());                   // prints 1
 
-  $a = 42;
-  print(add_one($a));             // prints 43
+  $a = 10;
+  print(plus_one($a));            // prints 11
 
-  @b = 3;
-  print(add_one_to_each($a, @b)); // prints 47
+  @b = 5;
+  add_one_to_each($a, @b);
+  print($a + @b)                  // prints 17
 
   side_effect(5)                  // prints 5
 
@@ -1031,10 +1030,6 @@ BEGIN {
 Some examples of invalid macro usage:
 
 ----
-macro not_expression() {
-  $var = 1;                    // BAD: Not an expression
-}
-
 macro unhygienic_access() {
   @x++                         // BAD: @x not passed in
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1219,16 +1219,25 @@ public:
       : Node(ctx, std::move(loc)),
         name(std::move(name)),
         vargs(std::move(vargs)),
-        block_expr(block_expr) {};
+        block(block_expr) {};
+  Macro(ASTContext &ctx,
+        std::string name,
+        ExpressionList &&vargs,
+        Block *block,
+        Location &&loc)
+      : Node(ctx, std::move(loc)),
+        name(std::move(name)),
+        vargs(std::move(vargs)),
+        block(block) {};
   explicit Macro(ASTContext &ctx, const Macro &other, const Location &loc)
       : Node(ctx, loc + other.loc),
         name(other.name),
         vargs(clone(ctx, other.vargs, loc)),
-        block_expr(clone(ctx, other.block_expr, loc)) {};
+        block(clone(ctx, other.block, loc)) {};
 
   std::string name;
   ExpressionList vargs;
-  BlockExpr *block_expr;
+  std::variant<BlockExpr *, Block *> block;
 };
 using MacroList = std::vector<Macro *>;
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -220,6 +220,7 @@ public:
   ScopedExpr visit(Subprog &subprog);
   ScopedExpr visit(Program &program);
   ScopedExpr visit(Block &block);
+  ScopedExpr visit(BlockExpr &block_expr);
 
   // compile is the primary entrypoint; it will return the generated LLVMModule.
   // Only one call to `compile` is permitted per instantiation.
@@ -2997,7 +2998,16 @@ ScopedExpr CodegenLLVM::visit(Block &block)
 {
   scope_stack_.push_back(&block);
   visit(block.stmts);
-  ScopedExpr value = visit(block.expr);
+  scope_stack_.pop_back();
+
+  return ScopedExpr();
+}
+
+ScopedExpr CodegenLLVM::visit(BlockExpr &block_expr)
+{
+  scope_stack_.push_back(&block_expr);
+  visit(block_expr.stmts);
+  ScopedExpr value = visit(block_expr.expr);
   scope_stack_.pop_back();
 
   return value;

--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -251,12 +251,10 @@ static std::optional<Expression> injectMap(Expression expr,
       call->vargs.insert(call->vargs.end(), args.begin(), args.end());
       return call;
     }
-  } else if (auto *block = expr.as<Block>()) {
-    if (block->expr) {
-      auto injected_expr = injectMap(block->expr.value(), map, key);
-      if (injected_expr) {
-        return block;
-      }
+  } else if (auto *block_expr = expr.as<BlockExpr>()) {
+    auto injected_expr = injectMap(block_expr->expr, map, key);
+    if (injected_expr) {
+      return block_expr;
     }
   }
   return std::nullopt;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -160,6 +160,7 @@ public:
   void visit(AttachPoint &ap);
   void visit(Probe &probe);
   void visit(Block &block);
+  void visit(BlockExpr &block_expr);
   void visit(Subprog &subprog);
 
 private:
@@ -3607,7 +3608,14 @@ void SemanticAnalyser::visit(Block &block)
 {
   scope_stack_.push_back(&block);
   accept_statements(block.stmts);
-  visit(block.expr);
+  scope_stack_.pop_back();
+}
+
+void SemanticAnalyser::visit(BlockExpr &block_expr)
+{
+  scope_stack_.push_back(&block_expr);
+  accept_statements(block_expr.stmts);
+  visit(block_expr.expr);
   scope_stack_.pop_back();
 }
 

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -206,7 +206,12 @@ public:
   R visit(Block &block)
   {
     visitImpl(block.stmts);
-    visitImpl(block.expr);
+    return default_value();
+  }
+  R visit(BlockExpr &block_expr)
+  {
+    visitImpl(block_expr.stmts);
+    visitImpl(block_expr.expr);
     return default_value();
   }
   R visit([[maybe_unused]] Macro &macro)

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -140,7 +140,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 
 %type <ast::AttachPoint *> attach_point
 %type <ast::AttachPointList> attach_points
-%type <ast::Block *> block_expr
+%type <ast::BlockExpr *> block_expr
 %type <ast::Call *> call
 %type <ast::Sizeof *> sizeof_expr
 %type <ast::Offsetof *> offsetof_expr
@@ -164,7 +164,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::Config *> config
 %type <ast::Import *> import_stmt
 %type <ast::ImportList> imports
-%type <ast::Statement> assign_stmt block_stmt expr_stmt if_stmt jump_stmt loop_stmt for_stmt
+%type <ast::Statement> assign_stmt block_stmt expr_stmt if_stmt jump_stmt loop_stmt for_stmt bare_block
 %type <ast::MapDeclList> map_decl_list
 %type <ast::VarDeclStatement *> var_decl_stmt
 %type <ast::StatementList> block block_or_if stmt_list
@@ -469,7 +469,11 @@ block_stmt:
                 loop_stmt    { $$ = $1; }
         |       if_stmt      { $$ = $1; }
         |       for_stmt     { $$ = $1; }
+        |       bare_block   { $$ = $1; }
                 ;
+
+bare_block:
+                "{" stmt_list "}"  { $$ = driver.ctx.make_node<ast::Block>(std::move($2), @2); }
 
 expr_stmt:
                 expr               { $$ = driver.ctx.make_node<ast::ExprStatement>($1, @1); }
@@ -596,7 +600,7 @@ tuple_access_expr:
                 ;
 
 block_expr:
-                "{" stmt_list expr "}" { $$ = driver.ctx.make_node<ast::Block>(std::move($2), $3, @$); }
+                "{" stmt_list expr "}" { $$ = driver.ctx.make_node<ast::BlockExpr>(std::move($2), $3, @$); }
                 ;
 
 unary_expr:

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -140,6 +140,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 
 %type <ast::AttachPoint *> attach_point
 %type <ast::AttachPointList> attach_points
+%type <ast::Block *> bare_block
 %type <ast::BlockExpr *> block_expr
 %type <ast::Call *> call
 %type <ast::Sizeof *> sizeof_expr
@@ -164,7 +165,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::Config *> config
 %type <ast::Import *> import_stmt
 %type <ast::ImportList> imports
-%type <ast::Statement> assign_stmt block_stmt expr_stmt if_stmt jump_stmt loop_stmt for_stmt bare_block
+%type <ast::Statement> assign_stmt block_stmt expr_stmt if_stmt jump_stmt loop_stmt for_stmt
 %type <ast::MapDeclList> map_decl_list
 %type <ast::VarDeclStatement *> var_decl_stmt
 %type <ast::StatementList> block block_or_if stmt_list
@@ -362,13 +363,14 @@ macros:
 
 macro:
                 MACRO IDENT "(" macro_args ")" block_expr { $$ = driver.ctx.make_node<ast::Macro>($2, std::move($4), $6, @$); }
-        |       MACRO IDENT "(" ")" block_expr { $$ = driver.ctx.make_node<ast::Macro>($2, ast::ExpressionList{}, $5, @$); }
+        |       MACRO IDENT "(" macro_args ")" bare_block { $$ = driver.ctx.make_node<ast::Macro>($2, std::move($4), $6, @$); }
 
 macro_args:
                 macro_args "," map { $$ = std::move($1); $$.push_back($3); }
         |       macro_args "," var { $$ = std::move($1); $$.push_back($3); }
         |       map                { $$ = ast::ExpressionList{$1}; }
         |       var                { $$ = ast::ExpressionList{$1}; }
+        |       %empty             { $$ = ast::ExpressionList{}; }
                 ;
 
 body:

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -57,6 +57,25 @@ void test_warning(const std::string& input, const std::string& warn)
 
 TEST(macro_expansion, basic_checks)
 {
+  test("macro print_me() { print(\"me\"); } BEGIN { print_me(); }");
+  test("macro add1($x) { $x + 1 } macro add2($x) { $x + add1($x) } macro "
+       "add3($x) { $x + add2($x) } BEGIN { print(add3(1)); }");
+  test("macro add1($x) { $x += 1; } BEGIN { $y = 1; add1($y); }");
+  test("macro add3($x) { $x += 1; $x += 1; $x += 1; } BEGIN { $y = 1; "
+       "add3($y); }");
+  test("macro add1($x) { $x += 1; $x } BEGIN { $y = 1; add1($y); }");
+  test("macro add2($x) { $x += 2; $x } macro add1($x) { $x += 1; add2($x); } "
+       "BEGIN { $y = 1; add1($y); }");
+
+  test_error("macro add1($x) { $x += 1; } BEGIN { $y = 1; $z = add1($y); }",
+             "Macro 'add1' expanded to a block instead of a block expression. "
+             "Try removing the semicolon from the end of the last statement in "
+             "the macro body.");
+  test_error("macro add2($y) { $y += 1; } macro add1($x) { $x += add2($x); } "
+             "BEGIN { $y = 1; add1($y); }",
+             "Macro 'add2' expanded to a block instead of a block expression. "
+             "Try removing the semicolon from the end of the last statement in "
+             "the macro body.");
   test_error("macro set($x) { $x += 1; $x } BEGIN { $a = 1; set($a, 1); }",
              "Call to macro has wrong number arguments. Expected: 1 but got 2");
   test_error("macro set($x, $x) { $x += 1; $x } BEGIN { $a = 1; set($a, 1); }",
@@ -64,9 +83,6 @@ TEST(macro_expansion, basic_checks)
   test_error("macro set($x) { $x += 1; $x } macro set($x) { $x } BEGIN { $a = "
              "1; set($a, 1); }",
              "Redifinition of macro: set");
-  test("macro add1($x) { $x + 1 } macro add2($x) { $x + add1($x) } macro "
-       "add3($x) { $x + add2($x) } BEGIN { print(add3(1)); }");
-
   test_error(
       "macro add1($x) { $x + add3($x) } macro add2($x) { $x + add1($x) } macro "
       "add3($x) { $x + add2($x) } BEGIN { print(add3(1)); }",

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2978,6 +2978,22 @@ BEGIN { $x: int8 = 1; }
 )");
 }
 
+TEST(Parser, bare_blocks)
+{
+  test("i:s:1 { $a = 1; { $b = 2; { $c = 3; } } }",
+       "Program\n"
+       " interval:s:1\n"
+       "  =\n"
+       "   variable: $a\n"
+       "   int: 1\n"
+       "  =\n"
+       "   variable: $b\n"
+       "   int: 2\n"
+       "  =\n"
+       "   variable: $c\n"
+       "   int: 3\n");
+}
+
 TEST(Parser, block_expressions)
 {
   // Non-legal trailing statement

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -1,13 +1,17 @@
 NAME it mutates the passed variable
-PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); print($a); exit(); }
+PROG macro inc($x) { $x += 1; } BEGIN { $a = 1; inc($a); print($a); exit(); }
 EXPECT 2
 
+NAME it assigns to the last expression
+PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; $b = inc($a); print(($a, $b)); exit(); }
+EXPECT (2, 2)
+
 NAME it mutates the passed non-scalar map
-PROG macro set(@x) { @x[1] = 2; 1 } BEGIN { @a[1] = 1; set(@a); exit(); }
+PROG macro set(@x) { @x[1] = 2; } BEGIN { @a[1] = 1; set(@a); exit(); }
 EXPECT @a[1]: 2
 
 NAME it mutates the passed scalar map
-PROG macro set(@x) { @x = 2; 1 } BEGIN { @a = 1; set(@a); exit(); }
+PROG macro set(@x) { @x = 2; } BEGIN { @a = 1; set(@a); exit(); }
 EXPECT @a: 2
 
 NAME it reads the passed map
@@ -15,15 +19,19 @@ PROG macro get(@x) { 1 + @x[1] } BEGIN { @a[1] = 1; print(get(@a)); exit(); }
 EXPECT 2
 
 NAME it can have side effects
-PROG macro print_me($x) { print(("me", $x)) } BEGIN { $a = 1; print_me($a); exit(); }
+PROG macro print_me($x) { print(("me", $x)); } BEGIN { $a = 1; print_me($a); exit(); }
 EXPECT (me, 1)
 
 NAME it can exit early
-PROG macro early() { exit() } BEGIN { early(); print(1); }
+PROG macro early() { exit(); } BEGIN { early(); print(1); }
 EXPECT_NONE 1
 
-NAME it can call other macros
+NAME it can call other macros as expressions
 PROG macro add1($x) { $x + 1 } macro add2($y) { $y + add1($y) } macro add3($z) { $z + add2($z) } BEGIN { print(add3(1)); exit(); }
+EXPECT 4
+
+NAME it can call other macros as statements
+PROG macro add1($x) { $x += 1; } macro add2($y) { add1($y); $y += 1; } macro add3($z) { add2($z); $z += 1; } BEGIN { $a = 1; add3($a); print($a); exit(); }
 EXPECT 4
 
 NAME macro definition order does not matter
@@ -47,7 +55,7 @@ PROG macro add_one($x) { $x + 1 } BEGIN { @a = 1; print(add_one(@a + 1)); exit()
 EXPECT 3
 
 NAME can call the same macro multiple times
-PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; inc($a); inc($a); inc($a); print($a); exit(); }
+PROG macro inc($x) { $x += 1; } BEGIN { $a = 1; inc($a); inc($a); inc($a); print($a); exit(); }
 EXPECT 4
 
 NAME for loops can be in macros


### PR DESCRIPTION
See individual commits but this essentially adds support for bare block statements e.g.
```
BEGIN {
  $a = 1;
  {
    $b = 2;
    print($b);
    {
       $c = 3;
       print($c);
    }
   }
   // $b and $c are not accessible
  }
```

This makes a distinction between a Block and a BlockExpression, where the latter evaluates to an expression and the former does not.

This also enables macros to produce a Block or a BlockExpression, which fixes some confusing behavior where macros need to end in a dangling expression even if it only produces side effects e.g. `macro print_me() { print("me"); }`

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
