### PR TITLE
util: add OpaqueValue to replace `std::vector<uint8_t>`

### DIFF
--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(util STATIC
   io.cpp
   kernel.cpp
   math.cpp
+  opaque.cpp
   paths.cpp
   result.cpp
   strings.cpp

--- a/src/util/opaque.cpp
+++ b/src/util/opaque.cpp
@@ -1,0 +1,56 @@
+#include <cstring>
+#include <functional>
+#include <iomanip>
+
+#include "util/opaque.h"
+
+namespace bpftrace::util {
+
+bool OpaqueValue::operator==(const OpaqueValue &other) const
+{
+  if (size() != other.size()) {
+    return false;
+  }
+  return std::memcmp(data(), other.data(), size()) == 0;
+}
+
+bool OpaqueValue::operator!=(const OpaqueValue &other) const
+{
+  return !(*this == other);
+}
+
+bool OpaqueValue::operator<(const OpaqueValue &other) const
+{
+  size_t min_len = std::min(size(), other.size());
+  int cmp = std::memcmp(data(), other.data(), min_len);
+  if (cmp != 0) {
+    return cmp < 0;
+  }
+  return size() < other.size();
+}
+
+size_t OpaqueValue::hash() const
+{
+  const char *backing_data = data();
+  // We don't expect hashing to be common, but we do use the OpaqueValue as the
+  // key for some map. We just use the simple djb2 algorithm, which should be
+  // fine across a range of different data.
+  size_t hash_value = 5381;
+  for (size_t i = 0; i < size(); i++) {
+    hash_value = ((hash_value << 5) + hash_value) +
+                 static_cast<unsigned char>(backing_data[i]);
+  }
+  return hash_value;
+}
+
+std::ostream &operator<<(std::ostream &out, const OpaqueValue &value)
+{
+  const char *data = value.data();
+  for (size_t i = 0; i < value.size(); i++) {
+    out << std::hex << std::setfill('0') << std::setw(2)
+        << static_cast<unsigned int>(static_cast<unsigned char>(data[i]));
+  }
+  return out;
+}
+
+} // namespace bpftrace::util

--- a/src/util/opaque.h
+++ b/src/util/opaque.h
@@ -1,0 +1,205 @@
+#pragma once
+
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <variant>
+
+namespace bpftrace::util {
+
+// OpaqueValue corresponds to a blob of type-erased memory. It owns its own
+// underlying memory, taking a copy if necessary. This allows it to be used
+// to read maps, rings, and other locations which may not be permanent.
+//
+// This class does not really provide safety beyond first-order memory safety.
+class OpaqueValue {
+private:
+  struct OwnedBuffer {
+    OwnedBuffer(char *data) : data(data) {};
+    OwnedBuffer(const OwnedBuffer &other) = delete;
+    OwnedBuffer(OwnedBuffer &&other) = delete;
+    OwnedBuffer &operator=(const OwnedBuffer &other) = delete;
+    OwnedBuffer &operator=(OwnedBuffer &&other) = delete;
+    ~OwnedBuffer()
+    {
+      free(data);
+    }
+    char *data;
+  };
+  using SharedMemory = std::shared_ptr<OwnedBuffer>;
+  using Storage = std::variant<uintptr_t, SharedMemory>;
+
+public:
+  // Allows for the creation of an OpaqueValue.
+  static OpaqueValue alloc(size_t length, std::function<void(char *)> init)
+  {
+    return { length, init };
+  }
+
+  // Create a zerod OpaqueValue.
+  static OpaqueValue alloc(size_t length)
+  {
+    return { length, [&](char *data) { memset(data, 0, length); } };
+  }
+
+  // Create a copy of a string.
+  static OpaqueValue string(const std::string &s, size_t sz)
+  {
+    return { sz, [&](char *data) {
+              size_t s_sz = std::min(s.size() + 1, sz);
+              memcpy(data, s.data(), s_sz);
+              memset(data + s_sz, 0, sz - s_sz);
+            } };
+  }
+
+  // Merge two OpaqueValues together.
+  OpaqueValue operator+(const OpaqueValue &other) const
+  {
+    return { size() + other.size(), [&](char *new_data) {
+              memcpy(new_data, data(), size());
+              memcpy(new_data + size(), other.data(), other.size());
+            } };
+  }
+
+  // Creates a copy of any type that has an iterator.
+  //
+  // This requires that the underlying type has a simple `from`, so we can't do
+  // complex types like strings in this way. This is intended for use in tests
+  // only and is therefore not optimized for performance in any way.
+  template <std::ranges::range T>
+  static OpaqueValue from(const T &other)
+  {
+    OpaqueValue res;
+    for (const auto &v : other) {
+      res = res + from(v);
+    }
+    if constexpr (std::is_same_v<T, std::string>) {
+      res = res + OpaqueValue::from<char>(0);
+    }
+    return res;
+  }
+
+  // Creates an OpaqueValue from an existing region.
+  template <typename T>
+  static OpaqueValue from(const T *orig_data, size_t length)
+  {
+    return { sizeof(T) * length, [&](char *data) {
+              memcpy(data,
+                     reinterpret_cast<const char *>(orig_data),
+                     sizeof(T) * length);
+            } };
+  }
+
+  // Creates a new OpaqueValue from any trivial type.
+  template <typename T>
+    requires(std::is_trivially_copyable_v<T>)
+  static OpaqueValue from(const T &other)
+  {
+    return { sizeof(other),
+             [&](char *data) { memcpy(data, &other, sizeof(other)); } };
+  }
+
+  // Returns bytes available.
+  size_t size() const
+  {
+    return length_ - offset_;
+  }
+
+  // Return the number of values that may fit.
+  template <typename T>
+  size_t count() const
+  {
+    return size() / sizeof(T);
+  }
+
+  // Creates a slice from an existing OpaqueValue.
+  //
+  // This does not copy any memory, and relies on the original ownership
+  // semantics for the current OpaqueValue.
+  OpaqueValue slice(size_t offset,
+                    std::optional<size_t> length = std::nullopt) const
+  {
+    size_t l = length ? *length : size() - offset;
+    check(offset, l);
+    return { mem_, offset_ + offset, offset_ + offset + l };
+  }
+
+  // Returns a pointer to the underlying memory for this object.
+  //
+  // This does not permit any mutation. The only way to mutate an OpaqueValue
+  // is with `alloc` that allows for construction-time mutation.
+  const char *data() const
+  {
+    if (std::holds_alternative<uintptr_t>(mem_)) {
+      const auto *ptr = std::get_if<uintptr_t>(&mem_);
+      return reinterpret_cast<const char *>(ptr) + offset_;
+    } else {
+      const auto &obj = std::get<SharedMemory>(mem_);
+      return obj->data + offset_;
+    }
+  }
+
+  template <typename T>
+  const T &bitcast(size_t index = 0) const
+  {
+    check(sizeof(T) * index, sizeof(T));
+    return reinterpret_cast<const T *>(data())[index];
+  }
+
+  bool operator==(const OpaqueValue &other) const;
+  bool operator!=(const OpaqueValue &other) const;
+  bool operator<(const OpaqueValue &other) const;
+  size_t hash() const;
+
+private:
+  // Creates an OpaqueValue of size zero.
+  OpaqueValue() : mem_(static_cast<uintptr_t>(0)) {};
+
+  // Creates a new OpaqueValue.
+  OpaqueValue(size_t length, std::function<void(char *)> init) : length_(length)
+  {
+    if (length > sizeof(uintptr_t)) {
+      auto *new_data = static_cast<char *>(malloc(length));
+      if (new_data == nullptr) {
+        throw std::bad_alloc();
+      }
+      mem_ = std::make_shared<OwnedBuffer>(new_data);
+    }
+    init(const_cast<char *>(data()));
+  }
+
+  // Low-level constructor.
+  OpaqueValue(Storage mem, size_t offset, size_t length)
+      : mem_(std::move(mem)), offset_(offset), length_(length) {};
+
+  void check(size_t offset, size_t length) const
+  {
+    // Check for overflow and underflow.
+    if (offset_ + offset < offset_ ||
+        offset_ + offset + length < offset_ + offset ||
+        offset_ + offset + length > length_) {
+      throw std::bad_alloc();
+    }
+  }
+
+  Storage mem_;
+  size_t offset_ = 0;
+  size_t length_ = 0;
+};
+
+std::ostream &operator<<(std::ostream &out, const OpaqueValue &value);
+
+} // namespace bpftrace::util
+
+namespace std {
+template <>
+struct hash<bpftrace::util::OpaqueValue> {
+  size_t operator()(const bpftrace::util::OpaqueValue &value) const
+  {
+    return value.hash();
+  }
+};
+} // namespace std

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(bpftrace_test
   macro_expansion.cpp
   main.cpp
   mocks.cpp
+  opaque.cpp
   output.cpp
   parser.cpp
   portability_analyser.cpp

--- a/tests/opaque.cpp
+++ b/tests/opaque.cpp
@@ -1,0 +1,387 @@
+#include "util/opaque.h"
+#include "gtest/gtest.h"
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace bpftrace::util::test::opaque {
+
+TEST(OpaqueValueTest, BasicAllocation)
+{
+  auto value = OpaqueValue::alloc(10, [](char* data) {
+    for (int i = 0; i < 10; ++i) {
+      data[i] = static_cast<char>(i);
+    }
+  });
+
+  EXPECT_EQ(value.size(), 10);
+  const char* data = value.data();
+  for (int i = 0; i < 10; ++i) {
+    EXPECT_EQ(data[i], static_cast<char>(i));
+  }
+}
+
+TEST(OpaqueValueTest, ZeroSizeAllocation)
+{
+  auto value = OpaqueValue::alloc(0);
+  EXPECT_EQ(value.size(), 0);
+}
+
+TEST(OpaqueValueTest, StringCreation)
+{
+  std::string test_str = "hello";
+  auto value = OpaqueValue::string(test_str, 10);
+
+  EXPECT_EQ(value.size(), 10);
+  const char* data = value.data();
+  EXPECT_STREQ(data, "hello");
+
+  for (size_t i = test_str.size() + 1; i < 10; ++i) {
+    EXPECT_EQ(data[i], 0);
+  }
+}
+
+TEST(OpaqueValueTest, StringCreationExactSize)
+{
+  std::string test_str = "hello";
+  auto value = OpaqueValue::string(test_str, test_str.size() + 1);
+
+  EXPECT_EQ(value.size(), 6);
+  EXPECT_STREQ(value.data(), "hello");
+}
+
+TEST(OpaqueValueTest, StringCreationTruncated)
+{
+  std::string test_str = "hello world";
+  auto value = OpaqueValue::string(test_str, 5);
+
+  EXPECT_EQ(value.size(), 5);
+  const char* data = value.data();
+  EXPECT_EQ(std::string(data, 5), "hello");
+}
+
+TEST(OpaqueValueTest, FromTrivialTypes)
+{
+  int test_int = 42;
+  auto int_value = OpaqueValue::from(test_int);
+
+  EXPECT_EQ(int_value.size(), sizeof(int));
+  EXPECT_EQ(int_value.bitcast<int>(), 42);
+
+  double test_double = std::numbers::pi;
+  auto double_value = OpaqueValue::from(test_double);
+
+  EXPECT_EQ(double_value.size(), sizeof(double));
+  EXPECT_DOUBLE_EQ(double_value.bitcast<double>(), std::numbers::pi);
+}
+
+TEST(OpaqueValueTest, FromPointerAndLength)
+{
+  int test_array[] = { 1, 2, 3, 4, 5 };
+  auto value = OpaqueValue::from(test_array, 5);
+
+  EXPECT_EQ(value.size(), sizeof(int) * 5);
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(value.bitcast<int>(i), i + 1);
+  }
+}
+
+TEST(OpaqueValueTest, FromVector)
+{
+  std::vector<int> test_vec = { 10, 20, 30 };
+  auto value = OpaqueValue::from(test_vec);
+
+  EXPECT_EQ(value.size(), sizeof(int) * 3);
+  for (size_t i = 0; i < 3; ++i) {
+    EXPECT_EQ(value.bitcast<int>(i), test_vec[i]);
+  }
+}
+
+TEST(OpaqueValueTest, FromStringRange)
+{
+  std::string test_str = "abc";
+  auto value = OpaqueValue::from(test_str);
+
+  // Should include null terminator.
+  EXPECT_EQ(value.size(), 4);
+  EXPECT_STREQ(value.data(), "abc");
+}
+
+TEST(OpaqueValueTest, Concatenation)
+{
+  auto value1 = OpaqueValue::from<int>(42);
+  auto value2 = OpaqueValue::from<double>(std::numbers::pi);
+
+  auto combined = value1 + value2;
+
+  EXPECT_EQ(combined.size(), sizeof(int) + sizeof(double));
+  EXPECT_EQ(combined.bitcast<int>(0), 42);
+  EXPECT_DOUBLE_EQ(combined.slice(sizeof(int)).bitcast<double>(0),
+                   std::numbers::pi);
+}
+
+TEST(OpaqueValueTest, MultipleConcatenations)
+{
+  auto value1 = OpaqueValue::from(1);
+  auto value2 = OpaqueValue::from(2);
+  auto value3 = OpaqueValue::from(3);
+
+  auto combined = value1 + value2 + value3;
+
+  EXPECT_EQ(combined.size(), sizeof(int) * 3);
+  EXPECT_EQ(combined.bitcast<int>(0), 1);
+  EXPECT_EQ(combined.bitcast<int>(1), 2);
+  EXPECT_EQ(combined.bitcast<int>(2), 3);
+}
+
+TEST(OpaqueValueTest, BasicSlicing)
+{
+  auto value = OpaqueValue::alloc(10, [](char* data) {
+    for (int i = 0; i < 10; ++i) {
+      data[i] = static_cast<char>(i);
+    }
+  });
+
+  auto slice = value.slice(2, 5);
+
+  EXPECT_EQ(slice.size(), 5);
+  const char* data = slice.data();
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(data[i], static_cast<char>(i + 2));
+  }
+}
+
+TEST(OpaqueValueTest, SlicingToEnd)
+{
+  auto value = OpaqueValue::alloc(10, [](char* data) {
+    for (int i = 0; i < 10; ++i) {
+      data[i] = static_cast<char>(i);
+    }
+  });
+
+  auto slice = value.slice(3);
+
+  EXPECT_EQ(slice.size(), 7);
+  const char* data = slice.data();
+  for (int i = 0; i < 7; ++i) {
+    EXPECT_EQ(data[i], static_cast<char>(i + 3));
+  }
+}
+
+TEST(OpaqueValueTest, NestedSlicing)
+{
+  auto value = OpaqueValue::alloc(10, [](char* data) {
+    for (int i = 0; i < 10; ++i) {
+      data[i] = static_cast<char>(i);
+    }
+  });
+
+  auto slice1 = value.slice(2, 6);
+  auto slice2 = slice1.slice(1, 3);
+
+  EXPECT_EQ(slice2.size(), 3);
+  const char* data = slice2.data();
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(data[i], static_cast<char>(i + 3));
+  }
+}
+
+TEST(OpaqueValueTest, CountMethod)
+{
+  constexpr size_t kSize = 20;
+  auto value = OpaqueValue::alloc(kSize,
+                                  [](char* data) { memset(data, 0, kSize); });
+
+  EXPECT_EQ(value.count<int>(), kSize / sizeof(int));
+  EXPECT_EQ(value.count<char>(), kSize / sizeof(char));
+  EXPECT_EQ(value.count<double>(), kSize / sizeof(double));
+}
+
+TEST(OpaqueValueTest, BitcastWithIndex)
+{
+  int test_array[] = { 10, 20, 30, 40 };
+  auto value = OpaqueValue::from(test_array, 4);
+
+  EXPECT_EQ(value.bitcast<int>(0), 10);
+  EXPECT_EQ(value.bitcast<int>(1), 20);
+  EXPECT_EQ(value.bitcast<int>(2), 30);
+  EXPECT_EQ(value.bitcast<int>(3), 40);
+}
+
+TEST(OpaqueValueTest, EqualityOperator)
+{
+  auto value1 = OpaqueValue::from(42);
+  auto value2 = OpaqueValue::from(42);
+  auto value3 = OpaqueValue::from(43);
+
+  EXPECT_TRUE(value1 == value2);
+  EXPECT_FALSE(value1 == value3);
+  EXPECT_FALSE(value1 != value2);
+  EXPECT_TRUE(value1 != value3);
+}
+
+TEST(OpaqueValueTest, EqualityDifferentSizes)
+{
+  auto value1 = OpaqueValue::from(42);
+  auto value2 = OpaqueValue::from(42.0);
+
+  EXPECT_FALSE(value1 == value2);
+  EXPECT_TRUE(value1 != value2);
+}
+
+TEST(OpaqueValueTest, EqualityWithSlices)
+{
+  auto value1 = OpaqueValue::alloc(8, [](char* data) {
+    memcpy(data, "abcdefgh", 8);
+  });
+
+  auto value2 = OpaqueValue::alloc(4,
+                                   [](char* data) { memcpy(data, "cdef", 4); });
+
+  auto slice = value1.slice(2, 4);
+
+  EXPECT_TRUE(slice == value2);
+  EXPECT_FALSE(slice != value2);
+}
+
+TEST(OpaqueValueTest, LessThanOperator)
+{
+  auto value1 = OpaqueValue::alloc(4,
+                                   [](char* data) { memcpy(data, "aaaa", 4); });
+
+  auto value2 = OpaqueValue::alloc(4,
+                                   [](char* data) { memcpy(data, "aaab", 4); });
+
+  auto value3 = OpaqueValue::alloc(3,
+                                   [](char* data) { memcpy(data, "aaa", 3); });
+
+  EXPECT_TRUE(value1 < value2);
+  EXPECT_FALSE(value2 < value1);
+  EXPECT_TRUE(value3 < value1); // Shorter length should be less.
+}
+
+TEST(OpaqueValueTest, HashFunctionality)
+{
+  auto value1 = OpaqueValue::from(42);
+  auto value2 = OpaqueValue::from(42);
+  auto value3 = OpaqueValue::from(43);
+
+  EXPECT_EQ(value1.hash(), value2.hash());
+  EXPECT_NE(value1.hash(), value3.hash());
+
+  std::hash<OpaqueValue> hasher;
+  EXPECT_EQ(hasher(value1), hasher(value2));
+  EXPECT_NE(hasher(value1), hasher(value3));
+}
+
+TEST(OpaqueValueTest, SliceOutOfBounds)
+{
+  auto value = OpaqueValue::alloc(10, [](char* data) { memset(data, 0, 10); });
+
+  EXPECT_THROW(value.slice(15), std::bad_alloc);
+  EXPECT_THROW(value.slice(5, 10), std::bad_alloc);
+  EXPECT_THROW(value.slice(0, 15), std::bad_alloc);
+}
+
+TEST(OpaqueValueTest, BitcastOutOfBounds)
+{
+  auto value = OpaqueValue::from<int>(42);
+
+  EXPECT_THROW(value.bitcast<int>(1), std::bad_alloc);
+  EXPECT_THROW(value.bitcast<double>(0), std::bad_alloc);
+}
+
+TEST(OpaqueValueTest, LargeAllocation)
+{
+  size_t large_size = 1024;
+  auto value = OpaqueValue::alloc(large_size, [large_size](char* data) {
+    for (size_t i = 0; i < large_size; ++i) {
+      data[i] = static_cast<char>(i % 256);
+    }
+  });
+
+  EXPECT_EQ(value.size(), large_size);
+  const char* data = value.data();
+  for (size_t i = 0; i < large_size; ++i) {
+    EXPECT_EQ(data[i], static_cast<char>(i % 256));
+  }
+}
+
+TEST(OpaqueValueTest, SmallAllocation)
+{
+  size_t small_size = sizeof(uintptr_t);
+  auto value = OpaqueValue::alloc(small_size, [small_size](char* data) {
+    for (size_t i = 0; i < small_size; ++i) {
+      data[i] = static_cast<char>(i);
+    }
+  });
+
+  EXPECT_EQ(value.size(), small_size);
+  const char* data = value.data();
+  for (size_t i = 0; i < small_size; ++i) {
+    EXPECT_EQ(data[i], static_cast<char>(i));
+  }
+}
+
+TEST(OpaqueValueTest, CopySemanticsSmall)
+{
+  auto original = OpaqueValue::alloc(1);
+  auto copy = OpaqueValue(original);
+
+  // These should always be stored inline.
+  EXPECT_NE(original.data(), copy.data());
+  EXPECT_TRUE(original == copy);
+}
+
+TEST(OpaqueValueTest, CopySemanticsLarge)
+{
+  auto original = OpaqueValue::alloc(10, [](char* data) {
+    for (int i = 0; i < 10; ++i) {
+      data[i] = static_cast<char>(i);
+    }
+  });
+  auto copy = OpaqueValue(original);
+  EXPECT_EQ(original.data(), copy.data());
+  EXPECT_TRUE(original == copy);
+
+  auto slice1 = copy.slice(2, 4);
+  auto slice2 = copy.slice(2, 4);
+
+  // Both slices should reference the same underlying data.
+  EXPECT_EQ(slice1.data(), slice2.data());
+  EXPECT_TRUE(slice1 == slice2);
+}
+
+TEST(OpaqueValueTest, ConcatenationWithEmpty)
+{
+  auto empty = OpaqueValue::alloc(0);
+  auto value = OpaqueValue::from(42);
+
+  auto result1 = empty + value;
+  auto result2 = value + empty;
+
+  EXPECT_EQ(result1.size(), sizeof(int));
+  EXPECT_EQ(result2.size(), sizeof(int));
+  EXPECT_EQ(result1.bitcast<int>(), 42);
+  EXPECT_EQ(result2.bitcast<int>(), 42);
+}
+
+TEST(OpaqueValueTest, ComplexTypeCombinations)
+{
+  auto int_val = OpaqueValue::from(42);
+  auto double_val = OpaqueValue::from(std::numbers::pi);
+  auto string_val = OpaqueValue::string("test", 8);
+
+  auto combined = int_val + double_val + string_val;
+
+  EXPECT_EQ(combined.size(), sizeof(int) + sizeof(double) + 8);
+  EXPECT_EQ(combined.bitcast<int>(0), 42);
+
+  auto double_slice = combined.slice(sizeof(int), sizeof(double));
+  EXPECT_DOUBLE_EQ(double_slice.bitcast<double>(), std::numbers::pi);
+
+  auto string_slice = combined.slice(sizeof(int) + sizeof(double), 8);
+  EXPECT_STREQ(string_slice.data(), "test");
+}
+
+} // namespace bpftrace::util::test::opaque


### PR DESCRIPTION
Stacked PRs:
 * #4323
 * #4322
 * #4321
 * __->__#4320


--- --- ---

### util: add OpaqueValue to replace `std::vector<uint8_t>`


This can be used to add safety and reduce copying. It is intended to
replace the ad-hoc ues of the `util::read_data` and other similar
methods which do not have any inherit bounds checks.

Signed-off-by: Adin Scannell <amscanne@meta.com>
