### PR TITLE
For non-scalar maps typeof returns the key type

### DIFF
--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -103,10 +103,12 @@ void MapDefaultKey::visit([[maybe_unused]] Typeof &typeof)
 {
   if (std::holds_alternative<Expression>(typeof.record)) {
     const auto &expr = std::get<Expression>(typeof.record);
-    if (expr.is<Map>()) {
-      // Do nothing; allow these to exist. It will extract the value of the map
-      // whether it is keyed or not.
-      return;
+    if (auto *map = expr.as<Map>()) {
+      // Don't de-sugar if it's a non-scalar map
+      auto val = metadata.scalar.find(map->ident);
+      if (val != metadata.scalar.end() && !val->second) {
+        return;
+      }
     }
   }
   Visitor<MapDefaultKey>::visit(typeof);


### PR DESCRIPTION
Stacked PRs:
 * __->__#4665


--- --- ---

### For non-scalar maps typeof returns the key type


To achieve this we need to make the change in the
typeof AST node in order to handle late
type resolution for map keys e.g.
```
begin { @a[@b] = 1; print(typeinfo(@a)); }
end { @b = "str"; }
```
This also updates map_sugar to de-sugar only
scalar maps inside of the `typeof` expression,
which is standard behavior in other locations.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>