### PR TITLE
codegen: use copy of named memory buffers

### DIFF
--- a/src/ast/passes/clang_build.cpp
+++ b/src/ast/passes/clang_build.cpp
@@ -117,12 +117,16 @@ static Result<> build(CompileContext &ctx,
 {
   llvm::IntrusiveRefCntPtr<llvm::vfs::InMemoryFileSystem> vfs(
       new llvm::vfs::InMemoryFileSystem());
-  vfs->addFile(name, 0, llvm::MemoryBuffer::getMemBuffer(obj.data()));
+  vfs->addFile(name,
+               0,
+               llvm::MemoryBuffer::getMemBufferCopy(obj.data(), "main"));
   for (const auto &[name, other] : stdlib::Stdlib::files) {
-    vfs->addFile(name, 0, llvm::MemoryBuffer::getMemBuffer(other));
+    vfs->addFile(name, 0, llvm::MemoryBuffer::getMemBufferCopy(other, name));
   }
   for (auto &[name, other] : imports.c_headers) {
-    vfs->addFile(name, 0, llvm::MemoryBuffer::getMemBuffer(other.data()));
+    vfs->addFile(name,
+                 0,
+                 llvm::MemoryBuffer::getMemBufferCopy(other.data(), name));
   }
 
   // Create the diagnostic options and client. We emit the error to


### PR DESCRIPTION
Stacked PRs:
 * #4276
 * #4275
 * #4274
 * __->__#4273


--- --- ---

### codegen: use copy of named memory buffers


We can't necessarily guaranteed that the embedded strings are
null-terminated in the way that LLVM expects, so use a slightly
different API for constructing the memory buffers and simply copy the
contents.

Signed-off-by: Adin Scannell <amscanne@meta.com>
