### PR TITLE
Fix passing max_ast_nodes env param

### DIFF
--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -24,11 +24,12 @@ namespace bpftrace::ast {
 // AllParsePasses returns a vector of passes representing all parser passes, in
 // the expected order. This should be used unless there's a reason not to.
 inline std::vector<Pass> AllParsePasses(
+    uint32_t max_ast_nodes = 0,
     std::vector<std::string> &&extra_flags = {},
     std::vector<std::string> &&import_paths = {})
 {
   std::vector<Pass> passes;
-  passes.emplace_back(CreateParsePass());
+  passes.emplace_back(CreateParsePass(max_ast_nodes));
   passes.emplace_back(CreateConfigPass());
   passes.emplace_back(CreateResolveImportsPass(std::move(import_paths)));
   // N.B. We expand the AST with all externally imported scripts, then check

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -912,7 +912,8 @@ int main(int argc, char* argv[])
     }
   };
   // Start with all the basic parsing steps.
-  for (auto& pass : ast::AllParsePasses(std::move(flags))) {
+  for (auto& pass :
+       ast::AllParsePasses(bpftrace.max_ast_nodes_, std::move(flags))) {
     addPass(std::move(pass));
   }
   pm.add(ast::CreateLLVMInitPass());

--- a/tests/imports.cpp
+++ b/tests/imports.cpp
@@ -91,7 +91,7 @@ void test(const std::string &input,
   auto ok = ast::PassManager()
                 .put(ast)
                 .put(bpftrace)
-                .add(ast::AllParsePasses({}, std::move(import_paths)))
+                .add(ast::AllParsePasses(0, {}, std::move(import_paths)))
                 .run();
   std::stringstream out;
   ast.diagnostics().emit(out);


### PR DESCRIPTION
Stacked PRs:
 * __->__#4493


--- --- ---

### Fix passing max_ast_nodes env param


This was missing from `CreateParsePass`
in `AllParsePasses`.

Signed-off-by: Jordan Rome <linux@jordanrome.com>