### PR TITLE
ast: Avoid undefined behavior in literal folding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
 - Drop support for LLVM 16
   - [#4534](https://github.com/bpftrace/bpftrace/pull/4534)
 #### Fixed
+- ast: Avoid undefined behavior in literal folding
+  - [#4649](https://github.com/bpftrace/bpftrace/pull/4649)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -248,17 +248,16 @@ static std::optional<std::variant<uint64_t, int64_t>> eval_binop(T left,
             res > static_cast<uint64_t>(right)) {
           return res;
         }
+        return std::nullopt;
       }
       if constexpr (std::is_same_v<T, int64_t>) {
         if ((left > 0 && right < 0) || (left < 0 && right > 0)) {
           return clamp(left + right);
         }
         if (left < 0 && right < 0) {
-          auto res = left + right;
-          if (res < left && res < right) {
-            return res;
-          }
-          return std::nullopt;
+          if (std::numeric_limits<int64_t>::min() - left > right)
+            return std::nullopt;
+          return left + right;
         }
       }
       return std::nullopt;
@@ -281,18 +280,15 @@ static std::optional<std::variant<uint64_t, int64_t>> eval_binop(T left,
       } else {
         if (right == 0) {
           return clamp(left);
-        } else if (right < 0) {
-          auto res = left - right;
-          if (res < left) {
-            return std::nullopt;
-          }
-          return clamp(res);
         } else {
-          auto res = left - right;
-          if (res > left) {
+          if (left > 0 && right < 0 &&
+              std::numeric_limits<int64_t>::max() - left < -right) {
+            return std::nullopt;
+          } else if (left < 0 && right > 0 &&
+                     std::numeric_limits<int64_t>::min() - left > -right) {
             return std::nullopt;
           }
-          return clamp(res);
+          return clamp(left - right);
         }
       }
     case Operator::MUL:
@@ -330,8 +326,15 @@ static std::optional<std::variant<uint64_t, int64_t>> eval_binop(T left,
     case Operator::BXOR:
       return clamp(left ^ right);
     case Operator::LEFT:
+      // Shifting negative amount of bits or more bits than the width of `left`
+      // (which is always 64 in our case) is undefined behavior in C++
+      if (right < 0 || right >= 64)
+        return std::nullopt;
       return clamp(left << right);
     case Operator::RIGHT:
+      // Same as above
+      if (right < 0 || right >= 64)
+        return std::nullopt;
       return clamp(left >> right);
     // Comparison operators are handled in `make_boolean` and checked in
     // `is_comparison_op`.

--- a/tests/fold_literals.cpp
+++ b/tests/fold_literals.cpp
@@ -390,13 +390,13 @@ TEST(fold_literals, binary)
   test("1 << 1", "int: 2 :: [int64]");
   test("1 << 2", "int: 4 :: [int64]");
   test("1 << 63", "int: 9223372036854775808 :: [uint64]");
-  test("1 << 64", "int: 1 :: [int64]"); // Wraps around, still signed
   test("0xff << 8", "int: 65280 :: [int64]");
   test("0xff << 56", "int: 18374686479671623680 :: [uint64]");
   test("-1 << 1", "negative int: -2");
   test("-1 << 63", "negative int: -9223372036854775808");
   test("0x7fffffffffffffff << 1", "int: 18446744073709551614 :: [uint64]");
   test("0x8000000000000000 << 1", "int: 0 :: [uint64]"); // Legal overflow
+  test_error("1 << 64", "overflow");
 
   test("8 >> 1", "int: 4 :: [int64]");
   test("8 >> 2", "int: 2 :: [int64]");
@@ -408,6 +408,7 @@ TEST(fold_literals, binary)
   test("-8 >> 2", "negative int: -2"); // Sign extension
   test("0x8000000000000000 >> 1", "int: 4611686018427387904 :: [uint64]");
   test("0x8000000000000000 >> 63", "int: 1 :: [uint64]");
+  test_error("1 >> 64", "overflow");
 
   test("true & true", "bool: true");
   test("true & false", "bool: false");


### PR DESCRIPTION
When detecting underflows and overflows in LiteralFolder, we execute the operation and then check if the result has overflown or not. This is, however, not always correct since underflows and overflows are undefined behaviors on signed integers which may lead to unexpected results in some compilers.

This commit fixes the issue by checking if an operation would overflow (using std::numeric_limits) before executing it.

Fixes #4613.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
