### PR TITLE
Add location expansion for RuntimeErrorInfo

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -625,10 +625,22 @@ int BPFtrace::run(output::Output &out,
     // callsite. After all, they all must be fixed.
     bool found = false;
     for (const auto &info : helper_use_loc_[e.func_id]) {
-      LOG(ERROR,
-          std::string(info.source_location),
-          std::vector(info.source_context))
-          << e.what();
+      bool first = true;
+      for (const auto &loc : info.locations) {
+        if (first) {
+          LOG(ERROR,
+              std::string(loc.source_location),
+              std::vector(loc.source_context))
+              << e.what();
+          first = false;
+        } else {
+          LOG(ERROR,
+              std::string(loc.source_location),
+              std::vector(loc.source_context))
+              << "expanded from";
+        }
+      }
+
       found = true;
     }
     if (!found) {

--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -404,12 +404,13 @@ void JsonOutput::print_error(const std::string &str,
   std::stringstream ss;
   ss << str;
   JsonEmitter<std::string>::emit(out_, ss.str());
+  // Json only prints the top level location
   out_ << R"(, "filename": )";
-  JsonEmitter<std::string>::emit(out_, info.filename);
+  JsonEmitter<std::string>::emit(out_, info.locations.begin()->filename);
   out_ << R"(, "line": )";
-  JsonEmitter<uint64_t>::emit(out_, info.line);
+  JsonEmitter<uint64_t>::emit(out_, info.locations.begin()->line);
   out_ << R"(, "col": )";
-  JsonEmitter<uint64_t>::emit(out_, info.column);
+  JsonEmitter<uint64_t>::emit(out_, info.locations.begin()->column);
   out_ << R"(})" << std::endl;
 }
 
@@ -476,12 +477,13 @@ void JsonOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
     }
   }
 
+  // Json only prints the top level location
   out_ << R"(, "filename": )";
-  JsonEmitter<std::string>::emit(out_, info.filename);
+  JsonEmitter<std::string>::emit(out_, info.locations.begin()->filename);
   out_ << R"(, "line": )";
-  JsonEmitter<uint64_t>::emit(out_, info.line);
+  JsonEmitter<uint64_t>::emit(out_, info.locations.begin()->line);
   out_ << R"(, "col": )";
-  JsonEmitter<uint64_t>::emit(out_, info.column);
+  JsonEmitter<uint64_t>::emit(out_, info.locations.begin()->column);
   out_ << R"(})" << std::endl;
 }
 

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -33,6 +33,14 @@ enum class RuntimeErrorId {
   PRINT_ERROR,
 };
 
+struct ErrorLocation {
+  const std::string filename;
+  const int line;
+  const int column;
+  const std::string source_location;
+  const std::vector<std::string> source_context;
+};
+
 class RuntimeErrorInfo {
 public:
   // This class effectively wraps a location, but preserves only the parts that
@@ -41,14 +49,23 @@ public:
   RuntimeErrorInfo(RuntimeErrorId error_id,
                    libbpf::bpf_func_id func_id,
                    const ast::Location &loc)
-      : error_id(error_id),
-        func_id(func_id),
-        filename(loc->filename()),
-        line(loc->line()),
-        column(loc->column()),
-        source_location(loc->source_location()),
-        source_context(loc->source_context())
+      : error_id(error_id), func_id(func_id)
   {
+    auto curr_loc = loc;
+
+    while (curr_loc) {
+      locations.emplace_back(curr_loc->filename(),
+                             curr_loc->line(),
+                             curr_loc->column(),
+                             curr_loc->source_location(),
+                             curr_loc->source_context());
+      auto &parent = curr_loc->parent;
+      if (parent) {
+        curr_loc = parent->loc;
+      } else {
+        break;
+      }
+    }
   }
 
   RuntimeErrorInfo(RuntimeErrorId error_id, const ast::Location &loc)
@@ -57,30 +74,18 @@ public:
 
   RuntimeErrorInfo()
       : error_id(RuntimeErrorId::HELPER_ERROR),
-        func_id(static_cast<libbpf::bpf_func_id>(-1)),
-        line(0),
-        column(0) {};
+        func_id(static_cast<libbpf::bpf_func_id>(-1)) {};
 
   const RuntimeErrorId error_id;
   const libbpf::bpf_func_id func_id;
-  const std::string filename;
-  const int line;
-  const int column;
-  const std::string source_location;
-  const std::vector<std::string> source_context;
+  std::vector<ErrorLocation> locations;
 
 private:
   friend class cereal::access;
   template <typename Archive>
   void serialize(Archive &archive)
   {
-    archive(error_id,
-            func_id,
-            filename,
-            line,
-            column,
-            source_location,
-            source_context);
+    archive(error_id, func_id, locations);
   }
 };
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -71,6 +71,12 @@ NAME print_error_length_modifiers
 PROG begin { $x = 0x12345678abcdef; print_error("%hhx %hx %x %jx\n", $x, $x, $x, $x);  }
 EXPECT stdin:1:32-80: ERROR: ef cdef 78abcdef 12345678abcdef
 
+NAME print_error_macro_expansion
+PROG macro bad() { print_error("Something bad"); } begin { bad(); }
+EXPECT stdin:1:15-43: ERROR: Something bad
+EXPECT stdin:1:55-60: ERROR: expanded from
+EXPECT macro bad() { print_error("Something bad"); } begin { bad(); }
+
 NAME time
 PROG i:ms:1 { time("%H:%M:%S\n"); exit();}
 EXPECT_REGEX [0-9]*:[0-9]*:[0-9]*


### PR DESCRIPTION
Add location expansion for RuntimeErrorInfo

This is so runtime errors, helper errors,
verifier errors, and `print_error` errros
show the call/macro chain.

```
Attached 1 probe
stdlib/base.bt:9:5-51: ERROR: Assertion failed. Msg: baby did a bad bad thing
stdin:1:9-50: ERROR: expanded from
BEGIN { assert(false, "baby did a bad bad thing"); }
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Signed-off-by: Jordan Rome <linux@jordanrome.com>