### PR TITLE
Make `get_pid_exe` failures not crash bpftrace

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -371,7 +371,7 @@ AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
       parts_.insert(parts_.begin() + 1, "");
 
     auto target = util::get_pid_exe(*pid);
-    parts_[1] = util::path_for_pid_mountns(*pid, target);
+    parts_[1] = target ? util::path_for_pid_mountns(*pid, *target) : "";
   }
 
   if (parts_.size() != 3 && parts_.size() != 4) {

--- a/src/bfd-disasm.cpp
+++ b/src/bfd-disasm.cpp
@@ -57,10 +57,14 @@ static AlignState is_aligned_buf(void *buf, uint64_t size, uint64_t offset)
 {
   disassembler_ftype disassemble;
   struct disassemble_info info;
-  std::string tpath = util::get_pid_exe("self");
+  auto tpath = util::get_pid_exe("self");
+  if (!tpath) {
+    return AlignState::Fail;
+  }
+
   bfd *bfdf;
 
-  bfdf = bfd_openr(tpath.c_str(), nullptr);
+  bfdf = bfd_openr(tpath->c_str(), nullptr);
   if (bfdf == nullptr)
     return AlignState::Fail;
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1446,7 +1446,11 @@ std::vector<std::string> BPFtrace::resolve_usym_stack(uint64_t addr,
                                                       bool perf_mode,
                                                       bool show_debug_info)
 {
-  std::string pid_exe = util::get_pid_exe(pid);
+  std::string pid_exe;
+  auto res = util::get_pid_exe(pid);
+  if (res) {
+    pid_exe = *res;
+  }
   if (pid_exe.empty() && probe_id != -1) {
     // sometimes program cannot be determined from PID, typically when the
     // process does not exist anymore; in that case, try to get program name

--- a/src/util/system.cpp
+++ b/src/util/system.cpp
@@ -13,7 +13,14 @@
 
 namespace bpftrace::util {
 
-std::string get_pid_exe(const std::string &pid)
+char GetPidError::ID;
+
+void GetPidError::log(llvm::raw_ostream &OS) const
+{
+  OS << "Error code: " << err_;
+}
+
+Result<std::string> get_pid_exe(const std::string &pid)
 {
   std::error_code ec;
   std::filesystem::path proc_path{ "/proc" };
@@ -23,15 +30,11 @@ std::string get_pid_exe(const std::string &pid)
   try {
     return std::filesystem::read_symlink(proc_path).string();
   } catch (const std::filesystem::filesystem_error &e) {
-    auto err = e.code().value();
-    if (err == ENOENT || err == EINVAL)
-      return {};
-    else
-      throw e;
+    return make_error<GetPidError>(e.code().value());
   }
 }
 
-std::string get_pid_exe(pid_t pid)
+Result<std::string> get_pid_exe(pid_t pid)
 {
   return get_pid_exe(std::to_string(pid));
 }
@@ -121,9 +124,10 @@ std::vector<std::string> get_mapped_paths_for_pid(pid_t pid)
   std::vector<std::string> paths;
 
   // start with the exe
-  std::string pid_exe = get_pid_exe(pid);
-  if (!pid_exe.empty() && pid_exe.find("(deleted)") == std::string::npos)
-    paths.push_back(get_pid_exe(pid));
+  auto pid_exe = get_pid_exe(pid);
+  if (pid_exe && !pid_exe->empty() &&
+      pid_exe->find("(deleted)") == std::string::npos)
+    paths.push_back(*pid_exe);
 
   // get all the mapped libraries
   std::string maps_path = get_proc_maps(pid);

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -3,10 +3,22 @@
 #include <string>
 #include <vector>
 
+#include "util/result.h"
+
 namespace bpftrace::util {
 
-std::string get_pid_exe(pid_t pid);
-std::string get_pid_exe(const std::string &pid);
+class GetPidError : public ErrorInfo<GetPidError> {
+public:
+  GetPidError(int err) : err_(err) {};
+  static char ID;
+  void log(llvm::raw_ostream &OS) const override;
+
+private:
+  int err_;
+};
+
+Result<std::string> get_pid_exe(pid_t pid);
+Result<std::string> get_pid_exe(const std::string &pid);
 std::string get_proc_maps(const std::string &pid);
 std::string get_proc_maps(pid_t pid);
 


### PR DESCRIPTION
As reported in the issue below a thrown error
in `get_pid_exe` was causing bpftrace to crash.
This makes sure to handle it more gracefully
by just returning a `Result`.

Issue:
https://github.com/bpftrace/bpftrace/issues/4309

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
