### PR TITLE
Remove unnecessary SystemTap package installations

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -272,7 +272,6 @@ Use specific OS build sections listed earlier if available.
 - Libcereal
 - Kernel requirements described earlier
 - Libpcap
-- Systemtap SDT headers
 - Zlib development package
 
 ### Compilation

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get install -y \
     libclang-dev \
     libclang-cpp-dev \
     pahole \
-    systemtap-sdt-dev \
     xxd \
     zlib1g-dev
 

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -26,7 +26,6 @@ RUN dnf install -y \
         llvm-devel \
         make \
         pahole \
-        systemtap-sdt-devel \
         xxd \
         zlib-devel
 

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -25,7 +25,6 @@ RUN apt-get update && apt-get install -y \
     libclang-cpp-dev \
     linux-tools-common \
     pahole \
-    systemtap-sdt-dev \
     xxd \
     zlib1g-dev
 

--- a/flake.nix
+++ b/flake.nix
@@ -173,7 +173,6 @@
                   pkgs.libopcodes
                   pkgs.libpcap
                   pkgs.systemdLibs
-                  pkgs.libsystemtap
                   pkgs."llvmPackages_${toString llvmVersion}".libclang
                   pkgs."llvmPackages_${toString llvmVersion}".llvm
                   pkgs.pahole


### PR DESCRIPTION
#### Summary
SystemTap packages are no longer needed since f466c311 vendored `sdt.h`.
This PR removes package installs from Dockerfiles and Nix flake.

#### Removed packages and what they provide
- Debian `systemtap-sdt-dev`
    - executed in a container built from `docker/Dockerfile.debian`
        <details><summary>apt-cache depends systemtap-sdt-dev</summary>

        ```
        systemtap-sdt-dev
        Depends: <python3:any>
            python3
        ```
        </details>

        <details><summary>apt-file list systemtap-sdt-dev</summary>

        ```
        systemtap-sdt-dev: /usr/bin/dtrace        
        systemtap-sdt-dev: /usr/include/x86_64-linux-gnu/sys/sdt-config.h
        systemtap-sdt-dev: /usr/include/x86_64-linux-gnu/sys/sdt.h
        systemtap-sdt-dev: /usr/share/doc/systemtap-sdt-dev/changelog.Debian.gz
        systemtap-sdt-dev: /usr/share/doc/systemtap-sdt-dev/copyright
        systemtap-sdt-dev: /usr/share/man/man1/dtrace.1.gz
        ```
        </details>

- Ubuntu `systemtap-sdt-dev`
    - executed in a container built from `docker/Dockerfile.ubuntu`
        <details><summary>apt-cache depends systemtap-sdt-dev</summary>

        ```
        systemtap-sdt-dev
        Depends: <python3:any>
            python3
        ```
        </details>

        <details><summary>apt-file list systemtap-sdt-dev</summary>

        ```
        systemtap-sdt-dev: /usr/bin/dtrace        
        systemtap-sdt-dev: /usr/include/x86_64-linux-gnu/sys/sdt-config.h
        systemtap-sdt-dev: /usr/include/x86_64-linux-gnu/sys/sdt.h
        systemtap-sdt-dev: /usr/share/doc/systemtap-sdt-dev/changelog.Debian.gz
        systemtap-sdt-dev: /usr/share/doc/systemtap-sdt-dev/copyright
        systemtap-sdt-dev: /usr/share/man/man1/dtrace.1.gz
        ```
        </details>

- Fedora `systemtap-sdt-devel`
    - executed in a container built from `docker/Dockerfile.fedora`

        <details><summary>dnf repoquery --requires systemtap-sdt-devel</summary>

        ```
        Updating and loading repositories:
        Repositories loaded.
        ```
        </details>

        <details><summary>rpm -ql systemtap-sdt-devel</summary>

        ```
        /usr/include/sys/sdt-config.h
        /usr/include/sys/sdt.h
        /usr/lib/rpm/macros.d/macros.systemtap
        /usr/share/doc/systemtap-sdt-devel
        /usr/share/doc/systemtap-sdt-devel/AUTHORS
        /usr/share/doc/systemtap-sdt-devel/NEWS
        /usr/share/doc/systemtap-sdt-devel/README
        /usr/share/licenses/systemtap-sdt-devel
        /usr/share/licenses/systemtap-sdt-devel/COPYING
        ```
        </details>

- Nix `libsystemtap`
    - hash: d5816sl2i6azgp75sz6ywqijhjg8mhi (checked in CI)

    <details><summary>nix-store --query --requisites /nix/store/rd5816sl2i6azgp75sz6ywqijhjg8mhi-libsystemtap-5.2</summary>

    ```
    /nix/store/rd5816sl2i6azgp75sz6ywqijhjg8mhi-libsystemtap-5.2
    ```
    </details>
    
    <details><summary>find /nix/store/rd5816sl2i6azgp75sz6ywqijhjg8mhi-libsystemtap-5.2 -type f</summary>

    ```
    /nix/store/rd5816sl2i6azgp75sz6ywqijhjg8mhi-libsystemtap-5.2/include/stap-probe.h
    /nix/store/rd5816sl2i6azgp75sz6ywqijhjg8mhi-libsystemtap-5.2/include/sys/sdt.h
    /nix/store/rd5816sl2i6azgp75sz6ywqijhjg8mhi-libsystemtap-5.2/include/sys/sdt-config.h
    /nix/store/rd5816sl2i6azgp75sz6ywqijhjg8mhi-libsystemtap-5.2/include/sys/.gitignore
    /nix/store/rd5816sl2i6azgp75sz6ywqijhjg8mhi-libsystemtap-5.2/include/sys/sdt-config.h.in
    ```

    </details>

#### checks and validation
- From the above results, the files that could potentially be removed are:
    - python3 
        - dependency of systemtap-sdt-dev on Debian/Ubuntu
    - dtrace binary
    - sdt.h
    - sdt-config.h
    - stap-probe.h

    I searched the repository and couldn't find any usage of the files other than `python3`, 
so I believe they are not used.
    For `python3`, I verified that it is installed in a container built from
`docker/Dockerfile.debian` and `docker/Dockerfile.ubuntu` in this MR.

- Local Docker builds  
  Verified that the following all completed with `Successfully built {{hash}}`:
    - `docker build -f docker/Dockerfile.debian .`
    - `docker build -f docker/Dockerfile.ubuntu .`
    - `docker build -f docker/Dockerfile.fedora .`


<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
 