### PR TITLE
Allow bare identifiers to be macro-expanded

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -624,6 +624,7 @@ macro add_two($x) {
 
 begin {
   print(one());                   // prints 1
+  print(one);                     // prints 1 (bare identifier works if the macro accepts 0 args)
 
   $a = 10;
   print(plus_one($a));            // prints 11

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -58,6 +58,7 @@ void test_warning(const std::string& input, const std::string& warn)
 TEST(macro_expansion, basic_checks)
 {
   test("macro print_me() { print(\"me\"); } begin { print_me(); }");
+  test("macro print_me() { print(\"me\"); } begin { print_me; }");
   test("macro add1($x) { $x + 1 } macro add2($x) { $x + add1($x) } macro "
        "add3($x) { $x + add2($x) } begin { print(add3(1)); }");
   test("macro add1($x) { $x += 1; } begin { $y = 1; add1($y); }");
@@ -87,6 +88,8 @@ TEST(macro_expansion, basic_checks)
       "macro add1($x) { $x + add3($x) } macro add2($x) { $x + add1($x) } macro "
       "add3($x) { $x + add2($x) } begin { print(add3(1)); }",
       "Recursive macro call detected. Call chain: add3 > add2 > add1 > add3");
+  test_error("macro add1($x) { $x += 1; $x } begin { $y = 1; $z = add1; }",
+             "ERROR: Call to macro has no number arguments. Expected: 1");
 }
 
 TEST(macro_expansion, variables)

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -77,3 +77,7 @@ EXPECT (2, 6)
 NAME it can be part of an expression passed to a macro
 PROG macro add_one($x) { $x + 1 } begin { $a = add_one(add_one(1) + 1); print($a);  }
 EXPECT 4
+
+NAME it expands idents if there is a matching macro
+PROG macro one() { $x = 1; $x } begin { $a = one; print($a);  }
+EXPECT 1


### PR DESCRIPTION
Stacked PRs:
 * #4426
 * #4425
 * #4420
 * __->__#4419


--- --- ---

### Allow bare identifiers to be macro-expanded


If there is a macro of the same name as an
identifier try to expand it.

Example:
```
macro print_me() { print(\"me\"); }
begin { print_me; }
```

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>