### PR TITLE
Move usdt_macro to internal.bt

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1115,14 +1115,6 @@ See the address-spaces section for more information on address-spaces.
 The pointer type is left unchanged.
 
 
-### usdt_arg
-- `int64 usdt_arg(int arg_num)`
-
-Returns the argument of an USDT probe at the given index
-
-This is equivalent to using the `argN` builtins
-
-
 ### usermode
 - `uint8 usermode()`
 - `uint8 usermode`

--- a/scripts/generate_stdlib_docs.py
+++ b/scripts/generate_stdlib_docs.py
@@ -101,8 +101,6 @@ def read_file_lines(file_path: str) -> Optional[list[Helper]]:
                         # undocumented macro.
                         if current.description:
                             helpers.append(current)
-                        else:
-                            print(f"Warning: Helper '{current.name}' will not be added to the docs.")
                     current = Helper()
                 else:
                     if current.name and current.description:

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -1253,14 +1253,6 @@ macro username() {
 //
 // Removes a watchpoint
 
-// Returns the argument of an USDT probe at the given index
-//
-// This is equivalent to using the `argN` builtins
-// :variant int64 usdt_arg(int arg_num)
-macro usdt_arg(x) {
-   __usdt_arg(ctx, x)
-}
-
 // :function zero
 // :variant void zero(map m)
 //

--- a/src/stdlib/internal.bt
+++ b/src/stdlib/internal.bt
@@ -1,0 +1,3 @@
+macro usdt_arg(x) {
+   __usdt_arg(ctx, x)
+}


### PR DESCRIPTION
Also remove the doc block so it doesn't
appear in stdlib.md as this is not meant
to be called by users directly.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
