### PR TITLE
fix setTargetTriple for LLVM >= 21

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -494,7 +494,11 @@ CodegenLLVM::CodegenLLVM(ASTContext &ast,
       b_(llvm_ctx, *module_, bpftrace, async_ids_),
       debug_(*module_)
 {
+#if LLVM_VERSION_MAJOR >= 21
+  module_->setTargetTriple(Triple(LLVMTargetTriple));
+#else
   module_->setTargetTriple(LLVMTargetTriple);
+#endif
   module_->setDataLayout(getTargetMachine()->createDataLayout());
 
   debug_.createCompileUnit(dwarf::DW_LANG_C,


### PR DESCRIPTION
LLVM >= 21 changed Module::setTargetTriple to take a Triple as an argument, not a const string. Change the call for LLVM >= 21.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc` (n/a)
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md` (n/a)
- [ ] The new behaviour is covered by tests (n/a)