### PR TITLE
Migrate `has_key` to the standard library

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -322,10 +322,9 @@ This utilizes the BPF helper `get_current_uid_gid`
 ### has_key
 - `boolean has_key(map m, mapkey k)`
 
-Return true (1) if the key exists in this map.
-Otherwise return false (0).
+Return `true` if the key exists in this map.
+Otherwise return `false`.
 Error if called with a map that has no keys (aka scalar map).
-Return value can also be used for scratch variables and map keys/values.
 
 ```
 kprobe:dummy {
@@ -338,9 +337,6 @@ kprobe:dummy {
     if (has_key(@scalar)) { // error
       print(("hello"));
     }
-
-    $a = has_key(@associative, (1,2)); // ok
-    @b[has_key(@associative, (1,2))] = has_key(@associative, (1,2)); // ok
 }
 ```
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1364,16 +1364,6 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       Value *expr = b_.CreateICmpEQ(ret, b_.getInt64(0), "delete_ret");
       return ScopedExpr(expr);
     }
-  } else if (call.func == "has_key") {
-    auto &arg = call.vargs.at(0);
-    auto &map = *arg.as<Map>();
-    auto scoped_key = getMapKey(map, call.vargs.at(1));
-
-    CallInst *lookup = b_.CreateMapLookup(map, scoped_key.value());
-    Value *expr = b_.CreateICmpNE(b_.CreateIntCast(lookup, b_.getPtrTy(), true),
-                                  b_.GetNull(),
-                                  "has_key");
-    return ScopedExpr(expr);
   } else if (call.func == "str") {
     const auto max_strlen = bpftrace_.config_->max_strlen;
     // Largest read we'll allow = our global string buffer size

--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -66,9 +66,9 @@ public:
 // In the future, this could be generalized by extracting information about the
 // specific function being called, and potentially respecting annotations on
 // these arguments.
-static std::unordered_set<std::string> RAW_MAP_ARG = {
-  "print", "clear", "zero", "len", "delete", "has_key",
-};
+static std::unordered_set<std::string> RAW_MAP_ARG = { "print",  "clear",
+                                                       "zero",   "len",
+                                                       "delete", "is_scalar" };
 
 void MapDefaultKey::visit(Map &map)
 {
@@ -204,8 +204,6 @@ void MapDefaultKey::visit(Call &call)
           call.addError() << "delete() requires 1 or 2 arguments ("
                           << call.vargs.size() << " provided)";
         }
-      } else if (call.func == "has_key") {
-        checkCall(*map, true, call);
       } else if (call.func == "len") {
         checkCall(*map, true, call);
       }

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -46,11 +46,11 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateParseBTFPass());
   passes.emplace_back(CreateProbeExpansionPass());
   passes.emplace_back(CreateParseTracepointFormatPass());
-  passes.emplace_back(CreateBuiltinsPass());
   passes.emplace_back(CreateFieldAnalyserPass());
   passes.emplace_back(CreateClangParsePass(std::move(extra_flags)));
   passes.emplace_back(CreateCMacroExpansionPass());
   passes.emplace_back(CreateMapSugarPass());
+  passes.emplace_back(CreateBuiltinsPass());
   passes.emplace_back(CreateNamedParamsPass());
   return passes;
 }

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -388,17 +388,6 @@ void ResourceAnalyser::visit(Call &call)
       resources_.max_map_key_size = std::max(resources_.max_map_key_size,
                                              map_key_size);
     }
-  } else if (call.func == "has_key") {
-    auto &map = *call.vargs.at(0).as<Map>();
-    auto &key_expr = call.vargs.at(1);
-    // has_key does not work on scalar maps (e.g. @a = 1), so we
-    // don't need to check if map.key_expr is set
-    if (needMapKeyAllocation(map, key_expr) &&
-        exceeds_stack_limit(map.key_type.GetSize())) {
-      resources_.map_key_buffers++;
-      resources_.max_map_key_size = std::max(resources_.max_map_key_size,
-                                             map.key_type.GetSize());
-    }
   } else if (call.func == "delete") {
     auto &map = *call.vargs.at(0).as<Map>();
     auto &key_expr = call.vargs.at(1);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -357,15 +357,6 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
       .max_args=1,
       .arg_types={
         arg_type_spec{ .type=Type::integer } } } },
-  { "has_key",
-    { .min_args=2,
-      .max_args=2,
-      .discard_ret_warn = true,
-      .arg_types={
-        map_type_spec{},
-        map_key_spec{ .map_index=0 },
-      }
-    } },
   { "hist",
     { .min_args=3,
       .max_args=4,
@@ -1340,8 +1331,6 @@ void SemanticAnalyser::visit(Call &call)
     call.return_type = CreateStats(true);
   } else if (call.func == "delete") {
     call.return_type = CreateUInt8();
-  } else if (call.func == "has_key") {
-    call.return_type = CreateBool();
   } else if (call.func == "str") {
     auto &arg = call.vargs.at(0);
     const auto &t = arg.type();

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -289,13 +289,11 @@ macro gid() {
   __builtin_gid
 }
 
-// :function has_key
 // :variant boolean has_key(map m, mapkey k)
 //
-// Return true (1) if the key exists in this map.
-// Otherwise return false (0).
+// Return `true` if the key exists in this map.
+// Otherwise return `false`.
 // Error if called with a map that has no keys (aka scalar map).
-// Return value can also be used for scratch variables and map keys/values.
 //
 // ```
 // kprobe:dummy {
@@ -308,11 +306,20 @@ macro gid() {
 //     if (has_key(@scalar)) { // error
 //       print(("hello"));
 //     }
-//
-//     $a = has_key(@associative, (1,2)); // ok
-//     @b[has_key(@associative, (1,2))] = has_key(@associative, (1,2)); // ok
 // }
 // ```
+macro has_key(@map, key) {
+  if (is_scalar(@map)) {
+    fail("has_key() expects a map with explicit keys (non-scalar map)")
+  }
+  $x = key;
+  {
+    // This is just to get a compile time type check on the map key
+    @map[$x]
+  };
+  $y = __has_key((void *)&@map, (void *)&$x) == 0;
+  $y
+}
 
 // :variant uint64 jiffies()
 // Jiffies of the kernel

--- a/src/stdlib/map_util.bpf.c
+++ b/src/stdlib/map_util.bpf.c
@@ -1,0 +1,12 @@
+#define __VMLINUX_H__
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
+int __has_key(void * map, void * key) {
+    void * val;
+    val = bpf_map_lookup_elem(map, key);
+    if (!val) {
+        return 1;
+    }
+    return 0;
+}

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -265,7 +265,6 @@ TEST_F(SemanticAnalyserTest, builtin_functions)
   test("kprobe:f { @x = 1; print(@x) }");
   test("kprobe:f { @x = 1; clear(@x) }");
   test("kprobe:f { @x = 1; zero(@x) }");
-  test("kprobe:f { @x[1] = 1; if (has_key(@x, 1)) {} }");
   test("kprobe:f { @x[1] = 1; @s = len(@x) }");
   test("kprobe:f { time() }");
   test("kprobe:f { exit() }");


### PR DESCRIPTION
Stacked PRs:
 * __->__#4530


--- --- ---

### Migrate `has_key` to the standard library


This also adds a new compile time intrinsic:
`is_scalar` for checking if the map passed
to this function has keys. This is used
by the `has_key` macro to determine if the
call is valid.

Signed-off-by: Jordan Rome <linux@jordanrome.com>