### PR TITLE
Make thrown runtime test errors a little noisier

### DIFF
--- a/tests/runtime/engine/main.py
+++ b/tests/runtime/engine/main.py
@@ -25,7 +25,7 @@ def main(test_filter, allowlist_file, run_aot_tests):
         test_suite = sorted(TestParser.read_all(run_aot_tests))
         test_suite = [ (n, sorted(t)) for n, t in test_suite ]
     except (UnknownFieldError, RequiredFieldError) as error:
-        print(fail(str(error)))
+        print(fail(f"[  FAILED  ] {str(error)}"))
         exit(1)
 
     # Apply filter

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -216,7 +216,7 @@ class TestParser(object):
             elif item_name == "RETURN_CODE":
                 return_code = int(line.strip(' '))
             else:
-                raise UnknownFieldError('Field %s is unknown. Suite: %s' % (item_name, test_suite))
+                raise UnknownFieldError('Field %s is not a runtime test directive. Suite: %s' % (item_name, test_suite))
 
         if name == '':
             raise RequiredFieldError('Test NAME is required. Suite: ' + test_suite)


### PR DESCRIPTION
I usually search for "FAILED" in the CI build
log to find issues. This prefixes thrown runtime
test errors to make them a little more obvious e.g.

[  FAILED  ] Field WARNING: is not a runtime test directive. Suite: probe

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
