### PR TITLE
Fix ast clone not cloning all variant nodes

### DIFF
--- a/src/ast/clone.h
+++ b/src/ast/clone.h
@@ -9,6 +9,8 @@ namespace bpftrace::ast {
 
 class Expression;
 class Statement;
+class Iterable;
+class RootStatement;
 
 template <typename T>
 struct Cloner {
@@ -21,7 +23,7 @@ struct Cloner {
 };
 
 template <typename T>
-  requires(std::is_same_v<T, Expression> || std::is_same_v<T, Statement>)
+  requires(std::is_same_v<T, Expression> || std::is_same_v<T, Statement> || std::is_same_v<T, Iterable> || std::is_same_v<T, RootStatement>)
 struct Cloner<T> {
   T operator()(ASTContext &ctx, const T &v, const Location &loc)
   {

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -102,6 +102,11 @@ NAME macro arg idents take precedence over macros with no arguments
 PROG macro add() { 2 } macro ident(add) { add } begin { print(ident(1)); }
 EXPECT 1
 
+# This is more of a regression test for clone that wasn't cloning the Iterable node
+NAME macro replaces all instances
+PROG macro first_key(@x) { let $x; for ($k : @x) { $x = $k.0; break; } $x } begin { @a[1] = 0; @b[2] = 0; print((first_key(@a), first_key(@b))); }
+EXPECT (1, 2)
+
 # Test builtins
 NAME builtin wrapper comm
 PROG begin { if (__builtin_comm == comm() && __builtin_comm == comm) { print(comm); } }


### PR DESCRIPTION
Stacked PRs:
 * #4571
 * __->__#4570


--- --- ---

### Fix ast clone not cloning all variant nodes


clone wasn't cloning Iterable and RootStatement;
it was instead taking a reference.

Add a regression test in the macro
test suite for an Iterable which hits
the clone path.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>