### PR TITLE
tools/opensnoop: support openat2(2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ and this project adheres to
 #### Security
 #### Docs
 #### Tools
+- opensnoop.bt: support openat2 syscall
+  - [#4310](https://github.com/bpftrace/bpftrace/pull/4310)
 - killsnoop.bt: display signal name instead of value
   - [#4234](https://github.com/bpftrace/bpftrace/pull/4234)
 - killsnoop.bt: support tkill() and tgkill()

--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -41,6 +41,8 @@
  * 08-Sep-2018	Brendan Gregg	Created this.
  */
 
+config = { missing_probes=warn }
+
 BEGIN
 {
 	printf("Tracing open syscalls... Hit Ctrl-C to end.\n");
@@ -48,13 +50,15 @@ BEGIN
 }
 
 tracepoint:syscalls:sys_enter_open,
-tracepoint:syscalls:sys_enter_openat
+tracepoint:syscalls:sys_enter_openat,
+tracepoint:syscalls:sys_enter_openat2
 {
 	@filename[tid] = args.filename;
 }
 
 tracepoint:syscalls:sys_exit_open,
-tracepoint:syscalls:sys_exit_openat
+tracepoint:syscalls:sys_exit_openat,
+tracepoint:syscalls:sys_exit_openat2
 /@filename[tid]/
 {
 	$ret = args.ret;


### PR DESCRIPTION
kernel v5.6 introduces fddb5d430ad9 ("open: introduce openat2(2) syscall").

