### PR TITLE
Revert "Make `blazesym` a required dependency"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,14 +141,7 @@ if(ENABLE_SYSTEMD)
   pkg_check_modules(libsystemd REQUIRED IMPORTED_TARGET libsystemd)
 endif()
 
-find_package(LibBlazesym REQUIRED)
-if("${LIBBLAZESYM_VERSION}" VERSION_LESS 0.1.1)
-  message(SEND_ERROR "bpftrace requires libblazesym 0.1.1 or greater")
-endif()
-
-if("${LIBBLAZESYM_VERSION}" VERSION_GREATER_EQUAL 0.2.0)
-  message(SEND_ERROR "bpftrace requires libblazesym 0.1.x")
-endif()
+find_package(LibBlazesym)
 
 if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)
@@ -225,6 +218,10 @@ endif(HAVE_LIBBPF_UPROBE_MULTI)
 
 if(ENABLE_SYSTEMD)
   set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_LIBSYSTEMD)
+endif()
+
+if(LIBBLAZESYM_FOUND)
+  set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_BLAZESYM)
 endif()
 
 add_subdirectory(src)

--- a/cmake/FindLibBlazesym.cmake
+++ b/cmake/FindLibBlazesym.cmake
@@ -26,14 +26,4 @@ FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibBlazesym "Please install the libblazesym de
   LIBBLAZESYM_LIBRARIES
   LIBBLAZESYM_INCLUDE_DIRS)
 
-# Parse version information from blazesym.h header file.
-file(READ "${LIBBLAZESYM_INCLUDE_DIRS}/blazesym.h" header_top LIMIT 256)
-string(REGEX MATCH "https://docs\.rs/blazesym-c/([0-9]+)\\.([0-9]+)\\.([0-9]+)\n" docsrs_match "${header_top}")
-set(LIBBLAZESYM_VERSION_MAJOR "${CMAKE_MATCH_1}")
-set(LIBBLAZESYM_VERSION_MINOR "${CMAKE_MATCH_2}")
-set(LIBBLAZESYM_VERSION_PATCH "${CMAKE_MATCH_3}")
-set(LIBBLAZESYM_VERSION "${LIBBLAZESYM_VERSION_MAJOR}.${LIBBLAZESYM_VERSION_MINOR}.${LIBBLAZESYM_VERSION_PATCH}")
-
-message(STATUS "Found libblazesym version ${LIBBLAZESYM_VERSION}")
-
 mark_as_advanced(LIBBLAZESYM_INCLUDE_DIRS LIBBLAZESYM_LIBRARIES)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3838,9 +3838,7 @@ The tradeoff is that bpftrace will use more memory.
 
 ==== show_debug_info
 
-Default: 1
-
-If enabled, when printing ustack and kstack symbols bpftrace will also show (if debug info is available) symbol file and line ('bpftrace' stack mode) and a label if the function was inlined ('bpftrace' and 'perf' stack modes).
+This is only available if the link:https://github.com/libbpf/blazesym[Blazesym] library is available at build time. If it is available this defaults to 1, meaning that when printing ustack and kstack symbols bpftrace will also show (if debug info is available) symbol file and line ('bpftrace' stack mode) and a label if the function was inlined ('bpftrace' and 'perf' stack modes).
 There might be a performance difference when symbolicating, which is the only reason to disable this.
 
 ==== stack_mode

--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -33,6 +33,12 @@ std::string BuildInfo::report()
 #else
       << "no" << std::endl;
 #endif
+  buf << "  blazesym (advanced symbolization): "
+#ifdef HAVE_BLAZESYM
+      << "yes" << std::endl;
+#else
+      << "no" << std::endl;
+#endif
 
   return buf.str();
 }

--- a/src/config.h
+++ b/src/config.h
@@ -45,8 +45,13 @@ public:
   ConfigUnstable unstable_macro = ConfigUnstable::warn;
   ConfigUnstable unstable_map_decl = ConfigUnstable::warn;
   ConfigUnstable unstable_import = ConfigUnstable::error;
+#ifdef HAVE_BLAZESYM
   bool use_blazesym = true;
   bool show_debug_info = true;
+#else
+  bool use_blazesym = false;
+  bool show_debug_info = false;
+#endif
   uint64_t log_size = 1000000;
   uint64_t max_bpf_progs = 1024;
   uint64_t max_cat_bytes = 10240;

--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -1,6 +1,9 @@
 #include <bcc/bcc_syms.h>
-#include <blazesym.h>
 #include <sstream>
+
+#ifdef HAVE_BLAZESYM
+#include <blazesym.h>
+#endif
 
 #include "ksyms.h"
 #include "scopeguard.h"
@@ -13,6 +16,7 @@ std::string stringify_addr(uint64_t addr)
   return symbol.str();
 }
 
+#ifdef HAVE_BLAZESYM
 std::string stringify_ksym(const char *name,
                            const blaze_symbolize_code_info *code_info,
                            uint64_t offset,
@@ -51,6 +55,7 @@ std::string stringify_ksym(const char *name,
 
   return symbol.str();
 }
+#endif
 
 } // namespace
 
@@ -65,8 +70,10 @@ Ksyms::~Ksyms()
   if (ksyms_)
     bcc_free_symcache(ksyms_, -1);
 
+#ifdef HAVE_BLAZESYM
   if (symbolizer_)
     blaze_symbolizer_free(symbolizer_);
+#endif
 }
 
 std::string Ksyms::resolve_bcc(uint64_t addr, bool show_offset)
@@ -86,6 +93,7 @@ std::string Ksyms::resolve_bcc(uint64_t addr, bool show_offset)
   return stringify_addr(addr);
 }
 
+#ifdef HAVE_BLAZESYM
 std::vector<std::string> Ksyms::resolve_blazesym_impl(uint64_t addr,
                                                       bool show_offset,
                                                       bool perf_mode,
@@ -164,15 +172,17 @@ std::vector<std::string> Ksyms::resolve_blazesym(uint64_t addr,
 
   return syms;
 }
+#endif
 
 std::vector<std::string> Ksyms::resolve(uint64_t addr,
                                         bool show_offset,
                                         [[maybe_unused]] bool perf_mode,
                                         [[maybe_unused]] bool show_debug_info)
 {
+#ifdef HAVE_BLAZESYM
   if (config_.use_blazesym)
     return resolve_blazesym(addr, show_offset, perf_mode, show_debug_info);
-
+#endif
   return std::vector<std::string>{ resolve_bcc(addr, show_offset) };
 }
 

--- a/src/ksyms.h
+++ b/src/ksyms.h
@@ -25,6 +25,7 @@ private:
   const Config &config_;
   void *ksyms_{ nullptr };
 
+#ifdef HAVE_BLAZESYM
   struct blaze_symbolizer *symbolizer_{ nullptr };
 
   std::vector<std::string> resolve_blazesym_impl(uint64_t addr,
@@ -35,6 +36,7 @@ private:
                                             bool show_offset,
                                             bool perf_mode,
                                             bool show_debug_info);
+#endif
 
   std::string resolve_bcc(uint64_t addr, bool show_offset);
 };

--- a/src/usyms.h
+++ b/src/usyms.h
@@ -46,6 +46,7 @@ private:
                           bool perf_mode);
   struct bcc_symbol_option& get_symbol_opts();
 
+#ifdef HAVE_BLAZESYM
   struct blaze_symbolizer* symbolizer_{ nullptr };
 
   struct blaze_symbolizer* create_symbolizer() const;
@@ -62,6 +63,7 @@ private:
                                             bool show_offset,
                                             bool perf_mode,
                                             bool show_debug_info);
+#endif
 };
 
 } // namespace bpftrace


### PR DESCRIPTION
Reverts bpftrace/bpftrace#4115 because blazesym is not yet ready on Fedora and Debian which is causing issues for bpftrace developers.