### PR TITLE
docs: erase redundant space

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -197,8 +197,7 @@ These can be set via the [Config Block](#config-block) directly in a script (bef
 Default: PER_PROGRAM if ASLR disabled or `-c` option given, PER_PID otherwise.
 
 * PER_PROGRAM - each program has its own cache. If there are more processes with enabled ASLR for a single program, this might produce incorrect results.
-* PER_PID - each process has its own cache. This is accurate for processes with ASLR enabled, and enables bpftrace to preload caches for processes running at probe attachment ti
-me.
+* PER_PID - each process has its own cache. This is accurate for processes with ASLR enabled, and enables bpftrace to preload caches for processes running at probe attachment time.
 If there are many processes running, it will consume a lot of a memory.
 * NONE - caching disabled. This saves the most memory, but at the cost of speed.
 


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Remove redundant space in `docs/language.md`.

Fixes https://github.com/bpftrace/bpftrace/issues/4316

Before (https://github.com/bpftrace/bpftrace/blob/c47425e913a2de2fa9cb361d839c56438fedf2d8/docs/language.md)

<img width="1000" height="217" alt="Screenshot from 2025-07-26 21-23-05" src="https://github.com/user-attachments/assets/6ce256b3-da1a-472f-9835-99b627586699" />

After (https://github.com/bin-101/bpftrace/blob/c015f93c0bc9d5eb76feeef91be5309ccfe63b51/docs/language.md)

<img width="1000" height="217" alt="Screenshot from 2025-07-26 21-26-28" src="https://github.com/user-attachments/assets/3308401e-c21d-446b-95b1-4ec2bdaf4c70" />

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
