### PR TITLE
build: fix building with gcc-16 (#4614)

### DIFF
--- a/src/util/int_parser.cpp
+++ b/src/util/int_parser.cpp
@@ -1,5 +1,5 @@
+#include <climits>
 #include <cstdint>
-#include <limits>
 #include <map>
 #include <optional>
 #include <ranges>

--- a/src/util/opaque.h
+++ b/src/util/opaque.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cstdlib>
 #include <cstring>
 #include <functional>

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1,3 +1,4 @@
+#include <climits>
 #include <cstdlib>
 #include <cstring>
 #include <fcntl.h>


### PR DESCRIPTION
Gcc-16 has once again tightened some transitive includes, which means some headers must now be explicitly included. For example:

  src/util/int_parser.cpp: In function ‘bpftrace::Result<long unsigned int> bpftrace::util::to_uint(const std::string&, int)’:
  src/util/int_parser.cpp:70:14: error: ‘ULLONG_MAX’ was not declared in this scope
     70 |   if (ret == ULLONG_MAX && errno == ERANGE) {
        |              ^~~~~~~~~~
  src/util/int_parser.cpp:8:1: note: ‘ULLONG_MAX’ is defined in header ‘<climits>’; this is probably fixable by adding ‘#include <climits>’
      7 | #include "util/int_parser.h"
    +++ |+#include <climits>
      8 | #include "util/result.h"

Tested with gcc-15.2.1-20250913, gcc-16.0.0-20250914 & clang-21.1.1.

Backport of this PR on the release branch: https://github.com/bpftrace/bpftrace/pull/4614

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
