### PR TITLE
codegen: handle pointer to integer casts

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2871,6 +2871,8 @@ ScopedExpr CodegenLLVM::visit(Cast &cast)
         array = buf;
       }
       return ScopedExpr(b_.CreateLoad(int_ty, array, true));
+    } else if (cast.expr.type().IsPtrTy()) {
+      return ScopedExpr(b_.CreatePtrToInt(scoped_expr.value(), int_ty));
     } else {
       return ScopedExpr(
           b_.CreateIntCast(scoped_expr.value(),

--- a/tests/codegen/llvm/builtin_ctx.ll
+++ b/tests/codegen/llvm/builtin_ctx.ll
@@ -20,11 +20,11 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %cast = zext ptr %0 to i64
+  %1 = ptrtoint ptr %0 to i64
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %cast, ptr %"@x_val", align 8
+  store i64 %1, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")


### PR DESCRIPTION
Stacked PRs:
 * __->__#4437


--- --- ---

### codegen: handle pointer to integer casts


This was likely being handled by the implicit casts correctly, however
we need to handle the explicit cast in the right way.

Signed-off-by: Adin Scannell <amscanne@meta.com>
