### PR TITLE
ast: add ClangBuilder

### DIFF
--- a/cmake/BuildBPF.cmake
+++ b/cmake/BuildBPF.cmake
@@ -1,9 +1,7 @@
 # Functions to build intermediate BPF modules.
 #
 # The `bpf` function will produce bitcode, an object as well as the BTF type
-# information for a given file. The `btf_header` function can be used to
-# produce a C header for a given BTF source file (often the kernel, but it
-# can be the output from any `bpf` rule, for example).
+# information for a given file.
 
 find_program(GCC gcc REQUIRED)
 find_program(BPFTOOL bpftool REQUIRED)
@@ -16,27 +14,6 @@ find_program(LLVM_OBJCOPY
 find_program(CLANG
   NAMES clang-${LLVM_VERSION_MAJOR}
   REQUIRED)
-
-function(btf_header NAME SOURCE)
-  cmake_parse_arguments(
-    ARG
-    ""
-    "OUTPUT"
-    ""
-    ${ARGN}
-  )
-  if (NOT DEFINED ARG_OUTPUT)
-    set(ARG_OUTPUT "${NAME}.h")
-  endif ()
-  add_custom_command(
-    OUTPUT ${ARG_OUTPUT}
-    COMMAND ${BPFTOOL} btf dump file "${ARG_SOURCE}" format c > ${CMAKE_CURRENT_BINARY_DIR}/${ARG_OUTPUT}
-    VERBATIM
-  )
-  add_custom_target(${NAME}
-    DEPENDS ${ARG_OUTPUT}
-  )
-endfunction()
 
 function(bpf NAME)
   cmake_parse_arguments(

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(ast STATIC
 
   passes/c_macro_expansion.cpp
   passes/clang_parser.cpp
+  passes/clang_build.cpp
   passes/codegen_resources.cpp
   passes/config_analyser.cpp
   passes/deprecated.cpp
@@ -54,25 +55,6 @@ target_compile_definitions(ast PUBLIC SYSTEM_INCLUDE_PATHS="${SYSTEM_INCLUDE_PAT
 if(STATIC_LINKING)
   include(Util)
 
-  set(clang_libs
-      clangAST
-      clangAnalysis
-      clangBasic
-      clangCodeGen
-      clangDriver
-      clangEdit
-      clangFormat
-      clangFrontend
-      clangIncludeFixerPlugin
-      clangIndex
-      clangLex
-      clangParse
-      clangRewrite
-      clangSema
-      clangSerialization
-      clangTidyPlugin
-      clangToolingCore)
-
   set(llvm_lib_names
       bpfcodegen
       coverage
@@ -103,7 +85,7 @@ if(STATIC_LINKING)
     target_link_libraries(ast PUBLIC libclang.a)
   endif()
 
-  target_link_libraries(ast PUBLIC ${clang_libs})
+  target_link_libraries(ast PUBLIC clangDriver clangFrontend clangCodeGen)
   target_link_libraries(ast PUBLIC ${llvm_libs})
 else()
   if (TARGET LLVM)
@@ -116,5 +98,5 @@ else()
     # have libLLVM.so, drop `USE_SHARED` to avoid forcing link to `-lLLVM`.
     llvm_config(ast bpfcodegen ipo irreader mcjit orcjit)
   endif()
-  target_link_libraries(ast PUBLIC libclang)
+  target_link_libraries(ast PUBLIC libclang clangDriver clangFrontend clangCodeGen)
 endif()

--- a/src/ast/passes/clang_build.cpp
+++ b/src/ast/passes/clang_build.cpp
@@ -1,0 +1,215 @@
+#include <clang/CodeGen/CodeGenAction.h>
+#include <clang/Driver/Driver.h>
+#include <clang/Frontend/CompilerInstance.h>
+#include <clang/Frontend/FrontendActions.h>
+#include <clang/Frontend/TextDiagnosticPrinter.h>
+#include <fcntl.h>
+#include <fstream>
+#include <llvm/ADT/IntrusiveRefCntPtr.h>
+#include <llvm/Bitcode/BitcodeWriter.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/VirtualFileSystem.h>
+#include <llvm/Support/raw_ostream.h>
+#include <llvm/TargetParser/Host.h>
+#include <sstream>
+
+#include "ast/ast.h"
+#include "ast/passes/clang_build.h"
+#include "ast/passes/resolve_imports.h"
+#include "stdlib/stdlib.h"
+#include "util/result.h"
+
+namespace bpftrace::ast {
+
+char ClangBuildError::ID;
+
+void ClangBuildError::log(llvm::raw_ostream &OS) const
+{
+  OS << msg_;
+}
+
+namespace {
+
+class PipeFds {
+public:
+  PipeFds(int rfd, int wfd)
+      : rfd_(rfd),
+        wfd_(wfd),
+        read_("/dev/fd/" + std::to_string(rfd)),
+        write_("/dev/fd/" + std::to_string(wfd)) {};
+  PipeFds(PipeFds &&other)
+      : rfd_(other.rfd_),
+        wfd_(other.wfd_),
+        read_(other.read_),
+        write_(other.write_)
+  {
+    other.rfd_ = -1;
+    other.wfd_ = -1;
+  }
+  PipeFds(const PipeFds &other) = delete;
+  ~PipeFds()
+  {
+    close_read();
+    close_write();
+  }
+
+  const std::string &write_file()
+  {
+    return write_;
+  }
+
+  std::string read_all()
+  {
+    close_write();
+    std::ifstream file(read_);
+    if (file.fail()) {
+      return ""; // Nothing to read.
+    }
+    std::stringstream contents;
+    contents << file.rdbuf();
+    return contents.str();
+  }
+
+  void close_read()
+  {
+    if (rfd_ >= 0) {
+      close(rfd_);
+      rfd_ = -1;
+    }
+  }
+
+  void close_write()
+  {
+    if (wfd_ >= 0) {
+      close(wfd_);
+      wfd_ = -1;
+    }
+  }
+
+private:
+  int rfd_ = -1;
+  int wfd_ = -1;
+  std::string read_;
+  std::string write_;
+};
+
+Result<PipeFds> create_pipe()
+{
+  int fds[2];
+  if (pipe2(fds, O_CLOEXEC) < 0) {
+    return make_error<ClangBuildError>("failed to create pipes");
+  }
+  return PipeFds(fds[0], fds[1]);
+}
+
+} // namespace
+
+static Result<> build(const std::string &name,
+                      LoadedObject &obj,
+                      Imports &imports,
+                      BitcodeModules &result)
+{
+  llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> vfs(
+      new llvm::vfs::InMemoryFileSystem());
+  vfs->addFile(name, 0, llvm::MemoryBuffer::getMemBuffer(obj.data()));
+  for (const auto &[name, other] : stdlib::Stdlib::files) {
+    vfs->addFile(name, 0, llvm::MemoryBuffer::getMemBuffer(other));
+  }
+  for (auto &[name, other] : imports.c_headers) {
+    vfs->addFile(name, 0, llvm::MemoryBuffer::getMemBuffer(other.data()));
+  }
+
+  // Create the diagnostic options and client. We emit the error to
+  // a string, which we can then capture and associate with the import.
+  std::string errstr;
+  llvm::raw_string_ostream err(errstr);
+  auto diagOpts = llvm::makeIntrusiveRefCnt<clang::DiagnosticOptions>();
+  auto diags = std::make_unique<clang::DiagnosticsEngine>(
+      llvm::makeIntrusiveRefCnt<clang::DiagnosticIDs>(),
+      diagOpts,
+      new clang::TextDiagnosticPrinter(err, diagOpts.get()));
+
+  // We create a temporary pipe that we can use to splurp the output,
+  // since the ClangDriver API is framed in terms of filenames. Perhaps
+  // we could use the internals here, but that carries other risks.
+  auto pipefds = create_pipe();
+  if (!pipefds) {
+    return pipefds.takeError();
+  }
+
+  // Create the compiler invocation. Note that the `-O2` introduces some passes
+  // that seem to be load-bearing with respect to generating useful debug
+  // information, for some reason. The generated module will be linked and
+  // optimized again regardless, but it is better safe than sorry.
+  std::vector<const char *> args = {
+    "-O2", "-Iinclude", "-o", pipefds->write_file().c_str(), name.c_str()
+  };
+
+  // Configure the instance. We want to read the source file named
+  // by `name` above, enable debug information and optimization.
+  auto inv = std::make_shared<clang::CompilerInvocation>();
+  clang::CompilerInvocation::CreateFromArgs(*inv,
+                                            llvm::ArrayRef<const char *>(args),
+                                            *diags);
+  inv->getTargetOpts().Triple = "bpf";
+
+  clang::CompilerInstance ci;
+  ci.setInvocation(inv);
+  ci.setDiagnostics(diags.release());
+  ci.setFileManager(new clang::FileManager(clang::FileSystemOptions(), vfs));
+  ci.createSourceManager(ci.getFileManager());
+
+  // Generate the object file, which should include the required BTF
+  // debug information. This also generates the module as a
+  // side-effect, which is what we actually extract for linking.
+  std::unique_ptr<clang::CodeGenAction> action =
+      std::make_unique<clang::EmitObjAction>();
+  if (!ci.ExecuteAction(*action)) {
+    // This is likely a build failure, we can surface this directly
+    // into the user context. We first highlight the location of the
+    // original import, then include the C message as a "hint".
+    auto &e = obj.node.addError();
+    e << "failed to build";
+    e.addHint() << errstr;
+    return OK();
+  }
+  if (!errstr.empty()) {
+    // If the compilation didn't fail, then these weren't errors but we
+    // can surface them as compilation warnings.
+    auto &e = obj.node.addWarning();
+    e << "found external warnings";
+    e.addHint() << errstr;
+  }
+  std::unique_ptr<llvm::LLVMContext> ctx(action->takeLLVMContext());
+  std::unique_ptr<llvm::Module> mod = action->takeModule();
+  if (!mod) {
+    // This is an internal error, not suitable to surface as a user
+    // diagnostic. Surface it directly as an error in the pipeline.
+    return make_error<ClangBuildError>("failed to generate module");
+  }
+  result.contexts.emplace_back(std::move(ctx));
+  result.modules.emplace_back(std::move(mod));
+  result.objects.emplace_back(pipefds->read_all());
+  return OK();
+}
+
+ast::Pass CreateClangBuildPass()
+{
+  return ast::Pass::create("ClangBuilder",
+                           [](ast::Imports &imports) -> Result<BitcodeModules> {
+                             BitcodeModules result;
+
+                             // For each of the source files in the imports, we
+                             // build it and turn it into a bitcode file.
+                             for (auto &[name, obj] : imports.c_sources) {
+                               auto ok = build(name, obj, imports, result);
+                               if (!ok) {
+                                 return ok.takeError();
+                               }
+                             }
+
+                             return result;
+                           });
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/clang_build.h
+++ b/src/ast/passes/clang_build.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+class BitcodeModules : public State<"bitcode"> {
+public:
+  std::vector<std::unique_ptr<llvm::LLVMContext>> contexts;
+  std::vector<std::unique_ptr<llvm::Module>> modules;
+  std::vector<std::string> objects;
+};
+
+class ClangBuildError : public ErrorInfo<ClangBuildError> {
+public:
+  static char ID;
+  void log(llvm::raw_ostream &OS) const override;
+  ClangBuildError(std::string msg) : msg_(std::move(msg)) {};
+
+private:
+  std::string msg_;
+};
+
+ast::Pass CreateClangBuildPass();
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/clang_parser.cpp
+++ b/src/ast/passes/clang_parser.cpp
@@ -1,8 +1,12 @@
 #include <algorithm>
 #include <clang-c/Index.h>
+#include <clang/Driver/Driver.h>
+#include <clang/Frontend/CompilerInstance.h>
 #include <cstring>
 #include <iostream>
 #include <llvm/Config/llvm-config.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/VirtualFileSystem.h>
 #include <regex>
 #include <sstream>
 #include <sys/utsname.h>
@@ -12,6 +16,7 @@
 
 #include "ast/ast.h"
 #include "ast/context.h"
+#include "ast/passes/resolve_imports.h"
 #include "bpftrace.h"
 #include "btf.h"
 #include "clang_parser.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "ast/diagnostic.h"
 #include "ast/helpers.h"
 #include "ast/pass_manager.h"
+#include "ast/passes/clang_build.h"
 #include "ast/passes/clang_parser.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/config_analyser.h"
@@ -907,6 +908,7 @@ int main(int argc, char* argv[])
   }
 
   pm.add(ast::CreateLLVMInitPass());
+  pm.add(ast::CreateClangBuildPass());
   pm.add(ast::CreateCompilePass());
   if (bt_debug.contains(DebugStage::Codegen)) {
     pm.add(ast::Pass::create("dump-ir-prefix", [&] {

--- a/src/stdlib/CMakeLists.txt
+++ b/src/stdlib/CMakeLists.txt
@@ -1,35 +1,17 @@
-include(BuildBPF)
 include(Embed)
 
-bpf(base
-  SOURCE  base.c
-  BITCODE base.bc
-  OBJECT  base.o
-  BTF     base.btf
+embed(
+  base_c
+  ${CMAKE_CURRENT_SOURCE_DIR}/base.c
+  OUTPUT  base_c.h
+  VAR     base_c
 )
 
 embed(
-  base_bitcode
-  base.bc
-  OUTPUT  base_bc.h
-  VAR     base_bc
-  DEPENDS base
-)
-
-embed(
-  base_btf
-  base.btf
-  OUTPUT  base_btf.h
-  VAR     base_btf
-  DEPENDS base
-)
-
-embed(
-  base_script
+  base_bt
   ${CMAKE_CURRENT_SOURCE_DIR}/base.bt
   OUTPUT  base_bt.h
   VAR     base_bt
-  DEPENDS base
 )
 
 foreach(header in float limits stdarg stdbool stddef __stddef_max_align_t stdint)
@@ -48,9 +30,8 @@ endforeach()
 
 add_library(stdlib STATIC stdlib.cpp)
 add_dependencies(stdlib
-  base_bitcode
-  base_btf
-  base_script
+  base_c
+  base_bt
   float_header
   limits_header
   stdarg_header

--- a/src/stdlib/stdlib.cpp
+++ b/src/stdlib/stdlib.cpp
@@ -8,10 +8,11 @@ std::string make_view(const unsigned char *v, size_t sz)
 }
 
 // Embedded file contents.
-#include "stdlib/__stddef_max_align_t.h"
-#include "stdlib/base_bc.h"
 #include "stdlib/base_bt.h"
-#include "stdlib/base_btf.h"
+#include "stdlib/base_c.h"
+
+// Standard headers.
+#include "stdlib/__stddef_max_align_t.h"
 #include "stdlib/float.h"
 #include "stdlib/limits.h"
 #include "stdlib/stdarg.h"
@@ -21,8 +22,7 @@ std::string make_view(const unsigned char *v, size_t sz)
 
 // Files is the immutable index of embedded files.
 const std::map<std::string, std::string> Stdlib::files = {
-  { "stdlib/base.btf", make_view(base_btf, sizeof(base_btf)) },
-  { "stdlib/base.bc", make_view(base_bc, sizeof(base_bc)) },
+  { "stdlib/base.c", make_view(base_c, sizeof(base_c)) },
   { "stdlib/base.bt", make_view(base_bt, sizeof(base_bt)) },
   { "include/float.h", make_view(float_h, sizeof(float_h)) },
   { "include/limits.h", make_view(limits_h, sizeof(limits_h)) },


### PR DESCRIPTION
Stacked PRs:
 * #4050
 * __->__#4228


--- --- ---

### ast: add ClangBuilder


This is a pass which will build `llvm::Module` using the linked
`libclang` for any C sources which have been imported. Since bitcode is
not stable, we need to use this mechanism or jump through very annoying
build hoops to have any kind of stability.

Instead, we can efficiently memoize compiled files (e.g. in the standard
`~/.cache/bpftrace` directory) based on a unique version of a) bpftrace,
b) our linked LLVM libraries, and c) the contents of the C file and all
imported headers.

Using C files directly allows us to remove the bitcode and BTF
generation that is currently part of the build. The build paths are
still neccessary for tests, but are not necessary in the main path.

Signed-off-by: Adin Scannell <amscanne@meta.com>
