### PR TITLE
Add branch pruning for conditional statements

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2758,6 +2758,14 @@ void SemanticAnalyser::visit(If &if_node)
 {
   visit(if_node.cond);
 
+  if (auto *b = if_node.cond.as<Boolean>()) {
+    if (b->value) {
+      if_node.else_block->stmts.clear();
+    } else {
+      if_node.if_block->stmts.clear();
+    }
+  }
+
   if (is_final_pass()) {
     const Type &cond = if_node.cond.type().GetTy();
     if (cond != Type::integer && cond != Type::pointer && cond != Type::boolean)
@@ -2820,6 +2828,12 @@ void SemanticAnalyser::visit(Jump &jump)
 void SemanticAnalyser::visit(While &while_block)
 {
   visit(while_block.cond);
+
+  if (auto *b = while_block.cond.as<Boolean>()) {
+    if (!b->value) {
+      while_block.block->stmts.clear();
+    }
+  }
 
   loop_depth_++;
   visit(while_block.block);

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -119,7 +119,7 @@ PROG begin { let $x: struct Foo[1];  }
 EXPECT Attached 1 probe
 
 NAME variable declaration not initialized
-PROG begin { let $a; if (false) { $a = 1; } @b = $a; }
+PROG begin { let $a: int64; if (false) { $a = 1; } @b = $a; }
 EXPECT @b: 0
 
 NAME variable doesn't escape scope


### PR DESCRIPTION
Stacked PRs:
 * #4475
 * __->__#4467


--- --- ---

### Add branch pruning for conditional statements


This includes: if, while, and ternary

Meaning if we can tell during compilation
that a branch will never be taken then
"prune" it by either removing all the statements
from the block that will never be reached
or, in the case of ternary, using either the
left or right expression to replaced the ternary.

Something similar can probably be done for
loops but let's start with something simple.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>