### PR TITLE
Move some map errors to semantic_analyser

### DIFF
--- a/src/ast/passes/map_sugar.h
+++ b/src/ast/passes/map_sugar.h
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 
+#include "ast/ast.h"
 #include "ast/pass_manager.h"
 
 namespace bpftrace::ast {
@@ -11,9 +12,18 @@ namespace bpftrace::ast {
 // For now, this is whether they are used as scalars. In the future, this may
 // be used as the basis for `MapInfo`, which can be propagated and used by
 // passes, rather than being mutated within the BPFtrace object.
+//
+// Additionally we track scalar/non-scalar map errors here but defer actually
+// issuing the errors on the nodes until a later pass as they may removed if
+// they are inside branch that is pruned at compile time
 class MapMetadata : public ast::State<"map-metadata"> {
 public:
   std::unordered_map<std::string, bool> scalar;
+  std::unordered_set<Node *> bad_scalar_access;
+  std::unordered_set<Node *> bad_indexed_access;
+  std::unordered_set<Node *> bad_scalar_call;
+  std::unordered_set<Node *> bad_indexed_call;
+  std::unordered_set<Node *> bad_iterator;
 };
 
 Pass CreateMapSugarPass();

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -345,9 +345,9 @@ TEST_F(SemanticAnalyserTest, consistent_map_keys)
   test("begin { @x[@y[@z]] = 5; @y[2] = 1; @z = @x[0]; }");
 
   test("begin { @x = 0; @x[1]; }", Error{ R"(
-stdin:1:17-19: ERROR: @x used as a map with an explicit key (non-scalar map), previously used without an explicit key (scalar map)
+stdin:1:17-22: ERROR: @x used as a map with an explicit key (non-scalar map), previously used without an explicit key (scalar map)
 begin { @x = 0; @x[1]; }
-                ~~
+                ~~~~~
 )" });
   test("begin { @x[1] = 0; @x; }", Error{ R"(
 stdin:1:20-22: ERROR: @x used as a map without an explicit key (scalar map), previously used with an explicit key (non-scalar map)
@@ -5621,6 +5621,18 @@ TEST_F(SemanticAnalyserTest, typeof_casts)
 stdin:1:61-74: ERROR: Cannot cast to "struct foo"
 struct foo { int x; } kprobe:f { $x = (struct foo*)0; $y = (typeof(*$x))0; }
                                                             ~~~~~~~~~~~~~
+)" });
+}
+
+TEST_F(SemanticAnalyserTest, if_comptime)
+{
+  test(R"(kprobe:f { @a = 1; if (comptime false) { @a[1] = 1; } })");
+  test(R"(kprobe:f { @a[1] = 1; if (comptime false) { @a = 1; } })");
+  test(R"(kprobe:f { @a = 1; if (comptime false) { for ($kv : @a) { } } })");
+  test(R"(kprobe:f { @a[1] = 1; if (comptime true) { @a = 1; } })", Error{ R"(
+stdin:1:44-46: ERROR: @a used as a map without an explicit key (scalar map), previously used with an explicit key (non-scalar map)
+kprobe:f { @a[1] = 1; if (comptime true) { @a = 1; } }
+                                           ~~
 )" });
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #4561
 * #4619
 * __->__#4618


--- --- ---

### Move some map errors to semantic_analyser


Instead of having the map_sugar pass add
these errors, save them into map metadata
so that they can be issued by semantic_analyser.

This is needed to allow for these errors
to be removed with comptime branch pruning, e.g.,
```
@a = 1;

if (comptime false) { @a[1] = 1; }
```
This should execute ok because the bad
map access is being pruned.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>