### PR TITLE
CMake: Enable UBSan builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(HARDENED_STDLIB OFF CACHE BOOL "Enable hardened definitions for standard lib
 set(STATIC_LINKING OFF CACHE BOOL "Build bpftrace as a statically linked executable")
 
 set(BUILD_ASAN OFF CACHE BOOL "Build bpftrace with -fsanitize=address")
+set(BUILD_UBSAN OFF CACHE BOOL "Build bpftrace with -fsanitize=undefined")
 set(ENABLE_MAN ON CACHE BOOL "Build man pages")
 set(BUILD_TESTING ON CACHE BOOL "Build test suite")
 set(ENABLE_TEST_VALIDATE_CODEGEN ON CACHE BOOL "Run LLVM IR validation tests")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,12 @@ if(HAVE_BFD_DISASM)
   set(BFD_DISASM_SRC bfd-disasm.cpp)
 endif()
 
+if (BUILD_UBSAN)
+  # This adds -fsanitize=undefined to all below compiler invocations, including
+  # subdirectories.
+  add_compile_options("-fsanitize=undefined")
+endif()
+
 add_library(required_resources required_resources.cpp)
 add_dependencies(required_resources parser)
 
@@ -199,6 +205,13 @@ endif()
 if (BUILD_ASAN)
   target_compile_options(bpftrace PUBLIC "-fsanitize=address")
   target_link_options(bpftrace PUBLIC "-fsanitize=address")
+endif()
+
+if (BUILD_UBSAN)
+  # We do not use add_link_options here since it doesn't work for some reason.
+  # Instead, just pass -fsanitize=undefined to the linker when linking the
+  # bpftrace target.
+  target_link_options(bpftrace PUBLIC "-fsanitize=undefined")
 endif()
 
 if (STATIC_LINKING)

--- a/src/aot/CMakeLists.txt
+++ b/src/aot/CMakeLists.txt
@@ -34,3 +34,7 @@ if(BUILD_ASAN)
   target_compile_options(bpftrace-aotrt PUBLIC "-fsanitize=address")
   target_link_options(bpftrace-aotrt PUBLIC "-fsanitize=address")
 endif()
+
+if(BUILD_UBSAN)
+  target_link_options(bpftrace-aotrt PUBLIC "-fsanitize=undefined")
+endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,11 @@ if(BUILD_ASAN)
   target_link_options(bpftrace_test PUBLIC "-fsanitize=address")
 endif()
 
+if(BUILD_UBSAN)
+  target_compile_options(bpftrace_test PUBLIC "-fsanitize=undefined")
+  target_link_options(bpftrace_test PUBLIC "-fsanitize=undefined")
+endif()
+
 # bpftrace tests require (at minimum) version 1.11.
 # There's no great way to enforce a minimum version from cmake -- the cmake
 # modules don't respect minimum requested version.


### PR DESCRIPTION
Add new CMake option `BUILD_UBSAN` which will add `-fsanitize=undefined` to the build. This helps to identify undefined behavior.

Once we fix all the UBSan reports, we should enable it in CI, similarly to ASan.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
