### PR TITLE
CHANGELOG: fix entry for string indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- Add support for indexing string types
+  - [#4540](https://github.com/bpftrace/bpftrace/pull/4540)
 #### Changed
 #### Deprecated
 #### Removed
@@ -106,8 +108,6 @@ and this project adheres to
   - [#4510](https://github.com/bpftrace/bpftrace/pull/4510)
 - Add support for LLVM 21
   - [#4528](https://github.com/bpftrace/bpftrace/pull/4528)
-- Add support for indexing string types
-  - [#4540](https://github.com/bpftrace/bpftrace/pull/4540)
 #### Changed
 - kprobe: support verbose mode listing
   - [#4362](https://github.com/bpftrace/bpftrace/pull/4362)


### PR DESCRIPTION
String indexing has been merged to master but is not going to be backported to 0.24.x so move the changelog entry to the unreleased section.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
