### PR TITLE
Update stdlib docs generation script

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1220,6 +1220,7 @@ Simple assertion macro that will exit the entire script with an error code if th
 
 #### Last Expression
 - **None**
+
 ### ppid
 Get the pid of the parent process
 


### PR DESCRIPTION
- Support short and long descriptions where by short descriptions go in the table
and long descriptions under the individual macro
subsections

- Account for the case when the end of the doc comment "*/" is not on it's own line

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
