### PR TITLE
Log the total lost event count

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -833,6 +833,16 @@ int BPFtrace::run(Output &out, BpfBytecode bytecode)
 
   poll_output(out, /* drain */ true);
 
+  uint64_t total_lost_events = bytecode_.get_event_loss_counter(*this,
+                                                                max_cpu_id_);
+  if (total_lost_events > 0) {
+    // We incrementally log lost event counts to stdout via `output`
+    // so users can get a record of it in their txt/json output
+    // but let's log to stderr here to make sure this message doesn't
+    // get lost to users in scripts with high frequency output
+    LOG(WARNING) << "Total lost event count: " << total_lost_events;
+  }
+
   return 0;
 }
 

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -229,7 +229,7 @@ EXPECT_REGEX_NONE @
 TIMEOUT 1
 
 NAME sigint under heavy load
-RUN {{BPFTRACE}} --unsafe -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
+RUN {{BPFTRACE}} --unsafe -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { print("end"); }'
 EXPECT end
 AFTER  ./testprogs/syscall nanosleep 2e9; pkill -SIGINT bpftrace
 


### PR DESCRIPTION
In high frequency output the single messages
about how many lost events there were can
easily be drowned out. Let's log the total
number of lost events at the end.

Also log it to std:err via `LOG(WARNING)`
so it also doesn't get potentially dropped
if stdout is flooded.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
