### PR TITLE
Remove 'is_tparg' flag

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2581,7 +2581,6 @@ ScopedExpr CodegenLLVM::visit(FieldAccess &acc)
 
   assert(type.IsRecordTy());
   bool is_ctx = type.IsCtxAccess();
-  bool is_tparg = type.is_tparg;
   bool is_internal = type.is_internal;
   bool is_funcarg = type.is_funcarg;
 
@@ -2601,15 +2600,12 @@ ScopedExpr CodegenLLVM::visit(FieldAccess &acc)
     }
   }
 
-  std::string cast_type = is_tparg ? TracepointFormatParser::get_struct_name(
-                                         *current_attach_point_)
-                                   : type.GetName();
+  std::string cast_type = type.GetName(current_attach_point_->name());
 
   // This overwrites the stored type!
   type = CreateRecord(cast_type, bpftrace_.structs.Lookup(cast_type));
   if (is_ctx)
     type.MarkCtxAccess();
-  type.is_tparg = is_tparg;
   type.is_internal = is_internal;
   type.is_funcarg = is_funcarg;
   // Restore the addrspace info


### PR DESCRIPTION
Stacked PRs:
 * __->__#4659
 * #4657


--- --- ---

### Remove 'is_tparg' flag


AFAICT this flag was mostly used to indicate that
we needed a different struct name for a tracepoint
arg in codegen. Instead, store the different struct
names in a map keyed on the attachpoint name
and have `GetName` return the correct struct name
when it's called with an attachpoint name.

Signed-off-by: Jordan Rome <linux@jordanrome.com>