### PR TITLE
Maintain original arg types for external funcs

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2101,7 +2101,10 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       llvm::Type *result_type = b_.GetType(call.return_type);
       SmallVector<llvm::Type *> arg_types;
       for (const auto &expr : call.vargs) {
-        arg_types.push_back(b_.GetType(expr.type()));
+        // The 'false' is to not emit_codegen_types because these are external
+        // functions and we don't want to change the types. More context in
+        // GetType.
+        arg_types.push_back(b_.GetType(expr.type(), false));
       }
       FunctionType *function_type = FunctionType::get(result_type,
                                                       arg_types,


### PR DESCRIPTION
We need to make sure to set `emit_codegen_types`
to false when creating arg types for external funcs or else pointers types become int64 types
and there is a signature mismatch.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
