### PR TITLE
semantics: add `fail` function to the SemanicAnalyser

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -633,6 +633,12 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
       .arg_types={
         arg_type_spec{ .type=Type::pointer }, // struct sock *
       } } },
+  { "fail",
+    { .min_args=1,
+      .max_args=1,
+      .arg_types={
+        arg_type_spec{ .type=Type::string, .literal=true },
+      } } },
 };
 // clang-format on
 
@@ -1893,6 +1899,10 @@ If you're seeing errors, try clamping the string sizes. For example:
       return;
     }
     call.return_type = CreateUInt64();
+  } else if (call.func == "fail") {
+    // This is basically a static_assert failure. It will halt the compilation.
+    // We expect to hit this path only when using the `typeof` folds.
+    call.addError() << call.vargs[0].as<String>()->value;
   } else {
     // Check here if this corresponds to an external function. We convert the
     // external type metadata into the internal `SizedType` representation and

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5603,4 +5603,14 @@ TEST_F(SemanticAnalyserTest, printf_str_conversion)
   test(R"(kprobe:f { $x = "foo"; printf("%s", $x) })");
 }
 
+TEST_F(SemanticAnalyserTest, fail)
+{
+  test(R"(kprobe:f { fail("always fail"); })", Error{ R"(
+stdin:1:12-31: ERROR: always fail
+kprobe:f { fail("always fail"); }
+           ~~~~~~~~~~~~~~~~~~~
+)" });
+  test(R"(kprobe:f { if (false) { fail("always false"); } })");
+}
+
 } // namespace bpftrace::test::semantic_analyser


### PR DESCRIPTION
Stacked PRs:
 * __->__#4462


--- --- ---

### semantics: add `fail` function to the SemanicAnalyser


This allows for compilation failure in non-pruned paths. For example,
consider a `static_assert` macro:

```
macro static_assert(v, msg) {
  if (typeof(v) != typeof(true)) {
    fail("unable to evaluate compile-time assert");
  } else if (!v) {
    fail(msg);
  }
}
```

Signed-off-by: Adin Scannell <amscanne@meta.com>
