### PR TITLE
Tests: add missing REQUIRES_FEATURE

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -72,14 +72,20 @@ NAME fentry_missing_probes
 PROG fentry:vfs_read,fentry:nonsense { exit(); }
 EXPECT ERROR: No BTF found for nonsense.
 WILL_FAIL
+REQUIRES_FEATURE fentry
+REQUIRES_FEATURE btf
 
 NAME fentry_warn_missing_probes
 PROG config = { missing_probes = "warn" } fentry:vfs_read,fentry:nonsense { exit(); }
 EXPECT WARNING: No BTF found for nonsense.
+REQUIRES_FEATURE fentry
+REQUIRES_FEATURE btf
 
 NAME fentry_ignore_missing_probes
 PROG config = { missing_probes = "ignore" } fentry:vfs_read,fentry:nonsense { exit(); }
 EXPECT_NONE WARNING: No BTF found for nonsense.
+REQUIRES_FEATURE fentry
+REQUIRES_FEATURE btf
 
 # Sanity check for kfunc/kretfunc alias
 NAME kfunc
@@ -606,6 +612,8 @@ NAME fexit_order
 RUN {{BPFTRACE}} runtime/scripts/fexit_order.bt
 EXPECT_REGEX (first)+ second
 AFTER ./testprogs/syscall nanosleep 233;
+REQUIRES_FEATURE fentry
+REQUIRES_FEATURE btf
 
 NAME software_order
 RUN {{BPFTRACE}} runtime/scripts/software_order.bt


### PR DESCRIPTION
Some tests in `tests/runtime/probe` using fentry/fexit were missing the `REQUIRES_FEATURE` annotations so they were failing on systems without fentry support.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
