### PR TITLE
syntax: accept single-element tuples

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -1641,10 +1641,10 @@ kprobe:dummy {
 
 ## Tuples
 
-bpftrace has support for immutable N-tuples (`n > 1`).
+bpftrace has support for immutable N-tuples.
 A tuple is a sequence type (like an array) where, unlike an array, every element can have a different type.
 
-Tuples are a comma separated list of expressions, enclosed in brackets, `(1,2)`
+Tuples are a comma separated list of expressions, enclosed in brackets, `(1,2)`.
 Individual fields can be accessed with the `.` operator.
 Tuples are zero indexed like arrays are.
 
@@ -1664,6 +1664,9 @@ interval:s:1 {
  * 3
  */
 ```
+
+Single-element and empty tuples can be specified using Python-like syntax.
+A single element tuple requires a trailing comma, `(1,)`, while the empty tuple is simply `()`.
 
 ## Type conversion
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -173,7 +173,12 @@ StructType *IRBuilderBPF::GetStructType(
   if (search != structs_.end())
     return search->second;
 
-  StructType *s = StructType::create(elements, name, packed);
+  StructType *s = nullptr;
+  if (!elements.empty()) {
+    s = StructType::create(module_.getContext(), elements, name, packed);
+  } else {
+    s = StructType::create(module_.getContext(), name);
+  }
   structs_.insert({ name, s });
   return s;
 }

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3385,10 +3385,9 @@ void SemanticAnalyser::visit(Tuple &tuple)
   for (auto &elem : tuple.elems) {
     visit(elem);
 
-    // If elem type is none that means that the tuple contains some
-    // invalid cast (e.g., (0, (aaa)0)). In this case, skip the tuple
-    // creation. Cast already emits the error.
-    if (elem.type().IsNoneTy() || elem.type().GetSize() == 0) {
+    // If elem type is none that means that the tuple is not yet resolved.
+    if (elem.type().IsNoneTy()) {
+      pass_tracker_.inc_num_unresolved();
       return;
     } else if (elem.type().IsMultiKeyMapTy()) {
       elem.node().addError()

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2640,6 +2640,46 @@ TEST(Parser, while_loop)
 )PROG");
 }
 
+TEST(Parser, tuples)
+{
+  test("k:f { print(()); }", R"PROG(Program
+ kprobe:f
+  call: print
+   tuple:
+)PROG");
+  // Not a tuple.
+  test("k:f { print((1)); }", R"PROG(Program
+ kprobe:f
+  call: print
+   int: 1 :: [int64]
+)PROG");
+  test("k:f{ print((1,)); }", R"PROG(Program
+ kprobe:f
+  call: print
+   tuple:
+    int: 1 :: [int64]
+)PROG");
+  test("k:f { print((1,2)); }", R"PROG(Program
+ kprobe:f
+  call: print
+   tuple:
+    int: 1 :: [int64]
+    int: 2 :: [int64]
+)PROG");
+  test("k:f { print((1,2,)); }", R"PROG(Program
+ kprobe:f
+  call: print
+   tuple:
+    int: 1 :: [int64]
+    int: 2 :: [int64]
+)PROG");
+  test_parse_failure("k:f { print((,)); }", R"(
+stdin:1:7-15: ERROR: syntax error, unexpected ","
+k:f { print((,)); }
+      ~~~~~~~~
+)");
+}
+
 TEST(Parser, tuple_assignment_error_message)
 {
   std::stringstream out;


### PR DESCRIPTION
Stacked PRs:
 * __->__#4520


--- --- ---

### syntax: accept single-element tuples


This generalized the tuple syntax to match Python's and accepts
single-element tuples and empty tuples.

Signed-off-by: Adin Scannell <amscanne@meta.com>
