### PR TITLE
Move session expansion to AST

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1138,7 +1138,6 @@ public:
         mode(other.mode),
         async(other.async),
         expansion(other.expansion),
-        ret_probe(other.ret_probe),
         address(other.address),
         func_offset(other.func_offset),
         ignore_invalid(other.ignore_invalid),
@@ -1171,7 +1170,6 @@ public:
   bool async = false; // for watchpoint probes, if it's an async watchpoint
 
   ExpansionType expansion = ExpansionType::NONE;
-  Probe *ret_probe = nullptr; // for session probes
 
   uint64_t address = 0;
   uint64_t func_offset = 0;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1121,6 +1121,8 @@ void SemanticAnalyser::visit(Builtin &builtin)
                             "tracepoint/fentry/uprobe probes ("
                          << type << " used here)";
     }
+  } else if (builtin.ident == "__session_is_return") {
+    builtin.builtin_type = CreateBool();
   } else {
     builtin.addError() << "Unknown builtin variable: '" << builtin.ident << "'";
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ add_executable(bpftrace_test
   output.cpp
   parser.cpp
   portability_analyser.cpp
+  probe_expansion.cpp
   procmon.cpp
   probe.cpp
   config_analyser.cpp

--- a/tests/codegen/llvm/kprobe_session.ll
+++ b/tests/codegen/llvm/kprobe_session.ll
@@ -23,28 +23,31 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %is_return = call i8 @bpf_session_is_return()
-  %1 = icmp ne i8 %is_return, 0
-  br i1 %1, label %exit_probe, label %entry_probe
+  %true_cond = icmp ne i8 %is_return, 0
+  br i1 %true_cond, label %if_body, label %else_body
 
-entry_probe:                                      ; preds = %entry
+if_body:                                          ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i64 0, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
+  br label %if_end
+
+if_end:                                           ; preds = %else_body, %if_body
   ret i64 0
 
-exit_probe:                                       ; preds = %entry
+else_body:                                        ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key1")
   store i64 0, ptr %"@_key1", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val2")
-  store i64 0, ptr %"@_val2", align 8
+  store i64 1, ptr %"@_val2", align 8
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key1", ptr %"@_val2", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val2")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key1")
-  ret i64 0
+  br label %if_end
 }
 
 ; Function Attrs: nounwind

--- a/tests/probe_expansion.cpp
+++ b/tests/probe_expansion.cpp
@@ -1,0 +1,53 @@
+#include "ast/passes/probe_expansion.h"
+#include "ast/attachpoint_parser.h"
+#include "ast/passes/printer.h"
+#include "driver.h"
+#include "mocks.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::probe_expansion {
+
+static void test(const std::string &prog, std::string_view expected_ast)
+{
+  auto mock_bpftrace = get_mock_bpftrace();
+
+  BPFtrace &bpftrace = *mock_bpftrace;
+  ast::ASTContext ast("stdin", prog);
+
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put(bpftrace)
+                .add(CreateParsePass())
+                .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateProbeExpansionPass())
+                .run();
+  ASSERT_TRUE(ok && ast.diagnostics().ok());
+
+  if (expected_ast[0] == '\n')
+    expected_ast.remove_prefix(1);
+
+  std::stringstream out;
+  ast::Printer printer(out);
+  printer.visit(ast.root);
+  EXPECT_EQ(out.str(), expected_ast);
+}
+
+TEST(probe_expansion, session_ast)
+{
+  test("kprobe:sys_* { @entry = 1 } kretprobe:sys_* { @exit = 1 }", R"(
+Program
+ kprobe:sys_*
+  if
+   builtin: __session_is_return
+   then
+    =
+     map: @exit
+     int: 1
+   else
+    =
+     map: @entry
+     int: 1
+)");
+}
+
+} // namespace bpftrace::test::probe_expansion


### PR DESCRIPTION
When doing session expansion, we need to take two probes and merge them into one. For instance:

    kprobe:* { XXX } kretprobe:* { YYY }

become

    kprobe:* { if (bpf_session_is_return()) { YYY } else  { XXX } }

Until now, we were doing it in codegen but now that we have proper AST mutation passes, we can do it directly in AST.

This changes the `SessionAnalyser` visitor in the `ProbeExpansion` pass to `SessionExpander` which directly does the above transformation. For the condition, we introduce an internal builtin `__session_is_return` which codegen transforms into a call to the `bpf_session_is_return` kfunc.

This also introduces a new test suite for probe expansions and a test which verifies what the AST looks like after the session expansion.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
