### PR TITLE
CMake: Fix dependency tracking for "embed" rule

### DIFF
--- a/cmake/Embed.cmake
+++ b/cmake/Embed.cmake
@@ -23,7 +23,7 @@ function(embed NAME SOURCE)
     OUTPUT ${ARG_HEX}
     COMMAND ${XXD} -i < ${SOURCE} > ${ARG_HEX}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    DEPENDS ${ARG_DEPENDS}
+    DEPENDS ${SOURCE} ${ARG_DEPENDS}
     VERBATIM
   )
   add_custom_command(


### PR DESCRIPTION
Have it depend on source files to trigger a rebuild when they change. The dependency on the CMake target does not trigger rebuilds, but is left to enforce ordering.

The dependency chain is roughly as follows (using data_source/BTF as an example but applies to all targets and formats):
1. data_source.c
2. data_source.o
3. data_source.btf
4. data_source_btf.hex
5. data_source_btf.h
6. bpftrace_test

An update to (1) triggers rebuilds of (2) and (3), but not (4) or later.

This change makes it so that (4) and also later targets are rebuilt when the source files change.

Tested with Make and Ninja build systems.