### PR TITLE
util: split TypeName into separate file

### DIFF
--- a/src/ast/pass_manager.h
+++ b/src/ast/pass_manager.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "util/result.h"
+#include "util/type_name.h"
 
 namespace bpftrace::ast {
 
@@ -18,24 +19,6 @@ namespace bpftrace::ast {
 // This class is essentially a type-erased generic constant storage.
 class PassContext {
 public:
-  // TypeName is used as a template parameter to work around restrictions on
-  // literals passes as template parameters. This is essentially a string
-  // literal used to name the type.
-  template <size_t N>
-  struct TypeName {
-    constexpr TypeName(const char (&s)[N])
-    {
-      std::copy_n(s, N, value);
-    }
-    char value[N];
-    std::string str() const
-    {
-      // N.B. the value here includes the trailing zero, so when constructing a
-      // string we truncate this zero.
-      return std::string(value, sizeof(value) - 1);
-    }
-  };
-
   // TypeId is a class which, when specialized, returns the type_id. This
   // works by storing a static variable for each specialization of the class,
   // which effectively memoizes an ID binding for the specific class.
@@ -162,7 +145,7 @@ private:
 //   };
 //
 // The `Variables` class can then be stored in the pass context.
-template <PassContext::TypeName name>
+template <util::TypeName name>
 class State : public PassContext::State {
 public:
   static std::string type_name()

--- a/src/util/type_name.h
+++ b/src/util/type_name.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+
+namespace bpftrace::util {
+
+// TypeName is used as a template parameter to work around restrictions on
+// literals passed as template parameters. This is essentially a string
+// literal used to name the type.
+template <size_t N>
+struct TypeName {
+  constexpr TypeName(const char (&s)[N])
+  {
+    std::copy_n(s, N, value);
+  }
+  char value[N];
+  std::string str() const
+  {
+    // N.B. the value here includes the trailing zero, so when constructing a
+    // string we truncate this zero.
+    return std::string(value, sizeof(value) - 1);
+  }
+};
+
+} // namespace bpftrace::util

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1792,8 +1792,8 @@ lhist_map_3:
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,
                                                  tc.name);
     HistogramMap values_by_key = {
-      { { 0 }, { 0, 10, 20, 30, 40, 50, 0 } },
-      { { 1 }, { 0, 2, 2, 2, 2, 2, 0 } },
+      { { 0, 0, 0, 0, 0, 0, 0, 0 }, { 0, 10, 20, 30, 40, 50, 0 } },
+      { { 1, 0, 0, 0, 0, 0, 0, 0 }, { 0, 2, 2, 2, 2, 2, 0 } },
     };
     EXPECT_CALL(*mock_map, collect_histogram_data(testing::_, testing::_))
         .WillOnce(testing::Return(
@@ -1895,8 +1895,8 @@ hist_map_3:
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,
                                                  tc.name);
     HistogramMap values_by_key = {
-      { { 0 }, { 0, 10, 20, 30, 40, 50, 0 } },
-      { { 1 }, { 0, 2, 2, 2, 2, 2, 0 } },
+      { { 0, 0, 0, 0, 0, 0, 0, 0 }, { 0, 10, 20, 30, 40, 50, 0 } },
+      { { 1, 0, 0, 0, 0, 0, 0, 0 }, { 0, 2, 2, 2, 2, 2, 0 } },
     };
     EXPECT_CALL(*mock_map, collect_histogram_data(testing::_, testing::_))
         .WillOnce(testing::Return(


### PR DESCRIPTION
Stacked PRs:
 * #4302
 * #4301
 * #4300
 * #4299
 * __->__#4298
 * #4304


--- --- ---

### util: split TypeName into separate file


In order to use this trick for other cases (registering classes that
correspond to standard library types), make this a separate util file.

Signed-off-by: Adin Scannell <adin@scannell.ca>
