### PR TITLE
ast: remove `Predicate` and just fold as an `If` over the body

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1011,18 +1011,6 @@ public:
   std::optional<Expression> return_value;
 };
 
-class Predicate : public Node {
-public:
-  explicit Predicate(ASTContext &ctx, Expression expr, Location &&loc)
-      : Node(ctx, std::move(loc)), expr(std::move(expr)) {};
-  explicit Predicate(ASTContext &ctx,
-                     const Predicate &other,
-                     const Location &loc)
-      : Node(ctx, loc + other.loc), expr(clone(ctx, other.expr, loc)) {};
-
-  Expression expr;
-};
-
 class IfExpr : public Node {
 public:
   explicit IfExpr(ASTContext &ctx,
@@ -1213,24 +1201,20 @@ class Probe : public Node {
 public:
   explicit Probe(ASTContext &ctx,
                  AttachPointList &&attach_points,
-                 Predicate *pred,
                  BlockExpr *block,
                  Location &&loc)
       : Node(ctx, std::move(loc)),
         attach_points(std::move(attach_points)),
-        pred(pred),
         block(block),
         orig_name(probe_orig_name(this->attach_points)) {};
   explicit Probe(ASTContext &ctx, const Probe &other, const Location &loc)
       : Node(ctx, loc + other.loc),
         attach_points(clone(ctx, other.attach_points, loc)),
-        pred(clone(ctx, other.pred, loc)),
         block(clone(ctx, other.block, loc)),
         orig_name(other.orig_name),
         index_(other.index_) {};
 
   AttachPointList attach_points;
-  Predicate *pred = nullptr;
   BlockExpr *block = nullptr;
   std::string orig_name;
 

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -377,9 +377,6 @@ void FieldAnalyser::visit(Probe &probe)
     prog_type_ = progtype(probe_type_);
     attach_func_ = ap->func;
   }
-  if (probe.pred) {
-    visit(probe.pred);
-  }
   visit(probe.block);
 }
 

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -499,16 +499,6 @@ void Printer::visit(Jump &jump)
   --depth_;
 }
 
-void Printer::visit(Predicate &pred)
-{
-  std::string indent(depth_, ' ');
-  out_ << indent << "pred" << std::endl;
-
-  ++depth_;
-  visit(pred.expr);
-  --depth_;
-}
-
 void Printer::visit(AttachPoint &ap)
 {
   std::string indent(depth_, ' ');
@@ -520,7 +510,6 @@ void Printer::visit(Probe &probe)
   visit(probe.attach_points);
 
   ++depth_;
-  visit(probe.pred);
   visit(probe.block);
   --depth_;
 }

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -53,7 +53,6 @@ public:
   void visit(For &for_loop);
   void visit(Config &config);
   void visit(Jump &jump);
-  void visit(Predicate &pred);
   void visit(AttachPoint &ap);
   void visit(Probe &probe);
   void visit(SubprogArg &arg);

--- a/src/ast/passes/probe_expansion.cpp
+++ b/src/ast/passes/probe_expansion.cpp
@@ -38,7 +38,6 @@ void ExpansionAnalyser::visit(Probe &probe)
   probe_ = &probe;
 
   visit(probe.attach_points);
-  visit(probe.pred);
   visit(probe.block);
 }
 
@@ -159,10 +158,9 @@ Probe *SessionExpander::find_matching_retprobe(Probe &probe)
   // - has a single kretprobe attach point
   // - attaches to the same target and function as probe
   // - is multi-expanded (session expansion uses the same attach mechanism)
-  // - has no predicate
   std::ranges::copy_if(
       ast_.root->probes, std::back_inserter(retprobes), [&](Probe *other) {
-        return other->attach_points.size() == 1 && other->pred == nullptr &&
+        return other->attach_points.size() == 1 &&
                probetype(other->attach_points[0]->provider) ==
                    ProbeType::kretprobe &&
                expansion_result_.get_expansion(*other->attach_points[0]) ==
@@ -184,10 +182,8 @@ void SessionExpander::visit(Probe &probe)
   // there's another probe with a single multi-expanded kretprobe attach point
   // with the same target. If so, perform session expansion by merging the two
   // probes together.
-  // Currently, we don't allow predicates in either of the probes.
   if (probe.attach_points.size() == 1 &&
-      probetype(probe.attach_points[0]->provider) == ProbeType::kprobe &&
-      probe.pred == nullptr) {
+      probetype(probe.attach_points[0]->provider) == ProbeType::kprobe) {
     Probe *retprobe = find_matching_retprobe(probe);
     if (!retprobe)
       return;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -167,7 +167,6 @@ public:
   void visit(AssignVarStatement &assignment);
   void visit(VarDeclStatement &decl);
   void visit(Unroll &unroll);
-  void visit(Predicate &pred);
   void visit(AttachPoint &ap);
   void visit(Probe &probe);
   void visit(BlockExpr &block);
@@ -3754,18 +3753,6 @@ void SemanticAnalyser::visit(VarDeclStatement &decl)
   variable_decls_[scope_stack_.back()].insert({ var_ident, decl });
 }
 
-void SemanticAnalyser::visit(Predicate &pred)
-{
-  visit(pred.expr);
-  if (is_final_pass()) {
-    const auto &ty = pred.expr.type();
-    if (!ty.IsIntTy() && !ty.IsPtrTy() && !ty.IsBoolTy()) {
-      pred.addError() << "Invalid type for predicate: "
-                      << pred.expr.type().GetTy();
-    }
-  }
-}
-
 void SemanticAnalyser::visit(AttachPoint &ap)
 {
   if (ap.provider == "kprobe" || ap.provider == "kretprobe") {
@@ -4088,7 +4075,6 @@ void SemanticAnalyser::visit(Probe &probe)
     }
     visit(ap);
   }
-  visit(probe.pred);
   visit(probe.block);
 }
 

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -212,14 +212,9 @@ public:
     visitImpl(for_loop.block);
     return default_value();
   }
-  R visit(Predicate &pred)
-  {
-    return visitImpl(pred.expr);
-  }
   R visit(Probe &probe)
   {
     visitImpl(probe.attach_points);
-    visitImpl(probe.pred);
     visitImpl(probe.block);
     return default_value();
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -681,8 +681,9 @@ static ast::ASTContext buildListProgram(const std::string& search)
 {
   ast::ASTContext ast("listing", search);
   auto* ap = ast.make_node<ast::AttachPoint>(search, true, location());
-  auto* probe = ast.make_node<ast::Probe>(
-      ast::AttachPointList({ ap }), nullptr, nullptr, location());
+  auto* probe = ast.make_node<ast::Probe>(ast::AttachPointList({ ap }),
+                                          nullptr,
+                                          location());
   ast.root = ast.make_node<ast::Program>("",
                                          nullptr,
                                          ast::ImportList(),

--- a/tests/codegen/llvm/call_cgroup.ll
+++ b/tests/codegen/llvm/call_cgroup.ll
@@ -22,13 +22,10 @@ entry:
   %"@x_key" = alloca i64, align 8
   %get_cgroup_id = call i64 inttoptr (i64 80 to ptr)() #2
   %1 = icmp eq i64 %get_cgroup_id, 4294967297
-  %predcond = icmp eq i1 %1, false
-  br i1 %predcond, label %pred_false, label %pred_true
+  %true_cond = icmp ne i1 %1, false
+  br i1 %true_cond, label %left, label %right
 
-pred_false:                                       ; preds = %entry
-  ret i64 1
-
-pred_true:                                        ; preds = %entry
+left:                                             ; preds = %entry
   %get_cgroup_id1 = call i64 inttoptr (i64 80 to ptr)() #2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
@@ -37,6 +34,12 @@ pred_true:                                        ; preds = %entry
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  br label %done
+
+right:                                            ; preds = %entry
+  br label %done
+
+done:                                             ; preds = %right, %left
   ret i64 1
 }
 

--- a/tests/codegen/llvm/fentry_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/fentry_recursion_check_with_predicate.ll
@@ -18,7 +18,6 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @fentry_mock_vmlinux_queued_spin_lock_slowpath_1(ptr %0) #0 section "s_fentry_mock_vmlinux_queued_spin_lock_slowpath_1" !dbg !52 {
 entry:
-  %lookup_key8 = alloca i32, align 4
   %lookup_key1 = alloca i32, align 4
   %lookup_key = alloca i32, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
@@ -43,8 +42,8 @@ lookup_merge:                                     ; preds = %lookup_success
   %pid = trunc i64 %2 to i32
   %3 = zext i32 %pid to i64
   %4 = icmp eq i64 %3, 1234
-  %predcond = icmp eq i1 %4, false
-  br i1 %predcond, label %pred_false, label %pred_true
+  %true_cond = icmp ne i1 %4, false
+  br i1 %true_cond, label %left, label %right
 
 value_is_set:                                     ; preds = %lookup_success
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
@@ -56,42 +55,29 @@ value_is_set:                                     ; preds = %lookup_success
   store i64 %8, ptr %6, align 8
   ret i64 0
 
-pred_false:                                       ; preds = %lookup_merge
+left:                                             ; preds = %lookup_merge
+  br label %done
+
+right:                                            ; preds = %lookup_merge
+  br label %done
+
+done:                                             ; preds = %right, %left
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key1)
   store i32 0, ptr %lookup_key1, align 4
   %lookup_elem2 = call ptr inttoptr (i64 1 to ptr)(ptr @recursion_prevention, ptr %lookup_key1)
   %map_lookup_cond6 = icmp ne ptr %lookup_elem2, null
   br i1 %map_lookup_cond6, label %lookup_success3, label %lookup_failure4
 
-pred_true:                                        ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key8)
-  store i32 0, ptr %lookup_key8, align 4
-  %lookup_elem9 = call ptr inttoptr (i64 1 to ptr)(ptr @recursion_prevention, ptr %lookup_key8)
-  %map_lookup_cond13 = icmp ne ptr %lookup_elem9, null
-  br i1 %map_lookup_cond13, label %lookup_success10, label %lookup_failure11
-
-lookup_success3:                                  ; preds = %pred_false
+lookup_success3:                                  ; preds = %done
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key1)
   %cast7 = ptrtoint ptr %lookup_elem2 to i64
   store i64 0, i64 %cast7, align 8
   br label %lookup_merge5
 
-lookup_failure4:                                  ; preds = %pred_false
+lookup_failure4:                                  ; preds = %done
   br label %lookup_merge5
 
 lookup_merge5:                                    ; preds = %lookup_failure4, %lookup_success3
-  ret i64 0
-
-lookup_success10:                                 ; preds = %pred_true
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key8)
-  %cast14 = ptrtoint ptr %lookup_elem9 to i64
-  store i64 0, i64 %cast14, align 8
-  br label %lookup_merge12
-
-lookup_failure11:                                 ; preds = %pred_true
-  br label %lookup_merge12
-
-lookup_merge12:                                   ; preds = %lookup_failure11, %lookup_success10
   ret i64 0
 }
 

--- a/tests/codegen/llvm/pred_binop.ll
+++ b/tests/codegen/llvm/pred_binop.ll
@@ -25,13 +25,10 @@ entry:
   %pid = trunc i64 %1 to i32
   %2 = zext i32 %pid to i64
   %3 = icmp eq i64 %2, 1234
-  %predcond = icmp eq i1 %3, false
-  br i1 %predcond, label %pred_false, label %pred_true
+  %true_cond = icmp ne i1 %3, false
+  br i1 %true_cond, label %left, label %right
 
-pred_false:                                       ; preds = %entry
-  ret i64 0
-
-pred_true:                                        ; preds = %entry
+left:                                             ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
@@ -39,6 +36,12 @@ pred_true:                                        ; preds = %entry
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
+  br label %done
+
+right:                                            ; preds = %entry
+  br label %done
+
+done:                                             ; preds = %right, %left
   ret i64 0
 }
 

--- a/tests/codegen/llvm/strncmp_no_literals.ll
+++ b/tests/codegen/llvm/strncmp_no_literals.ll
@@ -44,10 +44,7 @@ entry:
   %strcmp.cmp = icmp ne i8 %7, %9
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
-pred_false:                                       ; preds = %strcmp.false
-  ret i64 1
-
-pred_true:                                        ; preds = %strcmp.false
+left:                                             ; preds = %strcmp.false
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
@@ -55,14 +52,20 @@ pred_true:                                        ; preds = %strcmp.false
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
+  br label %done
+
+right:                                            ; preds = %strcmp.false
+  br label %done
+
+done:                                             ; preds = %right, %left
   ret i64 1
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
   %10 = load i1, ptr %strcmp.result, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %__builtin_comm)
-  %predcond = icmp eq i1 %10, false
-  br i1 %predcond, label %pred_false, label %pred_true
+  %true_cond = icmp ne i1 %10, false
+  br i1 %true_cond, label %left, label %right
 
 strcmp.done:                                      ; preds = %strcmp.loop57, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp54, %strcmp.loop_null_cmp50, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp42, %strcmp.loop_null_cmp38, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp30, %strcmp.loop_null_cmp26, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp18, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
   store i1 true, ptr %strcmp.result, align 1

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -823,9 +823,10 @@ TEST(Parser, predicate)
   test("kprobe:sys_open / @x / { 1; }",
        "Program\n"
        " kprobe:sys_open\n"
-       "  pred\n"
+       "  if\n"
        "   map: @x\n"
-       "  int: 1 :: [int64]\n");
+       "   then\n"
+       "    int: 1 :: [int64]\n");
 }
 
 TEST(Parser, predicate_containing_division)
@@ -833,11 +834,12 @@ TEST(Parser, predicate_containing_division)
   test("kprobe:sys_open /100/25/ { 1; }",
        "Program\n"
        " kprobe:sys_open\n"
-       "  pred\n"
+       "  if\n"
        "   /\n"
        "    int: 100 :: [int64]\n"
        "    int: 25 :: [int64]\n"
-       "  int: 1 :: [int64]\n");
+       "   then\n"
+       "    int: 1 :: [int64]\n");
 }
 
 TEST(Parser, expressions)
@@ -849,7 +851,7 @@ TEST(Parser, expressions)
        "}",
        "Program\n"
        " kprobe:sys_open\n"
-       "  pred\n"
+       "  if\n"
        "   ||\n"
        "    &&\n"
        "     <=\n"
@@ -868,7 +870,8 @@ TEST(Parser, expressions)
        "    ==\n"
        "     builtin: __builtin_comm\n"
        "     string: string\n"
-       "  int: 1 :: [int64]\n");
+       "   then\n"
+       "    int: 1 :: [int64]\n");
 }
 
 TEST(Parser, variable_post_increment_decrement)
@@ -940,15 +943,16 @@ TEST(Parser, bit_shifting)
   test("kprobe:do_nanosleep / 2 < 1 >> 8 / { $x = 1 }",
        "Program\n"
        " kprobe:do_nanosleep\n"
-       "  pred\n"
+       "  if\n"
        "   <\n"
        "    int: 2 :: [int64]\n"
        "    >>\n"
        "     int: 1 :: [int64]\n"
        "     int: 8 :: [int64]\n"
-       "  =\n"
-       "   variable: $x\n"
-       "   int: 1 :: [int64]\n");
+       "   then\n"
+       "    =\n"
+       "     variable: $x\n"
+       "     int: 1 :: [int64]\n");
 }
 
 TEST(Parser, ternary_int)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -424,18 +424,14 @@ TEST_F(SemanticAnalyserTest, predicate_expressions)
 {
   test("kprobe:f / 999 / { 123 }");
   test("kprobe:f / true / { 123 }");
-  test("kprobe:f / \"str\" / { 123 }", Error{ R"(
-stdin:1:10-19: ERROR: Invalid type for predicate: string
-kprobe:f / "str" / { 123 }
-         ~~~~~~~~~
-)" });
+  test("kprobe:f / \"str\" / { 123 }");
   test("kprobe:f / kstack / { 123 }", Error{ R"(
-stdin:1:10-20: ERROR: Invalid type for predicate: kstack
+stdin:1:10-20: ERROR: Invalid condition: kstack
 kprobe:f / kstack / { 123 }
          ~~~~~~~~~~
 )" });
   test("kprobe:f / @mymap / { @mymap = \"str\" }", Error{ R"(
-stdin:1:10-20: ERROR: Invalid type for predicate: string
+stdin:1:10-20: ERROR: Invalid condition: string
 kprobe:f / @mymap / { @mymap = "str" }
          ~~~~~~~~~~
 )" });


### PR DESCRIPTION
Stacked PRs:
 * #4516
 * #4513
 * #4515
 * __->__#4514


--- --- ---

### ast: remove `Predicate` and just fold as an `If` over the body


There is nothing special that happens for the predicate in any case. We
can just treat this as an `If`, which simplifies later passes and
ensures that this is treated correctly. If we want to do something
clever in the future with the predicate, we can generalize this feature
over any `if` expression in the probe, e.g. recursively lifting up the
if expression if it is the only top-level statement (regardless if it is
expressed as a syntactic predicate).

Signed-off-by: Adin Scannell <amscanne@meta.com>
