### PR TITLE
Move iter checking out of semantic analyser

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -85,6 +85,8 @@ int AttachPointParser::parse()
       probe->addError() << "No attach points for probe";
       failed++;
     }
+
+    has_iter_ap_ = false; // reset for each probe
   }
 
   return failed;
@@ -747,10 +749,26 @@ AttachPointParser::State AttachPointParser::iter_parser()
     return INVALID;
   }
 
+  if (!listing_) {
+    if (has_iter_ap_) {
+      errs_ << ap_->provider << " probe only supports one attach point."
+            << std::endl;
+      return INVALID;
+    }
+
+    if (util::has_wildcard(parts_[1]) ||
+        (parts_.size() == 3 && util::has_wildcard(parts_[2]))) {
+      errs_ << ap_->provider << " probe type does not support wildcards";
+      return INVALID;
+    }
+  }
+
   ap_->func = parts_[1];
 
   if (parts_.size() == 3)
     ap_->pin = parts_[2];
+
+  has_iter_ap_ = true;
   return OK;
 }
 

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -63,6 +63,7 @@ private:
   std::vector<std::string> parts_;
   AttachPointList new_attach_points;
   bool listing_;
+  bool has_iter_ap_ = false;
 };
 
 // The attachpoints are expanded in their own separate pass.

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -4113,19 +4113,8 @@ void SemanticAnalyser::visit(BlockExpr &block)
 
 void SemanticAnalyser::visit(Probe &probe)
 {
-  auto aps = probe.attach_points.size();
   top_level_node_ = &probe;
-
-  for (AttachPoint *ap : probe.attach_points) {
-    if (!listing_ && aps > 1 && ap->provider == "iter") {
-      if (util::has_wildcard(ap->raw_input))
-        ap->addError() << "iter probe type does not support wildcards";
-      else
-        ap->addError() << "Only single iter attach point is allowed.";
-      return;
-    }
-    visit(ap);
-  }
+  visit(probe.attach_points);
   visit(probe.block);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,7 @@ endif()
 add_executable(bpftrace_test
   arch.cpp
   async_action.cpp
+  attachpoint_parser.cpp
   bpfbytecode.cpp
   bpftrace.cpp
   btf.cpp

--- a/tests/attachpoint_parser.cpp
+++ b/tests/attachpoint_parser.cpp
@@ -1,0 +1,67 @@
+#include "ast/attachpoint_parser.h"
+#include "ast/passes/printer.h"
+#include "btf_common.h"
+#include "driver.h"
+#include "mocks.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::attachpoint_parser {
+
+using ::testing::HasSubstr;
+
+void test(const std::string& input,
+          bool listing = false,
+          const std::string& error = "")
+{
+  auto mock_bpftrace = get_mock_bpftrace();
+  BPFtrace& bpftrace = *mock_bpftrace;
+
+  // The input provided here is embedded into an expression.
+  ast::ASTContext ast("stdin", input);
+  std::stringstream msg;
+  msg << "\nInput:\n" << input << "\n\nOutput:\n";
+
+  // N.B. No C macro or tracepoint expansion.
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put(bpftrace)
+                .add(CreateParsePass())
+                .add(ast::CreateParseAttachpointsPass(listing))
+                .run();
+
+  std::ostringstream out;
+  ast::Printer printer(out);
+  printer.visit(ast.root);
+  ast.diagnostics().emit(out);
+
+  if (error.empty()) {
+    ASSERT_TRUE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+  } else {
+    ASSERT_FALSE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+    EXPECT_THAT(out.str(), HasSubstr(error)) << msg.str() << out.str();
+  }
+}
+
+void test_error(const std::string& input, const std::string& error)
+{
+  test(input, false, error);
+}
+
+TEST(attachpoint_parser, iter)
+{
+  test("iter:task { 1 }");
+  test("iter:task:pin { 1 }");
+  test("iter:task { 2 } iter:task_file { 1 }");
+  test_error("iter:task* { 1 }",
+             R"(iter probe type does not support wildcards)");
+  test_error("iter:task:* { 1 }",
+             R"(iter probe type does not support wildcards)");
+  test_error("iter:task, iter:task_file { 1 }",
+             R"(iter probe only supports one attach point)");
+  // Listing is ok
+  test("iter:task* { 1 }", true);
+  test("iter:task:* { 1 }", true);
+  test("iter:task, iter:task_file { 1 }", true);
+}
+
+} // namespace bpftrace::test::attachpoint_parser

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4441,21 +4441,6 @@ stdin:1:18-22: ERROR: The args builtin can only be used with tracepoint/fentry/u
 iter:task { $x = args.foo; }
                  ~~~~
 )" });
-  test("iter:task,iter:task_file { 1 }", Error{ R"(
-stdin:1:1-10: ERROR: Only single iter attach point is allowed.
-iter:task,iter:task_file { 1 }
-~~~~~~~~~
-)" });
-  test("iter:task,f:func_1 { 1 }", Error{ R"(
-stdin:1:1-10: ERROR: Only single iter attach point is allowed.
-iter:task,f:func_1 { 1 }
-~~~~~~~~~
-)" });
-  test("iter:task* { }", Error{ R"(
-stdin:1:1-11: ERROR: iter probe type does not support wildcards
-iter:task* { }
-~~~~~~~~~~
-)" });
 }
 
 TEST_F(SemanticAnalyserBTFTest, rawtracepoint)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4560


--- --- ---

### Move iter checking out of semantic analyser


Minor refactor to reduce code in semantic analyser.
Move the iter probe checks to attachpoint_parser
and add tests.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>