### PR TITLE
Add `print_error` function

### DIFF
--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -12,6 +12,7 @@ namespace bpftrace::ast {
   DO(join)                                                                     \
   DO(bpf_print)                                                                \
   DO(non_map_print)                                                            \
+  DO(print_error)                                                              \
   DO(printf)                                                                   \
   DO(map_key)                                                                  \
   DO(read_map_value)                                                           \

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -173,8 +173,8 @@ void ResourceAnalyser::visit(Call &call)
 {
   Visitor<ResourceAnalyser>::visit(call);
 
-  if (call.func == "printf" || call.func == "system" || call.func == "cat" ||
-      call.func == "debugf") {
+  if (call.func == "printf" || call.func == "print_error" ||
+      call.func == "system" || call.func == "cat" || call.func == "debugf") {
     std::vector<SizedType> args;
 
     // NOTE: the same logic can be found in the semantic_analyser pass
@@ -219,6 +219,11 @@ void ResourceAnalyser::visit(Call &call)
       } else {
         resources_.printf_args.emplace_back(fmtstr, tuple->fields);
       }
+    } else if (call.func == "print_error") {
+      resources_.print_error_args.emplace_back(
+          fmtstr,
+          tuple->fields,
+          RuntimeErrorInfo(RuntimeErrorId::PRINT_ERROR, call.loc));
     } else if (call.func == "debugf") {
       resources_.bpf_print_fmts.emplace_back(fmtstr);
     } else if (call.func == "system") {

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -240,8 +240,20 @@ void AsyncHandlers::printf(const OpaqueValue &data)
   auto &args = std::get<1>(bpftrace.resources.printf_args[id]);
   auto arg_values = bpftrace.get_arg_values(
       c_definitions, args, data.slice(sizeof(uint64_t)).data());
-
   out.printf(fmt.format_str(arg_values));
+}
+
+void AsyncHandlers::print_error(const OpaqueValue &data)
+{
+  auto id = data.bitcast<uint64_t>() -
+            static_cast<uint64_t>(AsyncAction::print_error);
+  auto &tuple = bpftrace.resources.print_error_args[id];
+  auto &fmt = std::get<0>(tuple);
+  auto &args = std::get<1>(tuple);
+  auto &errorInfo = std::get<2>(tuple);
+  auto arg_values = bpftrace.get_arg_values(
+      c_definitions, args, data.slice(sizeof(uint64_t)).data());
+  out.print_error(fmt.format_str(arg_values), errorInfo);
 }
 
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -8,13 +8,15 @@ namespace bpftrace::async_action {
 
 enum class AsyncAction {
   // clang-format off
-  printf      = 0,     // printf reserves 0-9999 for printf_ids
-  printf_end  = 9999,
-  syscall     = 10000, // system reserves 10000-19999 for printf_ids
-  syscall_end = 19999,
-  cat         = 20000, // cat reserves 20000-29999 for printf_ids
-  cat_end     = 29999,
-  exit        = 30000,
+  printf          = 0,     // printf reserves 0-9999 for printf_ids
+  printf_end      = 9999,
+  syscall         = 10000, // system reserves 10000-19999 for printf_ids
+  syscall_end     = 19999,
+  cat             = 20000, // cat reserves 20000-29999 for printf_ids
+  cat_end         = 29999,
+  print_error     = 30000, // print_error reserves 20000-29999 for printf_ids
+  print_error_end = 39999,
+  exit            = 40000,
   print,
   clear,
   zero,
@@ -52,6 +54,7 @@ public:
   void syscall(const OpaqueValue &data);
   void cat(const OpaqueValue &data);
   void printf(const OpaqueValue &data);
+  void print_error(const OpaqueValue &data);
 
 private:
   BPFtrace &bpftrace;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -269,6 +269,10 @@ void perf_event_printer(void *cb_cookie, void *raw_data, int size)
              printf_id <= async_action::AsyncAction::printf_end) {
     ctx->handlers.printf(data);
     return;
+  } else if (printf_id >= async_action::AsyncAction::print_error &&
+             printf_id <= async_action::AsyncAction::print_error_end) {
+    ctx->handlers.print_error(data);
+    return;
   } else {
     LOG(BUG) << "Unknown printf_id: " << static_cast<int64_t>(printf_id);
   }

--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -396,6 +396,23 @@ void JsonOutput::value(const Value &value)
   emit_data(out_, "value", std::nullopt, value);
 }
 
+void JsonOutput::print_error(const std::string &str,
+                             const RuntimeErrorInfo &info)
+{
+  out_ << R"({"type": "print_error")";
+  out_ << R"(, "msg": )";
+  std::stringstream ss;
+  ss << str;
+  JsonEmitter<std::string>::emit(out_, ss.str());
+  out_ << R"(, "filename": )";
+  JsonEmitter<std::string>::emit(out_, info.filename);
+  out_ << R"(, "line": )";
+  JsonEmitter<uint64_t>::emit(out_, info.line);
+  out_ << R"(, "col": )";
+  JsonEmitter<uint64_t>::emit(out_, info.column);
+  out_ << R"(})" << std::endl;
+}
+
 void JsonOutput::printf(const std::string &str)
 {
   emit_data(out_, "printf", std::nullopt, str);

--- a/src/output/json.h
+++ b/src/output/json.h
@@ -12,6 +12,8 @@ public:
 
   void map(const std::string &name, const Value &value) override;
   void value(const Value &value) override;
+  void print_error(const std::string &str,
+                   const RuntimeErrorInfo &info) override;
   void printf(const std::string &str) override;
   void time(const std::string &time) override;
   void cat(const std::string &cat) override;

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -148,6 +148,8 @@ public:
   virtual void value(const Value& value) = 0;
 
   // Specialized messages during execution.
+  virtual void print_error(const std::string& str,
+                           const RuntimeErrorInfo& info) = 0;
   virtual void printf(const std::string& str) = 0;
   virtual void time(const std::string& time) = 0;
   virtual void cat(const std::string& cat) = 0;

--- a/src/output/text.cpp
+++ b/src/output/text.cpp
@@ -523,6 +523,16 @@ void TextOutput::primitive(const Primitive &p)
   TextEmitter<Primitive>::emit(out_, p);
 }
 
+void TextOutput::print_error(const std::string &str,
+                             const RuntimeErrorInfo &info)
+{
+  LOG(ERROR,
+      std::string(info.source_location),
+      std::vector(info.source_context),
+      out_)
+      << str;
+}
+
 void TextOutput::printf(const std::string &str)
 {
   out_ << str;

--- a/src/output/text.h
+++ b/src/output/text.h
@@ -12,6 +12,8 @@ public:
 
   void map(const std::string &name, const Value &value) override;
   void value(const Value &value) override;
+  void print_error(const std::string &str,
+                   const RuntimeErrorInfo &info) override;
   void printf(const std::string &str) override;
   void time(const std::string &time) override;
   void cat(const std::string &cat) override;

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -37,8 +37,9 @@ void RequiredResources::load_state(const uint8_t *ptr, size_t len)
 std::ostream &operator<<(std::ostream &os, const RuntimeErrorInfo &info)
 {
   switch (info.error_id) {
-    case RuntimeErrorId::HELPER_ERROR: {
-      // Helper errors are handled separately in output
+    case RuntimeErrorId::HELPER_ERROR:
+    case RuntimeErrorId::PRINT_ERROR: {
+      // These errors are handled separately in output
       os << "";
       break;
     }

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -30,6 +30,7 @@ static const auto DIVIDE_BY_ZERO_MSG =
 enum class RuntimeErrorId {
   DIVIDE_BY_ZERO,
   HELPER_ERROR,
+  PRINT_ERROR,
 };
 
 class RuntimeErrorInfo {
@@ -112,6 +113,8 @@ public:
   // fmt strings for BPF helpers (bpf_seq_printf, bpf_trace_printk)
   std::vector<FormatString> bpf_print_fmts;
   std::vector<std::tuple<FormatString, std::vector<Field>>> cat_args;
+  std::vector<std::tuple<FormatString, std::vector<Field>, RuntimeErrorInfo>>
+      print_error_args;
   std::vector<std::string> join_args;
   std::vector<std::string> time_args;
   std::vector<std::string> strftime_args;
@@ -184,6 +187,7 @@ private:
             non_map_print_args,
             // Hard to annotate flex types, so skip
             // runtime_error_info,
+            // printe_error_info,
             printf_args,
             probe_ids,
             maps_info,

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -6,7 +6,7 @@ Simple assertion macro that will exit the entire script with an error code if th
 */
 macro assert($cond, $msg) {
   if (!$cond) {
-    printf("Assertion failed. Msg: %s", $msg);
+    print_error("Assertion failed. Msg: %s", $msg);
     exit(1);
   }
 }

--- a/tests/codegen/call_print_error.cpp
+++ b/tests/codegen/call_print_error.cpp
@@ -1,0 +1,13 @@
+#include "common.h"
+
+namespace bpftrace::test::codegen {
+
+TEST(codegen, call_print_error)
+{
+  test("struct Foo { char c; long l; } kprobe:f { $foo = (struct Foo*)arg0; "
+       "print_error(\"%c %lu\\n\", $foo->c, $foo->l) }",
+
+       NAME);
+}
+
+} // namespace bpftrace::test::codegen

--- a/tests/codegen/llvm/array_integer_equal_comparison.ll
+++ b/tests/codegen/llvm/array_integer_equal_comparison.ll
@@ -62,7 +62,7 @@ entry:
 if_body:                                          ; preds = %arraycmp.done
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
   %17 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %17, align 8
+  store i64 40000, ptr %17, align 8
   %18 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
   store i8 0, ptr %18, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)

--- a/tests/codegen/llvm/block_expression_cond.ll
+++ b/tests/codegen/llvm/block_expression_cond.ll
@@ -29,7 +29,7 @@ entry:
 if_body:                                          ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
   %2 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %2, align 8
+  store i64 40000, ptr %2, align 8
   %3 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
   store i8 0, ptr %3, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)

--- a/tests/codegen/llvm/builtin_ncpus.ll
+++ b/tests/codegen/llvm/builtin_ncpus.ll
@@ -33,7 +33,7 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
   %1 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %1, align 8
+  store i64 40000, ptr %1, align 8
   %2 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
   store i8 0, ptr %2, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)

--- a/tests/codegen/llvm/call_cgroup_path.ll
+++ b/tests/codegen/llvm/call_cgroup_path.ll
@@ -28,7 +28,7 @@ entry:
   store i64 %get_cgroup_id, ptr %2, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %print_cgroup_path_t_16_t)
   %3 = getelementptr %print_cgroup_path_t_16_t, ptr %print_cgroup_path_t_16_t, i64 0, i32 0
-  store i64 30007, ptr %3, align 8
+  store i64 40007, ptr %3, align 8
   %4 = getelementptr %print_cgroup_path_t_16_t, ptr %print_cgroup_path_t_16_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
   %5 = getelementptr %print_cgroup_path_t_16_t, ptr %print_cgroup_path_t_16_t, i32 0, i32 2

--- a/tests/codegen/llvm/call_clear.ll
+++ b/tests/codegen/llvm/call_clear.ll
@@ -43,7 +43,7 @@ entry:
   %"clear_@x" = alloca %clear_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"clear_@x")
   %1 = getelementptr %clear_t, ptr %"clear_@x", i64 0, i32 0
-  store i64 30002, ptr %1, align 8
+  store i64 40002, ptr %1, align 8
   %2 = getelementptr %clear_t, ptr %"clear_@x", i64 0, i32 1
   store i32 0, ptr %2, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %"clear_@x", i64 12, i64 0)

--- a/tests/codegen/llvm/call_exit.ll
+++ b/tests/codegen/llvm/call_exit.ll
@@ -24,7 +24,7 @@ entry:
   %exit = alloca %exit_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
   %1 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %1, align 8
+  store i64 40000, ptr %1, align 8
   %2 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
   store i8 0, ptr %2, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)

--- a/tests/codegen/llvm/call_join.ll
+++ b/tests/codegen/llvm/call_join.ll
@@ -49,7 +49,7 @@ lookup_join_failure:                              ; preds = %entry
 
 lookup_join_merge:                                ; preds = %entry
   %6 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 0
-  store i64 30005, ptr %6, align 8
+  store i64 40005, ptr %6, align 8
   %7 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 1
   store i64 0, ptr %7, align 8
   %8 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 2

--- a/tests/codegen/llvm/call_join_with_debug.ll
+++ b/tests/codegen/llvm/call_join_with_debug.ll
@@ -54,7 +54,7 @@ lookup_join_failure:                              ; preds = %entry
 
 lookup_join_merge:                                ; preds = %entry
   %6 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 0
-  store i64 30005, ptr %6, align 8
+  store i64 40005, ptr %6, align 8
   %7 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 1
   store i64 0, ptr %7, align 8
   %8 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 2

--- a/tests/codegen/llvm/call_offsetof.ll
+++ b/tests/codegen/llvm/call_offsetof.ll
@@ -31,7 +31,7 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
   %1 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %1, align 8
+  store i64 40000, ptr %1, align 8
   %2 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
   store i8 0, ptr %2, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)

--- a/tests/codegen/llvm/call_offsetof_sub_field.ll
+++ b/tests/codegen/llvm/call_offsetof_sub_field.ll
@@ -31,7 +31,7 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
   %1 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %1, align 8
+  store i64 40000, ptr %1, align 8
   %2 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
   store i8 0, ptr %2, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)

--- a/tests/codegen/llvm/call_print.ll
+++ b/tests/codegen/llvm/call_print.ll
@@ -43,7 +43,7 @@ entry:
   %"print_@x" = alloca %print_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"print_@x")
   %1 = getelementptr %print_t, ptr %"print_@x", i64 0, i32 0
-  store i64 30001, ptr %1, align 8
+  store i64 40001, ptr %1, align 8
   %2 = getelementptr %print_t, ptr %"print_@x", i64 0, i32 1
   store i32 0, ptr %2, align 4
   %3 = getelementptr %print_t, ptr %"print_@x", i64 0, i32 2

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -29,7 +29,7 @@ entry:
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @abc, i64 4, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %print_tuple_16_t)
   %3 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 0
-  store i64 30007, ptr %3, align 8
+  store i64 40007, ptr %3, align 8
   %4 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
   %5 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i32 0, i32 2

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -20,7 +20,7 @@ entry:
   %print_int_8_t = alloca %print_int_8_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %print_int_8_t)
   %1 = getelementptr %print_int_8_t, ptr %print_int_8_t, i64 0, i32 0
-  store i64 30007, ptr %1, align 8
+  store i64 40007, ptr %1, align 8
   %2 = getelementptr %print_int_8_t, ptr %print_int_8_t, i64 0, i32 1
   store i64 0, ptr %2, align 8
   %3 = getelementptr %print_int_8_t, ptr %print_int_8_t, i32 0, i32 2

--- a/tests/codegen/llvm/call_time.ll
+++ b/tests/codegen/llvm/call_time.ll
@@ -20,7 +20,7 @@ entry:
   %time_t = alloca %time_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %time_t)
   %1 = getelementptr %time_t, ptr %time_t, i64 0, i32 0
-  store i64 30004, ptr %1, align 8
+  store i64 40004, ptr %1, align 8
   %2 = getelementptr %time_t, ptr %time_t, i64 0, i32 1
   store i32 0, ptr %2, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %time_t, i64 12, i64 0)

--- a/tests/codegen/llvm/call_zero.ll
+++ b/tests/codegen/llvm/call_zero.ll
@@ -43,7 +43,7 @@ entry:
   %"zero_@x" = alloca %zero_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"zero_@x")
   %1 = getelementptr %zero_t, ptr %"zero_@x", i64 0, i32 0
-  store i64 30003, ptr %1, align 8
+  store i64 40003, ptr %1, align 8
   %2 = getelementptr %zero_t, ptr %"zero_@x", i64 0, i32 1
   store i32 0, ptr %2, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %"zero_@x", i64 12, i64 0)

--- a/tests/codegen/llvm/count_no_cast_for_print.ll
+++ b/tests/codegen/llvm/count_no_cast_for_print.ll
@@ -49,7 +49,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"print_@")
   %3 = getelementptr %print_t, ptr %"print_@", i64 0, i32 0
-  store i64 30001, ptr %3, align 8
+  store i64 40001, ptr %3, align 8
   %4 = getelementptr %print_t, ptr %"print_@", i64 0, i32 1
   store i32 0, ptr %4, align 4
   %5 = getelementptr %print_t, ptr %"print_@", i64 0, i32 2

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -56,7 +56,7 @@ is_zero:                                          ; preds = %if_body
   store i64 1, ptr %op_result, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %7, align 8
+  store i64 40006, ptr %7, align 8
   %8 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %8, align 8
   %9 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_comm.ll
+++ b/tests/codegen/llvm/runtime_error_check_comm.ll
@@ -33,7 +33,7 @@ entry:
 helper_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %3 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %3, align 8
+  store i64 40006, ptr %3, align 8
   %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
   %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
@@ -67,7 +67,7 @@ counter_merge:                                    ; preds = %event_loss_counter,
 helper_failure1:                                  ; preds = %helper_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t3)
   %12 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 0
-  store i64 30006, ptr %12, align 8
+  store i64 40006, ptr %12, align 8
   %13 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 1
   store i64 1, ptr %13, align 8
   %14 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_delete.ll
+++ b/tests/codegen/llvm/runtime_error_check_delete.ll
@@ -36,7 +36,7 @@ entry:
 helper_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %3 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %3, align 8
+  store i64 40006, ptr %3, align 8
   %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
   %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
@@ -72,7 +72,7 @@ counter_merge:                                    ; preds = %event_loss_counter,
 helper_failure2:                                  ; preds = %helper_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t4)
   %12 = getelementptr %runtime_error_t, ptr %runtime_error_t4, i64 0, i32 0
-  store i64 30006, ptr %12, align 8
+  store i64 40006, ptr %12, align 8
   %13 = getelementptr %runtime_error_t, ptr %runtime_error_t4, i64 0, i32 1
   store i64 1, ptr %13, align 8
   %14 = getelementptr %runtime_error_t, ptr %runtime_error_t4, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_for_map.ll
+++ b/tests/codegen/llvm/runtime_error_check_for_map.ll
@@ -38,7 +38,7 @@ entry:
 helper_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %3 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %3, align 8
+  store i64 40006, ptr %3, align 8
   %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
   %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
@@ -72,7 +72,7 @@ counter_merge:                                    ; preds = %event_loss_counter,
 helper_failure1:                                  ; preds = %helper_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t3)
   %12 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 0
-  store i64 30006, ptr %12, align 8
+  store i64 40006, ptr %12, align 8
   %13 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 1
   store i64 2, ptr %13, align 8
   %14 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 2
@@ -135,7 +135,7 @@ for_break:                                        ; No predecessors!
 helper_failure:                                   ; preds = %for_body
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %8 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %8, align 8
+  store i64 40006, ptr %8, align 8
   %9 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 1, ptr %9, align 8
   %10 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_lookup.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup.ll
@@ -40,7 +40,7 @@ lookup_failure:                                   ; preds = %entry
   store i64 0, ptr %lookup_elem_val, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %2 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %2, align 8
+  store i64 40006, ptr %2, align 8
   %3 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %3, align 8
   %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
@@ -77,7 +77,7 @@ counter_merge:                                    ; preds = %event_loss_counter,
 helper_failure:                                   ; preds = %lookup_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t1)
   %13 = getelementptr %runtime_error_t, ptr %runtime_error_t1, i64 0, i32 0
-  store i64 30006, ptr %13, align 8
+  store i64 40006, ptr %13, align 8
   %14 = getelementptr %runtime_error_t, ptr %runtime_error_t1, i64 0, i32 1
   store i64 1, ptr %14, align 8
   %15 = getelementptr %runtime_error_t, ptr %runtime_error_t1, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_lookup_no_warning.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup_no_warning.ll
@@ -53,7 +53,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 helper_failure:                                   ; preds = %lookup_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %6, align 8
+  store i64 40006, ptr %6, align 8
   %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %7, align 8
   %8 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_lookup_percpu.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup_percpu.ll
@@ -69,7 +69,7 @@ lookup_merge:                                     ; preds = %helper_merge, %look
 helper_failure:                                   ; preds = %lookup_failure
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %5, align 8
+  store i64 40006, ptr %5, align 8
   %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %6, align 8
   %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
@@ -135,7 +135,7 @@ lookup_failure3:                                  ; preds = %while_body
 error_success:                                    ; preds = %lookup_failure3
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t5)
   %22 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 0
-  store i64 30006, ptr %22, align 8
+  store i64 40006, ptr %22, align 8
   %23 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 1
   store i64 1, ptr %23, align 8
   %24 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_path.ll
+++ b/tests/codegen/llvm/runtime_error_check_path.ll
@@ -32,7 +32,7 @@ entry:
 helper_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %5, align 8
+  store i64 40006, ptr %5, align 8
   %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %6, align 8
   %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_pid_tid.ll
+++ b/tests/codegen/llvm/runtime_error_check_pid_tid.ll
@@ -43,7 +43,7 @@ entry:
 helper_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %5, align 8
+  store i64 40006, ptr %5, align 8
   %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %6, align 8
   %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
@@ -84,7 +84,7 @@ counter_merge:                                    ; preds = %event_loss_counter,
 helper_failure3:                                  ; preds = %helper_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t5)
   %15 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 0
-  store i64 30006, ptr %15, align 8
+  store i64 40006, ptr %15, align 8
   %16 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 1
   store i64 1, ptr %16, align 8
   %17 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_printf.ll
+++ b/tests/codegen/llvm/runtime_error_check_printf.ll
@@ -37,7 +37,7 @@ entry:
 helper_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %7, align 8
+  store i64 40006, ptr %7, align 8
   %8 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %8, align 8
   %9 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_signal.ll
+++ b/tests/codegen/llvm/runtime_error_check_signal.ll
@@ -26,7 +26,7 @@ entry:
 helper_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %3 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %3, align 8
+  store i64 40006, ptr %3, align 8
   %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
   %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2

--- a/tests/codegen/llvm/runtime_error_check_stack.ll
+++ b/tests/codegen/llvm/runtime_error_check_stack.ll
@@ -95,7 +95,7 @@ get_stack_fail:                                   ; preds = %helper_merge
 helper_failure:                                   ; preds = %lookup_stack_scratch_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
   %14 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %14, align 8
+  store i64 40006, ptr %14, align 8
   %15 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
   store i64 0, ptr %15, align 8
   %16 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
@@ -125,7 +125,7 @@ counter_merge:                                    ; preds = %event_loss_counter,
 helper_failure1:                                  ; preds = %get_stack_success
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t3)
   %22 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 0
-  store i64 30006, ptr %22, align 8
+  store i64 40006, ptr %22, align 8
   %23 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 1
   store i64 1, ptr %23, align 8
   %24 = getelementptr %runtime_error_t, ptr %runtime_error_t3, i64 0, i32 2
@@ -154,7 +154,7 @@ counter_merge6:                                   ; preds = %event_loss_counter5
 helper_failure11:                                 ; preds = %merge_block
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t13)
   %29 = getelementptr %runtime_error_t, ptr %runtime_error_t13, i64 0, i32 0
-  store i64 30006, ptr %29, align 8
+  store i64 40006, ptr %29, align 8
   %30 = getelementptr %runtime_error_t, ptr %runtime_error_t13, i64 0, i32 1
   store i64 2, ptr %30, align 8
   %31 = getelementptr %runtime_error_t, ptr %runtime_error_t13, i64 0, i32 2
@@ -228,7 +228,7 @@ get_stack_fail30:                                 ; preds = %helper_merge33
 helper_failure32:                                 ; preds = %lookup_stack_scratch_merge26
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t34)
   %46 = getelementptr %runtime_error_t, ptr %runtime_error_t34, i64 0, i32 0
-  store i64 30006, ptr %46, align 8
+  store i64 40006, ptr %46, align 8
   %47 = getelementptr %runtime_error_t, ptr %runtime_error_t34, i64 0, i32 1
   store i64 3, ptr %47, align 8
   %48 = getelementptr %runtime_error_t, ptr %runtime_error_t34, i64 0, i32 2
@@ -258,7 +258,7 @@ counter_merge37:                                  ; preds = %event_loss_counter3
 helper_failure43:                                 ; preds = %get_stack_success29
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t45)
   %54 = getelementptr %runtime_error_t, ptr %runtime_error_t45, i64 0, i32 0
-  store i64 30006, ptr %54, align 8
+  store i64 40006, ptr %54, align 8
   %55 = getelementptr %runtime_error_t, ptr %runtime_error_t45, i64 0, i32 1
   store i64 4, ptr %55, align 8
   %56 = getelementptr %runtime_error_t, ptr %runtime_error_t45, i64 0, i32 2
@@ -287,7 +287,7 @@ counter_merge48:                                  ; preds = %event_loss_counter4
 helper_failure53:                                 ; preds = %merge_block22
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t55)
   %61 = getelementptr %runtime_error_t, ptr %runtime_error_t55, i64 0, i32 0
-  store i64 30006, ptr %61, align 8
+  store i64 40006, ptr %61, align 8
   %62 = getelementptr %runtime_error_t, ptr %runtime_error_t55, i64 0, i32 1
   store i64 5, ptr %62, align 8
   %63 = getelementptr %runtime_error_t, ptr %runtime_error_t55, i64 0, i32 2

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -40,7 +40,7 @@ left:                                             ; preds = %entry
 right:                                            ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
   %5 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %5, align 8
+  store i64 40000, ptr %5, align 8
   %6 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
   store i8 0, ptr %6, align 1
   %ringbuf_output1 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -61,6 +61,16 @@ NAME printf_invalid_enum_symbolize_cast
 PROG enum Foo { ONE = 1, TWO = 2, OTHER = 99999 }; begin { $x = 100; printf("%d %s\n", ONE, (enum Foo)$x); exit() }
 EXPECT 1 100
 
+NAME print_error
+PROG begin { print_error("Something bad with args: %d, %s", 10, "arg2"); }
+EXPECT stdin:1:9-67: ERROR: Something bad with args: 10, arg2
+
+# Just a quick smoke test to show that print_error works
+# the same as printf
+NAME print_error_length_modifiers
+PROG begin { $x = 0x12345678abcdef; print_error("%hhx %hx %x %jx\n", $x, $x, $x, $x);  }
+EXPECT stdin:1:32-80: ERROR: ef cdef 78abcdef 12345678abcdef
+
 NAME time
 PROG i:ms:1 { time("%H:%M:%S\n"); exit();}
 EXPECT_REGEX [0-9]*:[0-9]*:[0-9]*

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2048,29 +2048,33 @@ TEST_F(SemanticAnalyserTest, unop_increment_decrement)
   test("kprobe:f { $x = \"a\"; $x++; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, printf)
+TEST_F(SemanticAnalyserTest, printf_and_print_error)
 {
-  test("kprobe:f { printf(\"hi\") }");
-  test("kprobe:f { printf(1234) }", Error{});
-  test("kprobe:f { printf() }", Error{});
-  test("kprobe:f { $fmt = \"mystring\"; printf($fmt) }", Error{});
-  test("kprobe:f { printf(\"%s\", comm) }");
-  test("kprobe:f { printf(\"%-16s\", comm) }");
-  test("kprobe:f { printf(\"%-10.10s\", comm) }");
-  test("kprobe:f { printf(\"%A\", comm) }", Error{});
-  test("kprobe:f { @x = printf(\"hi\") }", Error{});
-  test("kprobe:f { $x = printf(\"hi\") }", Error{});
-  test("kprobe:f { printf(\"%d %d %d %d %d %d %d %d %d\", "
-       "1, 2, 3, 4, 5, 6, 7, 8, 9); }");
-  test("kprobe:f { printf(\"%dns\", nsecs) }");
+  std::vector<std::string> funcs = { "printf", "print_error" };
+  for (const auto &func : funcs) {
+    test("kprobe:f { " + func + "(\"hi\") }");
+    test("kprobe:f { " + func + "(1234) }", Error{});
+    test("kprobe:f { " + func + "() }", Error{});
+    test("kprobe:f { $fmt = \"mystring\"; " + func + "($fmt) }", Error{});
+    test("kprobe:f { " + func + "(\"%s\", comm) }");
+    test("kprobe:f { " + func + "(\"%-16s\", comm) }");
+    test("kprobe:f { " + func + "(\"%-10.10s\", comm) }");
+    test("kprobe:f { " + func + "(\"%A\", comm) }", Error{});
+    test("kprobe:f { @x = " + func + "(\"hi\") }", Error{});
+    test("kprobe:f { $x = " + func + "(\"hi\") }", Error{});
+    test("kprobe:f { " + func +
+         "(\"%d %d %d %d %d %d %d %d %d\", "
+         "1, 2, 3, 4, 5, 6, 7, 8, 9); }");
+    test("kprobe:f { " + func + "(\"%dns\", nsecs) }");
 
-  {
-    // Long format string should be ok
-    std::stringstream prog;
+    {
+      // Long format string should be ok
+      std::stringstream prog;
 
-    prog << "i:ms:100 { printf(\"" << std::string(200, 'a')
-         << " %d\\n\", 1); }";
-    test(prog.str());
+      prog << "i:ms:100 { " + func + "(\"" << std::string(200, 'a')
+           << " %d\\n\", 1); }";
+      test(prog.str());
+    }
   }
 }
 


### PR DESCRIPTION
This works just like `printf` expect it logs
the message as an error with the source location
e.g.
```
stdin:1:9-50: ERROR: My message blah blah
BEGIN { print_error("My message %s", "blah blah"); }
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Additionally, use this for the `assert` macro.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
