### PR TITLE
codegen: automatically define required BPF-related defines

### DIFF
--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -34,6 +34,9 @@ public:
   // Returns the width of bits in kernel pointers.
   static size_t kernel_ptr_width();
 
+  // Returns additional C definitions that should be applied to compiled code.
+  static const std::vector<std::string>& c_defs();
+
   // Given a conventional register name, return the expression that should be
   // used to access this from `struct pt_regs`. This will be dynamically added
   // and evaluated using the standard type inference mechanisms.

--- a/src/arch/arm.cpp
+++ b/src/arch/arm.cpp
@@ -11,6 +11,15 @@ size_t Arch<Machine::ARM>::kernel_ptr_width()
 }
 
 template <>
+const std::vector<std::string>& Arch<Machine::ARM>::c_defs()
+{
+  static std::vector<std::string> defs = {
+    "__TARGET_ARCH_arm",
+  };
+  return defs;
+}
+
+template <>
 std::optional<std::string> Arch<Machine::ARM>::register_to_pt_regs_expr(
     const std::string& name)
 {
@@ -153,6 +162,15 @@ template <>
 size_t Arch<Machine::ARM64>::kernel_ptr_width()
 {
   return 64;
+}
+
+template <>
+const std::vector<std::string>& Arch<Machine::ARM64>::c_defs()
+{
+  static std::vector<std::string> defs = {
+    "__TARGET_ARCH_arm64",
+  };
+  return defs;
 }
 
 template <>

--- a/src/arch/loongarch64.cpp
+++ b/src/arch/loongarch64.cpp
@@ -11,6 +11,15 @@ size_t Arch<Machine::LOONGARCH64>::kernel_ptr_width()
 }
 
 template <>
+const std::vector<std::string>& Arch<Machine::LOONGARCH64>::c_defs()
+{
+  static std::vector<std::string> defs = {
+    "__TARGET_ARCH_loongarch",
+  };
+  return defs;
+}
+
+template <>
 std::optional<std::string> Arch<Machine::LOONGARCH64>::register_to_pt_regs_expr(
     const std::string& name)
 {

--- a/src/arch/mips64.cpp
+++ b/src/arch/mips64.cpp
@@ -11,6 +11,15 @@ size_t Arch<Machine::MIPS64>::kernel_ptr_width()
 }
 
 template <>
+const std::vector<std::string>& Arch<Machine::MIPS64>::c_defs()
+{
+  static std::vector<std::string> defs = {
+    "__TARGET_ARCH_mips",
+  };
+  return defs;
+}
+
+template <>
 std::optional<std::string> Arch<Machine::MIPS64>::register_to_pt_regs_expr(
     const std::string& name)
 {

--- a/src/arch/ppc64.cpp
+++ b/src/arch/ppc64.cpp
@@ -11,6 +11,15 @@ size_t Arch<Machine::PPC64>::kernel_ptr_width()
 }
 
 template <>
+const std::vector<std::string>& Arch<Machine::PPC64>::c_defs()
+{
+  static std::vector<std::string> defs = {
+    "__TARGET_ARCH_powerpc",
+  };
+  return defs;
+}
+
+template <>
 std::optional<std::string> Arch<Machine::PPC64>::register_to_pt_regs_expr(
     const std::string& name)
 {

--- a/src/arch/riscv64.cpp
+++ b/src/arch/riscv64.cpp
@@ -11,6 +11,15 @@ size_t Arch<Machine::RISCV64>::kernel_ptr_width()
 }
 
 template <>
+const std::vector<std::string>& Arch<Machine::RISCV64>::c_defs()
+{
+  static std::vector<std::string> defs = {
+    "__TARGET_ARCH_riscv",
+  };
+  return defs;
+}
+
+template <>
 std::optional<std::string> Arch<Machine::RISCV64>::register_to_pt_regs_expr(
     const std::string& name)
 {

--- a/src/arch/s390.cpp
+++ b/src/arch/s390.cpp
@@ -11,6 +11,15 @@ size_t Arch<Machine::S390X>::kernel_ptr_width()
 }
 
 template <>
+const std::vector<std::string>& Arch<Machine::S390X>::c_defs()
+{
+  static std::vector<std::string> defs = {
+    "__TARGET_ARCH_s390",
+  };
+  return defs;
+}
+
+template <>
 std::optional<std::string> Arch<Machine::S390X>::register_to_pt_regs_expr(
     const std::string& name)
 {

--- a/src/arch/x86_64.cpp
+++ b/src/arch/x86_64.cpp
@@ -11,6 +11,15 @@ size_t Arch<Machine::X86_64>::kernel_ptr_width()
 }
 
 template <>
+const std::vector<std::string>& Arch<Machine::X86_64>::c_defs()
+{
+  static std::vector<std::string> defs = {
+    "__TARGET_ARCH_x86",
+  };
+  return defs;
+}
+
+template <>
 std::optional<size_t> Arch<Machine::X86_64>::register_to_pt_regs_offset(
     const std::string& name)
 {

--- a/src/ast/passes/clang_build.cpp
+++ b/src/ast/passes/clang_build.cpp
@@ -17,6 +17,7 @@
 #include <clang/Basic/DebugInfoOptions.h>
 #endif
 
+#include "arch/arch.h"
 #include "ast/ast.h"
 #include "ast/passes/clang_build.h"
 #include "ast/passes/codegen_llvm.h"
@@ -151,9 +152,16 @@ static Result<> build(CompileContext &ctx,
   // that seem to be load-bearing with respect to generating useful debug
   // information, for some reason. The generated module will be linked and
   // optimized again regardless, but it is better safe than sorry.
-  std::vector<const char *> args = {
-    "-O2", "-Iinclude", "-o", pipefds->write_file().c_str(), name.c_str()
-  };
+  std::vector<const char *> args;
+  args.push_back("-O2");
+  args.push_back("-Iinclude");
+  for (const auto &s : arch::Host::c_defs()) {
+    args.push_back("-D");
+    args.push_back(s.c_str());
+  }
+  args.push_back("-o");
+  args.push_back(pipefds->write_file().c_str());
+  args.push_back(name.c_str());
 
   // Configure the instance. We want to read the source file named
   // by `name` above, enable debug information and optimization.

--- a/tests/arch.cpp
+++ b/tests/arch.cpp
@@ -41,6 +41,11 @@ TYPED_TEST(ArchTest, Sanity)
   EXPECT_GT(TypeParam::kernel_ptr_width(), 0);
 }
 
+TYPED_TEST(ArchTest, CDefs)
+{
+  EXPECT_TRUE(!TypeParam::c_defs().empty());
+}
+
 TYPED_TEST(ArchTest, ValidArguments)
 {
   for (const auto &reg : TypeParam::arguments()) {


### PR DESCRIPTION
Stacked PRs:
 * #4276
 * #4274
 * #4289
 * __->__#4275


--- --- ---

### codegen: automatically define required BPF-related defines


Some `libbpf` headers require specific defines in order to resolve the
appropriate arch-specific fields in kernel structures.

This adds an interface to the `Arch` class, which returns a set of
arch-specific definitions that will be added to C builds.

Signed-off-by: Adin Scannell <amscanne@meta.com>
