### PR TITLE
tools/runqlat.bt: ignore idle task

### DIFF
--- a/tools/runqlat.bt
+++ b/tools/runqlat.bt
@@ -191,6 +191,10 @@ tracepoint:sched:sched_switch
 	if (args.prev_state == TASK_RUNNING) {
 		@qtime[args.prev_pid] = nsecs;
 	}
+	// Ignore the idle task
+	if (args.next_pid == 0) {
+		return;
+	}
 
 	$ns = @qtime[args.next_pid];
 	if ($ns) {


### PR DESCRIPTION
- [not affected] Language changes are updated in `man/adoc/bpftrace.adoc`
- [not affected] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [not affected] The new behaviour is covered by tests

There is a bug in the `runqlat.bt` script:
When measuring task latencies, the idle task should be ignored since it only runs when no other tasks need to be scheduled on the CPU and measuring it's latency skews the overall measurement.

The original versions of runqlat in BCC do consider this (see [bcc version](https://github.com/iovisor/bcc/blob/74bddcbe646eb8a1595067f8c698f7d0416c90fb/tools/runqlat.py#L222) or [libbpf version](https://github.com/iovisor/bcc/blob/74bddcbe646eb8a1595067f8c698f7d0416c90fb/libbpf-tools/runqlat.bpf.c#L49))

Script runs a loaded system (with `stress-ng`):

without ignoring pid 0:

```
@usecs:
[0]                 8567 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[1]                 4036 |@@@@@@@@@@@@@@@@@@@@@@@@                            |
[2, 4)              5352 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                    |
[4, 8)              5709 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                  |
[8, 16)             3090 |@@@@@@@@@@@@@@@@@@                                  |
[16, 32)             715 |@@@@                                                |
[32, 64)             881 |@@@@@                                               |
[64, 128)            377 |@@                                                  |
[128, 256)           477 |@@                                                  |
[256, 512)           329 |@                                                   |
[512, 1K)            422 |@@                                                  |
[1K, 2K)             506 |@@@                                                 |
[2K, 4K)             571 |@@@                                                 |
[4K, 8K)             502 |@@@                                                 |
[8K, 16K)            265 |@                                                   |
[16K, 32K)            37 |                                                    |
[32K, 64K)             8 |                                                    |
```

ignoring pid 0:

```
@usecs:
[0]                 6841 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[1]                 4230 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@                    |
[2, 4)              4979 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@               |
[4, 8)              5192 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@             |
[8, 16)             3289 |@@@@@@@@@@@@@@@@@@@@@@@@@                           |
[16, 32)             816 |@@@@@@                                              |
[32, 64)             788 |@@@@@                                               |
[64, 128)            343 |@@                                                  |
[128, 256)           312 |@@                                                  |
[256, 512)           202 |@                                                   |
[512, 1K)            167 |@                                                   |
[1K, 2K)             144 |@                                                   |
[2K, 4K)             109 |                                                    |
[4K, 8K)              87 |                                                    |
[8K, 16K)             73 |                                                    |
[16K, 32K)             8 |                                                    |
```
