### PR TITLE
Fix usdt_arg for older kernel versions

### DIFF
--- a/src/stdlib/internal.bt
+++ b/src/stdlib/internal.bt
@@ -1,3 +1,3 @@
 macro usdt_arg(x) {
-   __usdt_arg(ctx, x)
+   __usdt_arg((void *)ctx, x)
 }

--- a/src/stdlib/usdt/usdt.bpf.c
+++ b/src/stdlib/usdt/usdt.bpf.c
@@ -2,7 +2,9 @@
 #include <vmlinux.h>
 #include <bpf/usdt.bpf.h>
 
-long __usdt_arg(struct pt_regs * ctx, long arg_num)
+// N.B. ctx is type erased because struct pt_regs is in a different location
+// depending on kernel version and it's just easier this way
+long __usdt_arg(void * ctx, long arg_num)
 {
   long _x;
   bpf_usdt_arg(ctx, arg_num, &_x);


### PR DESCRIPTION
On older kernel versions we're not
correctly resolving the type for `struct pt_regs *` in our bpf.c files. Probably because it was moved
and we're just not including the right header.
Error:
```

stdlib/internal.bt:2:15-18: ERROR: Expected  * for argument `ctx` got (ctx) struct pt_regs *
   __usdt_arg(ctx, x)
              ~~~
stdin:1:1-67: ERROR: expanded from
usdt:./tests/testprogs/usdt_multiple_locations:tracetest:testprobe { print(str(arg1)); }
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
stdlib/internal.bt:2:4-22: ERROR: Function `__usdt_arg` requires arguments ( *, int64)
   __usdt_arg(ctx, x)
   ~~~~~~~~~~~~~~~~~~
stdin:1:1-67: ERROR: expanded from
usdt:./tests/testprogs/usdt_multiple_locations:tracetest:testprobe { print(str(arg1)); }
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

So instead just pass it as a void ptr.

Tested this change on a kernel version with the issue and a later kernel (works on both).

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
