### PR TITLE
ast: limit pruning to `comptime` expressions

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -29,8 +29,15 @@ const SizedType &Expression::type() const
 
 bool Expression::is_literal() const
 {
-  return is<Integer>() || is<NegativeInteger>() || is<String>() ||
-         is<Boolean>();
+  if (is<Integer>() || is<NegativeInteger>() || is<String>() || is<Boolean>()) {
+    return true;
+  }
+  if (auto *tuple = as<Tuple>()) {
+    return std::ranges::all_of(tuple->elems, [](const auto &elem) {
+      return elem.is_literal();
+    });
+  }
+  return false;
 }
 
 static constexpr std::string_view ENUM = "enum ";

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -144,6 +144,7 @@ class Tuple;
 class IfExpr;
 class BlockExpr;
 class Typeinfo;
+class Comptime;
 
 class Expression : public VariantNode<Integer,
                                       NegativeInteger,
@@ -171,7 +172,8 @@ class Expression : public VariantNode<Integer,
                                       Tuple,
                                       IfExpr,
                                       BlockExpr,
-                                      Typeinfo> {
+                                      Typeinfo,
+                                      Comptime> {
 public:
   using VariantNode::VariantNode;
   Expression() : Expression(static_cast<BlockExpr *>(nullptr)) {};
@@ -535,6 +537,22 @@ public:
   }
 
   Typeof *typeof = nullptr;
+};
+
+class Comptime : public Node {
+public:
+  explicit Comptime(ASTContext &ctx, Expression expr, Location &&loc)
+      : Node(ctx, std::move(loc)), expr(std::move(expr)) {};
+  explicit Comptime(ASTContext &ctx, const Comptime &other, const Location &loc)
+      : Node(ctx, loc + other.loc),
+        expr(clone(ctx, other.expr, loc + other.loc)) {};
+
+  const SizedType &type() const
+  {
+    return expr.type();
+  }
+
+  Expression expr;
 };
 
 class MapDeclStatement : public Node {

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -95,6 +95,10 @@ public:
   {
     return visitImpl(typeinfo.typeof);
   }
+  R visit(Comptime &comptime)
+  {
+    return visitImpl(comptime.expr);
+  }
   R visit([[maybe_unused]] MapDeclStatement &decl)
   {
     return default_value();

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -182,6 +182,7 @@ oct_esc  [0-7]{1,3}
 "typeinfo"              { return Parser::make_TYPEINFO(yytext, driver.loc); }
 "let"                   { return Parser::make_LET(yytext, driver.loc); }
 "import"                { return Parser::make_IMPORT(yytext, driver.loc); }
+"comptime"              { return Parser::make_COMPTIME(yytext, driver.loc); }
 
 {int_type}              { return Parser::make_INT_TYPE(yytext, driver.loc); }
 {builtin_type}          { return Parser::make_BUILTIN_TYPE(yytext, driver.loc); }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -133,6 +133,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> OFFSETOF "offsetof"
 %token <std::string> TYPEOF "typeof"
 %token <std::string> TYPEINFO "typeinfo"
+%token <std::string> COMPTIME "comptime"
 %token <std::string> LET "let"
 %token <std::string> IMPORT "import"
 %token <bool> BOOL "bool"
@@ -145,6 +146,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::AttachPointList> attach_points
 %type <ast::BlockExpr *> none_block bare_block block_expr
 %type <ast::Call *> call
+%type <ast::Comptime *> comptime_expr
 %type <ast::Sizeof *> sizeof_expr
 %type <ast::Offsetof *> offsetof_expr
 %type <ast::Typeof *> typeof_expr any_type
@@ -700,6 +702,7 @@ unary_op:
 expr:
                 conditional_expr    { $$ = $1; }
         |       if_expr             { $$ = $1; }
+        |       comptime_expr       { $$ = $1; }
                 ;
 
 conditional_expr:
@@ -796,9 +799,14 @@ typeinfo_expr:
         |       TYPEINFO "(" expr ")"  { $$ = driver.ctx.make_node<ast::Typeinfo>(driver.ctx.make_node<ast::Typeof>($3, @$), @$); }
                 ;
 
+comptime_expr:
+                COMPTIME expr { $$ = driver.ctx.make_node<ast::Comptime>($2, @$); }
+                ;
+
 any_type:
                 type        { $$ = driver.ctx.make_node<ast::Typeof>($1, @$); }
         |       typeof_expr { $$ = $1; }
+                ;
 
 keyword:
                 BREAK         { $$ = $1; }
@@ -816,6 +824,7 @@ keyword:
         |       SUBPROG       { $$ = $1; }
         |       TYPEOF        { $$ = $1; }
         |       TYPEINFO      { $$ = $1; }
+        |       COMPTIME      { $$ = $1; }
                 ;
 
 ident:

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -7,8 +7,8 @@
 // copied into BPF memory.
 macro strcontains(haystack, needle) {
   // Accept anything that `str` accepts, but not integers.
-  if (typeinfo(haystack) == typeinfo(1) || typeinfo(haystack) == typeinfo(-1) ||
-      typeinfo(needle) == typeinfo(1) || typeinfo(needle) == typeinfo(-1)) {
+  if (comptime typeinfo(haystack) == typeinfo(1) || typeinfo(haystack) == typeinfo(-1) ||
+               typeinfo(needle) == typeinfo(1) || typeinfo(needle) == typeinfo(-1)) {
     fail("strcontains requires pointers or strings");
   }
   let $haystack = str(haystack);

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -16,10 +16,23 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
+  %"$s1" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s1")
+  store i64 0, ptr %"$s1", align 8
   %"$s" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
   store i64 0, ptr %"$s", align 8
+  br i1 true, label %left, label %right
+
+left:                                             ; preds = %entry
   store i64 10, ptr %"$s", align 8
+  br label %done
+
+right:                                            ; preds = %entry
+  store i64 20, ptr %"$s1", align 8
+  br label %done
+
+done:                                             ; preds = %right, %left
   ret i64 0
 }
 

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -22,7 +22,16 @@ entry:
   %"$x" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
   store i64 0, ptr %"$x", align 8
+  br i1 true, label %left, label %right
+
+left:                                             ; preds = %entry
   store i64 10, ptr %"$x", align 8
+  br label %done
+
+right:                                            ; preds = %entry
+  br label %done
+
+done:                                             ; preds = %right, %left
   %1 = load i64, ptr %"$x", align 8
   store i64 %1, ptr %"$y", align 8
   ret i64 0

--- a/tests/codegen/llvm/late_variable_decl.ll
+++ b/tests/codegen/llvm/late_variable_decl.ll
@@ -36,12 +36,21 @@ entry:
   %"$x" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
   store i64 0, ptr %"$x", align 8
+  br i1 true, label %left, label %right
+
+left:                                             ; preds = %entry
   store i64 1, ptr %"$x", align 8
+  br label %done
+
+right:                                            ; preds = %entry
+  br label %done
+
+done:                                             ; preds = %right, %left
   store i64 2, ptr %"$x1", align 8
   store i64 1, ptr %"$i", align 8
   br label %while_cond
 
-while_cond:                                       ; preds = %while_body, %entry
+while_cond:                                       ; preds = %while_body, %done
   %1 = load i64, ptr %"$i", align 8
   %true_cond = icmp ne i64 %1, 0
   br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !56


### PR DESCRIPTION
Stacked PRs:
 * #4584
 * #4583
 * __->__#4581


--- --- ---

### ast: limit pruning to `comptime` expressions


Taking inspiration from Zig, allow for the `comptime` keyword for
folding if statements and other expressions. This forces evaluation at
compile time, and will cause failure if it is not possible. This is
similar to `constexpr` in C++.

Note that most evaluation is not supported today, but these will
generate explicit error cases rather than silently *not* folding.
Similarly, nothing will be silently folded.

Signed-off-by: Adin Scannell <amscanne@meta.com>
