### PR TITLE
Refactor macro expansion pass

### DIFF
--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -107,6 +107,9 @@ TEST(macro_expansion, variables)
   test_error("macro add1($x) { $x += 1; $x } begin { add1(1 + 1); }",
              "Macro 'add1' assigns to parameter '$x', meaning it expects a "
              "variable, not an expression.");
+
+  test_error("macro set($x) { let $x; $x } begin { set(1); }",
+             "Variable declaration shadows macro arg $x");
 }
 
 TEST(macro_expansion, maps)

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -82,6 +82,10 @@ NAME it expands idents if there is a matching macro
 PROG macro one() { $x = 1; $x } begin { $a = one; print($a);  }
 EXPECT 1
 
+NAME it replaces the passed in expression in multiple locations
+PROG macro inc($x) { $y = $x + 1; $z = $x + 2; $y + $z } begin { $y = 2; print(inc({ $y +=1; $y })); }
+EXPECT 10
+
 # Test builtins
 NAME builtin wrapper comm
 PROG begin { if (__builtin_comm == comm() && __builtin_comm == comm) { print(comm); } }


### PR DESCRIPTION
Refactor macro expansion pass

Don't create temporary variables for passed in
expressions, just replace the referenced variables
with the passed in expressions.

This fixes an edge case bug where we're not
evaluating the passed in expression multiple times
in the macro body. Consider this example
```
macro inc($x) {
  $y = $x + 1;
  $z = $x + 2;
  $y + $z
}

begin {
  $y = 2;
  print(inc({ $y +=1; $y }));
}
```
This should print `10` because the expression passed
to `inc` is invoked twice in the macro body,
which increments the outer variable `$y` twice.
In trunk, this prints `9`.

Signed-off-by: Jordan Rome <linux@jordanrome.com>