### PR TITLE
Add support for duration literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to
   - [#4254](https://github.com/bpftrace/bpftrace/pull/4254)
 - Add boolean values (`true` and `false`)
   - [#4280](https://github.com/bpftrace/bpftrace/pull/4280)
+- Add duration literals - suffixes include: `ns`, `us`, `ms`, `s`, `m`, `h`, `d`
+  - [#4317](https://github.com/bpftrace/bpftrace/pull/4317)
 #### Changed
 - `-p` CLI flag now applies to all probes (except BEGIN/END)
   - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -428,6 +428,12 @@ To improve the readability of big literals an underscore `_` can be used as fiel
 Integer suffixes as found in the C language are parsed by bpftrace to ensure compatibility with C headers/definitions but they're not used as size specifiers.
 `123UL`, `123U` and `123LL` all result in the same integer type with a value of `123`.
 
+These duration suffixes are also supported: `ns`, `us`, `ms`, `s`, `m`, `h`, and `d`. All get turned into integer values in nanoseconds, e.g.
+```
+$a = 1m;
+print($a); // prints 60000000000
+```
+
 Character literals are not supported at this time, and the corresponding ASCII code must be used instead:
 
 ----
@@ -1315,6 +1321,7 @@ hardware:cache-misses:1e6 { @[pid] = count(); }
 === interval
 
 .variants
+* `interval:count`
 * `interval:us:count`
 * `interval:ms:count`
 * `interval:s:count`
@@ -1325,12 +1332,13 @@ hardware:cache-misses:1e6 { @[pid] = count(); }
 
 The interval probe fires at a fixed interval as specified by its time spec.
 Interval fires on one CPU at a time, unlike <<probes-profile>> probes.
+If a unit of time is not specified in the second position, the number is interpreted as nanoseconds; e.g., `interval:1s`, `interval:1000000000`, and `interval:s:1` are all equivalent.
 
 This prints the rate of syscalls per second.
 
 ----
 tracepoint:raw_syscalls:sys_enter { @syscalls = count(); }
-interval:s:1 { print(@syscalls); clear(@syscalls); }
+interval:1s { print(@syscalls); clear(@syscalls); }
 ----
 
 [#probes-iterator]
@@ -1572,6 +1580,7 @@ kretprobe:d_lookup
 === profile
 
 .variants
+* `profile:count`
 * `profile:us:count`
 * `profile:ms:count`
 * `profile:s:count`
@@ -1582,6 +1591,7 @@ kretprobe:d_lookup
 
 Profile probes fire on each CPU on the specified interval.
 These operate using perf_events (a Linux kernel facility, which is also used by the perf command).
+If a unit of time is not specified in the second position, the number is interpreted as nanoseconds; e.g., `interval:1s`, `interval:1000000000`, and `interval:s:1` are all equivalent.
 
 ----
 profile:hz:99 { @[tid] = count(); }

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -48,6 +48,8 @@ private:
   State iter_parser();
   State raw_tracepoint_parser();
 
+  State frequency_parser();
+
   State argument_count_error(int expected,
                              std::optional<int> expected2 = std::nullopt);
   std::optional<uint64_t> stoull(const std::string &str);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -29,7 +29,7 @@ static int read_from_source(char* buf, size_t max_size);
 %}
 
 /* https://en.cppreference.com/w/cpp/language/integer_literal#The_type_of_the_literal */
-int_size (([uU])|([uU]?[lL]?[lL]))
+int_size (([uU])|([uU]?[lL]?[lL])|(ns)|(us)|(ms)|(s)|(m)|(h)|(d))
 
 /* Number with underscores in it, e.g. 1_000_000 */
 int      [0-9]([0-9_]*[0-9])?{int_size}?

--- a/tools/loads.bt
+++ b/tools/loads.bt
@@ -6,9 +6,9 @@
  * These are the same load averages printed by "uptime", but to three decimal
  * places instead of two (not that it really matters). This is really a
  * demonstration of fetching and processing a kernel structure from bpftrace.
- * 
+ *
  * Example of usage:
- * 
+ *
  * # ./loads.bt
  * Attaching 2 probes...
  * Reading load averages... Hit Ctrl-C to end.
@@ -17,13 +17,13 @@
  * 21:29:19 load averages: 2.091 2.048 1.947
  * 21:29:20 load averages: 2.091 2.048 1.947
  * ^C
- * 
+ *
  * These are the same load averages printed by uptime:
- * 
+ *
  * # uptime
  *  21:29:24 up 2 days, 18:57,  3 users,  load average: 2.16, 2.06, 1.95
- * 
- * 
+ *
+ *
  * For more on load averages, see the post:
  * http://www.brendangregg.com/blog/2017-08-08/linux-load-averages.html
  *
@@ -39,7 +39,7 @@ BEGIN
 	printf("Reading load averages... Hit Ctrl-C to end.\n");
 }
 
-interval:s:1
+interval:1s
 {
 	/*
 	 * See fs/proc/loadavg.c and include/linux/sched/loadavg.h for the

--- a/tools/pidpersec.bt
+++ b/tools/pidpersec.bt
@@ -4,9 +4,9 @@
  *		For Linux, uses bpftrace and eBPF.
  *
  * Written as a basic example of counting on an event.
- * 
+ *
  * Example of usage:
- * 
+ *
  * # ./pidpersec.bt
  * Attaching 4 probes...
  * Tracing new processes... Hit Ctrl-C to end.
@@ -15,13 +15,13 @@
  * 22:29:52 PIDs/sec: @: 122
  * 22:29:53 PIDs/sec: @: 124
  * ^C
- * 
+ *
  * The output begins by showing a rate of new processes over 120 per second.
- * 
- * 
+ *
+ *
  * The following example shows a Linux build launched at 6:33:40, on a 36 CPU
  * server, with make -j36:
- * 
+ *
  * # ./pidpersec.bt
  * Attaching 4 probes...
  * Tracing new processes... Hit Ctrl-C to end.
@@ -31,7 +31,7 @@
  * 06:33:41 PIDs/sec: @: 2517
  * 06:33:42 PIDs/sec: @: 1345
  * 06:33:43 PIDs/sec: @: 1752
- * 
+ *
  * A Linux kernel build involves launched many thousands of short-lived processes,
  * which can be seen in the above output: a rate of over 1,000 processes per
  * second.
@@ -54,7 +54,7 @@ tracepoint:sched:sched_process_fork
 	@ = count();
 }
 
-interval:s:1
+interval:1s
 {
 	time("%H:%M:%S PIDs/sec: ");
 	print(@);

--- a/tools/swapin.bt
+++ b/tools/swapin.bt
@@ -3,33 +3,33 @@
  * swapin - Show swapins by process.
  *
  * See BPF Performance Tools, Chapter 7, for an explanation of this tool.
- * 
+ *
  * Example of usage:
- * 
+ *
  * # ./swapin.bt
  * Attaching 2 probes...
  * 13:36:59
- * 
+ *
  * 13:37:00
  * @[chrome, 4536]: 10809
  * @[gnome-shell, 2239]: 12410
- * 
+ *
  * 13:37:01
  * @[chrome, 4536]: 3826
- * 
+ *
  * 13:37:02
  * @[cron, 1180]: 23
  * @[gnome-shell, 2239]: 2462
- * 
+ *
  * 13:37:03
  * @[gnome-shell, 1444]: 4
  * @[gnome-shell, 2239]: 3420
- * 
+ *
  * 13:37:04
- * 
+ *
  * 13:37:05
  * [...]
- * 
+ *
  * While tracing, this showed that PID 2239 (gnome-shell) and PID 4536 (chrome)
  * suffered over ten thousand swapins.
  *
@@ -55,7 +55,7 @@ kprobe:swap_read_folio
         @[comm, pid] = count();
 }
 
-interval:s:1
+interval:1s
 {
         time();
         print(@);

--- a/tools/vfsstat.bt
+++ b/tools/vfsstat.bt
@@ -5,9 +5,9 @@
  *
  * Written as a basic example of counting multiple events and printing a
  * per-second summary.
- * 
+ *
  * Example of usage:
- * 
+ *
  * # ./vfsstat.bt
  * Attaching 8 probes...
  * Tracing key VFS calls... Hit Ctrl-C to end.
@@ -15,23 +15,23 @@
  * @[vfs_write]: 1274
  * @[vfs_open]: 8675
  * @[vfs_read]: 11515
- * 
+ *
  * 21:30:39
  * @[vfs_write]: 1155
  * @[vfs_open]: 8077
  * @[vfs_read]: 10398
- * 
+ *
  * 21:30:40
  * @[vfs_write]: 1222
  * @[vfs_open]: 8554
  * @[vfs_read]: 11011
- * 
+ *
  * 21:30:41
  * @[vfs_write]: 1230
  * @[vfs_open]: 8605
  * @[vfs_read]: 11077
  * ^C
- * 
+ *
  * Each second, a timestamp is printed ("HH:MM:SS") followed by common VFS
  * functions and the number of calls for that second. While tracing, the vfs_read()
  * kernel function was most frequent, occurring over 10,000 times per second.
@@ -59,7 +59,7 @@ kprobe:vfs_create
 	@[func] = count();
 }
 
-interval:s:1
+interval:1s
 {
 	time();
 	print(@);


### PR DESCRIPTION
This includes: ns, us, ms, s, m, h, d

This also allows users to pass duration
literals into interval and profile probes
as the second argument e.g.

`interval:1s` instead of `interval:s:1`

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
