### PR TITLE
codegen: generate `vmlinux.h` automatically for BPF C code

### DIFF
--- a/src/ast/passes/clang_build.cpp
+++ b/src/ast/passes/clang_build.cpp
@@ -22,6 +22,7 @@
 #include "ast/passes/clang_build.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/resolve_imports.h"
+#include "bpftrace.h"
 #include "stdlib/stdlib.h"
 #include "util/result.h"
 
@@ -113,6 +114,7 @@ Result<PipeFds> create_pipe()
 static Result<> build(CompileContext &ctx,
                       const std::string &name,
                       LoadedObject &obj,
+                      const llvm::MemoryBufferRef &vmlinux_h,
                       Imports &imports,
                       BitcodeModules &result)
 {
@@ -129,6 +131,7 @@ static Result<> build(CompileContext &ctx,
                  0,
                  llvm::MemoryBuffer::getMemBufferCopy(other.data(), name));
   }
+  vfs->addFileNoOwn("include/vmlinux.h", 0, vmlinux_h);
 
   // Create the diagnostic options and client. We emit the error to
   // a string, which we can then capture and associate with the import.
@@ -217,22 +220,39 @@ static Result<> build(CompileContext &ctx,
 
 ast::Pass CreateClangBuildPass()
 {
-  return ast::Pass::create("ClangBuilder",
-                           [](CompileContext &ctx,
-                              ast::Imports &imports) -> Result<BitcodeModules> {
-                             BitcodeModules result;
+  return ast::Pass::create(
+      "ClangBuilder",
+      [](BPFtrace &bpftrace,
+         CompileContext &ctx,
+         ast::Imports &imports) -> Result<BitcodeModules> {
+        BitcodeModules result;
 
-                             // For each of the source files in the imports, we
-                             // build it and turn it into a bitcode file.
-                             for (auto &[name, obj] : imports.c_sources) {
-                               auto ok = build(ctx, name, obj, imports, result);
-                               if (!ok) {
-                                 return ok.takeError();
-                               }
-                             }
+        // Nothing to do? Return directly.
+        if (imports.c_sources.empty()) {
+          return result;
+        }
 
-                             return result;
-                           });
+        // Construct our kernel headers. This is a rather expensive operation,
+        // so we ensure that we do this only once for all files.
+        std::string vmlinux_h = bpftrace.btf_->c_def();
+
+        // For each of the source files in the imports, we
+        // build it and turn it into a bitcode file.
+        for (auto &[name, obj] : imports.c_sources) {
+          auto ok = build(ctx,
+                          name,
+                          obj,
+                          llvm::MemoryBufferRef(llvm::StringRef(vmlinux_h),
+                                                "vmlinux.h"),
+                          imports,
+                          result);
+          if (!ok) {
+            return ok.takeError();
+          }
+        }
+
+        return result;
+      });
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/clang_parser.cpp
+++ b/src/ast/passes/clang_parser.cpp
@@ -796,7 +796,12 @@ void ClangParser::resolve_unknown_typedefs_from_btf(BPFtrace &bpftrace)
 
 CXUnsavedFile ClangParser::get_btf_generated_header(BPFtrace &bpftrace)
 {
-  btf_cdef = bpftrace.btf_->c_def(bpftrace.btf_set_);
+  // Note that `c_def` will provide the full set of types if an empty set is
+  // used here. We only want the types in `btf_set_` or nothing at all, so
+  // don't generate anything if this set is empty.
+  if (!bpftrace.btf_set_.empty()) {
+    btf_cdef = bpftrace.btf_->c_def(bpftrace.btf_set_);
+  }
   return CXUnsavedFile{
     .Filename = "/bpftrace/include/__btf_generated_header.h",
     .Contents = btf_cdef.c_str(),

--- a/src/btf.h
+++ b/src/btf.h
@@ -84,11 +84,16 @@ public:
     return btf_objects.size();
   }
   void load_module_btfs(const std::set<std::string>& modules);
-  std::string c_def(const std::unordered_set<std::string>& set);
   std::string type_of(std::string_view name, std::string_view field);
   std::string type_of(const BTFId& type_id, std::string_view field);
   SizedType get_stype(std::string_view type_name);
   SizedType get_var_type(std::string_view var_name);
+
+  // Returns a string containing the C definitions generated from the BTF data.
+  // If `set` is provided (non-empty), then the generated types will be limited
+  // to just those in the set. If `set` is not provided (empty), then all types
+  // will be generated.
+  std::string c_def(const std::unordered_set<std::string>& set = {});
 
   std::set<std::string> get_all_structs() const;
   std::unique_ptr<std::istream> get_all_funcs();


### PR DESCRIPTION
Stacked PRs:
 * #4276
 * #4332
 * __->__#4331


--- --- ---

### codegen: generate `vmlinux.h` automatically for BPF C code


Before building external sources, a single `vmlinux.h` file is generated
from the current BTF data using the `c_def` method. Note that building
this set required changing the internal generation mechanism from a
`std::string` to a `std::stringstream`, and using a `std::string`
results in endless memory churn due to the simple concatentation (it's
effectively `O(n^2)` in the length of the generated header, which is
quite substantial). Using a `std::stringstream` means that the internal
buffer is managed in a more sensible way (still taking a bit of time,
but much less noticeable).

If there are no external sources imported, then this generation does not
occur, in order to ensure that there are no regressions.

Signed-off-by: Adin Scannell <amscanne@meta.com>
