### PR TITLE
Move semantic errors on maps into semantic_analyser

### DIFF
--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -140,29 +140,24 @@ bool MapDefaultKey::check(Map &map, bool indexed)
 void MapDefaultKey::checkAccess(Map &map, bool indexed)
 {
   if (!check(map, indexed)) {
-    if (indexed) {
-      map.addError() << map.ident
-                     << " used as a map with an explicit key (non-scalar map), "
-                        "previously used without an explicit key (scalar map)";
-    } else {
-      map.addError()
-          << map.ident
-          << " used as a map without an explicit key (scalar map), previously "
-             "used with an explicit key (non-scalar map)";
-    }
+    metadata.errors[&map] =
+        indexed ? map.ident +
+                      " used as a map with an explicit key (non-scalar map), "
+                      "previously used without an explicit key (scalar map)"
+                : map.ident +
+                      " used as a map without an explicit key (scalar map), "
+                      "previously used with an explicit key (non-scalar map)";
   }
 }
 
 void MapDefaultKey::checkCall(Map &map, bool indexed, Call &call)
 {
   if (!check(map, indexed)) {
-    if (indexed) {
-      map.addError() << "call to " << call.func
-                     << "() expects a map with explicit keys (non-scalar map)";
-    } else {
-      map.addError() << "call to " << call.func
-                     << "() expects a map without explicit keys (scalar map)";
-    }
+    metadata.errors[&map] =
+        indexed ? "call to " + call.func +
+                      "() expects a map with explicit keys (non-scalar map)"
+                : "call to " + call.func +
+                      "() expects a map without explicit keys (scalar map)";
   }
 }
 

--- a/src/ast/passes/map_sugar.h
+++ b/src/ast/passes/map_sugar.h
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 
+#include "ast/ast.h"
 #include "ast/pass_manager.h"
 
 namespace bpftrace::ast {
@@ -14,6 +15,9 @@ namespace bpftrace::ast {
 class MapMetadata : public ast::State<"map-metadata"> {
 public:
   std::unordered_map<std::string, bool> scalar;
+  // Save errors for semantic analysis where branch pruning may discard
+  // branches where an error occured.
+  std::unordered_map<Map *, std::string> errors;
 };
 
 Pass CreateMapSugarPass();

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -346,9 +346,9 @@ TEST_F(SemanticAnalyserTest, consistent_map_keys)
   test("begin { @x[@y[@z]] = 5; @y[2] = 1; @z = @x[0]; }");
 
   test("begin { @x = 0; @x[1]; }", Error{ R"(
-stdin:1:17-19: ERROR: @x used as a map with an explicit key (non-scalar map), previously used without an explicit key (scalar map)
+stdin:1:17-22: ERROR: @x used as a map with an explicit key (non-scalar map), previously used without an explicit key (scalar map)
 begin { @x = 0; @x[1]; }
-                ~~
+                ~~~~~
 )" });
   test("begin { @x[1] = 0; @x; }", Error{ R"(
 stdin:1:20-22: ERROR: @x used as a map without an explicit key (scalar map), previously used with an explicit key (non-scalar map)


### PR DESCRIPTION
Stacked PRs:
 * #4466
 * __->__#4465


--- --- ---

### Move semantic errors on maps into semantic_analyser


map_sugar will record where an error occurs but
semantic_analyser will actually add the error
to the nodes.

The reason for this change is when we want to do
branch pruning, which will happen in semantic_analyser,
we don't want to issue errors for un-reachable
branches.

Example:
```
begin { @a = 1; if (true) { print(1); } else { @a[1] = 1; } }
```

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>