### PR TITLE
Remove all the logic around USDT locations

### DIFF
--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -32,8 +32,7 @@ public:
 };
 
 // Compiles the primary AST, and emits `CompiledModule`.
-Pass CreateCompilePass(std::optional<std::reference_wrapper<USDTHelper>>
-                           &&usdt_helper = std::nullopt);
+Pass CreateCompilePass();
 
 // Links any external bitcode into the module. This must follow the compile
 // pass, and should proceed any verification, optimization or external linking.
@@ -64,12 +63,10 @@ Pass CreateDumpASMPass(std::ostream &out);
 
 // AllCompilePasses returns a vector of passes representing all compile passes,
 // in the expected order.
-inline std::vector<Pass> AllCompilePasses(
-    std::optional<std::reference_wrapper<USDTHelper>> &&usdt_helper =
-        std::nullopt)
+inline std::vector<Pass> AllCompilePasses()
 {
   std::vector<Pass> passes;
-  passes.emplace_back(CreateCompilePass(std::move(usdt_helper)));
+  passes.emplace_back(CreateCompilePass());
   passes.emplace_back(CreateLinkBitcodePass());
   passes.emplace_back(CreateVerifyPass());
   passes.emplace_back(CreateOptimizePass());

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -82,19 +82,8 @@ BpfBytecode::BpfBytecode(std::span<const std::byte> elf)
 
 const BpfProgram &BpfBytecode::getProgramForProbe(const Probe &probe) const
 {
-  auto usdt_location_idx = (probe.type == ProbeType::usdt)
-                               ? std::make_optional<int>(
-                                     probe.usdt_location_idx)
-                               : std::nullopt;
-
-  auto prog = programs_.find(util::get_function_name_for_probe(
-      probe.name, probe.index, usdt_location_idx));
-  if (prog == programs_.end()) {
-    prog = programs_.find(util::get_function_name_for_probe(probe.orig_name,
-                                                            probe.index,
-                                                            usdt_location_idx));
-  }
-
+  auto prog = programs_.find(
+      util::get_function_name_for_probe(probe.name, probe.index));
   if (prog == programs_.end()) {
     std::stringstream msg;
     if (probe.name != probe.orig_name)

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -106,8 +106,7 @@ Probe BPFtrace::generateWatchpointSetupProbe(const ast::AttachPoint &ap,
 Probe BPFtrace::generate_probe(const ast::AttachPoint &ap,
                                const ast::Probe &p,
                                ast::ExpansionType expansion,
-                               std::set<std::string> expanded_funcs,
-                               int usdt_location_idx)
+                               std::set<std::string> expanded_funcs)
 {
   Probe probe;
   probe.path = ap.target;
@@ -121,7 +120,6 @@ Probe BPFtrace::generate_probe(const ast::AttachPoint &ap,
   probe.address = ap.address;
   probe.func_offset = ap.func_offset;
   probe.loc = 0;
-  probe.usdt_location_idx = usdt_location_idx;
   probe.index = ap.index() ?: p.index();
   probe.len = ap.len;
   probe.mode = ap.mode;
@@ -136,12 +134,10 @@ Probe BPFtrace::generate_probe(const ast::AttachPoint &ap,
 int BPFtrace::add_probe(const ast::AttachPoint &ap,
                         const ast::Probe &p,
                         ast::ExpansionType expansion,
-                        std::set<std::string> expanded_funcs,
-                        int usdt_location_idx)
+                        std::set<std::string> expanded_funcs)
 {
   auto type = probetype(ap.provider);
-  auto probe = generate_probe(
-      ap, p, expansion, std::move(expanded_funcs), usdt_location_idx);
+  auto probe = generate_probe(ap, p, expansion, std::move(expanded_funcs));
 
   // Add the new probe(s) to resources
   if (ap.provider == "begin" || ap.provider == "end") {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -117,8 +117,7 @@ public:
   virtual int add_probe(const ast::AttachPoint &ap,
                         const ast::Probe &p,
                         ast::ExpansionType expansion,
-                        std::set<std::string> expanded_funcs,
-                        int usdt_location_idx = 0);
+                        std::set<std::string> expanded_funcs);
   Probe generateWatchpointSetupProbe(const ast::AttachPoint &ap,
                                      const ast::Probe &probe);
   int num_probes() const;
@@ -269,8 +268,7 @@ private:
   Probe generate_probe(const ast::AttachPoint &ap,
                        const ast::Probe &p,
                        ast::ExpansionType expansion,
-                       std::set<std::string> expanded_funcs,
-                       int usdt_location_idx = 0);
+                       std::set<std::string> expanded_funcs);
   bool has_iter_ = false;
   struct ring_buffer *ringbuf_ = nullptr;
   struct perf_buffer *skb_perfbuf_ = nullptr;

--- a/src/probe_types.h
+++ b/src/probe_types.h
@@ -115,7 +115,6 @@ struct Probe {
   std::string pin;  // pin file for iterator probes
   std::string ns;   // for USDT probes, if provider namespace not from path
   uint64_t loc = 0; // for USDT probes
-  int usdt_location_idx = 0; // to disambiguate duplicate USDT markers
   uint64_t log_size = 1000000;
   int index = 0;
   int freq = 0;
@@ -141,7 +140,6 @@ private:
             pin,
             ns,
             loc,
-            usdt_location_idx,
             log_size,
             index,
             freq,

--- a/src/usdt.cpp
+++ b/src/usdt.cpp
@@ -32,14 +32,12 @@ static bool has_uprobe_multi_ = false;
 
 static void usdt_probe_each(struct bcc_usdt *usdt_probe)
 {
-  int num_locations = has_uprobe_multi_ ? 1 : usdt_probe->num_locations;
   usdt_provider_cache[usdt_probe->bin_path][usdt_probe->provider].emplace_back(
       usdt_probe_entry{
           .path = usdt_probe->bin_path,
           .provider = usdt_probe->provider,
           .name = usdt_probe->name,
           .semaphore_offset = usdt_probe->semaphore_offset,
-          .num_locations = num_locations,
       });
   current_pid_paths.emplace(usdt_probe->bin_path);
 }

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -12,7 +12,6 @@ struct usdt_probe_entry {
   std::string provider;
   std::string name;
   uint64_t semaphore_offset;
-  int num_locations;
 };
 
 using usdt_probe_list = std::vector<usdt_probe_entry>;

--- a/src/util/bpf_names.h
+++ b/src/util/bpf_names.h
@@ -10,17 +10,9 @@ std::string sanitise_bpf_program_name(const std::string &name);
 // Generate object file function name for a given probe
 inline std::string get_function_name_for_probe(
     const std::string &probe_name,
-    int index,
-    std::optional<int> usdt_location_index = std::nullopt)
+    int index)
 {
-  auto ret = sanitise_bpf_program_name(probe_name);
-
-  if (usdt_location_index)
-    ret += "_loc" + std::to_string(*usdt_location_index);
-
-  ret += "_" + std::to_string(index);
-
-  return ret;
+  return sanitise_bpf_program_name(probe_name) + "_" + std::to_string(index);
 }
 
 inline std::string get_section_name(const std::string &function_name)

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -96,27 +96,4 @@ kprobe:f
   EXPECT_EQ(args[3].offset, 24);
 }
 
-TEST(codegen, probe_count)
-{
-  ast::ASTContext ast("stdin", R"(
-kprobe:f { 1; } kprobe:d { 1; }
-)");
-  MockBPFtrace bpftrace;
-  EXPECT_CALL(bpftrace, add_probe(_, _, _, _, _)).Times(2);
-
-  // Override to mockbpffeature.
-  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-
-  auto ok = ast::PassManager()
-                .put(ast)
-                .put<BPFtrace>(bpftrace)
-                .add(ast::AllParsePasses())
-                .add(ast::CreateLLVMInitPass())
-                .add(ast::CreateClangBuildPass())
-                .add(ast::CreateTypeSystemPass())
-                .add(ast::CreateSemanticPass())
-                .add(ast::AllCompilePasses())
-                .run();
-  ASSERT_TRUE(ok && ast.diagnostics().ok());
-}
 } // namespace bpftrace::test::codegen

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -194,26 +194,4 @@ std::unique_ptr<MockBPFtrace> get_strict_mock_bpftrace()
   return bpftrace;
 }
 
-std::unique_ptr<MockUSDTHelper> get_mock_usdt_helper(int num_locations)
-{
-  auto usdt_helper = std::make_unique<NiceMock<MockUSDTHelper>>();
-
-  ON_CALL(*usdt_helper, find(_, _, _, _, _))
-      .WillByDefault([num_locations](std::optional<int>,
-                                     const std::string &,
-                                     const std::string &,
-                                     const std::string &,
-                                     bool) {
-        return usdt_probe_entry{
-          .path = "",
-          .provider = "",
-          .name = "",
-          .semaphore_offset = 0,
-          .num_locations = num_locations,
-        };
-      });
-
-  return usdt_helper;
-}
-
 } // namespace bpftrace::test

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -228,6 +228,4 @@ public:
 #pragma GCC diagnostic pop
 };
 
-std::unique_ptr<MockUSDTHelper> get_mock_usdt_helper(int num_locations);
-
 } // namespace bpftrace::test

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -125,22 +125,10 @@ RUN {{BPFTRACE}} -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p {{BEFORE_
 EXPECT Attached 2 probes
 BEFORE ./testprogs/usdt_test
 
-
-# When uprobe_multi is supported, a single ebpf program can be attached to multiple
-# identical usdt probes, so we only need to attach to 3 different usdt probes.
-# For systems without uprobe_multi support, we need to manually attach an ebpf
-# program to each probe location, resulting in 6 probes being attached.
-NAME usdt probes - attach to multiple probes with different number of locations by wildcard (with uprobe_multi)
+NAME usdt probes - attach to multiple probes with different number of locations by wildcard
 PROG usdt:./testprogs/usdt_multiple_locations:tracetest:testprobe* { printf("here\n" ); exit(); }
-REQUIRES_FEATURE uprobe_multi
 BEFORE ./testprogs/usdt_multiple_locations
 EXPECT_REGEX Attached 3 probes
-
-NAME usdt probes - attach to multiple probes with different number of locations by wildcard (without uprobe_multi)
-PROG usdt:./testprogs/usdt_multiple_locations:tracetest:testprobe* { printf("here\n" ); exit(); }
-REQUIRES_FEATURE !uprobe_multi
-BEFORE ./testprogs/usdt_multiple_locations
-EXPECT_REGEX Attached 6 probes
 
 NAME usdt probes - attach to probe with args by file
 PROG usdt:./testprogs/usdt_test:* { $a = str(arg1); print($a); @c[$a] = 1; if (len(@c) == 3) { exit(); } }


### PR DESCRIPTION
libbpf handles all this regardless if uprobe_multi is enabled or not so we don't need multiple
usdt progs for the same usdt ap regardless of it
exists in other locations in the binary.

Note: I ran all the usdt runtime tests against
a 5.19 kernel (no uprobe_multi).

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
