### PR TITLE
Add libbpf as a submodule

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -24,6 +24,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: true
     - uses: DeterminateSystems/nix-installer-action@v17
       with:
         determinate: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        submodules: true
     - uses: DeterminateSystems/nix-installer-action@v17
       with:
         determinate: true
@@ -90,6 +91,8 @@ jobs:
           AOT_ALLOWLIST_FILE: .github/include/aot_allow.txt
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - uses: DeterminateSystems/nix-installer-action@v17
       with:
         determinate: true

--- a/.github/workflows/distros.yml
+++ b/.github/workflows/distros.yml
@@ -23,5 +23,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - name: Build
       run: docker build -f ${{ matrix.dockerfile }} .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v3
+      with:
+        submodules: true
     - uses: DeterminateSystems/nix-installer-action@v17
       with:
         determinate: true

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,5 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - name: Build static bpftrace
       run: ./.github/include/static.sh

--- a/.github/workflows/tidy.yml
+++ b/.github/workflows/tidy.yml
@@ -20,6 +20,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       - uses: DeterminateSystems/nix-installer-action@v17
         with:
           determinate: true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libbpf"]
+	path = libbpf
+	url = https://github.com/libbpf/libbpf.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 #### Changed
 - Apply `-B` buffering semantics to file outputs.
   - [#4637](https://github.com/bpftrace/bpftrace/pull/4637)
+- Link against libbpf vendored from a submodule by default
+  - [#4688](https://github.com/bpftrace/bpftrace/pull/4688)
 #### Deprecated
 #### Removed
 - Drop support for LLVM 16

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ set(ENABLE_TEST_VALIDATE_CODEGEN ON CACHE BOOL "Run LLVM IR validation tests")
 set(ENABLE_SYSTEMD OFF CACHE BOOL "Enable systemd integration")
 set(KERNEL_HEADERS_DIR "" CACHE PATH "Hard-code kernel headers directory")
 set(SYSTEM_INCLUDE_PATHS "auto" CACHE STRING "Hard-code system include paths (colon separated, the default value \"auto\" queries clang at runtime)")
+set(USE_SYSTEM_LIBBPF OFF CACHE BOOL
+    "Use system libbpf instead of vendoring it from a submodule")
 
 set(ENABLE_SKB_OUTPUT ON CACHE BOOL "Enable skb_output, will include libpcap")
 
@@ -101,8 +103,8 @@ include_directories(SYSTEM ${LIBBCC_INCLUDE_DIRS})
 
 find_package(LibBpf REQUIRED)
 include_directories(SYSTEM ${LIBBPF_INCLUDE_DIRS})
-if("${LIBBPF_VERSION_MAJOR}.${LIBBPF_VERSION_MINOR}" VERSION_LESS 1.5)
-  message(SEND_ERROR "bpftrace requires libbpf 1.5 or greater")
+if(USE_SYSTEM_LIBBPF)
+  message(WARNING "Using system libbpf, please ensure that the version is greater than or equal to the submodule")
 endif()
 
 find_package(LibElf REQUIRED)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -291,6 +291,12 @@ The bpftrace binary will be in installed in /usr/local/bin/bpftrace, and tools
 in /usr/local/share/bpftrace/tools. You can change the install location using an
 argument to cmake, where the default is `-DCMAKE_INSTALL_PREFIX=/usr/local`.
 
+By default, bpftrace vendors libbpf and links against it statically. To change
+that, it is possible to use `-DUSE_SYSTEM_LIBBPF` in CMake to force linking
+against system libbpf, however, beware that system libbpf may not contain all
+the features that bpftrace requires from libbpf. See our [dependency
+support](docs/dependency_support.md#libbpf) for more details.
+
 To test that the build works, you can try running the unit tests and a one-liner:
 
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -240,7 +240,7 @@ make install
 
 # bpftrace
 cd $builddir
-git clone https://github.com/bpftrace/bpftrace
+git clone --recurse-submodules https://github.com/bpftrace/bpftrace
 cd bpftrace
 mkdir build; cd build
 cmake3 ..

--- a/cmake/FindLibBcc.cmake
+++ b/cmake/FindLibBcc.cmake
@@ -58,8 +58,6 @@ if(${LIBBCC_FOUND})
 if(STATIC_LINKING)
   # libbcc.a is not statically linked with libbpf.a, libelf.a, libz.a, and liblzma.a.
   # If we do a static bpftrace build, we must link them in.
-  find_package(LibBpf)
-  find_package(LibElf)
   find_package(LibLzma)
 
   if(ANDROID)

--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -5,23 +5,64 @@
 #  LIBBPF_VERSION_MAJOR - Libbpf major version
 #  LIBBPF_VERSION_MINOR - Libbpf minor version
 
-find_path (LIBBPF_INCLUDE_DIRS
-  NAMES
-    bpf/bpf.h
-    bpf/btf.h
-    bpf/libbpf.h
-  PATHS
-    ENV CPATH)
+if (USE_SYSTEM_LIBBPF)
+  find_path (LIBBPF_INCLUDE_DIRS
+    NAMES
+      bpf/bpf.h
+      bpf/btf.h
+      bpf/libbpf.h
+    PATHS
+      ENV CPATH)
 
-# We require that `libbpf` be linked statically, as we will implicitly vendor
-# the header into embedded code. See #4151 for more information.
-find_library (LIBBPF_LIBRARIES
-  NAMES
-    libbpf.a
-  PATHS
-    ENV LIBRARY_PATH
-    ENV LD_LIBRARY_PATH)
-set(LIBBPF_ERROR_MESSAGE "Please install the libbpf.a static library")
+  # We require that `libbpf` be linked statically, as we will implicitly vendor
+  # the header into embedded code. See #4151 for more information.
+  find_library (LIBBPF_LIBRARIES
+    NAMES
+      libbpf.a
+    PATHS
+      ENV LIBRARY_PATH
+      ENV LD_LIBRARY_PATH)
+  set(LIBBPF_ERROR_MESSAGE
+    "Please set -DUSE_SYSTEM_LIBBPF=Off to use the libbpf stored as a submodule
+    (preferred) or install the libbpf.a static library")
+else()
+  set(LIBBPF_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/libbpf/src)
+  set(LIBBPF_BUILD ${CMAKE_CURRENT_BINARY_DIR}/libbpf)
+  set(LIBBPF_LIBRARY ${LIBBPF_BUILD}/lib64/libbpf.a)
+
+  # We need to install headers during configure phase for two reasons:
+  # 1. To parse libbpf version from libbpf_version.h below.
+  # 2. For bpftrace's stdlib since libbpf headers are included in stdlib bpf.c
+  #    files (and the rules to embed them are generated in configure phase).
+  execute_process(
+    COMMAND make PREFIX=${LIBBPF_BUILD} install_headers
+    WORKING_DIRECTORY ${LIBBPF_SOURCE}
+    OUTPUT_QUIET)
+
+  # Build and install libbpf from source. This needs to be done in a rather
+  # complicated way to ensure proper dependency between the exported
+  # LIBBPF_LIBRARIES and the built libbpf.a. Note that we cannot use
+  # add_custom_target with COMMAND since CMake considers the target as always
+  # outdated, forcing rebuild of libbpf (and transitively of the entire bpftrace
+  # every time).
+  add_custom_command(
+    OUTPUT ${LIBBPF_LIBRARY}
+    # -fPIE here is needed by latest binutils when building with Clang
+    COMMAND make PREFIX=${LIBBPF_BUILD} EXTRA_CFLAGS="-fPIE" install > /dev/null
+    WORKING_DIRECTORY ${LIBBPF_SOURCE}
+    DEPENDS ${LIBBPF_SOURCE}/*
+    COMMENT "Building libbpf"
+    VERBATIM)
+  add_custom_target(libbpf_build DEPENDS ${LIBBPF_LIBRARY})
+  add_library(libbpf_static STATIC IMPORTED GLOBAL)
+  set_target_properties(libbpf_static PROPERTIES
+    IMPORTED_LOCATION ${LIBBPF_LIBRARY})
+  add_dependencies(libbpf_static libbpf_build)
+
+  # Set the output variables directly
+  set(LIBBPF_LIBRARIES libbpf_static)
+  set(LIBBPF_INCLUDE_DIRS ${LIBBPF_BUILD}/include)
+endif()
 
 include (FindPackageHandleStandardArgs)
 

--- a/docs/dependency_support.md
+++ b/docs/dependency_support.md
@@ -38,3 +38,20 @@ Please consult [static.sh][0] for the source of truth.
 
 
 [0]: https://github.com/bpftrace/bpftrace/blob/master/.github/include/static.sh
+
+## libbpf
+
+bpftrace relies on libbpf for most of the tasks related to management of BPF
+programs, particularly loading and attachment. Occasionally, it is necessary to
+introduce patches to libbpf to enable some bpftrace functionality or to fix
+bugs. For this reason, we require a very recent, often unreleased, version of
+libbpf.
+
+To simplify development and building, bpftrace vendors libbpf as a submodule and
+by default links against the vendored version statically. Since linking against
+vendored library versions is not preferred by most distributions, we also allow
+building against system libbpf by using `-DUSE_SYSTEM_LIBBPF=On` in CMake. Note
+that it is the responsibility of the builder to ensure that the linked libbpf
+contains all the necessary patches. The general recommendation is that the
+linked libbpf should be at or beyond the commit referenced by the libbpf
+submodule, which will be kept up to date when required patches change.

--- a/flake.nix
+++ b/flake.nix
@@ -39,42 +39,11 @@
           # The default LLVM version is the latest supported release
           defaultLlvmVersion = 21;
 
-          # Override to specify the libbpf build we want. Note that we need to
-          # capture a specific fix for linking which is not yet present in a
-          # release. Once this fix is present in a release, then this should be
-          # updated to the relevant version and we need to update the version
-          # constraint in `CMakeLists.txt`.
-          libbpfVersion = "5e3306e89a44cab09693ce4bfe50bfc0cb595941";
-          libbpf = pkgs.libbpf.overrideAttrs {
-            version = libbpfVersion;
-            src = pkgs.fetchFromGitHub {
-              owner = "libbpf";
-              repo = "libbpf";
-              rev = "${libbpfVersion}";
-              # Nix uses the hash to do lookups in its cache as well as check that the
-              # download from the internet hasn't changed. Therefore, it's necessary to
-              # update the hash every time you update the source. Failure to update the
-              # hash in a cached environment (warm development host and CI) will cause
-              # nix to use the old source and then fail at some point in the future when
-              # the stale cached content is evicted.
-              #
-              # If you don't know the hash, set:
-              #   sha256 = "";
-              # then nix will fail the build with such an error message:
-              #   hash mismatch in fixed-output derivation '/nix/store/m1ga09c0z1a6n7rj8ky3s31dpgalsn0n-source':
-              #   specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
-              # got:    sha256-173gxk0ymiw94glyjzjizp8bv8g72gwkjhacigd1an09jshdrjb4
-              sha256 = "sha256-giMF2DaBDk3/MKQkCzYcn5ZkcuCyrPXXoe9jI5E3QI0=";
-            };
-          };
-
           # Override to specify the bcc build we want.
-          # First overrides with the above libbpf and then overrides the rev.
           # We need a specific patch in BCC which resolves a build failure with
           # LLVM 21 and is not a part of any official release, yet.
           bccVersion = "8c5c96ad3beeed2fa827017f451a952306826974";
           bcc = (pkgs.bcc.override {
-            libbpf = libbpf;
             llvmPackages = pkgs."llvmPackages_${toString defaultLlvmVersion}";
           }).overridePythonAttrs {
             version = bccVersion;
@@ -164,7 +133,6 @@
                 buildInputs = [
                   bcc
                   blazesym_c
-                  libbpf
                   pkgs.asciidoctor
                   pkgs.cereal
                   pkgs.elfutils


### PR DESCRIPTION
Add libbpf as a submodule and integrate it into the bpftrace build. The build is done in `FindLibbpf.cmake` by running libbpf's make and installing it into the build directory.
    
There are a few specifics things that had to be done:
- We need to install libbpf headers during CMake configure phase since we need them (1) to determine libbpf version in CMake and (2) to build stdlib which embeds the headers.
- The build itself is done by a combination of `add_custom_command`, `add_custom_target`, and `add_custom_library` calls with some dependencies in between. I was not able to come up with a simpler combination of commands (see the comment in `FindLibbpf.cmake` for some details).

Building against system libbpf is still possible by using `-DUSE_SYSTEM_LIBBPF=On` in CMake.

Add a new section on libbpf to the dependency support doc which contains information on why vendoring is preferred and lists libbpf commits which are necessary for bpftrace to work properly (for the case when linking against system libbpf).

Finally, drop libbpf from Nix flakes completely.

Resolves #4543.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
