### PR TITLE
Fix builds on PowerPC

### DIFF
--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -93,8 +93,8 @@ constexpr Machine current()
   return Machine::ARM;
 #elif defined(__s390x__)
   return Machine::S390X;
-#elif defined(__ppc64__)
-  return Machine::POWERPC;
+#elif defined(__ppc64__) || defined(__powerpc64__)
+  return Machine::PPC64;
 #elif defined(__mips64)
   return Machine::MIPS64;
 #elif defined(__riscv) && (__riscv_xlen == 64)


### PR DESCRIPTION
Fix two issues which occurred when trying to build bpftrace on PowerPC:
1. The `Machine` enum entry for PowerPC is `PPC64`, not `POWERPC`.
2. Some GCC versions define `__powerpc64__` rather than `__ppc64__`.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
