### PR TITLE
Fix re-enabled usdt arg tests

### DIFF
--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -129,14 +129,14 @@ BEFORE ./testprogs/usdt_multiple_locations
 EXPECT Attached 6 probes
 
 NAME usdt probes - attach to probe with args by file
-PROG usdt:./testprogs/usdt_test:* { print(str(arg1)); @c = count(); if (@c > 20) { exit(); } }
+PROG usdt:./testprogs/usdt_test:* { $a = str(arg1); print($a); @c[$a] = 1; if (len(@c) == 3) { exit(); } }
 EXPECT Hello World1
 EXPECT Hello World2
 EXPECT Hello World3
 BEFORE ./testprogs/usdt_test
 
 NAME usdt probes - attach to probe with args by pid
-RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { print(str(arg1)); @c = count(); if (@c > 20) { exit(); } }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { $a = str(arg1); print($a); @c[$a] = 1; if (len(@c) == 3) { exit(); } }' -p {{BEFORE_PID}}
 EXPECT Hello World1
 EXPECT Hello World2
 EXPECT Hello World3

--- a/tests/testprogs/usdt_test.c
+++ b/tests/testprogs/usdt_test.c
@@ -21,8 +21,8 @@ int main()
 {
   while (1) {
     myclock();
-    // Sleep is necessary to not overflow perf buffer
-    usleep(1000);
+    // Reduce the frequency of events to reduce test flakyness
+    usleep(100000);
   }
   return 0;
 }


### PR DESCRIPTION
Make the tests more resilient and also
reduce the amount of incoming USDT events
to prevent log spew if they fail.

Saw these failing on our VM runs.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
