### PR TITLE
semantics: add `typeinfo` expression

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -143,6 +143,7 @@ class Cast;
 class Tuple;
 class IfExpr;
 class BlockExpr;
+class Typeinfo;
 
 class Expression : public VariantNode<Integer,
                                       NegativeInteger,
@@ -169,7 +170,8 @@ class Expression : public VariantNode<Integer,
                                       Cast,
                                       Tuple,
                                       IfExpr,
-                                      BlockExpr> {
+                                      BlockExpr,
+                                      Typeinfo> {
 public:
   using VariantNode::VariantNode;
   Expression() : Expression(static_cast<BlockExpr *>(nullptr)) {};
@@ -515,6 +517,25 @@ public:
   }
 
   std::variant<Expression, SizedType> record;
+};
+
+class Typeinfo : public Node {
+public:
+  explicit Typeinfo(ASTContext &ctx, Typeof *typeof, Location &&loc)
+      : Node(ctx, std::move(loc)), typeof(typeof) {};
+  explicit Typeinfo(ASTContext &ctx, const Typeinfo &other, const Location &loc)
+      : Node(ctx, loc + other.loc),
+        typeof(clone(ctx, other.typeof, loc + other.loc)) {};
+
+  const SizedType &type() const
+  {
+    // This must always be resolved inline, and when used as an expression will
+    // be replaced during semantic analysis with a suitable tuple.
+    static SizedType none = CreateNone();
+    return none;
+  }
+
+  Typeof *typeof = nullptr;
 };
 
 class MapDeclStatement : public Node {

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -155,6 +155,16 @@ void Printer::visit(Typeof &typeof)
   --depth_;
 }
 
+void Printer::visit(Typeinfo &typeinfo)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "typeinfo: " << std::endl;
+
+  ++depth_;
+  visit(typeinfo.typeof);
+  --depth_;
+}
+
 void Printer::visit(MapDeclStatement &decl)
 {
   std::string indent(depth_, ' ');

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -27,6 +27,7 @@ public:
   void visit(Sizeof &szof);
   void visit(Offsetof &offof);
   void visit(Typeof &typeof);
+  void visit(Typeinfo &typeinfo);
   void visit(Map &map);
   void visit(MapAddr &map_addr);
   void visit(MapDeclStatement &decl);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -45,23 +45,47 @@ class PassTracker {
 public:
   void mark_final_pass()
   {
-    is_final_pass_ = true;
+    assert(state_ == SecondChance);
+    state_ = FinalPass;
+  }
+  void mark_second_chance()
+  {
+    assert(state_ == Converging);
+    state_ = SecondChance;
+  }
+  void clear_second_chance()
+  {
+    assert(state_ == SecondChance);
+    state_ = Converging;
   }
   bool is_final_pass() const
   {
-    return is_final_pass_;
+    return state_ == FinalPass;
+  }
+  bool is_second_chance() const
+  {
+    return state_ == SecondChance;
   }
   void inc_num_unresolved()
   {
     num_unresolved_++;
   }
+  void add_unresolved_branch(IfExpr *if_expr)
+  {
+    unresolved_branches_.push_back(if_expr);
+  }
   void reset_num_unresolved()
   {
     num_unresolved_ = 0;
+    unresolved_branches_.clear();
   }
   int get_num_unresolved() const
   {
     return num_unresolved_;
+  }
+  const std::vector<IfExpr *> &get_unresolved_branches()
+  {
+    return unresolved_branches_;
   }
   int get_num_passes() const
   {
@@ -73,8 +97,14 @@ public:
   }
 
 private:
-  bool is_final_pass_ = false;
+  enum State {
+    Converging,
+    SecondChance,
+    FinalPass,
+  };
+  State state_ = Converging;
   int num_unresolved_ = 0;
+  std::vector<IfExpr *> unresolved_branches_;
   int num_passes_ = 1;
 };
 
@@ -181,6 +211,7 @@ private:
 
   bool is_final_pass() const;
   bool is_first_pass() const;
+  bool is_second_chance() const;
 
   std::optional<size_t> check(Sizeof &szof);
   std::optional<size_t> check(Offsetof &offof);
@@ -2721,7 +2752,36 @@ void SemanticAnalyser::visit(Unop &unop)
 
 void SemanticAnalyser::visit(IfExpr &if_expr)
 {
+  // In order to evaluate literals and resolved type operators, we need to fold
+  // the condition. This is handled in the `Expression` visitor. Branches that
+  // are always `false` are exempted from semantic checks. If after folding the
+  // condition still has unresolved `typeof` operators, then we are not able to
+  // visit yet. These branches are also not allowed to contain information
+  // necessary to resolve types, that is a cycle in the dependency graph, the
+  // `if` condition must be resolvable first. If the condition *is* resolvable
+  // and is a constant, then we prune the dead code paths and will never use
+  // them for semantic analysis.
   visit(if_expr.cond);
+  bool unresolved_types = false;
+  CollectNodes<Typeinfo>().visit(
+      if_expr.cond, [&]([[maybe_unused]] const Typeinfo &typeinfo) {
+        unresolved_types = true;
+        return false; // Don't collect.
+      });
+  if (unresolved_types) {
+    pass_tracker_.add_unresolved_branch(&if_expr);
+    return; // Skip visiting this `if` for now.
+  }
+  if (auto *b = if_expr.cond.as<Boolean>()) {
+    if (b->value) {
+      visit(if_expr.left);
+      return;
+    } else {
+      visit(if_expr.right);
+      return;
+    }
+  }
+
   visit(if_expr.left);
   visit(if_expr.right);
 
@@ -3360,6 +3420,16 @@ void SemanticAnalyser::visit(Expression &expr)
       expr.value = ctx_.make_node<Integer>(*v,
                                            Location(offof->loc),
                                            /*force_unsigned=*/true);
+    }
+  } else if (auto *type_id = expr.as<Typeinfo>()) {
+    const auto &ty = type_id->typeof->type();
+    if (!ty.IsNoneTy()) {
+      // We currently lack a globally-unique enumeration of types. For
+      // simplicity, just use the type string with a placeholder identifier.
+      auto *s = ctx_.make_node<String>(typestr(ty), Location(type_id->loc));
+      auto *id = ctx_.make_node<Integer>(0, Location(type_id->loc));
+      expr.value = ctx_.make_node<Tuple>(ExpressionList{ s, id },
+                                         Location(type_id->loc));
     }
   }
 }
@@ -4123,25 +4193,40 @@ int SemanticAnalyser::analyse()
 {
   std::string errors;
 
-  int last_num_unresolved = 0;
+  auto last_num_unresolved = std::numeric_limits<int>::max();
+  auto last_unresolved_branches = pass_tracker_.get_unresolved_branches();
+
   // Multiple passes to handle variables being used before they are defined
   while (ctx_.diagnostics().ok()) {
     pass_tracker_.reset_num_unresolved();
-
     visit(ctx_.root);
-
     if (is_final_pass()) {
       return pass_tracker_.get_num_passes();
     }
 
-    int num_unresolved = pass_tracker_.get_num_unresolved();
+    auto num_unresolved = pass_tracker_.get_num_unresolved();
+    auto unresolved_branches = pass_tracker_.get_unresolved_branches();
 
-    if (num_unresolved > 0 &&
-        (last_num_unresolved == 0 || num_unresolved < last_num_unresolved)) {
-      // If we're making progress, keep making passes
+    if (unresolved_branches != last_unresolved_branches) {
+      // While we have unresolved branches that are changing, we need to reset
+      // our unresolved number since it may increase.
+      last_unresolved_branches = std::move(unresolved_branches);
+      last_num_unresolved = std::numeric_limits<int>::max();
+      if (pass_tracker_.is_second_chance()) {
+        pass_tracker_.clear_second_chance();
+      }
+    } else if (num_unresolved > 0 && num_unresolved < last_num_unresolved) {
+      // If we're making progress, keep making passes.
       last_num_unresolved = num_unresolved;
+      if (pass_tracker_.is_second_chance()) {
+        pass_tracker_.clear_second_chance();
+      }
     } else {
-      pass_tracker_.mark_final_pass();
+      if (pass_tracker_.is_second_chance()) {
+        pass_tracker_.mark_final_pass();
+      } else {
+        pass_tracker_.mark_second_chance();
+      }
     }
 
     pass_tracker_.inc_num_passes();

--- a/src/ast/passes/unstable_feature.cpp
+++ b/src/ast/passes/unstable_feature.cpp
@@ -18,6 +18,7 @@ const auto IMPORTS = "imports";
 const auto MACROS = "macros";
 const auto TSERIES = "tseries";
 const auto ADDR = "address-of operator (&)";
+const auto TYPEINFO = "typeinfo";
 
 std::string get_warning(const std::string &feature, const std::string &config)
 {
@@ -47,6 +48,7 @@ public:
   void visit(VariableAddr &var_addr);
   void visit(Import &imp);
   void visit(Call &call);
+  void visit(Typeinfo &typeinfo);
 
 private:
   BPFtrace &bpftrace_;
@@ -118,6 +120,17 @@ void UnstableFeature::visit(Call &call)
       !warned_features.contains(UNSTABLE_TSERIES)) {
     LOG(WARNING) << get_warning(TSERIES, UNSTABLE_TSERIES);
     warned_features.insert(UNSTABLE_TSERIES);
+  }
+}
+
+void UnstableFeature::visit(Typeinfo &typeinfo)
+{
+  if (bpftrace_.config_->unstable_typeinfo == ConfigUnstable::error) {
+    typeinfo.addError() << get_error(TYPEINFO, UNSTABLE_TYPEINFO);
+  } else if (bpftrace_.config_->unstable_typeinfo == ConfigUnstable::warn &&
+             !warned_features.contains(UNSTABLE_TYPEINFO)) {
+    LOG(WARNING) << get_warning(TYPEINFO, UNSTABLE_TYPEINFO);
+    warned_features.insert(UNSTABLE_TYPEINFO);
   }
 }
 

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -91,6 +91,10 @@ public:
   {
     return visitImpl(typeof.record);
   }
+  R visit(Typeinfo &typeinfo)
+  {
+    return visitImpl(typeinfo.typeof);
+  }
   R visit([[maybe_unused]] MapDeclStatement &decl)
   {
     return default_value();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -284,6 +284,7 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { UNSTABLE_MAP_DECL, CONFIG_FIELD_PARSER(unstable_map_decl) },
   { UNSTABLE_TSERIES, CONFIG_FIELD_PARSER(unstable_tseries) },
   { UNSTABLE_ADDR, CONFIG_FIELD_PARSER(unstable_addr) },
+  { UNSTABLE_TYPEINFO, CONFIG_FIELD_PARSER(unstable_typeinfo) },
 };
 
 // These symbols are deprecated, and have been remapped elsewhere.

--- a/src/config.h
+++ b/src/config.h
@@ -25,6 +25,7 @@ static const auto UNSTABLE_MACRO = "unstable_macro";
 static const auto UNSTABLE_MAP_DECL = "unstable_map_decl";
 static const auto UNSTABLE_TSERIES = "unstable_tseries";
 static const auto UNSTABLE_ADDR = "unstable_addr";
+static const auto UNSTABLE_TYPEINFO = "unstable_typeinfo";
 
 class Config {
 public:
@@ -49,6 +50,7 @@ public:
   ConfigUnstable unstable_import = ConfigUnstable::warn;
   ConfigUnstable unstable_tseries = ConfigUnstable::warn;
   ConfigUnstable unstable_addr = ConfigUnstable::warn;
+  ConfigUnstable unstable_typeinfo = ConfigUnstable::error;
 #ifdef HAVE_BLAZESYM
   bool use_blazesym = true;
   bool show_debug_info = true;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -179,6 +179,7 @@ oct_esc  [0-7]{1,3}
 "sizeof"                { return Parser::make_SIZEOF(yytext, driver.loc); }
 "offsetof"              { return Parser::make_OFFSETOF(yytext, driver.loc); }
 "typeof"                { return Parser::make_TYPEOF(yytext, driver.loc); }
+"typeinfo"              { return Parser::make_TYPEINFO(yytext, driver.loc); }
 "let"                   { return Parser::make_LET(yytext, driver.loc); }
 "import"                { return Parser::make_IMPORT(yytext, driver.loc); }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5675,4 +5675,24 @@ struct foo { int x; } kprobe:f { $x = (struct foo*)0; $y = (typeof(*$x))0; }
 )" });
 }
 
+TEST_F(SemanticAnalyserTest, typeinfo_if_constexpr)
+{
+  // We should be able to selectively analyze specific branches. Only the
+  // correct type branch will be chosen, and we will not encounted a type error
+  // for the other branch.
+  test(
+      R"(kprobe:f { $x = 1; if (typeinfo($x) == typeinfo("abc")) { $x = "foo"; } else { $x = 2; } })");
+  test(
+      R"(kprobe:f { $x = "xyz"; if (typeinfo($x) == typeinfo("abc")) { $x = "foo"; } else { $x = 2; } })");
+  test(
+      R"(kprobe:f { $x = 1; if (typeinfo($x) != typeinfo(1)) { fail("only integers"); } })");
+  test(
+      R"(kprobe:f { $x = 1; if (typeinfo($x) == typeinfo(1)) { fail("no integers"); } })",
+      Error{ R"(
+stdin:1:55-74: ERROR: no integers
+kprobe:f { $x = 1; if (typeinfo($x) == typeinfo(1)) { fail("no integers"); } }
+                                                      ~~~~~~~~~~~~~~~~~~~
+)" });
+}
+
 } // namespace bpftrace::test::semantic_analyser


### PR DESCRIPTION
Stacked PRs:
 * #4463
 * __->__#4464


--- --- ---

### semantics: add `typeinfo` expression


To allow for type-specific behavior in macros and other parts of the
standard library, we need a way to do parameteric behavior based on
types. Rather than overloading, allow comparison of `typeinfo` expressions
and pruning of invalid branches during semantic analysis.

As a trivial example, consider:

```
macro is_signed($x) {
  let $r;
  if (typeinfo($x) == typeinfo(0xffffffffffffffff)) {
    $r = false;
  } else {
    $r = true;
  }
  $r
}

begin {
  if (is_signed(-1)) {
    print("-1 number is signed")
  } else {
    print("-1 number isn't signed")
  }
  if (is_signed(0xffffffffffffffff)) {
    print("big number number is signed")
  } else {
    print("big number number isn't signed")
  }
}
```

The `typeinfo` is an implementation-specific tuple, containing both the
string of the type and a globally unique identifier. (For now, we omit
the second one, but this will be filled in with BTF.)

Signed-off-by: Adin Scannell <amscanne@meta.com>
