### PR TITLE
Fix codegen ret value for strcmp

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1587,8 +1587,8 @@ Value *IRBuilderBPF::CreateStrncmp(Value *str1,
                                    uint64_t n,
                                    bool inverse)
 {
-  // This function compares each character of the two string. It returns true
-  // if all are equal and false if any are different.
+  // This function compares each character of the two strings. It returns 0
+  // if all are equal and 1 if any are different.
   //
   //  strcmp(String val1, String val2)
   //  {
@@ -1597,19 +1597,19 @@ Value *IRBuilderBPF::CreateStrncmp(Value *str1,
   //
   //       if (val1[i] != val2[i])
   //       {
-  //         return false;
+  //         return 1;
   //       }
   //       if (val1[i] == NULL)
   //       {
-  //         return true;
+  //         break;
   //       }
   //     }
   //
-  //     return true;
+  //     return 0;
   //  }
 
   llvm::Function *parent = GetInsertBlock()->getParent();
-  AllocaInst *store = CreateAllocaBPF(getInt1Ty(), "strcmp.result");
+  AllocaInst *store = CreateAllocaBPF(getInt64Ty(), "strcmp.result");
   BasicBlock *str_ne = BasicBlock::Create(module_.getContext(),
                                           "strcmp.false",
                                           parent);
@@ -1617,7 +1617,7 @@ Value *IRBuilderBPF::CreateStrncmp(Value *str1,
                                         "strcmp.done",
                                         parent);
 
-  CreateStore(getInt1(!inverse), store);
+  CreateStore(getInt64(inverse ? 0 : 1), store);
 
   Value *null_byte = getInt8(0);
   for (size_t i = 0; i < n; i++) {
@@ -1649,13 +1649,12 @@ Value *IRBuilderBPF::CreateStrncmp(Value *str1,
 
   CreateBr(done);
   SetInsertPoint(done);
-  CreateStore(getInt1(inverse), store);
+  CreateStore(getInt64(inverse ? 1 : 0), store);
 
   CreateBr(str_ne);
   SetInsertPoint(str_ne);
 
-  // store is a pointer to bool (i1 *)
-  Value *result = CreateLoad(getInt1Ty(), store);
+  Value *result = CreateLoad(getInt64Ty(), store);
   CreateLifetimeEnd(store);
 
   return result;

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2198,8 +2198,10 @@ ScopedExpr CodegenLLVM::binop_string(Binop &binop)
 
   size_t len = std::min(binop.left.type().GetSize(),
                         binop.right.type().GetSize());
-  return ScopedExpr(b_.CreateStrncmp(
-      left_string.value(), right_string.value(), len, inverse));
+  return ScopedExpr(b_.CreateIntCast(
+      b_.CreateStrncmp(left_string.value(), right_string.value(), len, inverse),
+      b_.getInt1Ty(),
+      false));
 }
 
 ScopedExpr CodegenLLVM::binop_integer_array(Binop &binop)
@@ -2245,7 +2247,10 @@ ScopedExpr CodegenLLVM::binop_buf(Binop &binop)
 
   size_t len = std::min(binop.left.type().GetSize(),
                         binop.right.type().GetSize());
-  return ScopedExpr(b_.CreateStrncmp(left_string, right_string, len, inverse));
+  return ScopedExpr(b_.CreateIntCast(
+      b_.CreateStrncmp(left_string, right_string, len, inverse),
+      b_.getInt1Ty(),
+      false));
 }
 
 ScopedExpr CodegenLLVM::binop_int(Binop &binop)

--- a/tests/codegen/llvm/builtin_probe_comparison.ll
+++ b/tests/codegen/llvm/builtin_probe_comparison.ll
@@ -17,9 +17,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @tracepoint_sched_sched_one_1(ptr %0) #0 section "s_tracepoint_sched_sched_one_1" !dbg !35 {
 entry:
-  %strcmp.result = alloca i1, align 1
+  %strcmp.result = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %strcmp.result)
-  store i1 false, ptr %strcmp.result, align 1
+  store i64 0, ptr %strcmp.result, align 8
   %1 = load i8, ptr @"tracepoint:sched:sched_one", align 1
   %2 = load i8, ptr @"tracepoint:sched:sched_one", align 1
   %strcmp.cmp = icmp ne i8 %1, %2
@@ -32,19 +32,20 @@ if_end:                                           ; preds = %if_body, %strcmp.fa
   ret i64 1
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop97, %strcmp.loop93, %strcmp.loop89, %strcmp.loop85, %strcmp.loop81, %strcmp.loop77, %strcmp.loop73, %strcmp.loop69, %strcmp.loop65, %strcmp.loop61, %strcmp.loop57, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
-  %3 = load i1, ptr %strcmp.result, align 1
+  %3 = load i64, ptr %strcmp.result, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
-  %true_cond = icmp ne i1 %3, false
+  %4 = trunc i64 %3 to i1
+  %true_cond = icmp ne i1 %4, false
   br i1 %true_cond, label %if_body, label %if_end
 
 strcmp.done:                                      ; preds = %strcmp.loop101, %strcmp.loop_null_cmp102, %strcmp.loop_null_cmp98, %strcmp.loop_null_cmp94, %strcmp.loop_null_cmp90, %strcmp.loop_null_cmp86, %strcmp.loop_null_cmp82, %strcmp.loop_null_cmp78, %strcmp.loop_null_cmp74, %strcmp.loop_null_cmp70, %strcmp.loop_null_cmp66, %strcmp.loop_null_cmp62, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp54, %strcmp.loop_null_cmp50, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp42, %strcmp.loop_null_cmp38, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp30, %strcmp.loop_null_cmp26, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp18, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
-  store i1 true, ptr %strcmp.result, align 1
+  store i64 1, ptr %strcmp.result, align 8
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %4 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 1), align 1
   %5 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 1), align 1
-  %strcmp.cmp3 = icmp ne i8 %4, %5
+  %6 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 1), align 1
+  %strcmp.cmp3 = icmp ne i8 %5, %6
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -52,260 +53,260 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %6 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 2), align 1
   %7 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 2), align 1
-  %strcmp.cmp7 = icmp ne i8 %6, %7
+  %8 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 2), align 1
+  %strcmp.cmp7 = icmp ne i8 %7, %8
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %4, 0
+  %strcmp.cmp_null4 = icmp eq i8 %5, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %8 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 3), align 1
   %9 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 3), align 1
-  %strcmp.cmp11 = icmp ne i8 %8, %9
+  %10 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 3), align 1
+  %strcmp.cmp11 = icmp ne i8 %9, %10
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %6, 0
+  %strcmp.cmp_null8 = icmp eq i8 %7, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %10 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 4), align 1
   %11 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 4), align 1
-  %strcmp.cmp15 = icmp ne i8 %10, %11
+  %12 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 4), align 1
+  %strcmp.cmp15 = icmp ne i8 %11, %12
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %8, 0
+  %strcmp.cmp_null12 = icmp eq i8 %9, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
-  %12 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 5), align 1
   %13 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 5), align 1
-  %strcmp.cmp19 = icmp ne i8 %12, %13
+  %14 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 5), align 1
+  %strcmp.cmp19 = icmp ne i8 %13, %14
   br i1 %strcmp.cmp19, label %strcmp.false, label %strcmp.loop_null_cmp18
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %10, 0
+  %strcmp.cmp_null16 = icmp eq i8 %11, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 strcmp.loop17:                                    ; preds = %strcmp.loop_null_cmp18
-  %14 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 6), align 1
   %15 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 6), align 1
-  %strcmp.cmp23 = icmp ne i8 %14, %15
+  %16 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 6), align 1
+  %strcmp.cmp23 = icmp ne i8 %15, %16
   br i1 %strcmp.cmp23, label %strcmp.false, label %strcmp.loop_null_cmp22
 
 strcmp.loop_null_cmp18:                           ; preds = %strcmp.loop13
-  %strcmp.cmp_null20 = icmp eq i8 %12, 0
+  %strcmp.cmp_null20 = icmp eq i8 %13, 0
   br i1 %strcmp.cmp_null20, label %strcmp.done, label %strcmp.loop17
 
 strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
-  %16 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 7), align 1
   %17 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 7), align 1
-  %strcmp.cmp27 = icmp ne i8 %16, %17
+  %18 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 7), align 1
+  %strcmp.cmp27 = icmp ne i8 %17, %18
   br i1 %strcmp.cmp27, label %strcmp.false, label %strcmp.loop_null_cmp26
 
 strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop17
-  %strcmp.cmp_null24 = icmp eq i8 %14, 0
+  %strcmp.cmp_null24 = icmp eq i8 %15, 0
   br i1 %strcmp.cmp_null24, label %strcmp.done, label %strcmp.loop21
 
 strcmp.loop25:                                    ; preds = %strcmp.loop_null_cmp26
-  %18 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 8), align 1
   %19 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 8), align 1
-  %strcmp.cmp31 = icmp ne i8 %18, %19
+  %20 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 8), align 1
+  %strcmp.cmp31 = icmp ne i8 %19, %20
   br i1 %strcmp.cmp31, label %strcmp.false, label %strcmp.loop_null_cmp30
 
 strcmp.loop_null_cmp26:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null28 = icmp eq i8 %16, 0
+  %strcmp.cmp_null28 = icmp eq i8 %17, 0
   br i1 %strcmp.cmp_null28, label %strcmp.done, label %strcmp.loop25
 
 strcmp.loop29:                                    ; preds = %strcmp.loop_null_cmp30
-  %20 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 9), align 1
   %21 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 9), align 1
-  %strcmp.cmp35 = icmp ne i8 %20, %21
+  %22 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 9), align 1
+  %strcmp.cmp35 = icmp ne i8 %21, %22
   br i1 %strcmp.cmp35, label %strcmp.false, label %strcmp.loop_null_cmp34
 
 strcmp.loop_null_cmp30:                           ; preds = %strcmp.loop25
-  %strcmp.cmp_null32 = icmp eq i8 %18, 0
+  %strcmp.cmp_null32 = icmp eq i8 %19, 0
   br i1 %strcmp.cmp_null32, label %strcmp.done, label %strcmp.loop29
 
 strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
-  %22 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 10), align 1
   %23 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 10), align 1
-  %strcmp.cmp39 = icmp ne i8 %22, %23
+  %24 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 10), align 1
+  %strcmp.cmp39 = icmp ne i8 %23, %24
   br i1 %strcmp.cmp39, label %strcmp.false, label %strcmp.loop_null_cmp38
 
 strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop29
-  %strcmp.cmp_null36 = icmp eq i8 %20, 0
+  %strcmp.cmp_null36 = icmp eq i8 %21, 0
   br i1 %strcmp.cmp_null36, label %strcmp.done, label %strcmp.loop33
 
 strcmp.loop37:                                    ; preds = %strcmp.loop_null_cmp38
-  %24 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 11), align 1
   %25 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 11), align 1
-  %strcmp.cmp43 = icmp ne i8 %24, %25
+  %26 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 11), align 1
+  %strcmp.cmp43 = icmp ne i8 %25, %26
   br i1 %strcmp.cmp43, label %strcmp.false, label %strcmp.loop_null_cmp42
 
 strcmp.loop_null_cmp38:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null40 = icmp eq i8 %22, 0
+  %strcmp.cmp_null40 = icmp eq i8 %23, 0
   br i1 %strcmp.cmp_null40, label %strcmp.done, label %strcmp.loop37
 
 strcmp.loop41:                                    ; preds = %strcmp.loop_null_cmp42
-  %26 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 12), align 1
   %27 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 12), align 1
-  %strcmp.cmp47 = icmp ne i8 %26, %27
+  %28 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 12), align 1
+  %strcmp.cmp47 = icmp ne i8 %27, %28
   br i1 %strcmp.cmp47, label %strcmp.false, label %strcmp.loop_null_cmp46
 
 strcmp.loop_null_cmp42:                           ; preds = %strcmp.loop37
-  %strcmp.cmp_null44 = icmp eq i8 %24, 0
+  %strcmp.cmp_null44 = icmp eq i8 %25, 0
   br i1 %strcmp.cmp_null44, label %strcmp.done, label %strcmp.loop41
 
 strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
-  %28 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 13), align 1
   %29 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 13), align 1
-  %strcmp.cmp51 = icmp ne i8 %28, %29
+  %30 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 13), align 1
+  %strcmp.cmp51 = icmp ne i8 %29, %30
   br i1 %strcmp.cmp51, label %strcmp.false, label %strcmp.loop_null_cmp50
 
 strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop41
-  %strcmp.cmp_null48 = icmp eq i8 %26, 0
+  %strcmp.cmp_null48 = icmp eq i8 %27, 0
   br i1 %strcmp.cmp_null48, label %strcmp.done, label %strcmp.loop45
 
 strcmp.loop49:                                    ; preds = %strcmp.loop_null_cmp50
-  %30 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 14), align 1
   %31 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 14), align 1
-  %strcmp.cmp55 = icmp ne i8 %30, %31
+  %32 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 14), align 1
+  %strcmp.cmp55 = icmp ne i8 %31, %32
   br i1 %strcmp.cmp55, label %strcmp.false, label %strcmp.loop_null_cmp54
 
 strcmp.loop_null_cmp50:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null52 = icmp eq i8 %28, 0
+  %strcmp.cmp_null52 = icmp eq i8 %29, 0
   br i1 %strcmp.cmp_null52, label %strcmp.done, label %strcmp.loop49
 
 strcmp.loop53:                                    ; preds = %strcmp.loop_null_cmp54
-  %32 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 15), align 1
   %33 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 15), align 1
-  %strcmp.cmp59 = icmp ne i8 %32, %33
+  %34 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 15), align 1
+  %strcmp.cmp59 = icmp ne i8 %33, %34
   br i1 %strcmp.cmp59, label %strcmp.false, label %strcmp.loop_null_cmp58
 
 strcmp.loop_null_cmp54:                           ; preds = %strcmp.loop49
-  %strcmp.cmp_null56 = icmp eq i8 %30, 0
+  %strcmp.cmp_null56 = icmp eq i8 %31, 0
   br i1 %strcmp.cmp_null56, label %strcmp.done, label %strcmp.loop53
 
 strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
-  %34 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 16), align 1
   %35 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 16), align 1
-  %strcmp.cmp63 = icmp ne i8 %34, %35
+  %36 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 16), align 1
+  %strcmp.cmp63 = icmp ne i8 %35, %36
   br i1 %strcmp.cmp63, label %strcmp.false, label %strcmp.loop_null_cmp62
 
 strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop53
-  %strcmp.cmp_null60 = icmp eq i8 %32, 0
+  %strcmp.cmp_null60 = icmp eq i8 %33, 0
   br i1 %strcmp.cmp_null60, label %strcmp.done, label %strcmp.loop57
 
 strcmp.loop61:                                    ; preds = %strcmp.loop_null_cmp62
-  %36 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 17), align 1
   %37 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 17), align 1
-  %strcmp.cmp67 = icmp ne i8 %36, %37
+  %38 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 17), align 1
+  %strcmp.cmp67 = icmp ne i8 %37, %38
   br i1 %strcmp.cmp67, label %strcmp.false, label %strcmp.loop_null_cmp66
 
 strcmp.loop_null_cmp62:                           ; preds = %strcmp.loop57
-  %strcmp.cmp_null64 = icmp eq i8 %34, 0
+  %strcmp.cmp_null64 = icmp eq i8 %35, 0
   br i1 %strcmp.cmp_null64, label %strcmp.done, label %strcmp.loop61
 
 strcmp.loop65:                                    ; preds = %strcmp.loop_null_cmp66
-  %38 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 18), align 1
   %39 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 18), align 1
-  %strcmp.cmp71 = icmp ne i8 %38, %39
+  %40 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 18), align 1
+  %strcmp.cmp71 = icmp ne i8 %39, %40
   br i1 %strcmp.cmp71, label %strcmp.false, label %strcmp.loop_null_cmp70
 
 strcmp.loop_null_cmp66:                           ; preds = %strcmp.loop61
-  %strcmp.cmp_null68 = icmp eq i8 %36, 0
+  %strcmp.cmp_null68 = icmp eq i8 %37, 0
   br i1 %strcmp.cmp_null68, label %strcmp.done, label %strcmp.loop65
 
 strcmp.loop69:                                    ; preds = %strcmp.loop_null_cmp70
-  %40 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 19), align 1
   %41 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 19), align 1
-  %strcmp.cmp75 = icmp ne i8 %40, %41
+  %42 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 19), align 1
+  %strcmp.cmp75 = icmp ne i8 %41, %42
   br i1 %strcmp.cmp75, label %strcmp.false, label %strcmp.loop_null_cmp74
 
 strcmp.loop_null_cmp70:                           ; preds = %strcmp.loop65
-  %strcmp.cmp_null72 = icmp eq i8 %38, 0
+  %strcmp.cmp_null72 = icmp eq i8 %39, 0
   br i1 %strcmp.cmp_null72, label %strcmp.done, label %strcmp.loop69
 
 strcmp.loop73:                                    ; preds = %strcmp.loop_null_cmp74
-  %42 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 20), align 1
   %43 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 20), align 1
-  %strcmp.cmp79 = icmp ne i8 %42, %43
+  %44 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 20), align 1
+  %strcmp.cmp79 = icmp ne i8 %43, %44
   br i1 %strcmp.cmp79, label %strcmp.false, label %strcmp.loop_null_cmp78
 
 strcmp.loop_null_cmp74:                           ; preds = %strcmp.loop69
-  %strcmp.cmp_null76 = icmp eq i8 %40, 0
+  %strcmp.cmp_null76 = icmp eq i8 %41, 0
   br i1 %strcmp.cmp_null76, label %strcmp.done, label %strcmp.loop73
 
 strcmp.loop77:                                    ; preds = %strcmp.loop_null_cmp78
-  %44 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 21), align 1
   %45 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 21), align 1
-  %strcmp.cmp83 = icmp ne i8 %44, %45
+  %46 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 21), align 1
+  %strcmp.cmp83 = icmp ne i8 %45, %46
   br i1 %strcmp.cmp83, label %strcmp.false, label %strcmp.loop_null_cmp82
 
 strcmp.loop_null_cmp78:                           ; preds = %strcmp.loop73
-  %strcmp.cmp_null80 = icmp eq i8 %42, 0
+  %strcmp.cmp_null80 = icmp eq i8 %43, 0
   br i1 %strcmp.cmp_null80, label %strcmp.done, label %strcmp.loop77
 
 strcmp.loop81:                                    ; preds = %strcmp.loop_null_cmp82
-  %46 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 22), align 1
   %47 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 22), align 1
-  %strcmp.cmp87 = icmp ne i8 %46, %47
+  %48 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 22), align 1
+  %strcmp.cmp87 = icmp ne i8 %47, %48
   br i1 %strcmp.cmp87, label %strcmp.false, label %strcmp.loop_null_cmp86
 
 strcmp.loop_null_cmp82:                           ; preds = %strcmp.loop77
-  %strcmp.cmp_null84 = icmp eq i8 %44, 0
+  %strcmp.cmp_null84 = icmp eq i8 %45, 0
   br i1 %strcmp.cmp_null84, label %strcmp.done, label %strcmp.loop81
 
 strcmp.loop85:                                    ; preds = %strcmp.loop_null_cmp86
-  %48 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 23), align 1
   %49 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 23), align 1
-  %strcmp.cmp91 = icmp ne i8 %48, %49
+  %50 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 23), align 1
+  %strcmp.cmp91 = icmp ne i8 %49, %50
   br i1 %strcmp.cmp91, label %strcmp.false, label %strcmp.loop_null_cmp90
 
 strcmp.loop_null_cmp86:                           ; preds = %strcmp.loop81
-  %strcmp.cmp_null88 = icmp eq i8 %46, 0
+  %strcmp.cmp_null88 = icmp eq i8 %47, 0
   br i1 %strcmp.cmp_null88, label %strcmp.done, label %strcmp.loop85
 
 strcmp.loop89:                                    ; preds = %strcmp.loop_null_cmp90
-  %50 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 24), align 1
   %51 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 24), align 1
-  %strcmp.cmp95 = icmp ne i8 %50, %51
+  %52 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 24), align 1
+  %strcmp.cmp95 = icmp ne i8 %51, %52
   br i1 %strcmp.cmp95, label %strcmp.false, label %strcmp.loop_null_cmp94
 
 strcmp.loop_null_cmp90:                           ; preds = %strcmp.loop85
-  %strcmp.cmp_null92 = icmp eq i8 %48, 0
+  %strcmp.cmp_null92 = icmp eq i8 %49, 0
   br i1 %strcmp.cmp_null92, label %strcmp.done, label %strcmp.loop89
 
 strcmp.loop93:                                    ; preds = %strcmp.loop_null_cmp94
-  %52 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 25), align 1
   %53 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 25), align 1
-  %strcmp.cmp99 = icmp ne i8 %52, %53
+  %54 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 25), align 1
+  %strcmp.cmp99 = icmp ne i8 %53, %54
   br i1 %strcmp.cmp99, label %strcmp.false, label %strcmp.loop_null_cmp98
 
 strcmp.loop_null_cmp94:                           ; preds = %strcmp.loop89
-  %strcmp.cmp_null96 = icmp eq i8 %50, 0
+  %strcmp.cmp_null96 = icmp eq i8 %51, 0
   br i1 %strcmp.cmp_null96, label %strcmp.done, label %strcmp.loop93
 
 strcmp.loop97:                                    ; preds = %strcmp.loop_null_cmp98
-  %54 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 26), align 1
   %55 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 26), align 1
-  %strcmp.cmp103 = icmp ne i8 %54, %55
+  %56 = load i8, ptr getelementptr (i8, ptr @"tracepoint:sched:sched_one", i32 26), align 1
+  %strcmp.cmp103 = icmp ne i8 %55, %56
   br i1 %strcmp.cmp103, label %strcmp.false, label %strcmp.loop_null_cmp102
 
 strcmp.loop_null_cmp98:                           ; preds = %strcmp.loop93
-  %strcmp.cmp_null100 = icmp eq i8 %52, 0
+  %strcmp.cmp_null100 = icmp eq i8 %53, 0
   br i1 %strcmp.cmp_null100, label %strcmp.done, label %strcmp.loop97
 
 strcmp.loop101:                                   ; preds = %strcmp.loop_null_cmp102
   br label %strcmp.done
 
 strcmp.loop_null_cmp102:                          ; preds = %strcmp.loop97
-  %strcmp.cmp_null104 = icmp eq i8 %54, 0
+  %strcmp.cmp_null104 = icmp eq i8 %55, 0
   br i1 %strcmp.cmp_null104, label %strcmp.done, label %strcmp.loop101
 }
 

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -21,13 +21,13 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !51 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i1, align 1
-  %strcmp.result = alloca i1, align 1
+  %strcmp.result = alloca i64, align 8
   %__builtin_comm = alloca [16 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.memset.p0.i64(ptr align 1 %__builtin_comm, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to ptr)(ptr %__builtin_comm, i64 16)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %strcmp.result)
-  store i1 false, ptr %strcmp.result, align 1
+  store i64 0, ptr %strcmp.result, align 8
   %1 = getelementptr i8, ptr %__builtin_comm, i32 0
   %2 = load i8, ptr %1, align 1
   %3 = load i8, ptr @sshd, align 1
@@ -35,12 +35,13 @@ entry:
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
-  %4 = load i1, ptr %strcmp.result, align 1
+  %4 = load i64, ptr %strcmp.result, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
+  %5 = trunc i64 %4 to i1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %5 = zext i1 %4 to i8
-  store i8 %5, ptr %"@_key", align 1
+  %6 = zext i1 %5 to i8
+  store i8 %6, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -49,14 +50,14 @@ strcmp.false:                                     ; preds = %strcmp.done, %strcm
   ret i64 0
 
 strcmp.done:                                      ; preds = %strcmp.loop13, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
-  store i1 true, ptr %strcmp.result, align 1
+  store i64 1, ptr %strcmp.result, align 8
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %6 = getelementptr i8, ptr %__builtin_comm, i32 1
-  %7 = load i8, ptr %6, align 1
-  %8 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
-  %strcmp.cmp3 = icmp ne i8 %7, %8
+  %7 = getelementptr i8, ptr %__builtin_comm, i32 1
+  %8 = load i8, ptr %7, align 1
+  %9 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
+  %strcmp.cmp3 = icmp ne i8 %8, %9
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -64,43 +65,43 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %9 = getelementptr i8, ptr %__builtin_comm, i32 2
-  %10 = load i8, ptr %9, align 1
-  %11 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
-  %strcmp.cmp7 = icmp ne i8 %10, %11
+  %10 = getelementptr i8, ptr %__builtin_comm, i32 2
+  %11 = load i8, ptr %10, align 1
+  %12 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
+  %strcmp.cmp7 = icmp ne i8 %11, %12
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %7, 0
+  %strcmp.cmp_null4 = icmp eq i8 %8, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %12 = getelementptr i8, ptr %__builtin_comm, i32 3
-  %13 = load i8, ptr %12, align 1
-  %14 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
-  %strcmp.cmp11 = icmp ne i8 %13, %14
+  %13 = getelementptr i8, ptr %__builtin_comm, i32 3
+  %14 = load i8, ptr %13, align 1
+  %15 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
+  %strcmp.cmp11 = icmp ne i8 %14, %15
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %10, 0
+  %strcmp.cmp_null8 = icmp eq i8 %11, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %15 = getelementptr i8, ptr %__builtin_comm, i32 4
-  %16 = load i8, ptr %15, align 1
-  %17 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
-  %strcmp.cmp15 = icmp ne i8 %16, %17
+  %16 = getelementptr i8, ptr %__builtin_comm, i32 4
+  %17 = load i8, ptr %16, align 1
+  %18 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
+  %strcmp.cmp15 = icmp ne i8 %17, %18
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %13, 0
+  %strcmp.cmp_null12 = icmp eq i8 %14, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
   br label %strcmp.done
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %16, 0
+  %strcmp.cmp_null16 = icmp eq i8 %17, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 }
 

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -21,13 +21,13 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !51 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i1, align 1
-  %strcmp.result = alloca i1, align 1
+  %strcmp.result = alloca i64, align 8
   %__builtin_comm = alloca [16 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.memset.p0.i64(ptr align 1 %__builtin_comm, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to ptr)(ptr %__builtin_comm, i64 16)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %strcmp.result)
-  store i1 true, ptr %strcmp.result, align 1
+  store i64 1, ptr %strcmp.result, align 8
   %1 = getelementptr i8, ptr %__builtin_comm, i32 0
   %2 = load i8, ptr %1, align 1
   %3 = load i8, ptr @sshd, align 1
@@ -35,12 +35,13 @@ entry:
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
-  %4 = load i1, ptr %strcmp.result, align 1
+  %4 = load i64, ptr %strcmp.result, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
+  %5 = trunc i64 %4 to i1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %5 = zext i1 %4 to i8
-  store i8 %5, ptr %"@_key", align 1
+  %6 = zext i1 %5 to i8
+  store i8 %6, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -49,14 +50,14 @@ strcmp.false:                                     ; preds = %strcmp.done, %strcm
   ret i64 0
 
 strcmp.done:                                      ; preds = %strcmp.loop13, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
-  store i1 false, ptr %strcmp.result, align 1
+  store i64 0, ptr %strcmp.result, align 8
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %6 = getelementptr i8, ptr %__builtin_comm, i32 1
-  %7 = load i8, ptr %6, align 1
-  %8 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
-  %strcmp.cmp3 = icmp ne i8 %7, %8
+  %7 = getelementptr i8, ptr %__builtin_comm, i32 1
+  %8 = load i8, ptr %7, align 1
+  %9 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
+  %strcmp.cmp3 = icmp ne i8 %8, %9
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -64,43 +65,43 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %9 = getelementptr i8, ptr %__builtin_comm, i32 2
-  %10 = load i8, ptr %9, align 1
-  %11 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
-  %strcmp.cmp7 = icmp ne i8 %10, %11
+  %10 = getelementptr i8, ptr %__builtin_comm, i32 2
+  %11 = load i8, ptr %10, align 1
+  %12 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
+  %strcmp.cmp7 = icmp ne i8 %11, %12
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %7, 0
+  %strcmp.cmp_null4 = icmp eq i8 %8, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %12 = getelementptr i8, ptr %__builtin_comm, i32 3
-  %13 = load i8, ptr %12, align 1
-  %14 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
-  %strcmp.cmp11 = icmp ne i8 %13, %14
+  %13 = getelementptr i8, ptr %__builtin_comm, i32 3
+  %14 = load i8, ptr %13, align 1
+  %15 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
+  %strcmp.cmp11 = icmp ne i8 %14, %15
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %10, 0
+  %strcmp.cmp_null8 = icmp eq i8 %11, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %15 = getelementptr i8, ptr %__builtin_comm, i32 4
-  %16 = load i8, ptr %15, align 1
-  %17 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
-  %strcmp.cmp15 = icmp ne i8 %16, %17
+  %16 = getelementptr i8, ptr %__builtin_comm, i32 4
+  %17 = load i8, ptr %16, align 1
+  %18 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
+  %strcmp.cmp15 = icmp ne i8 %17, %18
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %13, 0
+  %strcmp.cmp_null12 = icmp eq i8 %14, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
   br label %strcmp.done
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %16, 0
+  %strcmp.cmp_null16 = icmp eq i8 %17, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 }
 

--- a/tests/codegen/llvm/strncmp_no_literals.ll
+++ b/tests/codegen/llvm/strncmp_no_literals.ll
@@ -21,7 +21,7 @@ define i64 @tracepoint_file_filename_1(ptr %0) #0 section "s_tracepoint_file_fil
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %strcmp.result = alloca i1, align 1
+  %strcmp.result = alloca i64, align 8
   %__builtin_comm = alloca [16 x i8], align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
@@ -36,7 +36,7 @@ entry:
   call void @llvm.memset.p0.i64(ptr align 1 %__builtin_comm, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to ptr)(ptr %__builtin_comm, i64 16)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %strcmp.result)
-  store i1 false, ptr %strcmp.result, align 1
+  store i64 0, ptr %strcmp.result, align 8
   %6 = getelementptr i8, ptr %2, i32 0
   %7 = load i8, ptr %6, align 1
   %8 = getelementptr i8, ptr %__builtin_comm, i32 0
@@ -58,22 +58,23 @@ pred_true:                                        ; preds = %strcmp.false
   ret i64 1
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop53, %strcmp.loop49, %strcmp.loop45, %strcmp.loop41, %strcmp.loop37, %strcmp.loop33, %strcmp.loop29, %strcmp.loop25, %strcmp.loop21, %strcmp.loop17, %strcmp.loop13, %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
-  %10 = load i1, ptr %strcmp.result, align 1
+  %10 = load i64, ptr %strcmp.result, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
+  %11 = trunc i64 %10 to i1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %__builtin_comm)
-  %predcond = icmp eq i1 %10, false
+  %predcond = icmp eq i1 %11, false
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.done:                                      ; preds = %strcmp.loop57, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp54, %strcmp.loop_null_cmp50, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp42, %strcmp.loop_null_cmp38, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp30, %strcmp.loop_null_cmp26, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp18, %strcmp.loop_null_cmp14, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp6, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
-  store i1 true, ptr %strcmp.result, align 1
+  store i64 1, ptr %strcmp.result, align 8
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %11 = getelementptr i8, ptr %2, i32 1
-  %12 = load i8, ptr %11, align 1
-  %13 = getelementptr i8, ptr %__builtin_comm, i32 1
-  %14 = load i8, ptr %13, align 1
-  %strcmp.cmp3 = icmp ne i8 %12, %14
+  %12 = getelementptr i8, ptr %2, i32 1
+  %13 = load i8, ptr %12, align 1
+  %14 = getelementptr i8, ptr %__builtin_comm, i32 1
+  %15 = load i8, ptr %14, align 1
+  %strcmp.cmp3 = icmp ne i8 %13, %15
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -81,178 +82,178 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %15 = getelementptr i8, ptr %2, i32 2
-  %16 = load i8, ptr %15, align 1
-  %17 = getelementptr i8, ptr %__builtin_comm, i32 2
-  %18 = load i8, ptr %17, align 1
-  %strcmp.cmp7 = icmp ne i8 %16, %18
+  %16 = getelementptr i8, ptr %2, i32 2
+  %17 = load i8, ptr %16, align 1
+  %18 = getelementptr i8, ptr %__builtin_comm, i32 2
+  %19 = load i8, ptr %18, align 1
+  %strcmp.cmp7 = icmp ne i8 %17, %19
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %12, 0
+  %strcmp.cmp_null4 = icmp eq i8 %13, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %19 = getelementptr i8, ptr %2, i32 3
-  %20 = load i8, ptr %19, align 1
-  %21 = getelementptr i8, ptr %__builtin_comm, i32 3
-  %22 = load i8, ptr %21, align 1
-  %strcmp.cmp11 = icmp ne i8 %20, %22
+  %20 = getelementptr i8, ptr %2, i32 3
+  %21 = load i8, ptr %20, align 1
+  %22 = getelementptr i8, ptr %__builtin_comm, i32 3
+  %23 = load i8, ptr %22, align 1
+  %strcmp.cmp11 = icmp ne i8 %21, %23
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %16, 0
+  %strcmp.cmp_null8 = icmp eq i8 %17, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %23 = getelementptr i8, ptr %2, i32 4
-  %24 = load i8, ptr %23, align 1
-  %25 = getelementptr i8, ptr %__builtin_comm, i32 4
-  %26 = load i8, ptr %25, align 1
-  %strcmp.cmp15 = icmp ne i8 %24, %26
+  %24 = getelementptr i8, ptr %2, i32 4
+  %25 = load i8, ptr %24, align 1
+  %26 = getelementptr i8, ptr %__builtin_comm, i32 4
+  %27 = load i8, ptr %26, align 1
+  %strcmp.cmp15 = icmp ne i8 %25, %27
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %20, 0
+  %strcmp.cmp_null12 = icmp eq i8 %21, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
-  %27 = getelementptr i8, ptr %2, i32 5
-  %28 = load i8, ptr %27, align 1
-  %29 = getelementptr i8, ptr %__builtin_comm, i32 5
-  %30 = load i8, ptr %29, align 1
-  %strcmp.cmp19 = icmp ne i8 %28, %30
+  %28 = getelementptr i8, ptr %2, i32 5
+  %29 = load i8, ptr %28, align 1
+  %30 = getelementptr i8, ptr %__builtin_comm, i32 5
+  %31 = load i8, ptr %30, align 1
+  %strcmp.cmp19 = icmp ne i8 %29, %31
   br i1 %strcmp.cmp19, label %strcmp.false, label %strcmp.loop_null_cmp18
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %24, 0
+  %strcmp.cmp_null16 = icmp eq i8 %25, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 
 strcmp.loop17:                                    ; preds = %strcmp.loop_null_cmp18
-  %31 = getelementptr i8, ptr %2, i32 6
-  %32 = load i8, ptr %31, align 1
-  %33 = getelementptr i8, ptr %__builtin_comm, i32 6
-  %34 = load i8, ptr %33, align 1
-  %strcmp.cmp23 = icmp ne i8 %32, %34
+  %32 = getelementptr i8, ptr %2, i32 6
+  %33 = load i8, ptr %32, align 1
+  %34 = getelementptr i8, ptr %__builtin_comm, i32 6
+  %35 = load i8, ptr %34, align 1
+  %strcmp.cmp23 = icmp ne i8 %33, %35
   br i1 %strcmp.cmp23, label %strcmp.false, label %strcmp.loop_null_cmp22
 
 strcmp.loop_null_cmp18:                           ; preds = %strcmp.loop13
-  %strcmp.cmp_null20 = icmp eq i8 %28, 0
+  %strcmp.cmp_null20 = icmp eq i8 %29, 0
   br i1 %strcmp.cmp_null20, label %strcmp.done, label %strcmp.loop17
 
 strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
-  %35 = getelementptr i8, ptr %2, i32 7
-  %36 = load i8, ptr %35, align 1
-  %37 = getelementptr i8, ptr %__builtin_comm, i32 7
-  %38 = load i8, ptr %37, align 1
-  %strcmp.cmp27 = icmp ne i8 %36, %38
+  %36 = getelementptr i8, ptr %2, i32 7
+  %37 = load i8, ptr %36, align 1
+  %38 = getelementptr i8, ptr %__builtin_comm, i32 7
+  %39 = load i8, ptr %38, align 1
+  %strcmp.cmp27 = icmp ne i8 %37, %39
   br i1 %strcmp.cmp27, label %strcmp.false, label %strcmp.loop_null_cmp26
 
 strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop17
-  %strcmp.cmp_null24 = icmp eq i8 %32, 0
+  %strcmp.cmp_null24 = icmp eq i8 %33, 0
   br i1 %strcmp.cmp_null24, label %strcmp.done, label %strcmp.loop21
 
 strcmp.loop25:                                    ; preds = %strcmp.loop_null_cmp26
-  %39 = getelementptr i8, ptr %2, i32 8
-  %40 = load i8, ptr %39, align 1
-  %41 = getelementptr i8, ptr %__builtin_comm, i32 8
-  %42 = load i8, ptr %41, align 1
-  %strcmp.cmp31 = icmp ne i8 %40, %42
+  %40 = getelementptr i8, ptr %2, i32 8
+  %41 = load i8, ptr %40, align 1
+  %42 = getelementptr i8, ptr %__builtin_comm, i32 8
+  %43 = load i8, ptr %42, align 1
+  %strcmp.cmp31 = icmp ne i8 %41, %43
   br i1 %strcmp.cmp31, label %strcmp.false, label %strcmp.loop_null_cmp30
 
 strcmp.loop_null_cmp26:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null28 = icmp eq i8 %36, 0
+  %strcmp.cmp_null28 = icmp eq i8 %37, 0
   br i1 %strcmp.cmp_null28, label %strcmp.done, label %strcmp.loop25
 
 strcmp.loop29:                                    ; preds = %strcmp.loop_null_cmp30
-  %43 = getelementptr i8, ptr %2, i32 9
-  %44 = load i8, ptr %43, align 1
-  %45 = getelementptr i8, ptr %__builtin_comm, i32 9
-  %46 = load i8, ptr %45, align 1
-  %strcmp.cmp35 = icmp ne i8 %44, %46
+  %44 = getelementptr i8, ptr %2, i32 9
+  %45 = load i8, ptr %44, align 1
+  %46 = getelementptr i8, ptr %__builtin_comm, i32 9
+  %47 = load i8, ptr %46, align 1
+  %strcmp.cmp35 = icmp ne i8 %45, %47
   br i1 %strcmp.cmp35, label %strcmp.false, label %strcmp.loop_null_cmp34
 
 strcmp.loop_null_cmp30:                           ; preds = %strcmp.loop25
-  %strcmp.cmp_null32 = icmp eq i8 %40, 0
+  %strcmp.cmp_null32 = icmp eq i8 %41, 0
   br i1 %strcmp.cmp_null32, label %strcmp.done, label %strcmp.loop29
 
 strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
-  %47 = getelementptr i8, ptr %2, i32 10
-  %48 = load i8, ptr %47, align 1
-  %49 = getelementptr i8, ptr %__builtin_comm, i32 10
-  %50 = load i8, ptr %49, align 1
-  %strcmp.cmp39 = icmp ne i8 %48, %50
+  %48 = getelementptr i8, ptr %2, i32 10
+  %49 = load i8, ptr %48, align 1
+  %50 = getelementptr i8, ptr %__builtin_comm, i32 10
+  %51 = load i8, ptr %50, align 1
+  %strcmp.cmp39 = icmp ne i8 %49, %51
   br i1 %strcmp.cmp39, label %strcmp.false, label %strcmp.loop_null_cmp38
 
 strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop29
-  %strcmp.cmp_null36 = icmp eq i8 %44, 0
+  %strcmp.cmp_null36 = icmp eq i8 %45, 0
   br i1 %strcmp.cmp_null36, label %strcmp.done, label %strcmp.loop33
 
 strcmp.loop37:                                    ; preds = %strcmp.loop_null_cmp38
-  %51 = getelementptr i8, ptr %2, i32 11
-  %52 = load i8, ptr %51, align 1
-  %53 = getelementptr i8, ptr %__builtin_comm, i32 11
-  %54 = load i8, ptr %53, align 1
-  %strcmp.cmp43 = icmp ne i8 %52, %54
+  %52 = getelementptr i8, ptr %2, i32 11
+  %53 = load i8, ptr %52, align 1
+  %54 = getelementptr i8, ptr %__builtin_comm, i32 11
+  %55 = load i8, ptr %54, align 1
+  %strcmp.cmp43 = icmp ne i8 %53, %55
   br i1 %strcmp.cmp43, label %strcmp.false, label %strcmp.loop_null_cmp42
 
 strcmp.loop_null_cmp38:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null40 = icmp eq i8 %48, 0
+  %strcmp.cmp_null40 = icmp eq i8 %49, 0
   br i1 %strcmp.cmp_null40, label %strcmp.done, label %strcmp.loop37
 
 strcmp.loop41:                                    ; preds = %strcmp.loop_null_cmp42
-  %55 = getelementptr i8, ptr %2, i32 12
-  %56 = load i8, ptr %55, align 1
-  %57 = getelementptr i8, ptr %__builtin_comm, i32 12
-  %58 = load i8, ptr %57, align 1
-  %strcmp.cmp47 = icmp ne i8 %56, %58
+  %56 = getelementptr i8, ptr %2, i32 12
+  %57 = load i8, ptr %56, align 1
+  %58 = getelementptr i8, ptr %__builtin_comm, i32 12
+  %59 = load i8, ptr %58, align 1
+  %strcmp.cmp47 = icmp ne i8 %57, %59
   br i1 %strcmp.cmp47, label %strcmp.false, label %strcmp.loop_null_cmp46
 
 strcmp.loop_null_cmp42:                           ; preds = %strcmp.loop37
-  %strcmp.cmp_null44 = icmp eq i8 %52, 0
+  %strcmp.cmp_null44 = icmp eq i8 %53, 0
   br i1 %strcmp.cmp_null44, label %strcmp.done, label %strcmp.loop41
 
 strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
-  %59 = getelementptr i8, ptr %2, i32 13
-  %60 = load i8, ptr %59, align 1
-  %61 = getelementptr i8, ptr %__builtin_comm, i32 13
-  %62 = load i8, ptr %61, align 1
-  %strcmp.cmp51 = icmp ne i8 %60, %62
+  %60 = getelementptr i8, ptr %2, i32 13
+  %61 = load i8, ptr %60, align 1
+  %62 = getelementptr i8, ptr %__builtin_comm, i32 13
+  %63 = load i8, ptr %62, align 1
+  %strcmp.cmp51 = icmp ne i8 %61, %63
   br i1 %strcmp.cmp51, label %strcmp.false, label %strcmp.loop_null_cmp50
 
 strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop41
-  %strcmp.cmp_null48 = icmp eq i8 %56, 0
+  %strcmp.cmp_null48 = icmp eq i8 %57, 0
   br i1 %strcmp.cmp_null48, label %strcmp.done, label %strcmp.loop45
 
 strcmp.loop49:                                    ; preds = %strcmp.loop_null_cmp50
-  %63 = getelementptr i8, ptr %2, i32 14
-  %64 = load i8, ptr %63, align 1
-  %65 = getelementptr i8, ptr %__builtin_comm, i32 14
-  %66 = load i8, ptr %65, align 1
-  %strcmp.cmp55 = icmp ne i8 %64, %66
+  %64 = getelementptr i8, ptr %2, i32 14
+  %65 = load i8, ptr %64, align 1
+  %66 = getelementptr i8, ptr %__builtin_comm, i32 14
+  %67 = load i8, ptr %66, align 1
+  %strcmp.cmp55 = icmp ne i8 %65, %67
   br i1 %strcmp.cmp55, label %strcmp.false, label %strcmp.loop_null_cmp54
 
 strcmp.loop_null_cmp50:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null52 = icmp eq i8 %60, 0
+  %strcmp.cmp_null52 = icmp eq i8 %61, 0
   br i1 %strcmp.cmp_null52, label %strcmp.done, label %strcmp.loop49
 
 strcmp.loop53:                                    ; preds = %strcmp.loop_null_cmp54
-  %67 = getelementptr i8, ptr %2, i32 15
-  %68 = load i8, ptr %67, align 1
-  %69 = getelementptr i8, ptr %__builtin_comm, i32 15
-  %70 = load i8, ptr %69, align 1
-  %strcmp.cmp59 = icmp ne i8 %68, %70
+  %68 = getelementptr i8, ptr %2, i32 15
+  %69 = load i8, ptr %68, align 1
+  %70 = getelementptr i8, ptr %__builtin_comm, i32 15
+  %71 = load i8, ptr %70, align 1
+  %strcmp.cmp59 = icmp ne i8 %69, %71
   br i1 %strcmp.cmp59, label %strcmp.false, label %strcmp.loop_null_cmp58
 
 strcmp.loop_null_cmp54:                           ; preds = %strcmp.loop49
-  %strcmp.cmp_null56 = icmp eq i8 %64, 0
+  %strcmp.cmp_null56 = icmp eq i8 %65, 0
   br i1 %strcmp.cmp_null56, label %strcmp.done, label %strcmp.loop53
 
 strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
   br label %strcmp.done
 
 strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop53
-  %strcmp.cmp_null60 = icmp eq i8 %68, 0
+  %strcmp.cmp_null60 = icmp eq i8 %69, 0
   br i1 %strcmp.cmp_null60, label %strcmp.done, label %strcmp.loop57
 }
 

--- a/tests/codegen/llvm/strncmp_one_literal.ll
+++ b/tests/codegen/llvm/strncmp_one_literal.ll
@@ -21,13 +21,13 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
-  %strcmp.result = alloca i1, align 1
+  %strcmp.result = alloca i64, align 8
   %__builtin_comm = alloca [16 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.memset.p0.i64(ptr align 1 %__builtin_comm, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to ptr)(ptr %__builtin_comm, i64 16)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %strcmp.result)
-  store i1 true, ptr %strcmp.result, align 1
+  store i64 1, ptr %strcmp.result, align 8
   %1 = getelementptr i8, ptr %__builtin_comm, i32 0
   %2 = load i8, ptr %1, align 1
   %3 = load i8, ptr @sshd, align 1
@@ -35,12 +35,11 @@ entry:
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop, %entry
-  %4 = load i1, ptr %strcmp.result, align 1
+  %4 = load i64, ptr %strcmp.result, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %strcmp.result)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %__builtin_comm)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %5 = zext i1 %4 to i64
-  store i64 %5, ptr %"@_key", align 8
+  store i64 %4, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -49,14 +48,14 @@ strcmp.false:                                     ; preds = %strcmp.done, %strcm
   ret i64 0
 
 strcmp.done:                                      ; preds = %strcmp.loop1, %strcmp.loop_null_cmp2, %strcmp.loop_null_cmp
-  store i1 false, ptr %strcmp.result, align 1
+  store i64 0, ptr %strcmp.result, align 8
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %6 = getelementptr i8, ptr %__builtin_comm, i32 1
-  %7 = load i8, ptr %6, align 1
-  %8 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
-  %strcmp.cmp3 = icmp ne i8 %7, %8
+  %5 = getelementptr i8, ptr %__builtin_comm, i32 1
+  %6 = load i8, ptr %5, align 1
+  %7 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
+  %strcmp.cmp3 = icmp ne i8 %6, %7
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -67,7 +66,7 @@ strcmp.loop1:                                     ; preds = %strcmp.loop_null_cm
   br label %strcmp.done
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %7, 0
+  %strcmp.cmp_null4 = icmp eq i8 %6, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 }
 


### PR DESCRIPTION
The return SizedType for this function
is Uint64 but in codegen it was being
set to an Int1Ty which was causing a
type mismatch in predicate evaluation.

This just fixes the codegen type
so it matches the SizedType.

Example where the error occurs:
```
tracepoint:syscalls:sys_enter_open / strncmp(comm, "open", 4) / { printf("%s\n", comm); }'
```

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
