### PR TITLE
output: add second stream for `TextOutput`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
 - JSON serialization for unsupported and unknown types (e.g. `float`) may now
   use `null` now rather than the empty string
   - [#4302](https://github.com/bpftrace/bpftrace/pull/4302)
+- Text output now has errors emitted to `stderr` instead of mixed with `stdout`
+  - [#4504](https://github.com/bpftrace/bpftrace/pull/4504)
 #### Added
 - Add ncpus builtin to get the number of CPUs.
   - [#4105](https://github.com/bpftrace/bpftrace/pull/4105)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to
 - JSON serialization for unsupported and unknown types (e.g. `float`) may now
   use `null` now rather than the empty string
   - [#4302](https://github.com/bpftrace/bpftrace/pull/4302)
-- Text output now has errors emitted to `stderr` instead of mixed with `stdout`
+- Text mode now emits all non-script generated output (e.g., errors, attached notifications) to `stderr` instead of `stdout`
   - [#4504](https://github.com/bpftrace/bpftrace/pull/4504)
 #### Added
 - Add ncpus builtin to get the number of CPUs.

--- a/src/output/text.cpp
+++ b/src/output/text.cpp
@@ -535,13 +535,13 @@ void TextOutput::errorf(const std::string &str, const SourceInfo &info)
     if (first) {
       // No need to print the source context as that's just the `errorf`
       // call
-      LOG(ERROR, std::string(loc.source_location), out_) << str;
+      LOG(ERROR, std::string(loc.source_location), err_) << str;
       first = false;
     } else {
       LOG(ERROR,
           std::string(loc.source_location),
           std::vector(loc.source_context),
-          out_)
+          err_)
           << "expanded from";
     }
   }
@@ -569,15 +569,15 @@ void TextOutput::syscall(const std::string &syscall)
 
 void TextOutput::lost_events(uint64_t lost)
 {
-  out_ << "Lost " << lost << " events" << std::endl;
+  err_ << "Lost " << lost << " events" << std::endl;
 }
 
 void TextOutput::attached_probes(uint64_t num_probes)
 {
   if (num_probes == 1)
-    out_ << "Attached " << num_probes << " probe" << std::endl;
+    err_ << "Attached " << num_probes << " probe" << std::endl;
   else
-    out_ << "Attached " << num_probes << " probes" << std::endl;
+    err_ << "Attached " << num_probes << " probes" << std::endl;
 }
 
 void TextOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
@@ -607,7 +607,7 @@ void TextOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
       LOG(WARNING,
           std::string(info.locations.begin()->source_location),
           std::vector(info.locations.begin()->source_context),
-          out_)
+          err_)
           << msg << "\nAdditional Info - helper: " << info.func_id
           << ", retcode: " << retcode;
       break;
@@ -616,7 +616,7 @@ void TextOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
       LOG(WARNING,
           std::string(info.locations.begin()->source_location),
           std::vector(info.locations.begin()->source_context),
-          out_)
+          err_)
           << info;
       break;
     }
@@ -627,7 +627,7 @@ void TextOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
     LOG(WARNING,
         std::string(info.locations[i].source_location),
         std::vector(info.locations[i].source_context),
-        out_)
+        err_)
         << "expanded from";
   }
 }

--- a/src/output/text.h
+++ b/src/output/text.h
@@ -8,7 +8,9 @@ namespace bpftrace::output {
 
 class TextOutput : public Output {
 public:
-  explicit TextOutput(std::ostream &out = std::cout) : out_(out) {};
+  explicit TextOutput(std::ostream &out = std::cout,
+                      std::ostream &err = std::cerr)
+      : out_(out), err_(err) {};
 
   void map(const std::string &name, const Value &value) override;
   void value(const Value &value) override;
@@ -30,6 +32,7 @@ public:
 
 private:
   std::ostream &out_;
+  std::ostream &err_;
 };
 
 } // namespace bpftrace::output

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -87,6 +87,8 @@ int run_bpftrace(BPFtrace &bpftrace,
   }
   std::unique_ptr<output::Output> output;
   if (output_format.empty() || output_format == "text") {
+    // Note that there are two parameters here: we leave the err output as
+    // std::cerr, so this can be seen while running.
     output = std::make_unique<output::TextOutput>(*os);
   } else if (output_format == "json") {
     output = std::make_unique<output::JsonOutput>(*os);

--- a/tests/async_action.cpp
+++ b/tests/async_action.cpp
@@ -23,7 +23,7 @@ class AsyncActionTest : public testing::Test {
 public:
   AsyncActionTest()
       : bpftrace(get_mock_bpftrace()),
-        output(out),
+        output(out, out),
         handlers(*bpftrace, no_c_defs, output) {};
 
   std::unique_ptr<MockBPFtrace> bpftrace;

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -956,7 +956,7 @@ basic_map_4[7]: 5
 
   for (const auto &tc : test_cases) {
     std::stringstream out;
-    output::TextOutput output(out);
+    output::TextOutput output(out, out);
     auto bpftrace = get_mock_bpftrace();
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,
                                                  tc.name);
@@ -1031,7 +1031,7 @@ max_map_4[3]: 10
 
   for (const auto &tc : test_cases) {
     std::stringstream out;
-    output::TextOutput output(out);
+    output::TextOutput output(out, out);
     auto bpftrace = get_mock_bpftrace();
 
     bpftrace->ncpus_ = 3;
@@ -1107,7 +1107,7 @@ avg_map_4[3]: 100
 
   for (const auto &tc : test_cases) {
     std::stringstream out;
-    output::TextOutput output(out);
+    output::TextOutput output(out, out);
     auto bpftrace = get_mock_bpftrace();
 
     bpftrace->ncpus_ = 3;
@@ -1178,7 +1178,7 @@ string_map_4[3]: hello
 
   for (const auto &tc : test_cases) {
     std::stringstream out;
-    output::TextOutput output(out);
+    output::TextOutput output(out, out);
     auto bpftrace = get_mock_bpftrace();
 
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,
@@ -1272,7 +1272,7 @@ lhist_map_3[0]:
 
   for (const auto &tc : test_cases) {
     std::stringstream out;
-    output::TextOutput output(out);
+    output::TextOutput output(out, out);
     auto bpftrace = get_mock_bpftrace();
 
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,
@@ -1375,7 +1375,7 @@ hist_map_3[0]:
 
   for (const auto &tc : test_cases) {
     std::stringstream out;
-    output::TextOutput output(out);
+    output::TextOutput output(out, out);
     auto bpftrace = get_mock_bpftrace();
 
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,
@@ -1463,7 +1463,7 @@ hh:mm:ss.ms  |___________________________________________________|
 
   for (const auto &tc : test_cases) {
     std::stringstream out;
-    output::TextOutput output(out);
+    output::TextOutput output(out, out);
     auto bpftrace = get_mock_bpftrace();
 
     auto mock_map = std::make_unique<MockBpfMap>(libbpf::BPF_MAP_TYPE_HASH,

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -13,7 +13,7 @@ static ast::CDefinitions no_c_defs; // Used for format below.
 TEST(TextOutput, lhist_no_suffix)
 {
   std::stringstream out;
-  ::bpftrace::output::TextOutput output(out);
+  ::bpftrace::output::TextOutput output(out, out);
 
   auto bpftrace = get_mock_bpftrace();
   bpftrace->resources.maps_info["@mymap"] = MapInfo{
@@ -57,7 +57,7 @@ TEST(TextOutput, lhist_no_suffix)
 TEST(TextOutput, lhist_suffix)
 {
   std::stringstream out;
-  ::bpftrace::output::TextOutput output(out);
+  ::bpftrace::output::TextOutput output(out, out);
 
   auto bpftrace = get_mock_bpftrace();
   bpftrace->resources.maps_info["@mymap"] = MapInfo{

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -513,13 +513,13 @@ EXPECT_REGEX @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 
 # Output two microsecond timestamps, 123000 nsecs apart. Use python to evaluate and verify there's a 123us delta
 NAME strftime_microsecond_extension
-RUN {{BPFTRACE}} -e 'begin { printf("%s - %s\n", strftime("%s.%f", 123000), strftime("%s.%f", 0));  }' | tail -n +3 | bc
+RUN {{BPFTRACE}} -e 'begin { printf("%s - %s\n", strftime("%s.%f", 123000), strftime("%s.%f", 0));  }' | bc
 EXPECT .000123
 TIMEOUT 1
 
 # Similar to above test but test that rolling over past 1s works as expected
 NAME strftime_microsecond_extension_rollover
-RUN {{BPFTRACE}} -e 'begin { printf("%s - %s\n", strftime("%s.%f", 1000123000), strftime("%s.%f", 0));  }' | tail -n +3 | bc
+RUN {{BPFTRACE}} -e 'begin { printf("%s - %s\n", strftime("%s.%f", 1000123000), strftime("%s.%f", 0));  }' | bc
 EXPECT 1.000123
 TIMEOUT 1
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#4504


--- --- ---

### output: add second stream for `TextOutput`


Since `TextOutput` is likely to be interactive, require a second error
stream to be specified which will be left as `std::cerr` by default.

Fixes #4495

Signed-off-by: Adin Scannell <amscanne@meta.com>
