### PR TITLE
Fix `nix build` in presence of submodules

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -9,9 +9,11 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   build-and-upload:
+    name: ${{ (github.event_name == 'pull_request' && 'build' || 'build-and-upload') }} (${{ matrix.runner }})
     strategy:
       matrix:
         runner: [ubuntu-latest, ubuntu-24.04-arm]
@@ -33,10 +35,11 @@ jobs:
 
     - name: Build appimage
       run: |
-        nix build .#appimage
+        nix build .?submodules=1#appimage
         cp ./result bpftrace
 
     - name: Upload appimage
+      if: github.event_name == 'push' && github.ref == 'refs/heads/master'
       uses: actions/upload-artifact@v4
       with:
         name: bpftrace-${{ runner.arch }}

--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -27,6 +27,7 @@ if (USE_SYSTEM_LIBBPF)
     (preferred) or install the libbpf.a static library")
 else()
   set(LIBBPF_SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/libbpf/src)
+  file(GLOB LIBBPF_SRCS ${LIBBPF_SOURCE}/*)
   set(LIBBPF_BUILD ${CMAKE_CURRENT_BINARY_DIR}/libbpf)
   set(LIBBPF_LIBRARY ${LIBBPF_BUILD}/lib64/libbpf.a)
 
@@ -50,7 +51,7 @@ else()
     # -fPIE here is needed by latest binutils when building with Clang
     COMMAND make PREFIX=${LIBBPF_BUILD} EXTRA_CFLAGS="-fPIE" install > /dev/null
     WORKING_DIRECTORY ${LIBBPF_SOURCE}
-    DEPENDS ${LIBBPF_SOURCE}/*
+    DEPENDS ${LIBBPF_SRCS}
     COMMENT "Building libbpf"
     VERBATIM)
   add_custom_target(libbpf_build DEPENDS ${LIBBPF_LIBRARY})


### PR DESCRIPTION
The "Binary" GHA workflow runs `nix build` to create an AppImage. With the recent introduction of the libbpf submodule, we need to explicitly tell Nix to fetch also submodule sources, otherwise the build fails.
    
In addition, to catch similar problems earlier in future, run the "Binary" workflow for pull requests, too, just without the artifact upload part.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
