### PR TITLE
libbpf: update to include linking fix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,14 +39,18 @@
           # The default LLVM version is the latest supported release
           defaultLlvmVersion = 20;
 
-          # Override to specify the libbpf build we want
-          libbpfVersion = "1.5.0";
+          # Override to specify the libbpf build we want. Note that we need to
+          # capture a specific fix for linking which is not yet present in a
+          # release. Once this fix is present in a release, then this should be
+          # updated to the relevant version and we need to update the version
+          # constraint in `CMakeLists.txt`.
+          libbpfVersion = "5e3306e89a44cab09693ce4bfe50bfc0cb595941";
           libbpf = pkgs.libbpf.overrideAttrs {
             version = libbpfVersion;
             src = pkgs.fetchFromGitHub {
               owner = "libbpf";
               repo = "libbpf";
-              rev = "v${libbpfVersion}";
+              rev = "${libbpfVersion}";
               # Nix uses the hash to do lookups in its cache as well as check that the
               # download from the internet hasn't changed. Therefore, it's necessary to
               # update the hash every time you update the source. Failure to update the


### PR DESCRIPTION
Stacked PRs:
 * #4276
 * #4332
 * #4331
 * __->__#4333


--- --- ---

### libbpf: update to include linking fix


To use interop reliably, we require a fix [1] for libbpf. This change
updates our flake, and we will subsequently update once a release is
made containing this fix (along with updating the contraints in
`CMakeLists.txt`).

[1] https://github.com/libbpf/libbpf/commit/b58f5a3e7778908765a00e14809718fadcf90fb8

Signed-off-by: Adin Scannell <amscanne@meta.com>
