### PR TITLE
tests: Disable watchpoint test failing in CI

### DIFF
--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -1,9 +1,11 @@
+# Disabled - repeatedly fails on upstream kernel (6.14)
 NAME watchpoint - absolute address
 BEFORE ./testprogs/watchpoint
 RUN {{BPFTRACE}} -e "watchpoint:$(awk '{print $1}' /tmp/watchpoint_mem):8:w { printf(\"hit!\n\"); exit() }" -p {{BEFORE_PID}}
 EXPECT hit!
 ARCH aarch64|ppc64|ppc64le|x86_64
 CLEANUP rm -f /tmp/watchpoint_mem
+REQUIRES bash -c "exit 1"
 
 NAME kwatchpoint - knl absolute address
 RUN {{BPFTRACE}} -e "watchpoint:0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):4:w { printf(\"hit\n\"); exit(); }"


### PR DESCRIPTION
The `watchpoint.watchpoint - absolute address` runtime test keeps failing in CI in the latest kernel (currently 6.14). Until we fix it, disable it so that it doesn't block other PRs from merging.

Interestingly, it failed in the last 10 [attempts](https://github.com/bpftrace/bpftrace/actions/workflows/ci.yml) where all other tests passed, however, it's passing on [my fork](https://github.com/viktormalik/bpftrace/actions/runs/17851279150/job/50760283165) with the latest master.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
