### PR TITLE
codegen: Use a single `LLVMContext`

### DIFF
--- a/src/ast/passes/clang_build.h
+++ b/src/ast/passes/clang_build.h
@@ -9,7 +9,6 @@ namespace bpftrace::ast {
 
 class BitcodeModules : public State<"bitcode"> {
 public:
-  std::vector<std::unique_ptr<llvm::LLVMContext>> contexts;
   std::vector<std::unique_ptr<llvm::Module>> modules;
   std::vector<std::string> objects;
 };


### PR DESCRIPTION
Stacked PRs:
 * #4276
 * #4275
 * #4274
 * #4273
 * __->__#4272


--- --- ---

### codegen: Use a single `LLVMContext`


I was struggling with various failures during linking modules, which
were likely a result of the two modules have two different type systems
and two different sets of intrinsics. Using the same `LLVMContext`
resolves these problems, and was a likely user error.

Signed-off-by: Adin Scannell <amscanne@meta.com>
