### PR TITLE
Move multi-expansion to ProbeExpansion

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -172,7 +172,6 @@ AttachPoint *AttachPoint::create_expansion_copy(ASTContext &ctx,
   ap->len = len;
   ap->mode = mode;
   ap->async = async;
-  ap->expansion = expansion;
   ap->address = address;
   ap->func_offset = func_offset;
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -52,22 +52,6 @@ enum class Operator {
   BNOT,
 };
 
-// There are 2 kinds of attach point expansion:
-// - full expansion  - separate LLVM function is generated for each match
-// - multi expansion - one LLVM function and BPF program is generated for all
-//                     matches, the list of expanded functions is attached to
-//                     the BPF program using the k(u)probe.multi mechanism
-// - session expansion - extension of the multi expansion when a single BPF
-//                       program is shared for both the entry and the exit probe
-//                       (when they are both attached to the same attach points)
-//                       using the kprobe.session mechanism
-enum class ExpansionType {
-  NONE,
-  FULL,
-  MULTI,
-  SESSION,
-};
-
 class Node {
 public:
   Node(ASTContext &ctx, Location &&loc) : state_(*ctx.state_), loc(loc) {};
@@ -1137,7 +1121,6 @@ public:
         len(other.len),
         mode(other.mode),
         async(other.async),
-        expansion(other.expansion),
         address(other.address),
         func_offset(other.func_offset),
         ignore_invalid(other.ignore_invalid),
@@ -1168,8 +1151,6 @@ public:
   uint64_t len = 0;   // for watchpoint probes, the width of watched addr
   std::string mode;   // for watchpoint probes, the watch mode
   bool async = false; // for watchpoint probes, if it's an async watchpoint
-
-  ExpansionType expansion = ExpansionType::NONE;
 
   uint64_t address = 0;
   uint64_t func_offset = 0;

--- a/src/ast/passes/probe_expansion.h
+++ b/src/ast/passes/probe_expansion.h
@@ -1,8 +1,49 @@
 #pragma once
 
+#include "ast/ast.h"
 #include "ast/pass_manager.h"
 
 namespace bpftrace::ast {
+
+// There are 3 kinds of attach point expansion:
+// - full expansion  - separate LLVM function is generated for each match
+// - multi expansion - one LLVM function and BPF program is generated for all
+//                     matches, the list of expanded functions is attached to
+//                     the BPF program using the k(u)probe.multi mechanism
+// - session expansion - extension of the multi expansion when a single BPF
+//                       program is shared for both the entry and the exit probe
+//                       (when they are both attached to the same attach points)
+//                       using the kprobe.session mechanism
+enum class ExpansionType {
+  NONE,
+  FULL,
+  MULTI,
+  SESSION,
+};
+
+class ExpansionResult : public State<"expansions"> {
+public:
+  ExpansionResult() = default;
+  ExpansionResult(const ExpansionResult &) = delete;
+  ExpansionResult &operator=(const ExpansionResult &) = delete;
+  ExpansionResult(ExpansionResult &&) = default;
+  ExpansionResult &operator=(ExpansionResult &&) = default;
+
+  void set_expansion(AttachPoint &ap, ExpansionType type)
+  {
+    expansions[&ap] = type;
+  }
+  ExpansionType get_expansion(AttachPoint &ap)
+  {
+    auto exp = expansions.find(&ap);
+    if (exp == expansions.end())
+      return ExpansionType::NONE;
+    return exp->second;
+  }
+
+private:
+  std::unordered_map<AttachPoint *, ExpansionType> expansions;
+};
 
 Pass CreateProbeExpansionPass();
 

--- a/src/ast/passes/probe_expansion.h
+++ b/src/ast/passes/probe_expansion.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <set>
+
 #include "ast/ast.h"
 #include "ast/pass_manager.h"
 
@@ -41,8 +43,27 @@ public:
     return exp->second;
   }
 
+  void set_expanded_funcs(AttachPoint &ap, std::set<std::string> funcs)
+  {
+    expanded_funcs.emplace(&ap, std::move(funcs));
+  }
+  void add_expanded_func(AttachPoint &ap, const std::string &func)
+  {
+    auto funcs = expanded_funcs.emplace(&ap, std::set<std::string>());
+    funcs.first->second.insert(func);
+  }
+  std::set<std::string> get_expanded_funcs(AttachPoint &ap)
+  {
+    auto funcs = expanded_funcs.find(&ap);
+    if (funcs == expanded_funcs.end())
+      return {};
+
+    return funcs->second;
+  }
+
 private:
   std::unordered_map<AttachPoint *, ExpansionType> expansions;
+  std::unordered_map<AttachPoint *, std::set<std::string>> expanded_funcs;
 };
 
 Pass CreateProbeExpansionPass();

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -602,9 +602,8 @@ Result<std::unique_ptr<AttachedMultiKprobeProbe>> AttachedMultiKprobeProbe::
   std::vector<const char *> syms;
   unsigned int i = 0;
 
-  for (i = 0; i < probe.funcs.size(); i++) {
-    syms.push_back(probe.funcs[i].c_str());
-  }
+  for (const auto &func : probe.funcs)
+    syms.push_back(func.c_str());
 
   opts.kprobe_multi.syms = syms.data();
   opts.kprobe_multi.cnt = syms.size();

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -16,6 +16,7 @@
 #include "ast/ast.h"
 #include "ast/pass_manager.h"
 #include "ast/passes/clang_parser.h"
+#include "ast/passes/probe_expansion.h"
 #include "attached_probe.h"
 #include "bpfbytecode.h"
 #include "bpffeature.h"
@@ -117,6 +118,7 @@ public:
   virtual int add_probe(ast::ASTContext &ctx,
                         const ast::AttachPoint &ap,
                         const ast::Probe &p,
+                        ast::ExpansionType expansion,
                         int usdt_location_idx = 0);
   Probe generateWatchpointSetupProbe(const ast::AttachPoint &ap,
                                      const ast::Probe &probe);
@@ -270,6 +272,7 @@ private:
   struct bcc_symbol_option &get_symbol_opts();
   Probe generate_probe(const ast::AttachPoint &ap,
                        const ast::Probe &p,
+                       ast::ExpansionType expansion,
                        int usdt_location_idx = 0);
   bool has_iter_ = false;
   int epollfd_ = -1;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -115,10 +115,10 @@ public:
   {
   }
   ~BPFtrace() override;
-  virtual int add_probe(ast::ASTContext &ctx,
-                        const ast::AttachPoint &ap,
+  virtual int add_probe(const ast::AttachPoint &ap,
                         const ast::Probe &p,
                         ast::ExpansionType expansion,
+                        std::set<std::string> expanded_funcs,
                         int usdt_location_idx = 0);
   Probe generateWatchpointSetupProbe(const ast::AttachPoint &ap,
                                      const ast::Probe &probe);
@@ -273,6 +273,7 @@ private:
   Probe generate_probe(const ast::AttachPoint &ap,
                        const ast::Probe &p,
                        ast::ExpansionType expansion,
+                       std::set<std::string> expanded_funcs,
                        int usdt_location_idx = 0);
   bool has_iter_ = false;
   int epollfd_ = -1;

--- a/src/probe_types.h
+++ b/src/probe_types.h
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cereal/access.hpp>
 #include <ostream>
+#include <set>
 #include <string>
 #include <sys/types.h>
 #include <unistd.h>
@@ -124,7 +125,7 @@ struct Probe {
   uint64_t address = 0;
   uint64_t func_offset = 0;
   uint64_t bpf_prog_id = 0;
-  std::vector<std::string> funcs;
+  std::set<std::string> funcs;
   bool is_session = false;
 
 private:

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -2,6 +2,7 @@
 #include <cereal/types/map.hpp>
 #include <cereal/types/memory.hpp>
 #include <cereal/types/optional.hpp>
+#include <cereal/types/set.hpp>
 #include <cereal/types/string.hpp>
 #include <cereal/types/tuple.hpp>
 #include <cereal/types/unordered_set.hpp>

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -90,7 +90,7 @@ void check_kprobe(Probe &p,
 }
 
 void check_kprobe_multi(Probe &p,
-                        const std::vector<std::string> &funcs,
+                        const std::set<std::string> &funcs,
                         const std::string &orig_name,
                         const std::string &name)
 {
@@ -122,7 +122,7 @@ void check_uprobe(Probe &p,
 
 void check_uprobe_multi(Probe &p,
                         const std::string &path,
-                        const std::vector<std::string> &funcs,
+                        const std::set<std::string> &funcs,
                         const std::string &orig_name,
                         const std::string &name)
 {
@@ -302,7 +302,7 @@ TEST(bpftrace, add_probes_wildcard_kprobe_multi)
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_symbols_from_traceable_funcs(false))
-      .Times(2);
+      .Times(1);
 
   parse_probe("kprobe:sys_read,kprobe:my_*,kprobe:sys_write{}", *bpftrace);
 
@@ -525,7 +525,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_uprobe_multi)
 
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_func_symbols_from_file(no_pid, "/bin/sh"))
-      .Times(2);
+      .Times(1);
 
   parse_probe("uprobe:/bin/sh:*open {}", *bpftrace);
 
@@ -577,7 +577,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file_uprobe_multi)
 
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_func_symbols_from_file(no_pid, "/bin/*sh"))
-      .Times(2);
+      .Times(1);
 
   parse_probe("uprobe:/bin/*sh:*open {}", *bpftrace);
 
@@ -1197,7 +1197,7 @@ void check_probe(Probe &p, ProbeType type, const std::string &name)
 }
 
 void check_kprobe_session(Probe &p,
-                          const std::vector<std::string> &funcs,
+                          const std::set<std::string> &funcs,
                           const std::string &name)
 {
   check_kprobe_multi(p, funcs, name, name);
@@ -1328,7 +1328,7 @@ TEST_F(bpftrace_btf, add_probes_wildcard_kprobe_session)
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_symbols_from_traceable_funcs(false))
-      .Times(2);
+      .Times(1);
 
   parse_probe("kprobe:my_*{} kretprobe:my_*{}", *bpftrace);
 

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -3,6 +3,7 @@
 #include "ast/attachpoint_parser.h"
 #include "ast/passes/clang_parser.h"
 #include "ast/passes/field_analyser.h"
+#include "ast/passes/probe_expansion.h"
 #include "bpftrace.h"
 #include "btf_common.h"
 #include "driver.h"
@@ -26,6 +27,7 @@ static ast::CDefinitions parse(
                 .put(bpftrace)
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateProbeExpansionPass())
                 .add(ast::CreateFieldAnalyserPass())
                 .add(ast::CreateClangParsePass())
                 .run();

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -15,10 +15,11 @@ public:
 #ifdef __clang__
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
-  MOCK_METHOD4(add_probe,
+  MOCK_METHOD5(add_probe,
                int(ast::ASTContext &,
                    const ast::AttachPoint &,
                    const ast::Probe &,
+                   ast::ExpansionType,
                    int));
 #pragma GCC diagnostic pop
 
@@ -102,7 +103,7 @@ TEST(codegen, probe_count)
 kprobe:f { 1; } kprobe:d { 1; }
 )");
   MockBPFtrace bpftrace;
-  EXPECT_CALL(bpftrace, add_probe(_, _, _, _)).Times(2);
+  EXPECT_CALL(bpftrace, add_probe(_, _, _, _, _)).Times(2);
 
   // Override to mockbpffeature.
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -16,10 +16,10 @@ public:
 #pragma GCC diagnostic ignored "-Winconsistent-missing-override"
 #endif
   MOCK_METHOD5(add_probe,
-               int(ast::ASTContext &,
-                   const ast::AttachPoint &,
+               int(const ast::AttachPoint &,
                    const ast::Probe &,
                    ast::ExpansionType,
+                   std::set<std::string>,
                    int));
 #pragma GCC diagnostic pop
 

--- a/tests/pid_filter_pass.cpp
+++ b/tests/pid_filter_pass.cpp
@@ -2,6 +2,7 @@
 #include "ast/attachpoint_parser.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/printer.h"
+#include "ast/passes/probe_expansion.h"
 #include "driver.h"
 #include "mocks.h"
 #include "gtest/gtest.h"
@@ -29,6 +30,7 @@ void test(const std::string& input, bool has_pid, bool has_filter)
                 .put(bpftrace)
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreateProbeExpansionPass())
                 .add(ast::CreateFieldAnalyserPass())
                 .add(ast::CreatePidFilterPass())
                 .run();
@@ -62,7 +64,7 @@ TEST(pid_filter_pass, add_filter)
     "fentry:f",
     "fexit:f",
     "tracepoint:category:event",
-    "rawtracepoint:event",
+    "rawtracepoint:module:event",
   };
 
   for (auto& probe : filter_probes) {


### PR DESCRIPTION
When using kprobe_multi, uprobe_multi, or kprobe_session, we need to expand a wildcarded attach point and add all expanded target functions to `Probe::funcs`. At the moment, we do it in the `BPFtrace` class but there's no reason not to do it in the `ProbeExpansion` pass. This just needs to introduce a new `ast::AttachPoint::expanded_funcs` field which will be used to fill `Probe::funcs` later.
    
This allows to drop the remaining expansion code from `BPFtrace` and codegen. It also removes one call to `ProbeMatcher` (reflected in tests).

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
