### PR TITLE
Re-enable USDT arg tests

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,4 +1,2 @@
 tests/data/data_source.c
-tests/testprogs/usdt_inlined.c
-tests/testprogs/watchpoint_exec.c
-tests/testprogs/watchpoint_threaded.c
+tests/testprogs/*.c

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -128,25 +128,19 @@ PROG usdt:./testprogs/usdt_multiple_locations:tracetest:testprobe* { printf("her
 BEFORE ./testprogs/usdt_multiple_locations
 EXPECT Attached 6 probes
 
-# TODO(mmarchini): re-enable this test
-# This test relies on the latest version of bcc. Before re-enabling this test,
-# we should:
-#  - Skip if bcc doesn't support multiple probes with the same name
 NAME usdt probes - attach to probe with args by file
-PROG usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }
-EXPECT Hello world
+PROG usdt:./testprogs/usdt_test:* { print(str(arg1)); @c = count(); if (@c > 20) { exit(); } }
+EXPECT Hello World1
+EXPECT Hello World2
+EXPECT Hello World3
 BEFORE ./testprogs/usdt_test
-REQUIRES bash -c "exit 1"
 
-# TODO(mmarchini): re-enable this test
-# This test relies on the latest version of bcc. Before re-enabling this test,
-# we should:
-#  - Skip if bcc doesn't support multiple probes with the same name
 NAME usdt probes - attach to probe with args by pid
-RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
-EXPECT Hello world
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { print(str(arg1)); @c = count(); if (@c > 20) { exit(); } }' -p {{BEFORE_PID}}
+EXPECT Hello World1
+EXPECT Hello World2
+EXPECT Hello World3
 BEFORE ./testprogs/usdt_test
-REQUIRES bash -c "exit 1"
 
 NAME usdt probes - attach to probe with probe builtin and args by file
 PROG usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }

--- a/tests/testprogs/usdt_test.c
+++ b/tests/testprogs/usdt_test.c
@@ -8,9 +8,12 @@ static long myclock()
 {
   struct timeval tv;
   gettimeofday(&tv, NULL);
-  DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, "Hello world");
-  DTRACE_PROBE2(tracetest, testprobe2, tv.tv_sec, "Hello world2");
-  DTRACE_PROBE2(tracetest2, testprobe2, tv.tv_sec, "Hello world3");
+  static volatile char str1[] = "Hello World1";
+  static volatile char str2[] = "Hello World2";
+  static volatile char str3[] = "Hello World3";
+  DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, str1);
+  DTRACE_PROBE2(tracetest, testprobe2, tv.tv_sec, str2);
+  DTRACE_PROBE2(tracetest2, testprobe2, tv.tv_sec, str3);
   return tv.tv_sec;
 }
 
@@ -18,6 +21,8 @@ int main()
 {
   while (1) {
     myclock();
+    // Sleep is necessary to not overflow perf buffer
+    usleep(1000);
   }
   return 0;
 }


### PR DESCRIPTION
These were broken because the strings weren't market as volatile.

The `volatile` qualifier ensures that:

*   The strings remain in memory at a stable address
*   The compiler doesn't merge identical strings (which would break tracing)
*   The strings aren't moved to read-only memory sections


##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
