### PR TITLE
Add address-of operator: &

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -357,35 +357,18 @@ Default: true
 
 Controls whether maps are printed on exit. Set to `false` in order to change the default behavior and not automatically print maps at program exit.
 
-### unstable_macro
+### unstable features
+
+These are the list of unstable features:
+- `unstable_macro` -  feature flag for bpftrace macros
+- `unstable_map_decl` - feature flag for map declarations
+- `unstable_tseries` - feature flag for time series map type
+- `unstable_addr` - feature flag for address of operator (&)
+
+All of these accept the following options:
 
 Default: warn
 
-Feature flag for bpftrace macros.
-
-The possible options are:
-- `error` - fail if this feature is used
-- `warn` - enable feature but print a warning
-- `enable` - enable feature
-
-### unstable_map_decl
-
-Default: warn
-
-Feature flag for map declarations.
-
-The possible options are:
-- `error` - fail if this feature is used
-- `warn` - enable feature but print a warning
-- `enable` - enable feature
-
-### unstable_tseries
-
-Default: warn
-
-Feature flag for `tseries`.
-
-The possible options are:
 - `error` - fail if this feature is used
 - `warn` - enable feature but print a warning
 - `enable` - enable feature

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -130,6 +130,8 @@ class Sizeof;
 class Offsetof;
 class Map;
 class Variable;
+class VariableAddr;
+class MapAddr;
 class Binop;
 class Unop;
 class FieldAccess;
@@ -154,6 +156,8 @@ class Expression : public VariantNode<Integer,
                                       Offsetof,
                                       Map,
                                       Variable,
+                                      VariableAddr,
+                                      MapAddr,
                                       Binop,
                                       Unop,
                                       FieldAccess,
@@ -531,6 +535,42 @@ public:
 
   std::string ident;
   SizedType var_type;
+};
+
+class VariableAddr : public Node {
+public:
+  explicit VariableAddr(ASTContext &ctx, Variable *var, Location &&loc)
+      : Node(ctx, std::move(loc)), var(var), var_addr_type(CreateNone()) {};
+  explicit VariableAddr(ASTContext &ctx,
+                        const VariableAddr &other,
+                        const Location &loc)
+      : Node(ctx, loc + other.loc),
+        var(other.var),
+        var_addr_type(other.var_addr_type) {};
+
+  const SizedType &type() const
+  {
+    return var_addr_type;
+  }
+
+  Variable *var = nullptr;
+  SizedType var_addr_type;
+};
+
+class MapAddr : public Node {
+public:
+  explicit MapAddr(ASTContext &ctx, Map *map, Location &&loc)
+      : Node(ctx, std::move(loc)), map(map) {};
+  explicit MapAddr(ASTContext &ctx, const MapAddr &other, const Location &loc)
+      : Node(ctx, loc + other.loc), map(other.map) {};
+
+  const SizedType &type() const
+  {
+    static SizedType voidptr = CreatePointer(CreateVoid());
+    return voidptr;
+  }
+
+  Map *map = nullptr;
 };
 
 class Binop : public Node {

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -220,7 +220,9 @@ public:
   ScopedExpr visit(Sizeof &szof);
   ScopedExpr visit(Offsetof &offof);
   ScopedExpr visit(Map &map);
+  ScopedExpr visit(MapAddr &map_addr);
   ScopedExpr visit(Variable &var);
+  ScopedExpr visit(VariableAddr &var_addr);
   ScopedExpr visit(Binop &binop);
   ScopedExpr visit(Unop &unop);
   ScopedExpr visit(Ternary &ternary);
@@ -2179,6 +2181,11 @@ ScopedExpr CodegenLLVM::visit([[maybe_unused]] Map &map)
   return ScopedExpr();
 }
 
+ScopedExpr CodegenLLVM::visit(MapAddr &map_addr)
+{
+  return ScopedExpr(b_.GetMapVar(map_addr.map->ident));
+}
+
 ScopedExpr CodegenLLVM::visit(Variable &var)
 {
   // Arrays and structs are not memcopied for local variables
@@ -2189,6 +2196,11 @@ ScopedExpr CodegenLLVM::visit(Variable &var)
     auto &var_llvm = getVariable(var.ident);
     return ScopedExpr(b_.CreateLoad(var_llvm.type, var_llvm.value));
   }
+}
+
+ScopedExpr CodegenLLVM::visit(VariableAddr &var_addr)
+{
+  return ScopedExpr(getVariable(var_addr.var->ident).value);
 }
 
 ScopedExpr CodegenLLVM::binop_string(Binop &binop)
@@ -2488,7 +2500,12 @@ ScopedExpr CodegenLLVM::unop_ptr(Unop &unop)
   switch (unop.op) {
     case Operator::MUL: {
       ScopedExpr scoped_expr = visit(unop.expr);
-      if (unop.result_type.IsIntegerTy() || unop.result_type.IsPtrTy()) {
+      // FIXME(jordalgo): This requires more investigating/fixing as there still
+      // might be some internal types that don't deref properly after their
+      // address is taken via the & operator, e.g., &$x
+      if (unop.result_type.IsIntegerTy() || unop.result_type.IsPtrTy() ||
+          unop.result_type.IsUsernameTy() || unop.result_type.IsTimestampTy() ||
+          unop.result_type.IsKsymTy()) {
         const auto *et = type.GetPointeeTy();
         AllocaInst *dst = b_.CreateAllocaBPF(*et, "deref");
         b_.CreateProbeRead(

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -59,6 +59,7 @@ public:
 
   void visit(AssignVarStatement &assignment);
   void visit(Variable &var);
+  void visit(VariableAddr &var_addr);
   void visit(VarDeclStatement &decl);
   void visit(Map &map);
   void visit(Expression &expr);
@@ -148,6 +149,11 @@ void MacroExpander::visit(Variable &var)
   } else if (renamed_vars_.contains(var.ident)) {
     var.ident = get_new_var_ident(var.ident);
   }
+}
+
+void MacroExpander::visit(VariableAddr &var_addr)
+{
+  visit(var_addr.var);
 }
 
 void MacroExpander::visit(Map &map)

--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -17,6 +17,7 @@ public:
   void visit(For &for_loop);
   void visit(Map &map);
   void visit(MapAccess &acc);
+  void visit(MapAddr &map_addr);
   void visit(AssignScalarMapStatement &assign);
   void visit(AssignMapStatement &assign);
   void visit(Expression &expr);
@@ -77,6 +78,11 @@ void MapDefaultKey::visit(MapAccess &acc)
 {
   checkAccess(*acc.map, true);
   visit(acc.key);
+}
+
+void MapDefaultKey::visit([[maybe_unused]] MapAddr &map_addr)
+{
+  // Don't desugar this into a map access, we want the map pointer
 }
 
 void MapDefaultKey::visit(AssignScalarMapStatement &assign)

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -169,11 +169,33 @@ void Printer::visit(Map &map)
   out_ << std::endl;
 }
 
+void Printer::visit(MapAddr &map_addr)
+{
+  std::string indent(depth_, ' ');
+
+  out_ << indent << "&" << std::endl;
+
+  ++depth_;
+  visit(map_addr.map);
+  --depth_;
+}
+
 void Printer::visit(Variable &var)
 {
   std::string indent(depth_, ' ');
   out_ << indent << "variable: " << var.ident << type(var.var_type)
        << std::endl;
+}
+
+void Printer::visit(VariableAddr &var_addr)
+{
+  std::string indent(depth_, ' ');
+
+  out_ << indent << "&" << std::endl;
+
+  ++depth_;
+  visit(var_addr.var);
+  --depth_;
 }
 
 void Printer::visit(Binop &binop)

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -26,8 +26,10 @@ public:
   void visit(Sizeof &szof);
   void visit(Offsetof &offof);
   void visit(Map &map);
+  void visit(MapAddr &map_addr);
   void visit(MapDeclStatement &decl);
   void visit(Variable &var);
+  void visit(VariableAddr &var_addr);
   void visit(Binop &binop);
   void visit(Unop &unop);
   void visit(Ternary &ternary);

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -57,6 +57,10 @@ public:
   {
     return default_value();
   }
+  R visit([[maybe_unused]] VariableAddr &var_addr)
+  {
+    return visitImpl(var_addr.var);
+  }
   R visit([[maybe_unused]] SubprogArg &subprog_arg)
   {
     return default_value();
@@ -84,6 +88,10 @@ public:
   R visit([[maybe_unused]] Map &map)
   {
     return default_value();
+  }
+  R visit([[maybe_unused]] MapAddr &map_addr)
+  {
+    return visitImpl(map_addr.map);
   }
   R visit(Binop &binop)
   {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -283,6 +283,7 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { UNSTABLE_MACRO, CONFIG_FIELD_PARSER(unstable_macro) },
   { UNSTABLE_MAP_DECL, CONFIG_FIELD_PARSER(unstable_map_decl) },
   { UNSTABLE_TSERIES, CONFIG_FIELD_PARSER(unstable_tseries) },
+  { UNSTABLE_ADDR, CONFIG_FIELD_PARSER(unstable_addr) },
 };
 
 // These symbols are deprecated, and have been remapped elsewhere.

--- a/src/config.h
+++ b/src/config.h
@@ -20,10 +20,11 @@ enum class ConfigUnstable {
   error,
 };
 
+static const auto UNSTABLE_IMPORT = "unstable_import";
 static const auto UNSTABLE_MACRO = "unstable_macro";
 static const auto UNSTABLE_MAP_DECL = "unstable_map_decl";
-static const auto UNSTABLE_IMPORT = "unstable_import";
 static const auto UNSTABLE_TSERIES = "unstable_tseries";
+static const auto UNSTABLE_ADDR = "unstable_addr";
 
 class Config {
 public:
@@ -47,6 +48,7 @@ public:
   ConfigUnstable unstable_map_decl = ConfigUnstable::warn;
   ConfigUnstable unstable_import = ConfigUnstable::warn;
   ConfigUnstable unstable_tseries = ConfigUnstable::warn;
+  ConfigUnstable unstable_addr = ConfigUnstable::warn;
 #ifdef HAVE_BLAZESYM
   bool use_blazesym = true;
   bool show_debug_info = true;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -170,6 +170,8 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::ConfigStatementList> config_assign_stmt_list config_block
 %type <SizedType> type int_type pointer_type struct_type
 %type <ast::Variable *> var
+%type <ast::VariableAddr *> var_addr
+%type <ast::MapAddr *> map_addr
 %type <ast::Program *> program
 
 
@@ -558,6 +560,8 @@ primary_expr:
         |       param              { $$ = $1; }
         |       param_count        { $$ = $1; }
         |       var                { $$ = $1; }
+        |       var_addr           { $$ = $1; }
+        |       map_addr           { $$ = $1; }
         |       map_expr           { $$ = $1; }
         |       "(" vargs "," expr ")"
                 {
@@ -767,6 +771,14 @@ map_expr:
 
 var:
                 VAR { $$ = driver.ctx.make_node<ast::Variable>($1, @$); }
+                ;
+
+var_addr:
+                BAND var { $$ = driver.ctx.make_node<ast::VariableAddr>($2, @$); }
+                ;
+
+map_addr:
+                BAND map { $$ = driver.ctx.make_node<ast::MapAddr>($2, @$); }
                 ;
 
 vargs:

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -3133,6 +3133,32 @@ begin { $x: int8 = 1; }
 )");
 }
 
+TEST(Parser, variable_address)
+{
+  test("begin { $x = 1; &$x;  }", R"(
+Program
+ begin
+  =
+   variable: $x
+   int: 1
+  &
+   variable: $x
+)");
+}
+
+TEST(Parser, map_address)
+{
+  test("begin { @a = 1; &@a;  }", R"(
+Program
+ begin
+  =
+   map: @a
+   int: 1
+  &
+   map: @a
+)");
+}
+
 TEST(Parser, bare_blocks)
 {
   test("i:s:1 { $a = 1; { $b = 2; { $c = 3; } } }",

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -135,3 +135,19 @@ EXPECT (c, 0)
 NAME late map evaluation with ctx capture
 RUN {{BPFTRACE}} -e 'interval:ms:100 { $x = 1; for ($kv : @a) { print(($x, $kv.0, $kv.1)); exit(); } @a[1] = 1; }'
 EXPECT (1, 1, 1)
+
+NAME variable address with int
+PROG begin { $a = 1; $b = &$a; print(($b, *$b)); }
+EXPECT_REGEX (0x[0-9a-f]+, 1)
+
+NAME variable address with tuple
+PROG begin { $a = (1, "hello", 2); print(*(&$a)); }
+EXPECT (1, hello, 2)
+
+NAME variable address with string
+PROG begin { $a = "hello"; $b = (int8 *)&$a; printf("%c %c\n", *$b, *++$b); }
+EXPECT h e
+
+NAME variable address with builtin
+PROG begin { $a = username; $b = &$a; printf("SUCCESS %s\n", *$b); }
+EXPECT_REGEX SUCCESS .*

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5116,6 +5116,41 @@ begin { $x = 2; if (1) { let $x; } }
 )" });
 }
 
+TEST_F(SemanticAnalyserTest, variable_address)
+{
+  test("begin { $a = 1; $b = &$a; @c = &$a; }");
+
+  auto ast = test("begin { $a = 1; $b = &$a; }");
+  auto &stmts = ast.root->probes.at(0)->block->stmts;
+
+  auto *assignment = stmts.at(1).as<ast::AssignVarStatement>();
+  ASSERT_TRUE(assignment->var()->var_type.IsPtrTy());
+  ASSERT_TRUE(assignment->var()->var_type.GetPointeeTy()->IsIntTy());
+
+  test("begin { $a = 1; $b = &$c; }", Error{ R"(
+stdin:1:22-25: ERROR: Undefined or undeclared variable: $c
+begin { $a = 1; $b = &$c; }
+                     ~~~
+)" });
+
+  test("begin { let $a; $b = &$a; }", Error{ R"(
+stdin:1:22-25: ERROR: No type available for variable $a
+begin { let $a; $b = &$a; }
+                     ~~~
+)" });
+}
+
+TEST_F(SemanticAnalyserTest, map_address)
+{
+  test("begin { @a = 1; @b[1] = 2; $x = &@a; $y = &@b; }");
+
+  test("begin { $x = &@a; }", Error{ R"(
+stdin:1:14-17: ERROR: Undefined map: @a
+begin { $x = &@a; }
+             ~~~
+)" });
+}
+
 TEST_F(SemanticAnalyserTest, block_scoping)
 {
   // if/else

--- a/tests/unstable_feature.cpp
+++ b/tests/unstable_feature.cpp
@@ -76,6 +76,17 @@ TEST(unstable_feature, check_error)
       "config = { unstable_tseries=error } begin { @ = tseries(4, 1s, 10); }",
       "tseries feature is not enabled by default. To enable this unstable "
       "feature, set the config flag to enable. unstable_tseries=enable");
+
+  test("config = { unstable_addr=warn } begin { $x = 1; &$x; }");
+  test_error("config = { unstable_addr=error } begin { $x = 1; &$x; }",
+             "address-of operator (&) feature is not enabled by default. To "
+             "enable this unstable "
+             "feature, set the config flag to enable. unstable_addr=enable");
+  test("config = { unstable_addr=warn } begin { @x = 1; &@x; }");
+  test_error("config = { unstable_addr=error } begin { @x = 1; &@x; }",
+             "address-of operator (&) feature is not enabled by default. To "
+             "enable this unstable "
+             "feature, set the config flag to enable. unstable_addr=enable");
 }
 
 } // namespace bpftrace::test::unstable_feature


### PR DESCRIPTION
Stacked PRs:
 * __->__#4435


--- --- ---

### Add address-of operator: &


This is so we can pass scratch variables
and maps as pointers to external bpf.c
functions in imports and the standard library.

Usage example:
```
@a[2] = 2;
$x = 1;
external_func(&@a, &$x);
```

Putting this behind an unstable flag and keeping it
undocumented as there is still some weird behavior
when storing maps and some variable pointers to
scratch variables and maps.

One thing we need to add is a SizedType for map
pointers so that this could be valid.
```
@a = 1;
$x = &@a;
print(*$x);
```
At the moment this just prints `null`.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>