### PR TITLE
Remove manual TOCs from stdlib and language

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -1,7 +1,7 @@
 # The bpftrace Language
 
 The `bpftrace` (`bt`) language is inspired by the D language used by `dtrace` and uses the same program structure.
-Each script consists of a [Preamble](#preamble) and one or more [Action Blocks](#action-block).
+Each script consists of a [Preamble](#preamble) and one or more [Action Blocks](#action-blocks).
 
 ```
 preamble
@@ -9,31 +9,6 @@ preamble
 actionblock1
 actionblock2
 ```
-
-- [Action Blocks](#action-blocks)
-- [Arrays](#arrays)
-- [Command Line Parameters](#command-line-parameters)
-- [Comments](#comments)
-- [Conditionals](#conditionals)
-- [Config Block](#config-block)
-- [Config Variables](#config-variables)
-- [Data Types](#data-types)
-- [Filters/Predicates](#filterspedicates)
-- [Floating-point](#floating-point)
-- [Identifiers](#identifiers)
-- [Literals](#literals)
-- [Loops](#loops)
-- [Macros](#macros)
-- [Maps](#variables-and-maps)
-- [Operators and Expressions](#operators-and-expressions)
-- [Preamble](#preamble)
-- [Probes](#probes)
-- [Pointers](#pointers)
-- [Structs](#structs)
-- [Tuples](#tuples)
-- [Type conversion](#type-conversion)
-- [Variables](#variables-and-maps)
-- [**Advanced Topics**](#advanced-topics)
 
 ## Action Blocks
 

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1,10 +1,5 @@
 # bpftrace Standard Library
 
-- [Builtins](#builtins)
-- [Functions](#functions)
-- [Map Functions](#map-functions)
-- [Invocation Mode](#invocation-mode)
-
 ## Builtins
 
 Builtins are special variables built into the language.


### PR DESCRIPTION
These are not needed as github and other
markdown readers already provide an "outline"
feature for navigation of markdown docs.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
