### PR TITLE
Improve tuple comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 #### Fixed
 - ast: Avoid undefined behavior in literal folding
   - [#4649](https://github.com/bpftrace/bpftrace/pull/4649)
+- Improved tuple binop comparison
+  - [#4523](https://github.com/bpftrace/bpftrace/pull/4523)
 #### Security
 #### Docs
 #### Tools

--- a/docs/language.md
+++ b/docs/language.md
@@ -756,12 +756,29 @@ The following relational operators are defined for integers and pointers.
 | == | left-hand expression equal to right-hand |
 | != | left-hand expression not equal to right-hand |
 
-The following relation operators are available for comparing strings and integer arrays.
+The following relation operators are available for comparing strings, integer arrays, and tuples.
 
 |     |     |
 | --- | --- |
 | == | left-hand string equal to right-hand |
 | != | left-hand string not equal to right-hand |
+
+**Note:** Tuple comparison works by comparing each element of both tuples
+with a logical && chain, e.g., the comparison of these two tuples
+```
+$x = ("hello", -6);
+$y = ("bye", -6);
+```
+turns this:
+```
+$x == $y
+```
+into this
+```
+($x.0 == $y.0 && $x.1 == $y.1)
+```
+So if comparing literal tuples that have nested expression with side effects
+they may not execute due to short-circuiting if previous elements are not equal.
 
 ### Assignment Operators
 

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(ast STATIC
   passes/probe_prune.cpp
   passes/resource_analyser.cpp
   passes/semantic_analyser.cpp
+  passes/simplify_types.cpp
   passes/codegen_llvm.cpp
   passes/resolve_imports.cpp
   passes/return_path_analyser.cpp

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -16,6 +16,7 @@
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
 #include "ast/passes/semantic_analyser.h"
+#include "ast/passes/simplify_types.h"
 #include "ast/passes/type_system.h"
 #include "ast/signal_bt.h"
 #include "btf/compat.h"
@@ -2680,7 +2681,7 @@ void SemanticAnalyser::visit(Binop &binop)
   }
   // Compare type here, not the sized type as we it needs to work on strings
   // of different lengths
-  else if (lht.GetTy() != rht.GetTy()) {
+  else if (!lht.IsSameType(rht)) {
     auto &err = binop.addError();
     err << "Type mismatch for '" << opstr(binop) << "': comparing " << lht
         << " with " << rht;
@@ -3419,6 +3420,7 @@ void SemanticAnalyser::visit(Expression &expr)
   // Visit and fold all other values.
   Visitor<SemanticAnalyser>::visit(expr);
   fold(ctx_, expr);
+  simplify(ctx_, expr);
 
   // Inline specific constant expressions.
   if (auto *szof = expr.as<Sizeof>()) {

--- a/src/ast/passes/simplify_types.cpp
+++ b/src/ast/passes/simplify_types.cpp
@@ -1,0 +1,130 @@
+#include <optional>
+
+#include "ast/ast.h"
+#include "ast/passes/simplify_types.h"
+#include "ast/visitor.h"
+#include "struct.h"
+#include "types.h"
+
+namespace bpftrace::ast {
+
+class SimplifyTypes : public Visitor<SimplifyTypes, std::optional<Expression>> {
+public:
+  SimplifyTypes(ASTContext &ast) : ast_(ast) {};
+
+  using Visitor<SimplifyTypes, std::optional<Expression>>::visit;
+
+  std::optional<Expression> visit(Binop &op);
+  std::optional<Expression> visit(Expression &expr);
+
+private:
+  Expression create_land_chain(std::vector<Expression> &equal_exprs, Binop &op);
+  ASTContext &ast_;
+};
+
+std::optional<Expression> SimplifyTypes::visit(Expression &expr)
+{
+  auto r = Visitor<SimplifyTypes, std::optional<Expression>>::visit(expr.value);
+  if (r) {
+    expr.value = r->value;
+  }
+  return std::nullopt;
+}
+
+Expression SimplifyTypes::create_land_chain(
+    std::vector<Expression> &equal_exprs,
+    Binop &op)
+{
+  auto end = equal_exprs.back();
+  equal_exprs.pop_back();
+
+  if (equal_exprs.empty()) {
+    return end;
+  }
+
+  auto *and_binop = ast_.make_node<Binop>(end,
+                                          Operator::LAND,
+                                          create_land_chain(equal_exprs, op),
+                                          Location(op.loc));
+  and_binop->result_type = CreateBool();
+
+  return and_binop;
+}
+
+std::optional<Expression> SimplifyTypes::visit(Binop &op)
+{
+  visit(op.left);
+  visit(op.right);
+
+  if (op.op != Operator::EQ && op.op != Operator::NE) {
+    return std::nullopt;
+  }
+
+  const SizedType &left_ty = op.left.type();
+  const SizedType &right_ty = op.right.type();
+
+  if (!left_ty.IsTupleTy() || !right_ty.IsTupleTy()) {
+    return std::nullopt;
+  }
+
+  auto &left_fields = left_ty.GetFields();
+  auto &right_fields = right_ty.GetFields();
+
+  if (left_fields.size() != right_fields.size()) {
+    // This is a semantic error
+    return std::nullopt;
+  }
+
+  if (left_fields.empty()) {
+    return ast_.make_node<Boolean>(op.op == Operator::EQ, Location(op.loc));
+  }
+
+  // N.B. Because of the way we're accessing each field of the tuple
+  // and essentially turning this:
+  // `$x = ("hello", -6); $y = ("bye", -6); $x == $y`
+  // into
+  // `$x = ("hello", -6); $y = ("bye", -6); ($x.0 == $y.0 && $x.1 == $y.1)`
+  // If the tuple contains an expression, it might not be evaluated
+  // (due to short-circuiting) if previous elements in the tuple are not equal.
+  // We're doing this instead of a generic memcmp because we can be less
+  // strict about the inner types of the tuple matching up due to size
+  // and alignment issus.
+  // https://github.com/bpftrace/bpftrace/pull/4523#discussion_r2382109017
+  std::vector<Expression> equal_exprs;
+  for (size_t i = 0; i < left_fields.size(); ++i) {
+    auto *left_tpa = ast_.make_node<TupleAccess>(op.left, i, Location(op.loc));
+    left_tpa->element_type = left_fields[i].type;
+
+    auto *right_tpa = ast_.make_node<TupleAccess>(op.right,
+                                                  i,
+                                                  Location(op.loc));
+    right_tpa->element_type = right_fields[i].type;
+
+    auto *equal = ast_.make_node<Binop>(
+        left_tpa, Operator::EQ, right_tpa, Location(op.loc));
+    equal->result_type = CreateBool();
+
+    auto expanded = Visitor<SimplifyTypes, std::optional<Expression>>::visit(
+        equal);
+
+    equal_exprs.emplace_back(expanded ? *expanded : equal);
+  }
+
+  auto land_chain = create_land_chain(equal_exprs, op);
+  if (op.op == Operator::NE) {
+    auto *not_binop = ast_.make_node<Unop>(
+        land_chain, Operator::LNOT, false, Location(op.loc));
+    not_binop->result_type = CreateBool();
+    return not_binop;
+  } else {
+    return land_chain;
+  }
+}
+
+void simplify(ASTContext &ast, Expression &expr)
+{
+  SimplifyTypes simplifier(ast);
+  simplifier.visit(expr);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/simplify_types.h
+++ b/src/ast/passes/simplify_types.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+// No pass exists yet, this just gets called
+// from inside semantic_analyser because this
+// relies on previous and future type resolution
+void simplify(ASTContext &ast, Expression &expr);
+
+} // namespace bpftrace::ast

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -121,3 +121,13 @@ EXPECT Attached 1 probe
 NAME kstack in tuple
 PROG begin { print((kstack, "a"));  }
 EXPECT Attached 1 probe
+
+NAME tuple binop equals
+PROG begin { $x = ("hello", -6); $y = ("hello", -6); $a = (1, true, $x); @b = (1, true, $y); if ($a == @b) { printf("ok\n"); } if ($a == (1, true, ("ello", -6))) { printf("nok\n"); } }
+EXPECT ok
+EXPECT_NONE nok
+
+NAME tuple binop not equals
+PROG begin { $x = ("hello", -6); $y = ("hello", -6); $a = (1, true, $x); @b = (1, true, $y); if ($a != @b) { printf("nok\n"); } if ($a != (1, true, ("ello", -6))) { printf("ok\n"); } }
+EXPECT ok
+EXPECT_NONE nok


### PR DESCRIPTION
Stacked PRs:
 * __->__#4523


--- --- ---

### Improve tuple comparison


Tuple comparison is effectively broken
on master. This simplifies tuple comparison
by turning this:
```
$x = ("hello", -6); $y = ("bye", -6); $x == $y
```
into
```
$x = ("hello", -6); $y = ("bye", -6); ($x.0 == $y.0 && $x.1 == $y.1)
```

Note: it also works on nested tuples in the
same way.

This change also adds better type
checking for tuples in semantic analyzer
e.g. it now compares tuple lengths and
inner types.
Signed-off-by: Jordan Rome <linux@jordanrome.com>