### PR TITLE
Remove all map feature checks

### DIFF
--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -10,18 +10,6 @@
 
 namespace bpftrace {
 
-#define DEFINE_MAP_TEST(var, maptype)                                          \
-protected:                                                                     \
-  std::optional<bool> map_##var##_;                                            \
-                                                                               \
-public:                                                                        \
-  bool has_map_##var(void)                                                     \
-  {                                                                            \
-    if (!map_##var##_.has_value())                                             \
-      map_##var##_ = std::make_optional<bool>(detect_map((maptype)));          \
-    return *(map_##var##_);                                                    \
-  }
-
 #define DEFINE_HELPER_TEST(name, progtype)                                     \
 protected:                                                                     \
   std::optional<bool> has_##name##_;                                           \
@@ -82,11 +70,6 @@ public:
 
   std::string report();
 
-  DEFINE_MAP_TEST(array, BPF_MAP_TYPE_ARRAY);
-  DEFINE_MAP_TEST(hash, BPF_MAP_TYPE_HASH);
-  DEFINE_MAP_TEST(percpu_array, BPF_MAP_TYPE_PERCPU_ARRAY);
-  DEFINE_MAP_TEST(stack_trace, BPF_MAP_TYPE_STACK_TRACE);
-  DEFINE_MAP_TEST(ringbuf, BPF_MAP_TYPE_RINGBUF);
   DEFINE_HELPER_TEST(ktime_get_tai_ns, BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(get_func_ip, BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(map_lookup_percpu_elem, BPF_PROG_TYPE_KPROBE);
@@ -106,7 +89,6 @@ protected:
   std::unordered_map<Kfunc, bool> available_kernel_funcs_;
 
 private:
-  bool detect_map(bpf_map_type map_type);
   bool detect_helper(bpf_func_id func_id, bpf_prog_type prog_type);
   bool detect_prog_type(bpf_prog_type prog_type,
                         const char* name,
@@ -125,6 +107,5 @@ private:
   BTF& btf_;
 };
 
-#undef DEFINE_MAP_TEST
 #undef DEFINE_HELPER_TEST
 } // namespace bpftrace

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -47,13 +47,6 @@ int run_bpftrace(BPFtrace &bpftrace,
 {
   int err;
 
-  // Check for required features.
-  if (!bpftrace.feature_->has_map_ringbuf()) {
-    LOG(ERROR) << "Your kernel is too old and is missing the "
-                  "BPF_MAP_TYPE_RINGBUF, which bpftrace requires.";
-    return 1;
-  }
-
   // Process all arguments.
   auto named_param_vals = bpftrace.resources.global_vars.get_named_param_vals(
       named_params);

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -160,7 +160,6 @@ public:
     has_kprobe_multi_ = std::make_optional<bool>(has_features);
     has_kprobe_session_ = std::make_optional<bool>(has_features);
     has_uprobe_multi_ = std::make_optional<bool>(has_features);
-    map_ringbuf_ = std::make_optional<bool>(has_features);
     has_ktime_get_tai_ns_ = std::make_optional<bool>(has_features);
     has_get_func_ip_ = std::make_optional<bool>(has_features);
     has_map_lookup_percpu_elem_ = std::make_optional<bool>(has_features);

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -301,7 +301,7 @@ TIMEOUT 3
 
 NAME info flag
 RUN {{BPFTRACE}} --info
-EXPECT_REGEX ringbuf: yes
+EXPECT_REGEX kprobe_session:
 TIMEOUT 1
 
 NAME basic while loop


### PR DESCRIPTION
Stacked PRs:
 * #4560
 * #4553
 * __->__#4550


--- --- ---

### Remove all map feature checks


All the map types we use were added on
kernel versions way older than our min
kernel version (5.15) so these checks
can be deleted.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>