### PR TITLE
codegen: IR: Fix ICmp instruction are not of the same type

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1774,7 +1774,7 @@ void SemanticAnalyser::visit(Call &call)
     if (!call.vargs.at(2).is<Integer>()) {
       call.addError() << "Builtin strncmp requires a non-negative literal";
     }
-    call.return_type = CreateUInt64();
+    call.return_type = CreateBool();
   } else if (call.func == "strcontains") {
     static constexpr auto warning = R"(
 strcontains() is known to have verifier complexity issues when the product of both string sizes is larger than ~2000 bytes.

--- a/tests/codegen/llvm/strncmp_one_literal.ll
+++ b/tests/codegen/llvm/strncmp_one_literal.ll
@@ -8,19 +8,19 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.0" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
+@ringbuf = dso_local global %"struct map_internal_repr_t.0" zeroinitializer, section ".maps", !dbg !27
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
 @sshd = global [5 x i8] c"sshd\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !51 {
 entry:
   %"@_val" = alloca i64, align 8
-  %"@_key" = alloca i64, align 8
+  %"@_key" = alloca i1, align 1
   %strcmp.result = alloca i1, align 1
   %__builtin_comm = alloca [16 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %__builtin_comm)
@@ -39,8 +39,8 @@ strcmp.false:                                     ; preds = %strcmp.done, %strcm
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %5 = zext i1 %4 to i64
-  store i64 %5, ptr %"@_key", align 8
+  %5 = zext i1 %4 to i8
+  store i8 %5, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -84,8 +84,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48, !49}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49, !50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -97,7 +97,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -110,36 +110,36 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !15)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !7, !27, !41, !45}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = !{i32 7, !"uwtable", i32 0}
+!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!26, !23}
 !54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !23)

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -134,7 +134,7 @@ EXPECT I got hhvm-proc
 
 NAME strncmp function argument
 RUN {{BPFTRACE}} -e 'struct F {char s[8];} u:./testprogs/string_args:print { @=strncmp(((struct F*)arg0)->s, "hello", 5); }' -c ./testprogs/string_args
-EXPECT @: 0
+EXPECT @: false
 
 NAME short non null-terminated string print
 RUN {{BPFTRACE}} -e 'struct F {char s[5];} u:./testprogs/string_args:print { $a = ((struct F*)arg0)->s; printf("%s %s\n", $a, $a); }' -c ./testprogs/string_args


### PR DESCRIPTION
Since commit 4ccf8912cf51 ("Treat SizedType ptr types as ptrs in codegen (#4449)"), `Predicate` only checks the IsBoolTy() type, but this is not enough for strncmp() UInt64.

semantic_analyser check IsIntTy(), IsPtrTy() and IsBoolTy() for Predicate, we just use getInt64() type to be compatible with IsIntTy(), IsPtrTy() and IsBoolTy().

Error example: (llvm-20.1.8)

    $ cat a.bt
    tracepoint:syscalls:sys_enter_open,
    tracepoint:syscalls:sys_enter_openat,
    tracepoint:syscalls:sys_enter_openat2
    / !strncmp(comm, "open", 4) /
    {
    	printf("%s\n", comm);
    }

    Assertion:

    $ sudo a.bt
    bpftrace: /usr/include/llvm/IR/Instructions.h:1162: void llvm::ICmpInst::AssertOK(): Assertion `getOperand(0)->getType() == getOperand(1)->getType() && "Both operands to ICmp instruction are not of the same type!"' failed.
    Aborted

    The scoped_expr is 'i1', but the 'strncmp()' Constant::getNullValue is 'i64'.

Fix: commit 4ccf8912cf51 ("Treat SizedType ptr types as ptrs in codegen (#4449)")
