### PR TITLE
Make `fail` like `errorf` and `printf`

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -280,6 +280,17 @@ BEGIN {
 ```
 
 
+### fail
+- `void fail(const string fmt, args...)`
+
+`fail()` formats and prints data (similar to [`printf`](#printf)) as an error message with the source location but, as opposed to [`errorf`](#errorf), is treated like a static assert and halts compilation if it is visited. All args have to be literals since they are evaluated at compile time.
+
+```
+BEGIN { if ($1 < 2) { fail("Expected the first positional param to be greater than 1. Got %d", $1); } }
+```
+
+
+
 ### func
 - `string func()`
 - `string func`

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -27,6 +27,12 @@ const SizedType &Expression::type() const
       value);
 }
 
+bool Expression::is_literal() const
+{
+  return is<Integer>() || is<NegativeInteger>() || is<String>() ||
+         is<Boolean>();
+}
+
 static constexpr std::string_view ENUM = "enum ";
 
 std::string opstr(const Jump &jump)

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -179,6 +179,7 @@ public:
   // The `type` method is the only common thing required by all expression
   // types. This will on the variant types.
   const SizedType &type() const;
+  bool is_literal() const;
 };
 using ExpressionList = std::vector<Expression>;
 

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -253,6 +253,16 @@ macro elapsed() {
 // }
 // ```
 
+// :function fail
+// :variant void fail(const string fmt, args...)
+//
+// `fail()` formats and prints data (similar to [`printf`](#printf)) as an error message with the source location but, as opposed to [`errorf`](#errorf), is treated like a static assert and halts compilation if it is visited. All args have to be literals since they are evaluated at compile time.
+//
+// ```
+// BEGIN { if ($1 < 2) { fail("Expected the first positional param to be greater than 1. Got %d", $1); } }
+// ```
+//
+
 // :variant string func()
 // Name of the current function being traced (kprobes,uprobes,fentry)
 macro func() {

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5573,6 +5573,12 @@ stdin:1:12-31: ERROR: always fail
 kprobe:f { fail("always fail"); }
            ~~~~~~~~~~~~~~~~~~~
 )" });
+  test(R"(kprobe:f { fail("always fail %s %d %d %d", "now", 1, -1, false); })",
+       Error{ R"(
+stdin:1:12-64: ERROR: always fail now 1 -1 0
+kprobe:f { fail("always fail %s %d %d %d", "now", 1, -1, false); }
+           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+)" });
   test(R"(kprobe:f { if (false) { fail("always false"); } })");
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #4561
 * __->__#4555


--- --- ---

### Make `fail` like `errorf` and `printf`


In that it can accept variadic args
and format them.

This also documents `fail` in base.bt.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>