### PR TITLE
Fix bitfield in struct (#2801)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Add bitfield support when printing full structure using "print()"
+  - [#2801](https://github.com/bpftrace/bpftrace/issues/2801)
 #### Security
 #### Docs
 #### Tools

--- a/src/struct.h
+++ b/src/struct.h
@@ -33,15 +33,6 @@ struct Bitfield {
   // Then logical AND `mask` to mask out everything but this bitfield
   uint64_t mask;
 
-private:
-  friend class cereal::access;
-  template <typename Archive>
-  void serialize(Archive &archive)
-  {
-    archive(read_bytes, access_rshift, mask);
-  }
-
-public:
   template <typename T>
   bpftrace::util::OpaqueValue to_opaque(
       const bpftrace::util::OpaqueValue &data) const
@@ -56,6 +47,14 @@ public:
 
     return bpftrace::util::OpaqueValue::from<T>(
         (data.bitcast<T>() >> rshiftbits) & static_cast<T>(mask));
+  }
+
+private:
+  friend class cereal::access;
+  template <typename Archive>
+  void serialize(Archive &archive)
+  {
+    archive(read_bytes, access_rshift, mask);
   }
 };
 

--- a/src/struct.h
+++ b/src/struct.h
@@ -8,6 +8,7 @@
 #include "ast/ast.h"
 #include "types.h"
 #include "util/hash.h"
+#include "util/opaque.h"
 
 namespace bpftrace {
 
@@ -38,6 +39,23 @@ private:
   void serialize(Archive &archive)
   {
     archive(read_bytes, access_rshift, mask);
+  }
+
+public:
+  template <typename T>
+  bpftrace::util::OpaqueValue to_opaque(
+      const bpftrace::util::OpaqueValue &data) const
+  {
+    size_t rshiftbits;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    rshiftbits = access_rshift;
+#else
+    rshiftbits = (data.size() - read_bytes) * 8;
+    rshiftbits += access_rshift;
+#endif
+
+    return bpftrace::util::OpaqueValue::from<T>(
+        (data.bitcast<T>() >> rshiftbits) & static_cast<T>(mask));
   }
 };
 

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -157,6 +157,29 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
       output::Primitive::Record record;
       for (auto &field : type.GetFields()) {
         auto elem_data = value.slice(field.offset, field.type.GetSize());
+
+        if (field.bitfield) {
+          auto bf = field.bitfield.value_or(Bitfield{});
+
+          switch (field.type.GetIntBitWidth()) {
+            case 64:
+              elem_data = bf.to_opaque<uint64_t>(elem_data);
+              break;
+            case 32:
+              elem_data = bf.to_opaque<uint32_t>(elem_data);
+              break;
+            case 16:
+              elem_data = bf.to_opaque<uint16_t>(elem_data);
+              break;
+            case 8:
+              elem_data = bf.to_opaque<uint8_t>(elem_data);
+              break;
+            default:
+              // This type cannot be handled.
+              return make_error<TypeFormatError>(type);
+          }
+        }
+
         auto val = format(bpftrace, c_definitions, field.type, elem_data, div);
         if (!val) {
           return val.takeError();

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -159,8 +159,7 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
         auto elem_data = value.slice(field.offset, field.type.GetSize());
 
         if (field.bitfield) {
-          auto bf = field.bitfield.value_or(Bitfield{});
-
+          auto bf = *field.bitfield;
           switch (field.type.GetIntBitWidth()) {
             case 64:
               elem_data = bf.to_opaque<uint64_t>(elem_data);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(bpftrace_test
   ast_matchers.cpp
   attached_probe.cpp
   attachpoint_passes.cpp
+  bitfield.cpp
   bpfbytecode.cpp
   bpftrace.cpp
   btf.cpp

--- a/tests/bitfield.cpp
+++ b/tests/bitfield.cpp
@@ -1,0 +1,45 @@
+#include "struct.h"
+#include "util/opaque.h"
+#include "gtest/gtest.h"
+#include <unistd.h>
+
+namespace bpftrace::test::bitfield {
+
+TEST(bitfield, to_opaque)
+{
+  auto data = bpftrace::util::OpaqueValue::from<uint8_t>(0xff);
+  auto bf = bpftrace::Bitfield{ 1, 0, 0x1 };
+  EXPECT_EQ(bf.to_opaque<uint8_t>(data),
+            bpftrace::util::OpaqueValue::from<uint8_t>(0x1));
+
+  bf = bpftrace::Bitfield{ 1, 0, 0x3 };
+  EXPECT_EQ(bf.to_opaque<uint8_t>(data),
+            bpftrace::util::OpaqueValue::from<uint8_t>(0x3));
+
+  // test other data types
+  data = bpftrace::util::OpaqueValue::from<uint16_t>(0x0304);
+  bf = bpftrace::Bitfield{ 2, 8, 0xf };
+  EXPECT_EQ(bf.to_opaque<uint16_t>(data),
+            bpftrace::util::OpaqueValue::from<uint16_t>(0x3));
+
+  data = bpftrace::util::OpaqueValue::from<uint32_t>(0x01020304);
+  bf = bpftrace::Bitfield{ 4, 8, 0xf };
+  EXPECT_EQ(bf.to_opaque<uint32_t>(data),
+            bpftrace::util::OpaqueValue::from<uint32_t>(0x3));
+
+  data = bpftrace::util::OpaqueValue::from<uint64_t>(0x0102030405060708);
+  bf = bpftrace::Bitfield{ 8, 40, 0xf };
+  EXPECT_EQ(bf.to_opaque<uint64_t>(data),
+            bpftrace::util::OpaqueValue::from<uint64_t>(0x3));
+}
+
+TEST(bitfield, to_opaque_boundary)
+{
+  // test crossing the byte boundary
+  auto data = bpftrace::util::OpaqueValue::from<uint32_t>(0x01020304);
+  auto bf = bpftrace::Bitfield{ 4, 6, 0xf };
+  EXPECT_EQ(bf.to_opaque<uint32_t>(data),
+            bpftrace::util::OpaqueValue::from<uint32_t>(0xc));
+}
+
+} // namespace bpftrace::test::bitfield

--- a/tests/runtime/struct
+++ b/tests/runtime/struct
@@ -45,3 +45,7 @@ PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s = (1, *(
 EXPECT @s: (1, { .m = 2, .n = 3 })
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
+
+NAME struct with bitfield
+PROG struct foo { unsigned long long x_0:1; unsigned long long x_1:1; unsigned long long x_2:2; } begin { $val = (uint64)0x1e; $f = *(struct foo *)(&$val); print($f); }
+EXPECT { .x_0 = 0, .x_1 = 1, .x_2 = 3 }

--- a/tests/runtime/struct
+++ b/tests/runtime/struct
@@ -49,3 +49,4 @@ AFTER ./testprogs/simple_struct
 NAME struct with bitfield
 PROG struct foo { unsigned long long x_0:1; unsigned long long x_1:1; unsigned long long x_2:2; } begin { $val = (uint64)0x1e; $f = *(struct foo *)(&$val); print($f); }
 EXPECT { .x_0 = 0, .x_1 = 1, .x_2 = 3 }
+


### PR DESCRIPTION
Add bitfield support when printing full structure using "print()".

The recursive format() function is based on the field type. In the case of bitfield, the field type is undistinguishable from an integer type. This results in every bitfield printing out as an integer.

The fix is to check that the optional "bitfield" exists, mask out the necessary bits, before recurse to the field level format().

**Unit Test**

```
./build/tests/bpftrace_test --gtest_filter=bitfield.*

[==========] Running 2 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 2 tests from bitfield
[ RUN      ] bitfield.to_opaque
[       OK ] bitfield.to_opaque (0 ms)
[ RUN      ] bitfield.to_opaque_boundary
[       OK ] bitfield.to_opaque_boundary (0 ms)
```

**Runtime Test**

```
sudo ./build/tests/runtime-tests.sh --filter="struct with bitfield"

[==========] Running 1 tests from 1 test cases.

[----------] 1 tests from struct
[ RUN      ] struct.struct with bitfield
[       OK ] struct.struct with bitfield (423 ms)
[----------] 1 tests from struct

[==========] 1 tests from 1 test cases ran. (423 ms total)
[  PASSED  ] 1 tests.
```

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ x] The new behaviour is covered by tests
