### PR TITLE
Fix predicate type check to include bool

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3576,7 +3576,7 @@ void SemanticAnalyser::visit(Predicate &pred)
   visit(pred.expr);
   if (is_final_pass()) {
     const auto &ty = pred.expr.type();
-    if (!ty.IsIntTy() && !ty.IsPtrTy()) {
+    if (!ty.IsIntTy() && !ty.IsPtrTy() && !ty.IsBoolTy()) {
       pred.addError() << "Invalid type for predicate: "
                       << pred.expr.type().GetTy();
     }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -415,6 +415,7 @@ TEST_F(SemanticAnalyserTest, if_statements)
 TEST_F(SemanticAnalyserTest, predicate_expressions)
 {
   test("kprobe:f / 999 / { 123 }");
+  test("kprobe:f / true / { 123 }");
   test("kprobe:f / \"str\" / { 123 }", Error{ R"(
 stdin:1:10-19: ERROR: Invalid type for predicate: string
 kprobe:f / "str" / { 123 }


### PR DESCRIPTION
This broke:
```
kretprobe:shrink_memcg_cb /has_key(@a, tid)/ {
```
After this change:
- https://github.com/bpftrace/bpftrace/pull/4280

Forgot to include bool as allowable type for
probe predicates.

Also added a test.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
