### PR TITLE
Add 0 flag for printf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ and this project adheres to
   - [#4420](https://github.com/bpftrace/bpftrace/pull/4420)
 - Allow non-constant array access
   - [#4491](https://github.com/bpftrace/bpftrace/pull/4491)
+- Add '0' flag for printf to fill with leading 0s
+  - [#4510](https://github.com/bpftrace/bpftrace/pull/4510)
 #### Changed
 - kprobe: support verbose mode listing
   - [#4362](https://github.com/bpftrace/bpftrace/pull/4362)

--- a/src/format_string.h
+++ b/src/format_string.h
@@ -32,6 +32,7 @@ public:
   bool show_sign = false;      // +
   bool space_prefix = false;   // (space)
   bool alternate_form = false; // #
+  bool lead_zeros = false;     // 0
   int width = 0;               // field width
   int precision = -1;          // precision after decimal point
   std::string length_modifier; // h, l, ll, etc.

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -61,6 +61,10 @@ NAME printf_invalid_enum_symbolize_cast
 PROG enum Foo { ONE = 1, TWO = 2, OTHER = 99999 }; begin { $x = 100; printf("%d %s\n", ONE, (enum Foo)$x); exit() }
 EXPECT 1 100
 
+NAME printf_lead_zeros
+PROG begin { printf("%5s %04x", "ba", 2); }
+EXPECT    ba 0002
+
 NAME errorf
 PROG begin { errorf("Something bad with args: %d, %s", 10, "arg2"); }
 EXPECT stdin:1:9-62: ERROR: Something bad with args: 10, arg2


### PR DESCRIPTION
Stacked PRs:
 * __->__#4510


--- --- ---

### Add 0 flag for printf


The leading characters should be 0
when the 0 flag is specified.

Issue:
- https://github.com/bpftrace/bpftrace/issues/4501

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>