### PR TITLE
ArgsResolver: Fix detection of stack-passed args

### DIFF
--- a/src/ast/passes/args_resolver.cpp
+++ b/src/ast/passes/args_resolver.cpp
@@ -76,7 +76,7 @@ Result<std::shared_ptr<Struct>> ArgsResolver::resolve_args(
       Dwarf *dwarf = bpftrace_.get_dwarf(ap.target);
       if (dwarf) {
         auto args = dwarf->resolve_args(ap.func);
-        if (args && args->fields.size() >= arch::Host::arguments().size()) {
+        if (args && args->fields.size() > arch::Host::arguments().size()) {
           return make_error<ast::ArgParseError>(
               ap.name(),
               "\'args\' builtin is not supported for probes with stack-passed "


### PR DESCRIPTION
The condition for checking whether a function has stack-passed arguments has off-by-one error and rejects usage of the `args` builtin on functions that have the number of parameters equal to the number of register-passed arguments on the given architecture.

This makes tests working with `func_1` from data_source.c fail on s390x since s390x passes only 5 arguments via registers (and the function has 5 parameters).

Fix the off-by-one error.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
