### PR TITLE
Fix build with clang 21

### DIFF
--- a/src/ast/passes/clang_build.cpp
+++ b/src/ast/passes/clang_build.cpp
@@ -78,12 +78,25 @@ static Result<> build(CompileContext &ctx,
   // a string, which we can then capture and associate with the import.
   std::string errstr;
   llvm::raw_string_ostream err(errstr);
+#if LLVM_VERSION_MAJOR < 21
   auto diagOpts = llvm::makeIntrusiveRefCnt<clang::DiagnosticOptions>();
   auto diags = std::make_unique<clang::DiagnosticsEngine>(
       llvm::makeIntrusiveRefCnt<clang::DiagnosticIDs>(),
       diagOpts,
       new clang::TextDiagnosticPrinter(err, diagOpts.get()));
-
+#else
+  // Clang 21: DiagnosticOptions is NOT intrusive-refcounted anymore.
+  // Keep it alive for the program lifetime (or store it on a longer-lived
+  // object).
+  static std::shared_ptr<clang::DiagnosticOptions> diagOpts =
+      std::make_shared<clang::DiagnosticOptions>();
+  llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs> diagID(
+      new clang::DiagnosticIDs());
+  auto client = std::make_unique<clang::TextDiagnosticPrinter>(err, *diagOpts);
+  auto diags = std::make_unique<clang::DiagnosticsEngine>(diagID,
+                                                          *diagOpts,
+                                                          client.release());
+#endif
   // We create a temporary memfd that we can use to store the output,
   // since the ClangDriver API is framed in terms of filenames. Perhaps
   // we could use the internals here, but that carries other risks.
@@ -122,7 +135,9 @@ static Result<> build(CompileContext &ctx,
   inv->getCodeGenOpts().DebugColumnInfo = true;
 
   clang::CompilerInstance ci;
-  ci.setInvocation(inv);
+  // Cross-version friendly: assign into the existing invocation
+  // (works across modern Clang majors, including 21)
+  ci.getInvocation() = *inv;
   ci.setDiagnostics(diags.release());
   ci.setFileManager(new clang::FileManager(clang::FileSystemOptions(), vfs));
   ci.createSourceManager(ci.getFileManager());

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -992,11 +992,13 @@ std::chrono::time_point<std::chrono::system_clock> BPFtrace::resolve_timestamp(
           << "Cannot resolve timestamp due to failed boot time calculation";
     } else {
       t += std::chrono::seconds(boottime_->tv_sec);
-      t += std::chrono::nanoseconds(boottime_->tv_nsec);
+      t += std::chrono::duration_cast<std::chrono::system_clock::duration>(
+          std::chrono::nanoseconds(boottime_->tv_nsec));
     }
   }
 
-  t += std::chrono::nanoseconds(nsecs);
+  t += std::chrono::duration_cast<std::chrono::system_clock::duration>(
+      std::chrono::nanoseconds(nsecs));
   return t;
 }
 

--- a/src/util/bpf_names.cpp
+++ b/src/util/bpf_names.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
+#include <sstream> // for std::ostringstream
 
 #include "util/bpf_names.h"
 

--- a/tests/opaque.cpp
+++ b/tests/opaque.cpp
@@ -1,6 +1,7 @@
 #include "util/opaque.h"
 #include "gtest/gtest.h"
 #include <cstring>
+#include <numbers> // for std::numbers
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
These issues are found with clang-21 and using libc++ instead of libstdc++ for C++ runtime on Linux, ( distro is built using yocto)
##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
