### PR TITLE
codegen: ntop: remove extra comment line

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1573,7 +1573,6 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     //     char[16] inet6;
     //   }
     // }
-    //}
     std::vector<llvm::Type *> elements = { b_.getInt64Ty(),
                                            ArrayType::get(b_.getInt8Ty(), 16) };
     StructType *inet_struct = b_.GetStructType("inet", elements, false);


### PR DESCRIPTION
There is an extra useless line in the code comment.
