### PR TITLE
Add cast for conditional literal expressions

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3235,7 +3235,7 @@ void SemanticAnalyser::visit(Cast &cast)
   if (rhs.IsRecordTy()) {
     cast.addError() << "Cannot cast from struct type \"" << cast.expr.type()
                     << "\"";
-  } else if (rhs.IsNoneTy()) {
+  } else if (is_final_pass() && rhs.IsNoneTy()) {
     cast.addError() << "Cannot cast from \"" << cast.expr.type() << "\" type";
   }
 

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -16,24 +16,17 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$s1" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s1")
-  store i64 0, ptr %"$s1", align 8
   %"$s" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
-  br i1 true, label %if_body, label %else_body
+  br i1 true, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
   store i64 10, ptr %"$s", align 8
   br label %if_end
 
-if_end:                                           ; preds = %else_body, %if_body
+if_end:                                           ; preds = %if_body, %entry
   ret i64 0
-
-else_body:                                        ; preds = %entry
-  store i64 20, ptr %"$s1", align 8
-  br label %if_end
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)

--- a/tests/runtime/scripts/variable_scope.bt
+++ b/tests/runtime/scripts/variable_scope.bt
@@ -4,7 +4,7 @@ begin {
 	}
 
 	if (1) {
-		let $x;
+		let $x = 0;
 		if (0) {
 			$x = 5;
 		}

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5254,10 +5254,10 @@ stdin:1:28-37: ERROR: Undefined or undeclared variable: $a
 begin { if (1) { $a = 1; } print(($a)); }
                            ~~~~~~~~~
 )" });
-  test("begin { if (1) { $a = 1; } else { print(($a)); } }", Error{ R"(
-stdin:1:35-44: ERROR: Undefined or undeclared variable: $a
-begin { if (1) { $a = 1; } else { print(($a)); } }
-                                  ~~~~~~~~~
+  test("begin { $x = 1; if ($x) { $a = 1; } else { print(($a)); } }", Error{ R"(
+stdin:1:44-53: ERROR: Undefined or undeclared variable: $a
+begin { $x = 1; if ($x) { $a = 1; } else { print(($a)); } }
+                                           ~~~~~~~~~
 )" });
   test("begin { if (1) { $b = 1; } else { $b = 2; } print(($b)); }", Error{ R"(
 stdin:1:45-54: ERROR: Undefined or undeclared variable: $b


### PR DESCRIPTION
Stacked PRs:
 * __->__#4475
 * #4467


--- --- ---

### Add cast for conditional literal expressions


For `if`, `while`, and `ternary` add an AST cast
to a boolean and then fold the casted expression.
This also applies to literals casted to boolean, e.g.,
```
$x = (bool)1;
// becomes just
$x = true;
```

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>