### PR TITLE
Cloner: remove default copy constructor

### DIFF
--- a/src/ast/clone.h
+++ b/src/ast/clone.h
@@ -5,7 +5,11 @@
 #include "ast/ast.h"
 #include "ast/context.h"
 
-namespace bpftrace::ast {
+namespace bpftrace {
+
+class SizedType;
+
+namespace ast {
 
 class Expression;
 class Statement;
@@ -13,7 +17,11 @@ class Iterable;
 class RootStatement;
 
 template <typename T>
-struct Cloner {
+struct Cloner;
+
+template <typename T>
+  requires(std::is_same_v<T, SizedType>)
+struct Cloner<T> {
   T operator()([[maybe_unused]] ASTContext &ctx,
                const T &v,
                [[maybe_unused]] const Location &loc)
@@ -87,4 +95,5 @@ T clone(ASTContext &ctx, const T &t, const Location &loc = Location())
   return Cloner<V>()(ctx, t, loc);
 }
 
-} // namespace bpftrace::ast
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/clone.h
+++ b/src/ast/clone.h
@@ -9,6 +9,8 @@ namespace bpftrace::ast {
 
 class Expression;
 class Statement;
+class Iterable;
+class RootStatement;
 
 template <typename T>
 struct Cloner {
@@ -21,7 +23,7 @@ struct Cloner {
 };
 
 template <typename T>
-  requires(std::is_same_v<T, Expression> || std::is_same_v<T, Statement>)
+  requires(std::is_same_v<T, Expression> || std::is_same_v<T, Statement> || std::is_same_v<T, Iterable> || std::is_same_v<T, RootStatement>)
 struct Cloner<T> {
   T operator()(ASTContext &ctx, const T &v, const Location &loc)
   {

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -102,6 +102,11 @@ NAME macro arg idents take precedence over macros with no arguments
 PROG macro add() { 2 } macro ident(add) { add } begin { print(ident(1)); }
 EXPECT 1
 
+# This is more of a regression test for clone that wasn't cloning the Iterable node
+NAME macro replaces all instances
+PROG macro first_key(@x) { let $x; for ($k : @x) { $x = $k.0; break; } $x } begin { @a[1] = 0; @b[2] = 0; print((first_key(@a), first_key(@b))); }
+EXPECT (1, 2)
+
 # Test builtins
 NAME builtin wrapper comm
 PROG begin { if (__builtin_comm == comm() && __builtin_comm == comm) { print(comm); } }


### PR DESCRIPTION
Stacked PRs:
 * __->__#4571
 * #4570


--- --- ---

### Cloner: remove default copy constructor


Only allow SizedType to be copied.
This will cause a build failure if we add
a new VariantNode and forget to include
it explicitly in one of the specializations
as we don't want these copied - they
need to be visited and their internal
type copied.

Co-authored-by: Adin Scannell <amscanne@meta.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>