### PR TITLE
Release process: Improve tagging and versioning

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -21,6 +21,9 @@ For LLVM release schedule, see https://llvm.org/.
 
 ### Release progress
 
+- [ ] Mark the release in [CHANGELOG.md](https://github.com/bpftrace/bpftrace/blob/master/CHANGELOG.md) and create an "Unreleased" section
+- [ ] Set `bpftrace_VERSION_MINOR` to `<minor>` in [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt)
+- [ ] Add `v0.<minor>-rc0` tag to master
 - [ ] Create release branch `release/v0.<minor>.x` (<branching-date>)
 - [ ] Add support for LLVM <llvm>
   - [ ] Bump `MAX_LLVM_MAJOR` in [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt)
@@ -29,12 +32,10 @@ For LLVM release schedule, see https://llvm.org/.
 - [ ] Drop support for LLVM <deprecated-llvm>
 - [ ] Update LLVM in Nixpkgs to <llvm>.1.0
 - [ ] **Release bpftrace 0.<minor>.0 (<release-date>)**
-  - [ ] Mark the release in [CHANGELOG.md](https://github.com/bpftrace/bpftrace/blob/master/CHANGELOG.md)
-  - [ ] Update `bpftrace_VERSION_*` in [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt)
+  - [ ] Add the current date to [CHANGELOG.md](https://github.com/bpftrace/bpftrace/blob/master/CHANGELOG.md)
   - [ ] Draft a new release in GitHub
   - [ ] Update the docs on the bpftrace website. [Instructions](https://github.com/bpftrace/website?#updating-the-docs).
   - [ ] Add a new tools version link on the [tools readme](https://github.com/bpftrace/bpftrace/blob/master/tools/README.md) to the master branch.
-- [ ] Forward-port [CHANGELOG.md](https://github.com/bpftrace/bpftrace/blob/master/CHANGELOG.md) and [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt) changes to the master branch.
+- [ ] Forward-port [CHANGELOG.md](https://github.com/bpftrace/bpftrace/blob/master/CHANGELOG.md) changes to the master branch.
 
-See [Release Process](https://github.com/bpftrace/bpftrace/blob/master/docs/release_process.md) for general information on the
-release process.
+See [Release Process](https://github.com/bpftrace/bpftrace/blob/master/docs/release_process.md) for general information on the release process.

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -71,7 +71,7 @@ afterwards.
 1. Update Nixpkgs to the latest version to get the latest (pre-release) LLVM by
    running
    ```
-   nix flake update
+   nix flake update nixpkgs
    ```
    and committing the `flake.lock` changes to the repo. At this time, the `-rc2`
    or `-rc3` version of LLVM should be available.

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -60,13 +60,19 @@ The purpose of this release branch is to give sufficient time to test features
 in the upcoming bpftrace release without blocking the development on the master
 branch.
 
-When creating a branch, the following steps should be performed. Any changes to
-the code should be done in the master branch first and then backported to the
-release branch. In the rare case when the master-first approach is not possible
-(e.g. a feature present exclusively on master blocks the LLVM update), the
-changes can be done in the release branch first and forward-ported to master
-afterwards.
+When creating a branch for a release **v0.Y.0**, the following steps should be
+performed. Any changes to the code should be done in the master branch first and
+then backported to the release branch. In the rare case when the master-first
+approach is not possible (e.g. a feature present exclusively on master blocks
+the LLVM update), the changes can be done in the release branch first and
+forward-ported to master afterwards.
 
+1. Mark the release in [CHANGELOG.md](../CHANGELOG.md) by replacing the `##
+   Unreleased` header with `## [0.Y.0] TBD` and creating a new "Unreleased"
+   section with all the subsection headers below it.
+1. Update `bpftrace_VERSION_MINOR` in [CMakeLists.txt](../CMakeLists.txt) to
+   `Y`.
+1. Tag the latest commit in the master branch with `v0.Y-rc0`.
 1. Create a new branch according to the [Branching model](#branching-model).
 1. Update Nixpkgs to the latest version to get the latest (pre-release) LLVM by
    running
@@ -79,7 +85,7 @@ afterwards.
    [flake.nix](../flake.nix), resolve any potential issues, and add a CI job to
    [.github/workflows/ci.yml](../.github/workflows/ci.yml) for the new version.
 1. Once the final LLVM is released and present in Nixpkgs (usually 2-5 days
-   after the LLVM release), repeat step 2 to get the released LLVM in the CI
+   after the LLVM release), repeat step 4 to get the released LLVM in the CI
    environment.
 
 ### Branching model
@@ -100,11 +106,8 @@ You must do the following steps to formally release a version.
 
 In the release branch:
 
-1. Mark the release in [CHANGELOG.md](../CHANGELOG.md) by replacing the `##
-   Unreleased` header with `## [VERSION] date`.
-1. Update `bpftrace_VERSION_MAJOR`, `bpftrace_VERSION_MINOR`, and
-   `bpftrace_VERSION_PATCH` in [CMakeLists.txt](../CMakeLists.txt) to the target
-   version.
+1. Mark the release in [CHANGELOG.md](../CHANGELOG.md) by replacing `TBD` with
+   the current date in the corresponding header.
 1. Tag a release. We do this in the github UI by clicking "releases" (on same
    line as "commits"), then "Draft a new release". The tag version and release
    title should be the same and in `vX.Y.Z` format. The tag description should
@@ -116,4 +119,6 @@ In the release branch:
    bpftrace root dir and attach the generated archives to the release.
 
 Once the release is out:
-1. Forward-port the CHANGELOG.md changes from the release branch to master.
+1. Forward-port the CHANGELOG.md changes from the release branch to master. This
+   includes the release date and the entries which were backported from master
+   after the release branch was cut.


### PR DESCRIPTION
The current git tags and bpftrace versions for unreleased code are not representative. This causes `git describe` and `bpftrace --version` to return misleading version numbers on development branches.
    
This introduces a more thorough versioning process:
    
- bpftrace version points to the "future" release in any unreleased code. For master, that is `0.Y.0` until the branch for `v0.Y.0` is cut and `0.<Y+1>.0` afterwards. For release branches, it is `0.Y.Z` where `v0.Y.Z` is the upcoming release.
    
- The commit on master immediately following a release branch cut is tagged with `v0.Y.0-init` to mark the start of a new development cycle.
    
- In release branches, tagging doesn't change, i.e. `v0.Y.Z` is added once a release is cut.
    
In addition, we should update CHANGELOG for the upcoming minor release *just before* branch is cut such that master already contains information what changes will be in the planned release.
    
Reflect all the proposed changes in the release process doc and the release issue template.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
