### PR TITLE
fix: libbpf.a symbols shadow by libbcc_bpf.so

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,13 @@ endif()
 
 install(TARGETS bpftrace DESTINATION ${CMAKE_INSTALL_BINDIR})
 target_compile_definitions(bpftrace PRIVATE ${BPFTRACE_FLAGS})
-target_link_libraries(bpftrace libbpftrace)
+
+# TODO(Jiawei Zhao): this conditional can be removed when we no longer use bcc.
+if(STATIC_LINKING)
+  target_link_libraries(bpftrace libbpftrace)
+else()
+  target_link_libraries(bpftrace libbpftrace libbpf.a)
+endif(STATIC_LINKING)
 
 # compile definitions
 


### PR DESCRIPTION
Since the libbcc_bpf.so has defined same symbols as libbpf does and libbcc_bpf.so is linked before libbpf.a, some symbols in libbpf.a, like `bpf_program__attach_usdt`, will be shadowed by libbcc_bpf.so. Therefore, the libbpf.a should be linked before libbcc_bpf.so

```bash
nm /lib/x86_64-linux-gnu/libbcc_bpf.so.0 | grep bpf_program__attach_*
00000000000e1c60 T bpf_program__attach
00000000000e0dc0 T bpf_program__attach_cgroup
00000000000e15e0 T bpf_program__attach_freplace
00000000000e1770 T bpf_program__attach_iter
00000000000dd860 T bpf_program__attach_kprobe
00000000000ddc50 T bpf_program__attach_kprobe_multi_opts
00000000000dcf70 T bpf_program__attach_kprobe_opts
00000000000dd8c0 T bpf_program__attach_ksyscall
00000000000e0c10 T bpf_program__attach_lsm
00000000000e19e0 T bpf_program__attach_netfilter
00000000000e13d0 T bpf_program__attach_netkit
00000000000e0ec0 T bpf_program__attach_netns
00000000000dcd90 T bpf_program__attach_perf_event
00000000000dc970 T bpf_program__attach_perf_event_opts
00000000000e0700 T bpf_program__attach_raw_tracepoint
00000000000e0540 T bpf_program__attach_raw_tracepoint_opts
00000000000e0fc0 T bpf_program__attach_sockmap
00000000000e11c0 T bpf_program__attach_tcx
00000000000e0830 T bpf_program__attach_trace
00000000000e09e0 T bpf_program__attach_trace_opts
00000000000e0420 T bpf_program__attach_tracepoint
00000000000e0190 T bpf_program__attach_tracepoint_opts
00000000000dfda0 T bpf_program__attach_uprobe
00000000000de940 T bpf_program__attach_uprobe_multi
00000000000df030 T bpf_program__attach_uprobe_opts
00000000000dfe10 T bpf_program__attach_usdt
00000000000e10c0 T bpf_program__attach_xdp

nm /lib/x86_64-linux-gnu/libbpf.a | grep bpf_program__attach_*
000000000002231d T bpf_program__attach
0000000000020e9d t bpf_program__attach_btf_id
000000000002142e T bpf_program__attach_cgroup
0000000000021a50 T bpf_program__attach_freplace
0000000000021c4f T bpf_program__attach_iter
000000000001c9df T bpf_program__attach_kprobe
000000000001d430 T bpf_program__attach_kprobe_multi_opts
000000000001c465 T bpf_program__attach_kprobe_opts
000000000001ca85 T bpf_program__attach_ksyscall
00000000000211d7 T bpf_program__attach_lsm
0000000000021fac T bpf_program__attach_netfilter
000000000002179f T bpf_program__attach_netkit
000000000002145e T bpf_program__attach_netns
000000000001b68f T bpf_program__attach_perf_event
000000000001b0cd T bpf_program__attach_perf_event_opts
0000000000020cfa T bpf_program__attach_raw_tracepoint
0000000000020a7b T bpf_program__attach_raw_tracepoint_opts
000000000002148e T bpf_program__attach_sockmap
00000000000214ee T bpf_program__attach_tcx
000000000002118b T bpf_program__attach_trace
00000000000211ae T bpf_program__attach_trace_opts
0000000000020907 T bpf_program__attach_tracepoint
0000000000020686 T bpf_program__attach_tracepoint_opts
000000000001fe98 T bpf_program__attach_uprobe
000000000001ec45 T bpf_program__attach_uprobe_multi
000000000001f331 T bpf_program__attach_uprobe_opts
000000000001ff6f T bpf_program__attach_usdt
00000000000214be T bpf_program__attach_xdp
                 U bpf_program__attach_uprobe_multi
                 U bpf_program__attach_uprobe_opts
```


before change, the link sequence looks like:
```bash
$ nm src/bpftrace | grep bpf_program__attach_usdt                                                                           
                 U bpf_program__attach_usdt 
```

after change, the link sequence looks like 
```bash
$ nm src/bpftrace | grep bpf_program__attach_usdt                                                                           
000000000011c556 T bpf_program__attach_usdt   
```





<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
