### PR TITLE
Treat SizedType ptr types as ptrs in codegen

### DIFF
--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -32,7 +32,7 @@ public:
   AllocaInst *CreateAllocaBPF(int bytes, const std::string &name = "");
   void CreateMemsetBPF(Value *ptr, Value *val, uint32_t size);
   void CreateMemcpyBPF(Value *dst, Value *src, uint32_t size);
-  llvm::Type *GetType(const SizedType &stype, bool emit_codegen_types = true);
+  llvm::Type *GetType(const SizedType &stype);
   llvm::Type *GetMapValueType(const SizedType &stype);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Type *ty);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2099,10 +2099,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       llvm::Type *result_type = b_.GetType(call.return_type);
       SmallVector<llvm::Type *> arg_types;
       for (const auto &expr : call.vargs) {
-        // The 'false' is to not emit_codegen_types because these are external
-        // functions and we don't want to change the types. More context in
-        // GetType.
-        arg_types.push_back(b_.GetType(expr.type(), false));
+        arg_types.push_back(b_.GetType(expr.type()));
       }
       FunctionType *function_type = FunctionType::get(result_type,
                                                       arg_types,
@@ -2375,6 +2372,12 @@ ScopedExpr CodegenLLVM::binop_ptr(Binop &binop)
 
   // note: the semantic phase blocks invalid combinations
   if (compare) {
+    // The only other type pointers can be compared to is ints
+    if (!binop.left.type().IsPtrTy()) {
+      rhs = b_.CreatePtrToInt(rhs, b_.GetType(binop.left.type()));
+    } else if (!binop.right.type().IsPtrTy()) {
+      lhs = b_.CreatePtrToInt(lhs, b_.GetType(binop.right.type()));
+    }
     switch (binop.op) {
       case Operator::EQ:
         return ScopedExpr(b_.CreateICmpEQ(lhs, rhs));
@@ -2397,20 +2400,15 @@ ScopedExpr CodegenLLVM::binop_ptr(Binop &binop)
         __builtin_unreachable();
     }
   } else if (arith) {
-    // Cannot use GEP here as LLVM doesn't know its a pointer
     bool leftptr = binop.left.type().IsPtrTy();
     const auto &ptr_ty = leftptr ? binop.left.type() : binop.right.type();
-    const auto &other_ty = leftptr ? binop.right.type() : binop.left.type();
     Value *ptr_expr = leftptr ? lhs : rhs;
     Value *other_expr = leftptr ? rhs : lhs;
-
-    if (other_ty.IsIntTy() && other_ty.GetSize() != 8)
-      other_expr = b_.CreateZExt(other_expr, b_.getInt64Ty());
-    Value *expr = b_.CreatePtrOffset(*ptr_ty.GetPointeeTy(), other_expr);
-    if (binop.op == Operator::PLUS)
-      return ScopedExpr(b_.CreateAdd(ptr_expr, expr));
-    else
-      return ScopedExpr(b_.CreateSub(ptr_expr, expr));
+    return ScopedExpr(b_.CreateGEP(b_.GetType(*ptr_ty.GetPointeeTy()),
+                                   ptr_expr,
+                                   binop.op == Operator::PLUS
+                                       ? other_expr
+                                       : b_.CreateNeg(other_expr)));
   } else {
     LOG(BUG) << "unknown op \"" << opstr(binop) << "\"";
     __builtin_unreachable();
@@ -2687,8 +2685,10 @@ ScopedExpr CodegenLLVM::visit(FieldAccess &acc)
         } else {
           // Since `src` is treated as a offset for a constructed probe read,
           // we are not constrained in the same way.
-          Value *src = b_.CreateAdd(scoped_arg.value(),
-                                    b_.getInt64(field.offset));
+          Value *src = b_.CreateSafeGEP(b_.GetType(type),
+                                        scoped_arg.value(),
+                                        { b_.getInt64(0),
+                                          b_.getInt64(field.offset) });
           AllocaInst *dst = b_.CreateAllocaBPF(field.type,
                                                type.GetName() + "." +
                                                    acc.field);
@@ -2898,6 +2898,12 @@ ScopedExpr CodegenLLVM::visit(Cast &cast)
     Value *zero_value = Constant::getNullValue(scoped_expr.value()->getType());
     Value *cond = b_.CreateICmpNE(scoped_expr.value(), zero_value, "bool_cast");
     return ScopedExpr(cond);
+  } else if (cast.cast_type.IsPtrTy()) {
+    if (cast.expr.type().IsIntTy()) {
+      Value *val = b_.CreateIntToPtr(scoped_expr.value(), b_.getPtrTy());
+      return ScopedExpr(val);
+    }
+    return scoped_expr;
   } else {
     // FIXME(amscanne): The existing behavior is to simply pass the existing
     // expression back up when it is neither an integer nor an array.
@@ -3355,11 +3361,12 @@ ScopedExpr CodegenLLVM::visit(Predicate &pred)
 
   auto scoped_expr = visit(pred.expr);
 
-  // allow unop casts in predicates:
-  auto *cast_value = b_.CreateIntCast(scoped_expr.value(),
-                                      b_.getInt64Ty(),
-                                      false);
-  auto *cmp_value = b_.CreateICmpEQ(cast_value, b_.getInt64(0), "predcond");
+  auto *cmp_value = b_.CreateICmpEQ(scoped_expr.value(),
+                                    Constant::getNullValue(
+                                        pred.expr.type().IsBoolTy()
+                                            ? b_.getInt1Ty()
+                                            : b_.GetType(pred.expr.type())),
+                                    "predcond");
 
   b_.CreateCondBr(cmp_value, pred_false_block, pred_true_block);
   b_.SetInsertPoint(pred_false_block);
@@ -3677,6 +3684,8 @@ ScopedExpr CodegenLLVM::getMapKey(Map &map, Expression &key_expr)
       // We need to read the entire array/struct and save it
       b_.CreateProbeRead(
           key, key_expr.type(), scoped_key_expr.value(), map.loc);
+    } else if (key_expr.type().IsPtrTy()) {
+      b_.CreateStore(scoped_key_expr.value(), key);
     } else {
       b_.CreateStore(b_.CreateIntCast(scoped_key_expr.value(),
                                       b_.getInt64Ty(),
@@ -3795,7 +3804,7 @@ ScopedExpr CodegenLLVM::createLogicalAnd(Binop &binop)
                                                "&&_merge",
                                                parent);
 
-  Value *result = b_.CreateAllocaBPF(b_.getInt8Ty(), "&&_result");
+  Value *result = b_.CreateAllocaBPF(b_.getInt1Ty(), "&&_result");
 
   ScopedExpr scoped_lhs = visit(binop.left);
   Value *lhs = scoped_lhs.value();
@@ -3814,15 +3823,15 @@ ScopedExpr CodegenLLVM::createLogicalAnd(Binop &binop)
                   false_block);
 
   b_.SetInsertPoint(true_block);
-  b_.CreateStore(b_.getInt8(1), result);
+  b_.CreateStore(b_.getInt1(true), result);
   b_.CreateBr(merge_block);
 
   b_.SetInsertPoint(false_block);
-  b_.CreateStore(b_.getInt8(0), result);
+  b_.CreateStore(b_.getInt1(false), result);
   b_.CreateBr(merge_block);
 
   b_.SetInsertPoint(merge_block);
-  return ScopedExpr(b_.CreateLoad(b_.getInt8Ty(), result));
+  return ScopedExpr(b_.CreateLoad(b_.getInt1Ty(), result));
 }
 
 ScopedExpr CodegenLLVM::createLogicalOr(Binop &binop)
@@ -3846,7 +3855,7 @@ ScopedExpr CodegenLLVM::createLogicalOr(Binop &binop)
                                                "||_merge",
                                                parent);
 
-  Value *result = b_.CreateAllocaBPF(b_.getInt8Ty(), "||_result");
+  Value *result = b_.CreateAllocaBPF(b_.getInt1Ty(), "||_result");
 
   ScopedExpr scoped_lhs = visit(binop.left);
   Value *lhs = scoped_lhs.value();
@@ -3865,15 +3874,15 @@ ScopedExpr CodegenLLVM::createLogicalOr(Binop &binop)
                   false_block);
 
   b_.SetInsertPoint(false_block);
-  b_.CreateStore(b_.getInt8(0), result);
+  b_.CreateStore(b_.getInt1(false), result);
   b_.CreateBr(merge_block);
 
   b_.SetInsertPoint(true_block);
-  b_.CreateStore(b_.getInt8(1), result);
+  b_.CreateStore(b_.getInt1(true), result);
   b_.CreateBr(merge_block);
 
   b_.SetInsertPoint(merge_block);
-  return ScopedExpr(b_.CreateLoad(b_.getInt8Ty(), result));
+  return ScopedExpr(b_.CreateLoad(b_.getInt1Ty(), result));
 }
 
 llvm::Function *CodegenLLVM::createLog2Function()
@@ -4333,15 +4342,13 @@ void CodegenLLVM::createJoinCall(Call &call, int id)
                                     { b_.getInt64(0), b_.getInt32(2) });
 
   SizedType elem_type = CreatePointer(CreateInt8(), addrspace);
-  size_t ptr_width = b_.getPointerStorageTy()->getIntegerBitWidth();
-  assert(b_.GetType(elem_type) == b_.getInt64Ty());
 
   Value *value = scoped_arg.value();
   AllocaInst *arr = b_.CreateAllocaBPF(b_.getInt64Ty(), call.func + "_r0");
 
   for (unsigned int i = 0; i < bpftrace_.join_argnum_; i++) {
     if (i > 0) {
-      value = b_.CreateAdd(value, b_.getInt64(ptr_width / 8));
+      value = b_.CreateGEP(b_.GetType(elem_type), value, b_.getInt32(i));
     }
 
     b_.CreateProbeRead(arr, elem_type, value, call.loc);
@@ -4654,8 +4661,8 @@ ScopedExpr CodegenLLVM::probereadDatastructElem(ScopedExpr &&scoped_src,
         BasicBlock *pred_true_block = BasicBlock::Create(module_->getContext(),
                                                          "pred_true",
                                                          parent);
-        Value *cast = b_.CreateIntCast(expr, b_.getInt64Ty(), false);
-        Value *cmp = b_.CreateICmpEQ(cast, b_.getInt64(0), "predcond");
+        Value *cmp = b_.CreateICmpEQ(
+            expr, Constant::getNullValue(b_.GetType(elem_type)), "predcond");
 
         b_.CreateCondBr(cmp, pred_false_block, pred_true_block);
         b_.SetInsertPoint(pred_false_block);
@@ -4691,12 +4698,22 @@ ScopedExpr CodegenLLVM::createIncDec(Unop &unop)
     Value *oldval = b_.CreateMapLookupElem(map, scoped_key.value(), unop.loc);
     AllocaInst *newval = b_.CreateAllocaBPF(map.value_type,
                                             map.ident + "_newval");
-    if (is_increment)
-      b_.CreateStore(b_.CreateAdd(oldval, b_.GetIntSameSize(step, oldval)),
+
+    if (type.IsPtrTy()) {
+      b_.CreateStore(b_.CreateGEP(b_.GetType(*map.value_type.GetPointeeTy()),
+                                  oldval,
+                                  is_increment ? b_.getInt32(1)
+                                               : b_.getInt32(-1)),
                      newval);
-    else
-      b_.CreateStore(b_.CreateSub(oldval, b_.GetIntSameSize(step, oldval)),
-                     newval);
+    } else {
+      if (is_increment)
+        b_.CreateStore(b_.CreateAdd(oldval, b_.GetIntSameSize(step, oldval)),
+                       newval);
+      else
+        b_.CreateStore(b_.CreateSub(oldval, b_.GetIntSameSize(step, oldval)),
+                       newval);
+    }
+
     b_.CreateMapUpdateElem(map.ident, scoped_key.value(), newval, unop.loc);
 
     Value *value;
@@ -4710,10 +4727,18 @@ ScopedExpr CodegenLLVM::createIncDec(Unop &unop)
     const auto &variable = getVariable(var->ident);
     Value *oldval = b_.CreateLoad(variable.type, variable.value);
     Value *newval;
-    if (is_increment)
-      newval = b_.CreateAdd(oldval, b_.GetIntSameSize(step, oldval));
-    else
-      newval = b_.CreateSub(oldval, b_.GetIntSameSize(step, oldval));
+
+    if (type.IsPtrTy()) {
+      newval = b_.CreateGEP(b_.GetType(*type.GetPointeeTy()),
+                            oldval,
+                            is_increment ? b_.getInt32(1) : b_.getInt32(-1));
+    } else {
+      if (is_increment)
+        newval = b_.CreateAdd(oldval, b_.GetIntSameSize(step, oldval));
+      else
+        newval = b_.CreateSub(oldval, b_.GetIntSameSize(step, oldval));
+    }
+
     b_.CreateStore(newval, variable.value);
 
     if (unop.is_post_op)
@@ -5222,7 +5247,7 @@ llvm::Function *CodegenLLVM::DeclareKernelFunc(Kfunc kfunc, Node &call)
   std::vector<llvm::Type *> args;
   for (auto &field : func_struct->fields) {
     if (field.name != RETVAL_FIELD_NAME) {
-      args.push_back(b_.GetType(field.type, false));
+      args.push_back(b_.GetType(field.type));
       debug_args.AddField(field.name,
                           field.type,
                           field.offset,
@@ -5232,9 +5257,7 @@ llvm::Function *CodegenLLVM::DeclareKernelFunc(Kfunc kfunc, Node &call)
   }
 
   FunctionType *func_type = FunctionType::get(
-      b_.GetType(func_struct->GetField(RETVAL_FIELD_NAME).type, false),
-      args,
-      false);
+      b_.GetType(func_struct->GetField(RETVAL_FIELD_NAME).type), args, false);
 
   auto *fun = llvm::Function::Create(func_type,
                                      llvm::GlobalValue::ExternalWeakLinkage,

--- a/tests/codegen/llvm/array_integer_equal_comparison.ll
+++ b/tests/codegen/llvm/array_integer_equal_comparison.ll
@@ -23,12 +23,12 @@ entry:
   %arraycmp.result = alloca i1, align 1
   %v2 = alloca i32, align 4
   %v1 = alloca i32, align 4
-  %"$b" = alloca i64, align 8
+  %"$b" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$b")
-  store i64 0, ptr %"$b", align 8
-  %"$a" = alloca i64, align 8
+  store i0 0, ptr %"$b", align 1
+  %"$a" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
-  store i64 0, ptr %"$a", align 8
+  store i0 0, ptr %"$a", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
@@ -45,14 +45,12 @@ entry:
   %11 = getelementptr i8, ptr %10, i64 0
   %12 = ptrtoint ptr %11 to i64
   store i64 %12, ptr %"$b", align 8
-  %13 = load i64, ptr %"$a", align 8
-  %14 = load i64, ptr %"$b", align 8
+  %13 = load ptr, ptr %"$a", align 8
+  %14 = load ptr, ptr %"$b", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %v1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %v2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %arraycmp.result)
   store i1 true, ptr %arraycmp.result, align 1
-  %15 = inttoptr i64 %13 to ptr
-  %16 = inttoptr i64 %14 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %n)
   store i32 0, ptr %i, align 4
@@ -61,10 +59,10 @@ entry:
 
 if_body:                                          ; preds = %arraycmp.done
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
-  %17 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %17, align 8
-  %18 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
-  store i8 0, ptr %18, align 1
+  %15 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
+  store i64 30000, ptr %15, align 8
+  %16 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
+  store i8 0, ptr %16, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -73,21 +71,21 @@ if_end:                                           ; preds = %deadcode, %arraycmp
   ret i64 0
 
 while_cond:                                       ; preds = %arraycmp.loop, %entry
-  %19 = load i32, ptr %n, align 4
-  %20 = load i32, ptr %i, align 4
-  %size_check = icmp slt i32 %20, %19
+  %17 = load i32, ptr %n, align 4
+  %18 = load i32, ptr %i, align 4
+  %size_check = icmp slt i32 %18, %17
   br i1 %size_check, label %while_body, label %arraycmp.done, !llvm.loop !41
 
 while_body:                                       ; preds = %while_cond
-  %21 = load i32, ptr %i, align 4
-  %22 = getelementptr [4 x i32], ptr %15, i32 0, i32 %21
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %22)
-  %23 = load i32, ptr %v1, align 4
-  %24 = load i32, ptr %i, align 4
-  %25 = getelementptr [4 x i32], ptr %16, i32 0, i32 %24
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %25)
-  %26 = load i32, ptr %v2, align 4
-  %arraycmp.cmp = icmp ne i32 %23, %26
+  %19 = load i32, ptr %i, align 4
+  %20 = getelementptr [4 x i32], ptr %13, i32 0, i32 %19
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %v1, i32 4, ptr %20)
+  %21 = load i32, ptr %v1, align 4
+  %22 = load i32, ptr %i, align 4
+  %23 = getelementptr [4 x i32], ptr %14, i32 0, i32 %22
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %v2, i32 4, ptr %23)
+  %24 = load i32, ptr %v2, align 4
+  %arraycmp.cmp = icmp ne i32 %21, %24
   br i1 %arraycmp.cmp, label %arraycmp.false, label %arraycmp.loop
 
 arraycmp.false:                                   ; preds = %while_body
@@ -95,28 +93,28 @@ arraycmp.false:                                   ; preds = %while_body
   br label %arraycmp.done
 
 arraycmp.done:                                    ; preds = %arraycmp.false, %while_cond
-  %27 = load i1, ptr %arraycmp.result, align 1
+  %25 = load i1, ptr %arraycmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %arraycmp.result)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %v1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %v2)
-  %28 = zext i1 %27 to i64
-  %true_cond = icmp ne i64 %28, 0
+  %26 = zext i1 %25 to i64
+  %true_cond = icmp ne i64 %26, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 arraycmp.loop:                                    ; preds = %while_body
-  %29 = load i32, ptr %i, align 4
-  %30 = add i32 %29, 1
-  store i32 %30, ptr %i, align 4
+  %27 = load i32, ptr %i, align 4
+  %28 = add i32 %27, 1
+  store i32 %28, ptr %i, align 4
   br label %while_cond
 
 event_loss_counter:                               ; preds = %if_body
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %31 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %31
-  %32 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %33 = load i64, ptr %32, align 8
-  %34 = add i64 %33, 1
-  store i64 %34, ptr %32, align 8
+  %29 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %29
+  %30 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %31 = load i64, ptr %30, align 8
+  %32 = add i64 %31, 1
+  store i64 %32, ptr %30, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %if_body

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -37,80 +37,74 @@ entry:
   %"@b_key" = alloca i64, align 8
   %"@a_val" = alloca i64, align 8
   %"@a_key" = alloca i64, align 8
-  %"$x" = alloca i64, align 8
+  %"$x" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
+  store i0 0, ptr %"$x", align 1
   store ptr %0, ptr %"$x", align 8
-  %1 = load i64, ptr %"$x", align 8
-  %2 = inttoptr i64 %1 to ptr
-  %3 = call ptr @llvm.preserve.static.offset(ptr %2)
-  %4 = getelementptr i8, ptr %3, i64 0
-  %5 = load volatile i64, ptr %4, align 8
+  %1 = load ptr, ptr %"$x", align 8
+  %2 = call ptr @llvm.preserve.static.offset(ptr %1)
+  %3 = getelementptr i8, ptr %2, i64 0
+  %4 = load volatile i64, ptr %3, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
   store i64 0, ptr %"@a_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
-  store i64 %5, ptr %"@a_val", align 8
+  store i64 %4, ptr %"@a_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %"@a_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
-  %6 = load i64, ptr %"$x", align 8
-  %7 = inttoptr i64 %6 to ptr
-  %8 = call ptr @llvm.preserve.static.offset(ptr %7)
-  %9 = getelementptr i8, ptr %8, i64 8
-  %10 = ptrtoint ptr %9 to i64
-  %11 = inttoptr i64 %10 to ptr
-  %12 = call ptr @llvm.preserve.static.offset(ptr %11)
-  %13 = getelementptr i8, ptr %12, i64 0
-  %14 = load volatile i16, ptr %13, align 2
+  %5 = load ptr, ptr %"$x", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 8
+  %8 = ptrtoint ptr %7 to i64
+  %9 = inttoptr i64 %8 to ptr
+  %10 = call ptr @llvm.preserve.static.offset(ptr %9)
+  %11 = getelementptr i8, ptr %10, i64 0
+  %12 = load volatile i16, ptr %11, align 2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_key")
   store i64 0, ptr %"@b_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_val")
-  %15 = sext i16 %14 to i64
-  store i64 %15, ptr %"@b_val", align 8
+  %13 = sext i16 %12 to i64
+  store i64 %13, ptr %"@b_val", align 8
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_b, ptr %"@b_key", ptr %"@b_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_key")
-  %16 = load i64, ptr %"$x", align 8
-  %17 = inttoptr i64 %16 to ptr
-  %18 = call ptr @llvm.preserve.static.offset(ptr %17)
-  %19 = getelementptr i8, ptr %18, i64 16
-  %20 = call ptr @llvm.preserve.static.offset(ptr %19)
-  %21 = getelementptr i8, ptr %20, i64 0
-  %22 = load volatile i8, ptr %21, align 1
+  %14 = load ptr, ptr %"$x", align 8
+  %15 = call ptr @llvm.preserve.static.offset(ptr %14)
+  %16 = getelementptr i8, ptr %15, i64 16
+  %17 = call ptr @llvm.preserve.static.offset(ptr %16)
+  %18 = getelementptr i8, ptr %17, i64 0
+  %19 = load volatile i8, ptr %18, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@c_key")
   store i64 0, ptr %"@c_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@c_val")
-  %23 = sext i8 %22 to i64
-  store i64 %23, ptr %"@c_val", align 8
+  %20 = sext i8 %19 to i64
+  store i64 %20, ptr %"@c_val", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_c, ptr %"@c_key", ptr %"@c_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@c_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@c_key")
-  %24 = load i64, ptr %"$x", align 8
-  %25 = inttoptr i64 %24 to ptr
-  %26 = call ptr @llvm.preserve.static.offset(ptr %25)
-  %27 = getelementptr i8, ptr %26, i64 24
-  %28 = load volatile i64, ptr %27, align 8
-  %29 = inttoptr i64 %28 to ptr
-  %30 = call ptr @llvm.preserve.static.offset(ptr %29)
-  %31 = getelementptr i8, ptr %30, i64 0
+  %21 = load ptr, ptr %"$x", align 8
+  %22 = call ptr @llvm.preserve.static.offset(ptr %21)
+  %23 = getelementptr i8, ptr %22, i64 24
+  %24 = load volatile ptr, ptr %23, align 8
+  %25 = call ptr @llvm.preserve.static.offset(ptr %24)
+  %26 = getelementptr i8, ptr %25, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct c.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct c.c", i32 1, ptr %31)
-  %32 = load i8, ptr %"struct c.c", align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct c.c", i32 1, ptr %26)
+  %27 = load i8, ptr %"struct c.c", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct c.c")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@d_key")
   store i64 0, ptr %"@d_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@d_val")
-  %33 = sext i8 %32 to i64
-  store i64 %33, ptr %"@d_val", align 8
+  %28 = sext i8 %27 to i64
+  store i64 %28, ptr %"@d_val", align 8
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_d, ptr %"@d_key", ptr %"@d_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@d_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@d_key")
-  %34 = load i64, ptr %"$x", align 8
-  %35 = inttoptr i64 %34 to ptr
-  %36 = call ptr @llvm.preserve.static.offset(ptr %35)
-  %37 = getelementptr i8, ptr %36, i64 32
+  %29 = load ptr, ptr %"$x", align 8
+  %30 = call ptr @llvm.preserve.static.offset(ptr %29)
+  %31 = getelementptr i8, ptr %30, i64 32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct x.e")
-  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct x.e", i32 5, ptr %37)
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct x.e", i32 5, ptr %31)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@e_key")
   store i64 0, ptr %"@e_key", align 8
   %update_elem5 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_e, ptr %"@e_key", ptr %"struct x.e", i64 0)

--- a/tests/codegen/llvm/builtin_curtask.ll
+++ b/tests/codegen/llvm/builtin_curtask.ll
@@ -18,7 +18,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca ptr, align 8
   %"@x_key" = alloca i64, align 8
   %get_cur_task = call i64 inttoptr (i64 35 to ptr)() #2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/builtin_elapsed.ll
+++ b/tests/codegen/llvm/builtin_elapsed.ll
@@ -32,8 +32,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/builtin_probe_comparison.ll
+++ b/tests/codegen/llvm/builtin_probe_comparison.ll
@@ -34,8 +34,7 @@ if_end:                                           ; preds = %if_body, %strcmp.fa
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop97, %strcmp.loop93, %strcmp.loop89, %strcmp.loop85, %strcmp.loop81, %strcmp.loop77, %strcmp.loop73, %strcmp.loop69, %strcmp.loop65, %strcmp.loop61, %strcmp.loop57, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
   %3 = load i1, ptr %strcmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
-  %4 = zext i1 %3 to i64
-  %true_cond = icmp ne i64 %4, 0
+  %true_cond = icmp ne i1 %3, false
   br i1 %true_cond, label %if_body, label %if_end
 
 strcmp.done:                                      ; preds = %strcmp.loop101, %strcmp.loop_null_cmp102, %strcmp.loop_null_cmp98, %strcmp.loop_null_cmp94, %strcmp.loop_null_cmp90, %strcmp.loop_null_cmp86, %strcmp.loop_null_cmp82, %strcmp.loop_null_cmp78, %strcmp.loop_null_cmp74, %strcmp.loop_null_cmp70, %strcmp.loop_null_cmp66, %strcmp.loop_null_cmp62, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp54, %strcmp.loop_null_cmp50, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp42, %strcmp.loop_null_cmp38, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp30, %strcmp.loop_null_cmp26, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp18, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
@@ -43,9 +42,9 @@ strcmp.done:                                      ; preds = %strcmp.loop101, %st
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
+  %4 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 1), align 1
   %5 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 1), align 1
-  %6 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 1), align 1
-  %strcmp.cmp3 = icmp ne i8 %5, %6
+  %strcmp.cmp3 = icmp ne i8 %4, %5
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -53,260 +52,260 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
+  %6 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 2), align 1
   %7 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 2), align 1
-  %8 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 2), align 1
-  %strcmp.cmp7 = icmp ne i8 %7, %8
+  %strcmp.cmp7 = icmp ne i8 %6, %7
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %5, 0
+  %strcmp.cmp_null4 = icmp eq i8 %4, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
+  %8 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 3), align 1
   %9 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 3), align 1
-  %10 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 3), align 1
-  %strcmp.cmp11 = icmp ne i8 %9, %10
+  %strcmp.cmp11 = icmp ne i8 %8, %9
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %7, 0
+  %strcmp.cmp_null8 = icmp eq i8 %6, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
+  %10 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 4), align 1
   %11 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 4), align 1
-  %12 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 4), align 1
-  %strcmp.cmp15 = icmp ne i8 %11, %12
+  %strcmp.cmp15 = icmp ne i8 %10, %11
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %9, 0
+  %strcmp.cmp_null12 = icmp eq i8 %8, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
+  %12 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 5), align 1
   %13 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 5), align 1
-  %14 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 5), align 1
-  %strcmp.cmp19 = icmp ne i8 %13, %14
+  %strcmp.cmp19 = icmp ne i8 %12, %13
   br i1 %strcmp.cmp19, label %strcmp.false, label %strcmp.loop_null_cmp18
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %11, 0
+  %strcmp.cmp_null16 = icmp eq i8 %10, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 strcmp.loop17:                                    ; preds = %strcmp.loop_null_cmp18
+  %14 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 6), align 1
   %15 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 6), align 1
-  %16 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 6), align 1
-  %strcmp.cmp23 = icmp ne i8 %15, %16
+  %strcmp.cmp23 = icmp ne i8 %14, %15
   br i1 %strcmp.cmp23, label %strcmp.false, label %strcmp.loop_null_cmp22
 
 strcmp.loop_null_cmp18:                           ; preds = %strcmp.loop13
-  %strcmp.cmp_null20 = icmp eq i8 %13, 0
+  %strcmp.cmp_null20 = icmp eq i8 %12, 0
   br i1 %strcmp.cmp_null20, label %strcmp.done, label %strcmp.loop17
 
 strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
+  %16 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 7), align 1
   %17 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 7), align 1
-  %18 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 7), align 1
-  %strcmp.cmp27 = icmp ne i8 %17, %18
+  %strcmp.cmp27 = icmp ne i8 %16, %17
   br i1 %strcmp.cmp27, label %strcmp.false, label %strcmp.loop_null_cmp26
 
 strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop17
-  %strcmp.cmp_null24 = icmp eq i8 %15, 0
+  %strcmp.cmp_null24 = icmp eq i8 %14, 0
   br i1 %strcmp.cmp_null24, label %strcmp.done, label %strcmp.loop21
 
 strcmp.loop25:                                    ; preds = %strcmp.loop_null_cmp26
+  %18 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 8), align 1
   %19 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 8), align 1
-  %20 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 8), align 1
-  %strcmp.cmp31 = icmp ne i8 %19, %20
+  %strcmp.cmp31 = icmp ne i8 %18, %19
   br i1 %strcmp.cmp31, label %strcmp.false, label %strcmp.loop_null_cmp30
 
 strcmp.loop_null_cmp26:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null28 = icmp eq i8 %17, 0
+  %strcmp.cmp_null28 = icmp eq i8 %16, 0
   br i1 %strcmp.cmp_null28, label %strcmp.done, label %strcmp.loop25
 
 strcmp.loop29:                                    ; preds = %strcmp.loop_null_cmp30
+  %20 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 9), align 1
   %21 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 9), align 1
-  %22 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 9), align 1
-  %strcmp.cmp35 = icmp ne i8 %21, %22
+  %strcmp.cmp35 = icmp ne i8 %20, %21
   br i1 %strcmp.cmp35, label %strcmp.false, label %strcmp.loop_null_cmp34
 
 strcmp.loop_null_cmp30:                           ; preds = %strcmp.loop25
-  %strcmp.cmp_null32 = icmp eq i8 %19, 0
+  %strcmp.cmp_null32 = icmp eq i8 %18, 0
   br i1 %strcmp.cmp_null32, label %strcmp.done, label %strcmp.loop29
 
 strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
+  %22 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 10), align 1
   %23 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 10), align 1
-  %24 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 10), align 1
-  %strcmp.cmp39 = icmp ne i8 %23, %24
+  %strcmp.cmp39 = icmp ne i8 %22, %23
   br i1 %strcmp.cmp39, label %strcmp.false, label %strcmp.loop_null_cmp38
 
 strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop29
-  %strcmp.cmp_null36 = icmp eq i8 %21, 0
+  %strcmp.cmp_null36 = icmp eq i8 %20, 0
   br i1 %strcmp.cmp_null36, label %strcmp.done, label %strcmp.loop33
 
 strcmp.loop37:                                    ; preds = %strcmp.loop_null_cmp38
+  %24 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 11), align 1
   %25 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 11), align 1
-  %26 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 11), align 1
-  %strcmp.cmp43 = icmp ne i8 %25, %26
+  %strcmp.cmp43 = icmp ne i8 %24, %25
   br i1 %strcmp.cmp43, label %strcmp.false, label %strcmp.loop_null_cmp42
 
 strcmp.loop_null_cmp38:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null40 = icmp eq i8 %23, 0
+  %strcmp.cmp_null40 = icmp eq i8 %22, 0
   br i1 %strcmp.cmp_null40, label %strcmp.done, label %strcmp.loop37
 
 strcmp.loop41:                                    ; preds = %strcmp.loop_null_cmp42
+  %26 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 12), align 1
   %27 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 12), align 1
-  %28 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 12), align 1
-  %strcmp.cmp47 = icmp ne i8 %27, %28
+  %strcmp.cmp47 = icmp ne i8 %26, %27
   br i1 %strcmp.cmp47, label %strcmp.false, label %strcmp.loop_null_cmp46
 
 strcmp.loop_null_cmp42:                           ; preds = %strcmp.loop37
-  %strcmp.cmp_null44 = icmp eq i8 %25, 0
+  %strcmp.cmp_null44 = icmp eq i8 %24, 0
   br i1 %strcmp.cmp_null44, label %strcmp.done, label %strcmp.loop41
 
 strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
+  %28 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 13), align 1
   %29 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 13), align 1
-  %30 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 13), align 1
-  %strcmp.cmp51 = icmp ne i8 %29, %30
+  %strcmp.cmp51 = icmp ne i8 %28, %29
   br i1 %strcmp.cmp51, label %strcmp.false, label %strcmp.loop_null_cmp50
 
 strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop41
-  %strcmp.cmp_null48 = icmp eq i8 %27, 0
+  %strcmp.cmp_null48 = icmp eq i8 %26, 0
   br i1 %strcmp.cmp_null48, label %strcmp.done, label %strcmp.loop45
 
 strcmp.loop49:                                    ; preds = %strcmp.loop_null_cmp50
+  %30 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 14), align 1
   %31 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 14), align 1
-  %32 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 14), align 1
-  %strcmp.cmp55 = icmp ne i8 %31, %32
+  %strcmp.cmp55 = icmp ne i8 %30, %31
   br i1 %strcmp.cmp55, label %strcmp.false, label %strcmp.loop_null_cmp54
 
 strcmp.loop_null_cmp50:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null52 = icmp eq i8 %29, 0
+  %strcmp.cmp_null52 = icmp eq i8 %28, 0
   br i1 %strcmp.cmp_null52, label %strcmp.done, label %strcmp.loop49
 
 strcmp.loop53:                                    ; preds = %strcmp.loop_null_cmp54
+  %32 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 15), align 1
   %33 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 15), align 1
-  %34 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 15), align 1
-  %strcmp.cmp59 = icmp ne i8 %33, %34
+  %strcmp.cmp59 = icmp ne i8 %32, %33
   br i1 %strcmp.cmp59, label %strcmp.false, label %strcmp.loop_null_cmp58
 
 strcmp.loop_null_cmp54:                           ; preds = %strcmp.loop49
-  %strcmp.cmp_null56 = icmp eq i8 %31, 0
+  %strcmp.cmp_null56 = icmp eq i8 %30, 0
   br i1 %strcmp.cmp_null56, label %strcmp.done, label %strcmp.loop53
 
 strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
+  %34 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 16), align 1
   %35 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 16), align 1
-  %36 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 16), align 1
-  %strcmp.cmp63 = icmp ne i8 %35, %36
+  %strcmp.cmp63 = icmp ne i8 %34, %35
   br i1 %strcmp.cmp63, label %strcmp.false, label %strcmp.loop_null_cmp62
 
 strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop53
-  %strcmp.cmp_null60 = icmp eq i8 %33, 0
+  %strcmp.cmp_null60 = icmp eq i8 %32, 0
   br i1 %strcmp.cmp_null60, label %strcmp.done, label %strcmp.loop57
 
 strcmp.loop61:                                    ; preds = %strcmp.loop_null_cmp62
+  %36 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 17), align 1
   %37 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 17), align 1
-  %38 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 17), align 1
-  %strcmp.cmp67 = icmp ne i8 %37, %38
+  %strcmp.cmp67 = icmp ne i8 %36, %37
   br i1 %strcmp.cmp67, label %strcmp.false, label %strcmp.loop_null_cmp66
 
 strcmp.loop_null_cmp62:                           ; preds = %strcmp.loop57
-  %strcmp.cmp_null64 = icmp eq i8 %35, 0
+  %strcmp.cmp_null64 = icmp eq i8 %34, 0
   br i1 %strcmp.cmp_null64, label %strcmp.done, label %strcmp.loop61
 
 strcmp.loop65:                                    ; preds = %strcmp.loop_null_cmp66
+  %38 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 18), align 1
   %39 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 18), align 1
-  %40 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 18), align 1
-  %strcmp.cmp71 = icmp ne i8 %39, %40
+  %strcmp.cmp71 = icmp ne i8 %38, %39
   br i1 %strcmp.cmp71, label %strcmp.false, label %strcmp.loop_null_cmp70
 
 strcmp.loop_null_cmp66:                           ; preds = %strcmp.loop61
-  %strcmp.cmp_null68 = icmp eq i8 %37, 0
+  %strcmp.cmp_null68 = icmp eq i8 %36, 0
   br i1 %strcmp.cmp_null68, label %strcmp.done, label %strcmp.loop65
 
 strcmp.loop69:                                    ; preds = %strcmp.loop_null_cmp70
+  %40 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 19), align 1
   %41 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 19), align 1
-  %42 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 19), align 1
-  %strcmp.cmp75 = icmp ne i8 %41, %42
+  %strcmp.cmp75 = icmp ne i8 %40, %41
   br i1 %strcmp.cmp75, label %strcmp.false, label %strcmp.loop_null_cmp74
 
 strcmp.loop_null_cmp70:                           ; preds = %strcmp.loop65
-  %strcmp.cmp_null72 = icmp eq i8 %39, 0
+  %strcmp.cmp_null72 = icmp eq i8 %38, 0
   br i1 %strcmp.cmp_null72, label %strcmp.done, label %strcmp.loop69
 
 strcmp.loop73:                                    ; preds = %strcmp.loop_null_cmp74
+  %42 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 20), align 1
   %43 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 20), align 1
-  %44 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 20), align 1
-  %strcmp.cmp79 = icmp ne i8 %43, %44
+  %strcmp.cmp79 = icmp ne i8 %42, %43
   br i1 %strcmp.cmp79, label %strcmp.false, label %strcmp.loop_null_cmp78
 
 strcmp.loop_null_cmp74:                           ; preds = %strcmp.loop69
-  %strcmp.cmp_null76 = icmp eq i8 %41, 0
+  %strcmp.cmp_null76 = icmp eq i8 %40, 0
   br i1 %strcmp.cmp_null76, label %strcmp.done, label %strcmp.loop73
 
 strcmp.loop77:                                    ; preds = %strcmp.loop_null_cmp78
+  %44 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 21), align 1
   %45 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 21), align 1
-  %46 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 21), align 1
-  %strcmp.cmp83 = icmp ne i8 %45, %46
+  %strcmp.cmp83 = icmp ne i8 %44, %45
   br i1 %strcmp.cmp83, label %strcmp.false, label %strcmp.loop_null_cmp82
 
 strcmp.loop_null_cmp78:                           ; preds = %strcmp.loop73
-  %strcmp.cmp_null80 = icmp eq i8 %43, 0
+  %strcmp.cmp_null80 = icmp eq i8 %42, 0
   br i1 %strcmp.cmp_null80, label %strcmp.done, label %strcmp.loop77
 
 strcmp.loop81:                                    ; preds = %strcmp.loop_null_cmp82
+  %46 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 22), align 1
   %47 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 22), align 1
-  %48 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 22), align 1
-  %strcmp.cmp87 = icmp ne i8 %47, %48
+  %strcmp.cmp87 = icmp ne i8 %46, %47
   br i1 %strcmp.cmp87, label %strcmp.false, label %strcmp.loop_null_cmp86
 
 strcmp.loop_null_cmp82:                           ; preds = %strcmp.loop77
-  %strcmp.cmp_null84 = icmp eq i8 %45, 0
+  %strcmp.cmp_null84 = icmp eq i8 %44, 0
   br i1 %strcmp.cmp_null84, label %strcmp.done, label %strcmp.loop81
 
 strcmp.loop85:                                    ; preds = %strcmp.loop_null_cmp86
+  %48 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 23), align 1
   %49 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 23), align 1
-  %50 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 23), align 1
-  %strcmp.cmp91 = icmp ne i8 %49, %50
+  %strcmp.cmp91 = icmp ne i8 %48, %49
   br i1 %strcmp.cmp91, label %strcmp.false, label %strcmp.loop_null_cmp90
 
 strcmp.loop_null_cmp86:                           ; preds = %strcmp.loop81
-  %strcmp.cmp_null88 = icmp eq i8 %47, 0
+  %strcmp.cmp_null88 = icmp eq i8 %46, 0
   br i1 %strcmp.cmp_null88, label %strcmp.done, label %strcmp.loop85
 
 strcmp.loop89:                                    ; preds = %strcmp.loop_null_cmp90
+  %50 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 24), align 1
   %51 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 24), align 1
-  %52 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 24), align 1
-  %strcmp.cmp95 = icmp ne i8 %51, %52
+  %strcmp.cmp95 = icmp ne i8 %50, %51
   br i1 %strcmp.cmp95, label %strcmp.false, label %strcmp.loop_null_cmp94
 
 strcmp.loop_null_cmp90:                           ; preds = %strcmp.loop85
-  %strcmp.cmp_null92 = icmp eq i8 %49, 0
+  %strcmp.cmp_null92 = icmp eq i8 %48, 0
   br i1 %strcmp.cmp_null92, label %strcmp.done, label %strcmp.loop89
 
 strcmp.loop93:                                    ; preds = %strcmp.loop_null_cmp94
+  %52 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 25), align 1
   %53 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 25), align 1
-  %54 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 25), align 1
-  %strcmp.cmp99 = icmp ne i8 %53, %54
+  %strcmp.cmp99 = icmp ne i8 %52, %53
   br i1 %strcmp.cmp99, label %strcmp.false, label %strcmp.loop_null_cmp98
 
 strcmp.loop_null_cmp94:                           ; preds = %strcmp.loop89
-  %strcmp.cmp_null96 = icmp eq i8 %51, 0
+  %strcmp.cmp_null96 = icmp eq i8 %50, 0
   br i1 %strcmp.cmp_null96, label %strcmp.done, label %strcmp.loop93
 
 strcmp.loop97:                                    ; preds = %strcmp.loop_null_cmp98
+  %54 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 26), align 1
   %55 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 26), align 1
-  %56 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 26), align 1
-  %strcmp.cmp103 = icmp ne i8 %55, %56
+  %strcmp.cmp103 = icmp ne i8 %54, %55
   br i1 %strcmp.cmp103, label %strcmp.false, label %strcmp.loop_null_cmp102
 
 strcmp.loop_null_cmp98:                           ; preds = %strcmp.loop93
-  %strcmp.cmp_null100 = icmp eq i8 %53, 0
+  %strcmp.cmp_null100 = icmp eq i8 %52, 0
   br i1 %strcmp.cmp_null100, label %strcmp.done, label %strcmp.loop97
 
 strcmp.loop101:                                   ; preds = %strcmp.loop_null_cmp102
   br label %strcmp.done
 
 strcmp.loop_null_cmp102:                          ; preds = %strcmp.loop97
-  %strcmp.cmp_null104 = icmp eq i8 %55, 0
+  %strcmp.cmp_null104 = icmp eq i8 %54, 0
   br i1 %strcmp.cmp_null104, label %strcmp.done, label %strcmp.loop101
 }
 

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -21,10 +21,10 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !57 {
 entry:
   %"@x_key" = alloca i64, align 8
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
+  store ptr null, ptr %"$foo", align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
@@ -33,11 +33,10 @@ entry:
   store i32 16, ptr %3, align 4
   %4 = getelementptr %buffer_16_t, ptr %2, i32 0, i32 1
   call void @llvm.memset.p0.i64(ptr align 1 %4, i8 0, i64 16, i1 false)
-  %5 = load i64, ptr %"$foo", align 8
-  %6 = inttoptr i64 %5 to ptr
-  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
-  %8 = getelementptr i8, ptr %7, i64 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 16, ptr %8)
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 16, ptr %7)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %2, i64 0)

--- a/tests/codegen/llvm/call_cgroup.ll
+++ b/tests/codegen/llvm/call_cgroup.ll
@@ -22,8 +22,7 @@ entry:
   %"@x_key" = alloca i64, align 8
   %get_cgroup_id = call i64 inttoptr (i64 80 to ptr)() #2
   %1 = icmp eq i64 %get_cgroup_id, 4294967297
-  %2 = zext i1 %1 to i64
-  %predcond = icmp eq i64 %2, 0
+  %predcond = icmp eq i1 %1, false
   br i1 %predcond, label %pred_false, label %pred_true
 
 pred_false:                                       ; preds = %entry

--- a/tests/codegen/llvm/call_errorf.ll
+++ b/tests/codegen/llvm/call_errorf.ll
@@ -21,51 +21,50 @@ entry:
   %"struct Foo.l" = alloca i64, align 8
   %"struct Foo.c" = alloca i8, align 1
   %errorf_args = alloca %errorf_t, align 8
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %errorf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %errorf_args, i8 0, i64 24, i1 false)
-  %3 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 0
-  store i64 0, ptr %3, align 8
-  %4 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
-  %5 = load i64, ptr %"$foo", align 8
-  %6 = inttoptr i64 %5 to ptr
+  %4 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 0
+  store i64 0, ptr %4, align 8
+  %5 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
+  %6 = load ptr, ptr %"$foo", align 8
   %7 = call ptr @llvm.preserve.static.offset(ptr %6)
   %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.c")
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.c", i32 1, ptr %8)
   %9 = load i8, ptr %"struct Foo.c", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.c")
-  %10 = getelementptr %errorf_args_t, ptr %4, i32 0, i32 0
+  %10 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 0
   %11 = sext i8 %9 to i64
   store i64 %11, ptr %10, align 8
-  %12 = load i64, ptr %"$foo", align 8
-  %13 = inttoptr i64 %12 to ptr
-  %14 = call ptr @llvm.preserve.static.offset(ptr %13)
-  %15 = getelementptr i8, ptr %14, i64 8
+  %12 = load ptr, ptr %"$foo", align 8
+  %13 = call ptr @llvm.preserve.static.offset(ptr %12)
+  %14 = getelementptr i8, ptr %13, i64 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.l")
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, ptr %15)
-  %16 = load i64, ptr %"struct Foo.l", align 8
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, ptr %14)
+  %15 = load i64, ptr %"struct Foo.l", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.l")
-  %17 = getelementptr %errorf_args_t, ptr %4, i32 0, i32 1
-  store i64 %16, ptr %17, align 8
+  %16 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 1
+  store i64 %15, ptr %16, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %errorf_args, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
-  %18 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %18
-  %19 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %20 = load i64, ptr %19, align 8
-  %21 = add i64 %20, 1
-  store i64 %21, ptr %19, align 8
+  %17 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %17
+  %18 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %19 = load i64, ptr %18, align 8
+  %20 = add i64 %19, 1
+  store i64 %20, ptr %18, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %entry

--- a/tests/codegen/llvm/call_join.ll
+++ b/tests/codegen/llvm/call_join.ll
@@ -21,18 +21,17 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !55 {
 entry:
   %join_r0 = alloca i64, align 8
   %lookup_join_key = alloca i32, align 4
-  %"struct arg.argv" = alloca i64, align 8
-  %"$x" = alloca i64, align 8
+  %"struct arg.argv" = alloca ptr, align 8
+  %"$x" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
-  store i64 0, ptr %"$x", align 8
-  %1 = load i64, ptr %"$x", align 8
-  %2 = inttoptr i64 %1 to ptr
-  %3 = call ptr @llvm.preserve.static.offset(ptr %2)
-  %4 = getelementptr i8, ptr %3, i64 0
+  store i0 0, ptr %"$x", align 1
+  store ptr null, ptr %"$x", align 8
+  %1 = load ptr, ptr %"$x", align 8
+  %2 = call ptr @llvm.preserve.static.offset(ptr %1)
+  %3 = getelementptr i8, ptr %2, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct arg.argv")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct arg.argv", i32 8, ptr %4)
-  %5 = load i64, ptr %"struct arg.argv", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct arg.argv", i32 8, ptr %3)
+  %4 = load ptr, ptr %"struct arg.argv", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct arg.argv")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_join_key)
   store i32 0, ptr %lookup_join_key, align 4
@@ -48,103 +47,103 @@ lookup_join_failure:                              ; preds = %entry
   br label %failure_callback
 
 lookup_join_merge:                                ; preds = %entry
-  %6 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 0
-  store i64 30005, ptr %6, align 8
-  %7 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 1
-  store i64 0, ptr %7, align 8
-  %8 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 2
+  %5 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 0
+  store i64 30005, ptr %5, align 8
+  %6 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 1
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %join_r0)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %5)
-  %9 = getelementptr i8, ptr %8, i64 0
-  %10 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %9, i32 1024, i64 %10)
-  %11 = add i64 %5, 8
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %11)
-  %12 = getelementptr i8, ptr %8, i64 1024
-  %13 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str3 = call i64 inttoptr (i64 115 to ptr)(ptr %12, i32 1024, i64 %13)
-  %14 = add i64 %11, 8
-  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %14)
-  %15 = getelementptr i8, ptr %8, i64 2048
-  %16 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str5 = call i64 inttoptr (i64 115 to ptr)(ptr %15, i32 1024, i64 %16)
-  %17 = add i64 %14, 8
-  %probe_read_kernel6 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %17)
-  %18 = getelementptr i8, ptr %8, i64 3072
-  %19 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str7 = call i64 inttoptr (i64 115 to ptr)(ptr %18, i32 1024, i64 %19)
-  %20 = add i64 %17, 8
-  %probe_read_kernel8 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %20)
-  %21 = getelementptr i8, ptr %8, i64 4096
-  %22 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str9 = call i64 inttoptr (i64 115 to ptr)(ptr %21, i32 1024, i64 %22)
-  %23 = add i64 %20, 8
-  %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %23)
-  %24 = getelementptr i8, ptr %8, i64 5120
-  %25 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str11 = call i64 inttoptr (i64 115 to ptr)(ptr %24, i32 1024, i64 %25)
-  %26 = add i64 %23, 8
-  %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %26)
-  %27 = getelementptr i8, ptr %8, i64 6144
-  %28 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str13 = call i64 inttoptr (i64 115 to ptr)(ptr %27, i32 1024, i64 %28)
-  %29 = add i64 %26, 8
-  %probe_read_kernel14 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %29)
-  %30 = getelementptr i8, ptr %8, i64 7168
-  %31 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str15 = call i64 inttoptr (i64 115 to ptr)(ptr %30, i32 1024, i64 %31)
-  %32 = add i64 %29, 8
-  %probe_read_kernel16 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %32)
-  %33 = getelementptr i8, ptr %8, i64 8192
-  %34 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str17 = call i64 inttoptr (i64 115 to ptr)(ptr %33, i32 1024, i64 %34)
-  %35 = add i64 %32, 8
-  %probe_read_kernel18 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %35)
-  %36 = getelementptr i8, ptr %8, i64 9216
-  %37 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str19 = call i64 inttoptr (i64 115 to ptr)(ptr %36, i32 1024, i64 %37)
-  %38 = add i64 %35, 8
-  %probe_read_kernel20 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %38)
-  %39 = getelementptr i8, ptr %8, i64 10240
-  %40 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str21 = call i64 inttoptr (i64 115 to ptr)(ptr %39, i32 1024, i64 %40)
-  %41 = add i64 %38, 8
-  %probe_read_kernel22 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %41)
-  %42 = getelementptr i8, ptr %8, i64 11264
-  %43 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str23 = call i64 inttoptr (i64 115 to ptr)(ptr %42, i32 1024, i64 %43)
-  %44 = add i64 %41, 8
-  %probe_read_kernel24 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %44)
-  %45 = getelementptr i8, ptr %8, i64 12288
-  %46 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str25 = call i64 inttoptr (i64 115 to ptr)(ptr %45, i32 1024, i64 %46)
-  %47 = add i64 %44, 8
-  %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %47)
-  %48 = getelementptr i8, ptr %8, i64 13312
-  %49 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str27 = call i64 inttoptr (i64 115 to ptr)(ptr %48, i32 1024, i64 %49)
-  %50 = add i64 %47, 8
-  %probe_read_kernel28 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %50)
-  %51 = getelementptr i8, ptr %8, i64 14336
-  %52 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str29 = call i64 inttoptr (i64 115 to ptr)(ptr %51, i32 1024, i64 %52)
-  %53 = add i64 %50, 8
-  %probe_read_kernel30 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %53)
-  %54 = getelementptr i8, ptr %8, i64 15360
-  %55 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str31 = call i64 inttoptr (i64 115 to ptr)(ptr %54, i32 1024, i64 %55)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %4)
+  %8 = getelementptr i8, ptr %7, i64 0
+  %9 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %8, i32 1024, i64 %9)
+  %10 = getelementptr ptr, ptr %4, i32 1
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %10)
+  %11 = getelementptr i8, ptr %7, i64 1024
+  %12 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str3 = call i64 inttoptr (i64 115 to ptr)(ptr %11, i32 1024, i64 %12)
+  %13 = getelementptr ptr, ptr %10, i32 2
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %13)
+  %14 = getelementptr i8, ptr %7, i64 2048
+  %15 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str5 = call i64 inttoptr (i64 115 to ptr)(ptr %14, i32 1024, i64 %15)
+  %16 = getelementptr ptr, ptr %13, i32 3
+  %probe_read_kernel6 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %16)
+  %17 = getelementptr i8, ptr %7, i64 3072
+  %18 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str7 = call i64 inttoptr (i64 115 to ptr)(ptr %17, i32 1024, i64 %18)
+  %19 = getelementptr ptr, ptr %16, i32 4
+  %probe_read_kernel8 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %19)
+  %20 = getelementptr i8, ptr %7, i64 4096
+  %21 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str9 = call i64 inttoptr (i64 115 to ptr)(ptr %20, i32 1024, i64 %21)
+  %22 = getelementptr ptr, ptr %19, i32 5
+  %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %22)
+  %23 = getelementptr i8, ptr %7, i64 5120
+  %24 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str11 = call i64 inttoptr (i64 115 to ptr)(ptr %23, i32 1024, i64 %24)
+  %25 = getelementptr ptr, ptr %22, i32 6
+  %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %25)
+  %26 = getelementptr i8, ptr %7, i64 6144
+  %27 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str13 = call i64 inttoptr (i64 115 to ptr)(ptr %26, i32 1024, i64 %27)
+  %28 = getelementptr ptr, ptr %25, i32 7
+  %probe_read_kernel14 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %28)
+  %29 = getelementptr i8, ptr %7, i64 7168
+  %30 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str15 = call i64 inttoptr (i64 115 to ptr)(ptr %29, i32 1024, i64 %30)
+  %31 = getelementptr ptr, ptr %28, i32 8
+  %probe_read_kernel16 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %31)
+  %32 = getelementptr i8, ptr %7, i64 8192
+  %33 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str17 = call i64 inttoptr (i64 115 to ptr)(ptr %32, i32 1024, i64 %33)
+  %34 = getelementptr ptr, ptr %31, i32 9
+  %probe_read_kernel18 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %34)
+  %35 = getelementptr i8, ptr %7, i64 9216
+  %36 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str19 = call i64 inttoptr (i64 115 to ptr)(ptr %35, i32 1024, i64 %36)
+  %37 = getelementptr ptr, ptr %34, i32 10
+  %probe_read_kernel20 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %37)
+  %38 = getelementptr i8, ptr %7, i64 10240
+  %39 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str21 = call i64 inttoptr (i64 115 to ptr)(ptr %38, i32 1024, i64 %39)
+  %40 = getelementptr ptr, ptr %37, i32 11
+  %probe_read_kernel22 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %40)
+  %41 = getelementptr i8, ptr %7, i64 11264
+  %42 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str23 = call i64 inttoptr (i64 115 to ptr)(ptr %41, i32 1024, i64 %42)
+  %43 = getelementptr ptr, ptr %40, i32 12
+  %probe_read_kernel24 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %43)
+  %44 = getelementptr i8, ptr %7, i64 12288
+  %45 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str25 = call i64 inttoptr (i64 115 to ptr)(ptr %44, i32 1024, i64 %45)
+  %46 = getelementptr ptr, ptr %43, i32 13
+  %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %46)
+  %47 = getelementptr i8, ptr %7, i64 13312
+  %48 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str27 = call i64 inttoptr (i64 115 to ptr)(ptr %47, i32 1024, i64 %48)
+  %49 = getelementptr ptr, ptr %46, i32 14
+  %probe_read_kernel28 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %49)
+  %50 = getelementptr i8, ptr %7, i64 14336
+  %51 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str29 = call i64 inttoptr (i64 115 to ptr)(ptr %50, i32 1024, i64 %51)
+  %52 = getelementptr ptr, ptr %49, i32 15
+  %probe_read_kernel30 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %52)
+  %53 = getelementptr i8, ptr %7, i64 15360
+  %54 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str31 = call i64 inttoptr (i64 115 to ptr)(ptr %53, i32 1024, i64 %54)
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_join_map, i64 16400, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %lookup_join_merge
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %56 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %56
-  %57 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %58 = load i64, ptr %57, align 8
-  %59 = add i64 %58, 1
-  store i64 %59, ptr %57, align 8
+  %55 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %55
+  %56 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %57 = load i64, ptr %56, align 8
+  %58 = add i64 %57, 1
+  store i64 %58, ptr %56, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %lookup_join_merge

--- a/tests/codegen/llvm/call_join_with_debug.ll
+++ b/tests/codegen/llvm/call_join_with_debug.ll
@@ -22,18 +22,17 @@ entry:
   %join_r0 = alloca i64, align 8
   %fmt_str = alloca [70 x i8], align 1
   %lookup_join_key = alloca i32, align 4
-  %"struct arg.argv" = alloca i64, align 8
-  %"$x" = alloca i64, align 8
+  %"struct arg.argv" = alloca ptr, align 8
+  %"$x" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
-  store i64 0, ptr %"$x", align 8
-  %1 = load i64, ptr %"$x", align 8
-  %2 = inttoptr i64 %1 to ptr
-  %3 = call ptr @llvm.preserve.static.offset(ptr %2)
-  %4 = getelementptr i8, ptr %3, i64 0
+  store i0 0, ptr %"$x", align 1
+  store ptr null, ptr %"$x", align 8
+  %1 = load ptr, ptr %"$x", align 8
+  %2 = call ptr @llvm.preserve.static.offset(ptr %1)
+  %3 = getelementptr i8, ptr %2, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct arg.argv")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct arg.argv", i32 8, ptr %4)
-  %5 = load i64, ptr %"struct arg.argv", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct arg.argv", i32 8, ptr %3)
+  %4 = load ptr, ptr %"struct arg.argv", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct arg.argv")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_join_key)
   store i32 0, ptr %lookup_join_key, align 4
@@ -53,103 +52,103 @@ lookup_join_failure:                              ; preds = %entry
   br label %failure_callback
 
 lookup_join_merge:                                ; preds = %entry
-  %6 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 0
-  store i64 30005, ptr %6, align 8
-  %7 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 1
-  store i64 0, ptr %7, align 8
-  %8 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 2
+  %5 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 0
+  store i64 30005, ptr %5, align 8
+  %6 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 1
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr %join_t, ptr %lookup_join_map, i64 0, i32 2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %join_r0)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %5)
-  %9 = getelementptr i8, ptr %8, i64 0
-  %10 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %9, i32 1024, i64 %10)
-  %11 = add i64 %5, 8
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %11)
-  %12 = getelementptr i8, ptr %8, i64 1024
-  %13 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str3 = call i64 inttoptr (i64 115 to ptr)(ptr %12, i32 1024, i64 %13)
-  %14 = add i64 %11, 8
-  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %14)
-  %15 = getelementptr i8, ptr %8, i64 2048
-  %16 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str5 = call i64 inttoptr (i64 115 to ptr)(ptr %15, i32 1024, i64 %16)
-  %17 = add i64 %14, 8
-  %probe_read_kernel6 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %17)
-  %18 = getelementptr i8, ptr %8, i64 3072
-  %19 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str7 = call i64 inttoptr (i64 115 to ptr)(ptr %18, i32 1024, i64 %19)
-  %20 = add i64 %17, 8
-  %probe_read_kernel8 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %20)
-  %21 = getelementptr i8, ptr %8, i64 4096
-  %22 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str9 = call i64 inttoptr (i64 115 to ptr)(ptr %21, i32 1024, i64 %22)
-  %23 = add i64 %20, 8
-  %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %23)
-  %24 = getelementptr i8, ptr %8, i64 5120
-  %25 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str11 = call i64 inttoptr (i64 115 to ptr)(ptr %24, i32 1024, i64 %25)
-  %26 = add i64 %23, 8
-  %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %26)
-  %27 = getelementptr i8, ptr %8, i64 6144
-  %28 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str13 = call i64 inttoptr (i64 115 to ptr)(ptr %27, i32 1024, i64 %28)
-  %29 = add i64 %26, 8
-  %probe_read_kernel14 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %29)
-  %30 = getelementptr i8, ptr %8, i64 7168
-  %31 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str15 = call i64 inttoptr (i64 115 to ptr)(ptr %30, i32 1024, i64 %31)
-  %32 = add i64 %29, 8
-  %probe_read_kernel16 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %32)
-  %33 = getelementptr i8, ptr %8, i64 8192
-  %34 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str17 = call i64 inttoptr (i64 115 to ptr)(ptr %33, i32 1024, i64 %34)
-  %35 = add i64 %32, 8
-  %probe_read_kernel18 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %35)
-  %36 = getelementptr i8, ptr %8, i64 9216
-  %37 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str19 = call i64 inttoptr (i64 115 to ptr)(ptr %36, i32 1024, i64 %37)
-  %38 = add i64 %35, 8
-  %probe_read_kernel20 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %38)
-  %39 = getelementptr i8, ptr %8, i64 10240
-  %40 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str21 = call i64 inttoptr (i64 115 to ptr)(ptr %39, i32 1024, i64 %40)
-  %41 = add i64 %38, 8
-  %probe_read_kernel22 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %41)
-  %42 = getelementptr i8, ptr %8, i64 11264
-  %43 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str23 = call i64 inttoptr (i64 115 to ptr)(ptr %42, i32 1024, i64 %43)
-  %44 = add i64 %41, 8
-  %probe_read_kernel24 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %44)
-  %45 = getelementptr i8, ptr %8, i64 12288
-  %46 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str25 = call i64 inttoptr (i64 115 to ptr)(ptr %45, i32 1024, i64 %46)
-  %47 = add i64 %44, 8
-  %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %47)
-  %48 = getelementptr i8, ptr %8, i64 13312
-  %49 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str27 = call i64 inttoptr (i64 115 to ptr)(ptr %48, i32 1024, i64 %49)
-  %50 = add i64 %47, 8
-  %probe_read_kernel28 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %50)
-  %51 = getelementptr i8, ptr %8, i64 14336
-  %52 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str29 = call i64 inttoptr (i64 115 to ptr)(ptr %51, i32 1024, i64 %52)
-  %53 = add i64 %50, 8
-  %probe_read_kernel30 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, i64 %53)
-  %54 = getelementptr i8, ptr %8, i64 15360
-  %55 = load i64, ptr %join_r0, align 8
-  %probe_read_kernel_str31 = call i64 inttoptr (i64 115 to ptr)(ptr %54, i32 1024, i64 %55)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %4)
+  %8 = getelementptr i8, ptr %7, i64 0
+  %9 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %8, i32 1024, i64 %9)
+  %10 = getelementptr ptr, ptr %4, i32 1
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %10)
+  %11 = getelementptr i8, ptr %7, i64 1024
+  %12 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str3 = call i64 inttoptr (i64 115 to ptr)(ptr %11, i32 1024, i64 %12)
+  %13 = getelementptr ptr, ptr %10, i32 2
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %13)
+  %14 = getelementptr i8, ptr %7, i64 2048
+  %15 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str5 = call i64 inttoptr (i64 115 to ptr)(ptr %14, i32 1024, i64 %15)
+  %16 = getelementptr ptr, ptr %13, i32 3
+  %probe_read_kernel6 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %16)
+  %17 = getelementptr i8, ptr %7, i64 3072
+  %18 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str7 = call i64 inttoptr (i64 115 to ptr)(ptr %17, i32 1024, i64 %18)
+  %19 = getelementptr ptr, ptr %16, i32 4
+  %probe_read_kernel8 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %19)
+  %20 = getelementptr i8, ptr %7, i64 4096
+  %21 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str9 = call i64 inttoptr (i64 115 to ptr)(ptr %20, i32 1024, i64 %21)
+  %22 = getelementptr ptr, ptr %19, i32 5
+  %probe_read_kernel10 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %22)
+  %23 = getelementptr i8, ptr %7, i64 5120
+  %24 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str11 = call i64 inttoptr (i64 115 to ptr)(ptr %23, i32 1024, i64 %24)
+  %25 = getelementptr ptr, ptr %22, i32 6
+  %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %25)
+  %26 = getelementptr i8, ptr %7, i64 6144
+  %27 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str13 = call i64 inttoptr (i64 115 to ptr)(ptr %26, i32 1024, i64 %27)
+  %28 = getelementptr ptr, ptr %25, i32 7
+  %probe_read_kernel14 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %28)
+  %29 = getelementptr i8, ptr %7, i64 7168
+  %30 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str15 = call i64 inttoptr (i64 115 to ptr)(ptr %29, i32 1024, i64 %30)
+  %31 = getelementptr ptr, ptr %28, i32 8
+  %probe_read_kernel16 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %31)
+  %32 = getelementptr i8, ptr %7, i64 8192
+  %33 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str17 = call i64 inttoptr (i64 115 to ptr)(ptr %32, i32 1024, i64 %33)
+  %34 = getelementptr ptr, ptr %31, i32 9
+  %probe_read_kernel18 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %34)
+  %35 = getelementptr i8, ptr %7, i64 9216
+  %36 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str19 = call i64 inttoptr (i64 115 to ptr)(ptr %35, i32 1024, i64 %36)
+  %37 = getelementptr ptr, ptr %34, i32 10
+  %probe_read_kernel20 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %37)
+  %38 = getelementptr i8, ptr %7, i64 10240
+  %39 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str21 = call i64 inttoptr (i64 115 to ptr)(ptr %38, i32 1024, i64 %39)
+  %40 = getelementptr ptr, ptr %37, i32 11
+  %probe_read_kernel22 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %40)
+  %41 = getelementptr i8, ptr %7, i64 11264
+  %42 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str23 = call i64 inttoptr (i64 115 to ptr)(ptr %41, i32 1024, i64 %42)
+  %43 = getelementptr ptr, ptr %40, i32 12
+  %probe_read_kernel24 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %43)
+  %44 = getelementptr i8, ptr %7, i64 12288
+  %45 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str25 = call i64 inttoptr (i64 115 to ptr)(ptr %44, i32 1024, i64 %45)
+  %46 = getelementptr ptr, ptr %43, i32 13
+  %probe_read_kernel26 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %46)
+  %47 = getelementptr i8, ptr %7, i64 13312
+  %48 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str27 = call i64 inttoptr (i64 115 to ptr)(ptr %47, i32 1024, i64 %48)
+  %49 = getelementptr ptr, ptr %46, i32 14
+  %probe_read_kernel28 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %49)
+  %50 = getelementptr i8, ptr %7, i64 14336
+  %51 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str29 = call i64 inttoptr (i64 115 to ptr)(ptr %50, i32 1024, i64 %51)
+  %52 = getelementptr ptr, ptr %49, i32 15
+  %probe_read_kernel30 = call i64 inttoptr (i64 113 to ptr)(ptr %join_r0, i32 8, ptr %52)
+  %53 = getelementptr i8, ptr %7, i64 15360
+  %54 = load i64, ptr %join_r0, align 8
+  %probe_read_kernel_str31 = call i64 inttoptr (i64 115 to ptr)(ptr %53, i32 1024, i64 %54)
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %lookup_join_map, i64 16400, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %lookup_join_merge
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
-  %56 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %56
-  %57 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %58 = load i64, ptr %57, align 8
-  %59 = add i64 %58, 1
-  store i64 %59, ptr %57, align 8
+  %55 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %55
+  %56 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %57 = load i64, ptr %56, align 8
+  %58 = add i64 %57, 1
+  store i64 %58, ptr %56, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %lookup_join_merge

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -21,51 +21,50 @@ entry:
   %"struct Foo.l" = alloca i64, align 8
   %"struct Foo.c" = alloca i8, align 1
   %printf_args = alloca %printf_t, align 8
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 24, i1 false)
-  %3 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
-  store i64 0, ptr %3, align 8
-  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
-  %5 = load i64, ptr %"$foo", align 8
-  %6 = inttoptr i64 %5 to ptr
+  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  store i64 0, ptr %4, align 8
+  %5 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
+  %6 = load ptr, ptr %"$foo", align 8
   %7 = call ptr @llvm.preserve.static.offset(ptr %6)
   %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.c")
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.c", i32 1, ptr %8)
   %9 = load i8, ptr %"struct Foo.c", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.c")
-  %10 = getelementptr %printf_args_t, ptr %4, i32 0, i32 0
+  %10 = getelementptr %printf_args_t, ptr %5, i32 0, i32 0
   %11 = sext i8 %9 to i64
   store i64 %11, ptr %10, align 8
-  %12 = load i64, ptr %"$foo", align 8
-  %13 = inttoptr i64 %12 to ptr
-  %14 = call ptr @llvm.preserve.static.offset(ptr %13)
-  %15 = getelementptr i8, ptr %14, i64 8
+  %12 = load ptr, ptr %"$foo", align 8
+  %13 = call ptr @llvm.preserve.static.offset(ptr %12)
+  %14 = getelementptr i8, ptr %13, i64 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.l")
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, ptr %15)
-  %16 = load i64, ptr %"struct Foo.l", align 8
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.l", i32 8, ptr %14)
+  %15 = load i64, ptr %"struct Foo.l", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.l")
-  %17 = getelementptr %printf_args_t, ptr %4, i32 0, i32 1
-  store i64 %16, ptr %17, align 8
+  %16 = getelementptr %printf_args_t, ptr %5, i32 0, i32 1
+  store i64 %15, ptr %16, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
-  %18 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %18
-  %19 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %20 = load i64, ptr %19, align 8
-  %21 = add i64 %20, 1
-  store i64 %21, ptr %19, align 8
+  %17 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %17
+  %18 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %19 = load i64, ptr %18, align 8
+  %20 = add i64 %19, 1
+  store i64 %20, ptr %18, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %entry

--- a/tests/codegen/llvm/call_socket_cookie.ll
+++ b/tests/codegen/llvm/call_socket_cookie.ll
@@ -21,8 +21,8 @@ entry:
   store i64 0, ptr %"$ret", align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i64, ptr %1, i64 0
-  %sk = load volatile i64, ptr %2, align 8
-  %get_socket_cookie = call i64 inttoptr (i64 46 to ptr)(i64 %sk) #3
+  %sk = load volatile ptr, ptr %2, align 8
+  %get_socket_cookie = call i64 inttoptr (i64 46 to ptr)(ptr %sk) #3
   store i64 %get_socket_cookie, ptr %"$ret", align 8
   ret i64 0
 }

--- a/tests/codegen/llvm/call_tseries.ll
+++ b/tests/codegen/llvm/call_tseries.ll
@@ -95,8 +95,8 @@ exit:                                             ; preds = %update, %lookup_mer
   ret i64 0
 
 lookup_success3:                                  ; preds = %merge
-  %13 = load i64, ptr %lookup_elem2, align 8
-  store i64 %13, ptr %lookup_elem_val, align 8
+  %13 = load ptr, ptr %lookup_elem2, align 8
+  store ptr %13, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure4:                                  ; preds = %merge

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -24,15 +24,16 @@ entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_user = call i64 inttoptr (i64 112 to ptr)(ptr %deref, i32 2, i64 %arg0)
-  %3 = load i16, ptr %deref, align 2
+  %probe_read_user = call i64 inttoptr (i64 112 to ptr)(ptr %deref, i32 2, ptr %3)
+  %4 = load i16, ptr %deref, align 2
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %4 = sext i16 %3 to i64
-  store i64 %4, ptr %"@_val", align 8
+  %5 = sext i16 %4 to i64
+  store i64 %5, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -24,15 +24,16 @@ entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_user = call i64 inttoptr (i64 112 to ptr)(ptr %deref, i32 4, i64 %arg0)
-  %3 = load i32, ptr %deref, align 4
+  %probe_read_user = call i64 inttoptr (i64 112 to ptr)(ptr %deref, i32 4, ptr %3)
+  %4 = load i32, ptr %deref, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %4 = sext i32 %3 to i64
-  store i64 %4, ptr %"@_val", align 8
+  %5 = sext i32 %4 to i64
+  store i64 %5, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")

--- a/tests/codegen/llvm/cast_int_to_arr.ll
+++ b/tests/codegen/llvm/cast_int_to_arr.ll
@@ -20,23 +20,22 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %"$a" = alloca i64, align 8
+  %"$a" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
-  store i64 0, ptr %"$a", align 8
+  store i0 0, ptr %"$a", align 1
   %1 = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %1)
   store i64 0, ptr %1, align 8
   %2 = ptrtoint ptr %1 to i64
   store i64 %2, ptr %"$a", align 8
-  %3 = load i64, ptr %"$a", align 8
-  %4 = inttoptr i64 %3 to ptr
-  %5 = getelementptr [8 x i8], ptr %4, i32 0, i64 0
-  %6 = load volatile i8, ptr %5, align 1
+  %3 = load ptr, ptr %"$a", align 8
+  %4 = getelementptr [8 x i8], ptr %3, i32 0, i64 0
+  %5 = load volatile i8, ptr %4, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %7 = zext i8 %6 to i64
-  store i64 %7, ptr %"@_val", align 8
+  %6 = zext i8 %5 to i64
+  store i64 %6, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")

--- a/tests/codegen/llvm/fentry_dereference.ll
+++ b/tests/codegen/llvm/fentry_dereference.ll
@@ -23,19 +23,18 @@ entry:
   %"struct sock_common.skc_daddr" = alloca i32, align 4
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i64, ptr %1, i64 0
-  %sk = load volatile i64, ptr %2, align 8
-  %3 = inttoptr i64 %sk to ptr
-  %4 = call ptr @llvm.preserve.static.offset(ptr %3)
-  %5 = getelementptr i8, ptr %4, i64 0
-  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
-  %7 = getelementptr i8, ptr %6, i64 0
+  %sk = load volatile ptr, ptr %2, align 8
+  %3 = call ptr @llvm.preserve.static.offset(ptr %sk)
+  %4 = getelementptr i8, ptr %3, i64 0
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct sock_common.skc_daddr")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct sock_common.skc_daddr", i32 4, ptr %7)
-  %8 = load i32, ptr %"struct sock_common.skc_daddr", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct sock_common.skc_daddr", i32 4, ptr %6)
+  %7 = load i32, ptr %"struct sock_common.skc_daddr", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct sock_common.skc_daddr")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %9 = zext i32 %8 to i64
-  store i64 %9, ptr %"@_key", align 8
+  %8 = zext i32 %7 to i64
+  store i64 %8, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)

--- a/tests/codegen/llvm/fentry_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/fentry_recursion_check_with_predicate.ll
@@ -43,18 +43,17 @@ lookup_merge:                                     ; preds = %lookup_success
   %pid = trunc i64 %2 to i32
   %3 = zext i32 %pid to i64
   %4 = icmp eq i64 %3, 1234
-  %5 = zext i1 %4 to i64
-  %predcond = icmp eq i64 %5, 0
+  %predcond = icmp eq i1 %4, false
   br i1 %predcond, label %pred_false, label %pred_true
 
 value_is_set:                                     ; preds = %lookup_success
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
-  %6 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %6
-  %7 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %8 = load i64, ptr %7, align 8
-  %9 = add i64 %8, 1
-  store i64 %9, ptr %7, align 8
+  %5 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %7 = load i64, ptr %6, align 8
+  %8 = add i64 %7, 1
+  store i64 %8, ptr %6, align 8
   ret i64 0
 
 pred_false:                                       ; preds = %lookup_merge

--- a/tests/codegen/llvm/fexit_dereference.ll
+++ b/tests/codegen/llvm/fexit_dereference.ll
@@ -23,19 +23,18 @@ entry:
   %"struct sock_common.skc_daddr" = alloca i32, align 4
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i64, ptr %1, i64 5
-  %__builtin_retval = load volatile i64, ptr %2, align 8
-  %3 = inttoptr i64 %__builtin_retval to ptr
-  %4 = call ptr @llvm.preserve.static.offset(ptr %3)
-  %5 = getelementptr i8, ptr %4, i64 0
-  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
-  %7 = getelementptr i8, ptr %6, i64 0
+  %__builtin_retval = load volatile ptr, ptr %2, align 8
+  %3 = call ptr @llvm.preserve.static.offset(ptr %__builtin_retval)
+  %4 = getelementptr i8, ptr %3, i64 0
+  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
+  %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct sock_common.skc_daddr")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct sock_common.skc_daddr", i32 4, ptr %7)
-  %8 = load i32, ptr %"struct sock_common.skc_daddr", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct sock_common.skc_daddr", i32 4, ptr %6)
+  %7 = load i32, ptr %"struct sock_common.skc_daddr", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct sock_common.skc_daddr")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %9 = zext i32 %8 to i64
-  store i64 %9, ptr %"@_key", align 8
+  %8 = zext i32 %7 to i64
+  store i64 %8, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)

--- a/tests/codegen/llvm/int_propagation.ll
+++ b/tests/codegen/llvm/int_propagation.ll
@@ -41,8 +41,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -25,15 +25,16 @@ entry:
   %2 = getelementptr i8, ptr %1, i64 32
   %reg_bp = load volatile i64, ptr %2, align 8
   %3 = sub i64 %reg_bp, 1
+  %4 = inttoptr i64 %3 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 1, i64 %3)
-  %4 = load i8, ptr %deref, align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 1, ptr %4)
+  %5 = load i8, ptr %deref, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %5 = sext i8 %4 to i64
-  store i64 %5, ptr %"@_val", align 8
+  %6 = sext i8 %5 to i64
+  store i64 %6, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -29,25 +29,26 @@ entry:
   %2 = getelementptr i8, ptr %1, i64 32
   %reg_bp = load volatile i64, ptr %2, align 8
   %3 = sub i64 %reg_bp, 1
+  %4 = inttoptr i64 %3 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 1, i64 %3)
-  %4 = load i8, ptr %deref, align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 1, ptr %4)
+  %5 = load i8, ptr %deref, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
-  %5 = sext i8 %4 to i64
+  %6 = sext i8 %5 to i64
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_, ptr %"@_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %6 = load i64, ptr %lookup_elem, align 8
-  %7 = add i64 %6, %5
-  store i64 %7, ptr %lookup_elem, align 8
+  %7 = load i64, ptr %lookup_elem, align 8
+  %8 = add i64 %7, %6
+  store i64 %8, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
-  store i64 %5, ptr %initial_value, align 8
+  store i64 %6, ptr %initial_value, align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge

--- a/tests/codegen/llvm/iter_dereference.ll
+++ b/tests/codegen/llvm/iter_dereference.ll
@@ -23,23 +23,22 @@ entry:
   %"struct bpf_iter_meta.session_id" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 0
-  %3 = load volatile i64, ptr %2, align 8
-  %predcond = icmp eq i64 %3, 0
+  %3 = load volatile ptr, ptr %2, align 8
+  %predcond = icmp eq ptr %3, null
   br i1 %predcond, label %pred_false, label %pred_true
 
 pred_false:                                       ; preds = %entry
   ret i64 0
 
 pred_true:                                        ; preds = %entry
-  %4 = inttoptr i64 %3 to ptr
-  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
-  %6 = getelementptr i8, ptr %5, i64 8
+  %4 = call ptr @llvm.preserve.static.offset(ptr %3)
+  %5 = getelementptr i8, ptr %4, i64 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct bpf_iter_meta.session_id")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct bpf_iter_meta.session_id", i32 8, ptr %6)
-  %7 = load i64, ptr %"struct bpf_iter_meta.session_id", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct bpf_iter_meta.session_id", i32 8, ptr %5)
+  %6 = load i64, ptr %"struct bpf_iter_meta.session_id", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct bpf_iter_meta.session_id")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 %7, ptr %"@_key", align 8
+  store i64 %6, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)

--- a/tests/codegen/llvm/logical_and.ll
+++ b/tests/codegen/llvm/logical_and.ll
@@ -20,7 +20,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
   %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
-  %"&&_result" = alloca i8, align 1
+  %"&&_result" = alloca i1, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
@@ -40,19 +40,19 @@ entry:
   br i1 %rhs_true_cond, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
-  store i8 1, ptr %"&&_result", align 1
+  store i1 true, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_false":                                       ; preds = %"&&_lhs_true", %entry
-  store i8 0, ptr %"&&_result", align 1
+  store i1 false, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %7 = load i8, ptr %"&&_result", align 1
+  %7 = load i1, ptr %"&&_result", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i8 %7, ptr %"@x_val", align 1
+  store i1 %7, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -20,16 +20,16 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !42 {
 entry:
   %"struct Foo.m16" = alloca i32, align 4
-  %"||_result15" = alloca i8, align 1
+  %"||_result15" = alloca i1, align 1
   %"struct Foo.m8" = alloca i32, align 4
-  %"||_result" = alloca i8, align 1
+  %"||_result" = alloca i1, align 1
   %"struct Foo.m6" = alloca i32, align 4
-  %"&&_result5" = alloca i8, align 1
+  %"&&_result5" = alloca i1, align 1
   %"struct Foo.m" = alloca i32, align 4
-  %"&&_result" = alloca i8, align 1
-  %"$foo" = alloca i64, align 8
+  %"&&_result" = alloca i1, align 1
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   store i64 0, ptr %"$foo", align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
@@ -40,125 +40,121 @@ entry:
   store i64 0, ptr %3, align 8
   %4 = getelementptr %printf_t, ptr %2, i32 0, i32 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
-  %5 = load i64, ptr %"$foo", align 8
-  %6 = inttoptr i64 %5 to ptr
-  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
-  %8 = getelementptr i8, ptr %7, i64 0
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m")
-  %probe_read = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m", i32 4, ptr %8)
-  %9 = load i32, ptr %"struct Foo.m", align 4
+  %probe_read = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m", i32 4, ptr %7)
+  %8 = load i32, ptr %"struct Foo.m", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m")
-  %lhs_true_cond = icmp ne i32 %9, 0
+  %lhs_true_cond = icmp ne i32 %8, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
   br i1 false, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
-  store i8 1, ptr %"&&_result", align 1
+  store i1 true, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_false":                                       ; preds = %"&&_lhs_true", %entry
-  store i8 0, ptr %"&&_result", align 1
+  store i1 false, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %10 = load i8, ptr %"&&_result", align 1
-  %11 = getelementptr %printf_args_t, ptr %4, i32 0, i32 0
-  store i8 %10, ptr %11, align 1
+  %9 = load i1, ptr %"&&_result", align 1
+  %10 = getelementptr %printf_args_t, ptr %4, i32 0, i32 0
+  store i1 %9, ptr %10, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result5")
   br i1 true, label %"&&_lhs_true1", label %"&&_false3"
 
 "&&_lhs_true1":                                   ; preds = %"&&_merge"
-  %12 = load i64, ptr %"$foo", align 8
-  %13 = inttoptr i64 %12 to ptr
-  %14 = call ptr @llvm.preserve.static.offset(ptr %13)
-  %15 = getelementptr i8, ptr %14, i64 0
+  %11 = load ptr, ptr %"$foo", align 8
+  %12 = call ptr @llvm.preserve.static.offset(ptr %11)
+  %13 = getelementptr i8, ptr %12, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m6")
-  %probe_read7 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m6", i32 4, ptr %15)
-  %16 = load i32, ptr %"struct Foo.m6", align 4
+  %probe_read7 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m6", i32 4, ptr %13)
+  %14 = load i32, ptr %"struct Foo.m6", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m6")
-  %rhs_true_cond = icmp ne i32 %16, 0
+  %rhs_true_cond = icmp ne i32 %14, 0
   br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
 
 "&&_true2":                                       ; preds = %"&&_lhs_true1"
-  store i8 1, ptr %"&&_result5", align 1
+  store i1 true, ptr %"&&_result5", align 1
   br label %"&&_merge4"
 
 "&&_false3":                                      ; preds = %"&&_lhs_true1", %"&&_merge"
-  store i8 0, ptr %"&&_result5", align 1
+  store i1 false, ptr %"&&_result5", align 1
   br label %"&&_merge4"
 
 "&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %17 = load i8, ptr %"&&_result5", align 1
-  %18 = getelementptr %printf_args_t, ptr %4, i32 0, i32 1
-  store i8 %17, ptr %18, align 1
+  %15 = load i1, ptr %"&&_result5", align 1
+  %16 = getelementptr %printf_args_t, ptr %4, i32 0, i32 1
+  store i1 %15, ptr %16, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
-  %19 = load i64, ptr %"$foo", align 8
-  %20 = inttoptr i64 %19 to ptr
-  %21 = call ptr @llvm.preserve.static.offset(ptr %20)
-  %22 = getelementptr i8, ptr %21, i64 0
+  %17 = load ptr, ptr %"$foo", align 8
+  %18 = call ptr @llvm.preserve.static.offset(ptr %17)
+  %19 = getelementptr i8, ptr %18, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m8")
-  %probe_read9 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m8", i32 4, ptr %22)
-  %23 = load i32, ptr %"struct Foo.m8", align 4
+  %probe_read9 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m8", i32 4, ptr %19)
+  %20 = load i32, ptr %"struct Foo.m8", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m8")
-  %lhs_true_cond10 = icmp ne i32 %23, 0
+  %lhs_true_cond10 = icmp ne i32 %20, 0
   br i1 %lhs_true_cond10, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %"&&_merge4"
   br i1 false, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
-  store i8 0, ptr %"||_result", align 1
+  store i1 false, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_true":                                        ; preds = %"||_lhs_false", %"&&_merge4"
-  store i8 1, ptr %"||_result", align 1
+  store i1 true, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %24 = load i8, ptr %"||_result", align 1
-  %25 = getelementptr %printf_args_t, ptr %4, i32 0, i32 2
-  store i8 %24, ptr %25, align 1
+  %21 = load i1, ptr %"||_result", align 1
+  %22 = getelementptr %printf_args_t, ptr %4, i32 0, i32 2
+  store i1 %21, ptr %22, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result15")
   br i1 false, label %"||_true13", label %"||_lhs_false11"
 
 "||_lhs_false11":                                 ; preds = %"||_merge"
-  %26 = load i64, ptr %"$foo", align 8
-  %27 = inttoptr i64 %26 to ptr
-  %28 = call ptr @llvm.preserve.static.offset(ptr %27)
-  %29 = getelementptr i8, ptr %28, i64 0
+  %23 = load ptr, ptr %"$foo", align 8
+  %24 = call ptr @llvm.preserve.static.offset(ptr %23)
+  %25 = getelementptr i8, ptr %24, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.m16")
-  %probe_read17 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m16", i32 4, ptr %29)
-  %30 = load i32, ptr %"struct Foo.m16", align 4
+  %probe_read17 = call i64 inttoptr (i64 4 to ptr)(ptr %"struct Foo.m16", i32 4, ptr %25)
+  %26 = load i32, ptr %"struct Foo.m16", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.m16")
-  %rhs_true_cond18 = icmp ne i32 %30, 0
+  %rhs_true_cond18 = icmp ne i32 %26, 0
   br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
 
 "||_false12":                                     ; preds = %"||_lhs_false11"
-  store i8 0, ptr %"||_result15", align 1
+  store i1 false, ptr %"||_result15", align 1
   br label %"||_merge14"
 
 "||_true13":                                      ; preds = %"||_lhs_false11", %"||_merge"
-  store i8 1, ptr %"||_result15", align 1
+  store i1 true, ptr %"||_result15", align 1
   br label %"||_merge14"
 
 "||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %31 = load i8, ptr %"||_result15", align 1
-  %32 = getelementptr %printf_args_t, ptr %4, i32 0, i32 3
-  store i8 %31, ptr %32, align 1
+  %27 = load i1, ptr %"||_result15", align 1
+  %28 = getelementptr %printf_args_t, ptr %4, i32 0, i32 3
+  store i1 %27, ptr %28, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 40, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %"||_merge14"
   %get_cpu_id19 = call i64 inttoptr (i64 8 to ptr)() #4
-  %33 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded20 = and i64 %get_cpu_id19, %33
-  %34 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded20, i64 0
-  %35 = load i64, ptr %34, align 8
-  %36 = add i64 %35, 1
-  store i64 %36, ptr %34, align 8
+  %29 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded20 = and i64 %get_cpu_id19, %29
+  %30 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded20, i64 0
+  %31 = load i64, ptr %30, align 8
+  %32 = add i64 %31, 1
+  store i64 %32, ptr %30, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %"||_merge14"

--- a/tests/codegen/llvm/logical_or.ll
+++ b/tests/codegen/llvm/logical_or.ll
@@ -20,7 +20,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
   %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
-  %"||_result" = alloca i8, align 1
+  %"||_result" = alloca i1, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
@@ -40,19 +40,19 @@ entry:
   br i1 %rhs_true_cond, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
-  store i8 0, ptr %"||_result", align 1
+  store i1 false, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_true":                                        ; preds = %"||_lhs_false", %entry
-  store i8 1, ptr %"||_result", align 1
+  store i1 true, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %7 = load i8, ptr %"||_result", align 1
+  %7 = load i1, ptr %"||_result", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i8 %7, ptr %"@x_val", align 1
+  store i1 %7, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/map_args.ll
+++ b/tests/codegen/llvm/map_args.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.0" = type { ptr, ptr }
-%"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args" = type { i32, i64, i64, i64, i64 }
+%"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args" = type { i32, ptr, ptr, ptr, ptr }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7

--- a/tests/codegen/llvm/map_increment_decrement.ll
+++ b/tests/codegen/llvm/map_increment_decrement.ll
@@ -47,8 +47,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -72,8 +72,8 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br i1 %map_lookup_cond9, label %lookup_success5, label %lookup_failure6
 
 lookup_success5:                                  ; preds = %lookup_merge
-  %4 = load i64, ptr %lookup_elem4, align 8
-  store i64 %4, ptr %lookup_elem_val8, align 8
+  %4 = load ptr, ptr %lookup_elem4, align 8
+  store ptr %4, ptr %lookup_elem_val8, align 8
   br label %lookup_merge7
 
 lookup_failure6:                                  ; preds = %lookup_merge
@@ -98,8 +98,8 @@ lookup_merge7:                                    ; preds = %lookup_failure6, %l
   br i1 %map_lookup_cond18, label %lookup_success14, label %lookup_failure15
 
 lookup_success14:                                 ; preds = %lookup_merge7
-  %8 = load i64, ptr %lookup_elem13, align 8
-  store i64 %8, ptr %lookup_elem_val17, align 8
+  %8 = load ptr, ptr %lookup_elem13, align 8
+  store ptr %8, ptr %lookup_elem_val17, align 8
   br label %lookup_merge16
 
 lookup_failure15:                                 ; preds = %lookup_merge7
@@ -123,8 +123,8 @@ lookup_merge16:                                   ; preds = %lookup_failure15, %
   br i1 %map_lookup_cond27, label %lookup_success23, label %lookup_failure24
 
 lookup_success23:                                 ; preds = %lookup_merge16
-  %11 = load i64, ptr %lookup_elem22, align 8
-  store i64 %11, ptr %lookup_elem_val26, align 8
+  %11 = load ptr, ptr %lookup_elem22, align 8
+  store ptr %11, ptr %lookup_elem_val26, align 8
   br label %lookup_merge25
 
 lookup_failure24:                                 ; preds = %lookup_merge16

--- a/tests/codegen/llvm/map_key_probe.ll
+++ b/tests/codegen/llvm/map_key_probe.ll
@@ -28,8 +28,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -64,8 +64,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/map_key_scratch_buf.ll
@@ -49,8 +49,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %9 = load i64, ptr %lookup_elem, align 8
-  store i64 %9, ptr %8, align 8
+  %9 = load ptr, ptr %lookup_elem, align 8
+  store ptr %9, ptr %8, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/map_key_stack.ll
+++ b/tests/codegen/llvm/map_key_stack.ll
@@ -41,8 +41,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/map_key_struct.ll
+++ b/tests/codegen/llvm/map_key_struct.ll
@@ -23,8 +23,9 @@ entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@x_key", i32 4, i64 %arg0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@x_key", i32 4, ptr %3)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   store i64 44, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)

--- a/tests/codegen/llvm/map_value_int_scratch_buf.ll
+++ b/tests/codegen/llvm/map_value_int_scratch_buf.ll
@@ -48,8 +48,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %9 = load i64, ptr %lookup_elem, align 8
-  store i64 %9, ptr %8, align 8
+  %9 = load ptr, ptr %lookup_elem, align 8
+  store ptr %9, ptr %8, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/map_value_int_stack.ll
+++ b/tests/codegen/llvm/map_value_int_stack.ll
@@ -41,8 +41,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/nested_while_loop.ll
+++ b/tests/codegen/llvm/nested_while_loop.ll
@@ -64,8 +64,8 @@ while_end3:                                       ; preds = %while_cond1
   br label %while_cond
 
 lookup_success:                                   ; preds = %while_body2
-  %7 = load i64, ptr %lookup_elem, align 8
-  store i64 %7, ptr %lookup_elem_val, align 8
+  %7 = load ptr, ptr %lookup_elem, align 8
+  store ptr %7, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %while_body2

--- a/tests/codegen/llvm/pointer_add_int.ll
+++ b/tests/codegen/llvm/pointer_add_int.ll
@@ -16,13 +16,13 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$v" = alloca i64, align 8
+  %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
-  store i64 0, ptr %"$v", align 8
-  store i64 1000, ptr %"$v", align 8
-  %1 = load i64, ptr %"$v", align 8
-  %2 = add i64 %1, 20
-  store i64 %2, ptr %"$v", align 8
+  store i0 0, ptr %"$v", align 1
+  store ptr inttoptr (i64 1000 to ptr), ptr %"$v", align 8
+  %1 = load ptr, ptr %"$v", align 8
+  %2 = getelementptr i16, ptr %1, i64 10
+  store ptr %2, ptr %"$v", align 8
   ret i64 0
 }
 

--- a/tests/codegen/llvm/pointer_if_condition.ll
+++ b/tests/codegen/llvm/pointer_if_condition.ll
@@ -16,12 +16,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$v" = alloca i64, align 8
+  %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
-  store i64 0, ptr %"$v", align 8
-  store i64 1, ptr %"$v", align 8
-  %1 = load i64, ptr %"$v", align 8
-  %true_cond = icmp ne i64 %1, 0
+  store i0 0, ptr %"$v", align 1
+  store ptr inttoptr (i64 1 to ptr), ptr %"$v", align 8
+  %1 = load ptr, ptr %"$v", align 8
+  %true_cond = icmp ne ptr %1, null
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry

--- a/tests/codegen/llvm/pointer_inc_map.ll
+++ b/tests/codegen/llvm/pointer_inc_map.ll
@@ -18,15 +18,15 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
 entry:
-  %"@_newval" = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %"@_newval" = alloca ptr, align 8
+  %lookup_elem_val = alloca ptr, align 8
   %"@_key1" = alloca i64, align 8
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca ptr, align 8
   %"@_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1000, ptr %"@_val", align 8
+  store ptr inttoptr (i64 1000 to ptr), ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -38,20 +38,20 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, ptr %lookup_elem_val, align 8
+  store ptr null, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %2 = load i64, ptr %lookup_elem_val, align 8
+  %2 = load ptr, ptr %lookup_elem_val, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_newval")
-  %3 = add i64 %2, 2
-  store i64 %3, ptr %"@_newval", align 8
+  %3 = getelementptr i16, ptr %2, i32 1
+  store ptr %3, ptr %"@_newval", align 8
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key1", ptr %"@_newval", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_newval")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key1")

--- a/tests/codegen/llvm/pointer_inc_var.ll
+++ b/tests/codegen/llvm/pointer_inc_var.ll
@@ -16,13 +16,13 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$v" = alloca i64, align 8
+  %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
-  store i64 0, ptr %"$v", align 8
-  store i64 1000, ptr %"$v", align 8
-  %1 = load i64, ptr %"$v", align 8
-  %2 = add i64 %1, 2
-  store i64 %2, ptr %"$v", align 8
+  store i0 0, ptr %"$v", align 1
+  store ptr inttoptr (i64 1000 to ptr), ptr %"$v", align 8
+  %1 = load ptr, ptr %"$v", align 8
+  %2 = getelementptr i16, ptr %1, i32 1
+  store ptr %2, ptr %"$v", align 8
   ret i64 0
 }
 

--- a/tests/codegen/llvm/pointer_logical_and.ll
+++ b/tests/codegen/llvm/pointer_logical_and.ll
@@ -16,14 +16,14 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"&&_result" = alloca i8, align 1
-  %"$v" = alloca i64, align 8
+  %"&&_result" = alloca i1, align 1
+  %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
-  store i64 0, ptr %"$v", align 8
-  store i64 1, ptr %"$v", align 8
+  store i0 0, ptr %"$v", align 1
+  store ptr inttoptr (i64 1 to ptr), ptr %"$v", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
-  %1 = load i64, ptr %"$v", align 8
-  %lhs_true_cond = icmp ne i64 %1, 0
+  %1 = load ptr, ptr %"$v", align 8
+  %lhs_true_cond = icmp ne ptr %1, null
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 if_body:                                          ; preds = %"&&_merge"
@@ -36,16 +36,16 @@ if_end:                                           ; preds = %if_body, %"&&_merge
   br i1 false, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
-  store i8 1, ptr %"&&_result", align 1
+  store i1 true, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_false":                                       ; preds = %"&&_lhs_true", %entry
-  store i8 0, ptr %"&&_result", align 1
+  store i1 false, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %2 = load i8, ptr %"&&_result", align 1
-  %true_cond = icmp ne i8 %2, 0
+  %2 = load i1, ptr %"&&_result", align 1
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %if_body, label %if_end
 }
 

--- a/tests/codegen/llvm/pointer_logical_or.ll
+++ b/tests/codegen/llvm/pointer_logical_or.ll
@@ -16,14 +16,14 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"||_result" = alloca i8, align 1
-  %"$v" = alloca i64, align 8
+  %"||_result" = alloca i1, align 1
+  %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
-  store i64 0, ptr %"$v", align 8
-  store i64 1, ptr %"$v", align 8
+  store i0 0, ptr %"$v", align 1
+  store ptr inttoptr (i64 1 to ptr), ptr %"$v", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
-  %1 = load i64, ptr %"$v", align 8
-  %lhs_true_cond = icmp ne i64 %1, 0
+  %1 = load ptr, ptr %"$v", align 8
+  %lhs_true_cond = icmp ne ptr %1, null
   br i1 %lhs_true_cond, label %"||_true", label %"||_lhs_false"
 
 if_body:                                          ; preds = %"||_merge"
@@ -36,16 +36,16 @@ if_end:                                           ; preds = %if_body, %"||_merge
   br i1 false, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
-  store i8 0, ptr %"||_result", align 1
+  store i1 false, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_true":                                        ; preds = %"||_lhs_false", %entry
-  store i8 1, ptr %"||_result", align 1
+  store i1 true, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %2 = load i8, ptr %"||_result", align 1
-  %true_cond = icmp ne i8 %2, 0
+  %2 = load i1, ptr %"||_result", align 1
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %if_body, label %if_end
 }
 

--- a/tests/codegen/llvm/pointer_tenary_expression.ll
+++ b/tests/codegen/llvm/pointer_tenary_expression.ll
@@ -19,12 +19,12 @@ entry:
   %"$x" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
   store i64 0, ptr %"$x", align 8
-  %"$v" = alloca i64, align 8
+  %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
-  store i64 0, ptr %"$v", align 8
-  store i64 1, ptr %"$v", align 8
-  %1 = load i64, ptr %"$v", align 8
-  %true_cond = icmp ne i64 %1, 0
+  store i0 0, ptr %"$v", align 1
+  store ptr inttoptr (i64 1 to ptr), ptr %"$v", align 8
+  %1 = load ptr, ptr %"$v", align 8
+  %true_cond = icmp ne ptr %1, null
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry

--- a/tests/codegen/llvm/pred_binop.ll
+++ b/tests/codegen/llvm/pred_binop.ll
@@ -25,8 +25,7 @@ entry:
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
   %3 = icmp eq i64 %2, 1234
-  %4 = zext i1 %3 to i64
-  %predcond = icmp eq i64 %4, 0
+  %predcond = icmp eq i1 %3, false
   br i1 %predcond, label %pred_false, label %pred_true
 
 pred_false:                                       ; preds = %entry

--- a/tests/codegen/llvm/ptr_to_ptr.ll
+++ b/tests/codegen/llvm/ptr_to_ptr.ll
@@ -20,18 +20,18 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$res")
   store i32 0, ptr %"$res", align 4
   %deref1 = alloca i32, align 4
-  %deref = alloca i64, align 8
-  %"$pp" = alloca i64, align 8
+  %deref = alloca ptr, align 8
+  %"$pp" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$pp")
-  store i64 0, ptr %"$pp", align 8
-  store i64 0, ptr %"$pp", align 8
-  %1 = load i64, ptr %"$pp", align 8
+  store i0 0, ptr %"$pp", align 1
+  store ptr null, ptr %"$pp", align 8
+  %1 = load ptr, ptr %"$pp", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 8, i64 %1)
-  %2 = load i64, ptr %deref, align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 8, ptr %1)
+  %2 = load ptr, ptr %deref, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref1)
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %deref1, i32 4, i64 %2)
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to ptr)(ptr %deref1, i32 4, ptr %2)
   %3 = load i32, ptr %deref1, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref1)
   store i32 %3, ptr %"$res", align 4

--- a/tests/codegen/llvm/runtime_error_check_lookup.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup.ll
@@ -32,8 +32,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/runtime_error_check_lookup_no_warning.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup_no_warning.ll
@@ -31,8 +31,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -37,11 +37,10 @@ entry:
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
   %4 = load i1, ptr %strcmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
-  %5 = zext i1 %4 to i64
   call void @llvm.lifetime.end.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %6 = trunc i64 %5 to i8
-  store i8 %6, ptr %"@_key", align 1
+  %5 = zext i1 %4 to i8
+  store i8 %5, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -54,10 +53,10 @@ strcmp.done:                                      ; preds = %strcmp.loop13, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %7 = getelementptr i8, ptr %__builtin_comm, i32 1
-  %8 = load i8, ptr %7, align 1
-  %9 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
-  %strcmp.cmp3 = icmp ne i8 %8, %9
+  %6 = getelementptr i8, ptr %__builtin_comm, i32 1
+  %7 = load i8, ptr %6, align 1
+  %8 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
+  %strcmp.cmp3 = icmp ne i8 %7, %8
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -65,43 +64,43 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %10 = getelementptr i8, ptr %__builtin_comm, i32 2
-  %11 = load i8, ptr %10, align 1
-  %12 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
-  %strcmp.cmp7 = icmp ne i8 %11, %12
+  %9 = getelementptr i8, ptr %__builtin_comm, i32 2
+  %10 = load i8, ptr %9, align 1
+  %11 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
+  %strcmp.cmp7 = icmp ne i8 %10, %11
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %8, 0
+  %strcmp.cmp_null4 = icmp eq i8 %7, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %13 = getelementptr i8, ptr %__builtin_comm, i32 3
-  %14 = load i8, ptr %13, align 1
-  %15 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
-  %strcmp.cmp11 = icmp ne i8 %14, %15
+  %12 = getelementptr i8, ptr %__builtin_comm, i32 3
+  %13 = load i8, ptr %12, align 1
+  %14 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
+  %strcmp.cmp11 = icmp ne i8 %13, %14
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %11, 0
+  %strcmp.cmp_null8 = icmp eq i8 %10, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %16 = getelementptr i8, ptr %__builtin_comm, i32 4
-  %17 = load i8, ptr %16, align 1
-  %18 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
-  %strcmp.cmp15 = icmp ne i8 %17, %18
+  %15 = getelementptr i8, ptr %__builtin_comm, i32 4
+  %16 = load i8, ptr %15, align 1
+  %17 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
+  %strcmp.cmp15 = icmp ne i8 %16, %17
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %14, 0
+  %strcmp.cmp_null12 = icmp eq i8 %13, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
   br label %strcmp.done
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %17, 0
+  %strcmp.cmp_null16 = icmp eq i8 %16, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 }
 

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -37,11 +37,10 @@ entry:
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
   %4 = load i1, ptr %strcmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
-  %5 = zext i1 %4 to i64
   call void @llvm.lifetime.end.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %6 = trunc i64 %5 to i8
-  store i8 %6, ptr %"@_key", align 1
+  %5 = zext i1 %4 to i8
+  store i8 %5, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -54,10 +53,10 @@ strcmp.done:                                      ; preds = %strcmp.loop13, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %7 = getelementptr i8, ptr %__builtin_comm, i32 1
-  %8 = load i8, ptr %7, align 1
-  %9 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
-  %strcmp.cmp3 = icmp ne i8 %8, %9
+  %6 = getelementptr i8, ptr %__builtin_comm, i32 1
+  %7 = load i8, ptr %6, align 1
+  %8 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
+  %strcmp.cmp3 = icmp ne i8 %7, %8
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -65,43 +64,43 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %10 = getelementptr i8, ptr %__builtin_comm, i32 2
-  %11 = load i8, ptr %10, align 1
-  %12 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
-  %strcmp.cmp7 = icmp ne i8 %11, %12
+  %9 = getelementptr i8, ptr %__builtin_comm, i32 2
+  %10 = load i8, ptr %9, align 1
+  %11 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
+  %strcmp.cmp7 = icmp ne i8 %10, %11
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %8, 0
+  %strcmp.cmp_null4 = icmp eq i8 %7, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %13 = getelementptr i8, ptr %__builtin_comm, i32 3
-  %14 = load i8, ptr %13, align 1
-  %15 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
-  %strcmp.cmp11 = icmp ne i8 %14, %15
+  %12 = getelementptr i8, ptr %__builtin_comm, i32 3
+  %13 = load i8, ptr %12, align 1
+  %14 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
+  %strcmp.cmp11 = icmp ne i8 %13, %14
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %11, 0
+  %strcmp.cmp_null8 = icmp eq i8 %10, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %16 = getelementptr i8, ptr %__builtin_comm, i32 4
-  %17 = load i8, ptr %16, align 1
-  %18 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
-  %strcmp.cmp15 = icmp ne i8 %17, %18
+  %15 = getelementptr i8, ptr %__builtin_comm, i32 4
+  %16 = load i8, ptr %15, align 1
+  %17 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
+  %strcmp.cmp15 = icmp ne i8 %16, %17
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %14, 0
+  %strcmp.cmp_null12 = icmp eq i8 %13, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
   br label %strcmp.done
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %17, 0
+  %strcmp.cmp_null16 = icmp eq i8 %16, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 }
 

--- a/tests/codegen/llvm/strncmp_no_literals.ll
+++ b/tests/codegen/llvm/strncmp_no_literals.ll
@@ -30,8 +30,8 @@ entry:
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr null)
   %3 = call ptr @llvm.preserve.static.offset(ptr %0)
   %4 = getelementptr i8, ptr %3, i64 8
-  %5 = load volatile i64, ptr %4, align 8
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 1024, i64 %5)
+  %5 = load volatile ptr, ptr %4, align 8
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %2, i32 1024, ptr %5)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.memset.p0.i64(ptr align 1 %__builtin_comm, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to ptr)(ptr %__builtin_comm, i64 16)
@@ -60,9 +60,8 @@ pred_true:                                        ; preds = %strcmp.false
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
   %10 = load i1, ptr %strcmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
-  %11 = zext i1 %10 to i64
   call void @llvm.lifetime.end.p0(i64 -1, ptr %__builtin_comm)
-  %predcond = icmp eq i64 %11, 0
+  %predcond = icmp eq i1 %10, false
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.done:                                      ; preds = %strcmp.loop57, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp54, %strcmp.loop_null_cmp50, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp42, %strcmp.loop_null_cmp38, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp30, %strcmp.loop_null_cmp26, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp18, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
@@ -70,11 +69,11 @@ strcmp.done:                                      ; preds = %strcmp.loop57, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %12 = getelementptr i8, ptr %2, i32 1
-  %13 = load i8, ptr %12, align 1
-  %14 = getelementptr i8, ptr %__builtin_comm, i32 1
-  %15 = load i8, ptr %14, align 1
-  %strcmp.cmp3 = icmp ne i8 %13, %15
+  %11 = getelementptr i8, ptr %2, i32 1
+  %12 = load i8, ptr %11, align 1
+  %13 = getelementptr i8, ptr %__builtin_comm, i32 1
+  %14 = load i8, ptr %13, align 1
+  %strcmp.cmp3 = icmp ne i8 %12, %14
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -82,178 +81,178 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %16 = getelementptr i8, ptr %2, i32 2
-  %17 = load i8, ptr %16, align 1
-  %18 = getelementptr i8, ptr %__builtin_comm, i32 2
-  %19 = load i8, ptr %18, align 1
-  %strcmp.cmp7 = icmp ne i8 %17, %19
+  %15 = getelementptr i8, ptr %2, i32 2
+  %16 = load i8, ptr %15, align 1
+  %17 = getelementptr i8, ptr %__builtin_comm, i32 2
+  %18 = load i8, ptr %17, align 1
+  %strcmp.cmp7 = icmp ne i8 %16, %18
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %13, 0
+  %strcmp.cmp_null4 = icmp eq i8 %12, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %20 = getelementptr i8, ptr %2, i32 3
-  %21 = load i8, ptr %20, align 1
-  %22 = getelementptr i8, ptr %__builtin_comm, i32 3
-  %23 = load i8, ptr %22, align 1
-  %strcmp.cmp11 = icmp ne i8 %21, %23
+  %19 = getelementptr i8, ptr %2, i32 3
+  %20 = load i8, ptr %19, align 1
+  %21 = getelementptr i8, ptr %__builtin_comm, i32 3
+  %22 = load i8, ptr %21, align 1
+  %strcmp.cmp11 = icmp ne i8 %20, %22
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %17, 0
+  %strcmp.cmp_null8 = icmp eq i8 %16, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %24 = getelementptr i8, ptr %2, i32 4
-  %25 = load i8, ptr %24, align 1
-  %26 = getelementptr i8, ptr %__builtin_comm, i32 4
-  %27 = load i8, ptr %26, align 1
-  %strcmp.cmp15 = icmp ne i8 %25, %27
+  %23 = getelementptr i8, ptr %2, i32 4
+  %24 = load i8, ptr %23, align 1
+  %25 = getelementptr i8, ptr %__builtin_comm, i32 4
+  %26 = load i8, ptr %25, align 1
+  %strcmp.cmp15 = icmp ne i8 %24, %26
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %21, 0
+  %strcmp.cmp_null12 = icmp eq i8 %20, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
-  %28 = getelementptr i8, ptr %2, i32 5
-  %29 = load i8, ptr %28, align 1
-  %30 = getelementptr i8, ptr %__builtin_comm, i32 5
-  %31 = load i8, ptr %30, align 1
-  %strcmp.cmp19 = icmp ne i8 %29, %31
+  %27 = getelementptr i8, ptr %2, i32 5
+  %28 = load i8, ptr %27, align 1
+  %29 = getelementptr i8, ptr %__builtin_comm, i32 5
+  %30 = load i8, ptr %29, align 1
+  %strcmp.cmp19 = icmp ne i8 %28, %30
   br i1 %strcmp.cmp19, label %strcmp.false, label %strcmp.loop_null_cmp18
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %25, 0
+  %strcmp.cmp_null16 = icmp eq i8 %24, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 strcmp.loop17:                                    ; preds = %strcmp.loop_null_cmp18
-  %32 = getelementptr i8, ptr %2, i32 6
-  %33 = load i8, ptr %32, align 1
-  %34 = getelementptr i8, ptr %__builtin_comm, i32 6
-  %35 = load i8, ptr %34, align 1
-  %strcmp.cmp23 = icmp ne i8 %33, %35
+  %31 = getelementptr i8, ptr %2, i32 6
+  %32 = load i8, ptr %31, align 1
+  %33 = getelementptr i8, ptr %__builtin_comm, i32 6
+  %34 = load i8, ptr %33, align 1
+  %strcmp.cmp23 = icmp ne i8 %32, %34
   br i1 %strcmp.cmp23, label %strcmp.false, label %strcmp.loop_null_cmp22
 
 strcmp.loop_null_cmp18:                           ; preds = %strcmp.loop13
-  %strcmp.cmp_null20 = icmp eq i8 %29, 0
+  %strcmp.cmp_null20 = icmp eq i8 %28, 0
   br i1 %strcmp.cmp_null20, label %strcmp.done, label %strcmp.loop17
 
 strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
-  %36 = getelementptr i8, ptr %2, i32 7
-  %37 = load i8, ptr %36, align 1
-  %38 = getelementptr i8, ptr %__builtin_comm, i32 7
-  %39 = load i8, ptr %38, align 1
-  %strcmp.cmp27 = icmp ne i8 %37, %39
+  %35 = getelementptr i8, ptr %2, i32 7
+  %36 = load i8, ptr %35, align 1
+  %37 = getelementptr i8, ptr %__builtin_comm, i32 7
+  %38 = load i8, ptr %37, align 1
+  %strcmp.cmp27 = icmp ne i8 %36, %38
   br i1 %strcmp.cmp27, label %strcmp.false, label %strcmp.loop_null_cmp26
 
 strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop17
-  %strcmp.cmp_null24 = icmp eq i8 %33, 0
+  %strcmp.cmp_null24 = icmp eq i8 %32, 0
   br i1 %strcmp.cmp_null24, label %strcmp.done, label %strcmp.loop21
 
 strcmp.loop25:                                    ; preds = %strcmp.loop_null_cmp26
-  %40 = getelementptr i8, ptr %2, i32 8
-  %41 = load i8, ptr %40, align 1
-  %42 = getelementptr i8, ptr %__builtin_comm, i32 8
-  %43 = load i8, ptr %42, align 1
-  %strcmp.cmp31 = icmp ne i8 %41, %43
+  %39 = getelementptr i8, ptr %2, i32 8
+  %40 = load i8, ptr %39, align 1
+  %41 = getelementptr i8, ptr %__builtin_comm, i32 8
+  %42 = load i8, ptr %41, align 1
+  %strcmp.cmp31 = icmp ne i8 %40, %42
   br i1 %strcmp.cmp31, label %strcmp.false, label %strcmp.loop_null_cmp30
 
 strcmp.loop_null_cmp26:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null28 = icmp eq i8 %37, 0
+  %strcmp.cmp_null28 = icmp eq i8 %36, 0
   br i1 %strcmp.cmp_null28, label %strcmp.done, label %strcmp.loop25
 
 strcmp.loop29:                                    ; preds = %strcmp.loop_null_cmp30
-  %44 = getelementptr i8, ptr %2, i32 9
-  %45 = load i8, ptr %44, align 1
-  %46 = getelementptr i8, ptr %__builtin_comm, i32 9
-  %47 = load i8, ptr %46, align 1
-  %strcmp.cmp35 = icmp ne i8 %45, %47
+  %43 = getelementptr i8, ptr %2, i32 9
+  %44 = load i8, ptr %43, align 1
+  %45 = getelementptr i8, ptr %__builtin_comm, i32 9
+  %46 = load i8, ptr %45, align 1
+  %strcmp.cmp35 = icmp ne i8 %44, %46
   br i1 %strcmp.cmp35, label %strcmp.false, label %strcmp.loop_null_cmp34
 
 strcmp.loop_null_cmp30:                           ; preds = %strcmp.loop25
-  %strcmp.cmp_null32 = icmp eq i8 %41, 0
+  %strcmp.cmp_null32 = icmp eq i8 %40, 0
   br i1 %strcmp.cmp_null32, label %strcmp.done, label %strcmp.loop29
 
 strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
-  %48 = getelementptr i8, ptr %2, i32 10
-  %49 = load i8, ptr %48, align 1
-  %50 = getelementptr i8, ptr %__builtin_comm, i32 10
-  %51 = load i8, ptr %50, align 1
-  %strcmp.cmp39 = icmp ne i8 %49, %51
+  %47 = getelementptr i8, ptr %2, i32 10
+  %48 = load i8, ptr %47, align 1
+  %49 = getelementptr i8, ptr %__builtin_comm, i32 10
+  %50 = load i8, ptr %49, align 1
+  %strcmp.cmp39 = icmp ne i8 %48, %50
   br i1 %strcmp.cmp39, label %strcmp.false, label %strcmp.loop_null_cmp38
 
 strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop29
-  %strcmp.cmp_null36 = icmp eq i8 %45, 0
+  %strcmp.cmp_null36 = icmp eq i8 %44, 0
   br i1 %strcmp.cmp_null36, label %strcmp.done, label %strcmp.loop33
 
 strcmp.loop37:                                    ; preds = %strcmp.loop_null_cmp38
-  %52 = getelementptr i8, ptr %2, i32 11
-  %53 = load i8, ptr %52, align 1
-  %54 = getelementptr i8, ptr %__builtin_comm, i32 11
-  %55 = load i8, ptr %54, align 1
-  %strcmp.cmp43 = icmp ne i8 %53, %55
+  %51 = getelementptr i8, ptr %2, i32 11
+  %52 = load i8, ptr %51, align 1
+  %53 = getelementptr i8, ptr %__builtin_comm, i32 11
+  %54 = load i8, ptr %53, align 1
+  %strcmp.cmp43 = icmp ne i8 %52, %54
   br i1 %strcmp.cmp43, label %strcmp.false, label %strcmp.loop_null_cmp42
 
 strcmp.loop_null_cmp38:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null40 = icmp eq i8 %49, 0
+  %strcmp.cmp_null40 = icmp eq i8 %48, 0
   br i1 %strcmp.cmp_null40, label %strcmp.done, label %strcmp.loop37
 
 strcmp.loop41:                                    ; preds = %strcmp.loop_null_cmp42
-  %56 = getelementptr i8, ptr %2, i32 12
-  %57 = load i8, ptr %56, align 1
-  %58 = getelementptr i8, ptr %__builtin_comm, i32 12
-  %59 = load i8, ptr %58, align 1
-  %strcmp.cmp47 = icmp ne i8 %57, %59
+  %55 = getelementptr i8, ptr %2, i32 12
+  %56 = load i8, ptr %55, align 1
+  %57 = getelementptr i8, ptr %__builtin_comm, i32 12
+  %58 = load i8, ptr %57, align 1
+  %strcmp.cmp47 = icmp ne i8 %56, %58
   br i1 %strcmp.cmp47, label %strcmp.false, label %strcmp.loop_null_cmp46
 
 strcmp.loop_null_cmp42:                           ; preds = %strcmp.loop37
-  %strcmp.cmp_null44 = icmp eq i8 %53, 0
+  %strcmp.cmp_null44 = icmp eq i8 %52, 0
   br i1 %strcmp.cmp_null44, label %strcmp.done, label %strcmp.loop41
 
 strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
-  %60 = getelementptr i8, ptr %2, i32 13
-  %61 = load i8, ptr %60, align 1
-  %62 = getelementptr i8, ptr %__builtin_comm, i32 13
-  %63 = load i8, ptr %62, align 1
-  %strcmp.cmp51 = icmp ne i8 %61, %63
+  %59 = getelementptr i8, ptr %2, i32 13
+  %60 = load i8, ptr %59, align 1
+  %61 = getelementptr i8, ptr %__builtin_comm, i32 13
+  %62 = load i8, ptr %61, align 1
+  %strcmp.cmp51 = icmp ne i8 %60, %62
   br i1 %strcmp.cmp51, label %strcmp.false, label %strcmp.loop_null_cmp50
 
 strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop41
-  %strcmp.cmp_null48 = icmp eq i8 %57, 0
+  %strcmp.cmp_null48 = icmp eq i8 %56, 0
   br i1 %strcmp.cmp_null48, label %strcmp.done, label %strcmp.loop45
 
 strcmp.loop49:                                    ; preds = %strcmp.loop_null_cmp50
-  %64 = getelementptr i8, ptr %2, i32 14
-  %65 = load i8, ptr %64, align 1
-  %66 = getelementptr i8, ptr %__builtin_comm, i32 14
-  %67 = load i8, ptr %66, align 1
-  %strcmp.cmp55 = icmp ne i8 %65, %67
+  %63 = getelementptr i8, ptr %2, i32 14
+  %64 = load i8, ptr %63, align 1
+  %65 = getelementptr i8, ptr %__builtin_comm, i32 14
+  %66 = load i8, ptr %65, align 1
+  %strcmp.cmp55 = icmp ne i8 %64, %66
   br i1 %strcmp.cmp55, label %strcmp.false, label %strcmp.loop_null_cmp54
 
 strcmp.loop_null_cmp50:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null52 = icmp eq i8 %61, 0
+  %strcmp.cmp_null52 = icmp eq i8 %60, 0
   br i1 %strcmp.cmp_null52, label %strcmp.done, label %strcmp.loop49
 
 strcmp.loop53:                                    ; preds = %strcmp.loop_null_cmp54
-  %68 = getelementptr i8, ptr %2, i32 15
-  %69 = load i8, ptr %68, align 1
-  %70 = getelementptr i8, ptr %__builtin_comm, i32 15
-  %71 = load i8, ptr %70, align 1
-  %strcmp.cmp59 = icmp ne i8 %69, %71
+  %67 = getelementptr i8, ptr %2, i32 15
+  %68 = load i8, ptr %67, align 1
+  %69 = getelementptr i8, ptr %__builtin_comm, i32 15
+  %70 = load i8, ptr %69, align 1
+  %strcmp.cmp59 = icmp ne i8 %68, %70
   br i1 %strcmp.cmp59, label %strcmp.false, label %strcmp.loop_null_cmp58
 
 strcmp.loop_null_cmp54:                           ; preds = %strcmp.loop49
-  %strcmp.cmp_null56 = icmp eq i8 %65, 0
+  %strcmp.cmp_null56 = icmp eq i8 %64, 0
   br i1 %strcmp.cmp_null56, label %strcmp.done, label %strcmp.loop53
 
 strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
   br label %strcmp.done
 
 strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop53
-  %strcmp.cmp_null60 = icmp eq i8 %69, 0
+  %strcmp.cmp_null60 = icmp eq i8 %68, 0
   br i1 %strcmp.cmp_null60, label %strcmp.done, label %strcmp.loop57
 }
 

--- a/tests/codegen/llvm/strncmp_one_literal.ll
+++ b/tests/codegen/llvm/strncmp_one_literal.ll
@@ -37,9 +37,9 @@ entry:
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop, %entry
   %4 = load i1, ptr %strcmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
-  %5 = zext i1 %4 to i64
   call void @llvm.lifetime.end.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
+  %5 = zext i1 %4 to i64
   store i64 %5, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -21,26 +21,27 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i8, align 1
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
-  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
-  %6 = getelementptr i8, ptr %5, i64 0
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = ptrtoint ptr %3 to i64
+  store i64 %4, ptr %"$foo", align 8
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 1, ptr %6)
-  %7 = load i8, ptr %"struct Foo.x", align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 1, ptr %7)
+  %8 = load i8, ptr %"struct Foo.x", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %8 = sext i8 %7 to i64
-  store i64 %8, ptr %"@x_val", align 8
+  %9 = sext i8 %8 to i64
+  store i64 %9, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -21,15 +21,15 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i8, align 1
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
+  %4 = load ptr, ptr %"$foo", align 8
   %5 = call ptr @llvm.preserve.static.offset(ptr %4)
   %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -21,31 +21,32 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %deref = alloca i32, align 4
-  %"struct Foo.x" = alloca i64, align 8
-  %"$foo" = alloca i64, align 8
+  %"struct Foo.x" = alloca ptr, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
-  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
-  %6 = getelementptr i8, ptr %5, i64 0
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = ptrtoint ptr %3 to i64
+  store i64 %4, ptr %"$foo", align 8
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, ptr %6)
-  %7 = load i64, ptr %"struct Foo.x", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, ptr %7)
+  %8 = load ptr, ptr %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 4, i64 %7)
-  %8 = load i32, ptr %deref, align 4
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 4, ptr %8)
+  %9 = load i32, ptr %deref, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %9 = sext i32 %8 to i64
-  store i64 %9, ptr %"@x_val", align 8
+  %10 = sext i32 %9 to i64
+  store i64 %10, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -21,24 +21,24 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %deref = alloca i32, align 4
-  %"struct Foo.x" = alloca i64, align 8
-  %"$foo" = alloca i64, align 8
+  %"struct Foo.x" = alloca ptr, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
+  %4 = load ptr, ptr %"$foo", align 8
   %5 = call ptr @llvm.preserve.static.offset(ptr %4)
   %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, ptr %6)
-  %7 = load i64, ptr %"struct Foo.x", align 8
+  %7 = load ptr, ptr %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 4, i64 %7)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 4, ptr %7)
   %8 = load i32, ptr %deref, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -21,26 +21,27 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i32, align 4
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
-  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
-  %6 = getelementptr i8, ptr %5, i64 0
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = ptrtoint ptr %3 to i64
+  store i64 %4, ptr %"$foo", align 8
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 4, ptr %6)
-  %7 = load i32, ptr %"struct Foo.x", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 4, ptr %7)
+  %8 = load i32, ptr %"struct Foo.x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %8 = sext i32 %7 to i64
-  store i64 %8, ptr %"@x_val", align 8
+  %9 = sext i32 %8 to i64
+  store i64 %9, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -21,15 +21,15 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i32, align 4
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
+  %4 = load ptr, ptr %"$foo", align 8
   %5 = call ptr @llvm.preserve.static.offset(ptr %4)
   %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")

--- a/tests/codegen/llvm/struct_long_1.ll
+++ b/tests/codegen/llvm/struct_long_1.ll
@@ -21,25 +21,26 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i64, align 8
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
-  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
-  %6 = getelementptr i8, ptr %5, i64 0
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = ptrtoint ptr %3 to i64
+  store i64 %4, ptr %"$foo", align 8
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, ptr %6)
-  %7 = load i64, ptr %"struct Foo.x", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 8, ptr %7)
+  %8 = load i64, ptr %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %7, ptr %"@x_val", align 8
+  store i64 %8, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/struct_long_2.ll
+++ b/tests/codegen/llvm/struct_long_2.ll
@@ -21,15 +21,15 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i64, align 8
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
+  %4 = load ptr, ptr %"$foo", align 8
   %5 = call ptr @llvm.preserve.static.offset(ptr %4)
   %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -21,28 +21,29 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Foo::(unnamed at definitions.h:2:14).x" = alloca i32, align 4
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
-  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
-  %6 = getelementptr i8, ptr %5, i64 0
-  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
-  %8 = getelementptr i8, ptr %7, i64 0
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = ptrtoint ptr %3 to i64
+  store i64 %4, ptr %"$foo", align 8
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
+  %8 = call ptr @llvm.preserve.static.offset(ptr %7)
+  %9 = getelementptr i8, ptr %8, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo::(unnamed at definitions.h:2:14).x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo::(unnamed at definitions.h:2:14).x", i32 4, ptr %8)
-  %9 = load i32, ptr %"struct Foo::(unnamed at definitions.h:2:14).x", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo::(unnamed at definitions.h:2:14).x", i32 4, ptr %9)
+  %10 = load i32, ptr %"struct Foo::(unnamed at definitions.h:2:14).x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo::(unnamed at definitions.h:2:14).x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %10 = sext i32 %9 to i64
-  store i64 %10, ptr %"@x_val", align 8
+  %11 = sext i32 %10 to i64
+  store i64 %11, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -21,15 +21,15 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Foo::(unnamed at definitions.h:2:14).x" = alloca i32, align 4
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
+  %4 = load ptr, ptr %"$foo", align 8
   %5 = call ptr @llvm.preserve.static.offset(ptr %4)
   %6 = getelementptr i8, ptr %5, i64 0
   %7 = call ptr @llvm.preserve.static.offset(ptr %6)

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -21,28 +21,29 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Bar.x" = alloca i32, align 4
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
-  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
-  %6 = getelementptr i8, ptr %5, i64 0
-  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
-  %8 = getelementptr i8, ptr %7, i64 0
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = ptrtoint ptr %3 to i64
+  store i64 %4, ptr %"$foo", align 8
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
+  %8 = call ptr @llvm.preserve.static.offset(ptr %7)
+  %9 = getelementptr i8, ptr %8, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Bar.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, ptr %8)
-  %9 = load i32, ptr %"struct Bar.x", align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, ptr %9)
+  %10 = load i32, ptr %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Bar.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %10 = sext i32 %9 to i64
-  store i64 %10, ptr %"@x_val", align 8
+  %11 = sext i32 %10 to i64
+  store i64 %11, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -21,15 +21,15 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Bar.x" = alloca i32, align 4
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
+  %4 = load ptr, ptr %"$foo", align 8
   %5 = call ptr @llvm.preserve.static.offset(ptr %4)
   %6 = getelementptr i8, ptr %5, i64 0
   %7 = call ptr @llvm.preserve.static.offset(ptr %6)

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -21,23 +21,23 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Bar.x" = alloca i32, align 4
-  %"struct Foo.bar" = alloca i64, align 8
-  %"$foo" = alloca i64, align 8
+  %"struct Foo.bar" = alloca ptr, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
-  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
-  %6 = getelementptr i8, ptr %5, i64 0
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = ptrtoint ptr %3 to i64
+  store i64 %4, ptr %"$foo", align 8
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.bar")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.bar", i32 8, ptr %6)
-  %7 = load i64, ptr %"struct Foo.bar", align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.bar", i32 8, ptr %7)
+  %8 = load ptr, ptr %"struct Foo.bar", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.bar")
-  %8 = inttoptr i64 %7 to ptr
   %9 = call ptr @llvm.preserve.static.offset(ptr %8)
   %10 = getelementptr i8, ptr %9, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Bar.x")

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -21,34 +21,33 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Bar.x" = alloca i32, align 4
-  %"struct Foo.bar" = alloca i64, align 8
-  %"$foo" = alloca i64, align 8
+  %"struct Foo.bar" = alloca ptr, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
+  %4 = load ptr, ptr %"$foo", align 8
   %5 = call ptr @llvm.preserve.static.offset(ptr %4)
   %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.bar")
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.bar", i32 8, ptr %6)
-  %7 = load i64, ptr %"struct Foo.bar", align 8
+  %7 = load ptr, ptr %"struct Foo.bar", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.bar")
-  %8 = inttoptr i64 %7 to ptr
-  %9 = call ptr @llvm.preserve.static.offset(ptr %8)
-  %10 = getelementptr i8, ptr %9, i64 0
+  %8 = call ptr @llvm.preserve.static.offset(ptr %7)
+  %9 = getelementptr i8, ptr %8, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Bar.x")
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, ptr %10)
-  %11 = load i32, ptr %"struct Bar.x", align 4
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Bar.x", i32 4, ptr %9)
+  %10 = load i32, ptr %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Bar.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %12 = sext i32 %11 to i64
-  store i64 %12, ptr %"@x_val", align 8
+  %11 = sext i32 %10 to i64
+  store i64 %11, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/struct_save_1.ll
+++ b/tests/codegen/llvm/struct_save_1.ll
@@ -23,10 +23,11 @@ entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key")
   store i64 0, ptr %"@foo_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_val")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@foo_val", i32 12, i64 %arg0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@foo_val", i32 12, ptr %3)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_foo, ptr %"@foo_key", ptr %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_key")

--- a/tests/codegen/llvm/struct_save_2.ll
+++ b/tests/codegen/llvm/struct_save_2.ll
@@ -23,10 +23,11 @@ entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key")
   store i64 0, ptr %"@foo_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_val")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@foo_val", i32 12, i64 %arg0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@foo_val", i32 12, ptr %3)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_foo, ptr %"@foo_key", ptr %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_key")

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -34,10 +34,11 @@ entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key")
   store i64 0, ptr %"@foo_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_val")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@foo_val", i32 16, i64 %arg0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@foo_val", i32 16, ptr %3)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_foo, ptr %"@foo_key", ptr %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_key")
@@ -58,10 +59,10 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_key1")
-  %3 = getelementptr [16 x i8], ptr %lookup_elem_val, i32 0, i64 4
+  %4 = getelementptr [16 x i8], ptr %lookup_elem_val, i32 0, i64 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@bar_key")
   store i64 0, ptr %"@bar_key", align 8
-  %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_bar, ptr %"@bar_key", ptr %3, i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_bar, ptr %"@bar_key", ptr %4, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@bar_key")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key3")
@@ -81,15 +82,15 @@ lookup_failure6:                                  ; preds = %lookup_merge
 
 lookup_merge7:                                    ; preds = %lookup_failure6, %lookup_success5
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_key3")
-  %4 = getelementptr [16 x i8], ptr %lookup_elem_val8, i32 0, i64 4
-  %5 = getelementptr [8 x i8], ptr %4, i32 0, i64 0
-  %6 = load volatile i32, ptr %5, align 4
+  %5 = getelementptr [16 x i8], ptr %lookup_elem_val8, i32 0, i64 4
+  %6 = getelementptr [8 x i8], ptr %5, i32 0, i64 0
+  %7 = load volatile i32, ptr %6, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val8)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %7 = sext i32 %6 to i64
-  store i64 %7, ptr %"@x_val", align 8
+  %8 = sext i32 %7 to i64
+  store i64 %8, ptr %"@x_val", align 8
   %update_elem10 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/struct_save_string.ll
+++ b/tests/codegen/llvm/struct_save_string.ll
@@ -28,10 +28,11 @@ entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
+  %3 = inttoptr i64 %arg0 to ptr
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_key")
   store i64 0, ptr %"@foo_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@foo_val")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@foo_val", i32 32, i64 %arg0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@foo_val", i32 32, ptr %3)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_foo, ptr %"@foo_key", ptr %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_key")
@@ -52,10 +53,10 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@foo_key1")
-  %3 = getelementptr [32 x i8], ptr %lookup_elem_val, i32 0, i64 0
+  %4 = getelementptr [32 x i8], ptr %lookup_elem_val, i32 0, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@str_key")
   store i64 0, ptr %"@str_key", align 8
-  %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_str, ptr %"@str_key", ptr %3, i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_str, ptr %"@str_key", ptr %4, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@str_key")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   ret i64 0

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -21,26 +21,27 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i16, align 2
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
-  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
-  %6 = getelementptr i8, ptr %5, i64 0
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = ptrtoint ptr %3 to i64
+  store i64 %4, ptr %"$foo", align 8
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 2, ptr %6)
-  %7 = load i16, ptr %"struct Foo.x", align 2
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.x", i32 2, ptr %7)
+  %8 = load i16, ptr %"struct Foo.x", align 2
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.x")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %8 = sext i16 %7 to i64
-  store i64 %8, ptr %"@x_val", align 8
+  %9 = sext i16 %8 to i64
+  store i64 %9, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -21,15 +21,15 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i16, align 2
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
+  %4 = load ptr, ptr %"$foo", align 8
   %5 = call ptr @llvm.preserve.static.offset(ptr %4)
   %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.x")

--- a/tests/codegen/llvm/struct_string_array_1.ll
+++ b/tests/codegen/llvm/struct_string_array_1.ll
@@ -20,19 +20,20 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
   %"@mystr_key" = alloca i64, align 8
   %"struct Foo.str" = alloca [33 x i8], align 1
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
-  %5 = call ptr @llvm.preserve.static.offset(ptr %4)
-  %6 = getelementptr i8, ptr %5, i64 0
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = ptrtoint ptr %3 to i64
+  store i64 %4, ptr %"$foo", align 8
+  %5 = load ptr, ptr %"$foo", align 8
+  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
+  %7 = getelementptr i8, ptr %6, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.str")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.str", i32 33, ptr %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.str", i32 33, ptr %7)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@mystr_key")
   store i64 0, ptr %"@mystr_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_mystr, ptr %"@mystr_key", ptr %"struct Foo.str", i64 0)

--- a/tests/codegen/llvm/struct_string_array_2.ll
+++ b/tests/codegen/llvm/struct_string_array_2.ll
@@ -20,15 +20,15 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
   %"@mystr_key" = alloca i64, align 8
   %"struct Foo.str" = alloca [33 x i8], align 1
-  %"$foo" = alloca i64, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
-  %3 = load i64, ptr %"$foo", align 8
-  %4 = inttoptr i64 %3 to ptr
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
+  %4 = load ptr, ptr %"$foo", align 8
   %5 = call ptr @llvm.preserve.static.offset(ptr %4)
   %6 = getelementptr i8, ptr %5, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.str")

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -20,31 +20,31 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !54 {
 entry:
   %"@mystr_key" = alloca i64, align 8
-  %"struct Foo.str" = alloca i64, align 8
-  %"$foo" = alloca i64, align 8
+  %"struct Foo.str" = alloca ptr, align 8
+  %"$foo" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
-  store i64 0, ptr %"$foo", align 8
+  store i0 0, ptr %"$foo", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  store i64 %arg0, ptr %"$foo", align 8
+  %3 = inttoptr i64 %arg0 to ptr
+  store ptr %3, ptr %"$foo", align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %3 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %3
-  %4 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %4, i32 1024, ptr null)
-  %5 = load i64, ptr %"$foo", align 8
-  %6 = inttoptr i64 %5 to ptr
+  %4 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %4
+  %5 = getelementptr [1 x [1 x [1024 x i8]]], ptr @__bt__get_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %5, i32 1024, ptr null)
+  %6 = load ptr, ptr %"$foo", align 8
   %7 = call ptr @llvm.preserve.static.offset(ptr %6)
   %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct Foo.str")
   %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct Foo.str", i32 8, ptr %8)
-  %9 = load i64, ptr %"struct Foo.str", align 8
+  %9 = load ptr, ptr %"struct Foo.str", align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct Foo.str")
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %4, i32 1024, i64 %9)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %5, i32 1024, ptr %9)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@mystr_key")
   store i64 0, ptr %"@mystr_key", align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_mystr, ptr %"@mystr_key", ptr %4, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_mystr, ptr %"@mystr_key", ptr %5, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@mystr_key")
   ret i64 0
 }

--- a/tests/codegen/llvm/tuple_array_struct.ll
+++ b/tests/codegen/llvm/tuple_array_struct.ll
@@ -24,18 +24,19 @@ entry:
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
-  %3 = call ptr @llvm.preserve.static.offset(ptr %0)
-  %4 = getelementptr i8, ptr %3, i64 104
-  %arg1 = load volatile i64, ptr %4, align 8
-  %5 = inttoptr i64 %arg1 to ptr
-  %6 = call ptr @llvm.preserve.static.offset(ptr %5)
-  %7 = getelementptr i8, ptr %6, i64 0
+  %3 = inttoptr i64 %arg0 to ptr
+  %4 = call ptr @llvm.preserve.static.offset(ptr %0)
+  %5 = getelementptr i8, ptr %4, i64 104
+  %arg1 = load volatile i64, ptr %5, align 8
+  %6 = inttoptr i64 %arg1 to ptr
+  %7 = call ptr @llvm.preserve.static.offset(ptr %6)
+  %8 = getelementptr i8, ptr %7, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 24, i1 false)
-  %8 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %tuple, i32 0, i32 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %8, i32 8, i64 %arg0)
-  %9 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %tuple, i32 0, i32 1
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %9, i32 16, ptr %7)
+  %9 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %tuple, i32 0, i32 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %9, i32 8, ptr %3)
+  %10 = getelementptr %"struct Foo_int32[4]__tuple_t", ptr %tuple, i32 0, i32 1
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to ptr)(ptr %10, i32 16, ptr %8)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %tuple, i64 0)

--- a/tests/codegen/llvm/unroll.ll
+++ b/tests/codegen/llvm/unroll.ll
@@ -55,8 +55,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load i64, ptr %lookup_elem, align 8
-  store i64 %1, ptr %lookup_elem_val, align 8
+  %1 = load ptr, ptr %lookup_elem, align 8
+  store ptr %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -83,8 +83,8 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br i1 %map_lookup_cond11, label %lookup_success7, label %lookup_failure8
 
 lookup_success7:                                  ; preds = %lookup_merge
-  %4 = load i64, ptr %lookup_elem6, align 8
-  store i64 %4, ptr %lookup_elem_val10, align 8
+  %4 = load ptr, ptr %lookup_elem6, align 8
+  store ptr %4, ptr %lookup_elem_val10, align 8
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %lookup_merge
@@ -111,8 +111,8 @@ lookup_merge9:                                    ; preds = %lookup_failure8, %l
   br i1 %map_lookup_cond21, label %lookup_success17, label %lookup_failure18
 
 lookup_success17:                                 ; preds = %lookup_merge9
-  %7 = load i64, ptr %lookup_elem16, align 8
-  store i64 %7, ptr %lookup_elem_val20, align 8
+  %7 = load ptr, ptr %lookup_elem16, align 8
+  store ptr %7, ptr %lookup_elem_val20, align 8
   br label %lookup_merge19
 
 lookup_failure18:                                 ; preds = %lookup_merge9
@@ -139,8 +139,8 @@ lookup_merge19:                                   ; preds = %lookup_failure18, %
   br i1 %map_lookup_cond31, label %lookup_success27, label %lookup_failure28
 
 lookup_success27:                                 ; preds = %lookup_merge19
-  %10 = load i64, ptr %lookup_elem26, align 8
-  store i64 %10, ptr %lookup_elem_val30, align 8
+  %10 = load ptr, ptr %lookup_elem26, align 8
+  store ptr %10, ptr %lookup_elem_val30, align 8
   br label %lookup_merge29
 
 lookup_failure28:                                 ; preds = %lookup_merge19
@@ -167,8 +167,8 @@ lookup_merge29:                                   ; preds = %lookup_failure28, %
   br i1 %map_lookup_cond41, label %lookup_success37, label %lookup_failure38
 
 lookup_success37:                                 ; preds = %lookup_merge29
-  %13 = load i64, ptr %lookup_elem36, align 8
-  store i64 %13, ptr %lookup_elem_val40, align 8
+  %13 = load ptr, ptr %lookup_elem36, align 8
+  store ptr %13, ptr %lookup_elem_val40, align 8
   br label %lookup_merge39
 
 lookup_failure38:                                 ; preds = %lookup_merge29

--- a/tests/codegen/llvm/variable_assign_array.ll
+++ b/tests/codegen/llvm/variable_assign_array.ll
@@ -21,9 +21,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %array_access = alloca i32, align 4
-  %"$var" = alloca i64, align 8
+  %"$var" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
-  store i64 0, ptr %"$var", align 8
+  store i0 0, ptr %"$var", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
@@ -32,19 +32,20 @@ entry:
   %5 = getelementptr i8, ptr %4, i64 0
   %6 = ptrtoint ptr %5 to i64
   store i64 %6, ptr %"$var", align 8
-  %7 = load i64, ptr %"$var", align 8
-  %8 = inttoptr i64 %7 to ptr
-  %9 = call ptr @llvm.preserve.static.offset(ptr %8)
-  %10 = getelementptr i8, ptr %9, i64 0
+  %7 = load ptr, ptr %"$var", align 8
+  %8 = ptrtoint ptr %7 to i64
+  %9 = inttoptr i64 %8 to ptr
+  %10 = call ptr @llvm.preserve.static.offset(ptr %9)
+  %11 = getelementptr i8, ptr %10, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %array_access)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %array_access, i32 4, ptr %10)
-  %11 = load i32, ptr %array_access, align 4
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %array_access, i32 4, ptr %11)
+  %12 = load i32, ptr %array_access, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %array_access)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %12 = sext i32 %11 to i64
-  store i64 %12, ptr %"@x_val", align 8
+  %13 = sext i32 %12 to i64
+  store i64 %13, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/runtime/pointers
+++ b/tests/runtime/pointers
@@ -99,3 +99,7 @@ EXPECT @: 2
 NAME Pointer is useable in logical or expressions
 PROG begin { @ = (curtask || 0) ? 1 : 2;  }
 EXPECT @: 1
+
+NAME pointer/int comparison
+PROG begin { $a = (int64*) 0x32; $a++; if (0x32 < $a && $a > 0x32) { print("SUCCESS"); }  }
+EXPECT SUCCESS


### PR DESCRIPTION
Stacked PRs:
 * #4451
 * __->__#4449


--- --- ---

### Treat SizedType ptr types as ptrs in codegen


Don't covert ptr types to integers by default.
Also utilize GEP for pointer arithmetic.

This involved a lot of refactoring to make sure
we're comparing the same types.

This also removes the `emit_codegen_types` param
from the `GetType` irbuilderbpf method.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>