### PR TITLE
Always use cmake version for bpftrace --info

### DIFF
--- a/cmake/Version.cmake
+++ b/cmake/Version.cmake
@@ -10,21 +10,22 @@
 #     bpftrace_VERSION_MINOR
 #     bpftrace_VERSION_PATCH
 
-# Try and get a version string from Git tags
+# Check if we're in a git repo
 execute_process(
-  COMMAND git describe --abbrev=4 --dirty --tags
+  COMMAND git rev-parse --short HEAD
   WORKING_DIRECTORY ${bpftrace_SOURCE_DIR}
-  OUTPUT_VARIABLE BPFTRACE_VERSION
-  ERROR_VARIABLE GIT_DESCRIBE_ERROR
+  OUTPUT_VARIABLE GIT_SHORT_HASH
   OUTPUT_STRIP_TRAILING_WHITESPACE
   RESULT_VARIABLE retcode
 )
 
-# If the build is not done from a git repo, get the version information from
-# the version variables in main CMakeLists.txt
-if(NOT ${retcode} EQUAL 0)
-  set(BPFTRACE_VERSION "v${bpftrace_VERSION_MAJOR}.${bpftrace_VERSION_MINOR}.${bpftrace_VERSION_PATCH}")
-  message(STATUS "Could not obtain version string from Git. Falling back to CMake version string.")
+set(BPFTRACE_BASE_VERSION "v${bpftrace_VERSION_MAJOR}.${bpftrace_VERSION_MINOR}.${bpftrace_VERSION_PATCH}")
+
+# Append git hash if we're in a git repository
+if(retcode EQUAL 0)
+  set(BPFTRACE_VERSION "${BPFTRACE_BASE_VERSION}-${GIT_SHORT_HASH}")
+else()
+  set(BPFTRACE_VERSION "${BPFTRACE_BASE_VERSION}")
 endif()
 
 configure_file(${VERSION_H_IN} ${VERSION_H} @ONLY)


### PR DESCRIPTION
Stacked PRs:
 * #4539
 * __->__#4538


--- --- ---

### Always use cmake version for bpftrace --info


Even when we're building in a git repo
use the cmake version instead of a git tag
so we don't have to remember to merge the tag
when we're branching releases.

Mark the internal git build with the top
short commit hash.

Issue:
- https://github.com/bpftrace/bpftrace/issues/4536

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>