### PR TITLE
Remove max_ast_nodes env var

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -319,7 +319,6 @@ def fuzz():
                     "AFL_NO_AFFINITY": "1",
                     "ASAN_OPTIONS": "abort_on_error=1,symbolize=0",
                     "BPFTRACE_BTF": "",
-                    "BPFTRACE_MAX_AST_NODES": "200",
                     "BPFTRACE_AVAILABLE_FUNCTIONS_TEST": "",
                     # This setting [1] is used to skip the core pattern check,
                     # so crashes may be missed. Since this is just a smoke

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -21,13 +21,6 @@ fuzzer and the function.
 
 ## Options
 
-### `BPFTRACE_MAX_AST_NODES` environment variable
-
-When doing fuzzing, it is important to limit the number of AST nodes because
-otherwise, a fuzzer might keep generating a very long program that causes a
-stack overflow.  `BPFTRACE_MAX_AST_NODES` environment variable controls the
-maximum number of AST nodes.
-
 ## Fuzzing with AFL
 
 Before starting, it is highly recommended to read the [AFL][AFL] or
@@ -73,7 +66,6 @@ the fuzzer is by using the `--test=codegen` mode and providing overrides:
 AFL_NO_AFFINITY=1 \
 ASAN_OPTIONS=abort_on_error=1,symbolize=0 \
 BPFTRACE_BTF= \
-BPFTRACE_MAX_AST_NODES=200 \
 BPFTRACE_AVAILABLE_FUNCTIONS_TEST= \
 afl-fuzz -a text -M 0 -m none -i ./input -o ./output -t 3000 -- \
      src/bpftrace --test=codegen @@ 2>/dev/null

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -29,7 +29,7 @@ inline std::vector<Pass> AllParsePasses(
     bool debug = false)
 {
   std::vector<Pass> passes;
-  passes.emplace_back(CreateParsePass(0, debug));
+  passes.emplace_back(CreateParsePass(debug));
   passes.emplace_back(CreateConfigPass());
   passes.emplace_back(CreateResolveImportsPass(std::move(import_paths)));
   // N.B. We expand the AST with all externally imported scripts, then check

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -211,7 +211,6 @@ public:
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
   int helper_check_level_ = 1;
-  uint64_t max_ast_nodes_ = std::numeric_limits<uint64_t>::max();
   bool debug_output_ = false;
   std::optional<struct timespec> boottime_;
   std::optional<struct timespec> delta_taitime_;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -297,8 +297,7 @@ const std::map<std::string, std::string> DEPRECATED = {
 // These are configuration names that are consumed elsewhere. We use this only
 // to check if we should produce a more helpful error for the user.
 const std::unordered_set<std::string> ENV_ONLY = {
-  "btf",           "debug_output",   "kernel_build", "kernel_source",
-  "max_ast_nodes", "verify_llvm_ir", "vmlinux",
+  "btf", "debug_output", "kernel_build", "kernel_source", "vmlinux",
 };
 
 // This is applied for all environment variables, and will also be accepted

--- a/src/driver.h
+++ b/src/driver.h
@@ -43,6 +43,6 @@ private:
   void parse(Parser::symbol_type first_token);
 };
 
-ast::Pass CreateParsePass(uint32_t max_ast_nodes = 0, bool debug = false);
+ast::Pass CreateParsePass(bool debug = false);
 
 } // namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -717,8 +717,6 @@ int main(int argc, char* argv[])
   // Most configuration can be applied during the configuration pass, however
   // we need to extract a few bits of configuration up front, because they may
   // affect the actual compilation process.
-  util::get_uint64_env_var("BPFTRACE_MAX_AST_NODES",
-                           [&](uint64_t x) { bpftrace.max_ast_nodes_ = x; });
   util::get_bool_env_var("BPFTRACE_DEBUG_OUTPUT",
                          [&](bool x) { bpftrace.debug_output_ = x; });
 
@@ -880,8 +878,7 @@ int main(int argc, char* argv[])
   if (args.listing) {
     ast::CDefinitions no_c_defs; // See above.
     ast::TypeMetadata no_types;  // See above.
-    pm.add(CreateParsePass(bpftrace.max_ast_nodes_,
-                           bt_debug.contains(DebugStage::Parse)))
+    pm.add(CreateParsePass(bt_debug.contains(DebugStage::Parse)))
         .put(no_c_defs)
         .put(no_types)
         .add(ast::CreateParseAttachpointsPass(args.listing))

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -78,10 +78,9 @@ static void test_lookup_error(const std::string &key,
 TEST(Config, get_config_key)
 {
   test_lookup_error("logsize", 1, "logsize: not a known configuration option");
-  test_lookup_error(
-      "max_ast_nodes",
-      1,
-      "max_ast_nodes: can only be set as an environment variable");
+  test_lookup_error("kernel_build",
+                    1,
+                    "kernel_build: can only be set as an environment variable");
 }
 
 } // namespace bpftrace::test

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -130,10 +130,10 @@ config = { BPFTRACE_MAX_PROBES = "hello" } begin { }
 )",
       false);
   test(
-      "config = { max_ast_nodes=1 } begin { }",
-      R"(stdin:1:12-27: ERROR: max_ast_nodes: can only be set as an environment variable
-config = { max_ast_nodes=1 } begin { }
-           ~~~~~~~~~~~~~~~
+      "config = { kernel_build=1 } begin { }",
+      R"(stdin:1:12-26: ERROR: kernel_build: can only be set as an environment variable
+config = { kernel_build=1 } begin { }
+           ~~~~~~~~~~~~~~
 )",
       false);
 }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4232,14 +4232,6 @@ begin { $i = tid(1); }
 )" });
 }
 
-TEST_F(SemanticAnalyserTest, config)
-{
-  test("config = { BPFTRACE_MAX_AST_NODES=1 } "
-       "begin { $ns = nsecs(); }");
-  test("config = { BPFTRACE_MAX_AST_NODES=1; stack_mode=raw } "
-       "begin { $ns = nsecs(); }");
-}
-
 TEST_F(SemanticAnalyserTest, subprog_return)
 {
   test("fn f(): void { return; }");


### PR DESCRIPTION
Stacked PRs:
 * __->__#4506


--- --- ---

### Remove max_ast_nodes env var


This wasn't actually getting passed to CreateParsePass
due to a refactoring error but the fuzzing test
seems to continue working fine.

Let's remove for now and see if it causes any issues.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>