### PR TITLE
util: split out time formatting

### DIFF
--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(util STATIC
   symbols.cpp
   system.cpp
   temp.cpp
+  time.cpp
   tseries.cpp
   wildcard.cpp
   )

--- a/src/util/time.cpp
+++ b/src/util/time.cpp
@@ -1,0 +1,45 @@
+#include "util/time.h"
+
+namespace bpftrace::util {
+
+using namespace std::chrono_literals;
+
+std::pair<DisplayUnit, uint64_t> duration_str(
+    const std::chrono::duration<uint64_t, std::nano> &ns)
+{
+  uint64_t count = ns.count();
+  uint64_t scale = 1;
+  auto unit = DisplayUnit::ns;
+  if (count >= std::chrono::duration<uint64_t, std::nano>(1s).count()) {
+    unit = DisplayUnit::s;
+    scale = std::chrono::duration<uint64_t, std::nano>(1s).count();
+  } else if (count >= std::chrono::duration<uint64_t, std::nano>(1ms).count()) {
+    unit = DisplayUnit::ms;
+    scale = std::chrono::duration<uint64_t, std::nano>(1ms).count();
+  } else if (count >= std::chrono::duration<uint64_t, std::nano>(1us).count()) {
+    unit = DisplayUnit::us;
+    scale = std::chrono::duration<uint64_t, std::nano>(1us).count();
+  }
+  return { unit, scale };
+}
+
+std::ostream &operator<<(std::ostream &out, const DisplayUnit &unit)
+{
+  switch (unit) {
+    case DisplayUnit::ns:
+      out << "ns";
+      break;
+    case DisplayUnit::ms:
+      out << "ms";
+      break;
+    case DisplayUnit::us:
+      out << "μs";
+      break;
+    case DisplayUnit::s:
+      out << "s";
+      break;
+  }
+  return out;
+}
+
+} // namespace bpftrace::util

--- a/src/util/time.h
+++ b/src/util/time.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <chrono>
+#include <iostream>
+
+namespace bpftrace::util {
+
+// DisplayUnit is a time display unit.
+//
+// For convenience, the *value* of each enum is the maximum formatting width
+// when printing the fractions of a second in decimal, using the scaling factor
+// given.
+//
+//   auto [unit, scale] = duration_str(d);
+//   ... // display seconds, HH:mm:ss or whatever you prefer.
+//   if (unit != DisplayUnit::s) {
+//     auto ns = (d - std::chrono::floor<std::chrono::seconds>(d)).count();
+//     out << '.' << std::setfill('0') << std::setw(unit) << ns/scale;
+//   }
+//
+// This will print a string like: `342.028` if the unit is milliseconds, or a
+// string like `342.028234` if the unit is microseconds, etc.
+//
+// If you are printing the unit itself, this is likely not needed.
+enum class DisplayUnit {
+  s = 0,
+  ms = 3,
+  us = 6,
+  ns = 9,
+};
+
+// Emits the human-readable name for the unit.
+std::ostream &operator<<(std::ostream &out, const DisplayUnit &unit);
+
+// Returns a human-readable unit and the scale-factor for a duration.
+std::pair<DisplayUnit, uint64_t> duration_str(
+    const std::chrono::duration<uint64_t, std::nano> &ns);
+
+} // namespace bpftrace::util


### PR DESCRIPTION
Stacked PRs:
 * #4323
 * #4322
 * #4321
 * #4320
 * #4302
 * #4301
 * __->__#4356


--- --- ---

### util: split out time formatting


This is being done ahead of the output refactoring, to reduce some minor
duplication.

Signed-off-by: Adin Scannell <adin@scannell.ca>
