### PR TITLE
imports: Allow `ensure_import` call for other passes to add imports

### DIFF
--- a/src/ast/passes/resolve_imports.h
+++ b/src/ast/passes/resolve_imports.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -10,7 +11,13 @@
 #include "ast/context.h"
 #include "ast/pass_manager.h"
 
-namespace bpftrace::ast {
+namespace bpftrace {
+
+class BPFtrace;
+
+namespace ast {
+
+class ASTContext;
 
 // LoadedObject is a generic wrapper around some data that was either embedded,
 // or has been loaded off the filesystem. We no longer depend on any files.
@@ -58,8 +65,22 @@ public:
   std::map<std::string, LoadedObject> c_headers;
   std::map<std::string, ExternalObject> objects;
   std::map<std::string, ASTContext> scripts;
+
+  // Record full packages/directories that have been imported separately from
+  // the specific modules, in order to avoid re-importing these paths.
+  std::unordered_set<std::string> packages;
 };
 
+// Ensure the existing of some internal import.
+Result<> ensure_import(ASTContext &ast,
+                       BPFtrace &b,
+                       Imports &imports,
+                       const std::string &name);
+
+// This pass resolves imports from the AST itself. It produces an `Imports`
+// object. This can later be added to via the `ensure_import` function call
+// above, if needed.
 Pass CreateResolveImportsPass(std::vector<std::string> &&import_paths);
 
-} // namespace bpftrace::ast
+} // namespace ast
+} // namespace bpftrace


### PR DESCRIPTION
imports: Allow `ensure_import` call for other passes to add imports

Signed-off-by: Adin Scannell <amscanne@meta.com>