### PR TITLE
benchmark: Prevent duplicate `BENCH` probe names

### DIFF
--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2321,6 +2321,14 @@ stdin:1:1-7: ERROR: bench probes must have a name
 bench: { 1 }
 ~~~~~~
 )" });
+  test("BENCH:a { 1 } BENCH:a { 2 }", Error{ R"(
+stdin:1:14-22: ERROR: "a" was used as the name for more than one BENCH probe
+BENCH:a { 1 } BENCH:a { 2 }
+             ~~~~~~~~
+stdin:1:1-8: ERROR: this is the other instance
+BENCH:a { 1 } BENCH:a { 2 }
+~~~~~~~
+)" });
 }
 
 TEST_F(SemanticAnalyserTest, self_probe)


### PR DESCRIPTION
Currently, `BENCH` probe names are allowed to be reused, but the benchmark results only show one row per unique name:

```
BENCH:my_bench {
    @a = 1;
}

BENCH:my_bench {
    @b = 1;
}
```

```
Attached 1 probe

+-----------+--------------+
| BENCHMARK | AVERAGE TIME |
+-----------+--------------+
| my_bench  | 155ns        |
+-----------+--------------+
```

This is incorrect and confusing. To ensure consistency between the script and the output, we have two options:

1. Continue to allow duplicate `BENCH` probe names and teach the output logic how to display one row per `BENCH` probe instead of one row per unique name.
2. Prevent users from creating two `BENCH` probes with the same name.

Since there doesn't seem to be much legitimate reason to allow for duplicate names, go with option two and check for duplicate names in semantic analysis.

```
script.bt:3-5: ERROR: "my_bench" was used as the name for more than one BENCH probe
}

BENCH:my_bench {
script.bt:1:1-15: ERROR: this is the other instance
BENCH:my_bench {
~~~~~~~~~~~~~~
```

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
