### PR TITLE
Codegen: Mark some helpers as "pure" so that LLVM can optimise calls to them

### DIFF
--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -162,6 +162,7 @@ public:
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
                              FunctionType *helper_type,
                              ArrayRef<Value *> args,
+                             bool is_pure,
                              const Twine &Name,
                              const Location &loc);
   CallInst *createCall(FunctionType *callee_type,

--- a/tests/codegen/llvm/block_expression_complex.ll
+++ b/tests/codegen/llvm/block_expression_complex.ll
@@ -24,14 +24,14 @@ entry:
   %"$p" = alloca i32, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$p")
   store i32 0, ptr %"$p", align 4
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   store i32 %pid, ptr %"$p", align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
   %2 = lshr i64 %get_pid_tgid1, 32
   %pid2 = trunc i64 %2 to i32
   %3 = zext i32 %pid2 to i64
@@ -74,6 +74,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!50}
 !llvm.module.flags = !{!52, !53}

--- a/tests/codegen/llvm/builtin_cpu.ll
+++ b/tests/codegen/llvm/builtin_cpu.ll
@@ -19,7 +19,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !42 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -38,6 +38,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/builtin_curtask.ll
+++ b/tests/codegen/llvm/builtin_curtask.ll
@@ -19,7 +19,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !42 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_cur_task = call i64 inttoptr (i64 35 to ptr)()
+  %get_cur_task = call i64 inttoptr (i64 35 to ptr)() #2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -38,6 +38,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/builtin_func_fentry.ll
+++ b/tests/codegen/llvm/builtin_func_fentry.ll
@@ -19,7 +19,7 @@ define i64 @fentry_mock_vmlinux_f_1(ptr %0) #0 section "s_fentry_mock_vmlinux_f_
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_func_ip = call i64 inttoptr (i64 173 to ptr)(ptr %0)
+  %get_func_ip = call i64 inttoptr (i64 173 to ptr)(ptr %0) #2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -38,6 +38,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/builtin_func_kretprobe.ll
+++ b/tests/codegen/llvm/builtin_func_kretprobe.ll
@@ -19,7 +19,7 @@ define i64 @kretprobe_f_1(ptr %0) #0 section "s_kretprobe_f_1" !dbg !42 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_func_ip = call i64 inttoptr (i64 173 to ptr)(ptr %0)
+  %get_func_ip = call i64 inttoptr (i64 173 to ptr)(ptr %0) #2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -38,6 +38,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/builtin_func_uprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uprobe.ll
@@ -24,7 +24,7 @@ entry:
   %2 = getelementptr i8, ptr %1, i64 128
   %func = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %3 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %3 to i32
   %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
@@ -53,6 +53,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44, !45}

--- a/tests/codegen/llvm/builtin_func_uretprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uretprobe.ll
@@ -20,9 +20,9 @@ define i64 @uretprobe__bin_sh_f_1(ptr %0) #0 section "s_uretprobe__bin_sh_f_1" !
 entry:
   %"@x_key" = alloca i64, align 8
   %usym = alloca %usym_t, align 8
-  %get_func_ip = call i64 inttoptr (i64 173 to ptr)(ptr %0)
+  %get_func_ip = call i64 inttoptr (i64 173 to ptr)(ptr %0) #2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
@@ -47,6 +47,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44, !45}

--- a/tests/codegen/llvm/builtin_numaid.ll
+++ b/tests/codegen/llvm/builtin_numaid.ll
@@ -19,7 +19,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !42 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_numa_id = call i64 inttoptr (i64 42 to ptr)()
+  %get_numa_id = call i64 inttoptr (i64 42 to ptr)() #2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -38,6 +38,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/builtin_pid_tid.ll
+++ b/tests/codegen/llvm/builtin_pid_tid.ll
@@ -23,7 +23,7 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -34,7 +34,7 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
   %tid = trunc i64 %get_pid_tgid1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
@@ -55,6 +55,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!40}
 !llvm.module.flags = !{!42, !43}

--- a/tests/codegen/llvm/builtin_uid_gid.ll
+++ b/tests/codegen/llvm/builtin_uid_gid.ll
@@ -23,7 +23,7 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_uid_gid = call i64 inttoptr (i64 15 to ptr)()
+  %get_uid_gid = call i64 inttoptr (i64 15 to ptr)() #2
   %1 = and i64 %get_uid_gid, 4294967295
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
@@ -32,7 +32,7 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %get_uid_gid1 = call i64 inttoptr (i64 15 to ptr)()
+  %get_uid_gid1 = call i64 inttoptr (i64 15 to ptr)() #2
   %2 = lshr i64 %get_uid_gid1, 32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
@@ -52,6 +52,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!40}
 !llvm.module.flags = !{!42, !43}

--- a/tests/codegen/llvm/builtin_username.ll
+++ b/tests/codegen/llvm/builtin_username.ll
@@ -23,7 +23,7 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_uid_gid = call i64 inttoptr (i64 15 to ptr)()
+  %get_uid_gid = call i64 inttoptr (i64 15 to ptr)() #2
   %1 = and i64 %get_uid_gid, 4294967295
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
@@ -32,7 +32,7 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %get_uid_gid1 = call i64 inttoptr (i64 15 to ptr)()
+  %get_uid_gid1 = call i64 inttoptr (i64 15 to ptr)() #2
   %2 = lshr i64 %get_uid_gid1, 32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
@@ -52,6 +52,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!40}
 !llvm.module.flags = !{!42, !43}

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -39,7 +39,7 @@ stack_scratch_failure:                            ; preds = %lookup_stack_scratc
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
   %1 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 2
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #4
   %2 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %2 to i32
   store i32 %pid, ptr %1, align 4
@@ -165,6 +165,7 @@ attributes #0 = { nounwind }
 attributes #1 = { alwaysinline nounwind }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #4 = { memory(none) }
 
 !llvm.dbg.cu = !{!78}
 !llvm.module.flags = !{!80, !81}

--- a/tests/codegen/llvm/call_avg.ll
+++ b/tests/codegen/llvm/call_avg.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -67,6 +67,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!50}
 !llvm.module.flags = !{!52, !53}

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   store i64 0, ptr %"$foo", align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -61,6 +61,7 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #4 = { memory(none) }
 
 !llvm.dbg.cu = !{!51}
 !llvm.module.flags = !{!53, !54}

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -21,7 +21,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !55 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -56,6 +56,7 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #3 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #4 = { memory(none) }
 
 !llvm.dbg.cu = !{!51}
 !llvm.module.flags = !{!53, !54}

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -26,7 +26,7 @@ entry:
   %arg1 = load volatile i64, ptr %2, align 8
   %length.cmp = icmp ule i64 %arg1, 1020
   %length.select = select i1 %length.cmp, i64 %arg1, i64 1020
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %3 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %3
   %4 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -58,6 +58,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50, !51}

--- a/tests/codegen/llvm/call_cgroup.ll
+++ b/tests/codegen/llvm/call_cgroup.ll
@@ -19,7 +19,7 @@ define i64 @tracepoint_syscalls_sys_enter_openat_1(ptr %0) #0 section "s_tracepo
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_cgroup_id = call i64 inttoptr (i64 80 to ptr)()
+  %get_cgroup_id = call i64 inttoptr (i64 80 to ptr)() #2
   %1 = icmp eq i64 %get_cgroup_id, 4294967297
   %2 = zext i1 %1 to i64
   %predcond = icmp eq i64 %2, 0
@@ -29,7 +29,7 @@ pred_false:                                       ; preds = %entry
   ret i64 1
 
 pred_true:                                        ; preds = %entry
-  %get_cgroup_id1 = call i64 inttoptr (i64 80 to ptr)()
+  %get_cgroup_id1 = call i64 inttoptr (i64 80 to ptr)() #2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -48,6 +48,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/call_cgroup_path.ll
+++ b/tests/codegen/llvm/call_cgroup_path.ll
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %cgroup_path_args)
   %1 = getelementptr %cgroup_path_t, ptr %cgroup_path_args, i64 0, i32 0
   store i64 0, ptr %1, align 8
-  %get_cgroup_id = call i64 inttoptr (i64 80 to ptr)()
+  %get_cgroup_id = call i64 inttoptr (i64 80 to ptr)() #4
   %2 = getelementptr %cgroup_path_t, ptr %cgroup_path_args, i64 0, i32 1
   store i64 %get_cgroup_id, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %print_cgroup_path_t_16_t)
@@ -63,6 +63,7 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #4 = { memory(none) }
 
 !llvm.dbg.cu = !{!25}
 !llvm.module.flags = !{!27, !28}

--- a/tests/codegen/llvm/call_hist.ll
+++ b/tests/codegen/llvm/call_hist.ll
@@ -20,7 +20,7 @@ entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca [16 x i8], align 1
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -132,6 +132,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { alwaysinline nounwind }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48, !49}

--- a/tests/codegen/llvm/call_len_ustack_kstack.ll
+++ b/tests/codegen/llvm/call_len_ustack_kstack.ll
@@ -47,7 +47,7 @@ stack_scratch_failure:                            ; preds = %lookup_stack_scratc
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
   %1 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 2
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #4
   %2 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %2 to i32
   store i32 %pid, ptr %1, align 4
@@ -223,6 +223,7 @@ attributes #0 = { nounwind }
 attributes #1 = { alwaysinline nounwind }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #4 = { memory(none) }
 
 !llvm.dbg.cu = !{!76}
 !llvm.module.flags = !{!78, !79}

--- a/tests/codegen/llvm/call_lhist.ll
+++ b/tests/codegen/llvm/call_lhist.ll
@@ -20,7 +20,7 @@ entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca [16 x i8], align 1
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -117,6 +117,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { alwaysinline nounwind }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48, !49}

--- a/tests/codegen/llvm/call_map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/call_map_key_scratch_buf.ll
@@ -27,7 +27,7 @@ entry:
   %lookup_elem_val7 = alloca i64, align 8
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [3 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -53,7 +53,7 @@ lookup_failure:                                   ; preds = %entry
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   %log2 = call i64 @log2(i64 10, i64 0)
-  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #3
   %5 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
   %6 = getelementptr [1 x [3 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
@@ -82,14 +82,14 @@ lookup_failure5:                                  ; preds = %lookup_merge
 lookup_merge6:                                    ; preds = %lookup_failure5, %lookup_success4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val7)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %6)
-  %get_cpu_id11 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id11 = call i64 inttoptr (i64 8 to ptr)() #3
   %11 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded12 = and i64 %get_cpu_id11, %11
   %12 = getelementptr [1 x [3 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded12, i64 2, i64 0
   store i64 1, ptr %12, align 8
   %lookup_elem13 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %12)
   %has_key = icmp ne ptr %lookup_elem13, null
-  %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)() #3
   %13 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded15 = and i64 %get_cpu_id14, %13
   %14 = getelementptr [1 x [3 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
@@ -177,6 +177,7 @@ hist.is_not_zero:                                 ; preds = %hist.is_not_less_th
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { alwaysinline nounwind }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!70}
 !llvm.module.flags = !{!72, !73}

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -73,6 +73,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!50}
 !llvm.module.flags = !{!52, !53}

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -73,6 +73,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!50}
 !llvm.module.flags = !{!52, !53}

--- a/tests/codegen/llvm/call_path.ll
+++ b/tests/codegen/llvm/call_path.ll
@@ -17,7 +17,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @fentry_mock_vmlinux_filp_close_1(ptr %0) #0 section "s_fentry_mock_vmlinux_filp_close_1" !dbg !40 {
 entry:
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #1
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -27,6 +27,7 @@ entry:
 }
 
 attributes #0 = { nounwind }
+attributes #1 = { memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38, !39}

--- a/tests/codegen/llvm/call_path_with_optional_size.ll
+++ b/tests/codegen/llvm/call_path_with_optional_size.ll
@@ -17,7 +17,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @fentry_mock_vmlinux_filp_close_1(ptr %0) #0 section "s_fentry_mock_vmlinux_filp_close_1" !dbg !40 {
 entry:
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #1
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -27,6 +27,7 @@ entry:
 }
 
 attributes #0 = { nounwind }
+attributes #1 = { memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38, !39}

--- a/tests/codegen/llvm/call_percpu_kaddr.ll
+++ b/tests/codegen/llvm/call_percpu_kaddr.ll
@@ -16,12 +16,13 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @BEGIN_1(ptr %0) #0 section "s_BEGIN_1" !dbg !31 {
 entry:
-  %per_cpu_ptr = call ptr inttoptr (i64 153 to ptr)(ptr @process_counts, i64 0)
+  %per_cpu_ptr = call ptr inttoptr (i64 153 to ptr)(ptr @process_counts, i64 0) #1
   %1 = ptrtoint ptr %per_cpu_ptr to i64
   ret i64 0
 }
 
 attributes #0 = { nounwind }
+attributes #1 = { memory(none) }
 
 !llvm.dbg.cu = !{!27}
 !llvm.module.flags = !{!29, !30}

--- a/tests/codegen/llvm/call_percpu_kaddr_this_cpu.ll
+++ b/tests/codegen/llvm/call_percpu_kaddr_this_cpu.ll
@@ -16,12 +16,13 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @BEGIN_1(ptr %0) #0 section "s_BEGIN_1" !dbg !31 {
 entry:
-  %this_cpu_ptr = call ptr inttoptr (i64 154 to ptr)(ptr @process_counts)
+  %this_cpu_ptr = call ptr inttoptr (i64 154 to ptr)(ptr @process_counts) #1
   %1 = ptrtoint ptr %this_cpu_ptr to i64
   ret i64 0
 }
 
 attributes #0 = { nounwind }
+attributes #1 = { memory(none) }
 
 !llvm.dbg.cu = !{!27}
 !llvm.module.flags = !{!29, !30}

--- a/tests/codegen/llvm/call_pid_tid.ll
+++ b/tests/codegen/llvm/call_pid_tid.ll
@@ -23,7 +23,7 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -34,7 +34,7 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
   %tid = trunc i64 %get_pid_tgid1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
@@ -55,6 +55,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!40}
 !llvm.module.flags = !{!42, !43}

--- a/tests/codegen/llvm/call_pid_tid_curr_ns.ll
+++ b/tests/codegen/llvm/call_pid_tid_curr_ns.ll
@@ -23,7 +23,7 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -34,7 +34,7 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
   %tid = trunc i64 %get_pid_tgid1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
@@ -55,6 +55,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!40}
 !llvm.module.flags = !{!42, !43}

--- a/tests/codegen/llvm/call_pid_tid_init.ll
+++ b/tests/codegen/llvm/call_pid_tid_init.ll
@@ -23,7 +23,7 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -34,7 +34,7 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
   %tid = trunc i64 %get_pid_tgid1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
@@ -55,6 +55,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!40}
 !llvm.module.flags = !{!42, !43}

--- a/tests/codegen/llvm/call_pid_tid_init_ns_in_child_ns.ll
+++ b/tests/codegen/llvm/call_pid_tid_init_ns_in_child_ns.ll
@@ -23,7 +23,7 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -34,7 +34,7 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
   %tid = trunc i64 %get_pid_tgid1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
@@ -55,6 +55,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!40}
 !llvm.module.flags = !{!42, !43}

--- a/tests/codegen/llvm/call_stats.ll
+++ b/tests/codegen/llvm/call_stats.ll
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -66,6 +66,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50, !51}

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -20,7 +20,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !52 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -48,6 +48,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50, !51}

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -25,7 +25,7 @@ entry:
   %arg1 = load volatile i64, ptr %2, align 8
   %str.min.cmp = icmp ule i64 %arg1, 1024
   %str.min.select = select i1 %str.min.cmp, i64 %arg1, i64 1024
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %3 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %3
   %4 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -54,6 +54,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50, !51}

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -20,7 +20,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !55 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -48,6 +48,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!51}
 !llvm.module.flags = !{!53, !54}

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -23,7 +23,7 @@ entry:
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -59,6 +59,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!44}
 !llvm.module.flags = !{!46, !47}

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -53,7 +53,7 @@ stack_scratch_failure:                            ; preds = %lookup_stack_scratc
 
 merge_block:                                      ; preds = %stack_scratch_failure, %get_stack_success, %get_stack_fail
   %1 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 2
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #4
   %2 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %2 to i32
   store i32 %pid, ptr %1, align 4
@@ -100,7 +100,7 @@ stack_scratch_failure3:                           ; preds = %lookup_stack_scratc
 
 merge_block4:                                     ; preds = %stack_scratch_failure3, %get_stack_success10, %get_stack_fail11
   %9 = getelementptr %ustack_key, ptr %stack_key2, i64 0, i32 2
-  %get_pid_tgid15 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid15 = call i64 inttoptr (i64 14 to ptr)() #4
   %10 = lshr i64 %get_pid_tgid15, 32
   %pid16 = trunc i64 %10 to i32
   store i32 %pid16, ptr %9, align 4
@@ -147,7 +147,7 @@ stack_scratch_failure19:                          ; preds = %lookup_stack_scratc
 
 merge_block20:                                    ; preds = %stack_scratch_failure19, %get_stack_success27, %get_stack_fail28
   %17 = getelementptr %ustack_key, ptr %stack_key18, i64 0, i32 2
-  %get_pid_tgid32 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid32 = call i64 inttoptr (i64 14 to ptr)() #4
   %18 = lshr i64 %get_pid_tgid32, 32
   %pid33 = trunc i64 %18 to i32
   store i32 %pid33, ptr %17, align 4
@@ -273,6 +273,7 @@ attributes #0 = { nounwind }
 attributes #1 = { alwaysinline nounwind }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #4 = { memory(none) }
 
 !llvm.dbg.cu = !{!91}
 !llvm.module.flags = !{!93, !94}

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -21,7 +21,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %usym = alloca %usym_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
@@ -45,6 +45,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48, !49}

--- a/tests/codegen/llvm/fentry_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/fentry_recursion_check_with_predicate.ll
@@ -37,7 +37,7 @@ lookup_failure:                                   ; preds = %entry
   ret i64 0
 
 lookup_merge:                                     ; preds = %lookup_success
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %2 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %2 to i32
   %3 = zext i32 %pid to i64
@@ -97,6 +97,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!44}
 !llvm.module.flags = !{!46, !47}

--- a/tests/codegen/llvm/fmt_str_args_scratch_buf.ll
+++ b/tests/codegen/llvm/fmt_str_args_scratch_buf.ll
@@ -19,7 +19,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !40 {
 entry:
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @__bt__fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -51,6 +51,7 @@ declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noal
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38, !39}

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -19,7 +19,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !29 {
 entry:
   %printf_args1 = alloca %printf_t.0, align 8
   %printf_args = alloca %printf_t, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -77,6 +77,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!25}
 !llvm.module.flags = !{!27, !28}

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -17,7 +17,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !29 {
 entry:
   %printf_args = alloca %printf_t, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -26,7 +26,7 @@ entry:
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
-  %get_pid_tgid3 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid3 = call i64 inttoptr (i64 14 to ptr)() #3
   %4 = lshr i64 %get_pid_tgid3, 32
   %pid4 = trunc i64 %4 to i32
   %5 = zext i32 %pid4 to i64
@@ -71,6 +71,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!25}
 !llvm.module.flags = !{!27, !28}

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -17,7 +17,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !29 {
 entry:
   %printf_args = alloca %printf_t, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -30,7 +30,7 @@ if_body:                                          ; preds = %entry
   call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 16, i1 false)
   %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
   store i64 0, ptr %4, align 8
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #3
   %5 = lshr i64 %get_pid_tgid1, 32
   %pid2 = trunc i64 %5 to i32
   %6 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
@@ -64,6 +64,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!25}
 !llvm.module.flags = !{!27, !28}

--- a/tests/codegen/llvm/logical_and.ll
+++ b/tests/codegen/llvm/logical_and.ll
@@ -21,7 +21,7 @@ entry:
   %"@x_key" = alloca i64, align 8
   %"&&_result" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -30,7 +30,7 @@ entry:
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
   %4 = lshr i64 %get_pid_tgid1, 32
   %pid2 = trunc i64 %4 to i32
   %5 = zext i32 %pid2 to i64
@@ -66,6 +66,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -30,7 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
   store i64 0, ptr %"$foo", align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [40 x i8]]], ptr @__bt__fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -173,6 +173,7 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #4 = { memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38, !39}

--- a/tests/codegen/llvm/logical_or.ll
+++ b/tests/codegen/llvm/logical_or.ll
@@ -21,7 +21,7 @@ entry:
   %"@x_key" = alloca i64, align 8
   %"||_result" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -30,7 +30,7 @@ entry:
   br i1 %lhs_true_cond, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %entry
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
   %4 = lshr i64 %get_pid_tgid1, 32
   %pid2 = trunc i64 %4 to i32
   %5 = zext i32 %pid2 to i64
@@ -66,6 +66,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/map_key_scratch_buf.ll
@@ -24,24 +24,24 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !72 {
 entry:
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #1
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [2 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   store i64 1, ptr %2, align 8
-  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #1
   %3 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %3
   %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
   store i64 1, ptr %4, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %4, i64 0)
-  %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)() #1
   %5 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded4 = and i64 %get_cpu_id3, %5
   %6 = getelementptr [1 x [2 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded4, i64 1, i64 0
   store i64 1, ptr %6, align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %6)
-  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)() #1
   %7 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded6 = and i64 %get_cpu_id5, %7
   %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__read_map_val_buf, i64 0, i64 %cpu.id.bounded6, i64 0, i64 0
@@ -59,7 +59,7 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %10 = load i64, ptr %8, align 8
-  %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)() #1
   %11 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded8 = and i64 %get_cpu_id7, %11
   %12 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded8, i64 0, i64 0
@@ -69,6 +69,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 }
 
 attributes #0 = { nounwind }
+attributes #1 = { memory(none) }
 
 !llvm.dbg.cu = !{!68}
 !llvm.module.flags = !{!70, !71}

--- a/tests/codegen/llvm/map_value_int_scratch_buf.ll
+++ b/tests/codegen/llvm/map_value_int_scratch_buf.ll
@@ -23,24 +23,24 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !61 {
 entry:
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #1
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [3 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   store i64 0, ptr %2, align 8
-  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #1
   %3 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %3
   %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
   store i64 1, ptr %4, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %4, i64 0)
-  %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)() #1
   %5 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded4 = and i64 %get_cpu_id3, %5
   %6 = getelementptr [1 x [3 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded4, i64 1, i64 0
   store i64 0, ptr %6, align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %6)
-  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)() #1
   %7 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded6 = and i64 %get_cpu_id5, %7
   %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__read_map_val_buf, i64 0, i64 %cpu.id.bounded6, i64 0, i64 0
@@ -58,12 +58,12 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %10 = load i64, ptr %8, align 8
-  %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)() #1
   %11 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded8 = and i64 %get_cpu_id7, %11
   %12 = getelementptr [1 x [3 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded8, i64 2, i64 0
   store i64 0, ptr %12, align 8
-  %get_cpu_id9 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id9 = call i64 inttoptr (i64 8 to ptr)() #1
   %13 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded10 = and i64 %get_cpu_id9, %13
   %14 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded10, i64 0, i64 0
@@ -73,6 +73,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 }
 
 attributes #0 = { nounwind }
+attributes #1 = { memory(none) }
 
 !llvm.dbg.cu = !{!57}
 !llvm.module.flags = !{!59, !60}

--- a/tests/codegen/llvm/map_value_tuple_scratch_buf.ll
+++ b/tests/codegen/llvm/map_value_tuple_scratch_buf.ll
@@ -28,7 +28,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !73 {
 entry:
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [2 x [16 x i8]]], ptr @__bt__tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -37,12 +37,12 @@ entry:
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 @xxx, i64 4, i1 false)
   %4 = getelementptr %"string[4]_int64__tuple_t", ptr %2, i32 0, i32 1
   store i64 1, ptr %4, align 8
-  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #3
   %5 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
   %6 = getelementptr [1 x [4 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
   store i64 0, ptr %6, align 8
-  %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)() #3
   %7 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded4 = and i64 %get_cpu_id3, %7
   %8 = getelementptr [1 x [1 x [16 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded4, i64 0, i64 0
@@ -54,7 +54,7 @@ entry:
   %12 = getelementptr %"string[8]_int64__tuple_t", ptr %8, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %11, i64 8, i1 false)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %6, ptr %8, i64 0)
-  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)() #3
   %13 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded6 = and i64 %get_cpu_id5, %13
   %14 = getelementptr [1 x [2 x [16 x i8]]], ptr @__bt__tuple_buf, i64 0, i64 %cpu.id.bounded6, i64 1, i64 0
@@ -63,19 +63,19 @@ entry:
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %15, ptr align 1 @xxxxxxx, i64 8, i1 false)
   %16 = getelementptr %"string[8]_int64__tuple_t", ptr %14, i32 0, i32 1
   store i64 1, ptr %16, align 8
-  %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)() #3
   %17 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded8 = and i64 %get_cpu_id7, %17
   %18 = getelementptr [1 x [4 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded8, i64 1, i64 0
   store i64 0, ptr %18, align 8
   %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %18, ptr %14, i64 0)
-  %get_cpu_id10 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id10 = call i64 inttoptr (i64 8 to ptr)() #3
   %19 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded11 = and i64 %get_cpu_id10, %19
   %20 = getelementptr [1 x [4 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded11, i64 2, i64 0
   store i64 0, ptr %20, align 8
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %20)
-  %get_cpu_id12 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id12 = call i64 inttoptr (i64 8 to ptr)() #3
   %21 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded13 = and i64 %get_cpu_id12, %21
   %22 = getelementptr [1 x [1 x [16 x i8]]], ptr @__bt__read_map_val_buf, i64 0, i64 %cpu.id.bounded13, i64 0, i64 0
@@ -91,7 +91,7 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)() #3
   %23 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded15 = and i64 %get_cpu_id14, %23
   %24 = getelementptr [1 x [4 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
@@ -109,6 +109,7 @@ declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noal
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!69}
 !llvm.module.flags = !{!71, !72}

--- a/tests/codegen/llvm/pid_filter.ll
+++ b/tests/codegen/llvm/pid_filter.ll
@@ -18,7 +18,7 @@ entry:
   %"$x" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
   store i64 0, ptr %"$x", align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -42,6 +42,7 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!25}
 !llvm.module.flags = !{!27, !28}

--- a/tests/codegen/llvm/pred_binop.ll
+++ b/tests/codegen/llvm/pred_binop.ll
@@ -19,7 +19,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !42 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -50,6 +50,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/probe_str_scratch_buf.ll
+++ b/tests/codegen/llvm/probe_str_scratch_buf.ll
@@ -20,7 +20,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @tracepoint_sched_sched_one_1(ptr %0) #0 section "s_tracepoint_sched_sched_one_1" !dbg !53 {
 entry:
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #1
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -30,6 +30,7 @@ entry:
 }
 
 attributes #0 = { nounwind }
+attributes #1 = { memory(none) }
 
 !llvm.dbg.cu = !{!49}
 !llvm.module.flags = !{!51, !52}

--- a/tests/codegen/llvm/runtime_error_check_path.ll
+++ b/tests/codegen/llvm/runtime_error_check_path.ll
@@ -19,7 +19,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @fentry_mock_vmlinux_filp_close_1(ptr %0) #0 section "s_fentry_mock_vmlinux_filp_close_1" !dbg !40 {
 entry:
   %helper_error_t = alloca %helper_error_t, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -61,6 +61,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38, !39}

--- a/tests/codegen/llvm/runtime_error_check_pid_tid.ll
+++ b/tests/codegen/llvm/runtime_error_check_pid_tid.ll
@@ -26,7 +26,7 @@ entry:
   %helper_error_t = alloca %helper_error_t, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -54,7 +54,7 @@ helper_failure:                                   ; preds = %entry
 helper_merge:                                     ; preds = %counter_merge, %entry
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
   %tid = trunc i64 %get_pid_tgid1 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
@@ -108,6 +108,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!40}
 !llvm.module.flags = !{!42, !43}

--- a/tests/codegen/llvm/runtime_error_check_stack.ll
+++ b/tests/codegen/llvm/runtime_error_check_stack.ll
@@ -52,7 +52,7 @@ stack_scratch_failure:                            ; preds = %lookup_stack_scratc
 
 merge_block:                                      ; preds = %stack_scratch_failure, %helper_merge2, %get_stack_fail
   %1 = getelementptr %ustack_key, ptr %stack_key, i64 0, i32 2
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #4
   %2 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %2 to i32
   store i32 %pid, ptr %1, align 4
@@ -368,6 +368,7 @@ attributes #0 = { nounwind }
 attributes #1 = { alwaysinline nounwind }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #4 = { memory(none) }
 
 !llvm.dbg.cu = !{!83}
 !llvm.module.flags = !{!85, !86}

--- a/tests/codegen/llvm/str_scratch_buf.ll
+++ b/tests/codegen/llvm/str_scratch_buf.ll
@@ -17,7 +17,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !40 {
 entry:
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [64 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -38,6 +38,7 @@ declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38, !39}

--- a/tests/codegen/llvm/strcontains_no_literals.ll
+++ b/tests/codegen/llvm/strcontains_no_literals.ll
@@ -19,7 +19,7 @@ define i64 @kprobe_foo_1(ptr %0) #0 section "s_kprobe_foo_1" !dbg !42 {
 entry:
   %strcontains.j = alloca i64, align 8
   %strcontains.i = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [2 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -28,7 +28,7 @@ entry:
   %4 = getelementptr i8, ptr %3, i64 112
   %arg0 = load volatile i64, ptr %4, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 1024, i64 %arg0)
-  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #3
   %5 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
   %6 = getelementptr [1 x [2 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
@@ -123,6 +123,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/strcontains_one_literal.ll
+++ b/tests/codegen/llvm/strcontains_one_literal.ll
@@ -20,7 +20,7 @@ define i64 @kprobe_foo_1(ptr %0) #0 section "s_kprobe_foo_1" !dbg !40 {
 entry:
   %strcontains.j = alloca i64, align 8
   %strcontains.i = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -114,6 +114,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38, !39}

--- a/tests/codegen/llvm/strncmp_no_literals.ll
+++ b/tests/codegen/llvm/strncmp_no_literals.ll
@@ -23,7 +23,7 @@ entry:
   %"@_key" = alloca i64, align 8
   %strcmp.result = alloca i1, align 1
   %comm = alloca [16 x i8], align 1
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -273,6 +273,7 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #4 = { memory(none) }
 
 !llvm.dbg.cu = !{!47}
 !llvm.module.flags = !{!49, !50}

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -28,7 +28,7 @@ entry:
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   store i64 %arg0, ptr %"$foo", align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %3 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %3
   %4 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -61,6 +61,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!48}
 !llvm.module.flags = !{!50, !51}

--- a/tests/codegen/llvm/ternary_buf.ll
+++ b/tests/codegen/llvm/ternary_buf.ll
@@ -32,7 +32,7 @@ entry:
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
   %2 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %2
   %3 = getelementptr [1 x [2 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -45,7 +45,7 @@ left:                                             ; preds = %entry
   br label %done
 
 right:                                            ; preds = %entry
-  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #4
   %6 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %6
   %7 = getelementptr [1 x [2 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
@@ -79,6 +79,7 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #4 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/ternary_int.ll
+++ b/tests/codegen/llvm/ternary_int.ll
@@ -19,7 +19,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !42 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -53,6 +53,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -19,7 +19,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !29 {
 entry:
   %exit = alloca %exit_t, align 8
   %printf_args = alloca %printf_t, align 8
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
@@ -81,6 +81,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!25}
 !llvm.module.flags = !{!27, !28}

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -22,12 +22,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !55 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %3 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %3 to i32
   %4 = zext i32 %pid to i64
@@ -63,6 +63,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!51}
 !llvm.module.flags = !{!53, !54}

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -26,7 +26,7 @@ entry:
   %2 = getelementptr i8, ptr %1, i64 128
   %reg_ip = load volatile i64, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)()
+  %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #5
   %3 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %3 to i32
   %4 = getelementptr %usym_t, ptr %usym, i64 0, i32 0
@@ -71,6 +71,7 @@ attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memo
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #4 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #5 = { memory(none) }
 
 !llvm.dbg.cu = !{!47}
 !llvm.module.flags = !{!49, !50}

--- a/tests/codegen/llvm/tuple_scratch_buf.ll
+++ b/tests/codegen/llvm/tuple_scratch_buf.ll
@@ -19,7 +19,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !40 {
 entry:
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @__bt__tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -40,6 +40,7 @@ declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noal
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { memory(none) }
 
 !llvm.dbg.cu = !{!36}
 !llvm.module.flags = !{!38, !39}

--- a/tests/codegen/llvm/variable_scratch_buf.ll
+++ b/tests/codegen/llvm/variable_scratch_buf.ll
@@ -17,12 +17,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !42 {
 entry:
-  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #2
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %1
   %2 = getelementptr [1 x [2 x [8 x i8]]], ptr @__bt__var_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
   store i64 0, ptr %2, align 8
-  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)()
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
   %3 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %3
   %4 = getelementptr [1 x [2 x [8 x i8]]], ptr @__bt__var_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
@@ -51,6 +51,7 @@ declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!38}
 !llvm.module.flags = !{!40, !41}


### PR DESCRIPTION
If a BPF helper has no side effects and always returns the same value when called repeatedly within a single probe's context, we can get LLVM to optimise out repeated calls to the same helper.

Most of these helpers are not inlined in the current latest kernel, making the cost of repeated helper calls higher.

One common pattern which is helped is recording both the `pid` and the `tid`. Since `pid` and `tid` are both implemented with the `get_current_pid_tgid` helper, this script would have previously required two identical helper calls, but now only one is needed: `print((pid, tid, ...))`

Concise example script:
```
BEGIN { pid; tid; }
```

Old IR (optimised):
```
define noundef i64 @BEGIN_1(ptr nocapture readnone %0) local_unnamed_addr #0 section "s_BEGIN_1" !dbg !29 {
entry:
  %get_pid_tgid = tail call i64 inttoptr (i64 14 to ptr)() #0
  %get_pid_tgid1 = tail call i64 inttoptr (i64 14 to ptr)() #0
  ret i64 0
}
attributes #0 = { nounwind }
```

New IR (optimised):
```
define noundef i64 @BEGIN_1(ptr nocapture readnone %0) local_unnamed_addr #0 section "s_BEGIN_1" !dbg !29 {
entry:
  %get_pid_tgid = tail call i64 inttoptr (i64 14 to ptr)() #1
  ret i64 0
}
attributes #0 = { nofree nosync nounwind memory(none) }
attributes #1 = { nounwind memory(none) }
```

##### Checklist

- ~[ ]~ Language changes are updated in `man/adoc/bpftrace.adoc`
- ~[ ]~ User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
