### PR TITLE
core: use `OpaqueValue` for async dispatch

### DIFF
--- a/src/async_action.h
+++ b/src/async_action.h
@@ -38,20 +38,20 @@ public:
                 output::Output &output)
       : bpftrace(bpftrace), c_definitions(c_definitions), out(output) {};
 
-  void exit(const void *data);
-  void join(const void *data);
-  void time(const void *data);
-  void helper_error(const void *data);
-  void print_non_map(const void *data);
-  void print_map(const void *data);
-  void zero_map(const void *data);
-  void clear_map(const void *data);
-  void watchpoint_attach(const void *data);
-  void watchpoint_detach(const void *data);
-  void skboutput(void *data, int size);
-  void syscall(AsyncAction printf_id, uint8_t *arg_data);
-  void cat(AsyncAction printf_id, uint8_t *arg_data);
-  void printf(AsyncAction printf_id, uint8_t *arg_data);
+  void exit(const OpaqueValue &data);
+  void join(const OpaqueValue &data);
+  void time(const OpaqueValue &data);
+  void helper_error(const OpaqueValue &data);
+  void print_non_map(const OpaqueValue &data);
+  void print_map(const OpaqueValue &data);
+  void zero_map(const OpaqueValue &data);
+  void clear_map(const OpaqueValue &data);
+  void watchpoint_attach(const OpaqueValue &data);
+  void watchpoint_detach(const OpaqueValue &data);
+  void skboutput(const OpaqueValue &data);
+  void syscall(const OpaqueValue &data);
+  void cat(const OpaqueValue &data);
+  void printf(const OpaqueValue &data);
 
 private:
   BPFtrace &bpftrace;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -164,7 +164,7 @@ public:
   std::vector<std::unique_ptr<IPrintable>> get_arg_values(
       const ast::CDefinitions &c_definitions,
       const std::vector<Field> &args,
-      uint8_t *arg_data);
+      const char *arg_data);
   void add_param(const std::string &param);
   std::string get_param(size_t index) const;
   size_t num_params() const;
@@ -178,8 +178,7 @@ public:
       const std::string &name) const;
   virtual const std::optional<struct stat> &get_pidns_self_stat() const;
 
-  bool write_pcaps(uint64_t id, uint64_t ns, uint8_t *pkt, unsigned int size);
-
+  bool write_pcaps(uint64_t id, uint64_t ns, const OpaqueValue &pkt);
   void parse_module_btf(const std::set<std::string> &modules);
   bool has_btf_data() const;
   Dwarf *get_dwarf(const std::string &filename);

--- a/src/pcap_writer.cpp
+++ b/src/pcap_writer.cpp
@@ -24,7 +24,7 @@ void PCAPwriter::close()
 #define NSEC_PER_SEC 1000000000L
 #define NSEC_PER_USEC 1000L
 
-bool PCAPwriter::write(uint64_t ns, void *pkt, unsigned int size)
+bool PCAPwriter::write(uint64_t ns, const void *pkt, unsigned int size)
 {
   time_t secs, usecs, nsecs = ns;
 

--- a/src/pcap_writer.h
+++ b/src/pcap_writer.h
@@ -19,7 +19,7 @@ public:
   bool open(std::string file);
   void close();
 
-  bool write(uint64_t ns, void *pkt, unsigned int size);
+  bool write(uint64_t ns, const void *pkt, unsigned int size);
 
 private:
   pcap_t *pd_;

--- a/src/printf.h
+++ b/src/printf.h
@@ -64,7 +64,7 @@ private:
 
 class PrintableBuffer : public virtual IPrintable {
 public:
-  PrintableBuffer(char* buffer, size_t size)
+  PrintableBuffer(const char* buffer, size_t size)
       : value_(std::vector<char>(buffer, buffer + size))
   {
   }

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -81,19 +81,19 @@ kprobe:f
   // a perf event buffer
   EXPECT_TRUE(args[0].type.IsIntTy());
   EXPECT_EQ(args[0].type.GetSize(), 8U);
-  EXPECT_EQ(args[0].offset, 8);
+  EXPECT_EQ(args[0].offset, 0);
 
   EXPECT_TRUE(args[1].type.IsIntTy());
   EXPECT_EQ(args[1].type.GetSize(), 8U);
-  EXPECT_EQ(args[1].offset, 16);
+  EXPECT_EQ(args[1].offset, 8);
 
   EXPECT_TRUE(args[2].type.IsStringTy());
   EXPECT_EQ(args[2].type.GetSize(), 10U);
-  EXPECT_EQ(args[2].offset, 24);
+  EXPECT_EQ(args[2].offset, 16);
 
   EXPECT_TRUE(args[3].type.IsIntTy());
   EXPECT_EQ(args[3].type.GetSize(), 8U);
-  EXPECT_EQ(args[3].offset, 40);
+  EXPECT_EQ(args[3].offset, 32);
 }
 
 TEST(codegen, probe_count)

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -4,7 +4,8 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr }
-%printf_t = type { i64, i64, i64 }
+%printf_t = type { i64, %printf_args_t }
+%printf_args_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -31,39 +32,40 @@ entry:
   call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 24, i1 false)
   %3 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
   store i64 0, ptr %3, align 8
-  %4 = load i64, ptr %"$foo", align 8
-  %5 = inttoptr i64 %4 to ptr
-  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
-  %7 = getelementptr i8, ptr %6, i64 0
+  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
+  %5 = load i64, ptr %"$foo", align 8
+  %6 = inttoptr i64 %5 to ptr
+  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
+  %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.c", i32 1, ptr %7)
-  %8 = load i8, ptr %"struct Foo.c", align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.c", i32 1, ptr %8)
+  %9 = load i8, ptr %"struct Foo.c", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.c")
-  %9 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
-  %10 = sext i8 %8 to i64
-  store i64 %10, ptr %9, align 8
-  %11 = load i64, ptr %"$foo", align 8
-  %12 = inttoptr i64 %11 to ptr
-  %13 = call ptr @llvm.preserve.static.offset(ptr %12)
-  %14 = getelementptr i8, ptr %13, i64 8
+  %10 = getelementptr %printf_args_t, ptr %4, i32 0, i32 0
+  %11 = sext i8 %9 to i64
+  store i64 %11, ptr %10, align 8
+  %12 = load i64, ptr %"$foo", align 8
+  %13 = inttoptr i64 %12 to ptr
+  %14 = call ptr @llvm.preserve.static.offset(ptr %13)
+  %15 = getelementptr i8, ptr %14, i64 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.l")
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, ptr %14)
-  %15 = load i64, ptr %"struct Foo.l", align 8
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, ptr %15)
+  %16 = load i64, ptr %"struct Foo.l", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.l")
-  %16 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 2
-  store i64 %15, ptr %16, align 8
+  %17 = getelementptr %printf_args_t, ptr %4, i32 0, i32 1
+  store i64 %16, ptr %17, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
-  %17 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %17
-  %18 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %19 = load i64, ptr %18, align 8
-  %20 = add i64 %19, 1
-  store i64 %20, ptr %18, align 8
+  %18 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %18
+  %19 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %20 = load i64, ptr %19, align 8
+  %21 = add i64 %20, 1
+  store i64 %21, ptr %19, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %entry

--- a/tests/codegen/llvm/call_system.ll
+++ b/tests/codegen/llvm/call_system.ll
@@ -4,7 +4,8 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr }
-%system_t = type { i64, i64 }
+%system_t = type { i64, %system_args_t }
+%system_args_t = type { i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -23,19 +24,20 @@ entry:
   %1 = getelementptr %system_t, ptr %system_args, i32 0, i32 0
   store i64 10000, ptr %1, align 8
   %2 = getelementptr %system_t, ptr %system_args, i32 0, i32 1
-  store i64 100, ptr %2, align 8
+  %3 = getelementptr %system_args_t, ptr %2, i32 0, i32 0
+  store i64 100, ptr %3, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %system_args, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %3 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %3
-  %4 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %5 = load i64, ptr %4, align 8
-  %6 = add i64 %5, 1
-  store i64 %6, ptr %4, align 8
+  %4 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %4
+  %5 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %6 = load i64, ptr %5, align 8
+  %7 = add i64 %6, 1
+  store i64 %7, ptr %5, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %entry

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -4,7 +4,8 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr }
-%printf_t = type { i64, i64, i64, i64, i64 }
+%printf_t = type { i64, %printf_args_t }
+%printf_args_t = type { i64, i64, i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -37,16 +38,17 @@ entry:
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 40, i1 false)
   %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
   store i64 0, ptr %3, align 8
+  %4 = getelementptr %printf_t, ptr %2, i32 0, i32 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
-  %4 = load i64, ptr %"$foo", align 8
-  %5 = inttoptr i64 %4 to ptr
-  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
-  %7 = getelementptr i8, ptr %6, i64 0
+  %5 = load i64, ptr %"$foo", align 8
+  %6 = inttoptr i64 %5 to ptr
+  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
+  %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m")
-  %probe_read = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m", i32 4, ptr %7)
-  %8 = load i32, ptr %"struct Foo.m", align 4
+  %probe_read = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m", i32 4, ptr %8)
+  %9 = load i32, ptr %"struct Foo.m", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m")
-  %lhs_true_cond = icmp ne i32 %8, 0
+  %lhs_true_cond = icmp ne i32 %9, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
@@ -61,22 +63,22 @@ entry:
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %9 = load i8, ptr %"&&_result", align 1
-  %10 = getelementptr %printf_t, ptr %2, i32 0, i32 1
-  store i8 %9, ptr %10, align 1
+  %10 = load i8, ptr %"&&_result", align 1
+  %11 = getelementptr %printf_args_t, ptr %4, i32 0, i32 0
+  store i8 %10, ptr %11, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result5")
   br i1 true, label %"&&_lhs_true1", label %"&&_false3"
 
 "&&_lhs_true1":                                   ; preds = %"&&_merge"
-  %11 = load i64, ptr %"$foo", align 8
-  %12 = inttoptr i64 %11 to ptr
-  %13 = call ptr @llvm.preserve.static.offset(ptr %12)
-  %14 = getelementptr i8, ptr %13, i64 0
+  %12 = load i64, ptr %"$foo", align 8
+  %13 = inttoptr i64 %12 to ptr
+  %14 = call ptr @llvm.preserve.static.offset(ptr %13)
+  %15 = getelementptr i8, ptr %14, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m6")
-  %probe_read7 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m6", i32 4, ptr %14)
-  %15 = load i32, ptr %"struct Foo.m6", align 4
+  %probe_read7 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m6", i32 4, ptr %15)
+  %16 = load i32, ptr %"struct Foo.m6", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m6")
-  %rhs_true_cond = icmp ne i32 %15, 0
+  %rhs_true_cond = icmp ne i32 %16, 0
   br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
 
 "&&_true2":                                       ; preds = %"&&_lhs_true1"
@@ -88,19 +90,19 @@ entry:
   br label %"&&_merge4"
 
 "&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %16 = load i8, ptr %"&&_result5", align 1
-  %17 = getelementptr %printf_t, ptr %2, i32 0, i32 2
-  store i8 %16, ptr %17, align 1
+  %17 = load i8, ptr %"&&_result5", align 1
+  %18 = getelementptr %printf_args_t, ptr %4, i32 0, i32 1
+  store i8 %17, ptr %18, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
-  %18 = load i64, ptr %"$foo", align 8
-  %19 = inttoptr i64 %18 to ptr
-  %20 = call ptr @llvm.preserve.static.offset(ptr %19)
-  %21 = getelementptr i8, ptr %20, i64 0
+  %19 = load i64, ptr %"$foo", align 8
+  %20 = inttoptr i64 %19 to ptr
+  %21 = call ptr @llvm.preserve.static.offset(ptr %20)
+  %22 = getelementptr i8, ptr %21, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m8")
-  %probe_read9 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m8", i32 4, ptr %21)
-  %22 = load i32, ptr %"struct Foo.m8", align 4
+  %probe_read9 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m8", i32 4, ptr %22)
+  %23 = load i32, ptr %"struct Foo.m8", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m8")
-  %lhs_true_cond10 = icmp ne i32 %22, 0
+  %lhs_true_cond10 = icmp ne i32 %23, 0
   br i1 %lhs_true_cond10, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %"&&_merge4"
@@ -115,22 +117,22 @@ entry:
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %23 = load i8, ptr %"||_result", align 1
-  %24 = getelementptr %printf_t, ptr %2, i32 0, i32 3
-  store i8 %23, ptr %24, align 1
+  %24 = load i8, ptr %"||_result", align 1
+  %25 = getelementptr %printf_args_t, ptr %4, i32 0, i32 2
+  store i8 %24, ptr %25, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result15")
   br i1 false, label %"||_true13", label %"||_lhs_false11"
 
 "||_lhs_false11":                                 ; preds = %"||_merge"
-  %25 = load i64, ptr %"$foo", align 8
-  %26 = inttoptr i64 %25 to ptr
-  %27 = call ptr @llvm.preserve.static.offset(ptr %26)
-  %28 = getelementptr i8, ptr %27, i64 0
+  %26 = load i64, ptr %"$foo", align 8
+  %27 = inttoptr i64 %26 to ptr
+  %28 = call ptr @llvm.preserve.static.offset(ptr %27)
+  %29 = getelementptr i8, ptr %28, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m16")
-  %probe_read17 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m16", i32 4, ptr %28)
-  %29 = load i32, ptr %"struct Foo.m16", align 4
+  %probe_read17 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m16", i32 4, ptr %29)
+  %30 = load i32, ptr %"struct Foo.m16", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m16")
-  %rhs_true_cond18 = icmp ne i32 %29, 0
+  %rhs_true_cond18 = icmp ne i32 %30, 0
   br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
 
 "||_false12":                                     ; preds = %"||_lhs_false11"
@@ -142,21 +144,21 @@ entry:
   br label %"||_merge14"
 
 "||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %30 = load i8, ptr %"||_result15", align 1
-  %31 = getelementptr %printf_t, ptr %2, i32 0, i32 4
-  store i8 %30, ptr %31, align 1
+  %31 = load i8, ptr %"||_result15", align 1
+  %32 = getelementptr %printf_args_t, ptr %4, i32 0, i32 3
+  store i8 %31, ptr %32, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 40, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %"||_merge14"
   %get_cpu_id19 = call i64 inttoptr (i64 8 to ptr)() #4
-  %32 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded20 = and i64 %get_cpu_id19, %32
-  %33 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded20, i64 0
-  %34 = load i64, ptr %33, align 8
-  %35 = add i64 %34, 1
-  store i64 %35, ptr %33, align 8
+  %33 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded20 = and i64 %get_cpu_id19, %33
+  %34 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded20, i64 0
+  %35 = load i64, ptr %34, align 8
+  %36 = add i64 %35, 1
+  store i64 %36, ptr %34, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %"||_merge14"


### PR DESCRIPTION
Stacked PRs:
 * #4323
 * __->__#4322


--- --- ---

### core: use `OpaqueValue` for async dispatch


This effectively adds suitable bounds checking to all async dispatch
functions and standardizes the way casting and pointer munging works.

Signed-off-by: Adin Scannell <amscanne@meta.com>
