### PR TITLE
Duplicate probe ASTs that use args or retval

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -376,7 +376,8 @@ void AttachPoint::set_index(int index)
 
 std::string Probe::args_typename() const
 {
-  return "struct " + orig_name + "_args";
+  assert(attach_points.size() == 1);
+  return "struct " + orig_name + attach_points.front()->func + "_args";
 }
 
 int Probe::index() const

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3259,7 +3259,7 @@ void CodegenLLVM::add_probe(AttachPoint &ap,
   generateProbe(probe, probefull_, func_type);
   bpftrace_.add_probe(ap,
                       probe,
-                      expansions_.get_expansion(ap),
+                      expansions_.get_ap_expansion(ap),
                       expansions_.get_expanded_funcs(ap));
   current_attach_point_ = nullptr;
 }

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -231,106 +231,48 @@ void FieldAnalyser::visit(Unop &unop)
 
 void FieldAnalyser::resolve_args(Probe &probe)
 {
-  for (auto *ap : probe.attach_points) {
-    // load probe arguments into a special record type "struct <probename>_args"
-    std::shared_ptr<Struct> probe_args;
+  assert(probe.attach_points.size() == 1);
+  auto *ap = probe.attach_points.front();
 
-    auto probe_type = probetype(ap->provider);
-    if (probe_type != ProbeType::fentry && probe_type != ProbeType::fexit &&
-        probe_type != ProbeType::rawtracepoint &&
-        probe_type != ProbeType::uprobe)
-      continue;
+  auto probe_type = probetype(ap->provider);
+  if (probe_type != ProbeType::fentry && probe_type != ProbeType::fexit &&
+      probe_type != ProbeType::rawtracepoint &&
+      probe_type != ProbeType::uprobe) {
+    return;
+  }
 
-    if (expansions_.get_expansion(*ap) != ExpansionType::NONE) {
-      std::set<std::string> matches;
+  // load probe arguments into a special record type "struct <probename>_args"
+  std::shared_ptr<Struct> probe_args;
 
-      // Find all the matches for the wildcard..
-      try {
-        matches = bpftrace_.probe_matcher_->get_matches_for_ap(*ap);
-      } catch (const WildcardException &e) {
-        probe.addError() << e.what();
-        return;
-      }
+  std::string err;
+  // Resolving args for an explicit function failed, print an error and fail
+  if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit) {
+    probe_args = bpftrace_.btf_->resolve_args(
+        ap->func, probe_type == ProbeType::fexit, true, false, err);
 
-      // ... and check if they share same arguments.
-
-      std::shared_ptr<Struct> ap_args;
-      for (const auto &match : matches) {
-        // Both uprobes and fentry have a target (binary for uprobes, kernel
-        // module for fentry).
-        std::string func = match;
-        std::string target = util::erase_prefix(func);
-        std::string err;
-
-        // Trying to attach to multiple fentry. If some of them fails on
-        // argument resolution, do not fail hard, just print a warning and
-        // continue with other functions.
-        if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit) {
-          ap_args = bpftrace_.btf_->resolve_args(
-              func, probe_type == ProbeType::fexit, true, false, err);
-
-        } else if (probe_type == ProbeType::rawtracepoint) {
-          ap_args = bpftrace_.btf_->resolve_raw_tracepoint_args(func, err);
-        } else { // uprobe
-          Dwarf *dwarf = bpftrace_.get_dwarf(target);
-          if (dwarf)
-            ap_args = dwarf->resolve_args(func);
-          else
-            ap->addWarning() << "No debuginfo found for " << target;
-        }
-
-        if (!ap_args) {
-          ap->addWarning() << probetypeName(probe_type) << ap->func << ": "
-                           << err;
-          continue;
-        }
-
-        if (!probe_args)
-          probe_args = ap_args;
-        else if (*ap_args != *probe_args) {
-          ap->addError() << "Probe has attach points with mixed arguments";
-          break;
-        }
-      }
+  } else if (probe_type == ProbeType::rawtracepoint) {
+    probe_args = bpftrace_.btf_->resolve_raw_tracepoint_args(ap->func, err);
+  } else { // uprobe
+    Dwarf *dwarf = bpftrace_.get_dwarf(ap->target);
+    if (dwarf) {
+      probe_args = dwarf->resolve_args(ap->func);
     } else {
-      std::string err;
-      // Resolving args for an explicit function failed, print an error and fail
-      if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit) {
-        probe_args = bpftrace_.btf_->resolve_args(
-            ap->func, probe_type == ProbeType::fexit, true, false, err);
-
-      } else if (probe_type == ProbeType::rawtracepoint) {
-        probe_args = bpftrace_.btf_->resolve_raw_tracepoint_args(ap->func, err);
-      } else { // uprobe
-        Dwarf *dwarf = bpftrace_.get_dwarf(ap->target);
-        if (dwarf) {
-          probe_args = dwarf->resolve_args(ap->func);
-        } else {
-          ap->addWarning() << "No debuginfo found for " << ap->target;
-        }
-        if (probe_args &&
-            probe_args->fields.size() >= arch::Host::arguments().size()) {
-          ap->addError() << "\'args\' builtin is not supported for "
-                         << "probes with stack-passed arguments.";
-        }
-      }
-
-      if (!probe_args) {
-        ap->addError() << probetypeName(probe_type) << ap->func << ": " << err;
-        return;
-      }
+      ap->addWarning() << "No debuginfo found for " << ap->target;
     }
-
-    // check if we already stored arguments for this probe
-    auto args = bpftrace_.structs.Lookup(probe.args_typename()).lock();
-    if (args && *args != *probe_args) {
-      // we did, and it's different...trigger the error
-      ap->addError() << "Probe has attach points with mixed arguments";
-    } else {
-      // store/save args for each ap for later processing
-      bpftrace_.structs.Add(probe.args_typename(), std::move(probe_args));
+    if (probe_args &&
+        probe_args->fields.size() >= arch::Host::arguments().size()) {
+      ap->addError() << "\'args\' builtin is not supported for "
+                     << "probes with stack-passed arguments.";
     }
   }
+
+  if (!probe_args) {
+    ap->addError() << probetypeName(probe_type) << ap->func << ": " << err;
+    return;
+  }
+
+  // store/save args for each ap for later processing
+  bpftrace_.structs.Add(probe.args_typename(), std::move(probe_args));
 }
 
 void FieldAnalyser::resolve_fields(SizedType &type)

--- a/src/ast/passes/probe_expansion.h
+++ b/src/ast/passes/probe_expansion.h
@@ -31,14 +31,14 @@ public:
   ExpansionResult(ExpansionResult &&) = default;
   ExpansionResult &operator=(ExpansionResult &&) = default;
 
-  void set_expansion(AttachPoint &ap, ExpansionType type)
+  void set_ap_expansion(AttachPoint &ap, ExpansionType type)
   {
-    expansions[&ap] = type;
+    ap_expansions[&ap] = type;
   }
-  ExpansionType get_expansion(AttachPoint &ap)
+  ExpansionType get_ap_expansion(AttachPoint &ap)
   {
-    auto exp = expansions.find(&ap);
-    if (exp == expansions.end())
+    auto exp = ap_expansions.find(&ap);
+    if (exp == ap_expansions.end())
       return ExpansionType::NONE;
     return exp->second;
   }
@@ -61,9 +61,18 @@ public:
     return funcs->second;
   }
 
+  void add_probe(Probe * probe) {
+    probe_expansions.insert(probe);
+  }
+
+  bool has_probe(Probe* probe) {
+    return probe_expansions.contains(probe);
+  }
+
 private:
-  std::unordered_map<AttachPoint *, ExpansionType> expansions;
+  std::unordered_map<AttachPoint *, ExpansionType> ap_expansions;
   std::unordered_map<AttachPoint *, std::set<std::string>> expanded_funcs;
+  std::unordered_set<Probe *> probe_expansions;
 };
 
 Pass CreateProbeExpansionPass();

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1080,14 +1080,10 @@ void SemanticAnalyser::visit(Builtin &builtin)
     }
 
     ProbeType type = single_provider_type(probe);
+    assert(type != ProbeType::invalid);
 
-    if (type == ProbeType::invalid) {
-      builtin.addError()
-          << "The args builtin can only be used within the context of a single "
-             "probe type, e.g. \"probe1 {args}\" is valid while "
-             "\"probe1,probe2 {args}\" is not.";
-    } else if (type == ProbeType::fentry || type == ProbeType::fexit ||
-               type == ProbeType::uprobe || type == ProbeType::rawtracepoint) {
+    if (type == ProbeType::fentry || type == ProbeType::fexit ||
+        type == ProbeType::uprobe || type == ProbeType::rawtracepoint) {
       for (auto *attach_point : probe->attach_points) {
         if (attach_point->target == "bpf") {
           builtin.addError() << "The args builtin cannot be used for "

--- a/tests/codegen/llvm/map_args.ll
+++ b/tests/codegen/llvm/map_args.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.0" = type { ptr, ptr }
-%"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args" = type { i32, ptr, ptr, ptr, ptr }
+%"uprobe:/tmp/bpftrace-test-dwarf-data:func_1func_1_args" = type { i32, ptr, ptr, ptr, ptr }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -20,33 +20,33 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @uprobe__tmp_bpftrace_test_dwarf_data_func_1_1(ptr %0) #0 section "s_uprobe__tmp_bpftrace_test_dwarf_data_func_1_1" !dbg !50 {
 entry:
   %"@_key" = alloca i64, align 8
-  %args = alloca %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", align 8
+  %args = alloca %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1func_1_args", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %args)
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
   %3 = trunc i64 %arg0 to i32
-  %4 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 0
+  %4 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1func_1_args", ptr %args, i64 0, i32 0
   store i32 %3, ptr %4, align 4
   %5 = call ptr @llvm.preserve.static.offset(ptr %0)
   %6 = getelementptr i8, ptr %5, i64 104
   %arg1 = load volatile i64, ptr %6, align 8
-  %7 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 1
+  %7 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1func_1_args", ptr %args, i64 0, i32 1
   store i64 %arg1, ptr %7, align 8
   %8 = call ptr @llvm.preserve.static.offset(ptr %0)
   %9 = getelementptr i8, ptr %8, i64 96
   %arg2 = load volatile i64, ptr %9, align 8
-  %10 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 2
+  %10 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1func_1_args", ptr %args, i64 0, i32 2
   store i64 %arg2, ptr %10, align 8
   %11 = call ptr @llvm.preserve.static.offset(ptr %0)
   %12 = getelementptr i8, ptr %11, i64 88
   %arg3 = load volatile i64, ptr %12, align 8
-  %13 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 3
+  %13 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1func_1_args", ptr %args, i64 0, i32 3
   store i64 %arg3, ptr %13, align 8
   %14 = call ptr @llvm.preserve.static.offset(ptr %0)
   %15 = getelementptr i8, ptr %14, i64 72
   %arg4 = load volatile i64, ptr %15, align 8
-  %16 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", ptr %args, i64 0, i32 4
+  %16 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1func_1_args", ptr %args, i64 0, i32 4
   store i64 %arg4, ptr %16, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -40,28 +40,6 @@ void test(const std::string &input, bool ok = true)
 
 class field_analyser_btf : public test_btf {};
 
-TEST_F(field_analyser_btf, fentry_args)
-{
-  // func_1 and func_2 have different args, but none of them
-  // is used in probe code, so we're good -> PASS
-  test("fentry:func_1, fentry:func_2 { }", true);
-  // func_1 and func_2 have different args, one of them
-  // is used in probe code, we can't continue -> FAIL
-  test("fentry:func_1, fentry:func_2 { $x = args.foo; }", false);
-  // func_2 and func_3 have same args -> PASS
-  test("fentry:func_2, fentry:func_3 { }", true);
-  // func_2 and func_3 have same args -> PASS
-  test("fentry:func_2, fentry:func_3 { $x = args.foo1; }", true);
-  // aaa does not exist -> FAIL
-  test("fentry:func_2, fentry:aaa { $x = args.foo1; }", false);
-  // func_* have different args, but none of them
-  // is used in probe code, so we're good -> PASS
-  test("fentry:func_* { }", true);
-  // func_* have different args, one of them
-  // is used in probe code, we can't continue -> FAIL
-  test("fentry:func_* { $x = args.foo1; }", false);
-}
-
 TEST_F(field_analyser_btf, btf_types)
 {
   auto bpftrace = get_mock_bpftrace();
@@ -400,34 +378,6 @@ TEST_F(field_analyser_btf, btf_anon_union_first_in_struct)
 #ifdef HAVE_LIBDW
 
 class field_analyser_dwarf : public test_dwarf {};
-
-TEST_F(field_analyser_dwarf, uprobe_args)
-{
-  std::string uprobe = "uprobe:" + std::string(bin_);
-  test(uprobe + ":func_1 { $x = args.a; }", true);
-  test(uprobe + ":func_2 { $x = args.b; }", true);
-  // Backwards compatibility
-  test(uprobe + ":func_1 { $x = args->a; }", true);
-
-  // func_1 and func_2 have different args, but none of them
-  // is used in probe code, so we're good -> PASS
-  test(uprobe + ":func_1, " + uprobe + ":func_2 { }", true);
-  // func_1 and func_2 have different args, one of them
-  // is used in probe code, we can't continue -> FAIL
-  test(uprobe + ":func_1, " + uprobe + ":func_2 { $x = args.a; }", false);
-  // func_2 and func_3 have same args -> PASS
-  test(uprobe + ":func_2, " + uprobe + ":func_3 { }", true);
-  test(uprobe + ":func_2, " + uprobe + ":func_3 { $x = args.a; }", true);
-
-  // Probes with wildcards (need non-mock BPFtrace)
-  BPFtrace bpftrace;
-  // func_* have different args, but none of them
-  // is used in probe code, so we're good -> PASS
-  test(bpftrace, uprobe + ":func_* { }", true);
-  // func_* have different args, one of them
-  // is used in probe code, we can't continue -> FAIL
-  test(bpftrace, uprobe + ":func_* { $x = args.a; }", false);
-}
 
 TEST_F(field_analyser_dwarf, parse_struct)
 {

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -4657,11 +4657,8 @@ kprobe:f { @map[0] = 1; for ($kv : @map) { arg0 } }
 
 TEST_F(SemanticAnalyserBTFTest, args_builtin_mixed_probes)
 {
-  test("fentry:func_1,tracepoint:sched:sched_one { args }", Error{ R"(
-stdin:1:44-48: ERROR: The args builtin can only be used within the context of a single probe type, e.g. "probe1 {args}" is valid while "probe1,probe2 {args}" is not.
-fentry:func_1,tracepoint:sched:sched_one { args }
-                                           ~~~~
-)" });
+  // Should separate each of these into their own programs
+  test("fentry:func_1,tracepoint:sched:sched_one { args }");
 }
 
 TEST_F(SemanticAnalyserBTFTest, binop_late_ptr_resolution)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4694


--- --- ---

### Duplicate probe ASTs that use args or retval


In cases where there are multiple attachpoints
or a wildcard in the attachpoint and there is a use
of the `args` or `retval` builtins instead
of issuing an error if the types for these are
not uniform then automatically duplicate the entire
probe by attachpoint so the `args` or `retval`
size types are unique for each of these duplicated
probes.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>