### PR TITLE
Add links to other tools versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -4,12 +4,12 @@ about: Create a tracker issue for the upcoming release. Should be used by mainta
 
 ---
 
-<!-- 
+<!--
 The title of the issue should be "Release v0.<minor>.0".
 
 Fill in the placeholders in the checklist below:
 
-- <minor> is the release minor number 
+- <minor> is the release minor number
 - <llvm> is the LLVM major number
 - <branching-date> is the date of creating the release branch
 - <release-date> is date of bpftrace release
@@ -31,6 +31,7 @@ For LLVM release schedule, see https://llvm.org/.
   - [ ] Update `bpftrace_VERSION_*` in [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt)
   - [ ] Draft a new release in GitHub
   - [ ] Update the docs on the bpftrace website. [Instructions](https://github.com/bpftrace/website?#updating-the-docs).
+  - [ ] Add a new tools version link on the [tools readme](https://github.com/bpftrace/bpftrace/blob/master/tools/README.md) to the master branch.
 - [ ] Forward-port [CHANGELOG.md](https://github.com/bpftrace/bpftrace/blob/master/CHANGELOG.md) and [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt) changes to the master branch.
 
 See [Release Process](https://github.com/bpftrace/bpftrace/blob/master/docs/release_process.md) for general information on the

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,15 @@
 
 These tools are a small collection curated by the bpftrace maintainers that have been battle-tested and are packaged with bpftrace. We're currently building a set of [community tools](https://github.com/bpftrace/user-tools), which is now accepting [contributions](https://github.com/bpftrace/user-tools/blob/master/CONTRIBUTING.md).
 
-[Read more about how tools get added to this repository](../CONTRIBUTING-TOOLS.md).
+[Read more about how tools get added to THIS repository](../CONTRIBUTING-TOOLS.md).
+
+**Note**: make sure you are using a version of these tools that matches against your bpftrace version:
+- [0.23 tools](https://github.com/bpftrace/bpftrace/tree/release/0.23.x/tools)
+- [0.22 tools](https://github.com/bpftrace/bpftrace/tree/release/0.22.x/tools)
+- [0.21 tools](https://github.com/bpftrace/bpftrace/tree/release/0.21.x/tools)
+- [0.20 tools](https://github.com/bpftrace/bpftrace/tree/release/0.20.x/tools)
+
+These tools are updated to work against the bpftrace code at their same commit hash.
 
 - tools/[bashreadline.bt](bashreadline.bt) - Print entered bash commands system wide.
 - tools/[biolatency.bt](biolatency.bt) - Block I/O latency as a histogram.


### PR DESCRIPTION
This is to help new users who might not be aware
that the current tools in the repo are tied to the unreleased version of bpftrace.

Issue:
- https://github.com/bpftrace/bpftrace/issues/4489

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
