### PR TITLE
docs: Use `//` for generating stdlib docs

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1220,6 +1220,7 @@ Simple assertion macro that will exit the entire script with an error code if th
 
 #### Last Expression
 - **None**
+
 ### ppid
 Get the pid of the parent process
 

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -1,9 +1,7 @@
-/*
-Simple assertion macro that will exit the entire script with an error code if the condition is not met.
-
-:param (bool) $cond: The condition to check
-:param (string) $msg: The message to print if the condition is not met
-*/
+// Simple assertion macro that will exit the entire script with an error code if the condition is not met.
+//
+// :param (bool) $cond: The condition to check
+// :param (string) $msg: The message to print if the condition is not met
 macro assert($cond, $msg) {
   if (!$cond) {
     printf("Assertion failed. Msg: %s", $msg);
@@ -11,13 +9,10 @@ macro assert($cond, $msg) {
   }
 }
 
-/*
-Get the pid of the parent process
-
-:param (struct task_struct *) $task: The current task struct
-
-:last_expr (uint32): The pid of the parent process
-*/
+// Get the pid of the parent process
+//
+// :param (struct task_struct *) $task: The current task struct
+// :last_expr (uint32): The pid of the parent process
 macro ppid($task) {
     $task->real_parent->pid
 }


### PR DESCRIPTION
Stacked PRs:
 * #4397
 * #4402
 * __->__#4393


--- --- ---

### docs: Use `//` for generating stdlib docs


This allows for a simpler parser, since we don't have to take into
account any of the common C-style multi-line strings, e.g.

```
/*
 * Something.
 */
```

Further, this change adds support for a longer description in addition
to the table based summary. The summary is used in the table, and both
the summary and description are used in the detailed markdown section.

Signed-off-by: Adin Scannell <amscanne@meta.com>
