### PR TITLE
Consolidate linking of libbpf and bcc

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -299,6 +299,23 @@ $ ./tests/bpftrace_test
 # ./src/bpftrace -e 'kprobe:do_nanosleep { printf("sleep by %s\n", comm); }'
 ```
 
+## libbpf dependency
+
+One of the most important dependencies of bpftrace is the
+[libbpf](https://github.com/libbpf/libbpf) library. We usually require a very
+recent version of libbpf and, since bpftrace version 0.24, link against libbpf
+statically. Since some distros do not package the static version of libbpf
+(`libbpf.a`) and some distros package too old version of libbpf, it may be
+necessary to build libbpf [from
+source](https://github.com/libbpf/libbpf?tab=readme-ov-file#building-libbpf).
+
+After building libbpf, it should be installed into some standard path (such as
+`/usr/local/`). In case a non-standard directory is used, you can pass it to the
+above CMake command by setting the `LibBpf_ROOT` variable:
+```
+cmake -DCMAKE_BUILD_TYPE=Release .. -DLibBpf_ROOT=/path/to/libbpf/installation
+```
+
 # Disable Lockdown
 
 From the original patch set description:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,13 +65,6 @@ endif()
 install(TARGETS bpftrace DESTINATION ${CMAKE_INSTALL_BINDIR})
 target_compile_definitions(bpftrace PRIVATE ${BPFTRACE_FLAGS})
 
-# TODO(Jiawei Zhao): this conditional can be removed when we no longer use bcc.
-if(STATIC_LINKING)
-  target_link_libraries(bpftrace libbpftrace)
-else()
-  target_link_libraries(bpftrace libbpftrace libbpf.a)
-endif(STATIC_LINKING)
-
 # compile definitions
 
 # This is run on every build to ensure the version string is always up-to-date
@@ -99,8 +92,14 @@ if(STATIC_LINKING)
 endif(STATIC_LINKING)
 
 
+target_link_libraries(bpftrace libbpftrace)
 target_link_libraries(runtime debugfs output tracefs util)
-target_link_libraries(runtime ${LIBBPF_LIBRARIES} ${ZLIB_LIBRARIES})
+target_link_libraries(runtime ${ZLIB_LIBRARIES})
+# We need to tell the linker to prefer static linking for libbpf. The reason
+# is that bcc links agains libbpf and if bcc is linked dynamically, that will
+# transitively pull dynamic libbpf, too. This makes sure that symbols from the
+# static one are preferred.
+target_link_libraries(runtime -Wl,-Bstatic ${LIBBPF_LIBRARIES} -Wl,-Bdynamic)
 target_link_libraries(libbpftrace parser runtime aot ast arch util cxxdemangler_llvm)
 
 if(LIBPCAP_FOUND)
@@ -145,8 +144,6 @@ endif()
 
 if(STATIC_LINKING)
   # These are not part of the static libbcc so have to be added separate
-  target_link_libraries(runtime ${LIBBCC_BPF_LIBRARIES})
-  target_link_libraries(runtime ${LIBBPF_LIBRARIES})
   target_link_libraries(runtime ${LIBBCC_LOADER_LIBRARY_STATIC})
 
   find_package(LibLzma)

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -47,7 +47,7 @@ add_library(ast STATIC
 
 add_dependencies(ast parser)
 target_compile_definitions(ast PRIVATE ${BPFTRACE_FLAGS})
-target_link_libraries(ast PRIVATE debugfs tracefs util stdlib ${LIBBPF_LIBRARIES})
+target_link_libraries(ast PRIVATE debugfs tracefs util stdlib)
 target_link_libraries(ast PUBLIC ast_defs arch compiler_core parser btf)
 
 if (NOT SYSTEM_INCLUDE_PATHS EQUAL "auto")

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -29,3 +29,5 @@ endif()
 target_compile_definitions(util PUBLIC KERNEL_HEADERS_DIR="${KERNEL_HEADERS_DIR}")
 
 target_link_libraries(util debugfs ${LIBELF_LIBRARIES} ${ZLIB_LIBRARIES})
+# See comment in src/CMakeLists.txt for explanation of the below.
+target_link_libraries(util -Wl,-Bstatic ${LIBBPF_LIBRARIES} -Wl,-Bdynamic)


### PR DESCRIPTION
In CMake, we link `LIBBPF_LIBRARIES` and `LIBBCC_LIBRARIES` from several places, many of which are redundant. In addition, in one place, we link against `libbpf.a`, which CMake turns into `-Wl,-Bstatic -lbpf`, which causes system libbpf be used even if different `libbpf.a` was found in `FindBpf.cmake` (see #4454 for details).
    
Consolidate `CMakeLists.txt` files such that every target which needs `LIBBPF_LIBRARIES` and `LIBBCC_LIBRARIES` links them exactly once. Also drop linking libbpf from the `ast` target (which doesn't need it) and instead add it to the `util` target (since `util/bpf_progs.cpp` uses it).
    
To prevent the bug fixed by #4429 from repeating, add an explicit `-Wl,-Bstatic` before each linking of `libbpf.a`.

Finally, add a new section to `INSTALL.md` on how to build and install libbpf from source and how to point CMake to it when it is installed in a non-standard directory. This is useful especially since we now require the latest static libbpf library which many distros do not ship (they either shop too old libbpf or they don't ship static libraries).

This should resolve #4454.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
