### PR TITLE
Add errorf function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to
   - [#4343](https://github.com/bpftrace/bpftrace/pull/4343)
 - Add 'assert' and 'ppid' to the macro standard library
   - [#4366](https://github.com/bpftrace/bpftrace/pull/4366)
+- Add 'errorf' for printing error messages with the source location
+  - [#4414](https://github.com/bpftrace/bpftrace/pull/4414)
 #### Changed
 - kprobe: support verbose mode listing
   - [#4362](https://github.com/bpftrace/bpftrace/pull/4362)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -41,6 +41,7 @@ Unlike scratch and map variables they don’t need a `$` or `@` as prefix (excep
 | [`cat`](#cat) | Print file content | Async |
 | [`cgroupid`](#cgroupid) | Resolve cgroup ID | Compile Time |
 | [`cgroup_path`](#cgroup_path) | Convert cgroup id to cgroup path | Sync |
+| [`errorf`](#errorf) | Print a formatted error | Async |
 | [`exit`](#exit) | Quit bpftrace with an optional exit code | Async |
 | [`getopt`](#getopt) | Get named command line option/parameter | Sync |
 | [`join`](#join) | Combine an array of char* into one string and print it | Async |
@@ -214,6 +215,26 @@ BEGIN {
   print($cgroup_path); /* This may print a different path */
   printf("%s %s", $cgroup_path, $cgroup_path); /* This may print two different paths */
 }
+```
+
+### errorf
+
+**variants**
+
+* `void errorf(const string fmt, args...)`
+
+**async**
+
+`errorf()` formats and prints data (similar to [`printf`](#printf)) as an error message with the source location.
+
+```
+BEGIN { errorf("Something bad with args: %d, %s", 10, "arg2"); }
+```
+
+Prints:
+
+```
+EXPECT stdin:1:9-62: ERROR: Something bad with args: 10, arg2
 ```
 
 ### exit

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -173,8 +173,8 @@ void ResourceAnalyser::visit(Call &call)
 {
   Visitor<ResourceAnalyser>::visit(call);
 
-  if (call.func == "printf" || call.func == "system" || call.func == "cat" ||
-      call.func == "debugf") {
+  if (call.func == "printf" || call.func == "errorf" || call.func == "system" ||
+      call.func == "cat" || call.func == "debugf") {
     std::vector<SizedType> args;
 
     // NOTE: the same logic can be found in the semantic_analyser pass
@@ -217,8 +217,12 @@ void ResourceAnalyser::visit(Call &call)
           single_provider_type_postsema(probe_) == ProbeType::iter) {
         resources_.bpf_print_fmts.emplace_back(fmtstr);
       } else {
-        resources_.printf_args.emplace_back(fmtstr, tuple->fields);
+        resources_.printf_args.emplace_back(
+            fmtstr, tuple->fields, PrintfSeverity::NONE, SourceInfo(call.loc));
       }
+    } else if (call.func == "errorf") {
+      resources_.printf_args.emplace_back(
+          fmtstr, tuple->fields, PrintfSeverity::ERROR, SourceInfo(call.loc));
     } else if (call.func == "debugf") {
       resources_.bpf_print_fmts.emplace_back(fmtstr);
     } else if (call.func == "system") {

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -341,6 +341,11 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
         map_key_spec{ .map_index=0 },
       }
        } },
+  { "errorf",
+    { .min_args=1,
+      .max_args=128,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true } } } },
   { "exit",
     { .min_args=0,
       .max_args=1,
@@ -752,7 +757,7 @@ void SemanticAnalyser::visit(String &string)
   // Skip check for printf()'s format string (1st argument) and create the
   // string with the original size. This is because format string is not part of
   // bpf byte code.
-  if (func_ == "printf" && func_arg_idx_ == 0)
+  if ((func_ == "printf" || func_ == "errorf") && func_arg_idx_ == 0)
     return;
 
   const auto str_len = bpftrace_.config_->max_strlen;
@@ -1558,8 +1563,9 @@ void SemanticAnalyser::visit(Call &call)
     call.return_type = CreatePointer(CreateInt(pointee_size), AddrSpace::user);
   } else if (call.func == "cgroupid") {
     call.return_type = CreateUInt64();
-  } else if (call.func == "printf" || call.func == "system" ||
-             call.func == "cat" || call.func == "debugf") {
+  } else if (call.func == "printf" || call.func == "errorf" ||
+             call.func == "system" || call.func == "cat" ||
+             call.func == "debugf") {
     if (is_final_pass()) {
       const auto &fmt = call.vargs.at(0).as<String>()->value;
       std::vector<SizedType> args;

--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -401,6 +401,23 @@ void JsonOutput::printf(const std::string &str)
   emit_data(out_, "printf", std::nullopt, str);
 }
 
+void JsonOutput::errorf(const std::string &str, const SourceInfo &info)
+{
+  out_ << R"({"type": "errorf")";
+  out_ << R"(, "msg": )";
+  std::stringstream ss;
+  ss << str;
+  JsonEmitter<std::string>::emit(out_, ss.str());
+  // Json only prints the top level location
+  out_ << R"(, "filename": )";
+  JsonEmitter<std::string>::emit(out_, info.locations.begin()->filename);
+  out_ << R"(, "line": )";
+  JsonEmitter<uint64_t>::emit(out_, info.locations.begin()->line);
+  out_ << R"(, "col": )";
+  JsonEmitter<uint64_t>::emit(out_, info.locations.begin()->column);
+  out_ << R"(})" << std::endl;
+}
+
 void JsonOutput::time(const std::string &time)
 {
   emit_data(out_, "time", std::nullopt, time);

--- a/src/output/json.h
+++ b/src/output/json.h
@@ -13,6 +13,7 @@ public:
   void map(const std::string &name, const Value &value) override;
   void value(const Value &value) override;
   void printf(const std::string &str) override;
+  void errorf(const std::string &str, const SourceInfo &info) override;
   void time(const std::string &time) override;
   void cat(const std::string &cat) override;
   void join(const std::string &join) override;

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -149,6 +149,7 @@ public:
 
   // Specialized messages during execution.
   virtual void printf(const std::string& str) = 0;
+  virtual void errorf(const std::string& str, const SourceInfo& info) = 0;
   virtual void time(const std::string& time) = 0;
   virtual void cat(const std::string& cat) = 0;
   virtual void join(const std::string& join) = 0;

--- a/src/output/text.cpp
+++ b/src/output/text.cpp
@@ -528,6 +528,25 @@ void TextOutput::printf(const std::string &str)
   out_ << str;
 }
 
+void TextOutput::errorf(const std::string &str, const SourceInfo &info)
+{
+  bool first = true;
+  for (const auto &loc : info.locations) {
+    if (first) {
+      // No need to print the source context as that's just the `errorf`
+      // call
+      LOG(ERROR, std::string(loc.source_location), out_) << str;
+      first = false;
+    } else {
+      LOG(ERROR,
+          std::string(loc.source_location),
+          std::vector(loc.source_context),
+          out_)
+          << "expanded from";
+    }
+  }
+}
+
 void TextOutput::time(const std::string &time)
 {
   out_ << time;

--- a/src/output/text.h
+++ b/src/output/text.h
@@ -13,6 +13,7 @@ public:
   void map(const std::string &name, const Value &value) override;
   void value(const Value &value) override;
   void printf(const std::string &str) override;
+  void errorf(const std::string &str, const SourceInfo &info) override;
   void time(const std::string &time) override;
   void cat(const std::string &cat) override;
   void join(const std::string &join) override;

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -32,6 +32,11 @@ enum class RuntimeErrorId {
   HELPER_ERROR,
 };
 
+enum class PrintfSeverity {
+  NONE,
+  ERROR,
+};
+
 struct SourceLocation {
   std::string filename;
   int line;
@@ -138,7 +143,9 @@ public:
   void load_state(const uint8_t *ptr, size_t len);
 
   // Async argument metadata
-  std::vector<std::tuple<FormatString, std::vector<Field>>> printf_args;
+  std::vector<
+      std::tuple<FormatString, std::vector<Field>, PrintfSeverity, SourceInfo>>
+      printf_args;
   std::vector<std::tuple<FormatString, std::vector<Field>>> system_args;
   // fmt strings for BPF helpers (bpf_seq_printf, bpf_trace_printk)
   std::vector<FormatString> bpf_print_fmts;

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -4,7 +4,7 @@
 // :param (string) $msg: The message to print if the condition is not met
 macro assert($cond, $msg) {
   if (!$cond) {
-    printf("Assertion failed. Msg: %s", $msg);
+    errorf("assert failed: %s", $msg);
     exit(1);
   }
 }

--- a/tests/async_action.cpp
+++ b/tests/async_action.cpp
@@ -86,7 +86,8 @@ std::string handler_proxy(AsyncActionTest &test,
     test.bpftrace->resources.cat_args.emplace_back(fmt, fields);
     test.handlers.cat(arg_data);
   } else if (id == AsyncAction::printf) {
-    test.bpftrace->resources.printf_args.emplace_back(fmt, fields);
+    test.bpftrace->resources.printf_args.emplace_back(
+        fmt, fields, PrintfSeverity::NONE, SourceInfo());
     test.handlers.printf(arg_data);
   }
 

--- a/tests/codegen/call_errorf.cpp
+++ b/tests/codegen/call_errorf.cpp
@@ -1,0 +1,13 @@
+#include "common.h"
+
+namespace bpftrace::test::codegen {
+
+TEST(codegen, call_errorf)
+{
+  test("struct Foo { char c; long l; } kprobe:f { $foo = (struct Foo*)arg0; "
+       "errorf(\"%c %lu\\n\", $foo->c, $foo->l) }",
+
+       NAME);
+}
+
+} // namespace bpftrace::test::codegen

--- a/tests/codegen/llvm/call_errorf.ll
+++ b/tests/codegen/llvm/call_errorf.ll
@@ -1,0 +1,137 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf"
+
+%"struct map_internal_repr_t" = type { ptr, ptr }
+%errorf_t = type { i64, %errorf_args_t }
+%errorf_args_t = type { i64, i64 }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
+@ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !22
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !29
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+; Function Attrs: nounwind
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
+entry:
+  %"struct Foo.l" = alloca i64, align 8
+  %"struct Foo.c" = alloca i8, align 1
+  %errorf_args = alloca %errorf_t, align 8
+  %"$foo" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
+  store i64 0, ptr %"$foo", align 8
+  %1 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %2 = getelementptr i8, ptr %1, i64 112
+  %arg0 = load volatile i64, ptr %2, align 8
+  store i64 %arg0, ptr %"$foo", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %errorf_args)
+  call void @llvm.memset.p0.i64(ptr align 1 %errorf_args, i8 0, i64 24, i1 false)
+  %3 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 0
+  store i64 0, ptr %3, align 8
+  %4 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
+  %5 = load i64, ptr %"$foo", align 8
+  %6 = inttoptr i64 %5 to ptr
+  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
+  %8 = getelementptr i8, ptr %7, i64 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.c")
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.c", i32 1, ptr %8)
+  %9 = load i8, ptr %"struct Foo.c", align 1
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.c")
+  %10 = getelementptr %errorf_args_t, ptr %4, i32 0, i32 0
+  %11 = sext i8 %9 to i64
+  store i64 %11, ptr %10, align 8
+  %12 = load i64, ptr %"$foo", align 8
+  %13 = inttoptr i64 %12 to ptr
+  %14 = call ptr @llvm.preserve.static.offset(ptr %13)
+  %15 = getelementptr i8, ptr %14, i64 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.l")
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, ptr %15)
+  %16 = load i64, ptr %"struct Foo.l", align 8
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.l")
+  %17 = getelementptr %errorf_args_t, ptr %4, i32 0, i32 1
+  store i64 %16, ptr %17, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %errorf_args, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
+  %18 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %18
+  %19 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %20 = load i64, ptr %19, align 8
+  %21 = add i64 %20, 1
+  store i64 %21, ptr %19, align 8
+  br label %counter_merge
+
+counter_merge:                                    ; preds = %event_loss_counter, %entry
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %errorf_args)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare ptr @llvm.preserve.static.offset(ptr readnone %0) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #2
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #4 = { memory(none) }
+
+!llvm.dbg.cu = !{!31}
+!llvm.module.flags = !{!33, !34}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 32, elements: !5)
+!4 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!5 = !{!6}
+!6 = !DISubrange(count: 4, lowerBound: 0)
+!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
+!8 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !10)
+!10 = !{!11, !17}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !15)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !{!16}
+!16 = !DISubrange(count: 27, lowerBound: 0)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !18, size: 64, offset: 64)
+!18 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !20)
+!20 = !{!21}
+!21 = !DISubrange(count: 262144, lowerBound: 0)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 64, elements: !27)
+!25 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !27)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !{!28}
+!28 = !DISubrange(count: 1, lowerBound: 0)
+!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
+!30 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!31 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !32)
+!32 = !{!0, !7, !22, !29}
+!33 = !{i32 2, !"Debug Info Version", i32 3}
+!34 = !{i32 7, !"uwtable", i32 0}
+!35 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !36, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !31, retainedNodes: !39)
+!36 = !DISubroutineType(types: !37)
+!37 = !{!26, !38}
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!39 = !{!40}
+!40 = !DILocalVariable(name: "ctx", arg: 1, scope: !35, file: !2, type: !38)

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1820,6 +1820,7 @@ TEST(Parser, wildcard_func)
     "arg0",
     "args",
     "curtask",
+    "errorf",
     "func",
     "gid"
     "rand",

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -61,6 +61,22 @@ NAME printf_invalid_enum_symbolize_cast
 PROG enum Foo { ONE = 1, TWO = 2, OTHER = 99999 }; begin { $x = 100; printf("%d %s\n", ONE, (enum Foo)$x); exit() }
 EXPECT 1 100
 
+NAME errorf
+PROG begin { errorf("Something bad with args: %d, %s", 10, "arg2"); }
+EXPECT stdin:1:9-62: ERROR: Something bad with args: 10, arg2
+
+# Just a quick smoke test to show that errorf works
+# the same as printf
+NAME errorf_length_modifiers
+PROG begin { $x = 0x12345678abcdef; errorf("%hhx %hx %x %jx\n", $x, $x, $x, $x);  }
+EXPECT stdin:1:32-75: ERROR: ef cdef 78abcdef 12345678abcdef
+
+NAME errorf_macro_expansion
+PROG macro bad() { errorf("Something bad"); } begin { bad(); }
+EXPECT stdin:1:15-38: ERROR: Something bad
+EXPECT stdin:1:50-55: ERROR: expanded from
+EXPECT macro bad() { errorf("Something bad"); } begin { bad(); }
+
 NAME time
 PROG i:ms:1 { time("%H:%M:%S\n"); exit();}
 EXPECT_REGEX [0-9]*:[0-9]*:[0-9]*

--- a/tests/runtime/stdlib
+++ b/tests/runtime/stdlib
@@ -1,6 +1,6 @@
 NAME assert_macro
 PROG BEGIN { assert(false, "My error message"); }
-EXPECT Assertion failed. Msg: My error message
+EXPECT stdlib/base.bt:7:5-38: ERROR: assert failed: My error message
 WILL_FAIL
 
 NAME ppid_macro

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2054,29 +2054,33 @@ TEST_F(SemanticAnalyserTest, unop_increment_decrement)
   test("kprobe:f { $x = \"a\"; $x++; }", Error{});
 }
 
-TEST_F(SemanticAnalyserTest, printf)
+TEST_F(SemanticAnalyserTest, printf_and_errorf)
 {
-  test("kprobe:f { printf(\"hi\") }");
-  test("kprobe:f { printf(1234) }", Error{});
-  test("kprobe:f { printf() }", Error{});
-  test("kprobe:f { $fmt = \"mystring\"; printf($fmt) }", Error{});
-  test("kprobe:f { printf(\"%s\", comm) }");
-  test("kprobe:f { printf(\"%-16s\", comm) }");
-  test("kprobe:f { printf(\"%-10.10s\", comm) }");
-  test("kprobe:f { printf(\"%A\", comm) }", Error{});
-  test("kprobe:f { @x = printf(\"hi\") }", Error{});
-  test("kprobe:f { $x = printf(\"hi\") }", Error{});
-  test("kprobe:f { printf(\"%d %d %d %d %d %d %d %d %d\", "
-       "1, 2, 3, 4, 5, 6, 7, 8, 9); }");
-  test("kprobe:f { printf(\"%dns\", nsecs) }");
+  std::vector<std::string> funcs = { "printf", "errorf" };
+  for (const auto &func : funcs) {
+    test("kprobe:f { " + func + "(\"hi\") }");
+    test("kprobe:f { " + func + "(1234) }", Error{});
+    test("kprobe:f { " + func + "() }", Error{});
+    test("kprobe:f { $fmt = \"mystring\"; " + func + "($fmt) }", Error{});
+    test("kprobe:f { " + func + "(\"%s\", comm) }");
+    test("kprobe:f { " + func + "(\"%-16s\", comm) }");
+    test("kprobe:f { " + func + "(\"%-10.10s\", comm) }");
+    test("kprobe:f { " + func + "(\"%A\", comm) }", Error{});
+    test("kprobe:f { @x = " + func + "(\"hi\") }", Error{});
+    test("kprobe:f { $x = " + func + "(\"hi\") }", Error{});
+    test("kprobe:f { " + func +
+         "(\"%d %d %d %d %d %d %d %d %d\", "
+         "1, 2, 3, 4, 5, 6, 7, 8, 9); }");
+    test("kprobe:f { " + func + "(\"%dns\", nsecs) }");
 
-  {
-    // Long format string should be ok
-    std::stringstream prog;
+    {
+      // Long format string should be ok
+      std::stringstream prog;
 
-    prog << "i:ms:100 { printf(\"" << std::string(200, 'a')
-         << " %d\\n\", 1); }";
-    test(prog.str());
+      prog << "i:ms:100 { " + func + "(\"" << std::string(200, 'a')
+           << " %d\\n\", 1); }";
+      test(prog.str());
+    }
   }
 }
 
@@ -3643,7 +3647,7 @@ TEST_F(SemanticAnalyserTest, struct_member_keywords)
     "arg0",   "args",   "curtask", "func",   "gid",      "rand",
     "uid",    "avg",    "cat",     "exit",   "kaddr",    "min",
     "printf", "usym",   "kstack",  "ustack", "bpftrace", "perf",
-    "raw",    "uprobe", "kprobe",  "config", "fn",
+    "raw",    "uprobe", "kprobe",  "config", "fn",       "errorf",
   };
   for (auto kw : keywords) {
     test("struct S{ int " + kw + ";}; k:f { ((struct S*)arg0)->" + kw + "}");


### PR DESCRIPTION
Stacked PRs:
 * __->__#4414


--- --- ---

### Add errorf function


This works just like `printf` expect it logs
the message as an error with the source location
e.g.
```
stdin:1:9-50: ERROR: My message blah blah
BEGIN { errorf("My message %s", "blah blah"); }
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Additionally, use this for the `assert` macro.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>