### PR TITLE
semantics: support automatic dereference with `.`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 #### Added
 - Add support for indexing string types
   - [#4540](https://github.com/bpftrace/bpftrace/pull/4540)
+- Automatic dereferencing is supported via `.`, now the preferred access operator
+  - [#4673](https://github.com/bpftrace/bpftrace/pull/4673)
 #### Changed
 - Apply `-B` buffering semantics to file outputs.
   - [#4637](https://github.com/bpftrace/bpftrace/pull/4637)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -706,7 +706,7 @@ be rejected.
 interval:s:1 {
   $runqueues = (struct rq *)percpu_kaddr("runqueues", 0);
   if ($runqueues != 0) {         // The check is mandatory here
-    print($runqueues->nr_running);
+    print($runqueues.nr_running);
   }
 }
 ```
@@ -895,12 +895,12 @@ Usage
 ```
 # cat dump.bt
 fentry:napi_gro_receive {
-  $ret = skboutput("receive.pcap", args.skb, args.skb->len, 0);
+  $ret = skboutput("receive.pcap", args.skb, args.skb.len, 0);
 }
 
 fentry:dev_queue_xmit {
   // setting offset to 14, to exclude ethernet header
-  $ret = skboutput("output.pcap", args.skb, args.skb->len, 14);
+  $ret = skboutput("output.pcap", args.skb, args.skb.len, 14);
   printf("skboutput returns %d\n", $ret);
 }
 
@@ -930,8 +930,8 @@ This function returns a `uint64` unique number on success, or 0 if **sk** is NUL
 ```
 fentry:tcp_rcv_established
 {
-  $cookie = socket_cookie(args->sk);
-  @psize[$cookie] = hist(args->skb->len);
+  $cookie = socket_cookie(args.sk);
+  @psize[$cookie] = hist(args.skb.len);
 }
 ```
 

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -394,7 +394,7 @@ Headers are included in the order they are defined, and they are included before
 
 ----
 # bpftrace --include linux/path.h --include linux/dcache.h \
-    -e 'kprobe:vfs_open { printf("open path: %s\n", str(((struct path *)arg0)->dentry->d_name.name)); }'
+    -e 'kprobe:vfs_open { printf("open path: %s\n", str(((struct path *)arg0).dentry.d_name.name)); }'
 
 Attached 1 probe
 open path: .com.google.Chrome.ASsbu2

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -127,6 +127,13 @@ void FieldAnalyser::visit(FieldAccess &acc)
 
   visit(acc.expr);
 
+  // Automatically resolve through pointers.
+  while (sized_type_.IsPtrTy()) {
+    auto tmp = *sized_type_.GetPointeeTy();
+    sized_type_ = std::move(tmp);
+    resolve_fields(sized_type_);
+  }
+
   if (has_builtin_args_) {
     const auto *arg = bpftrace_.structs.GetProbeArg(*probe_, acc.field);
     if (arg)

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -665,7 +665,7 @@ array_access_expr:
 
 field_access_expr:
                 primary_expr DOT external_name { $$ = driver.ctx.make_node<ast::FieldAccess>($1, $3, @2); }
-        |       primary_expr PTR external_name { $$ = driver.ctx.make_node<ast::FieldAccess>(driver.ctx.make_node<ast::Unop>($1, ast::Operator::MUL, false, @2), $3, @$); }
+        |       primary_expr PTR external_name { $$ = driver.ctx.make_node<ast::FieldAccess>($1, $3, @2); }
                 ;
 
 block_expr:

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2053,8 +2053,7 @@ TEST(Parser, cast_precedence)
        " kprobe:sys_read\n"
        "  (struct mytype *)\n"
        "   .\n"
-       "    dereference\n"
-       "     builtin: arg0\n"
+       "    builtin: arg0\n"
        "    field\n");
 
   test("kprobe:sys_read { (struct mytype)arg0+123; }",
@@ -2197,8 +2196,7 @@ TEST(Parser, field_access)
        "Program\n"
        " kprobe:sys_read\n"
        "  .\n"
-       "   dereference\n"
-       "    map: @x\n"
+       "   map: @x\n"
        "   myfield\n");
 }
 
@@ -2215,8 +2213,7 @@ TEST(Parser, field_access_builtin)
        "Program\n"
        " kprobe:sys_read\n"
        "  .\n"
-       "   dereference\n"
-       "    map: @x\n"
+       "   map: @x\n"
        "   count\n");
 }
 
@@ -2233,8 +2230,7 @@ TEST(Parser, field_access_builtin_type)
        "Program\n"
        " kprobe:sys_read\n"
        "  .\n"
-       "   dereference\n"
-       "    map: @x\n"
+       "   map: @x\n"
        "   timestamp\n");
 }
 
@@ -2251,8 +2247,7 @@ TEST(Parser, field_access_sized_type)
        "Program\n"
        " kprobe:sys_read\n"
        "  .\n"
-       "   dereference\n"
-       "    map: @x\n"
+       "   map: @x\n"
        "   string\n");
 }
 
@@ -2887,18 +2882,36 @@ TEST(Parser, keywords_as_identifiers)
                                         "unroll",   "while" };
   for (const auto &keyword : keywords) {
     test("begin { $x = (struct Foo*)0; $x->" + keyword + "; }",
-         "Program\n begin\n  =\n   variable: $x\n   (struct Foo *)\n    int: "
-         "0 :: [int64]\n "
-         " .\n   dereference\n    variable: $x\n   " +
+         "Program\n"
+         " begin\n"
+         "  =\n"
+         "   variable: $x\n"
+         "   (struct Foo *)\n"
+         "    int: 0 :: [int64]\n"
+         "  .\n"
+         "   variable: $x\n"
+         "   " +
              keyword + "\n");
     test("begin { $x = (struct Foo)0; $x." + keyword + "; }",
-         "Program\n begin\n  =\n   variable: $x\n   (struct Foo)\n    int: 0 "
-         ":: [int64]\n "
-         " .\n   variable: $x\n   " +
+         "Program\n"
+         " begin\n"
+         "  =\n"
+         "   variable: $x\n"
+         "   (struct Foo)\n"
+         "    int: 0 :: [int64]\n"
+         "  .\n"
+         "   variable: $x\n"
+         "   " +
              keyword + "\n");
     test("begin { $x = offsetof(*__builtin_curtask, " + keyword + "); }",
-         "Program\n begin\n  =\n   variable: $x\n   offsetof: \n    "
-         "dereference\n     builtin: __builtin_curtask\n    " +
+         "Program\n"
+         " begin\n"
+         "  =\n"
+         "   variable: $x\n"
+         "   offsetof: \n"
+         "    dereference\n"
+         "     builtin: __builtin_curtask\n"
+         "    " +
              keyword + "\n");
   }
 }

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -1,103 +1,103 @@
 NAME array element access - assign to map
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; @x = $a->x[0]; exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; @x = $a.x[0]; exit(); }
 EXPECT @x: 1
 AFTER ./testprogs/array_access
 
 NAME array element access - with variable index
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $y = (uint64)0; $a = (struct A *) arg0; @x = $a->x[$y]; exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $y = (uint64)0; $a = (struct A *) arg0; @x = $a.x[$y]; exit(); }
 EXPECT @x: 1
 AFTER ./testprogs/array_access
 
 NAME array element access - assign to var
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[0]; printf("Result: %d\n", $x); exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a.x[0]; printf("Result: %d\n", $x); exit(); }
 EXPECT Result: 1
 AFTER ./testprogs/array_access
 
 NAME array element access - out of bounds
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[5]; printf("%d\n", $x); exit(); }
-EXPECT stdin:1:104-107: ERROR: the index 5 is out of bounds for array of size 4
-       struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[5]; printf("%d\n", $x); exit(); }
-                                                                                                              ~~~
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a.x[5]; printf("%d\n", $x); exit(); }
+EXPECT stdin:1:103-106: ERROR: the index 5 is out of bounds for array of size 4
+       struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a.x[5]; printf("%d\n", $x); exit(); }
+                                                                                                             ~~~
 AFTER ./testprogs/array_access
 WILL_FAIL
 
 NAME array element access - out of bounds runtime
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $y = (uint64)100; $a = (struct A *) arg0; @x = $a->x[$y]; exit(); }
-EXPECT stdin:1:122-126: WARNING: Array access out of bounds. This can lead to unexpected results.
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $y = (uint64)100; $a = (struct A *) arg0; @x = $a.x[$y]; exit(); }
+EXPECT stdin:1:121-125: WARNING: Array access out of bounds. This can lead to unexpected results.
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into var
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; $x = $a[0]; printf("Result: %d\n", $x); exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0).x; $x = $a[0]; printf("Result: %d\n", $x); exit(); }
 EXPECT Result: 1
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into map
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; printf("Result: %d\n", @a[0][0]); exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0).x; printf("Result: %d\n", @a[0][0]); exit(); }
 EXPECT Result: 1
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into map and var
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0).x; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }
 EXPECT Result: 1
 AFTER ./testprogs/array_access
 
 NAME array assignment into map
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0).x; exit(); }
 EXPECT @a: [1,2,3,4]
 AFTER ./testprogs/array_access
 
 NAME array as a map key
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x] = 0; exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0).x] = 0; exit(); }
 EXPECT @x[[1,2,3,4]]: 0
 AFTER ./testprogs/array_access
 
 NAME array as a part of map multikey
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x, 42] = 0; exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0).x, 42] = 0; exit(); }
 EXPECT @x[[1,2,3,4], 42]: 0
 AFTER ./testprogs/array_access
 
 NAME array as a map key assigned from another map
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; @x[@a] = 0; exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0).x; @x[@a] = 0; exit(); }
 EXPECT @x[[1,2,3,4]]: 0
 AFTER ./testprogs/array_access
 
 NAME array in a tuple
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x = (1, ((struct A *) arg0)->x); exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x = (1, ((struct A *) arg0).x); exit(); }
 EXPECT @x: (1, [1,2,3,4])
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access
-PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $x = ((struct B *) arg1)->y[1][0]; printf("Result: %d\n", $x); exit(); }
+PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $x = ((struct B *) arg1).y[1][0]; printf("Result: %d\n", $x); exit(); }
 EXPECT Result: 7
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into var
-PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; $y = $b[1][0]; printf("Result: %d\n", $y); exit(); }
+PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1).y; $y = $b[1][0]; printf("Result: %d\n", $y); exit(); }
 EXPECT Result: 7
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into map
-PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; printf("Result: %d\n", @b[0][1][0]); exit(); }
+PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1).y; printf("Result: %d\n", @b[0][1][0]); exit(); }
 EXPECT Result: 7
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into map and var
-PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; $x = @b[0]; printf("Result: %d\n", $x[1][0]); exit(); }
+PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1).y; $x = @b[0]; printf("Result: %d\n", $x[1][0]); exit(); }
 EXPECT Result: 7
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array assignment into map
-PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; exit(); }
+PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1).y; exit(); }
 EXPECT @b: [[5,6],[7,8]]
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array as a map key
-PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @x[((struct B *) arg1)->y] = 0; exit(); }
+PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @x[((struct B *) arg1).y] = 0; exit(); }
 EXPECT @x[[[5,6],[7,8]]]: 0
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array as a map key assigned from another map
-PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; @x[@b] = 0; exit(); }
+PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1).y; @x[@b] = 0; exit(); }
 EXPECT @x[[[5,6],[7,8]]]: 0
 AFTER ./testprogs/array_access
 
@@ -127,27 +127,27 @@ EXPECT Result: 1
 AFTER ./testprogs/array_access
 
 NAME array element access via positional index
-RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[$1]; printf("Result: %d\n", $x); exit(); }' 0
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a.x[$1]; printf("Result: %d\n", $x); exit(); }' 0
 EXPECT Result: 1
 AFTER ./testprogs/array_access
 
 NAME array of pointers element access
-PROG struct C { int *z[4]; } uprobe:./testprogs/array_access:test_ptr_array { @x = *((struct C*)arg0)->z[1]; exit(); }
+PROG struct C { int *z[4]; } uprobe:./testprogs/array_access:test_ptr_array { @x = *((struct C*)arg0).z[1]; exit(); }
 EXPECT @x: 2
 AFTER ./testprogs/array_access
 
 NAME array compare eq
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_arrays { $a = (struct A *) arg0; $b = (struct A *) arg0; if ($a->x == $b->x) { printf("two int arrays are equal.\n"); } exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_arrays { $a = (struct A *) arg0; $b = (struct A *) arg0; if ($a.x == $b.x) { printf("two int arrays are equal.\n"); } exit(); }
 EXPECT two int arrays are equal.
 AFTER ./testprogs/array_access
 
 NAME array compare ne
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_arrays { $a = (struct A *) arg0; $b = (struct A *) arg1; if ($a->x != $b->x) { printf("two int arrays are not equal.\n"); } exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_arrays { $a = (struct A *) arg0; $b = (struct A *) arg1; if ($a.x != $b.x) { printf("two int arrays are not equal.\n"); } exit(); }
 EXPECT two int arrays are not equal.
 AFTER ./testprogs/array_access
 
 NAME variable array element access - assign to map
-PROG struct D { int x; int y[0]; } uprobe:./testprogs/array_access:test_variable_array { $a = (struct D *) arg0; @y = $a->y[0]; exit(); }
+PROG struct D { int x; int y[0]; } uprobe:./testprogs/array_access:test_variable_array { $a = (struct D *) arg0; @y = $a.y[0]; exit(); }
 EXPECT @y: 1
 AFTER ./testprogs/array_access
 
@@ -167,6 +167,6 @@ EXPECT ip: 100007f
 AFTER ./testprogs/array_access
 
 NAME cast int array to int proberead
-RUN {{BPFTRACE}} --include "stdint.h" -e 'struct A { int x[4]; uint8_t y[4]; } uprobe:./testprogs/array_access:test_arrays { $y = (int32)((struct A *)arg0)->y; printf("y: %x\n", $y); exit()}'
+RUN {{BPFTRACE}} --include "stdint.h" -e 'struct A { int x[4]; uint8_t y[4]; } uprobe:./testprogs/array_access:test_arrays { $y = (int32)((struct A *)arg0).y; printf("y: %x\n", $y); exit()}'
 EXPECT y: ddccbbaa
 AFTER ./testprogs/array_access

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -4,12 +4,12 @@ EXPECT Attached 1 probe
 REQUIRES_FEATURE btf
 
 NAME tracepoint_pointer_type_resolution
-PROG tracepoint:syscalls:sys_enter_nanosleep { args.rqtp->tv_sec; exit(); }
+PROG tracepoint:syscalls:sys_enter_nanosleep { args.rqtp.tv_sec; exit(); }
 EXPECT Attached 1 probe
 REQUIRES_FEATURE btf
 
 NAME tracepoint_nested_pointer_type_resolution
-PROG tracepoint:napi:napi_poll { args.napi->dev->name; exit(); }
+PROG tracepoint:napi:napi_poll { args.napi.dev.name; exit(); }
 EXPECT Attached 1 probe
 REQUIRES_FEATURE btf
 
@@ -19,12 +19,12 @@ EXPECT_REGEX ^8$
 REQUIRES_FEATURE btf
 
 NAME redefine_btf_type
-PROG struct task_struct { int x; } begin { printf("%d\n", curtask->x); exit() }
+PROG struct task_struct { int x; } begin { printf("%d\n", curtask.x); exit() }
 EXPECT_REGEX -?[0-9][0-9]*
 REQUIRES_FEATURE btf
 
 NAME redefine_btf_type_missing_def
-PROG struct task_struct { struct thread_info x; } begin { printf("%d\n", curtask->x.status); }
+PROG struct task_struct { struct thread_info x; } begin { printf("%d\n", curtask.x.status); }
 EXPECT_REGEX error:.*'struct thread_info'
 REQUIRES_FEATURE btf
 WILL_FAIL
@@ -54,7 +54,7 @@ REQUIRES nft --help
 CLEANUP nft delete table bpftrace
 
 NAME kernel_module_types
-RUN {{BPFTRACE}} -e 'fentry:nf_tables_newtable { printf("skb len: %d\n", args.skb->len); exit(); }'
+RUN {{BPFTRACE}} -e 'fentry:nf_tables_newtable { printf("skb len: %d\n", args.skb.len); exit(); }'
 AFTER nft add table bpftrace
 EXPECT_REGEX ^skb len: [0-9]+$
 REQUIRES lsmod | grep '^nf_tables'
@@ -71,13 +71,13 @@ REQUIRES lsmod | grep "^xfs"
 # 'vmlinux' BTF and fully defined in 'kvm' BTF.
 # This tests checks that the correct BTF definition is pulled from 'kvm'.
 NAME kernel_module_type_fwd
-PROG fentry:kvm:x86_emulate_insn { printf("%d\n", args.ctxt->mode); exit(); }
+PROG fentry:kvm:x86_emulate_insn { printf("%d\n", args.ctxt.mode); exit(); }
 EXPECT Attached 1 probe
 TIMEOUT 2
 REQUIRES lsmod | grep '^kvm'
 
 NAME kprobe_kernel_module_type_fwd
-PROG kprobe:kvm:x86_emulate_insn { $ctxt = (struct x86_emulate_ctxt *) arg0; printf("%d\n", $ctxt->mode); exit(); }
+PROG kprobe:kvm:x86_emulate_insn { $ctxt = (struct x86_emulate_ctxt *) arg0; printf("%d\n", $ctxt.mode); exit(); }
 EXPECT Attached 1 probe
 TIMEOUT 2
 REQUIRES lsmod | grep '^kvm'
@@ -85,6 +85,6 @@ REQUIRES lsmod | grep '^kvm'
 # This test only matters on Clang-built kernels, which support btf_type_tag
 # and require special handling in bpftrace
 NAME btf_type_tag_access
-PROG begin { printf("SUCCESS %d\n", curtask->parent->pid); exit() }
+PROG begin { printf("SUCCESS %d\n", curtask.parent.pid); exit() }
 EXPECT_REGEX SUCCESS [0-9][0-9]*
 REQUIRES_FEATURE btf

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -114,7 +114,7 @@ PROG i:ms:1 { printf("SUCCESS %p\n", curtask); exit(); }
 EXPECT_REGEX SUCCESS 0x[0-9a-f]+
 
 NAME curtask_field
-PROG struct task_struct {int x;} i:ms:1 { printf("SUCCESS %d\n", curtask->x); exit(); }
+PROG struct task_struct {int x;} i:ms:1 { printf("SUCCESS %d\n", curtask.x); exit(); }
 EXPECT_REGEX SUCCESS -?[0-9][0-9]*
 
 NAME rand
@@ -126,7 +126,7 @@ PROG i:ms:1 { printf("SUCCESS %llu\n", cgroup); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
 
 NAME ctx
-PROG struct x {unsigned long x}; i:ms:1 { printf("SUCCESS %lu\n", ((struct x*)ctx)->x); exit(); }
+PROG struct x {unsigned long x}; i:ms:1 { printf("SUCCESS %lu\n", ((struct x*)ctx).x); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
 
 NAME cat

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -15,7 +15,7 @@ PROG begin { @start = nsecs; } i:s:1 { printf("Elapsed time: %llus\n", (nsecs - 
 EXPECT Elapsed time: 1s
 
 NAME printf_argument_alignment
-RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:testprogs/uprobe_test:uprobeFunction2 { $foo = (struct Foo *)arg0; $foo2 = (struct Foo *)arg1; printf("%d %s %d %s\n", $foo->a, $foo->b, $foo2->a, $foo2->b) }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:testprogs/uprobe_test:uprobeFunction2 { $foo = (struct Foo *)arg0; $foo2 = (struct Foo *)arg1; printf("%d %s %d %s\n", $foo.a, $foo.b, $foo2.a, $foo2.b) }' -c ./testprogs/uprobe_test
 EXPECT 123 hello 456 world
 
 NAME printf_more_arguments
@@ -47,7 +47,7 @@ PROG enum Foo { A, B, C, }; begin { printf("%-5s %5s %s\n", A, B, C); exit() }
 EXPECT A         B C
 
 NAME printf_enum_symbolize_tracepoint
-PROG tracepoint:skb:kfree_skb { $r = args->reason; printf("%d %s\n", args->reason, $r); exit() }
+PROG tracepoint:skb:kfree_skb { $r = args.reason; printf("%d %s\n", args.reason, $r); exit() }
 EXPECT_REGEX ^\d+ [A-Z_]+$
 SETUP ip link set lo up
 AFTER ping localhost -c 5
@@ -244,12 +244,12 @@ AFTER ./testprogs/syscall execve /$(python3 -c "print('X'*5555)")
 TIMEOUT 1
 
 NAME buf
-RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s.a, 4), buf($s.b, 4), buf($s.c), buf($s.d), buf($s.e), buf($s.f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \x09\x08\x07\x06-\x05\x04\x03\x02-\x01\x02\x03\x04-\x05\x00\x00\x00\x06\x00\x00\x00\x07\x00\x00\x00\x08\x00\x00\x00-\x09\x00\x0a\x00\x0b\x00\x0c\x00-\x0d\x00\x00\x00\x00\x00\x00\x00\x0e\x00\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x10\x00\x00\x00\x00\x00\x00\x00
 ARCH x86_64|ppc64le|aarch64|armv7l
 
 NAME buf
-RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s.a, 4), buf($s.b, 4), buf($s.c), buf($s.d), buf($s.e), buf($s.f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \x09\x08\x07\x06-\x05\x04\x03\x02-\x01\x02\x03\x04-\x00\x00\x00\x05\x00\x00\x00\x06\x00\x00\x00\x07\x00\x00\x00\x08-\x00\x09\x00\x0a\x00\x0b\x00\x0c-\x00\x00\x00\x00\x00\x00\x00\x0d\x00\x00\x00\x00\x00\x00\x00\x0e\x00\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00\x00\x00\x00\x10
 ARCH s390x|ppc64
 
@@ -509,12 +509,12 @@ EXPECT (1, 2, string)
 TIMEOUT 1
 
 NAME print_non_map_array
-PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; print($a); exit(); }
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0).x; print($a); exit(); }
 EXPECT [1,2,3,4]
 AFTER ./testprogs/array_access
 
 NAME print_non_map_multi_dimensional_array
-PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; print($b); exit(); }
+PROG struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1).y; print($b); exit(); }
 EXPECT [[5,6],[7,8]]
 AFTER ./testprogs/array_access
 
@@ -583,13 +583,13 @@ EXPECT_REGEX begin\n@\[1\]:(.*\n)+@\[2\]:(.*\n)+@\[3\]:(.*\n)+end
 TIMEOUT 1
 
 NAME path
-RUN {{BPFTRACE}} -ve 'fentry:security_file_open { if (!strncmp(path(args.file->f_path), "/tmp/bpftrace_runtime_test_syscall_gen_open_temp", 49)) { printf("OK\n"); exit(); } }'
+RUN {{BPFTRACE}} -ve 'fentry:security_file_open { if (!strncmp(path(args.file.f_path), "/tmp/bpftrace_runtime_test_syscall_gen_open_temp", 49)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath
 AFTER TMPDIR=/tmp ./testprogs/syscall open
 
 NAME path_with_optional_size
-RUN {{BPFTRACE}} -ve 'fentry:security_file_open { $p = path(args.file->f_path, 48);  if ( sizeof($p) == 48 && !strncmp($p, "tmp/bpftrace_runtime_test_syscall_gen_open_temp", 48)) { printf("OK\n"); exit(); } }'
+RUN {{BPFTRACE}} -ve 'fentry:security_file_open { $p = path(args.file.f_path, 48);  if ( sizeof($p) == 48 && !strncmp($p, "tmp/bpftrace_runtime_test_syscall_gen_open_temp", 48)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath
 AFTER TMPDIR=/tmp ./testprogs/syscall open
@@ -597,38 +597,38 @@ AFTER TMPDIR=/tmp ./testprogs/syscall open
 # The extra prints are here to confirm that we report on the correct helper, not
 # just the first or the last one.
 NAME path_in_unsupported_fentry
-PROG fentry:vfs_read { print("a"); print(path(args.file->f_path)); print("b"); }
-EXPECT stdin:1:37-60: ERROR: helper bpf_d_path not allowed in probe
-       fentry:vfs_read { print("a"); print(path(args.file->f_path)); print("b"); }
-                                           ~~~~~~~~~~~~~~~~~~~~~~~
+PROG fentry:vfs_read { print("a"); print(path(args.file.f_path)); print("b"); }
+EXPECT stdin:1:37-59: ERROR: helper bpf_d_path not allowed in probe
+       fentry:vfs_read { print("a"); print(path(args.file.f_path)); print("b"); }
+                                           ~~~~~~~~~~~~~~~~~~~~~~
 REQUIRES_FEATURE dpath
 WILL_FAIL
 AFTER ./testprogs/syscall read
 
 NAME macaddr
-RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); printf("P: %s\n", macaddr($s->mac)); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); printf("P: %s\n", macaddr($s.mac)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: 05:04:03:02:01:02
 
 NAME macaddr as map key
-RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[macaddr($s->mac)] = 1; exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[macaddr($s.mac)] = 1; exit(); }' -c ./testprogs/complex_struct
 EXPECT @[05:04:03:02:01:02]: 1
 
 NAME macaddr as map value
-RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[1] = macaddr($s->mac); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[1] = macaddr($s.mac); exit(); }' -c ./testprogs/complex_struct
 EXPECT @[1]: 05:04:03:02:01:02
 
 NAME iter:task
-PROG iter:task { printf("comm: %s\n", ctx->task->comm); exit(); }
+PROG iter:task { printf("comm: %s\n", ctx.task.comm); exit(); }
 EXPECT comm: bpftrace
 REQUIRES_FEATURE iter
 
 NAME iter:task_file
-PROG iter:task_file { printf("comm: %s\n", ctx->task->comm); exit(); }
+PROG iter:task_file { printf("comm: %s\n", ctx.task.comm); exit(); }
 EXPECT comm: bpftrace
 REQUIRES_FEATURE iter
 
 NAME iter:task_vma
-PROG iter:task_vma { printf("comm: %s\n", ctx->task->comm); exit(); }
+PROG iter:task_vma { printf("comm: %s\n", ctx.task.comm); exit(); }
 EXPECT comm: bpftrace
 REQUIRES_FEATURE iter
 
@@ -682,7 +682,7 @@ EXPECT 1234
 TIMEOUT 1
 
 NAME skboutput
-RUN {{BPFTRACE}} -e 'fentry:__dev_queue_xmit { $ret = skboutput("skb.pcap", args.skb, args.skb->len, 14); printf("ret: %d\n", $ret); exit(); }'
+RUN {{BPFTRACE}} -e 'fentry:__dev_queue_xmit { $ret = skboutput("skb.pcap", args.skb, args.skb.len, 14); printf("ret: %d\n", $ret); exit(); }'
 SETUP ip netns add bpftrace-test && ip -netns bpftrace-test link set lo up
 AFTER ip netns exec bpftrace-test ./testprogs/syscall connect 127.0.0.1 80
 CLEANUP ip netns delete bpftrace-test
@@ -702,7 +702,7 @@ EXPECT_REGEX ret: [0-9]+
 
 # Just test that the verifier doesn't reject this
 NAME socket_cookie rawtracepoint
-RUN {{BPFTRACE}} -e 'rawtracepoint:tcp_probe { $ret = socket_cookie(args->sk); printf("ret: %llu\n", $ret); exit(); }'
+RUN {{BPFTRACE}} -e 'rawtracepoint:tcp_probe { $ret = socket_cookie(args.sk); printf("ret: %llu\n", $ret); exit(); }'
 EXPECT Attached 1 probe
 
 # debugf can be slow so add some time before checking the trace pipe
@@ -767,13 +767,13 @@ PROG begin { if (*percpu_kaddr("process_counts") == *percpu_kaddr("process_count
 EXPECT SUCCESS
 
 NAME percpu_kaddr field access
-PROG begin { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); if ($runq != 0) { printf("nr_running: %d\n", $runq->nr_running) } exit() }
+PROG begin { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); if ($runq != 0) { printf("nr_running: %d\n", $runq.nr_running) } exit() }
 EXPECT_REGEX nr_running: [0-9]+
 
 NAME percpu_kaddr field access no NULL check
-PROG begin { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); printf("nr_running: %d\n", $runq->nr_running); exit() }
+PROG begin { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); printf("nr_running: %d\n", $runq.nr_running); exit() }
 EXPECT stdin:1:31-59: ERROR: helper bpf_per_cpu_ptr: result needs to be null-checked before accessing fields
-       begin { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); printf("nr_running: %d\n", $runq->nr_running); exit() }
+       begin { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); printf("nr_running: %d\n", $runq.nr_running); exit() }
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 WILL_FAIL
 

--- a/tests/runtime/complex_types
+++ b/tests/runtime/complex_types
@@ -11,5 +11,5 @@ RUN {{BPFTRACE}} runtime/scripts/struct_let.bt -c ./testprogs/struct_array
 EXPECT 100 102 104 106 108
 
 NAME pointer_to_pointer
-RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:./testprogs/ptr_to_ptr:function { $pp = (struct Foo **)arg0; printf("%d\n", (*$pp)->a); }' -c ./testprogs/ptr_to_ptr
+RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:./testprogs/ptr_to_ptr:function { $pp = (struct Foo **)arg0; printf("%d\n", (*$pp).a); }' -c ./testprogs/ptr_to_ptr
 EXPECT 123

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -31,8 +31,8 @@ TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobe arg by name - struct
-PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->a = %d\n", args.foo1->a); exit(); }
-EXPECT foo1->a = 123
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1.a = %d\n", args.foo1.a); exit(); }
+EXPECT foo1.a = 123
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
@@ -46,29 +46,29 @@ TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME struct field string
-PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->b = %s\n", args.foo1->b); exit(); }
-EXPECT foo1->b = hello
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1.b = %s\n", args.foo1.b); exit(); }
+EXPECT foo1.b = hello
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME struct field array
-PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { print(args.foo1->c); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { print(args.foo1.c); exit(); }
 EXPECT [1,2,3]
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME cast to struct
-PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->a = %d\n", ((struct Foo *)arg0)->a); exit(); }
-EXPECT foo1->a = 123
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1.a = %d\n", ((struct Foo *)arg0).a); exit(); }
+EXPECT foo1.a = 123
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME struct override
-PROG struct Foo { int b; } uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->b = %d\n", ((struct Foo *)arg0)->b); exit(); }
-EXPECT foo1->b = 123
+PROG struct Foo { int b; } uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1.b = %d\n", ((struct Foo *)arg0).b); exit(); }
+EXPECT foo1.b = 123
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -182,8 +182,8 @@ EXPECT {"type": "hist", "data": {"@": {"1": [{"min": 8, "max": 15, "count": 1}],
 TIMEOUT 1
 
 NAME helper_error
-RUN {{BPFTRACE}} -k -q -f json -e 'struct foo {int a;}; begin { $tmp = ((struct foo*) 0)->a;  }'
-EXPECT {"type": "helper_error", "msg": "Bad address", "helper": "probe_read", "retcode": -14, "filename": "stdin", "line": 1, "col": 37}
+RUN {{BPFTRACE}} -k -q -f json -e 'struct foo {int a;}; begin { $tmp = ((struct foo*) 0).a;  }'
+EXPECT {"type": "helper_error", "msg": "Bad address", "helper": "probe_read", "retcode": -14, "filename": "stdin", "line": 1, "col": 54}
 TIMEOUT 1
 
 NAME cgroup_path

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -133,11 +133,11 @@ RUN {{BPFTRACE}} -e 'begin { if (strncmp(str($1), str($2), 4) == 0) { printf("I 
 EXPECT I got hhvm-proc
 
 NAME strncmp function argument
-RUN {{BPFTRACE}} -e 'struct F {char s[8];} u:./testprogs/string_args:print { @=strncmp(((struct F*)arg0)->s, "hello", 5); }' -c ./testprogs/string_args
+RUN {{BPFTRACE}} -e 'struct F {char s[8];} u:./testprogs/string_args:print { @=strncmp(((struct F*)arg0).s, "hello", 5); }' -c ./testprogs/string_args
 EXPECT @: 0
 
 NAME short non null-terminated string print
-RUN {{BPFTRACE}} -e 'struct F {char s[5];} u:./testprogs/string_args:print { $a = ((struct F*)arg0)->s; printf("%s %s\n", $a, $a); }' -c ./testprogs/string_args
+RUN {{BPFTRACE}} -e 'struct F {char s[5];} u:./testprogs/string_args:print { $a = ((struct F*)arg0).s; printf("%s %s\n", $a, $a); }' -c ./testprogs/string_args
 EXPECT hello hello
 
 NAME optional_positional_int
@@ -234,12 +234,12 @@ EXPECT end
 AFTER  ./testprogs/syscall nanosleep 2e9; pkill -SIGINT bpftrace
 
 NAME bitfield access
-PROG struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe:./testprogs/bitfield_test:func{ $foo = (struct Foo *)arg0; printf("%d %d %d %d %d\n", $foo->a, $foo->b, $foo->c, $foo->d, $foo->e); exit()}
+PROG struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe:./testprogs/bitfield_test:func{ $foo = (struct Foo *)arg0; printf("%d %d %d %d %d\n", $foo.a, $foo.b, $foo.c, $foo.d, $foo.e); exit()}
 EXPECT 1 2 5 0 65535
 AFTER ./testprogs/bitfield_test
 
 NAME bitfield_access_2
-PROG struct Bar { short a:4, b:8, c:3, d:1; int e:9, f:15, g:1, h:2, i:5 } uprobe:./testprogs/bitfield_test:func2 { $bar = (struct Bar *)arg0; printf("%d %d %d %d %d", $bar->a, $bar->b, $bar->c, $bar->d, $bar->e); printf(" %d %d %d %d", $bar->f, $bar->g, $bar->h, $bar->i); exit()}
+PROG struct Bar { short a:4, b:8, c:3, d:1; int e:9, f:15, g:1, h:2, i:5 } uprobe:./testprogs/bitfield_test:func2 { $bar = (struct Bar *)arg0; printf("%d %d %d %d %d", $bar.a, $bar.b, $bar.c, $bar.d, $bar.e); printf(" %d %d %d %d", $bar.f, $bar.g, $bar.h, $bar.i); exit()}
 EXPECT 1 217 5 1 500 31117 1 2 27
 AFTER ./testprogs/bitfield_test
 

--- a/tests/runtime/pointers
+++ b/tests/runtime/pointers
@@ -75,7 +75,7 @@ RUN {{BPFTRACE}} runtime/scripts/struct_walk.bt -c ./testprogs/struct_walk
 EXPECT a: 45 b: 1000
 
 NAME Pointer arith with int32
-PROG struct C { uint32_t a; }; uprobe:./testprogs/struct_walk:clear { $c = (struct C *)arg0; printf("ptr: %p\n", $c + $c->a); exit() }
+PROG struct C { uint32_t a; }; uprobe:./testprogs/struct_walk:clear { $c = (struct C *)arg0; printf("ptr: %p\n", $c + $c.a); exit() }
 AFTER ./testprogs/struct_walk
 EXPECT_REGEX ^ptr: 0x[0-9a-z]+
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -431,7 +431,7 @@ WILL_FAIL
 
 # Test that we get at least two characters out
 NAME rawtracepoint args
-PROG rawtracepoint:irq_handler_entry { print(str(((struct irqaction*)args.action)->name)); exit(); }
+PROG rawtracepoint:irq_handler_entry { print(str(((struct irqaction*)args.action).name)); exit(); }
 EXPECT_REGEX ..+
 
 NAME profile

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -1,18 +1,18 @@
 # https://github.com/bpftrace/bpftrace/pull/566#issuecomment-487295113
 NAME codegen_struct_save_nested
-PROG struct Foo { int m; struct { int x; int y; } bar; int n; } begin { @foo = (struct Foo *)0; @bar = @foo->bar; @x = @foo->bar.x; printf("_%s_\n", "done");  }
+PROG struct Foo { int m; struct { int x; int y; } bar; int n; } begin { @foo = (struct Foo *)0; @bar = @foo.bar; @x = @foo.bar.x; printf("_%s_\n", "done");  }
 EXPECT _done_
 TIMEOUT 1
 
 NAME logical_and_or_different_sizes
-PROG struct Foo { int m; } uprobe:./testprogs/simple_struct:func { $foo = (struct Foo*)arg0; printf("%d %d %d %d %d\n", $foo->m, $foo->m && 0, 1 && $foo->m, $foo->m || 0, 0 || $foo->m); exit(); }
+PROG struct Foo { int m; } uprobe:./testprogs/simple_struct:func { $foo = (struct Foo*)arg0; printf("%d %d %d %d %d\n", $foo.m, $foo.m && 0, 1 && $foo.m, $foo.m || 0, 0 || $foo.m); exit(); }
 AFTER ./testprogs/simple_struct
 EXPECT 2 0 1 1 1
 
 # https://github.com/bpftrace/bpftrace/issues/759
 # Update test once https://github.com/bpftrace/bpftrace/pull/781 lands
 # NAME ntop_map_printf
-# RUN {{BPFTRACE}} -e 'union ip { char v4[4]; char v6[16]; } uprobe:./testprogs/ntop:test_ntop { @a = ntop(2, ((union ip*)arg0)->v4); printf("v4: %s; ", @a); @b = ntop(10, ((union ip*)arg1)->v6); exit() } end { printf("v6: %s", @b); clear(@a); clear(@b) }'
+# RUN {{BPFTRACE}} -e 'union ip { char v4[4]; char v6[16]; } uprobe:./testprogs/ntop:test_ntop { @a = ntop(2, ((union ip*)arg0).v4); printf("v4: %s; ", @a); @b = ntop(10, ((union ip*)arg1).v6); exit() } end { printf("v6: %s", @b); clear(@a); clear(@b) }'
 # AFTER ./testprogs/ntop
 # EXPECT v4: 127.0.0.1; v6: ffee:ffee:ddcc:ddcc:bbaa:bbaa:c0a8:1
 # TIMEOUT 1
@@ -42,7 +42,7 @@ EXPECT stdin:1:48-49: WARNING: Divide or modulo by 0 detected. This can lead to 
 TIMEOUT 1
 
 NAME c_array_indexing
-RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:uprobeFunction2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:uprobeFunction2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo.b[0], $foo.b[1], $foo.b[2], $foo.b[3], $foo.b[4]) }' -c ./testprogs/uprobe_test
 EXPECT h e l l o
 
 # https://github.com/bpftrace/bpftrace/issues/1773
@@ -104,19 +104,19 @@ TIMEOUT 1
 # array accesses so we must use bpf_probe_read_kernel, otherwise the program is
 # rejected. The below two tests make sure that we handle such situations.
 NAME fentry double pointer dereference
-PROG fentry:__module_get { print((*args.module->trace_events)->flags); exit(); }
+PROG fentry:__module_get { print((*args.module.trace_events).flags); exit(); }
 AFTER lsmod
 EXPECT Attached 1 probe
 TIMEOUT 1
 
 NAME fentry double pointer array access
-PROG fentry:__module_get { print(args.module->trace_events[1]->flags); exit(); }
+PROG fentry:__module_get { print(args.module.trace_events[1].flags); exit(); }
 AFTER lsmod
 EXPECT Attached 1 probe
 TIMEOUT 1
 
 NAME fentry array access via pointer
-PROG fentry:__module_get { print(args.module->version[0]); exit(); }
+PROG fentry:__module_get { print(args.module.version[0]); exit(); }
 AFTER lsmod
 EXPECT Attached 1 probe
 TIMEOUT 1

--- a/tests/runtime/strcontains
+++ b/tests/runtime/strcontains
@@ -1,5 +1,5 @@
 NAME path
-PROG fentry:security_file_open { if (strcontains(path(args.file->f_path, 128), "tmp")) { printf("OK\n"); exit(); } }
+PROG fentry:security_file_open { if (strcontains(path(args.file.f_path, 128), "tmp")) { printf("OK\n"); exit(); } }
 EXPECT OK
 REQUIRES_FEATURE dpath
 AFTER TMPDIR=/tmp ./testprogs/syscall open

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -79,12 +79,12 @@ EXPECT 12
 AFTER ./testprogs/simple_struct
 
 NAME array in tuple
-PROG struct A { int x[4]; } u:./testprogs/array_access:test_struct { @t = (1, ((struct A *)arg0)->x); exit(); }
+PROG struct A { int x[4]; } u:./testprogs/array_access:test_struct { @t = (1, ((struct A *)arg0).x); exit(); }
 EXPECT @t: (1, [1,2,3,4])
 AFTER ./testprogs/array_access
 
 NAME array in tuple sizing
-PROG struct A { int x[4]; } u:./testprogs/array_access:test_struct { $t = ((int32)1, ((struct A *)arg0)->x); print(sizeof($t)); exit(); }
+PROG struct A { int x[4]; } u:./testprogs/array_access:test_struct { $t = ((int32)1, ((struct A *)arg0).x); print(sizeof($t)); exit(); }
 EXPECT 20
 AFTER ./testprogs/array_access
 

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -111,7 +111,7 @@ PROG begin { let $a; $a = 10; printf("a=%d\n", $a); }
 EXPECT a=10
 
 NAME variable declaration with builtin
-PROG begin { let $f: struct task_struct *; $f = curtask; print($f->pid); }
+PROG begin { let $f: struct task_struct *; $f = curtask; print($f.pid); }
 EXPECT_REGEX [0-9]+
 
 NAME variable declaration with unresolved type

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1808,9 +1808,9 @@ TEST_F(SemanticAnalyserTest, array_as_map_key)
       @x[((struct MyStruct *)0)->y] = 1;
     })",
        Error{ R"(
-stdin:4:10-35: ERROR: Argument mismatch for @x: trying to access with arguments: 'int32[4]' when map expects arguments: 'int32[2]'
+stdin:4:32-34: ERROR: Argument mismatch for @x: trying to access with arguments: 'int32[4]' when map expects arguments: 'int32[2]'
       @x[((struct MyStruct *)0)->y] = 1;
-         ~~~~~~~~~~~~~~~~~~~~~~~~~
+                               ~~
 )" });
 }
 
@@ -2573,7 +2573,7 @@ TEST_F(SemanticAnalyserTest, field_access_pointer)
 {
   std::string structs = "struct type1 { int field; }";
   test(structs + "kprobe:f { ((struct type1*)0)->field }");
-  test(structs + "kprobe:f { ((struct type1*)0).field }", Error{});
+  test(structs + "kprobe:f { ((struct type1*)0).field }");
   test(structs + "kprobe:f { *((struct type1*)0) }");
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #4621
 * #4620
 * #4674
 * __->__#4673


--- --- ---

### semantics: support automatic dereference with `.`


Similar to Go, allow for automatic resolution with `.` since we're aware
of whether the type is a pointer or not. This allows us to define `.` as
the canonical syntax for all struct accesses.

Signed-off-by: Adin Scannell <amscanne@meta.com>
