### PR TITLE
arch: ensure all code is built all the time

### DIFF
--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -1,19 +1,10 @@
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(arm|aarch64)")
-    add_library(arch STATIC arm.cpp)
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64" OR
-       CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
-    add_library(arch STATIC ppc64.cpp)
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "s390" OR
-       CMAKE_SYSTEM_PROCESSOR STREQUAL "s390x")
-    add_library(arch STATIC s390.cpp)
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-    add_library(arch STATIC x86_64.cpp)
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "mips64")
-    add_library(arch STATIC  mips64.cpp)
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64")
-    add_library(arch STATIC riscv64.cpp)
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "loongarch64")
-    add_library(arch STATIC loongarch64.cpp)
-else()
-  message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-endif()
+add_library(arch STATIC
+  arm.cpp
+  ppc64.cpp
+  s390.cpp
+  arch.cpp
+  x86_64.cpp
+  mips64.cpp
+  riscv64.cpp
+  loongarch64.cpp
+)

--- a/src/arch/arch.cpp
+++ b/src/arch/arch.cpp
@@ -1,0 +1,42 @@
+#include <iostream>
+
+#include "arch/arch.h"
+
+namespace bpftrace::arch {
+
+std::ostream& operator<<(std::ostream& out, Machine m)
+{
+  switch (m) {
+    case Machine::X86_64:
+      out << "x86_64";
+      break;
+    case Machine::ARM:
+      out << "arm";
+      break;
+    case Machine::ARM64:
+      out << "arm64";
+      break;
+    case Machine::S390X:
+      out << "s390x";
+      break;
+    case Machine::PPC64:
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      out << "ppc64le";
+#else
+      out << "ppc64";
+#endif // __BYTE_ORDER__
+      break;
+    case Machine::MIPS64:
+      out << "mips64";
+      break;
+    case Machine::RISCV64:
+      out << "riscv64";
+      break;
+    case Machine::LOONGARCH64:
+      out << "loongarch64";
+      break;
+  }
+  return out;
+}
+
+} // namespace bpftrace::arch

--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -1,23 +1,106 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 namespace bpftrace::arch {
 
-int offset(std::string reg_name);
-int max_arg();
-int arg_offset(int arg_num);
-int ret_offset();
-int pc_offset();
-int sp_offset();
-int arg_stack_offset();
-std::string name();
+// Canonical enum for different architectures.
+enum Machine {
+  X86_64,
+  ARM,
+  ARM64,
+  S390X,
+  PPC64,
+  MIPS64,
+  RISCV64,
+  LOONGARCH64,
+};
 
-// Returns the set of valid watchpoint modes.
-const std::unordered_set<std::string> &watchpoint_modes();
+// Allow printing of the machine type.
+std::ostream& operator<<(std::ostream& out, Machine m);
 
-// Returns the width in bits of kernel pointers.
-int get_kernel_ptr_width();
+// In order to ensure that all architecture sources are always compiled, we
+// define the architecture details as a specific instance of the various
+// architecture classes. Unused architectures should be stripped out at link
+// time as those functions are unreferenced.
+template <Machine M>
+class Arch {
+public:
+  constexpr static auto Machine = M;
+
+  // Returns the width of bits in kernel pointers.
+  static size_t kernel_ptr_width();
+
+  // Given a conventional register name, return the expression that should be
+  // used to access this from `struct pt_regs`. This will be dynamically added
+  // and evaluated using the standard type inference mechanisms.
+  static std::optional<std::string> register_to_pt_regs_expr(
+      const std::string& name);
+
+  // Returns the offset into the context where this register resides.
+  //
+  // FIXME(#3873): This should be removed in the future. With BTF, there is no
+  // need to statically encode the register offsets and we should instead treat
+  // these as regular field references into the context (e.g. `ctx.ax`). These
+  // field names can then be checked, and will support dynamic reloations, etc.
+  // A pass can be added early to transform `regs("r")` into `ctx.r`, and we
+  // can have proper type inference and type-checking while throwing out code.
+  // However, for now, we retain this method to faciliate the transition.
+  static std::optional<size_t> register_to_pt_regs_offset(
+      const std::string& name);
+
+  // Returns the canonical sequence of registers used for the default calling
+  // convention on this architecture. These should be in the form of fields for
+  // `struct pt_regs` (the function above will not be called).
+  static const std::vector<std::string>& arguments();
+
+  // Returns the canonical offset into the stack where arguments start to spill.
+  static size_t argument_stack_offset();
+
+  // Returns the canonical register used for the return value on this
+  // architecture, also in the form of a `struct pt_regs` field.
+  static std::string return_value();
+
+  // Returns the canonical register used to store the instruction pointer,
+  // also in the form of a `struct pt_regs` field.
+  static std::string pc_value();
+
+  // Returns the canonical register used to store the stack pointer, in
+  // the form of a `struct pt_regs` fields.
+  static std::string sp_value();
+
+  // Returns the set of valid watchpoint modes.
+  static const std::unordered_set<std::string>& watchpoint_modes();
+};
+
+// Returns the `Machine` for the compiled architecture.
+constexpr Machine current()
+{
+#if defined(__x86_64__) || defined(__amd64__)
+  return Machine::X86_64;
+#elif defined(__aarch64__)
+  return Machine::ARM64;
+#elif defined(__arm__)
+  return Machine::ARM;
+#elif defined(__s390x__)
+  return Machine::S390X;
+#elif defined(__ppc64__)
+  return Machine::POWERPC;
+#elif defined(__mips64)
+  return Machine::MIPS64;
+#elif defined(__riscv) && (__riscv_xlen == 64)
+  return Machine::RISCV64;
+#elif defined(__loongarch64)
+  return Machine::LOONGARCH64;
+#else
+#error "Unknown architecture."
+#endif
+}
+
+// Alias for the current host architecture.
+using Host = Arch<current()>;
 
 } // namespace bpftrace::arch

--- a/src/arch/loongarch64.cpp
+++ b/src/arch/loongarch64.cpp
@@ -1,159 +1,220 @@
-#include <algorithm>
-#include <array>
+#include <unordered_map>
 
 #include "arch.h"
 
-// SP points to the first argument that is passed on the stack
-#define ARG0_STACK 0
-
 namespace bpftrace::arch {
 
-// clang-format off
-static std::array<std::string, 34> registers = {
-  "r0",
-  "r1",
-  "r2",
-  "r3",
-  "r4",
-  "r5",
-  "r6",
-  "r7",
-  "r8",
-  "r9",
-  "r10",
-  "r11",
-  "r12",
-  "r13",
-  "r14",
-  "r15",
-  "r16",
-  "r17",
-  "r18",
-  "r19",
-  "r20",
-  "r21",
-  "r22",
-  "r23",
-  "r24",
-  "r25",
-  "r26",
-  "r27",
-  "r28",
-  "r29",
-  "r30",
-  "r31",
-  "orig_a0",
-  "pc",
-};
-
-// Alternative register names that match struct pt_regs
-static std::array<std::string, 34> ptrace_registers = {
-  "regs[0]",
-  "regs[1]",
-  "regs[2]",
-  "regs[3]",
-  "regs[4]",
-  "regs[5]",
-  "regs[6]",
-  "regs[7]",
-  "regs[8]",
-  "regs[9]",
-  "regs[10]",
-  "regs[11]",
-  "regs[12]",
-  "regs[13]",
-  "regs[14]",
-  "regs[15]",
-  "regs[16]",
-  "regs[17]",
-  "regs[18]",
-  "regs[19]",
-  "regs[20]",
-  "regs[21]",
-  "regs[22]",
-  "regs[23]",
-  "regs[24]",
-  "regs[25]",
-  "regs[26]",
-  "regs[27]",
-  "regs[28]",
-  "regs[29]",
-  "regs[30]",
-  "regs[31]",
-  "orig_a0",
-  "csr_era",
-};
-
-static std::array<std::string, 8> arg_registers = {
-  "r4",
-  "r5",
-  "r6",
-  "r7",
-  "r8",
-  "r9",
-  "r10",
-  "r11",
-};
-// clang-format on
-
-int offset(std::string reg_name)
-{
-  auto it = find(registers.begin(), registers.end(), reg_name);
-  if (it == registers.end()) {
-    // Also allow register names that match the fields in struct pt_regs.
-    // These appear in USDT probe arguments.
-    it = find(ptrace_registers.begin(), ptrace_registers.end(), reg_name);
-    if (it == ptrace_registers.end()) {
-      return -1;
-    }
-    return distance(ptrace_registers.begin(), it);
-  }
-  return distance(registers.begin(), it);
-}
-
-int max_arg()
-{
-  return arg_registers.size() - 1;
-}
-
-int arg_offset(int arg_num)
-{
-  return offset(arg_registers.at(arg_num));
-}
-
-int pc_offset()
-{
-  return offset("pc");
-}
-
-int ret_offset()
-{
-  return offset("r4");
-}
-
-int sp_offset()
-{
-  return offset("r3");
-}
-
-int arg_stack_offset()
-{
-  return ARG0_STACK / 8;
-}
-
-std::string name()
-{
-  return std::string("loongarch64");
-}
-
-const std::unordered_set<std::string> &watchpoint_modes()
-{
-  return {}; // Not supported.
-}
-
-int get_kernel_ptr_width()
+template <>
+size_t Arch<Machine::LOONGARCH64>::kernel_ptr_width()
 {
   return 64;
+}
+
+template <>
+std::optional<std::string> Arch<Machine::LOONGARCH64>::register_to_pt_regs_expr(
+    const std::string& name)
+{
+  static const std::unordered_map<std::string, std::string> register_exprs = {
+    { "r0", "regs[0]" },
+    { "r1", "regs[1]" },
+    { "r2", "regs[2]" },
+    { "r3", "regs[3]" },
+    { "r4", "regs[4]" },
+    { "r5", "regs[5]" },
+    { "r6", "regs[6]" },
+    { "r7", "regs[7]" },
+    { "r8", "regs[8]" },
+    { "r9", "regs[9]" },
+    { "r10", "regs[10]" },
+    { "r11", "regs[11]" },
+    { "r12", "regs[12]" },
+    { "r13", "regs[13]" },
+    { "r14", "regs[14]" },
+    { "r15", "regs[15]" },
+    { "r16", "regs[16]" },
+    { "r17", "regs[17]" },
+    { "r18", "regs[18]" },
+    { "r19", "regs[19]" },
+    { "r20", "regs[20]" },
+    { "r21", "regs[21]" },
+    { "r22", "regs[22]" },
+    { "r23", "regs[23]" },
+    { "r24", "regs[24]" },
+    { "r25", "regs[25]" },
+    { "r26", "regs[26]" },
+    { "r27", "regs[27]" },
+    { "r28", "regs[28]" },
+    { "r29", "regs[29]" },
+    { "r30", "regs[30]" },
+    { "r31", "regs[31]" },
+
+    // Support full expressions as string literals.
+    { "regs[0]", "regs[0]" },
+    { "regs[1]", "regs[1]" },
+    { "regs[2]", "regs[2]" },
+    { "regs[3]", "regs[3]" },
+    { "regs[4]", "regs[4]" },
+    { "regs[5]", "regs[5]" },
+    { "regs[6]", "regs[6]" },
+    { "regs[7]", "regs[7]" },
+    { "regs[8]", "regs[8]" },
+    { "regs[9]", "regs[9]" },
+    { "regs[10]", "regs[10]" },
+    { "regs[11]", "regs[11]" },
+    { "regs[12]", "regs[12]" },
+    { "regs[13]", "regs[13]" },
+    { "regs[14]", "regs[14]" },
+    { "regs[15]", "regs[15]" },
+    { "regs[16]", "regs[16]" },
+    { "regs[17]", "regs[17]" },
+    { "regs[18]", "regs[18]" },
+    { "regs[19]", "regs[19]" },
+    { "regs[20]", "regs[20]" },
+    { "regs[21]", "regs[21]" },
+    { "regs[22]", "regs[22]" },
+    { "regs[23]", "regs[23]" },
+    { "regs[24]", "regs[24]" },
+    { "regs[25]", "regs[25]" },
+    { "regs[26]", "regs[26]" },
+    { "regs[27]", "regs[27]" },
+    { "regs[28]", "regs[28]" },
+    { "regs[29]", "regs[29]" },
+    { "regs[30]", "regs[30]" },
+    { "regs[31]", "regs[31]" },
+
+    // Special registers.
+    { "orig_a0", "orig_a0" },
+    { "pc", "csr_era" },
+  };
+  auto it = register_exprs.find(name);
+  if (it != register_exprs.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+template <>
+std::optional<size_t> Arch<Machine::LOONGARCH64>::register_to_pt_regs_offset(
+    const std::string& name)
+{
+  static const std::unordered_map<std::string, size_t> register_offsets = {
+    { "r0", 0 },
+    { "r1", 8 },
+    { "r2", 16 },
+    { "r3", 24 },
+    { "r4", 32 },
+    { "r5", 40 },
+    { "r6", 48 },
+    { "r7", 56 },
+    { "r8", 64 },
+    { "r9", 72 },
+    { "r10", 80 },
+    { "r11", 88 },
+    { "r12", 96 },
+    { "r13", 104 },
+    { "r14", 112 },
+    { "r15", 120 },
+    { "r16", 128 },
+    { "r17", 136 },
+    { "r18", 144 },
+    { "r19", 152 },
+    { "r20", 160 },
+    { "r21", 168 },
+    { "r22", 176 },
+    { "r23", 184 },
+    { "r24", 192 },
+    { "r25", 200 },
+    { "r26", 208 },
+    { "r27", 216 },
+    { "r28", 224 },
+    { "r29", 232 },
+    { "r30", 240 },
+    { "r31", 248 },
+
+    // Support full expressions as string literals.
+    { "regs[0]", 0 },
+    { "regs[1]", 8 },
+    { "regs[2]", 16 },
+    { "regs[3]", 24 },
+    { "regs[4]", 32 },
+    { "regs[5]", 40 },
+    { "regs[6]", 48 },
+    { "regs[7]", 56 },
+    { "regs[8]", 64 },
+    { "regs[9]", 72 },
+    { "regs[10]", 80 },
+    { "regs[11]", 88 },
+    { "regs[12]", 96 },
+    { "regs[13]", 104 },
+    { "regs[14]", 112 },
+    { "regs[15]", 120 },
+    { "regs[16]", 128 },
+    { "regs[17]", 136 },
+    { "regs[18]", 144 },
+    { "regs[19]", 152 },
+    { "regs[20]", 160 },
+    { "regs[21]", 168 },
+    { "regs[22]", 176 },
+    { "regs[23]", 184 },
+    { "regs[24]", 192 },
+    { "regs[25]", 200 },
+    { "regs[26]", 208 },
+    { "regs[27]", 216 },
+    { "regs[28]", 224 },
+    { "regs[29]", 232 },
+    { "regs[30]", 240 },
+    { "regs[31]", 248 },
+
+    // Special registers.
+    { "orig_a0", 256 },
+    { "pc", 264 },
+  };
+  auto it = register_offsets.find(name);
+  if (it != register_offsets.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+template <>
+const std::vector<std::string>& Arch<Machine::LOONGARCH64>::arguments()
+{
+  static std::vector<std::string> args = {
+    "r4", "r5", "r6", "r7", "r8", "r9", "r10", "r11",
+  };
+  return args;
+}
+
+template <>
+size_t Arch<Machine::LOONGARCH64>::argument_stack_offset()
+{
+  return 0;
+}
+
+template <>
+std::string Arch<Machine::LOONGARCH64>::return_value()
+{
+  return "r4";
+}
+
+template <>
+std::string Arch<Machine::LOONGARCH64>::pc_value()
+{
+  return "pc";
+}
+
+template <>
+std::string Arch<Machine::LOONGARCH64>::sp_value()
+{
+  return "r3";
+}
+
+template <>
+const std::unordered_set<std::string>& Arch<
+    Machine::LOONGARCH64>::watchpoint_modes()
+{
+  static std::unordered_set<std::string> valid_modes = {};
+  return valid_modes;
 }
 
 } // namespace bpftrace::arch

--- a/src/arch/ppc64.cpp
+++ b/src/arch/ppc64.cpp
@@ -1,143 +1,144 @@
-#include <array>
-#include <set>
-#include <vector>
+#include <unordered_map>
 
 #include "arch.h"
 
-#define ARG_REGISTERS 8
-// For little endian 64 bit, sp + 32 + 8 regs save area + argX
-#define ARG0_STACK_LE 96
-// For big endian 64 bit, sp + 48 + 8 regs save area + argX
-#define ARG0_STACK_BE 112
-
 namespace bpftrace::arch {
 
-// clang-format off
-static std::vector<std::set<std::string>> registers = {
-  { "r0", "gpr[0]" },
-  { "r1", "gpr[1]" },
-  { "r2", "gpr[2]" },
-  { "r3", "gpr[3]" },
-  { "r4", "gpr[4]" },
-  { "r5", "gpr[5]" },
-  { "r6", "gpr[6]" },
-  { "r7", "gpr[7]" },
-  { "r8", "gpr[8]" },
-  { "r9", "gpr[9]" },
-  { "r10", "gpr[10]" },
-  { "r11", "gpr[11]" },
-  { "r12", "gpr[12]" },
-  { "r13", "gpr[13]" },
-  { "r14", "gpr[14]" },
-  { "r15", "gpr[15]" },
-  { "r16", "gpr[16]" },
-  { "r17", "gpr[17]" },
-  { "r18", "gpr[18]" },
-  { "r19", "gpr[19]" },
-  { "r20", "gpr[20]" },
-  { "r21", "gpr[21]" },
-  { "r22", "gpr[22]" },
-  { "r23", "gpr[23]" },
-  { "r24", "gpr[24]" },
-  { "r25", "gpr[25]" },
-  { "r26", "gpr[26]" },
-  { "r27", "gpr[27]" },
-  { "r28", "gpr[28]" },
-  { "r29", "gpr[29]" },
-  { "r30", "gpr[30]" },
-  { "r31", "gpr[31]" },
-  { "nip" },
-  { "msr" },
-  { "orig_gpr3" },
-  { "ctr" },
-  { "link" },
-  { "xer" },
-  { "ccr" },
-  { "softe" },
-  { "trap" },
-  { "dar" },
-  { "dsisr" },
-  { "result" },
-};
-
-static std::array<std::string, ARG_REGISTERS> arg_registers = {
-  "r3",
-  "r4",
-  "r5",
-  "r6",
-  "r7",
-  "r8",
-  "r9",
-  "r10",
-};
-// clang-format on
-
-int offset(std::string reg_name)
+template <>
+size_t Arch<Machine::PPC64>::kernel_ptr_width()
 {
-  for (unsigned int i = 0; i < registers.size(); i++) {
-    if (registers[i].count(reg_name))
-      return i;
+  return 64;
+}
+
+template <>
+std::optional<std::string> Arch<Machine::PPC64>::register_to_pt_regs_expr(
+    const std::string& name)
+{
+  // PowerPC pt_regs structure field mapping
+  static const std::unordered_map<std::string, std::string> register_exprs = {
+    { "r0", "gpr[0]" },
+    { "r1", "gpr[1]" },
+    { "r2", "gpr[2]" },
+    { "r3", "gpr[3]" },
+    { "r4", "gpr[4]" },
+    { "r5", "gpr[5]" },
+    { "r6", "gpr[6]" },
+    { "r7", "gpr[7]" },
+    { "r8", "gpr[8]" },
+    { "r9", "gpr[9]" },
+    { "r10", "gpr[10]" },
+    { "r11", "gpr[11]" },
+    { "r12", "gpr[12]" },
+    { "r13", "gpr[13]" },
+    { "r14", "gpr[14]" },
+    { "r15", "gpr[15]" },
+    { "r16", "gpr[16]" },
+    { "r17", "gpr[17]" },
+    { "r18", "gpr[18]" },
+    { "r19", "gpr[19]" },
+    { "r20", "gpr[20]" },
+    { "r21", "gpr[21]" },
+    { "r22", "gpr[22]" },
+    { "r23", "gpr[23]" },
+    { "r24", "gpr[24]" },
+    { "r25", "gpr[25]" },
+    { "r26", "gpr[26]" },
+    { "r27", "gpr[27]" },
+    { "r28", "gpr[28]" },
+    { "r29", "gpr[29]" },
+    { "r30", "gpr[30]" },
+    { "r31", "gpr[31]" },
+    { "nip", "nip" },
+    { "msr", "msr" },
+    { "orig_gpr3", "orig_gpr3" },
+    { "ctr", "ctr" },
+    { "link", "link" },
+    { "xer", "xer" },
+    { "ccr", "ccr" },
+    { "softe", "softe" },
+    { "trap", "trap" },
+    { "dar", "dar" },
+    { "dsisr", "dsisr" },
+    { "result", "result" },
+  };
+  auto it = register_exprs.find(name);
+  if (it != register_exprs.end()) {
+    return it->second;
   }
-  return -1;
+  return std::nullopt;
 }
 
-int max_arg()
+template <>
+std::optional<size_t> Arch<Machine::PPC64>::register_to_pt_regs_offset(
+    const std::string& name)
 {
-  return arg_registers.size() - 1;
+  static const std::unordered_map<std::string, size_t> register_offsets = {
+    { "r0", 0 },     { "r1", 8 },    { "r2", 16 },         { "r3", 24 },
+    { "r4", 32 },    { "r5", 40 },   { "r6", 48 },         { "r7", 56 },
+    { "r8", 64 },    { "r9", 72 },   { "r10", 80 },        { "r11", 88 },
+    { "r12", 96 },   { "r13", 104 }, { "r14", 112 },       { "r15", 120 },
+    { "r16", 128 },  { "r17", 136 }, { "r18", 144 },       { "r19", 152 },
+    { "r20", 160 },  { "r21", 168 }, { "r22", 176 },       { "r23", 184 },
+    { "r24", 192 },  { "r25", 200 }, { "r26", 208 },       { "r27", 216 },
+    { "r28", 224 },  { "r29", 232 }, { "r30", 240 },       { "r31", 248 },
+    { "nip", 256 },  { "msr", 264 }, { "orig_gpr3", 272 }, { "ctr", 280 },
+    { "link", 288 }, { "xer", 296 }, { "ccr", 304 },       { "softe", 312 },
+    { "trap", 320 }, { "dar", 328 }, { "dsisr", 336 },     { "result", 344 },
+  };
+  auto it = register_offsets.find(name);
+  if (it != register_offsets.end()) {
+    return it->second;
+  }
+  return std::nullopt;
 }
 
-int arg_offset(int arg_num)
+template <>
+const std::vector<std::string>& Arch<Machine::PPC64>::arguments()
 {
-  return offset(arg_registers.at(arg_num));
+  static std::vector<std::string> args = {
+    "r3", "r4", "r5", "r6", "r7", "r8", "r9", "r10",
+  };
+  return args;
 }
 
-int ret_offset()
-{
-  return offset("r3");
-}
-
-int pc_offset()
-{
-  return offset("nip");
-}
-
-int sp_offset()
-{
-  return offset("r1");
-}
-
-int arg_stack_offset()
+template <>
+size_t Arch<Machine::PPC64>::argument_stack_offset()
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-  return ARG0_STACK_LE / 8;
+  return 96; // Little endian: sp + 32 + 8 regs save area + argX
 #else
-  return ARG0_STACK_BE / 8;
-#endif
-}
-
-std::string name()
-{
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-  return std::string("ppc64le");
-#else
-  return std::string("ppc64");
+  return 112; // Big endian: sp + 48 + 8 regs save area + argX
 #endif // __BYTE_ORDER__
 }
 
-const std::unordered_set<std::string> &watchpoint_modes()
+template <>
+std::string Arch<Machine::PPC64>::return_value()
 {
-  // See PowerISA Book III v3.1B, Section 5.4.4 and 10.4
+  return "r3";
+}
+
+template <>
+std::string Arch<Machine::PPC64>::pc_value()
+{
+  return "nip";
+}
+
+template <>
+std::string Arch<Machine::PPC64>::sp_value()
+{
+  return "r1";
+}
+
+template <>
+const std::unordered_set<std::string>& Arch<Machine::PPC64>::watchpoint_modes()
+{
+  // See PowerISA Book III v3.1B, Section 5.4.4 and 10.4.
   static std::unordered_set<std::string> valid_modes = {
     "r",
     "w",
     "rw",
   };
   return valid_modes;
-}
-
-int get_kernel_ptr_width()
-{
-  return 64;
 }
 
 } // namespace bpftrace::arch

--- a/src/arch/riscv64.cpp
+++ b/src/arch/riscv64.cpp
@@ -1,113 +1,95 @@
-#include <algorithm>
-#include <array>
+#include <unordered_map>
 
-#include "arch.h"
-
-// SP points to the first argument that is passed on the stack
-#define ARG0_STACK 0
+#include "arch/arch.h"
 
 namespace bpftrace::arch {
 
-// clang-format off
-static std::array<std::string, 32> registers = {
-  "pc",
-  "ra",
-  "sp",
-  "gp",
-  "tp",
-  "t0",
-  "t1",
-  "t2",
-  "s0",
-  "s1",
-  "a0",
-  "a1",
-  "a2",
-  "a3",
-  "a4",
-  "a5",
-  "a6",
-  "a7",
-  "s2",
-  "s3",
-  "s4",
-  "s5",
-  "s6",
-  "s7",
-  "s8",
-  "s9",
-  "s10",
-  "s11",
-  "t3",
-  "t4",
-  "t5",
-  "t6",
-};
-
-static std::array<std::string, 8> arg_registers = {
-  "a0",
-  "a1",
-  "a2",
-  "a3",
-  "a4",
-  "a5",
-  "a6",
-  "a7",
-};
-// clang-format on
-
-int offset(std::string reg_name)
-{
-  auto it = find(registers.begin(), registers.end(), reg_name);
-  if (it == registers.end()) {
-    return -1;
-  }
-  return distance(registers.begin(), it);
-}
-
-int max_arg()
-{
-  return arg_registers.size() - 1;
-}
-
-int arg_offset(int arg_num)
-{
-  return offset(arg_registers.at(arg_num));
-}
-
-int pc_offset()
-{
-  return offset("pc");
-}
-
-int ret_offset()
-{
-  return offset("a0");
-}
-
-int sp_offset()
-{
-  return offset("sp");
-}
-
-int arg_stack_offset()
-{
-  return ARG0_STACK / 8;
-}
-
-std::string name()
-{
-  return std::string("riscv64");
-}
-
-const std::unordered_set<std::string> &watchpoint_modes()
-{
-  return {}; // Not supported.
-}
-
-int get_kernel_ptr_width()
+template <>
+size_t Arch<Machine::RISCV64>::kernel_ptr_width()
 {
   return 64;
+}
+
+template <>
+std::optional<std::string> Arch<Machine::RISCV64>::register_to_pt_regs_expr(
+    const std::string& name)
+{
+  static const std::unordered_map<std::string, std::string> register_exprs = {
+    { "pc", "epc" }, { "ra", "ra" }, { "sp", "sp" },   { "gp", "gp" },
+    { "tp", "tp" },  { "t0", "t0" }, { "t1", "t1" },   { "t2", "t2" },
+    { "s0", "s0" },  { "s1", "s1" }, { "a0", "a0" },   { "a1", "a1" },
+    { "a2", "a2" },  { "a3", "a3" }, { "a4", "a4" },   { "a5", "a5" },
+    { "a6", "a6" },  { "a7", "a7" }, { "s2", "s2" },   { "s3", "s3" },
+    { "s4", "s4" },  { "s5", "s5" }, { "s6", "s6" },   { "s7", "s7" },
+    { "s8", "s8" },  { "s9", "s9" }, { "s10", "s10" }, { "s11", "s11" },
+    { "t3", "t3" },  { "t4", "t4" }, { "t5", "t5" },   { "t6", "t6" },
+  };
+  auto it = register_exprs.find(name);
+  if (it != register_exprs.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+template <>
+std::optional<size_t> Arch<Machine::RISCV64>::register_to_pt_regs_offset(
+    const std::string& name)
+{
+  static const std::unordered_map<std::string, size_t> register_offsets = {
+    { "pc", 0 },   { "ra", 8 },    { "sp", 16 },   { "gp", 24 },  { "tp", 32 },
+    { "t0", 40 },  { "t1", 48 },   { "t2", 56 },   { "s0", 64 },  { "s1", 72 },
+    { "a0", 80 },  { "a1", 88 },   { "a2", 96 },   { "a3", 104 }, { "a4", 112 },
+    { "a5", 120 }, { "a6", 128 },  { "a7", 136 },  { "s2", 144 }, { "s3", 152 },
+    { "s4", 160 }, { "s5", 168 },  { "s6", 176 },  { "s7", 184 }, { "s8", 192 },
+    { "s9", 200 }, { "s10", 208 }, { "s11", 216 }, { "t3", 224 }, { "t4", 232 },
+    { "t5", 240 }, { "t6", 248 },
+  };
+  auto it = register_offsets.find(name);
+  if (it != register_offsets.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+template <>
+const std::vector<std::string>& Arch<Machine::RISCV64>::arguments()
+{
+  static std::vector<std::string> args = {
+    "a0", "a1", "a2", "a3", "a4", "a5", "a6", "a7",
+  };
+  return args;
+}
+
+template <>
+size_t Arch<Machine::RISCV64>::argument_stack_offset()
+{
+  return 0;
+}
+
+template <>
+std::string Arch<Machine::RISCV64>::return_value()
+{
+  return "a0";
+}
+
+template <>
+std::string Arch<Machine::RISCV64>::pc_value()
+{
+  return "pc";
+}
+
+template <>
+std::string Arch<Machine::RISCV64>::sp_value()
+{
+  return "sp";
+}
+
+template <>
+const std::unordered_set<std::string>& Arch<
+    Machine::RISCV64>::watchpoint_modes()
+{
+  static std::unordered_set<std::string> valid_modes = {};
+  return valid_modes;
 }
 
 } // namespace bpftrace::arch

--- a/src/arch/s390.cpp
+++ b/src/arch/s390.cpp
@@ -1,102 +1,93 @@
-#include <array>
-#include <set>
-#include <vector>
+#include <unordered_map>
 
 #include "arch.h"
 
-#define ARG_REGISTERS 5
-// For s390x, r2-r6 registers are used as function arguments, then the extra
-// arguments can be found starting at sp+160
-#define ARG0_STACK 160
-
 namespace bpftrace::arch {
 
-// clang-format off
-static std::vector<std::set<std::string>> registers = {
-  // Breakpoint event address
-  { "arg" },
-  { "pswmask" },
-  // Instruction address
-  { "pswaddr" },
-  { "r0", "gprs[0]" },
-  { "r1", "gprs[1]" },
-  { "r2", "gprs[2]" },
-  { "r3", "gprs[3]" },
-  { "r4", "gprs[4]" },
-  { "r5", "gprs[5]" },
-  { "r6", "gprs[6]" },
-  { "r7", "gprs[7]" },
-  { "r8", "gprs[8]" },
-  { "r9", "gprs[9]" },
-  { "r10", "gprs[10]" },
-  { "r11", "gprs[11]" },
-  { "r12", "gprs[12]" },
-  { "r13", "gprs[13]" },
-  { "r14", "gprs[14]" },
-  { "r15", "gprs[15]" }
-};
-
-static std::array<std::string, ARG_REGISTERS> arg_registers = {
-  "r2",
-  "r3",
-  "r4",
-  "r5",
-  "r6",
-};
-// clang-format on
-
-int offset(std::string reg_name)
-{
-  for (unsigned int i = 0; i < registers.size(); i++) {
-    if (registers[i].count(reg_name))
-      return i;
-  }
-  return -1;
-}
-
-int max_arg()
-{
-  return arg_registers.size() - 1;
-}
-
-int arg_offset(int arg_num)
-{
-  return offset(arg_registers.at(arg_num));
-}
-
-int ret_offset()
-{
-  return offset("r2");
-}
-
-int pc_offset()
-{
-  return offset("pswaddr");
-}
-
-int sp_offset()
-{
-  return offset("r15");
-}
-
-int arg_stack_offset()
-{
-  return ARG0_STACK / 8;
-}
-
-std::string name()
-{
-  return std::string("s390x");
-}
-
-const std::unordered_set<std::string> &watchpoint_modes()
-{
-  return {}; // Not supported.
-}
-
-int get_kernel_ptr_width()
+template <>
+size_t Arch<Machine::S390X>::kernel_ptr_width()
 {
   return 64;
+}
+
+template <>
+std::optional<std::string> Arch<Machine::S390X>::register_to_pt_regs_expr(
+    const std::string& name)
+{
+  static const std::unordered_map<std::string, std::string> register_exprs = {
+    { "arg", "args[0]" },  { "pswmask", "psw.mask" }, { "pswaddr", "psw.addr" },
+    { "r0", "gprs[0]" },   { "r1", "gprs[1]" },       { "r2", "gprs[2]" },
+    { "r3", "gprs[3]" },   { "r4", "gprs[4]" },       { "r5", "gprs[5]" },
+    { "r6", "gprs[6]" },   { "r7", "gprs[7]" },       { "r8", "gprs[8]" },
+    { "r9", "gprs[9]" },   { "r10", "gprs[10]" },     { "r11", "gprs[11]" },
+    { "r12", "gprs[12]" }, { "r13", "gprs[13]" },     { "r14", "gprs[14]" },
+    { "r15", "gprs[15]" },
+  };
+  auto it = register_exprs.find(name);
+  if (it != register_exprs.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+template <>
+std::optional<size_t> Arch<Machine::S390X>::register_to_pt_regs_offset(
+    const std::string& name)
+{
+  static const std::unordered_map<std::string, size_t> register_offsets = {
+    { "arg", 0 },   { "pswmask", 8 }, { "pswaddr", 16 }, { "r0", 24 },
+    { "r1", 32 },   { "r2", 40 },     { "r3", 48 },      { "r4", 56 },
+    { "r5", 64 },   { "r6", 72 },     { "r7", 80 },      { "r8", 88 },
+    { "r9", 96 },   { "r10", 104 },   { "r11", 112 },    { "r12", 120 },
+    { "r13", 128 }, { "r14", 136 },   { "r15", 144 },
+  };
+  auto it = register_offsets.find(name);
+  if (it != register_offsets.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
+template <>
+const std::vector<std::string>& Arch<Machine::S390X>::arguments()
+{
+  static std::vector<std::string> args = {
+    "r2", "r3", "r4", "r5", "r6",
+  };
+  return args;
+}
+
+template <>
+size_t Arch<Machine::S390X>::argument_stack_offset()
+{
+  // For s390x, r2-r6 registers are used as function arguments, then the extra
+  // arguments can be found starting at sp+160.
+  return 160;
+}
+
+template <>
+std::string Arch<Machine::S390X>::return_value()
+{
+  return "r2";
+}
+
+template <>
+std::string Arch<Machine::S390X>::pc_value()
+{
+  return "pswaddr";
+}
+
+template <>
+std::string Arch<Machine::S390X>::sp_value()
+{
+  return "r15";
+}
+
+template <>
+const std::unordered_set<std::string>& Arch<Machine::S390X>::watchpoint_modes()
+{
+  static std::unordered_set<std::string> valid_modes = {};
+  return valid_modes;
 }
 
 } // namespace bpftrace::arch

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -203,7 +203,7 @@ public:
   Value *CreateGetTid(const Location &loc, bool force_init);
   AllocaInst *CreateUSym(Value *val, int probe_id, const Location &loc);
   Value *CreateRegisterRead(Value *ctx, const std::string &builtin);
-  Value *CreateRegisterRead(Value *ctx, int offset, const std::string &name);
+  Value *CreateRegisterRead(Value *ctx, size_t offset, const std::string &name);
   Value *CreateKFuncArg(Value *ctx, SizedType &type, std::string &name);
   Value *CreateRawTracepointArg(Value *ctx, const std::string &builtin);
   Value *CreateUprobeArgsRecord(Value *ctx, const SizedType &args_type);

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -297,8 +297,8 @@ void FieldAnalyser::resolve_args(Probe &probe)
         } else {
           ap->addWarning() << "No debuginfo found for " << ap->target;
         }
-        if (probe_args && probe_args->fields.size() >
-                              static_cast<size_t>(arch::max_arg() + 1)) {
+        if (probe_args &&
+            probe_args->fields.size() >= arch::Host::arguments().size()) {
           ap->addError() << "\'args\' builtin is not supported for "
                          << "probes with stack-passed arguments.";
         }

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -495,7 +495,7 @@ std::shared_ptr<Struct> BTF::resolve_args(std::string_view func,
 
   const struct btf_param *p = btf_params(t);
   __u16 vlen = btf_vlen(t);
-  if (vlen > arch::max_arg() + 1) {
+  if (vlen >= arch::Host::arguments().size()) {
     err = "functions with more than 6 parameters are "
           "not supported.";
     return nullptr;
@@ -574,7 +574,7 @@ std::string BTF::get_all_funcs_from_btf(const BTFObj &btf_obj) const
     if (bpftrace_ && !bpftrace_->is_traceable_func(func_name))
       continue;
 
-    if (btf_vlen(t) > arch::max_arg() + 1)
+    if (btf_vlen(t) >= arch::Host::arguments().size())
       continue;
 
     funcs += btf_obj.name + ":" + func_name + "\n";
@@ -615,7 +615,7 @@ std::string BTF::get_all_raw_tracepoints_from_btf(const BTFObj &btf_obj) const
       break;
     }
 
-    if (btf_vlen(t) > arch::max_arg() + 1)
+    if (btf_vlen(t) >= arch::Host::arguments().size())
       continue;
 
     bool found = false;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ else()
 endif()
 
 add_executable(bpftrace_test
+  arch.cpp
   ast.cpp
   async_action.cpp
   bpfbytecode.cpp

--- a/tests/arch.cpp
+++ b/tests/arch.cpp
@@ -1,0 +1,94 @@
+#include <gmock/gmock-matchers.h>
+#include <gtest/gtest.h>
+#include <sstream>
+
+#include "arch/arch.h"
+
+namespace bpftrace::test::arch {
+
+using namespace bpftrace::arch;
+using ::testing::AnyOf;
+using ::testing::Eq;
+
+template <typename T>
+class ArchTest : public testing::Test {
+  using Arch = T;
+};
+
+class ArchTestNameGenerator {
+public:
+  template <typename T>
+  static std::string GetName([[maybe_unused]] int index)
+  {
+    std::stringstream ss;
+    ss << T::Machine;
+    return ss.str();
+  }
+};
+
+using MachineTypes = ::testing::Types<Arch<Machine::X86_64>,
+                                      Arch<Machine::ARM>,
+                                      Arch<Machine::ARM64>,
+                                      Arch<Machine::S390X>,
+                                      Arch<Machine::PPC64>,
+                                      Arch<Machine::MIPS64>,
+                                      Arch<Machine::RISCV64>,
+                                      Arch<Machine::LOONGARCH64>>;
+TYPED_TEST_SUITE(ArchTest, MachineTypes, ArchTestNameGenerator);
+
+TYPED_TEST(ArchTest, Sanity)
+{
+  EXPECT_GT(TypeParam::kernel_ptr_width(), 0);
+}
+
+TYPED_TEST(ArchTest, ValidArguments)
+{
+  for (const auto &reg : TypeParam::arguments()) {
+    EXPECT_TRUE(TypeParam::register_to_pt_regs_expr(reg).has_value());
+    EXPECT_TRUE(TypeParam::register_to_pt_regs_offset(reg).has_value());
+  }
+}
+
+TYPED_TEST(ArchTest, InvalidRegister)
+{
+  EXPECT_FALSE(TypeParam::register_to_pt_regs_expr("invalid").has_value());
+  EXPECT_FALSE(TypeParam::register_to_pt_regs_offset("invalid").has_value());
+}
+
+TYPED_TEST(ArchTest, ValidReturnValue)
+{
+  EXPECT_TRUE(!TypeParam::return_value().empty());
+  EXPECT_TRUE(TypeParam::register_to_pt_regs_expr(TypeParam::return_value())
+                  .has_value());
+  EXPECT_TRUE(TypeParam::register_to_pt_regs_offset(TypeParam::return_value())
+                  .has_value());
+}
+
+TYPED_TEST(ArchTest, ValidProgramCounter)
+{
+  EXPECT_TRUE(!TypeParam::pc_value().empty());
+  EXPECT_TRUE(
+      TypeParam::register_to_pt_regs_expr(TypeParam::pc_value()).has_value());
+  EXPECT_TRUE(
+      TypeParam::register_to_pt_regs_offset(TypeParam::pc_value()).has_value());
+}
+
+TYPED_TEST(ArchTest, ValidStackPointer)
+{
+  EXPECT_TRUE(!TypeParam::sp_value().empty());
+  EXPECT_TRUE(
+      TypeParam::register_to_pt_regs_expr(TypeParam::sp_value()).has_value());
+  EXPECT_TRUE(
+      TypeParam::register_to_pt_regs_offset(TypeParam::sp_value()).has_value());
+}
+
+TYPED_TEST(ArchTest, ValidWatchpointModes)
+{
+  for (const auto &mode : TypeParam::watchpoint_modes()) {
+    for (const auto &c : mode) {
+      EXPECT_THAT(c, AnyOf(Eq('r'), Eq('w'), Eq('x')));
+    }
+  }
+}
+
+} // namespace bpftrace::test::arch

--- a/tests/codegen/llvm/array_integer_equal_comparison.ll
+++ b/tests/codegen/llvm/array_integer_equal_comparison.ll
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
   store i64 0, ptr %"$a", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = inttoptr i64 %arg0 to ptr
   %4 = call ptr @llvm.preserve.static.offset(ptr %3)
@@ -37,7 +37,7 @@ entry:
   %6 = ptrtoint ptr %5 to i64
   store i64 %6, ptr %"$a", align 8
   %7 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %8 = getelementptr i64, ptr %7, i64 14
+  %8 = getelementptr i8, ptr %7, i64 112
   %arg01 = load volatile i64, ptr %8, align 8
   %9 = inttoptr i64 %arg01 to ptr
   %10 = call ptr @llvm.preserve.static.offset(ptr %9)

--- a/tests/codegen/llvm/builtin_arg.ll
+++ b/tests/codegen/llvm/builtin_arg.ll
@@ -24,7 +24,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
@@ -34,7 +34,7 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %4 = getelementptr i64, ptr %3, i64 12
+  %4 = getelementptr i8, ptr %3, i64 96
   %arg2 = load volatile i64, ptr %4, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8

--- a/tests/codegen/llvm/builtin_func_kprobe.ll
+++ b/tests/codegen/llvm/builtin_func_kprobe.ll
@@ -20,7 +20,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 16
+  %2 = getelementptr i8, ptr %1, i64 128
   %func = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8

--- a/tests/codegen/llvm/builtin_func_uprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uprobe.ll
@@ -21,7 +21,7 @@ entry:
   %"@x_key" = alloca i64, align 8
   %usym = alloca %usym_t, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 16
+  %2 = getelementptr i8, ptr %1, i64 128
   %func = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()

--- a/tests/codegen/llvm/builtin_func_wild.ll
+++ b/tests/codegen/llvm/builtin_func_wild.ll
@@ -20,7 +20,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 16
+  %2 = getelementptr i8, ptr %1, i64 128
   %func = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8

--- a/tests/codegen/llvm/builtin_retval.ll
+++ b/tests/codegen/llvm/builtin_retval.ll
@@ -20,7 +20,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 10
+  %2 = getelementptr i8, ptr %1, i64 80
   %retval = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8

--- a/tests/codegen/llvm/builtin_sarg.ll
+++ b/tests/codegen/llvm/builtin_sarg.ll
@@ -26,10 +26,10 @@ entry:
   %"@x_key" = alloca i64, align 8
   %sarg0 = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 19
+  %2 = getelementptr i8, ptr %1, i64 152
   %reg_sp = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %sarg0)
-  %3 = add i64 %reg_sp, 8
+  %3 = add i64 %reg_sp, 64
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %sarg0, i32 8, i64 %3)
   %4 = load i64, ptr %sarg0, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %sarg0)
@@ -41,10 +41,10 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   %5 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %6 = getelementptr i64, ptr %5, i64 19
+  %6 = getelementptr i8, ptr %5, i64 152
   %reg_sp1 = load volatile i64, ptr %6, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %sarg2)
-  %7 = add i64 %reg_sp1, 24
+  %7 = add i64 %reg_sp1, 80
   %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %sarg2, i32 8, i64 %7)
   %8 = load i64, ptr %sarg2, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %sarg2)

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -30,7 +30,7 @@ entry:
   %4 = getelementptr %buffer_1_t, ptr %2, i32 0, i32 1
   call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 1, i1 false)
   %5 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %6 = getelementptr i64, ptr %5, i64 14
+  %6 = getelementptr i8, ptr %5, i64 112
   %arg0 = load volatile i64, ptr %6, align 8
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 1, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -22,7 +22,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !52 {
 entry:
   %"@x_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 13
+  %2 = getelementptr i8, ptr %1, i64 104
   %arg1 = load volatile i64, ptr %2, align 8
   %length.cmp = icmp ule i64 %arg1, 1020
   %length.select = select i1 %length.cmp, i64 %arg1, i64 1020
@@ -36,7 +36,7 @@ entry:
   %7 = getelementptr %buffer_1020_t, ptr %4, i32 0, i32 1
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %7, i32 1020, ptr null)
   %8 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %9 = getelementptr i64, ptr %8, i64 14
+  %9 = getelementptr i8, ptr %8, i64 112
   %arg0 = load volatile i64, ptr %9, align 8
   %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %7, i32 %6, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/call_override.ll
+++ b/tests/codegen/llvm/call_override.ll
@@ -16,7 +16,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !29 {
 entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %override = call i64 inttoptr (i64 58 to ptr)(ptr %0, i64 %arg0)
   ret i64 0

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)

--- a/tests/codegen/llvm/call_reg.ll
+++ b/tests/codegen/llvm/call_reg.ll
@@ -20,7 +20,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 16
+  %2 = getelementptr i8, ptr %1, i64 128
   %reg_ip = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8

--- a/tests/codegen/llvm/call_signal.ll
+++ b/tests/codegen/llvm/call_signal.ll
@@ -16,7 +16,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !29 {
 entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = trunc i64 %arg0 to i32
   %signal = call i64 inttoptr (i64 109 to ptr)(i32 %3)

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -26,7 +26,7 @@ entry:
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %4 = getelementptr i64, ptr %3, i64 14
+  %4 = getelementptr i8, ptr %3, i64 112
   %arg0 = load volatile i64, ptr %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 1024, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -21,7 +21,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !52 {
 entry:
   %"@x_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 13
+  %2 = getelementptr i8, ptr %1, i64 104
   %arg1 = load volatile i64, ptr %2, align 8
   %str.min.cmp = icmp ule i64 %arg1, 1024
   %str.min.select = select i1 %str.min.cmp, i64 %arg1, i64 1024
@@ -31,7 +31,7 @@ entry:
   %4 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 1024, ptr null)
   %5 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %6 = getelementptr i64, ptr %5, i64 14
+  %6 = getelementptr i8, ptr %5, i64 112
   %arg0 = load volatile i64, ptr %6, align 8
   %7 = trunc i64 %str.min.select to i32
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %4, i32 %7, i64 %arg0)

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -26,7 +26,7 @@ entry:
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %4 = getelementptr i64, ptr %3, i64 14
+  %4 = getelementptr i8, ptr %3, i64 112
   %arg0 = load volatile i64, ptr %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 6, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -21,7 +21,7 @@ entry:
   %"@_key" = alloca i64, align 8
   %deref = alloca i16, align 2
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
   %probe_read_user = call i64 inttoptr (i64 112 to ptr)(ptr %deref, i32 2, i64 %arg0)

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -21,7 +21,7 @@ entry:
   %"@_key" = alloca i64, align 8
   %deref = alloca i32, align 4
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
   %probe_read_user = call i64 inttoptr (i64 112 to ptr)(ptr %deref, i32 4, i64 %arg0)

--- a/tests/codegen/llvm/comparison_extend.ll
+++ b/tests/codegen/llvm/comparison_extend.ll
@@ -20,7 +20,7 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = icmp ult i64 1, %arg0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 10
+  %2 = getelementptr i8, ptr %1, i64 80
   %retval = load volatile i64, ptr %2, align 8
   %cast = trunc i64 %retval to i32
   %3 = sext i32 %cast to i64

--- a/tests/codegen/llvm/intcast_retval.ll
+++ b/tests/codegen/llvm/intcast_retval.ll
@@ -20,7 +20,7 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 10
+  %2 = getelementptr i8, ptr %1, i64 80
   %retval = load volatile i64, ptr %2, align 8
   %cast = trunc i64 %retval to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -21,7 +21,7 @@ entry:
   %"@_key" = alloca i64, align 8
   %deref = alloca i8, align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 4
+  %2 = getelementptr i8, ptr %1, i64 32
   %reg_bp = load volatile i64, ptr %2, align 8
   %3 = sub i64 %reg_bp, 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 4
+  %2 = getelementptr i8, ptr %1, i64 32
   %reg_bp = load volatile i64, ptr %2, align 8
   %3 = sub i64 %reg_bp, 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)

--- a/tests/codegen/llvm/map_args.ll
+++ b/tests/codegen/llvm/map_args.ll
@@ -22,28 +22,28 @@ entry:
   %args = alloca %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %args)
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = trunc i64 %arg0 to i32
   %4 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 0
   store i32 %3, ptr %4, align 4
   %5 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %6 = getelementptr i64, ptr %5, i64 13
+  %6 = getelementptr i8, ptr %5, i64 104
   %arg1 = load volatile i64, ptr %6, align 8
   %7 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 1
   store i64 %arg1, ptr %7, align 8
   %8 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %9 = getelementptr i64, ptr %8, i64 12
+  %9 = getelementptr i8, ptr %8, i64 96
   %arg2 = load volatile i64, ptr %9, align 8
   %10 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 2
   store i64 %arg2, ptr %10, align 8
   %11 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %12 = getelementptr i64, ptr %11, i64 11
+  %12 = getelementptr i8, ptr %11, i64 88
   %arg3 = load volatile i64, ptr %12, align 8
   %13 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 3
   store i64 %arg3, ptr %13, align 8
   %14 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %15 = getelementptr i64, ptr %14, i64 9
+  %15 = getelementptr i8, ptr %14, i64 72
   %arg4 = load volatile i64, ptr %15, align 8
   %16 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 4
   store i64 %arg4, ptr %16, align 8

--- a/tests/codegen/llvm/map_assign_array.ll
+++ b/tests/codegen/llvm/map_assign_array.ll
@@ -25,7 +25,7 @@ entry:
   %"@x_val" = alloca [4 x i32], align 4
   %"@x_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = inttoptr i64 %arg0 to ptr
   %4 = call ptr @llvm.preserve.static.offset(ptr %3)

--- a/tests/codegen/llvm/map_key_array.ll
+++ b/tests/codegen/llvm/map_key_array.ll
@@ -20,7 +20,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca [4 x i32], align 4
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = inttoptr i64 %arg0 to ptr
   %4 = call ptr @llvm.preserve.static.offset(ptr %3)

--- a/tests/codegen/llvm/map_key_struct.ll
+++ b/tests/codegen/llvm/map_key_struct.ll
@@ -20,7 +20,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca [4 x i8], align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@x_key", i32 4, i64 %arg0)

--- a/tests/codegen/llvm/nested_array_struct.ll
+++ b/tests/codegen/llvm/nested_array_struct.ll
@@ -26,7 +26,7 @@ entry:
   %"@bar_val" = alloca [2 x [2 x [4 x i8]]], align 1
   %"@bar_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = inttoptr i64 %arg0 to ptr
   %4 = call ptr @llvm.preserve.static.offset(ptr %3)

--- a/tests/codegen/llvm/str_scratch_buf.ll
+++ b/tests/codegen/llvm/str_scratch_buf.ll
@@ -23,7 +23,7 @@ entry:
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 64, i1 false)
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %4 = getelementptr i64, ptr %3, i64 14
+  %4 = getelementptr i8, ptr %3, i64 112
   %arg0 = load volatile i64, ptr %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 64, i64 %arg0)
   ret i64 0

--- a/tests/codegen/llvm/str_stack.ll
+++ b/tests/codegen/llvm/str_stack.ll
@@ -19,7 +19,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %str)
   call void @llvm.memset.p0.i64(ptr align 1 %str, i8 0, i64 64, i1 false)
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %str, i32 64, i64 %arg0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %str)

--- a/tests/codegen/llvm/strcontains_no_literals.ll
+++ b/tests/codegen/llvm/strcontains_no_literals.ll
@@ -25,7 +25,7 @@ entry:
   %2 = getelementptr [1 x [2 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %4 = getelementptr i64, ptr %3, i64 14
+  %4 = getelementptr i8, ptr %3, i64 112
   %arg0 = load volatile i64, ptr %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 1024, i64 %arg0)
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
@@ -34,7 +34,7 @@ entry:
   %6 = getelementptr [1 x [2 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
   %probe_read_kernel3 = call i64 inttoptr (i64 113 to ptr)(ptr %6, i32 1024, ptr null)
   %7 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %8 = getelementptr i64, ptr %7, i64 13
+  %8 = getelementptr i8, ptr %7, i64 104
   %arg1 = load volatile i64, ptr %8, align 8
   %probe_read_kernel_str4 = call i64 inttoptr (i64 115 to ptr)(ptr %6, i32 1024, i64 %arg1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %strcontains.i)

--- a/tests/codegen/llvm/strcontains_one_literal.ll
+++ b/tests/codegen/llvm/strcontains_one_literal.ll
@@ -26,7 +26,7 @@ entry:
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %4 = getelementptr i64, ptr %3, i64 14
+  %4 = getelementptr i8, ptr %3, i64 112
   %arg0 = load volatile i64, ptr %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 1024, i64 %arg0)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %strcontains.i)

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_long_1.ll
+++ b/tests/codegen/llvm/struct_long_1.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_long_2.ll
+++ b/tests/codegen/llvm/struct_long_2.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_save_1.ll
+++ b/tests/codegen/llvm/struct_save_1.ll
@@ -20,7 +20,7 @@ entry:
   %"@foo_val" = alloca [12 x i8], align 1
   %"@foo_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key")
   store i64 0, ptr %"@foo_key", align 8

--- a/tests/codegen/llvm/struct_save_2.ll
+++ b/tests/codegen/llvm/struct_save_2.ll
@@ -20,7 +20,7 @@ entry:
   %"@foo_val" = alloca [12 x i8], align 1
   %"@foo_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key")
   store i64 0, ptr %"@foo_key", align 8

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -31,7 +31,7 @@ entry:
   %"@foo_val" = alloca [16 x i8], align 1
   %"@foo_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key")
   store i64 0, ptr %"@foo_key", align 8

--- a/tests/codegen/llvm/struct_save_string.ll
+++ b/tests/codegen/llvm/struct_save_string.ll
@@ -25,7 +25,7 @@ entry:
   %"@foo_val" = alloca [32 x i8], align 1
   %"@foo_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key")
   store i64 0, ptr %"@foo_key", align 8

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_string_array_1.ll
+++ b/tests/codegen/llvm/struct_string_array_1.ll
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_string_array_2.ll
+++ b/tests/codegen/llvm/struct_string_array_2.ll
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %3 = load i64, ptr %"$foo", align 8

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()

--- a/tests/codegen/llvm/tuple_array_struct.ll
+++ b/tests/codegen/llvm/tuple_array_struct.ll
@@ -21,10 +21,10 @@ entry:
   %"@t_key" = alloca i64, align 8
   %tuple = alloca %"struct Foo_int32[4]__tuple_t", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %4 = getelementptr i64, ptr %3, i64 13
+  %4 = getelementptr i8, ptr %3, i64 104
   %arg1 = load volatile i64, ptr %4, align 8
   %5 = inttoptr i64 %arg1 to ptr
   %6 = call ptr @llvm.preserve.static.offset(ptr %5)

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -23,7 +23,7 @@ entry:
   %tuple = alloca %uint8_usym_t_int64__tuple_t, align 8
   %usym = alloca %usym_t, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 16
+  %2 = getelementptr i8, ptr %1, i64 128
   %reg_ip = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()

--- a/tests/codegen/llvm/variable_assign_array.ll
+++ b/tests/codegen/llvm/variable_assign_array.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
   store i64 0, ptr %"$var", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = inttoptr i64 %arg0 to ptr
   %4 = call ptr @llvm.preserve.static.offset(ptr %3)

--- a/tests/codegen/llvm/variable_scratch_buf.ll
+++ b/tests/codegen/llvm/variable_scratch_buf.ll
@@ -28,7 +28,7 @@ entry:
   %4 = getelementptr [1 x [2 x [8 x i8]]], ptr @var_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   store i64 0, ptr %4, align 8
   %5 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %6 = getelementptr i64, ptr %5, i64 14
+  %6 = getelementptr i8, ptr %5, i64 112
   %arg0 = load volatile i64, ptr %6, align 8
   %7 = icmp ugt i64 %arg0, 0
   %true_cond = icmp ne i1 %7, false

--- a/tests/codegen/llvm/variable_stack.ll
+++ b/tests/codegen/llvm/variable_stack.ll
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
   store i64 0, ptr %"$x", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %2 = getelementptr i64, ptr %1, i64 14
+  %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = icmp ugt i64 %arg0, 0
   %true_cond = icmp ne i1 %3, false


### PR DESCRIPTION
Stacked PRs:
 * __->__#4269


--- --- ---

### arch: ensure all code is built all the time


Each architecture is a specialization of the generic `Arch` class. The
only `#ifdef` is used for a `constexpr` function which returns the
current architecture, which can be used to instantiate (in a non-virtual
way) the intended archiecture helpers.

In general, I expect that all unused implementations will be stripped
out by the linker as they are unreferenced. However, we can easily
create a parameterized test that *does* use all these implementations to
provide a uniform sanity test.

Updates #4017

Signed-off-by: Adin Scannell <amscanne@meta.com>