### PR TITLE
passes: add new builtins pass

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(ast STATIC
   pass_manager.cpp
   signal.cpp
 
+  passes/builtins.cpp
   passes/c_macro_expansion.cpp
   passes/clang_parser.cpp
   passes/clang_build.cpp

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -1,0 +1,79 @@
+#include <optional>
+
+#include "arch/arch.h"
+#include "ast/passes/builtins.h"
+#include "ast/visitor.h"
+#include "bpftrace.h"
+
+namespace bpftrace::ast {
+
+namespace {
+
+class Builtins : public Visitor<Builtins, std::optional<Expression>> {
+public:
+  explicit Builtins(ASTContext &ast, BPFtrace &bpftrace)
+      : ast_(ast), bpftrace_(bpftrace) {};
+
+  using Visitor<Builtins, std::optional<Expression>>::visit;
+  std::optional<Expression> visit(Builtin &builtin);
+  std::optional<Expression> visit(Identifier &identifier);
+  std::optional<Expression> visit(Expression &expression);
+  std::optional<Expression> check(const std::string &ident, Node &node);
+
+private:
+  ASTContext &ast_;
+  BPFtrace &bpftrace_;
+};
+
+} // namespace
+
+std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
+{
+  // N.B. this pass *should* include all the compile-time builtins (probe,
+  // provider, etc.) but it presently cannot due to the expansion rules. All
+  // builtins should be added here once probes are fully-expanded up front.
+  //
+  // All of these builtins should be directly evaluated and folded and not
+  // associated with any code generation. These builtins should be kept to the
+  // minimum possible set to support the standard library.
+  if (ident == "__builtin_arch") {
+    std::stringstream ss;
+    ss << bpftrace::arch::current();
+    return ast_.make_node<String>(ss.str(), Location(node.loc));
+  }
+  if (ident == "__builtin_safe_mode") {
+    return ast_.make_node<Boolean>(bpftrace_.safe_mode_, Location(node.loc));
+  }
+  return std::nullopt;
+}
+
+std::optional<Expression> Builtins::visit(Builtin &builtin)
+{
+  return check(builtin.ident, builtin);
+}
+
+std::optional<Expression> Builtins::visit(Identifier &identifier)
+{
+  return check(identifier.ident, identifier);
+}
+
+std::optional<Expression> Builtins::visit(Expression &expression)
+{
+  auto replacement = visit(expression.value);
+  if (replacement) {
+    expression.value = replacement->value;
+  }
+  return std::nullopt;
+}
+
+Pass CreateBuiltinsPass()
+{
+  auto fn = [&](ASTContext &ast, BPFtrace &bpftrace) {
+    Builtins builtins(ast, bpftrace);
+    builtins.visit(ast.root);
+  };
+
+  return Pass::create("Builtins", fn);
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/builtins.h
+++ b/src/ast/passes/builtins.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+// Fill in the values of all intrinsics.
+Pass CreateBuiltinsPass();
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -2,6 +2,7 @@
 
 #include "ast/attachpoint_parser.h"
 #include "ast/pass_manager.h"
+#include "ast/passes/builtins.h"
 #include "ast/passes/c_macro_expansion.h"
 #include "ast/passes/clang_parser.h"
 #include "ast/passes/config_analyser.h"
@@ -44,6 +45,7 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateParseBTFPass());
   passes.emplace_back(CreateProbeExpansionPass());
   passes.emplace_back(CreateParseTracepointFormatPass());
+  passes.emplace_back(CreateBuiltinsPass());
   passes.emplace_back(CreateFieldAnalyserPass());
   passes.emplace_back(CreateClangParsePass(std::move(extra_flags)));
   passes.emplace_back(CreateCMacroExpansionPass());


### PR DESCRIPTION
Stacked PRs:
 * #4511
 * __->__#4457


--- --- ---

### passes: add new builtins pass


This pass materializes fixed builtins. It is used as a replacement for
the builtins in the fold literals pass.

As an initial example of how this pass works, add builtins for the arch
and whether bpftrace is being invoked in safe_mode.

Signed-off-by: Adin Scannell <amscanne@meta.com>
