### PR TITLE
fix: consistent use of blazesym types (#4566)

### DIFF
--- a/src/ksyms.cpp
+++ b/src/ksyms.cpp
@@ -1,10 +1,6 @@
 #include <bcc/bcc_syms.h>
 #include <sstream>
 
-#ifdef HAVE_BLAZESYM
-#include <blazesym.h>
-#endif
-
 #include "ksyms.h"
 #include "scopeguard.h"
 

--- a/src/ksyms.h
+++ b/src/ksyms.h
@@ -4,6 +4,10 @@
 #include <optional>
 #include <string>
 
+#ifdef HAVE_BLAZESYM
+#include <blazesym.h>
+#endif
+
 #include "config.h"
 
 namespace bpftrace {
@@ -26,7 +30,7 @@ private:
   void *ksyms_{ nullptr };
 
 #ifdef HAVE_BLAZESYM
-  struct blaze_symbolizer *symbolizer_{ nullptr };
+  blaze_symbolizer *symbolizer_{ nullptr };
 
   std::vector<std::string> resolve_blazesym_impl(uint64_t addr,
                                                  bool show_offset,

--- a/src/usyms.cpp
+++ b/src/usyms.cpp
@@ -3,10 +3,6 @@
 #include <bcc/bcc_syms.h>
 #include <sstream>
 
-#ifdef HAVE_BLAZESYM
-#include <blazesym.h>
-#endif
-
 #include "config.h"
 #include "log.h"
 #include "scopeguard.h"

--- a/src/usyms.h
+++ b/src/usyms.h
@@ -6,6 +6,10 @@
 #include <map>
 #include <string>
 
+#ifdef HAVE_BLAZESYM
+#include <blazesym.h>
+#endif
+
 #include "util/symbols.h"
 
 namespace bpftrace {
@@ -47,9 +51,9 @@ private:
   struct bcc_symbol_option& get_symbol_opts();
 
 #ifdef HAVE_BLAZESYM
-  struct blaze_symbolizer* symbolizer_{ nullptr };
+  blaze_symbolizer* symbolizer_{ nullptr };
 
-  struct blaze_symbolizer* create_symbolizer() const;
+  blaze_symbolizer* create_symbolizer() const;
   void cache_blazesym(const std::string& elf_file, std::optional<int> opt_pid);
   std::vector<std::string> resolve_blazesym_impl(uint64_t addr,
                                                  int32_t pid,


### PR DESCRIPTION
Building with LTO found redundant and inconsistent type declarations
for blaze_symbolizer in bpftrace's Ksym and Usym classes.

For example:
```
[417/417] : && /usr/bin/x86_64-pc-linux-gnu-g++ -pipe -O2 -flto <...>
src/ksyms.h:12:7: warning: type 'struct Ksyms' violates the C++ One Definition Rule [-Wodr]
   12 | class Ksyms {
      |       ^
src/ksyms.h:12:7: note: a different type is defined in another translation unit
   12 | class Ksyms {
      |       ^
src/ksyms.h:29:28: note: the first difference of corresponding definitions is field 'symbolizer_'
   29 |   struct blaze_symbolizer *symbolizer_{ nullptr };
      |                            ^
src/ksyms.h:29:28: note: a field of same name but different type is defined in another translation unit
   29 |   struct blaze_symbolizer *symbolizer_{ nullptr };
      |                            ^
src/ksyms.h:29:10: note: type name 'bpftrace::blaze_symbolizer' should match type name 'blaze_symbolizer'
   29 |   struct blaze_symbolizer *symbolizer_{ nullptr };
      |          ^
/usr/include/blazesym.h:702:16: note: the incompatible type is defined here
  702 | typedef struct blaze_symbolizer blaze_symbolizer;
      |                ^
```
Fix this by using blazesym's authoritative declarations.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
