### PR TITLE
Fix up CHANGELOG.md formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,9 +79,9 @@ and this project adheres to
 - Change "Attaching N probes..." to "Attached N probes"
   - [#4194](https://github.com/bpftrace/bpftrace/pull/4194)
 - runqlat.bt: ignore idle task
-    [#4194](https://github.com/bpftrace/bpftrace/pull/4291)
+  - [#4194](https://github.com/bpftrace/bpftrace/pull/4291)
 - Only cache symbols from targeted process
-    [#4315](https://github.com/bpftrace/bpftrace/pull/4315)
+  - [#4315](https://github.com/bpftrace/bpftrace/pull/4315)
 #### Deprecated
 #### Removed
 #### Fixed


### PR DESCRIPTION
Add missing '-' to ensure consistency with the rest of the list entries; otherwise, they look a little out of place.

<img width="561" alt="Screenshot 2025-06-30 at 7 28 47 AM" src="https://github.com/user-attachments/assets/6939d507-76d8-4a7a-af7c-dee6419be89b" />