### PR TITLE
helpers: handle unsupported helpers from interop files

### DIFF
--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -252,6 +252,10 @@ void BpfBytecode::load_progs(const RequiredResources &resources,
                                         " not allowed in probe");
       maybe_throw_helper_verifier_error(
           log,
+          "program of this type cannot use helper",
+          " not allowed in probe");
+      maybe_throw_helper_verifier_error(
+          log,
           "pointer arithmetic on ptr_or_null_ prohibited, null-check it first",
           ": result needs to be null-checked before accessing fields");
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -643,11 +643,19 @@ int BPFtrace::run(output::Output &out,
   } catch (const HelperVerifierError &e) {
     // To provide the most useful diagnostics, provide the error for every
     // callsite. After all, they all must be fixed.
+    bool found = false;
     for (const auto &info : helper_use_loc_[e.func_id]) {
       LOG(ERROR,
           std::string(info.source_location),
           std::vector(info.source_context))
           << e.what();
+      found = true;
+    }
+    if (!found) {
+      // An error occurred, but we don't have location for this helper. It may
+      // be a C file or elsewhere, and we need to plumb this through somehow.
+      // At least inform the user what has gone wrong in this case.
+      LOG(ERROR) << e.what();
     }
     return -1;
   } catch (const std::runtime_error &e) {


### PR DESCRIPTION
Stacked PRs:
 * #4397
 * #4399
 * #4393
 * #4392
 * #4395
 * #4394
 * __->__#4396


--- --- ---

### helpers: handle unsupported helpers from interop files


When the verifier rejects a program because of the preserve of a helper
call, we can extract the error and inform the user. For now, we don't
tie this to a location in the AST, but this can be done in the future in
a more dynamic way (using the debug information directly, rather than
storing our own debug information as a separate format).

Signed-off-by: Adin Scannell <amscanne@meta.com>
