### PR TITLE
opaque value: handle unaligned accesses

### DIFF
--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -65,11 +65,6 @@ struct Strftime {
 
 struct Buf {
   uint32_t length;
-  // Seems like GCC 7.4.x can't handle `char content[]`. Work around by using
-  // 0 sized array (a GCC extension that clang also accepts:
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70932). It also looks like
-  // the issue doesn't exist in GCC 7.5.x.
-  char content[0];
 
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, uint32_t length);
 } __attribute__((packed));

--- a/src/util/tseries.cpp
+++ b/src/util/tseries.cpp
@@ -22,7 +22,7 @@ std::pair<uint64_t, uint64_t> reduce_tseries_value(const OpaqueValue &value,
   uint64_t latest_epoch = 0;
 
   for (size_t i = 0; i < value.count<tseries_data<T>>(); i++) {
-    const auto &v = value.bitcast<tseries_data<T>>(i);
+    auto v = value.bitcast<tseries_data<T>>(i);
     if (v.epoch == 0) {
       // Don't consider buckets where epoch is 0. This means it was never used.
       continue;


### PR DESCRIPTION
Stacked PRs:
 * __->__#4651


--- --- ---

### opaque value: handle unaligned accesses


Since the types being bitcast will generally be small, it is more
efficient to simply return an instance of these types. This requires
that they are trivially copyable (which will be the case already).

Note that the `constexpr` if is not a premature optimization here; some
copied types lack a default constructor but *are* copyable. We still
require them to be trivially copyable (to avoid that set of footguns),
but allows these for objects that don't have alignment constraints.

Fixes #4644

Signed-off-by: Adin Scannell <amscanne@meta.com>
