### PR TITLE
Make `fail` like `errorf` and `printf`

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -280,6 +280,17 @@ BEGIN {
 ```
 
 
+### fail
+- `void fail(const string fmt, args...)`
+
+`fail()` formats and prints data (similar to [`printf`](#printf)) as an error message with the source location but, as opposed to [`errorf`](#errorf), is treated like a static assert and halts compilation if it is visited. All args have to be literals since they are evaluated at compile time.
+
+```
+BEGIN { if ($1 < 2) { fail("Expected the first positional param to be greater than 1. Got %d", $1); } }
+```
+
+
+
 ### func
 - `string func()`
 - `string func`

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -151,6 +151,12 @@ bool is_comparison_op(Operator op)
   return false; // unreached
 }
 
+bool is_literal(const Expression &expr)
+{
+  return expr.is<Integer>() || expr.is<NegativeInteger>() ||
+         expr.is<String>() || expr.is<Boolean>();
+}
+
 AttachPoint *AttachPoint::create_expansion_copy(ASTContext &ctx,
                                                 const std::string &match) const
 {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1385,4 +1385,6 @@ bool is_comparison_op(Operator op);
 SizedType ident_to_record(const std::string &ident, int pointer_level = 0);
 SizedType ident_to_sized_type(const std::string &ident);
 
+bool is_literal(const Expression &expr);
+
 } // namespace bpftrace::ast

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -47,12 +47,6 @@ private:
 
 } // namespace
 
-static bool is_literal(const Expression &expr)
-{
-  return expr.is<Integer>() || expr.is<NegativeInteger>() ||
-         expr.is<String>() || expr.is<Boolean>();
-}
-
 static bool eval_bool(Expression expr)
 {
   if (auto *integer = expr.as<Integer>()) {

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -663,7 +663,7 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
       } } },
   { "fail",
     { .min_args=1,
-      .max_args=1,
+      .max_args=128,
       .arg_types={
         arg_type_spec{ .type=Type::string, .literal=true },
       } } },
@@ -1930,7 +1930,36 @@ If you're seeing errors, try clamping the string sizes. For example:
   } else if (call.func == "fail") {
     // This is basically a static_assert failure. It will halt the compilation.
     // We expect to hit this path only when using the `typeof` folds.
-    call.addError() << call.vargs[0].as<String>()->value;
+    bool fail_valid = true;
+    std::vector<output::Primitive> args;
+    for (size_t i = 0; i < call.vargs.size(); ++i) {
+      if (!is_literal(call.vargs[i])) {
+        fail_valid = false;
+        call.addError() << "fail() arguments need to be literals";
+      } else {
+        if (i != 0) {
+          if (auto *val = call.vargs[i].as<String>()) {
+            args.emplace_back(val->value);
+          } else if (auto *val = call.vargs[i].as<Integer>()) {
+            args.emplace_back(val->value);
+          } else if (auto *val = call.vargs[i].as<NegativeInteger>()) {
+            args.emplace_back(val->value);
+          } else if (auto *val = call.vargs[i].as<Boolean>()) {
+            args.emplace_back(val->value);
+          }
+        } else {
+          if (!call.vargs[0].is<String>()) {
+            call.addError()
+                << "first argument to fail() must be a string literal";
+          }
+        }
+      }
+    }
+
+    if (fail_valid) {
+      FormatString fs(call.vargs[0].as<String>()->value);
+      call.addError() << fs.format(args);
+    }
   } else {
     // Check here if this corresponds to an external function. We convert the
     // external type metadata into the internal `SizedType` representation and

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -253,6 +253,16 @@ macro elapsed() {
 // }
 // ```
 
+// :function fail
+// :variant void fail(const string fmt, args...)
+//
+// `fail()` formats and prints data (similar to [`printf`](#printf)) as an error message with the source location but, as opposed to [`errorf`](#errorf), is treated like a static assert and halts compilation if it is visited. All args have to be literals since they are evaluated at compile time.
+//
+// ```
+// BEGIN { if ($1 < 2) { fail("Expected the first positional param to be greater than 1. Got %d", $1); } }
+// ```
+//
+
 // :variant string func()
 // Name of the current function being traced (kprobes,uprobes,fentry)
 macro func() {

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5617,6 +5617,12 @@ stdin:1:12-31: ERROR: always fail
 kprobe:f { fail("always fail"); }
            ~~~~~~~~~~~~~~~~~~~
 )" });
+  test(R"(kprobe:f { fail("always fail %s %d %d %d", "now", 1, -1, false); })",
+       Error{ R"(
+stdin:1:12-64: ERROR: always fail now 1 -1 0
+kprobe:f { fail("always fail %s %d %d %d", "now", 1, -1, false); }
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+)" });
   test(R"(kprobe:f { if (false) { fail("always false"); } })");
 }
 


### PR DESCRIPTION
Make `fail` like `errorf` and `printf`

In that it can accept variadic args
and format them.

This also documents `fail` in base.bt.

Signed-off-by: Jordan Rome <linux@jordanrome.com>