### PR TITLE
for: add `for (x in (0, 3, "foo"))` tuple-iteration

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1088,7 +1088,7 @@ public:
   Expression end;
 };
 
-class Iterable : public VariantNode<Map, Range> {
+class Iterable : public VariantNode<Map, Tuple, Range> {
 public:
   using VariantNode::VariantNode;
   Iterable() : Iterable(static_cast<Map *>(nullptr)) {};
@@ -1098,21 +1098,12 @@ class For : public Node {
 public:
   explicit For(ASTContext &ctx,
                Variable *decl,
-               Map *map,
+               Iterable iterable,
                StatementList &&stmts,
                Location &&loc)
       : Node(ctx, std::move(loc)),
         decl(decl),
-        iterable(map),
-        stmts(std::move(stmts)) {};
-  explicit For(ASTContext &ctx,
-               Variable *decl,
-               Range *range,
-               StatementList &&stmts,
-               Location &&loc)
-      : Node(ctx, std::move(loc)),
-        decl(decl),
-        iterable(range),
+        iterable(iterable),
         stmts(std::move(stmts)) {};
   explicit For(ASTContext &ctx, const For &other, const Location &loc)
       : Node(ctx, loc + other.loc),

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3334,7 +3334,16 @@ ScopedExpr CodegenLLVM::visit(While &while_block)
 ScopedExpr CodegenLLVM::visit(For &f)
 {
   scope_stack_.push_back(&f);
-  std::visit([&](auto *iter) { visit(f, *iter); }, f.iterable.value);
+  std::visit(
+      [&](auto *iter) {
+        // This is a macro syntax, we don't support this during codegen.
+        if constexpr (std::is_same_v<decltype(iter), Tuple *>) {
+          LOG(BUG) << "For contains unexpected tuple during codegen.";
+        } else {
+          visit(f, *iter);
+        }
+      },
+      f.iterable.value);
   scope_stack_.pop_back();
   return ScopedExpr();
 }

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2828,6 +2828,8 @@ void SemanticAnalyser::visit(While &while_block)
 
 void SemanticAnalyser::visit(For &f)
 {
+  // This must be expanded earlier.
+  assert(!f.iterable.is<Tuple>());
   if (f.iterable.is<Range>() && !bpftrace_.feature_->has_helper_loop()) {
     f.addError() << "Missing required kernel feature: loop";
   }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -3029,7 +3029,7 @@ begin { for ($kv : @map) print($kv); }
 
   // Map for decl
   test_parse_failure("begin { for (@kv : @map) { } }", R"(
-stdin:1:13-17: ERROR: syntax error, unexpected map, expecting variable
+stdin:1:13-17: ERROR: syntax error, unexpected map, expecting identifier or variable
 begin { for (@kv : @map) { } }
             ~~~~
 )");

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -135,3 +135,7 @@ EXPECT_REGEX .*\n1\n5\n\n
 NAME range with continue
 PROG begin { for ($i : 1..4) { if ($i == 2) { continue; } print($i); }  }
 EXPECT_REGEX .*\n1\n3\n\n
+
+NAME tuple
+PROG BEGIN { for (i : (0, "foo", "bar")) { print(i); } }
+EXPECT_REGEX .*\n0\nfoo\nbar\n\n

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4925,6 +4925,18 @@ TEST_F(SemanticAnalyserTest, for_range_nested_range)
        "} } }");
 }
 
+TEST_F(SemanticAnalyserTest, for_loop_tuple)
+{
+  // Same type.
+  test("begin { for (i : (0, 1, 2)) { print(i); } }");
+
+  // Multiple types.
+  test(R"(begin { for (i : (0, "foo")) { print(i); } })");
+
+  // More complex logic, with external variables.
+  test(R"(begin { $x = 0; for (i : (0, "foo")) { printf("%d: %s\n", $x, i); $x += 1; } })");
+}
+
 TEST_F(SemanticAnalyserTest, castable_map_missing_feature)
 {
   test("k:f {  @a = count(); }", NoFeatures::Enable);


### PR DESCRIPTION
Stacked PRs:
 * #4473
 * __->__#4472
 * #4471


--- --- ---

### for: add `for (x in (0, 3, "foo"))` tuple-iteration


Unlike other loops, this is a macro and is expanded during macro
expansion. It only accepts an in-place tuple expression, and does
substitution on the variable itself.

This is not intended to be a significant feature on its own, although it
is a basic convenience. Rather, this lays the basic groundwork for
variadiac macro arguments.

Signed-off-by: Adin Scannell <amscanne@meta.com>