### PR TITLE
Add CLI opts syntax

### DIFF
--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -16,7 +16,7 @@ public:
   explicit ConfigAnalyser(BPFtrace &bpftrace) : bpftrace_(bpftrace) {};
 
   using Visitor<ConfigAnalyser>::visit;
-  void visit(AssignConfigVarStatement &assignment);
+  void visit(AssignNonProgVarStatement &assignment);
 
 private:
   BPFtrace &bpftrace_;
@@ -29,7 +29,7 @@ static std::unordered_set<std::string> DEPRECATED_CONFIGS = {
   "max_type_res_iterations",
 };
 
-void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
+void ConfigAnalyser::visit(AssignNonProgVarStatement &assignment)
 {
   // If this is deprecated, just emit a warning and move on. This is done here
   // because they are no longer understood by the actual config type.

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -318,7 +318,7 @@ void Printer::visit(AssignVarStatement &assignment)
   }
 }
 
-void Printer::visit(AssignConfigVarStatement &assignment)
+void Printer::visit(AssignNonProgVarStatement &assignment)
 {
   std::string indent(depth_, ' ');
   out_ << indent << "=" << std::endl;
@@ -442,6 +442,28 @@ void Printer::visit(Config &config)
   --depth_;
 }
 
+void Printer::visit(Opts &opts)
+{
+  std::string indent(depth_, ' ');
+
+  out_ << indent << "opts" << std::endl;
+
+  ++depth_;
+  visit(opts.opt_blocks);
+  --depth_;
+}
+
+void Printer::visit(OptBlock &opt_block)
+{
+  std::string indent(depth_, ' ');
+
+  out_ << indent << "opt" << std::endl;
+
+  ++depth_;
+  visit(opt_block.stmts);
+  --depth_;
+}
+
 void Printer::visit(Jump &jump)
 {
   std::string indent(depth_, ' ');
@@ -522,6 +544,10 @@ void Printer::visit(Program &program)
 
   ++depth_;
   visit(program.config);
+  --depth_;
+
+  ++depth_;
+  visit(program.opts);
   --depth_;
 
   ++depth_;

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -40,13 +40,15 @@ public:
   void visit(AssignMapStatement &assignment);
   void visit(AssignScalarMapStatement &assignment);
   void visit(AssignVarStatement &assignment);
-  void visit(AssignConfigVarStatement &assignment);
+  void visit(AssignNonProgVarStatement &assignment);
   void visit(VarDeclStatement &decl);
   void visit(If &if_node);
   void visit(Unroll &unroll);
   void visit(While &while_block);
   void visit(For &for_loop);
   void visit(Config &config);
+  void visit(Opts &opts);
+  void visit(OptBlock &opt_block);
   void visit(Jump &jump);
   void visit(Predicate &pred);
   void visit(AttachPoint &ap);

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -149,7 +149,7 @@ public:
     visitImpl(assignment.expr);
     return default_value();
   }
-  R visit([[maybe_unused]] AssignConfigVarStatement &assignment)
+  R visit([[maybe_unused]] AssignNonProgVarStatement &assignment)
   {
     return default_value();
   }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -165,6 +165,7 @@ oct_esc  [0-7]{1,3}
 "unroll"                { return Parser::make_UNROLL(yytext, driver.loc); }
 "while"                 { return Parser::make_WHILE(yytext, driver.loc); }
 "config"                { return Parser::make_CONFIG(yytext, driver.loc); }
+"opts"                  { return Parser::make_OPTS(yytext, driver.loc); }
 "for"                   { return Parser::make_FOR(yytext, driver.loc); }
 "return"                { return Parser::make_RETURN(yytext, driver.loc); }
 "continue"              { return Parser::make_CONTINUE(yytext, driver.loc); }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -665,6 +665,7 @@ static ast::ASTContext buildListProgram(const std::string& search)
       ast::AttachPointList({ ap }), nullptr, nullptr, location());
   ast.root = ast.make_node<ast::Program>("",
                                          nullptr,
+                                         nullptr,
                                          ast::ImportList(),
                                          ast::MapDeclList(),
                                          ast::MacroList(),


### PR DESCRIPTION
This is the first PR in a series that will
add a syntax that allows users to specify
named command line arguments rather than
relying on positional params.

Issue:
https://github.com/bpftrace/bpftrace/issues/1945

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
