### PR TITLE
Fix bad modulo optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,8 @@ and this project adheres to
   - [#4244](https://github.com/bpftrace/bpftrace/pull/4244)
 - Report expanded probe name when trying to attach
   - [#4353](https://github.com/bpftrace/bpftrace/pull/4353)
+- Fix codegen optimization bug with the modulo operator
+  - [#4383](https://github.com/bpftrace/bpftrace/pull/4383)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/async_event_types.cpp
+++ b/src/ast/async_event_types.cpp
@@ -59,7 +59,7 @@ std::vector<llvm::Type*> Buf::asLLVMType(ast::IRBuilderBPF& b, uint32_t length)
   };
 }
 
-std::vector<llvm::Type*> HelperError::asLLVMType(ast::IRBuilderBPF& b)
+std::vector<llvm::Type*> RuntimeError::asLLVMType(ast::IRBuilderBPF& b)
 {
   return {
     b.getInt64Ty(), // asyncid

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -74,7 +74,7 @@ struct Buf {
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, uint32_t length);
 } __attribute__((packed));
 
-struct HelperError {
+struct RuntimeError {
   uint64_t action_id;
   uint64_t error_id;
   int32_t return_value;

--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -8,7 +8,7 @@ namespace bpftrace::ast {
 #define FOR_LIST_OF_ASYNC_IDS(DO)                                              \
   DO(cat)                                                                      \
   DO(cgroup_path)                                                              \
-  DO(helper_error)                                                             \
+  DO(runtime_error)                                                            \
   DO(join)                                                                     \
   DO(bpf_print)                                                                \
   DO(non_map_print)                                                            \

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -465,7 +465,9 @@ CallInst *IRBuilderBPF::CreateHelperCall(libbpf::bpf_func_id func_id,
                                          const Twine &Name,
                                          const Location &loc)
 {
-  bpftrace_.helper_use_loc_[func_id].emplace_back(func_id, loc);
+  bpftrace_.helper_use_loc_[func_id].emplace_back(RuntimeErrorId::HELPER_ERROR,
+                                                  func_id,
+                                                  loc);
   PointerType *helper_ptr_type = PointerType::get(helper_type, 0);
   Constant *helper_func = ConstantExpr::getCast(Instruction::IntToPtr,
                                                 getInt64(func_id),
@@ -814,7 +816,10 @@ Value *IRBuilderBPF::CreateMapLookupElem(const std::string &map_name,
     CreateMemsetBPF(value, getInt8(0), type.GetSize());
   else
     CreateStore(getInt64(0), value);
-  CreateHelperError(getInt32(0), libbpf::BPF_FUNC_map_lookup_elem, loc);
+  CreateRuntimeError(RuntimeErrorId::HELPER_ERROR,
+                     getInt32(0),
+                     libbpf::BPF_FUNC_map_lookup_elem,
+                     loc);
   CreateBr(lookup_merge_block);
 
   SetInsertPoint(lookup_merge_block);
@@ -933,7 +938,10 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Map &map,
 
   SetInsertPoint(error_success_block);
 
-  CreateHelperError(getInt32(0), libbpf::BPF_FUNC_map_lookup_percpu_elem, loc);
+  CreateRuntimeError(RuntimeErrorId::HELPER_ERROR,
+                     getInt32(0),
+                     libbpf::BPF_FUNC_map_lookup_percpu_elem,
+                     loc);
   CreateBr(while_end);
 
   SetInsertPoint(error_failure_block);
@@ -2572,38 +2580,48 @@ static bool return_zero_if_err(libbpf::bpf_func_id func_id)
   return false;
 }
 
-void IRBuilderBPF::CreateHelperError(Value *return_value,
-                                     libbpf::bpf_func_id func_id,
-                                     const Location &loc)
+void IRBuilderBPF::CreateRuntimeError(RuntimeErrorId rte_id,
+                                      const Location &loc)
 {
-  assert(return_value && return_value->getType() == getInt32Ty());
+  CreateRuntimeError(
+      rte_id, getInt64(0), static_cast<libbpf::bpf_func_id>(-1), loc);
+}
 
-  if (bpftrace_.helper_check_level_ == 0 ||
-      (bpftrace_.helper_check_level_ == 1 && return_zero_if_err(func_id)))
-    return;
+void IRBuilderBPF::CreateRuntimeError(RuntimeErrorId rte_id,
+                                      Value *return_value,
+                                      libbpf::bpf_func_id func_id,
+                                      const Location &loc)
+{
+  if (rte_id == RuntimeErrorId::HELPER_ERROR) {
+    assert(return_value && return_value->getType() == getInt32Ty());
 
-  int error_id = async_ids_.helper_error();
-  bpftrace_.resources.helper_error_info.try_emplace(
-      error_id, HelperErrorInfo(func_id, loc));
-  auto elements = AsyncEvent::HelperError().asLLVMType(*this);
-  StructType *helper_error_struct = GetStructType("helper_error_t",
-                                                  elements,
-                                                  true);
-  AllocaInst *buf = CreateAllocaBPF(helper_error_struct, "helper_error_t");
+    if (bpftrace_.helper_check_level_ == 0 ||
+        (bpftrace_.helper_check_level_ == 1 && return_zero_if_err(func_id)))
+      return;
+  }
+
+  int error_id = async_ids_.runtime_error();
+  bpftrace_.resources.runtime_error_info.try_emplace(
+      error_id, RuntimeErrorInfo(rte_id, func_id, loc));
+  auto elements = AsyncEvent::RuntimeError().asLLVMType(*this);
+  StructType *runtime_error_struct = GetStructType("runtime_error_t",
+                                                   elements,
+                                                   true);
+  AllocaInst *buf = CreateAllocaBPF(runtime_error_struct, "runtime_error_t");
   CreateStore(
       GetIntSameSize(static_cast<int64_t>(
-                         async_action::AsyncAction::helper_error),
+                         async_action::AsyncAction::runtime_error),
                      elements.at(0)),
-      CreateGEP(helper_error_struct, buf, { getInt64(0), getInt32(0) }));
+      CreateGEP(runtime_error_struct, buf, { getInt64(0), getInt32(0) }));
   CreateStore(
       GetIntSameSize(error_id, elements.at(1)),
-      CreateGEP(helper_error_struct, buf, { getInt64(0), getInt32(1) }));
+      CreateGEP(runtime_error_struct, buf, { getInt64(0), getInt32(1) }));
   CreateStore(
       return_value,
-      CreateGEP(helper_error_struct, buf, { getInt64(0), getInt32(2) }));
+      CreateGEP(runtime_error_struct, buf, { getInt64(0), getInt32(2) }));
 
   const auto &layout = module_.getDataLayout();
-  auto struct_size = layout.getTypeAllocSize(helper_error_struct);
+  auto struct_size = layout.getTypeAllocSize(runtime_error_struct);
   CreateOutput(buf, struct_size, loc);
   CreateLifetimeEnd(buf);
 }
@@ -2631,7 +2649,7 @@ void IRBuilderBPF::CreateHelperErrorCond(Value *return_value,
   Value *condition = CreateICmpSGE(ret, Constant::getNullValue(ret->getType()));
   CreateCondBr(condition, helper_merge_block, helper_failure_block);
   SetInsertPoint(helper_failure_block);
-  CreateHelperError(ret, func_id, loc);
+  CreateRuntimeError(RuntimeErrorId::HELPER_ERROR, ret, func_id, loc);
   CreateBr(helper_merge_block);
   SetInsertPoint(helper_merge_block);
 }

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -190,9 +190,11 @@ public:
                          const Location &loc);
   void CreateSignal(Value *sig, const Location &loc);
   void CreateOverrideReturn(Value *ctx, Value *rc);
-  void CreateHelperError(Value *return_value,
-                         libbpf::bpf_func_id func_id,
-                         const Location &loc);
+  void CreateRuntimeError(RuntimeErrorId rte_id, const Location &loc);
+  void CreateRuntimeError(RuntimeErrorId rte_id,
+                          Value *return_value,
+                          libbpf::bpf_func_id func_id,
+                          const Location &loc);
   void CreateHelperErrorCond(Value *return_value,
                              libbpf::bpf_func_id func_id,
                              const Location &loc,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -264,6 +264,8 @@ public:
                     bool max,
                     bool is_signed);
 
+  llvm::Value *CreateCheckedBinop(Binop &binop, Value *lhs, Value *rhs);
+
 private:
   Module &module_;
   BPFtrace &bpftrace_;

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2284,12 +2284,51 @@ ScopedExpr CodegenLLVM::binop_int(Binop &binop)
       return ScopedExpr(b_.CreateMul(lhs, rhs), std::move(del));
     case Operator::DIV:
       return ScopedExpr(b_.CreateUDiv(lhs, rhs), std::move(del));
-    case Operator::MOD:
+    case Operator::MOD: {
       // Always do an unsigned modulo operation here even if `do_signed`
       // is true. bpf instruction set does not support signed division.
       // We already warn in the semantic analyser that signed modulo can
       // lead to undefined behavior (because we will treat it as unsigned).
-      return ScopedExpr(b_.CreateURem(lhs, rhs), std::move(del));
+      // Additionally, we need to do a 0 check or else a compiler optimization
+      // will assume that the value can't ever be null and remove the null check
+      // which is problematic if the right side of the modulo is a map value
+      // e.g. (10 % @my_map[1]) - From Google's AI: "LLVM, like other optimizing
+      // compilers, is allowed to make assumptions based on the absence of
+      // undefined behavior. If a program's code, after optimization, would
+      // result in undefined behavior (like division by zero by CreateURem), the
+      // compiler is free to make transformations that assume such a situation
+      // will never occur."
+      AllocaInst *mod_result = b_.CreateAllocaBPF(b_.getInt64Ty(),
+                                                  "mod_result");
+
+      llvm::Function *parent = b_.GetInsertBlock()->getParent();
+      BasicBlock *is_zero = BasicBlock::Create(module_->getContext(),
+                                               "is_zero",
+                                               parent);
+      BasicBlock *not_zero = BasicBlock::Create(module_->getContext(),
+                                                "not_zero",
+                                                parent);
+      BasicBlock *zero_merge = BasicBlock::Create(module_->getContext(),
+                                                  "zero_merge",
+                                                  parent);
+
+      Value *cond = b_.CreateICmpEQ(rhs, b_.getInt64(0), "zero_cond");
+
+      b_.CreateCondBr(cond, is_zero, not_zero);
+      b_.SetInsertPoint(is_zero);
+      b_.CreateStore(b_.getInt64(1), mod_result);
+      b_.CreateBr(zero_merge);
+
+      b_.SetInsertPoint(not_zero);
+      b_.CreateStore(b_.CreateURem(lhs, rhs), mod_result);
+      b_.CreateBr(zero_merge);
+
+      b_.SetInsertPoint(zero_merge);
+      return ScopedExpr(b_.CreateLoad(b_.getInt64Ty(), mod_result),
+                        [this, mod_result, d = std::move(del)] {
+                          b_.CreateLifetimeEnd(mod_result);
+                        });
+    }
     case Operator::BAND:
       return ScopedExpr(b_.CreateAnd(lhs, rhs), std::move(del));
     case Operator::BOR:

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -55,13 +55,13 @@ void AsyncHandlers::time(const OpaqueValue &data)
   out.time(timestr);
 }
 
-void AsyncHandlers::helper_error(const OpaqueValue &data)
+void AsyncHandlers::runtime_error(const OpaqueValue &data)
 {
-  const auto &helper_error = data.bitcast<AsyncEvent::HelperError>();
-  auto error_id = helper_error.error_id;
-  const auto return_value = helper_error.return_value;
-  const auto &info = bpftrace.resources.helper_error_info[error_id];
-  out.helper_error(return_value, info);
+  const auto &runtime_error = data.bitcast<AsyncEvent::RuntimeError>();
+  auto error_id = runtime_error.error_id;
+  const auto return_value = runtime_error.return_value;
+  const auto &info = bpftrace.resources.runtime_error_info[error_id];
+  out.runtime_error(return_value, info);
 }
 
 void AsyncHandlers::print_non_map(const OpaqueValue &data)

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -20,7 +20,7 @@ enum class AsyncAction {
   zero,
   time,
   join,
-  helper_error,
+  runtime_error,
   print_non_map,
   strftime,
   watchpoint_attach,
@@ -41,7 +41,7 @@ public:
   void exit(const OpaqueValue &data);
   void join(const OpaqueValue &data);
   void time(const OpaqueValue &data);
-  void helper_error(const OpaqueValue &data);
+  void runtime_error(const OpaqueValue &data);
   void print_non_map(const OpaqueValue &data);
   void print_map(const OpaqueValue &data);
   void zero_map(const OpaqueValue &data);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -245,8 +245,8 @@ void perf_event_printer(void *cb_cookie, void *raw_data, int size)
   } else if (printf_id == async_action::AsyncAction::join) {
     ctx->handlers.join(data);
     return;
-  } else if (printf_id == async_action::AsyncAction::helper_error) {
-    ctx->handlers.helper_error(data);
+  } else if (printf_id == async_action::AsyncAction::runtime_error) {
+    ctx->handlers.runtime_error(data);
     return;
   } else if (printf_id == async_action::AsyncAction::watchpoint_attach) {
     ctx->handlers.watchpoint_attach(data);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -199,7 +199,7 @@ public:
   StructManager structs;
   FunctionRegistry functions;
   // For each helper, list of all generated call sites.
-  std::map<libbpf::bpf_func_id, std::vector<HelperErrorInfo>> helper_use_loc_;
+  std::map<libbpf::bpf_func_id, std::vector<RuntimeErrorInfo>> helper_use_loc_;
   const util::FuncsModulesMap &get_traceable_funcs() const;
   const util::FuncsModulesMap &get_raw_tracepoints() const;
   util::KConfig kconfig;

--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -434,17 +434,31 @@ void JsonOutput::attached_probes(uint64_t num_probes)
        << std::endl;
 }
 
-void JsonOutput::helper_error(int retcode, const HelperErrorInfo &info)
+void JsonOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
 {
-  out_ << R"({"type": "helper_error")";
-  out_ << R"(, "msg": )";
-  JsonEmitter<std::string>::emit(out_, strerror(-retcode));
-  out_ << R"(, "helper": )";
-  std::stringstream ss;
-  ss << info.func_id;
-  JsonEmitter<std::string>::emit(out_, ss.str());
-  out_ << R"(, "retcode": )";
-  JsonEmitter<int64_t>::emit(out_, retcode);
+  switch (info.error_id) {
+    case RuntimeErrorId::HELPER_ERROR: {
+      out_ << R"({"type": "helper_error")";
+      out_ << R"(, "msg": )";
+      JsonEmitter<std::string>::emit(out_, strerror(-retcode));
+      out_ << R"(, "helper": )";
+      std::stringstream ss;
+      ss << info.func_id;
+      JsonEmitter<std::string>::emit(out_, ss.str());
+      out_ << R"(, "retcode": )";
+      JsonEmitter<int64_t>::emit(out_, retcode);
+      break;
+    }
+    default: {
+      out_ << R"({"type": "runtime_error")";
+      out_ << R"(, "msg": )";
+      std::stringstream ss;
+      ss << info;
+      JsonEmitter<std::string>::emit(out_, ss.str());
+      break;
+    }
+  }
+
   out_ << R"(, "filename": )";
   JsonEmitter<std::string>::emit(out_, info.filename);
   out_ << R"(, "line": )";

--- a/src/output/json.h
+++ b/src/output/json.h
@@ -19,7 +19,7 @@ public:
   void syscall(const std::string &syscall) override;
   void lost_events(uint64_t lost) override;
   void attached_probes(uint64_t num_probes) override;
-  void helper_error(int retcode, const HelperErrorInfo &info) override;
+  void runtime_error(int retcode, const RuntimeErrorInfo &info) override;
   void benchmark_results(
       const std::vector<std::pair<std::string, uint32_t>> &results) override;
   void end() override;

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -7,7 +7,7 @@
 #include <variant>
 #include <vector>
 
-#include "required_resources.h" // For HelperErrorInfo.
+#include "required_resources.h" // For RuntimeErrorInfo.
 
 namespace bpftrace::output {
 
@@ -155,7 +155,7 @@ public:
   virtual void syscall(const std::string& syscall) = 0;
   virtual void lost_events(uint64_t lost) = 0;
   virtual void attached_probes(uint64_t num_probes) = 0;
-  virtual void helper_error(int retcode, const HelperErrorInfo& info) = 0;
+  virtual void runtime_error(int retcode, const RuntimeErrorInfo& info) = 0;
   virtual void benchmark_results(
       const std::vector<std::pair<std::string, uint32_t>>& results) = 0;
   virtual void end() = 0;

--- a/src/output/text.h
+++ b/src/output/text.h
@@ -19,7 +19,7 @@ public:
   void syscall(const std::string &syscall) override;
   void lost_events(uint64_t lost) override;
   void attached_probes(uint64_t num_probes) override;
-  void helper_error(int retcode, const HelperErrorInfo &info) override;
+  void runtime_error(int retcode, const RuntimeErrorInfo &info) override;
   void benchmark_results(
       const std::vector<std::pair<std::string, uint32_t>> &results) override;
   void end() override;

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -34,4 +34,20 @@ void RequiredResources::load_state(const uint8_t *ptr, size_t len)
   archive(*this);
 }
 
+std::ostream &operator<<(std::ostream &os, const RuntimeErrorInfo &info)
+{
+  switch (info.error_id) {
+    case RuntimeErrorId::HELPER_ERROR: {
+      // Helper errors are handled separately in output
+      os << "";
+      break;
+    }
+    case RuntimeErrorId::DIVIDE_BY_ZERO: {
+      os << DIVIDE_BY_ZERO_MSG;
+      break;
+    }
+  }
+  return os;
+}
+
 } // namespace bpftrace

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -5,6 +5,7 @@ target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr }
 %printf_t = type { i64 }
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -18,6 +19,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
   %printf_args = alloca %printf_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %mod_result = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
@@ -43,40 +45,63 @@ if_body1:                                         ; preds = %zero_merge
   call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 8, i1 false)
   %6 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
   store i64 0, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 8, i64 0)
-  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
-  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+  %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 8, i64 0)
+  %ringbuf_loss9 = icmp slt i64 %ringbuf_output6, 0
+  br i1 %ringbuf_loss9, label %event_loss_counter7, label %counter_merge8
 
-if_end2:                                          ; preds = %counter_merge, %zero_merge
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %mod_result)
+if_end2:                                          ; preds = %counter_merge8, %zero_merge
   br label %if_end
 
 is_zero:                                          ; preds = %if_body
   store i64 1, ptr %mod_result, align 8
-  br label %zero_merge
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
+  store i64 30006, ptr %7, align 8
+  %8 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
+  store i64 0, ptr %8, align 8
+  %9 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
+  store i64 0, ptr %9, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 not_zero:                                         ; preds = %if_body
-  %7 = urem i64 %5, 2
-  store i64 %7, ptr %mod_result, align 8
+  %10 = urem i64 %5, 2
+  store i64 %10, ptr %mod_result, align 8
   br label %zero_merge
 
-zero_merge:                                       ; preds = %not_zero, %is_zero
-  %8 = load i64, ptr %mod_result, align 8
-  %9 = icmp eq i64 %8, 0
-  %true_cond5 = icmp ne i1 %9, false
+zero_merge:                                       ; preds = %not_zero, %counter_merge
+  %11 = load i64, ptr %mod_result, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %mod_result)
+  %12 = icmp eq i64 %11, 0
+  %true_cond5 = icmp ne i1 %12, false
   br i1 %true_cond5, label %if_body1, label %if_end2
 
-event_loss_counter:                               ; preds = %if_body1
+event_loss_counter:                               ; preds = %is_zero
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %10 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %10
-  %11 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %12 = load i64, ptr %11, align 8
-  %13 = add i64 %12, 1
-  store i64 %13, ptr %11, align 8
+  %13 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %13
+  %14 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %15 = load i64, ptr %14, align 8
+  %16 = add i64 %15, 1
+  store i64 %16, ptr %14, align 8
   br label %counter_merge
 
-counter_merge:                                    ; preds = %event_loss_counter, %if_body1
+counter_merge:                                    ; preds = %event_loss_counter, %is_zero
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
+  br label %zero_merge
+
+event_loss_counter7:                              ; preds = %if_body1
+  %get_cpu_id10 = call i64 inttoptr (i64 8 to ptr)() #3
+  %17 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded11 = and i64 %get_cpu_id10, %17
+  %18 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded11, i64 0
+  %19 = load i64, ptr %18, align 8
+  %20 = add i64 %19, 1
+  store i64 %20, ptr %18, align 8
+  br label %counter_merge8
+
+counter_merge8:                                   ; preds = %event_loss_counter7, %if_body1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %printf_args)
   br label %if_end2
 }
@@ -84,11 +109,11 @@ counter_merge:                                    ; preds = %event_loss_counter,
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
-declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -20,7 +20,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
   %printf_args = alloca %printf_t, align 8
   %runtime_error_t = alloca %runtime_error_t, align 8
-  %mod_result = alloca i64, align 8
+  %op_result = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
@@ -34,7 +34,7 @@ if_body:                                          ; preds = %entry
   %4 = lshr i64 %get_pid_tgid3, 32
   %pid4 = trunc i64 %4 to i32
   %5 = zext i32 %pid4 to i64
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %mod_result)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %op_result)
   br i1 false, label %is_zero, label %not_zero
 
 if_end:                                           ; preds = %if_end2, %entry
@@ -53,7 +53,7 @@ if_end2:                                          ; preds = %counter_merge8, %ze
   br label %if_end
 
 is_zero:                                          ; preds = %if_body
-  store i64 1, ptr %mod_result, align 8
+  store i64 1, ptr %op_result, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %7, align 8
@@ -67,12 +67,12 @@ is_zero:                                          ; preds = %if_body
 
 not_zero:                                         ; preds = %if_body
   %10 = urem i64 %5, 2
-  store i64 %10, ptr %mod_result, align 8
+  store i64 %10, ptr %op_result, align 8
   br label %zero_merge
 
 zero_merge:                                       ; preds = %not_zero, %counter_merge
-  %11 = load i64, ptr %mod_result, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %mod_result)
+  %11 = load i64, ptr %op_result, align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %op_result)
   %12 = icmp eq i64 %11, 0
   %true_cond5 = icmp ne i1 %12, false
   br i1 %true_cond5, label %if_body1, label %if_end2

--- a/tests/codegen/llvm/runtime_error_check_comm.ll
+++ b/tests/codegen/llvm/runtime_error_check_comm.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -19,9 +19,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %helper_error_t3 = alloca %helper_error_t, align 8
+  %runtime_error_t3 = alloca %runtime_error_t, align 8
   %"@x_key" = alloca i64, align 8
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %comm = alloca [16 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %comm)
   call void @llvm.memset.p0.i64(ptr align 1 %comm, i8 0, i64 16, i1 false)
@@ -31,14 +31,14 @@ entry:
   br i1 %2, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %3 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %3 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %3, align 8
-  %4 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
-  %5 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %1, ptr %5, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -61,18 +61,18 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 
 helper_failure1:                                  ; preds = %helper_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t3)
-  %12 = getelementptr %helper_error_t, ptr %helper_error_t3, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t3)
+  %12 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 0
   store i64 30006, ptr %12, align 8
-  %13 = getelementptr %helper_error_t, ptr %helper_error_t3, i64 0, i32 1
+  %13 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 1
   store i64 1, ptr %13, align 8
-  %14 = getelementptr %helper_error_t, ptr %helper_error_t3, i64 0, i32 2
+  %14 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 2
   store i32 %6, ptr %14, align 4
-  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t3, i64 20, i64 0)
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t3, i64 20, i64 0)
   %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
   br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
 
@@ -92,7 +92,7 @@ event_loss_counter5:                              ; preds = %helper_failure1
   br label %counter_merge6
 
 counter_merge6:                                   ; preds = %event_loss_counter5, %helper_failure1
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t3)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t3)
   br label %helper_merge2
 }
 

--- a/tests/codegen/llvm/runtime_error_check_delete.ll
+++ b/tests/codegen/llvm/runtime_error_check_delete.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -19,9 +19,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %helper_error_t4 = alloca %helper_error_t, align 8
+  %runtime_error_t4 = alloca %runtime_error_t, align 8
   %"@x_key1" = alloca i64, align 8
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -34,14 +34,14 @@ entry:
   br i1 %2, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %3 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %3 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %3, align 8
-  %4 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
-  %5 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %1, ptr %5, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -66,18 +66,18 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 
 helper_failure2:                                  ; preds = %helper_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t4)
-  %12 = getelementptr %helper_error_t, ptr %helper_error_t4, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t4)
+  %12 = getelementptr %runtime_error_t, ptr %runtime_error_t4, i64 0, i32 0
   store i64 30006, ptr %12, align 8
-  %13 = getelementptr %helper_error_t, ptr %helper_error_t4, i64 0, i32 1
+  %13 = getelementptr %runtime_error_t, ptr %runtime_error_t4, i64 0, i32 1
   store i64 1, ptr %13, align 8
-  %14 = getelementptr %helper_error_t, ptr %helper_error_t4, i64 0, i32 2
+  %14 = getelementptr %runtime_error_t, ptr %runtime_error_t4, i64 0, i32 2
   store i32 %6, ptr %14, align 4
-  %ringbuf_output5 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t4, i64 20, i64 0)
+  %ringbuf_output5 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t4, i64 20, i64 0)
   %ringbuf_loss8 = icmp slt i64 %ringbuf_output5, 0
   br i1 %ringbuf_loss8, label %event_loss_counter6, label %counter_merge7
 
@@ -97,7 +97,7 @@ event_loss_counter6:                              ; preds = %helper_failure2
   br label %counter_merge7
 
 counter_merge7:                                   ; preds = %event_loss_counter6, %helper_failure2
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t4)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t4)
   br label %helper_merge3
 }
 

--- a/tests/codegen/llvm/runtime_error_check_for_map.ll
+++ b/tests/codegen/llvm/runtime_error_check_for_map.ll
@@ -6,7 +6,7 @@ target triple = "bpf"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 %int64_int64__tuple_t = type { i64, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
@@ -22,8 +22,8 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !61 {
 entry:
-  %helper_error_t3 = alloca %helper_error_t, align 8
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t3 = alloca %runtime_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %"@map_val" = alloca i64, align 8
   %"@map_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
@@ -36,14 +36,14 @@ entry:
   br i1 %2, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %3 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %3 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %3, align 8
-  %4 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
-  %5 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %1, ptr %5, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -66,18 +66,18 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 
 helper_failure1:                                  ; preds = %helper_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t3)
-  %12 = getelementptr %helper_error_t, ptr %helper_error_t3, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t3)
+  %12 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 0
   store i64 30006, ptr %12, align 8
-  %13 = getelementptr %helper_error_t, ptr %helper_error_t3, i64 0, i32 1
+  %13 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 1
   store i64 2, ptr %13, align 8
-  %14 = getelementptr %helper_error_t, ptr %helper_error_t3, i64 0, i32 2
+  %14 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 2
   store i32 %6, ptr %14, align 4
-  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t3, i64 20, i64 0)
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t3, i64 20, i64 0)
   %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
   br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
 
@@ -95,7 +95,7 @@ event_loss_counter5:                              ; preds = %helper_failure1
   br label %counter_merge6
 
 counter_merge6:                                   ; preds = %event_loss_counter5, %helper_failure1
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t3)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t3)
   br label %helper_merge2
 }
 
@@ -108,7 +108,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nounwind
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !67 {
 for_body:
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %"@x_key" = alloca i64, align 8
   %"$kv" = alloca %int64_int64__tuple_t, align 8
   %key = load i64, ptr %1, align 8
@@ -133,14 +133,14 @@ for_break:                                        ; No predecessors!
   ret i64 1
 
 helper_failure:                                   ; preds = %for_body
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %8 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %8 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %8, align 8
-  %9 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %9 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 1, ptr %9, align 8
-  %10 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %10 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %6, ptr %10, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -159,7 +159,7 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 }
 

--- a/tests/codegen/llvm/runtime_error_check_lookup.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -19,9 +19,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
 entry:
-  %helper_error_t1 = alloca %helper_error_t, align 8
+  %runtime_error_t1 = alloca %runtime_error_t, align 8
   %"@_newval" = alloca i64, align 8
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
@@ -38,14 +38,14 @@ lookup_success:                                   ; preds = %entry
 
 lookup_failure:                                   ; preds = %entry
   store i64 0, ptr %lookup_elem_val, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %2 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %2 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %2, align 8
-  %3 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %3 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %3, align 8
-  %4 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 0, ptr %4, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -71,18 +71,18 @@ event_loss_counter:                               ; preds = %lookup_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %lookup_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %lookup_merge
 
 helper_failure:                                   ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t1)
-  %13 = getelementptr %helper_error_t, ptr %helper_error_t1, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t1)
+  %13 = getelementptr %runtime_error_t, ptr %runtime_error_t1, i64 0, i32 0
   store i64 30006, ptr %13, align 8
-  %14 = getelementptr %helper_error_t, ptr %helper_error_t1, i64 0, i32 1
+  %14 = getelementptr %runtime_error_t, ptr %runtime_error_t1, i64 0, i32 1
   store i64 1, ptr %14, align 8
-  %15 = getelementptr %helper_error_t, ptr %helper_error_t1, i64 0, i32 2
+  %15 = getelementptr %runtime_error_t, ptr %runtime_error_t1, i64 0, i32 2
   store i32 %7, ptr %15, align 4
-  %ringbuf_output2 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t1, i64 20, i64 0)
+  %ringbuf_output2 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t1, i64 20, i64 0)
   %ringbuf_loss5 = icmp slt i64 %ringbuf_output2, 0
   br i1 %ringbuf_loss5, label %event_loss_counter3, label %counter_merge4
 
@@ -102,7 +102,7 @@ event_loss_counter3:                              ; preds = %helper_failure
   br label %counter_merge4
 
 counter_merge4:                                   ; preds = %event_loss_counter3, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t1)
   br label %helper_merge
 }
 

--- a/tests/codegen/llvm/runtime_error_check_lookup_no_warning.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup_no_warning.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -19,7 +19,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
 entry:
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %"@_newval" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
@@ -51,14 +51,14 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br i1 %5, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %6 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %6, align 8
-  %7 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %7, align 8
-  %8 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %8 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %4, ptr %8, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -78,7 +78,7 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 }
 

--- a/tests/codegen/llvm/runtime_error_check_lookup_percpu.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup_percpu.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -23,12 +23,12 @@ entry:
   %"$a" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
   store i64 0, ptr %"$a", align 8
-  %helper_error_t5 = alloca %helper_error_t, align 8
+  %runtime_error_t5 = alloca %runtime_error_t, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
   %"@_key1" = alloca i64, align 8
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
@@ -67,14 +67,14 @@ lookup_merge:                                     ; preds = %helper_merge, %look
   br label %while_cond
 
 helper_failure:                                   ; preds = %lookup_failure
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %5 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %5, align 8
-  %6 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %6, align 8
-  %7 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %3, ptr %7, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -93,7 +93,7 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 
 while_cond:                                       ; preds = %lookup_success2, %lookup_merge
@@ -133,14 +133,14 @@ lookup_failure3:                                  ; preds = %while_body
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure3
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t5)
-  %22 = getelementptr %helper_error_t, ptr %helper_error_t5, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t5)
+  %22 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 0
   store i64 30006, ptr %22, align 8
-  %23 = getelementptr %helper_error_t, ptr %helper_error_t5, i64 0, i32 1
+  %23 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 1
   store i64 1, ptr %23, align 8
-  %24 = getelementptr %helper_error_t, ptr %helper_error_t5, i64 0, i32 2
+  %24 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 2
   store i32 0, ptr %24, align 4
-  %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t5, i64 20, i64 0)
+  %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t5, i64 20, i64 0)
   %ringbuf_loss9 = icmp slt i64 %ringbuf_output6, 0
   br i1 %ringbuf_loss9, label %event_loss_counter7, label %counter_merge8
 
@@ -159,7 +159,7 @@ event_loss_counter7:                              ; preds = %error_success
   br label %counter_merge8
 
 counter_merge8:                                   ; preds = %event_loss_counter7, %error_success
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t5)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t5)
   br label %while_end
 }
 

--- a/tests/codegen/llvm/runtime_error_check_path.ll
+++ b/tests/codegen/llvm/runtime_error_check_path.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -18,7 +18,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @fentry_mock_vmlinux_filp_close_1(ptr %0) #0 section "s_fentry_mock_vmlinux_filp_close_1" !dbg !42 {
 entry:
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
@@ -30,14 +30,14 @@ entry:
   br i1 %4, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %5 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %5, align 8
-  %6 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %6, align 8
-  %7 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %3, ptr %7, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -55,7 +55,7 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 }
 

--- a/tests/codegen/llvm/runtime_error_check_pid_tid.ll
+++ b/tests/codegen/llvm/runtime_error_check_pid_tid.ll
@@ -6,7 +6,7 @@ target triple = "bpf"
 %"struct map_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.0" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.1" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -21,10 +21,10 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %helper_error_t5 = alloca %helper_error_t, align 8
+  %runtime_error_t5 = alloca %runtime_error_t, align 8
   %"@y_val" = alloca i64, align 8
   %"@y_key" = alloca i64, align 8
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
@@ -41,14 +41,14 @@ entry:
   br i1 %4, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %5 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %5, align 8
-  %6 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %6, align 8
-  %7 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %3, ptr %7, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -78,18 +78,18 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 
 helper_failure3:                                  ; preds = %helper_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t5)
-  %15 = getelementptr %helper_error_t, ptr %helper_error_t5, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t5)
+  %15 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 0
   store i64 30006, ptr %15, align 8
-  %16 = getelementptr %helper_error_t, ptr %helper_error_t5, i64 0, i32 1
+  %16 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 1
   store i64 1, ptr %16, align 8
-  %17 = getelementptr %helper_error_t, ptr %helper_error_t5, i64 0, i32 2
+  %17 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 2
   store i32 %9, ptr %17, align 4
-  %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t5, i64 20, i64 0)
+  %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t5, i64 20, i64 0)
   %ringbuf_loss9 = icmp slt i64 %ringbuf_output6, 0
   br i1 %ringbuf_loss9, label %event_loss_counter7, label %counter_merge8
 
@@ -109,7 +109,7 @@ event_loss_counter7:                              ; preds = %helper_failure3
   br label %counter_merge8
 
 counter_merge8:                                   ; preds = %event_loss_counter7, %helper_failure3
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t5)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t5)
   br label %helper_merge4
 }
 

--- a/tests/codegen/llvm/runtime_error_check_printf.ll
+++ b/tests/codegen/llvm/runtime_error_check_printf.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -18,7 +18,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @iter_task_file_1(ptr %0) #0 section "s_iter_task_file_1" !dbg !35 {
 entry:
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %data = alloca [1 x i64], align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %data)
   call void @llvm.memset.p0.i64(ptr align 1 %data, i8 0, i64 8, i1 false)
@@ -35,14 +35,14 @@ entry:
   br i1 %6, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %7 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %7, align 8
-  %8 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %8 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %8, align 8
-  %9 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %9 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %5, ptr %9, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -60,7 +60,7 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 }
 

--- a/tests/codegen/llvm/runtime_error_check_signal.ll
+++ b/tests/codegen/llvm/runtime_error_check_signal.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_t" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
@@ -17,21 +17,21 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %signal = call i64 inttoptr (i64 109 to ptr)(i32 8)
   %1 = trunc i64 %signal to i32
   %2 = icmp sge i32 %1, 0
   br i1 %2, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %entry
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %3 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %3 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %3, align 8
-  %4 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
-  %5 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %1, ptr %5, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -49,7 +49,7 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 }
 

--- a/tests/codegen/llvm/runtime_error_check_stack.ll
+++ b/tests/codegen/llvm/runtime_error_check_stack.ll
@@ -8,7 +8,7 @@ target triple = "bpf"
 %"struct map_t.1" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.2" = type { ptr, ptr, ptr, ptr }
 %"struct map_t.3" = type { ptr, ptr }
-%helper_error_t = type <{ i64, i64, i32 }>
+%runtime_error_t = type <{ i64, i64, i32 }>
 %kstack_key = type { i64, i64 }
 %ustack_key = type { i64, i64, i32, i32 }
 
@@ -27,16 +27,16 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !91 {
 entry:
-  %helper_error_t55 = alloca %helper_error_t, align 8
+  %runtime_error_t55 = alloca %runtime_error_t, align 8
   %"@y_key" = alloca i64, align 8
-  %helper_error_t45 = alloca %helper_error_t, align 8
-  %helper_error_t34 = alloca %helper_error_t, align 8
+  %runtime_error_t45 = alloca %runtime_error_t, align 8
+  %runtime_error_t34 = alloca %runtime_error_t, align 8
   %lookup_stack_scratch_key23 = alloca i32, align 4
   %stack_key20 = alloca %kstack_key, align 8
-  %helper_error_t13 = alloca %helper_error_t, align 8
+  %runtime_error_t13 = alloca %runtime_error_t, align 8
   %"@x_key" = alloca i64, align 8
-  %helper_error_t3 = alloca %helper_error_t, align 8
-  %helper_error_t = alloca %helper_error_t, align 8
+  %runtime_error_t3 = alloca %runtime_error_t, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %lookup_stack_scratch_key = alloca i32, align 4
   %stack_key = alloca %ustack_key, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %stack_key)
@@ -93,14 +93,14 @@ get_stack_fail:                                   ; preds = %helper_merge
   br label %merge_block
 
 helper_failure:                                   ; preds = %lookup_stack_scratch_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t)
-  %14 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %14 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
   store i64 30006, ptr %14, align 8
-  %15 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 1
+  %15 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %15, align 8
-  %16 = getelementptr %helper_error_t, ptr %helper_error_t, i64 0, i32 2
+  %16 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
   store i32 %6, ptr %16, align 4
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t, i64 20, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -119,18 +119,18 @@ event_loss_counter:                               ; preds = %helper_failure
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
   br label %helper_merge
 
 helper_failure1:                                  ; preds = %get_stack_success
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t3)
-  %22 = getelementptr %helper_error_t, ptr %helper_error_t3, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t3)
+  %22 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 0
   store i64 30006, ptr %22, align 8
-  %23 = getelementptr %helper_error_t, ptr %helper_error_t3, i64 0, i32 1
+  %23 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 1
   store i64 1, ptr %23, align 8
-  %24 = getelementptr %helper_error_t, ptr %helper_error_t3, i64 0, i32 2
+  %24 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 2
   store i32 %12, ptr %24, align 4
-  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t3, i64 20, i64 0)
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t3, i64 20, i64 0)
   %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
   br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
 
@@ -148,18 +148,18 @@ event_loss_counter5:                              ; preds = %helper_failure1
   br label %counter_merge6
 
 counter_merge6:                                   ; preds = %event_loss_counter5, %helper_failure1
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t3)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t3)
   br label %helper_merge2
 
 helper_failure11:                                 ; preds = %merge_block
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t13)
-  %29 = getelementptr %helper_error_t, ptr %helper_error_t13, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t13)
+  %29 = getelementptr %runtime_error_t, ptr %runtime_error_t13, i64 0, i32 0
   store i64 30006, ptr %29, align 8
-  %30 = getelementptr %helper_error_t, ptr %helper_error_t13, i64 0, i32 1
+  %30 = getelementptr %runtime_error_t, ptr %runtime_error_t13, i64 0, i32 1
   store i64 2, ptr %30, align 8
-  %31 = getelementptr %helper_error_t, ptr %helper_error_t13, i64 0, i32 2
+  %31 = getelementptr %runtime_error_t, ptr %runtime_error_t13, i64 0, i32 2
   store i32 %4, ptr %31, align 4
-  %ringbuf_output14 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t13, i64 20, i64 0)
+  %ringbuf_output14 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t13, i64 20, i64 0)
   %ringbuf_loss17 = icmp slt i64 %ringbuf_output14, 0
   br i1 %ringbuf_loss17, label %event_loss_counter15, label %counter_merge16
 
@@ -185,7 +185,7 @@ event_loss_counter15:                             ; preds = %helper_failure11
   br label %counter_merge16
 
 counter_merge16:                                  ; preds = %event_loss_counter15, %helper_failure11
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t13)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t13)
   br label %helper_merge12
 
 stack_scratch_failure21:                          ; preds = %lookup_stack_scratch_failure25
@@ -226,14 +226,14 @@ get_stack_fail30:                                 ; preds = %helper_merge33
   br label %merge_block22
 
 helper_failure32:                                 ; preds = %lookup_stack_scratch_merge26
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t34)
-  %46 = getelementptr %helper_error_t, ptr %helper_error_t34, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t34)
+  %46 = getelementptr %runtime_error_t, ptr %runtime_error_t34, i64 0, i32 0
   store i64 30006, ptr %46, align 8
-  %47 = getelementptr %helper_error_t, ptr %helper_error_t34, i64 0, i32 1
+  %47 = getelementptr %runtime_error_t, ptr %runtime_error_t34, i64 0, i32 1
   store i64 3, ptr %47, align 8
-  %48 = getelementptr %helper_error_t, ptr %helper_error_t34, i64 0, i32 2
+  %48 = getelementptr %runtime_error_t, ptr %runtime_error_t34, i64 0, i32 2
   store i32 %38, ptr %48, align 4
-  %ringbuf_output35 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t34, i64 20, i64 0)
+  %ringbuf_output35 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t34, i64 20, i64 0)
   %ringbuf_loss38 = icmp slt i64 %ringbuf_output35, 0
   br i1 %ringbuf_loss38, label %event_loss_counter36, label %counter_merge37
 
@@ -252,18 +252,18 @@ event_loss_counter36:                             ; preds = %helper_failure32
   br label %counter_merge37
 
 counter_merge37:                                  ; preds = %event_loss_counter36, %helper_failure32
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t34)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t34)
   br label %helper_merge33
 
 helper_failure43:                                 ; preds = %get_stack_success29
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t45)
-  %54 = getelementptr %helper_error_t, ptr %helper_error_t45, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t45)
+  %54 = getelementptr %runtime_error_t, ptr %runtime_error_t45, i64 0, i32 0
   store i64 30006, ptr %54, align 8
-  %55 = getelementptr %helper_error_t, ptr %helper_error_t45, i64 0, i32 1
+  %55 = getelementptr %runtime_error_t, ptr %runtime_error_t45, i64 0, i32 1
   store i64 4, ptr %55, align 8
-  %56 = getelementptr %helper_error_t, ptr %helper_error_t45, i64 0, i32 2
+  %56 = getelementptr %runtime_error_t, ptr %runtime_error_t45, i64 0, i32 2
   store i32 %44, ptr %56, align 4
-  %ringbuf_output46 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t45, i64 20, i64 0)
+  %ringbuf_output46 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t45, i64 20, i64 0)
   %ringbuf_loss49 = icmp slt i64 %ringbuf_output46, 0
   br i1 %ringbuf_loss49, label %event_loss_counter47, label %counter_merge48
 
@@ -281,18 +281,18 @@ event_loss_counter47:                             ; preds = %helper_failure43
   br label %counter_merge48
 
 counter_merge48:                                  ; preds = %event_loss_counter47, %helper_failure43
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t45)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t45)
   br label %helper_merge44
 
 helper_failure53:                                 ; preds = %merge_block22
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %helper_error_t55)
-  %61 = getelementptr %helper_error_t, ptr %helper_error_t55, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t55)
+  %61 = getelementptr %runtime_error_t, ptr %runtime_error_t55, i64 0, i32 0
   store i64 30006, ptr %61, align 8
-  %62 = getelementptr %helper_error_t, ptr %helper_error_t55, i64 0, i32 1
+  %62 = getelementptr %runtime_error_t, ptr %runtime_error_t55, i64 0, i32 1
   store i64 5, ptr %62, align 8
-  %63 = getelementptr %helper_error_t, ptr %helper_error_t55, i64 0, i32 2
+  %63 = getelementptr %runtime_error_t, ptr %runtime_error_t55, i64 0, i32 2
   store i32 %36, ptr %63, align 4
-  %ringbuf_output56 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %helper_error_t55, i64 20, i64 0)
+  %ringbuf_output56 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t55, i64 20, i64 0)
   %ringbuf_loss59 = icmp slt i64 %ringbuf_output56, 0
   br i1 %ringbuf_loss59, label %event_loss_counter57, label %counter_merge58
 
@@ -311,7 +311,7 @@ event_loss_counter57:                             ; preds = %helper_failure53
   br label %counter_merge58
 
 counter_merge58:                                  ; preds = %event_loss_counter57, %helper_failure53
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %helper_error_t55)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t55)
   br label %helper_merge54
 }
 

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -34,6 +34,13 @@ EXPECT 1
 EXPECT stdin:1:48-49: WARNING: Divide or modulo by 0 detected. This can lead to unexpected results. 1 is being used as the result.
 TIMEOUT 1
 
+# For a division operation where the RHS is 0 we treat the result as 1
+NAME zero_divide
+PROG BEGIN { @mod1 = 1; @mod0 = 0; print((uint64)10 / (uint64)@mod0); }
+EXPECT 1
+EXPECT stdin:1:48-49: WARNING: Divide or modulo by 0 detected. This can lead to unexpected results. 1 is being used as the result.
+TIMEOUT 1
+
 NAME c_array_indexing
 RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:uprobeFunction2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
 EXPECT h e l l o

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -31,6 +31,7 @@ TIMEOUT 1
 NAME zero_modulo
 PROG BEGIN { @mod1 = 1; @mod0 = 0; print((uint64)10 % (uint64)@mod0); }
 EXPECT 1
+EXPECT stdin:1:48-49: WARNING: Divide or modulo by 0 detected. This can lead to unexpected results. 1 is being used as the result.
 TIMEOUT 1
 
 NAME c_array_indexing

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -21,6 +21,18 @@ NAME modulo_operator
 PROG begin { @x = 4; printf("%d\n", @x % 2); exit() }
 EXPECT 0
 
+# More details: https://github.com/bpftrace/bpftrace/issues/4379
+NAME bad_modulo_optimization
+PROG BEGIN { @mod1 = 1; @mod0 = 0; print((uint64)10 % (uint64)@mod1); }
+EXPECT 0
+TIMEOUT 1
+
+# For a modulo operation where the RHS is 0 we treat the result as 1
+NAME zero_modulo
+PROG BEGIN { @mod1 = 1; @mod0 = 0; print((uint64)10 % (uint64)@mod0); }
+EXPECT 1
+TIMEOUT 1
+
 NAME c_array_indexing
 RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:uprobeFunction2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
 EXPECT h e l l o


### PR DESCRIPTION
Some compilers will assume that the RHS of a modulo operation can never be null/0 as that is undefined behavior so it will
remove the null check on a map lookup, which the BPF verifier does not like.

This PR has three commits:

1. Add a a zero check for the RHS of a modulo, which means the compiler can't optimize away the null ref check as it's no longer going straight to the modulo operation.

2. Create a new runtime error for divide by zero and rename HelperError to RuntimeError

3. Add a zero check for the RHS of a divide operation. Wasn't seeing the same compiler issue but good have the same behavior as modulo.

Issue: https://github.com/bpftrace/bpftrace/issues/4379

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
