### PR TITLE
codegen: move initialization to the first `LLVMInit` pass

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -77,10 +77,6 @@ static constexpr auto LICENSE = "LICENSE";
 static auto getTargetMachine()
 {
   static auto *target = []() {
-    LLVMInitializeBPFTargetInfo();
-    LLVMInitializeBPFTarget();
-    LLVMInitializeBPFTargetMC();
-    LLVMInitializeBPFAsmPrinter();
     std::string error_str;
     const auto *target = llvm::TargetRegistry::lookupTarget(LLVMTargetTriple,
                                                             error_str);
@@ -5270,6 +5266,10 @@ std::unique_ptr<llvm::Module> CodegenLLVM::compile()
 
 Pass CreateLLVMInitPass()
 {
+  LLVMInitializeBPFTargetInfo();
+  LLVMInitializeBPFTarget();
+  LLVMInitializeBPFTargetMC();
+  LLVMInitializeBPFAsmPrinter();
   return Pass::create("llvm-init", [] { return CompileContext(); });
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #4397
 * #4396
 * #4395
 * #4394
 * #4393
 * #4392
 * __->__#4391


--- --- ---

### codegen: move initialization to the first `LLVMInit` pass


Some tests don't run an actual compile, but want to compile native code
for types. Ensure that everything is initialized by moving the
initialization into the logical place, the `LLVMInit` pass.

Signed-off-by: Adin Scannell <amscanne@meta.com>
