### PR TITLE
semantics: introduce `typeof`

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2866,9 +2866,10 @@ ScopedExpr CodegenLLVM::visit(MapAccess &acc)
 
 ScopedExpr CodegenLLVM::visit(Cast &cast)
 {
+  const auto &ty = cast.type();
   auto scoped_expr = visit(cast.expr);
-  if (cast.cast_type.IsIntTy()) {
-    auto *int_ty = b_.GetType(cast.cast_type);
+  if (ty.IsIntTy()) {
+    auto *int_ty = b_.GetType(ty);
     if (cast.expr.type().IsArrayTy()) {
       // we need to read the array into the integer
       Value *array = scoped_expr.value();
@@ -2878,28 +2879,27 @@ ScopedExpr CodegenLLVM::visit(Cast &cast)
           array = b_.CreateIntToPtr(array, b_.getPtrTy());
       } else {
         // array is in memory - need to proberead
-        auto *buf = b_.CreateAllocaBPF(cast.cast_type);
-        b_.CreateProbeRead(
-            buf, cast.cast_type, array, cast.loc, cast.expr.type().GetAS());
+        auto *buf = b_.CreateAllocaBPF(ty);
+        b_.CreateProbeRead(buf, ty, array, cast.loc, cast.expr.type().GetAS());
         array = buf;
       }
       return ScopedExpr(b_.CreateLoad(int_ty, array, true /*volatile*/));
     } else if (cast.expr.type().IsPtrTy()) {
       return ScopedExpr(b_.CreatePtrToInt(scoped_expr.value(), int_ty));
     } else {
-      return ScopedExpr(b_.CreateIntCast(
-          scoped_expr.value(),
-          b_.getIntNTy(cast.cast_type.GetIntBitWidth()),
-          cast.expr.type().IsBoolTy() ? false : cast.cast_type.IsSigned(),
-          "cast"));
+      return ScopedExpr(
+          b_.CreateIntCast(scoped_expr.value(),
+                           b_.getIntNTy(ty.GetIntBitWidth()),
+                           cast.expr.type().IsBoolTy() ? false : ty.IsSigned(),
+                           "cast"));
     }
-  } else if (cast.cast_type.IsArrayTy() && cast.expr.type().IsIntTy()) {
+  } else if (ty.IsArrayTy() && cast.expr.type().IsIntTy()) {
     // We need to store the cast integer on stack and reinterpret the pointer to
     // it to an array pointer.
     auto *v = b_.CreateAllocaBPF(scoped_expr.value()->getType());
     b_.CreateStore(scoped_expr.value(), v);
     return ScopedExpr(v, [this, v] { b_.CreateLifetimeEnd(v); });
-  } else if (cast.cast_type.IsBoolTy()) {
+  } else if (ty.IsBoolTy()) {
     if (cast.expr.type().IsStringTy()) {
       auto *first_char = b_.CreateGEP(b_.getInt8Ty(),
                                       scoped_expr.value(),
@@ -2912,7 +2912,7 @@ ScopedExpr CodegenLLVM::visit(Cast &cast)
     Value *zero_value = Constant::getNullValue(scoped_expr.value()->getType());
     Value *cond = b_.CreateICmpNE(scoped_expr.value(), zero_value, "bool_cast");
     return ScopedExpr(cond);
-  } else if (cast.cast_type.IsPtrTy()) {
+  } else if (ty.IsPtrTy()) {
     if (cast.expr.type().IsIntTy()) {
       Value *val = b_.CreateIntToPtr(scoped_expr.value(), b_.getPtrTy());
       return ScopedExpr(val);
@@ -3449,14 +3449,12 @@ ScopedExpr CodegenLLVM::visit(Subprog &subprog)
   // arguments to the function
   arg_types.push_back(b_.getPtrTy());
   std::ranges::transform(subprog.args,
-
                          std::back_inserter(arg_types),
                          [this](SubprogArg *arg) {
-                           return b_.GetType(arg->type);
+                           return b_.GetType(arg->typeof->type());
                          });
-  FunctionType *func_type = FunctionType::get(b_.GetType(subprog.return_type),
-                                              arg_types,
-                                              false);
+  FunctionType *func_type = FunctionType::get(
+      b_.GetType(subprog.return_type->type()), arg_types, false);
 
   auto *func = llvm::Function::Create(
       func_type, llvm::Function::InternalLinkage, subprog.name, module_.get());
@@ -3469,16 +3467,17 @@ ScopedExpr CodegenLLVM::visit(Subprog &subprog)
 
   int arg_index = 0;
   for (SubprogArg *arg : subprog.args) {
-    auto *alloca = b_.CreateAllocaBPF(b_.GetType(arg->type), arg->name);
+    auto *alloca = b_.CreateAllocaBPF(b_.GetType(arg->typeof->type()),
+                                      arg->var->ident);
     b_.CreateStore(func->getArg(arg_index + 1), alloca);
-    variables_[scope_stack_.back()][arg->name] = VariableLLVM{
+    variables_[scope_stack_.back()][arg->var->ident] = VariableLLVM{
       .value = alloca, .type = alloca->getAllocatedType()
     };
     ++arg_index;
   }
 
   visit(subprog.block);
-  if (subprog.return_type.IsVoidTy())
+  if (subprog.return_type->type().IsVoidTy())
     createRet();
 
   FunctionPassManager fpm;

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -32,9 +32,9 @@ public:
   void visit(FieldAccess &acc);
   void visit(ArrayAccess &arr);
   void visit(MapAccess &acc);
-  void visit(Cast &cast);
   void visit(Sizeof &szof);
   void visit(Offsetof &offof);
+  void visit(Typeof &typeof);
   void visit(AssignMapStatement &assignment);
   void visit(AssignVarStatement &assignment);
   void visit(Unop &unop);
@@ -172,12 +172,6 @@ void FieldAnalyser::visit(MapAccess &acc)
   visit(acc.map); // Leaves sized_type_ as value type.
 }
 
-void FieldAnalyser::visit(Cast &cast)
-{
-  visit(cast.expr);
-  resolve_type(cast.cast_type);
-}
-
 void FieldAnalyser::visit(Sizeof &szof)
 {
   if (std::holds_alternative<SizedType>(szof.record)) {
@@ -193,6 +187,15 @@ void FieldAnalyser::visit(Offsetof &offof)
     resolve_type(std::get<SizedType>(offof.record));
   } else {
     visit(offof.record);
+  }
+}
+
+void FieldAnalyser::visit(Typeof &typeof)
+{
+  if (std::holds_alternative<SizedType>(typeof.record)) {
+    resolve_type(std::get<SizedType>(typeof.record));
+  } else {
+    visit(typeof.record);
   }
 }
 

--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -18,6 +18,7 @@ public:
   void visit(Map &map);
   void visit(MapAccess &acc);
   void visit(MapAddr &map_addr);
+  void visit(Typeof &typeof);
   void visit(AssignScalarMapStatement &assign);
   void visit(AssignMapStatement &assign);
   void visit(Expression &expr);
@@ -83,6 +84,19 @@ void MapDefaultKey::visit(MapAccess &acc)
 void MapDefaultKey::visit([[maybe_unused]] MapAddr &map_addr)
 {
   // Don't desugar this into a map access, we want the map pointer
+}
+
+void MapDefaultKey::visit([[maybe_unused]] Typeof &typeof)
+{
+  if (std::holds_alternative<Expression>(typeof.record)) {
+    const auto &expr = std::get<Expression>(typeof.record);
+    if (expr.is<Map>()) {
+      // Do nothing; allow these to exist. It will extract the value of the map
+      // whether it is keyed or not.
+      return;
+    }
+  }
+  Visitor<MapDefaultKey>::visit(typeof);
 }
 
 void MapDefaultKey::visit(AssignScalarMapStatement &assign)

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -145,6 +145,16 @@ void Printer::visit(Offsetof &offof)
   --depth_;
 }
 
+void Printer::visit(Typeof &typeof)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "typeof: " << std::endl;
+
+  ++depth_;
+  visit(typeof.record);
+  --depth_;
+}
+
 void Printer::visit(MapDeclStatement &decl)
 {
   std::string indent(depth_, ' ');
@@ -386,8 +396,8 @@ void Printer::visit(VarDeclStatement &decl)
 {
   std::string indent(depth_, ' ');
 
-  if (decl.type) {
-    out_ << indent << "decl" << type(*decl.type) << std::endl;
+  if (decl.typeof) {
+    out_ << indent << "decl" << type(decl.typeof->type()) << std::endl;
   } else {
     out_ << indent << "decl" << std::endl;
   }
@@ -520,15 +530,15 @@ void Printer::visit(SubprogArg &arg)
   std::string indent(depth_, ' ');
 
   ++depth_;
-  out_ << indent << arg.name << type(arg.type) << std::endl;
+  out_ << indent << arg.var->ident << type(arg.typeof->type()) << std::endl;
   --depth_;
 }
 
 void Printer::visit(Subprog &subprog)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "subprog: " << subprog.name << type(subprog.return_type)
-       << std::endl;
+  out_ << indent << "subprog: " << subprog.name
+       << type(subprog.return_type->type()) << std::endl;
 
   ++depth_;
 

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -26,6 +26,7 @@ public:
   void visit(Call &call);
   void visit(Sizeof &szof);
   void visit(Offsetof &offof);
+  void visit(Typeof &typeof);
   void visit(Map &map);
   void visit(MapAddr &map_addr);
   void visit(MapDeclStatement &decl);

--- a/src/ast/passes/return_path_analyser.cpp
+++ b/src/ast/passes/return_path_analyser.cpp
@@ -29,7 +29,7 @@ bool ReturnPathAnalyser::visit(Program &prog)
 
 bool ReturnPathAnalyser::visit(Subprog &subprog)
 {
-  if (subprog.return_type.IsVoidTy())
+  if (subprog.return_type->type().IsVoidTy())
     return true;
 
   if (!visit(subprog.block)) {

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -143,6 +143,7 @@ public:
   void visit(Call &call);
   void visit(Sizeof &szof);
   void visit(Offsetof &offof);
+  void visit(Typeof &typeof);
   void visit(Map &map);
   void visit(MapAddr &map_addr);
   void visit(MapDeclStatement &decl);
@@ -2091,6 +2092,14 @@ void SemanticAnalyser::visit(Offsetof &offof)
   }
 }
 
+void SemanticAnalyser::visit(Typeof &typeof)
+{
+  Visitor<SemanticAnalyser>::visit(typeof);
+  if (std::holds_alternative<SizedType>(typeof.record)) {
+    resolve_struct_type(std::get<SizedType>(typeof.record), typeof);
+  }
+}
+
 void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
 {
   call.return_type = CreateStack(kernel);
@@ -2786,12 +2795,13 @@ void SemanticAnalyser::visit(Jump &jump)
         visit(jump.return_value);
       }
       if (auto *subprog = dynamic_cast<Subprog *>(top_level_node_)) {
-        if ((subprog->return_type.IsVoidTy() !=
-             !jump.return_value.has_value()) ||
-            (jump.return_value.has_value() &&
-             jump.return_value->type() != subprog->return_type)) {
+        const auto &ty = subprog->return_type->type();
+        if (is_final_pass() && !ty.IsNoneTy() &&
+            (ty.IsVoidTy() != !jump.return_value.has_value() ||
+             (jump.return_value.has_value() &&
+              jump.return_value->type() != ty))) {
           jump.addError() << "Function " << subprog->name << " is of type "
-                          << subprog->return_type << ", cannot return "
+                          << ty << ", cannot return "
                           << (jump.return_value.has_value()
                                   ? jump.return_value->type()
                                   : CreateVoid());
@@ -3202,64 +3212,74 @@ static std::unordered_map<std::string_view, std::string_view>
 void SemanticAnalyser::visit(Cast &cast)
 {
   visit(cast.expr);
+  visit(cast.typeof);
 
-  // cast type is synthesised in parser, if it is a struct, it needs resolving
-  resolve_struct_type(cast.cast_type, cast);
+  const auto &resolved_ty = cast.type();
+  if (resolved_ty.IsNoneTy()) {
+    pass_tracker_.inc_num_unresolved();
+    if (is_final_pass()) {
+      cast.addError() << "Incomplete cast, unknown type";
+    }
+    return; // Revisit next cycle.
+  }
 
   auto rhs = cast.expr.type();
   if (rhs.IsRecordTy()) {
     cast.addError() << "Cannot cast from struct type \"" << cast.expr.type()
                     << "\"";
   } else if (rhs.IsNoneTy()) {
-    cast.addError() << "Cannot cast from \"" << cast.expr.type() << "\" type";
+    if (is_final_pass()) {
+      cast.addError() << "Cannot cast from \"" << cast.expr.type() << "\" type";
+    } else {
+      return; // Revisit later.
+    }
   }
 
-  if (!cast.cast_type.IsIntTy() && !cast.cast_type.IsPtrTy() &&
-      !cast.cast_type.IsBoolTy() &&
-      (!cast.cast_type.IsPtrTy() || cast.cast_type.GetElementTy()->IsIntTy() ||
-       cast.cast_type.GetElementTy()->IsRecordTy()) &&
+  // Resolved the type because we may mutate it below, for various reasons.
+  cast.typeof->record = resolved_ty;
+  auto &ty = std::get<SizedType>(cast.typeof->record);
+
+  if (!ty.IsIntTy() && !ty.IsPtrTy() && !ty.IsBoolTy() &&
+      (!ty.IsPtrTy() || ty.GetElementTy()->IsIntTy() ||
+       ty.GetElementTy()->IsRecordTy()) &&
       // we support casting integers to int arrays
-      !(cast.cast_type.IsArrayTy() &&
-        cast.cast_type.GetElementTy()->IsBoolTy()) &&
-      !(cast.cast_type.IsArrayTy() &&
-        cast.cast_type.GetElementTy()->IsIntTy())) {
+      !(ty.IsArrayTy() && ty.GetElementTy()->IsBoolTy()) &&
+      !(ty.IsArrayTy() && ty.GetElementTy()->IsIntTy())) {
     auto &err = cast.addError();
-    err << "Cannot cast to \"" << cast.cast_type << "\"";
-    if (auto it = KNOWN_TYPE_ALIASES.find(cast.cast_type.GetName());
+    err << "Cannot cast to \"" << ty << "\"";
+    if (auto it = KNOWN_TYPE_ALIASES.find(ty.GetName());
         it != KNOWN_TYPE_ALIASES.end()) {
       err.addHint() << "Did you mean \"" << it->second << "\"?";
     }
   }
 
-  if (cast.cast_type.IsArrayTy()) {
-    if (cast.cast_type.GetNumElements() == 0) {
-      if (cast.cast_type.GetElementTy()->GetSize() == 0)
+  if (ty.IsArrayTy()) {
+    if (ty.GetNumElements() == 0) {
+      if (ty.GetElementTy()->GetSize() == 0)
         cast.addError() << "Could not determine size of the array";
       else {
-        if (rhs.GetSize() % cast.cast_type.GetElementTy()->GetSize() != 0) {
+        if (rhs.GetSize() % ty.GetElementTy()->GetSize() != 0) {
           cast.addError() << "Cannot determine array size: the element size is "
                              "incompatible with the cast integer size";
         }
 
         // cast to unsized array (e.g. int8[]), determine size from RHS
-        auto num_elems = rhs.GetSize() /
-                         cast.cast_type.GetElementTy()->GetSize();
-        cast.cast_type = CreateArray(num_elems, *cast.cast_type.GetElementTy());
+        auto num_elems = rhs.GetSize() / ty.GetElementTy()->GetSize();
+        ty = CreateArray(num_elems, *ty.GetElementTy());
       }
     }
 
     if (rhs.IsIntTy() || rhs.IsBoolTy())
-      cast.cast_type.is_internal = true;
+      ty.is_internal = true;
   }
 
-  if (cast.cast_type.IsEnumTy()) {
-    if (!c_definitions_.enum_defs.contains(cast.cast_type.GetName())) {
-      cast.addError() << "Unknown enum: " << cast.cast_type.GetName();
+  if (ty.IsEnumTy()) {
+    if (!c_definitions_.enum_defs.contains(ty.GetName())) {
+      cast.addError() << "Unknown enum: " << ty.GetName();
     } else {
       if (auto *integer = cast.expr.as<Integer>()) {
-        if (!c_definitions_.enum_defs[cast.cast_type.GetName()].contains(
-                integer->value)) {
-          cast.addError() << "Enum: " << cast.cast_type.GetName()
+        if (!c_definitions_.enum_defs[ty.GetName()].contains(integer->value)) {
+          cast.addError() << "Enum: " << ty.GetName()
                           << " doesn't contain a variant value of "
                           << integer->value;
         }
@@ -3267,39 +3287,36 @@ void SemanticAnalyser::visit(Cast &cast)
     }
   }
 
-  if (cast.cast_type.IsBoolTy() && !rhs.IsIntTy() && !rhs.IsStringTy() &&
-      !rhs.IsPtrTy() && !rhs.IsCastableMapTy()) {
+  if (ty.IsBoolTy() && !rhs.IsIntTy() && !rhs.IsStringTy() && !rhs.IsPtrTy() &&
+      !rhs.IsCastableMapTy()) {
     if (is_final_pass()) {
-      cast.addError() << "Cannot cast from \"" << rhs << "\" to \""
-                      << cast.cast_type << "\"";
+      cast.addError() << "Cannot cast from \"" << rhs << "\" to \"" << ty
+                      << "\"";
     }
   }
 
-  if ((cast.cast_type.IsIntTy() && !rhs.IsIntTy() && !rhs.IsPtrTy() &&
-       !rhs.IsBoolTy() && !rhs.IsCtxAccess() && !rhs.IsArrayTy() &&
-       !rhs.IsCastableMapTy()) ||
+  if ((ty.IsIntTy() && !rhs.IsIntTy() && !rhs.IsPtrTy() && !rhs.IsBoolTy() &&
+       !rhs.IsCtxAccess() && !rhs.IsArrayTy() && !rhs.IsCastableMapTy()) ||
       // casting from/to int arrays must respect the size
-      (cast.cast_type.IsArrayTy() &&
-       (!rhs.IsBoolTy() || cast.cast_type.GetSize() != rhs.GetSize()) &&
-       (!rhs.IsIntTy() || cast.cast_type.GetSize() != rhs.GetSize())) ||
-      (rhs.IsArrayTy() && (!cast.cast_type.IsIntTy() ||
-                           cast.cast_type.GetSize() != rhs.GetSize()))) {
-    cast.addError() << "Cannot cast from \"" << rhs << "\" to \""
-                    << cast.cast_type << "\"";
+      (ty.IsArrayTy() && (!rhs.IsBoolTy() || ty.GetSize() != rhs.GetSize()) &&
+       (!rhs.IsIntTy() || ty.GetSize() != rhs.GetSize())) ||
+      (rhs.IsArrayTy() && (!ty.IsIntTy() || ty.GetSize() != rhs.GetSize()))) {
+    cast.addError() << "Cannot cast from \"" << rhs << "\" to \"" << ty << "\"";
   }
 
-  if (cast.expr.type().IsCtxAccess() && !cast.cast_type.IsIntTy())
-    cast.cast_type.MarkCtxAccess();
-  cast.cast_type.SetAS(cast.expr.type().GetAS());
+  if (cast.expr.type().IsCtxAccess() && !ty.IsIntTy()) {
+    ty.MarkCtxAccess();
+  }
+  ty.SetAS(cast.expr.type().GetAS());
   // case : begin { @foo = (struct Foo)0; }
   // case : profile:hz:99 $task = (struct task_struct *)curtask.
-  if (cast.cast_type.GetAS() == AddrSpace::none) {
+  if (ty.GetAS() == AddrSpace::none) {
     if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
       ProbeType type = single_provider_type(probe);
-      cast.cast_type.SetAS(find_addrspace(type));
+      ty.SetAS(find_addrspace(type));
     } else {
-      // Assume kernel space for data in subprogs
-      cast.cast_type.SetAS(AddrSpace::kernel);
+      // Assume kernel space for data in subprogs.
+      ty.SetAS(AddrSpace::kernel);
     }
   }
 }
@@ -3390,7 +3407,9 @@ void SemanticAnalyser::visit(AssignMapStatement &assignment)
   // @y`
   const bool map_contains_int = map_type_before && map_type_before->IsIntTy();
   if (map_contains_int && assignment.expr.type().IsCastableMapTy()) {
-    assignment.expr = ctx_.make_node<Cast>(*map_type_before,
+    auto *typeof = ctx_.make_node<Typeof>(*map_type_before,
+                                          Location(assignment.loc));
+    assignment.expr = ctx_.make_node<Cast>(typeof,
                                            assignment.expr,
                                            Location(assignment.loc));
   }
@@ -3498,7 +3517,9 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
   }
 
   if (assignment.expr.type().IsCastableMapTy()) {
-    assignment.expr = ctx_.make_node<Cast>(CreateInt64(),
+    auto *typeof = ctx_.make_node<Typeof>(CreateInt64(),
+                                          Location(assignment.loc));
+    assignment.expr = ctx_.make_node<Cast>(typeof,
                                            assignment.expr,
                                            Location(assignment.loc));
   }
@@ -3551,10 +3572,12 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
                 << storedTy << "'";
           } else {
             assignTy = storedTy;
-            assignment.expr = ctx_.make_node<Cast>(
+            auto *typeof = ctx_.make_node<Typeof>(
                 CreateInteger(storedTy.GetSize() * 8, true),
-                assignment.expr,
                 Location(assignment.loc));
+            assignment.expr = ctx_.make_node<Cast>(typeof,
+                                                   assignment.expr,
+                                                   Location(assignment.loc));
             visit(assignment.expr);
           }
         }
@@ -3570,10 +3593,12 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
         }
         if (can_fit) {
           assignTy = storedTy;
-          assignment.expr = ctx_.make_node<Cast>(
+          auto *typeof = ctx_.make_node<Typeof>(
               CreateInteger(storedTy.GetSize() * 8, storedTy.IsSigned()),
-              assignment.expr,
               Location(assignment.loc));
+          assignment.expr = ctx_.make_node<Cast>(typeof,
+                                                 assignment.expr,
+                                                 Location(assignment.loc));
           visit(assignment.expr);
         } else {
           assignment.addError()
@@ -3651,12 +3676,21 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
 
 void SemanticAnalyser::visit(VarDeclStatement &decl)
 {
+  visit(decl.typeof);
   const std::string &var_ident = decl.var->ident;
 
-  if (decl.type && !IsValidVarDeclType(*decl.type)) {
-    decl.addError() << "Invalid variable declaration type: " << *decl.type;
-  } else if (decl.type && decl.var->var_type.IsNoneTy()) {
-    decl.var->var_type = *decl.type;
+  if (decl.typeof) {
+    const auto &ty = decl.typeof->type();
+    if (!ty.IsNoneTy()) {
+      if (!IsValidVarDeclType(ty)) {
+        decl.addError() << "Invalid variable declaration type: " << ty;
+      } else {
+        decl.var->var_type = ty;
+      }
+    } else if (is_final_pass()) {
+      // We couldn't resolve that specific type by now.
+      decl.addError() << "Type cannot be resolved: still none";
+    }
   }
 
   // Only checking on the first pass for cases like this:
@@ -4057,14 +4091,46 @@ void SemanticAnalyser::visit(Probe &probe)
 
 void SemanticAnalyser::visit(Subprog &subprog)
 {
+  // Note that we visit the subprogram and process arguments *after*
+  // constructing the stack with the variable states. This is because the
+  // arguments, etc. may have types defined in terms of the arguments
+  // themselves. We already handle detecting circular dependencies.
   scope_stack_.push_back(&subprog);
   top_level_node_ = &subprog;
   for (SubprogArg *arg : subprog.args) {
-    variables_[scope_stack_.back()].insert(
-        { arg->name,
-          { .type = arg->type, .can_resize = true, .was_assigned = true } });
+    const auto &ty = arg->typeof->type();
+    auto &var = variables_[scope_stack_.back()]
+                    .emplace(arg->var->ident,
+                             variable{ .type = ty,
+                                       .can_resize = true,
+                                       .was_assigned = true })
+                    .first->second;
+    var.type = ty; // Override in case it has changed.
   }
-  Visitor<SemanticAnalyser>::visit(subprog);
+
+  // Validate that arguments are set.
+  visit(subprog.args);
+  for (SubprogArg *arg : subprog.args) {
+    if (arg->typeof->type().IsNoneTy()) {
+      pass_tracker_.inc_num_unresolved();
+      if (is_final_pass()) {
+        arg->addError() << "Unable to resolve argument type.";
+      }
+    }
+  }
+
+  // Visit all statements.
+  visit(subprog.block);
+
+  // Validate that the return type is valid.
+  visit(subprog.return_type);
+  if (subprog.return_type->type().IsNoneTy()) {
+    pass_tracker_.inc_num_unresolved();
+    if (is_final_pass()) {
+      subprog.return_type->addError()
+          << "Unable to resolve suitable return type.";
+    }
+  }
   scope_stack_.pop_back();
 }
 

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -65,8 +65,10 @@ public:
   {
     return visitImpl(var_addr.var);
   }
-  R visit([[maybe_unused]] SubprogArg &subprog_arg)
+  R visit(SubprogArg &subprog_arg)
   {
+    visitImpl(subprog_arg.var);
+    visitImpl(subprog_arg.typeof);
     return default_value();
   }
   R visit([[maybe_unused]] AttachPoint &ap)
@@ -81,9 +83,13 @@ public:
   {
     return visitImpl(szof.record);
   }
-  R visit([[maybe_unused]] Offsetof &ofof)
+  R visit(Offsetof &ofof)
   {
     return visitImpl(ofof.record);
+  }
+  R visit(Typeof &typeof)
+  {
+    return visitImpl(typeof.record);
   }
   R visit([[maybe_unused]] MapDeclStatement &decl)
   {
@@ -136,7 +142,9 @@ public:
   }
   R visit(Cast &cast)
   {
-    return visitImpl(cast.expr);
+    visitImpl(cast.expr);
+    visitImpl(cast.typeof);
+    return default_value();
   }
   R visit(Tuple &tuple)
   {
@@ -171,7 +179,9 @@ public:
   }
   R visit(VarDeclStatement &decl)
   {
-    return visitImpl(decl.var);
+    visitImpl(decl.var);
+    visitImpl(decl.typeof);
+    return default_value();
   }
   R visit(Jump &jump)
   {
@@ -234,6 +244,7 @@ public:
   {
     visitImpl(subprog.args);
     visitImpl(subprog.block);
+    visitImpl(subprog.return_type);
     return default_value();
   }
   R visit([[maybe_unused]] Import &imp)

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -178,6 +178,7 @@ oct_esc  [0-7]{1,3}
 "break"                 { return Parser::make_BREAK(yytext, driver.loc); }
 "sizeof"                { return Parser::make_SIZEOF(yytext, driver.loc); }
 "offsetof"              { return Parser::make_OFFSETOF(yytext, driver.loc); }
+"typeof"                { return Parser::make_TYPEOF(yytext, driver.loc); }
 "let"                   { return Parser::make_LET(yytext, driver.loc); }
 "import"                { return Parser::make_IMPORT(yytext, driver.loc); }
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -131,6 +131,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> BREAK "break"
 %token <std::string> SIZEOF "sizeof"
 %token <std::string> OFFSETOF "offsetof"
+%token <std::string> TYPEOF "typeof"
 %token <std::string> LET "let"
 %token <std::string> IMPORT "import"
 %token <bool> BOOL "bool"
@@ -145,6 +146,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::Call *> call
 %type <ast::Sizeof *> sizeof_expr
 %type <ast::Offsetof *> offsetof_expr
+%type <ast::Typeof *> typeof_expr any_type
 %type <ast::Expression> and_expr addi_expr primary_expr cast_expr conditional_expr equality_expr expr logical_and_expr muli_expr
 %type <ast::Expression> logical_or_expr or_expr postfix_expr relational_expr shift_expr tuple_access_expr unary_expr xor_expr
 %type <ast::ExpressionList> vargs
@@ -340,11 +342,11 @@ config_assign_stmt:
                 ;
 
 subprog:
-                SUBPROG IDENT "(" subprog_args ")" ":" type none_block {
-                    $$ = driver.ctx.make_node<ast::Subprog>($2, $7, std::move($4), $8, @$);
+                SUBPROG IDENT "(" subprog_args ")" ":" any_type none_block {
+                    $$ = driver.ctx.make_node<ast::Subprog>($2, $7, std::move($4), std::move($8), @$);
                 }
-        |       SUBPROG IDENT "(" ")" ":" type none_block {
-                    $$ = driver.ctx.make_node<ast::Subprog>($2, $6, ast::SubprogArgList(), $7, @$);
+        |       SUBPROG IDENT "(" ")" ":" any_type none_block {
+                    $$ = driver.ctx.make_node<ast::Subprog>($2, $6, ast::SubprogArgList(), std::move($7), @$);
                 }
                 ;
 
@@ -354,7 +356,7 @@ subprog_args:
                 ;
 
 subprog_arg:
-                VAR ":" type { $$ = driver.ctx.make_node<ast::SubprogArg>($1, $3, @$); }
+                var ":" any_type { $$ = driver.ctx.make_node<ast::SubprogArg>($1, $3, @$); }
                 ;
 
 macro:
@@ -539,8 +541,8 @@ map_decl_stmt:
         ;
 
 var_decl_stmt:
-                 LET var {  $$ = driver.ctx.make_node<ast::VarDeclStatement>($2, @$); }
-        |        LET var COLON type {  $$ = driver.ctx.make_node<ast::VarDeclStatement>($2, $4, @$); }
+                 LET var                {  $$ = driver.ctx.make_node<ast::VarDeclStatement>($2, @$); }
+        |        LET var COLON any_type {  $$ = driver.ctx.make_node<ast::VarDeclStatement>($2, $4, @$); }
         ;
 
 primary_expr:
@@ -729,11 +731,11 @@ addi_expr:
 
 cast_expr:
                 unary_expr                                  { $$ = $1; }
-        |       LPAREN type RPAREN cast_expr                { $$ = driver.ctx.make_node<ast::Cast>($2, $4, @1 + @3); }
+        |       LPAREN any_type RPAREN cast_expr            { $$ = driver.ctx.make_node<ast::Cast>($2, $4, @1 + @3); }
 /* workaround for typedef types, see https://github.com/bpftrace/bpftrace/pull/2560#issuecomment-1521783935 */
-        |       LPAREN IDENT RPAREN cast_expr               { $$ = driver.ctx.make_node<ast::Cast>(ast::ident_to_record($2, 0), $4, @1 + @3); }
-        |       LPAREN IDENT "*" RPAREN cast_expr           { $$ = driver.ctx.make_node<ast::Cast>(ast::ident_to_record($2, 1), $5, @1 + @4); }
-        |       LPAREN IDENT "*" "*" RPAREN cast_expr       { $$ = driver.ctx.make_node<ast::Cast>(ast::ident_to_record($2, 2), $6, @1 + @5); }
+        |       LPAREN IDENT RPAREN cast_expr               { $$ = driver.ctx.make_node<ast::Cast>(driver.ctx.make_node<ast::Typeof>(ast::ident_to_record($2, 0), @2), $4, @1 + @3); }
+        |       LPAREN IDENT "*" RPAREN cast_expr           { $$ = driver.ctx.make_node<ast::Cast>(driver.ctx.make_node<ast::Typeof>(ast::ident_to_record($2, 1), @2), $5, @1 + @4); }
+        |       LPAREN IDENT "*" "*" RPAREN cast_expr       { $$ = driver.ctx.make_node<ast::Cast>(driver.ctx.make_node<ast::Typeof>(ast::ident_to_record($2, 2), @2), $6, @1 + @5); }
                 ;
 
 sizeof_expr:
@@ -746,6 +748,15 @@ offsetof_expr:
                 /* For example: offsetof(*curtask, comm) */
         |       OFFSETOF "(" expr "," struct_field ")"             { $$ = driver.ctx.make_node<ast::Offsetof>($3, $5, @$); }
                 ;
+
+typeof_expr:
+                TYPEOF "(" type ")"  { $$ = driver.ctx.make_node<ast::Typeof>($3, @$); }
+        |       TYPEOF "(" expr ")"  { $$ = driver.ctx.make_node<ast::Typeof>($3, @$); }
+                ;
+
+any_type:
+                type        { $$ = driver.ctx.make_node<ast::Typeof>($1, @$); }
+        |       typeof_expr { $$ = $1; }
 
 keyword:
                 BREAK         { $$ = $1; }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2903,7 +2903,7 @@ TEST(Parser, subprog_invalid_return_type)
 {
   // Error location is incorrect: #3063
   test_parse_failure("fn f(): nonexistent {}", R"(
-stdin:1:9-21: ERROR: syntax error, unexpected identifier, expecting struct or integer type or builtin type or sized type
+stdin:1:9-21: ERROR: syntax error, unexpected identifier
 fn f(): nonexistent {}
         ~~~~~~~~~~~~
 )");
@@ -2968,7 +2968,7 @@ TEST(Parser, subprog_invalid_arg)
 {
   // Error location is incorrect: #3063
   test_parse_failure("fn f($x : invalid): void {}", R"(
-stdin:1:11-19: ERROR: syntax error, unexpected identifier, expecting struct or integer type or builtin type or sized type
+stdin:1:11-19: ERROR: syntax error, unexpected identifier
 fn f($x : invalid): void {}
           ~~~~~~~~
 )");


### PR DESCRIPTION
Stacked PRs:
 * #4463
 * #4464
 * __->__#4401


--- --- ---

### semantics: introduce `typeof`


To allow for type-specific behavior in macros and other parts of the
standard library, we need a way to do parameteric behavior based on
types. Rather than overloading, we introduce a `typeof` operator that
can do the following:

* Create variables of types associated with other expressions
* Cast values to types with a specific expression
* Express subprogram arguments in terms of each other

As a trivial example, consider:

```
macro val_or_zero(x) {
  let $v = x;
  let $zero : typeof($v);
  if (...) {
     return $v;
  } else {
     return $zero;
  }
}
```

Signed-off-by: Adin Scannell <amscanne@meta.com>
