### PR TITLE
build: Fix linking for Fedora build

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     libpcap-dev \
     llvm-dev \
     libclang-dev \
+    libclang-cpp-dev \
     pahole \
     systemtap-sdt-dev \
     xxd \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     libpcap-dev \
     llvm-dev \
     libclang-dev \
+    libclang-cpp-dev \
     linux-tools-common \
     pahole \
     systemtap-sdt-dev \

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -77,15 +77,7 @@ if(STATIC_LINKING)
   unlink_transitive_dependency("${CLANG_EXPORTED_TARGETS}" "LLVM")
   unlink_transitive_dependency("${CLANG_EXPORTED_TARGETS}" "$<LINK_ONLY:clang-cpp>")
 
-  if(TARGET libclang_static)
-    target_link_libraries(ast PUBLIC libclang_static)
-  else()
-    # old LLVM versions don't export libclang_static in ClangTargets.cmake; fall back to
-    # libclang.a in that case
-    target_link_libraries(ast PUBLIC libclang.a)
-  endif()
-
-  target_link_libraries(ast PUBLIC clangDriver clangFrontend clangCodeGen)
+  target_link_libraries(ast PUBLIC libclang_static clangDriver clangFrontend clangCodeGen)
   target_link_libraries(ast PUBLIC ${llvm_libs})
 else()
   if (TARGET LLVM)
@@ -98,5 +90,6 @@ else()
     # have libLLVM.so, drop `USE_SHARED` to avoid forcing link to `-lLLVM`.
     llvm_config(ast bpfcodegen ipo irreader mcjit orcjit)
   endif()
-  target_link_libraries(ast PUBLIC libclang clangDriver clangFrontend clangCodeGen)
+
+  target_link_libraries(ast PUBLIC libclang clang-cpp)
 endif()


### PR DESCRIPTION
It seems Fedora packages the clang libraries differently. When building the Docker image, set the `cmake` flag appropriately.

##### Checklist

- ~[ ] Language changes are updated in `man/adoc/bpftrace.adoc`~
- ~[ ] User-visible and non-trivial changes updated in `CHANGELOG.md`~
- ~[ ] The new behaviour is covered by tests~
