### PR TITLE
Small documentation fixes

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -56,13 +56,13 @@ This refers to traced function and tracepoint arguments.
 
 There are two ways to access these arguments and the way you choose depends on the [probe type](#probes).
 
-- For `uprobe`, `kprob`, and `usdt` use the `argN` format.
+- For `uprobe`, `kprobe`, and `usdt` use the `argN` format.
 - For `rawtracepoint`, `tracepoint`, `fentry`, `fexit`, and `uprobe` (with DWARF) use the `args` format.
 
 ### argN
 
 These keywords allow access to the nth argument passed to the function being traced.
-For the first argument use `arg1`, for the second `arg2`, and so forth.
+For the first argument use `arg0`, for the second `arg1`, and so forth.
 The type of each arg is an `int64` and will often require casting to non scalar types, e.g., `$x = (struct qstr *)arg1`.
 These are extracted from the CPU registers.
 The amount of args passed in registers depends on the CPU architecture.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -187,7 +187,7 @@ This utilizes the BPF helper `get_current_task`
 
 ### delete
 - `bool delete(map m, mapkey k)`
-- `deprecated `bool delete(mapkey k)`
+- deprecated `bool delete(mapkey k)`
 
 Delete a single key from a map.
 For scalar maps (e.g. no explicit keys), the key is omitted and is equivalent to calling `clear`.

--- a/scripts/generate_stdlib_docs.py
+++ b/scripts/generate_stdlib_docs.py
@@ -12,13 +12,24 @@ from typing import Optional
 class Helper:
     name: str = ""
     variants: list[str] = []
+    deprecated_variants: list[str] = []
     description: str = ""
 
     def __init__(self):
-      self.variants = []
+        self.variants = []
+        self.deprecated_variants = []
 
 def parse_variant_string(line: str) -> Optional[str]:
     pattern = r':variant\s+(.+)'
+
+    match = re.match(pattern, line.strip())
+    if match:
+        return match.group(1).strip()
+
+    return None
+
+def parse_deprecated_variant_string(line: str) -> Optional[str]:
+    pattern = r':deprecated_variant\s+(.+)'
 
     match = re.match(pattern, line.strip())
     if match:
@@ -71,6 +82,10 @@ def read_file_lines(file_path: str) -> Optional[list[Helper]]:
                             current.variants.append(parsed_variant)
                             if variant_has_no_args(parsed_variant):
                                 current.variants.append(parsed_variant.replace("()", ""))
+                    elif line_content.startswith(":deprecated_variant"):
+                        parsed_variant = parse_deprecated_variant_string(line_content)
+                        if parsed_variant:
+                            current.deprecated_variants.append(parsed_variant)
 
                     elif line_content.startswith(":function"):
                         parsed_function_name = parse_function_name_string(line_content)
@@ -137,6 +152,8 @@ def write_markdown_doc(helpers: list[Helper]):
                 updated_lines.append(f"### {helper.name}\n")
                 for variant in helper.variants:
                     updated_lines.append(f"- `{variant}`\n")
+                for variant in helper.deprecated_variants:
+                    updated_lines.append(f"- deprecated `{variant}`\n")
                 updated_lines.append("\n")
                 updated_lines.append(f"{helper.description}\n")
                 updated_lines.append("\n")

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -164,7 +164,7 @@ macro curtask() {
 
 // :function delete
 // :variant bool delete(map m, mapkey k)
-// :variant deprecated `bool delete(mapkey k)
+// :deprecated_variant bool delete(mapkey k)
 //
 // Delete a single key from a map.
 // For scalar maps (e.g. no explicit keys), the key is omitted and is equivalent to calling `clear`.


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Found when looking at #4425.

This does two things:
- introduce `:deprecated_variant` marker for stdlib docs to improve rendering of deprecated helper variants
- fix incorrect info and typos in the "Arguments" section

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests

