### PR TITLE
codegen: Prefer *ARRAY* to *HASH* for scalar maps

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -213,6 +213,7 @@ AttachPoint &AttachPoint::create_expansion_copy(ASTContext &ctx,
     case ProbeType::interval:
     case ProbeType::profile:
     case ProbeType::special:
+    case ProbeType::benchmark:
     case ProbeType::iter:
     case ProbeType::invalid:
       break;
@@ -242,6 +243,7 @@ bool AttachPoint::check_available(const std::string &identifier) const
         return true;
       case ProbeType::invalid:
       case ProbeType::special:
+      case ProbeType::benchmark:
       case ProbeType::tracepoint:
       case ProbeType::fentry:
       case ProbeType::fexit:
@@ -257,6 +259,7 @@ bool AttachPoint::check_available(const std::string &identifier) const
         return true;
       case ProbeType::invalid:
       case ProbeType::special:
+      case ProbeType::benchmark:
       case ProbeType::kprobe:
       case ProbeType::kretprobe:
       case ProbeType::tracepoint:
@@ -287,6 +290,7 @@ bool AttachPoint::check_available(const std::string &identifier) const
         return true;
       case ProbeType::invalid:
       case ProbeType::special:
+      case ProbeType::benchmark:
       case ProbeType::interval:
       case ProbeType::software:
       case ProbeType::hardware:

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -157,6 +157,8 @@ AttachPointParser::State AttachPointParser::parse_attachpoint(AttachPoint &ap)
   switch (probetype(ap.provider)) {
     case ProbeType::special:
       return special_parser();
+    case ProbeType::benchmark:
+      return benchmark_parser();
     case ProbeType::kprobe:
       return kprobe_parser();
     case ProbeType::kretprobe:
@@ -283,6 +285,22 @@ AttachPointParser::State AttachPointParser::special_parser()
     }
     ap_->target = parts_[1];
     ap_->func = parts_[2];
+  }
+
+  return OK;
+}
+
+AttachPointParser::State AttachPointParser::benchmark_parser()
+{
+  // Can only have reached here if provider is `BENCHMARK`
+  assert(ap_->provider == "BENCHMARK");
+
+  if (ap_->provider == "BENCHMARK") {
+    if (parts_.size() != 2) {
+      return argument_count_error(1);
+    }
+
+    ap_->target = parts_[1];
   }
 
   return OK;

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -33,6 +33,7 @@ private:
   State lex_attachpoint(const AttachPoint &ap);
 
   State special_parser();
+  State benchmark_parser();
   State kprobe_parser(bool allow_offset = true);
   State kretprobe_parser();
   State uprobe_parser(bool allow_offset = true, bool allow_abs_addr = true);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3359,6 +3359,7 @@ int CodegenLLVM::getReturnValueForProbe(ProbeType probe_type)
       // programs bad citizens. Return 1 instead.
       return 1;
     case ProbeType::special:
+    case ProbeType::benchmark:
     case ProbeType::kprobe:
     case ProbeType::kretprobe:
     case ProbeType::uprobe:

--- a/src/ast/passes/pid_filter_pass.cpp
+++ b/src/ast/passes/pid_filter_pass.cpp
@@ -51,6 +51,7 @@ bool probe_needs_pid_filter(AttachPoint *ap)
     case ProbeType::hardware:
     // We don't filter by pid for BEGIN/END probes
     case ProbeType::special:
+    case ProbeType::benchmark:
       return false;
   }
 

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -1,5 +1,6 @@
 
 #include <algorithm>
+#include <variant>
 
 #include "ast/async_event_types.h"
 #include "ast/codegen_helper.h"
@@ -9,8 +10,10 @@
 #include "ast/visitor.h"
 #include "bpftrace.h"
 #include "log.h"
+#include "map_info.h"
 #include "required_resources.h"
 #include "struct.h"
+#include "types.h"
 
 namespace libbpf {
 #include "libbpf/bpf.h"
@@ -572,7 +575,8 @@ void ResourceAnalyser::update_map_info(Map &map)
     // hist() and lhist() transparently create additional elements in whatever
     // map they are assigned to. So even if the map looks like it has no keys,
     // multiple keys are necessary.
-    if (!map.type().IsMultiKeyMapTy() && map_info.is_scalar) {
+    if (map_info.is_scalar && !map.type().IsHistTy() &&
+        !map.type().IsLhistTy()) {
       map_info.max_entries = 1;
     } else {
       map_info.max_entries = bpftrace_.config_->max_map_keys;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -840,6 +840,7 @@ AddrSpace SemanticAnalyser::find_addrspace(ProbeType pt)
     // if addrspace cannot be detected.
     case ProbeType::invalid:
     case ProbeType::special:
+    case ProbeType::benchmark:
     case ProbeType::profile:
     case ProbeType::interval:
     case ProbeType::software:
@@ -3624,6 +3625,9 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       return;
     }
     ap.addError() << ap.target << " is not a supported trigger";
+  } else if (ap.provider == "BENCHMARK") {
+    if (!ap.func.empty())
+      ap.addError() << "BENCHMARK probes should not have a target";
   } else if (ap.provider == "fentry" || ap.provider == "fexit") {
     if (!bpftrace_.feature_->has_fentry()) {
       ap.addError() << "fentry/fexit not available for your kernel version.";

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -52,6 +52,7 @@ bpf_probe_attach_type attachtype(ProbeType t)
     case ProbeType::kprobe:    return BPF_PROBE_ENTRY;  break;
     case ProbeType::kretprobe: return BPF_PROBE_RETURN; break;
     case ProbeType::special:   return BPF_PROBE_ENTRY;  break;
+    case ProbeType::benchmark: return BPF_PROBE_ENTRY;  break;
     case ProbeType::uprobe:    return BPF_PROBE_ENTRY;  break;
     case ProbeType::uretprobe: return BPF_PROBE_RETURN; break;
     case ProbeType::usdt:      return BPF_PROBE_ENTRY;  break;
@@ -66,6 +67,7 @@ libbpf::bpf_prog_type progtype(ProbeType t)
   switch (t) {
       // clang-format off
     case ProbeType::special:    return libbpf::BPF_PROG_TYPE_RAW_TRACEPOINT; break;
+    case ProbeType::benchmark:  return libbpf::BPF_PROG_TYPE_XDP; break;
     case ProbeType::kprobe:     return libbpf::BPF_PROG_TYPE_KPROBE; break;
     case ProbeType::kretprobe:  return libbpf::BPF_PROG_TYPE_KPROBE; break;
     case ProbeType::uprobe:     return libbpf::BPF_PROG_TYPE_KPROBE; break;
@@ -1629,7 +1631,8 @@ Result<std::unique_ptr<AttachedProbe>> AttachedProbe::make(
       return AttachedUprobeProbe::make(probe, prog, pid, safe_mode);
     }
     case ProbeType::invalid:
-    case ProbeType::special: {
+    case ProbeType::special:
+    case ProbeType::benchmark: {
       LOG(BUG) << "invalid attached probe type \"" << probe.type << "\"";
     }
   }

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -206,6 +206,7 @@ void BpfBytecode::load_progs(const RequiredResources &resources,
   for (auto probe : resources.special_probes)
     special_probes.push_back(probe.second);
   prepare_progs(special_probes, btf, feature, config);
+  prepare_progs(resources.benchmark_probes, btf, feature, config);
   prepare_progs(resources.signal_probes, btf, feature, config);
   prepare_progs(resources.probes, btf, feature, config);
   prepare_progs(resources.watchpoint_probes, btf, feature, config);

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -212,7 +212,7 @@ std::string to_string(MapType t)
 
 libbpf::bpf_map_type get_bpf_map_type(const SizedType &val_type, bool scalar)
 {
-  if (scalar && !val_type.IsHistTy() && !val_type.IsLhistTy()) {
+  if (scalar && !val_type.IsHistTy()) {
     return val_type.NeedsPercpuMap() ? libbpf::BPF_MAP_TYPE_PERCPU_ARRAY
                                      : libbpf::BPF_MAP_TYPE_ARRAY;
   } else {

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -212,12 +212,12 @@ std::string to_string(MapType t)
 
 libbpf::bpf_map_type get_bpf_map_type(const SizedType &val_type, bool scalar)
 {
-  if (val_type.IsCountTy() && scalar) {
-    return libbpf::BPF_MAP_TYPE_PERCPU_ARRAY;
-  } else if (val_type.NeedsPercpuMap()) {
-    return libbpf::BPF_MAP_TYPE_PERCPU_HASH;
+  if (scalar && !val_type.IsHistTy() && !val_type.IsLhistTy()) {
+    return val_type.NeedsPercpuMap() ? libbpf::BPF_MAP_TYPE_PERCPU_ARRAY
+                                     : libbpf::BPF_MAP_TYPE_ARRAY;
   } else {
-    return libbpf::BPF_MAP_TYPE_HASH;
+    return val_type.NeedsPercpuMap() ? libbpf::BPF_MAP_TYPE_PERCPU_HASH
+                                     : libbpf::BPF_MAP_TYPE_HASH;
   }
 }
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -127,6 +127,7 @@ public:
   int run_iter();
   int print_maps(Output &out);
   int print_map(Output &out, const BpfMap &map, uint32_t top, uint32_t div);
+  void print_benchmark_results(Output &out);
   std::string get_stack(int64_t stackid,
                         uint32_t nr_stack_frames,
                         int32_t pid,
@@ -279,6 +280,7 @@ private:
   mutable util::FuncsModulesMap traceable_funcs_;
   mutable util::FuncsModulesMap raw_tracepoints_;
   std::unordered_map<std::string, std::unique_ptr<Dwarf>> dwarves_;
+  std::map<std::string, uint32_t> benchmark_results;
 };
 
 } // namespace bpftrace

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -361,7 +361,7 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
               return std::to_string(
                   util::reduce_value<int8_t>(value, nvalues) / static_cast<int8_t>(div));
             return std::to_string(util::reduce_value<uint8_t>(value, nvalues) / div);
-            // clang-format on
+          // clang-format on
         default:
           LOG(BUG) << "value_to_str: Invalid int bitwidth: "
                    << type.GetIntBitWidth() << "provided";
@@ -851,6 +851,44 @@ void TextOutput::helper_error(int retcode, const HelperErrorInfo &info) const
       << ", retcode: " << retcode;
 }
 
+void TextOutput::benchmark_results(
+    const std::map<std::string, uint32_t> &results) const
+{
+  if (results.size() == 0) {
+    return;
+  }
+
+  std::string BENCHMARK = "BENCHMARK";
+  std::string NANOSECONDS = "NANOSECONDS";
+  size_t longest_name = BENCHMARK.size();
+
+  for (const auto &benchmark : results) {
+    longest_name = std::max(longest_name, benchmark.first.size());
+  }
+
+  out_ << "+" << std::setw(longest_name + 2) << std::setfill('-') << ""
+       << "+" << std::setw(NANOSECONDS.size() + 2) << std::setfill('-') << ""
+       << "+" << std::endl;
+  out_ << "| " << std::left << std::setw(longest_name) << std::setfill(' ')
+       << BENCHMARK << " | " << NANOSECONDS << " |" << std::endl;
+  out_ << "+" << std::setw(longest_name + 2) << std::setfill('-') << ""
+       << "+" << std::setw(NANOSECONDS.size() + 2) << std::setfill('-') << ""
+       << "+" << std::endl;
+
+  for (const auto &benchmark : results) {
+    out_ << "| " << std::left << std::setw(longest_name) << std::setfill(' ')
+         << benchmark.first << " | " << std::left
+         << std::setw(NANOSECONDS.size()) << std::setfill(' ')
+         << benchmark.second << " |" << std::endl;
+  }
+
+  out_ << "+" << std::setw(longest_name + 2) << std::setfill('-') << ""
+       << "+" << std::setw(NANOSECONDS.size() + 2) << std::setfill('-') << ""
+       << "+" << std::endl;
+
+  out_ << std::endl;
+}
+
 std::string TextOutput::field_to_str(const std::string &name,
                                      const std::string &value) const
 {
@@ -1148,6 +1186,11 @@ void JsonOutput::helper_error(int retcode, const HelperErrorInfo &info) const
        << info.func_id << R"(", "retcode": )" << retcode << R"(, "filename": ")"
        << info.filename << R"(", "line": )" << info.line << R"(, "col": )"
        << info.column << "}" << std::endl;
+}
+
+void JsonOutput::benchmark_results(
+    const std::map<std::string, uint32_t> &results [[maybe_unused]]) const
+{
 }
 
 std::string JsonOutput::field_to_str(const std::string &name,

--- a/src/output.h
+++ b/src/output.h
@@ -98,6 +98,8 @@ public:
   virtual void lost_events(uint64_t lost) const = 0;
   virtual void attached_probes(uint64_t num_probes) const = 0;
   virtual void helper_error(int retcode, const HelperErrorInfo &info) const = 0;
+  virtual void benchmark_results(
+      const std::map<std::string, uint32_t> &results) const = 0;
 
 protected:
   ast::CDefinitions &c_definitions_;
@@ -244,6 +246,8 @@ public:
   void lost_events(uint64_t lost) const override;
   void attached_probes(uint64_t num_probes) const override;
   void helper_error(int retcode, const HelperErrorInfo &info) const override;
+  void benchmark_results(
+      const std::map<std::string, uint32_t> &results) const override;
 
 protected:
   std::string value_to_str(BPFtrace &bpftrace,
@@ -321,6 +325,8 @@ public:
   void lost_events(uint64_t lost) const override;
   void attached_probes(uint64_t num_probes) const override;
   void helper_error(int retcode, const HelperErrorInfo &info) const override;
+  void benchmark_results(
+      const std::map<std::string, uint32_t> &results) const override;
 
 private:
   std::string json_escape(const std::string &str) const;

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -185,6 +185,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
       break;
     }
     case ProbeType::special:
+    case ProbeType::benchmark:
       return { target + ":" };
     default:
       return {};
@@ -539,6 +540,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
       break;
     }
     case ProbeType::special:
+    case ProbeType::benchmark:
     case ProbeType::uprobe:
     case ProbeType::uretprobe:
     case ProbeType::watchpoint:

--- a/src/probe_types.cpp
+++ b/src/probe_types.cpp
@@ -53,6 +53,7 @@ std::string probetypeName(ProbeType t)
   {
     case ProbeType::invalid:     return "invalid";     break;
     case ProbeType::special:     return "special";     break;
+    case ProbeType::benchmark:   return "benchmark";     break;
     case ProbeType::kprobe:      return "kprobe";      break;
     case ProbeType::kretprobe:   return "kretprobe";   break;
     case ProbeType::uprobe:      return "uprobe";      break;

--- a/src/probe_types.h
+++ b/src/probe_types.h
@@ -14,6 +14,7 @@ namespace bpftrace {
 enum class ProbeType {
   invalid,
   special,
+  benchmark,
   kprobe,
   kretprobe,
   uprobe,
@@ -62,6 +63,9 @@ const std::vector<ProbeItem> PROBE_LIST = {
   { .name = "BEGIN", .aliases = { "BEGIN" }, .type = ProbeType::special },
   { .name = "END", .aliases = { "END" }, .type = ProbeType::special },
   { .name = "self", .aliases = { "self" }, .type = ProbeType::special },
+  { .name = "BENCHMARK",
+    .aliases = { "BENCHMARK" },
+    .type = ProbeType::benchmark },
   { .name = "tracepoint",
     .aliases = { "t" },
     .type = ProbeType::tracepoint,

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -133,6 +133,7 @@ public:
   // be collecting this, but it's complex to move the logic.
   std::vector<Probe> probes;
   std::unordered_map<std::string, Probe> special_probes;
+  std::vector<Probe> benchmark_probes;
   std::vector<Probe> signal_probes;
   std::vector<Probe> watchpoint_probes;
 
@@ -160,7 +161,8 @@ private:
             using_skboutput,
             probes,
             signal_probes,
-            special_probes);
+            special_probes,
+            benchmark_probes);
   }
 };
 

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -81,6 +81,8 @@ int run_bpftrace(BPFtrace &bpftrace,
 
   std::cout << "\n\n";
 
+  bpftrace.print_benchmark_results(output);
+
   // Print maps if needed (true by default).
   if (bpftrace.config_->print_maps_on_exit)
     err = bpftrace.print_maps(output);


### PR DESCRIPTION
*TODO*

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
