### PR TITLE
Remove bad positional param test block

### DIFF
--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2951,12 +2951,6 @@ TEST_F(SemanticAnalyserTest, positional_parameters)
   // Parameters can be used as string literals
   test("kprobe:f { printf(\"%d\", cgroupid(str($2))); }", Mock{ *bpftrace });
 
-  auto ast = test("k:f { $1 }");
-  auto *stmt =
-      ast.root->probes.at(0)->block->stmts.at(0).as<ast::ExprStatement>();
-  auto *pp = stmt->expr.as<ast::PositionalParameter>();
-  EXPECT_EQ(CreateNone(), pp->type());
-
   bpftrace->add_param("0999");
   test("kprobe:f { printf(\"%d\", $4); }", Mock{ *bpftrace }, Error{});
 }


### PR DESCRIPTION
Empty positional params will get turned into
a `0` (ast::Integer) so this block is just
wrong. It's curious how it was passing at all.

Issue:
- https://github.com/bpftrace/bpftrace/issues/4647

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
