### PR TITLE
cmake: Ensure Clang version matches LLVM version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,7 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}: ${LLVM_CMAKE_DIR}")
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
-find_package(Clang REQUIRED)
+find_package(Clang ${LLVM_PACKAGE_VERSION} REQUIRED)
 include_directories(SYSTEM ${CLANG_INCLUDE_DIRS})
 
 # BPFtrace compile definitions


### PR DESCRIPTION
When multiple LLVM/Clang versions are installed, `find_package(Clang REQUIRED)` may change the detected LLVM version, causing version mismatch with the previously found LLVM version via `find_package(LLVM REQUIRED)` or `find_package(LLVM ${LLVM_REQUESTED_VERSION} REQUIRED)`.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
