### PR TITLE
tests: fix key data for map tests

### DIFF
--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1792,8 +1792,8 @@ lhist_map_3:
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,
                                                  tc.name);
     HistogramMap values_by_key = {
-      { { 0 }, { 0, 10, 20, 30, 40, 50, 0 } },
-      { { 1 }, { 0, 2, 2, 2, 2, 2, 0 } },
+      { { 0, 0, 0, 0, 0, 0, 0, 0 }, { 0, 10, 20, 30, 40, 50, 0 } },
+      { { 1, 0, 0, 0, 0, 0, 0, 0 }, { 0, 2, 2, 2, 2, 2, 0 } },
     };
     EXPECT_CALL(*mock_map, collect_histogram_data(testing::_, testing::_))
         .WillOnce(testing::Return(
@@ -1895,8 +1895,8 @@ hist_map_3:
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,
                                                  tc.name);
     HistogramMap values_by_key = {
-      { { 0 }, { 0, 10, 20, 30, 40, 50, 0 } },
-      { { 1 }, { 0, 2, 2, 2, 2, 2, 0 } },
+      { { 0, 0, 0, 0, 0, 0, 0, 0 }, { 0, 10, 20, 30, 40, 50, 0 } },
+      { { 1, 0, 0, 0, 0, 0, 0, 0 }, { 0, 2, 2, 2, 2, 2, 0 } },
     };
     EXPECT_CALL(*mock_map, collect_histogram_data(testing::_, testing::_))
         .WillOnce(testing::Return(


### PR DESCRIPTION
Stacked PRs:
 * #4302
 * #4301
 * #4300
 * #4299
 * #4298
 * __->__#4304


--- --- ---

### tests: fix key data for map tests


It is unclear why this is working currently. The key type is an int64,
and the `util::read_data` function *will* read a full 8 bytes from the
starting point of this vector. Since the type of the key vector is
`std::vector<uint8_t>`, we need to have 8 entries for this to work.

We should consider updating the `util` helpers to use the bounds of the
vector, rather than running off the end.

Note that this is little-endian specific, but this change is not
adjusting the current semantics. I intend to replace these vectors with
a mechanism that is safer and works independently of the endianness.

Signed-off-by: Adin Scannell <amscanne@meta.com>
