### PR TITLE
Release/0.24.x recursion fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#4649](https://github.com/bpftrace/bpftrace/pull/4649)
 - Fix missing map key buffers for map aggregate functions
   - [#4670](https://github.com/bpftrace/bpftrace/pull/4670)
+- Fix fentry/fexit recursion check
+  - [#4684](https://github.com/bpftrace/bpftrace/pull/4684)
 #### Docs
 - Fix docs for PERCPU map types
   - [#4646](https://github.com/bpftrace/bpftrace/pull/4646)

--- a/tests/codegen/llvm/fentry_recursion_check.ll
+++ b/tests/codegen/llvm/fentry_recursion_check.ll
@@ -28,8 +28,7 @@ entry:
 
 lookup_success:                                   ; preds = %entry
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key)
-  %cast = ptrtoint ptr %lookup_elem to i64
-  %1 = atomicrmw xchg i64 %cast, i64 1 seq_cst, align 8
+  %1 = atomicrmw xchg ptr %lookup_elem, i64 1 seq_cst, align 8
   %value_set_condition = icmp eq i64 %1, 0
   br i1 %value_set_condition, label %lookup_merge, label %value_is_set
 
@@ -55,8 +54,7 @@ value_is_set:                                     ; preds = %lookup_success
 
 lookup_success3:                                  ; preds = %lookup_merge
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key1)
-  %cast7 = ptrtoint ptr %lookup_elem2 to i64
-  store i64 0, i64 %cast7, align 8
+  store i64 0, ptr %lookup_elem2, align 8
   br label %lookup_merge5
 
 lookup_failure4:                                  ; preds = %lookup_merge
@@ -85,8 +83,7 @@ entry:
 
 lookup_success:                                   ; preds = %entry
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key)
-  %cast = ptrtoint ptr %lookup_elem to i64
-  %1 = atomicrmw xchg i64 %cast, i64 1 seq_cst, align 8
+  %1 = atomicrmw xchg ptr %lookup_elem, i64 1 seq_cst, align 8
   %value_set_condition = icmp eq i64 %1, 0
   br i1 %value_set_condition, label %lookup_merge, label %value_is_set
 
@@ -112,8 +109,7 @@ value_is_set:                                     ; preds = %lookup_success
 
 lookup_success3:                                  ; preds = %lookup_merge
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key1)
-  %cast7 = ptrtoint ptr %lookup_elem2 to i64
-  store i64 0, i64 %cast7, align 8
+  store i64 0, ptr %lookup_elem2, align 8
   br label %lookup_merge5
 
 lookup_failure4:                                  ; preds = %lookup_merge

--- a/tests/codegen/llvm/fentry_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/fentry_recursion_check_with_predicate.ll
@@ -18,7 +18,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @fentry_mock_vmlinux_queued_spin_lock_slowpath_1(ptr %0) #0 section "s_fentry_mock_vmlinux_queued_spin_lock_slowpath_1" !dbg !52 {
 entry:
-  %lookup_key8 = alloca i32, align 4
+  %lookup_key7 = alloca i32, align 4
   %lookup_key1 = alloca i32, align 4
   %lookup_key = alloca i32, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key)
@@ -29,8 +29,7 @@ entry:
 
 lookup_success:                                   ; preds = %entry
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key)
-  %cast = ptrtoint ptr %lookup_elem to i64
-  %1 = atomicrmw xchg i64 %cast, i64 1 seq_cst, align 8
+  %1 = atomicrmw xchg ptr %lookup_elem, i64 1 seq_cst, align 8
   %value_set_condition = icmp eq i64 %1, 0
   br i1 %value_set_condition, label %lookup_merge, label %value_is_set
 
@@ -64,16 +63,15 @@ pred_false:                                       ; preds = %lookup_merge
   br i1 %map_lookup_cond6, label %lookup_success3, label %lookup_failure4
 
 pred_true:                                        ; preds = %lookup_merge
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key8)
-  store i32 0, ptr %lookup_key8, align 4
-  %lookup_elem9 = call ptr inttoptr (i64 1 to ptr)(ptr @recursion_prevention, ptr %lookup_key8)
-  %map_lookup_cond13 = icmp ne ptr %lookup_elem9, null
-  br i1 %map_lookup_cond13, label %lookup_success10, label %lookup_failure11
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_key7)
+  store i32 0, ptr %lookup_key7, align 4
+  %lookup_elem8 = call ptr inttoptr (i64 1 to ptr)(ptr @recursion_prevention, ptr %lookup_key7)
+  %map_lookup_cond12 = icmp ne ptr %lookup_elem8, null
+  br i1 %map_lookup_cond12, label %lookup_success9, label %lookup_failure10
 
 lookup_success3:                                  ; preds = %pred_false
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key1)
-  %cast7 = ptrtoint ptr %lookup_elem2 to i64
-  store i64 0, i64 %cast7, align 8
+  store i64 0, ptr %lookup_elem2, align 8
   br label %lookup_merge5
 
 lookup_failure4:                                  ; preds = %pred_false
@@ -82,16 +80,15 @@ lookup_failure4:                                  ; preds = %pred_false
 lookup_merge5:                                    ; preds = %lookup_failure4, %lookup_success3
   ret i64 0
 
-lookup_success10:                                 ; preds = %pred_true
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key8)
-  %cast14 = ptrtoint ptr %lookup_elem9 to i64
-  store i64 0, i64 %cast14, align 8
-  br label %lookup_merge12
+lookup_success9:                                  ; preds = %pred_true
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_key7)
+  store i64 0, ptr %lookup_elem8, align 8
+  br label %lookup_merge11
 
-lookup_failure11:                                 ; preds = %pred_true
-  br label %lookup_merge12
+lookup_failure10:                                 ; preds = %pred_true
+  br label %lookup_merge11
 
-lookup_merge12:                                   ; preds = %lookup_failure11, %lookup_success10
+lookup_merge11:                                   ; preds = %lookup_failure10, %lookup_success9
   ret i64 0
 }
 


### PR DESCRIPTION
Note: This is broken on master too but there is a PR out to remove this whole codegen path:
- https://github.com/bpftrace/bpftrace/pull/4588

@viktormalik We'll need this before the next patch release.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
