### PR TITLE
kprobe: Add suport for attaching kprobes via source location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- Add `kprobe` support for source location attachpoints.
+  - [#5115](https://github.com/bpftrace/bpftrace/pull/5115)
 - Extend support for DWARF formats
   - [#5095](https://github.com/bpftrace/bpftrace/pull/5095)
 - Ternary operator supports an empty second operand.

--- a/docs/language.md
+++ b/docs/language.md
@@ -1236,6 +1236,7 @@ fexit:fget {
 * `kprobe[:module]:fn`
 * `kprobe[:module]:fn+offset`
 * `kprobe:addr`
+* `kprobe@file:line[:col]`
 * `kretprobe[:module]:fn`
 * `kretprobe:addr`
 
@@ -1319,6 +1320,16 @@ kretprobe:d_lookup
 {
 	printf("%-8d %-6d %-16s M %s\n", elapsed / 1e6, pid, comm,
 	    str(@fname[tid]));
+}
+```
+
+If DWARF debugging symbols are availaible for kernel and/or kernel modules, `kprobe` s can be attached via `file:line[:col]` source file location, requiring the `--unsafe` flag. `file` path may be absolute or relative, and `line:col` must refer to a valid statement in that file. Useful for probing inside a functions body.
+
+```
+kprobe@fs/open.c:1077
+{
+  printf("0x%lx\n", reg("ip"));
+  exit();
 }
 ```
 

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -39,8 +39,12 @@ private:
 void AttachPointChecker::visit(AttachPoint &ap)
 {
   if (ap.provider == "kprobe" || ap.provider == "kretprobe") {
-    if (ap.func.empty() && ap.address == 0)
-      ap.addError() << "kprobes should be attached to a function or an address";
+    if (ap.func.empty() && ap.address == 0 &&
+        (ap.source_file.empty() || ap.line_num == 0))
+      ap.addError() << "kprobes should be attached to a function"
+                    << (bpftrace_.get_dwarf(ap)
+                            ? ", address, or source file and line (using DWARF)"
+                            : " or an address");
     // Warn if user tries to attach to a non-traceable function
     if (bpftrace_.config_->missing_probes != ConfigMissingProbes::ignore &&
         !util::has_wildcard(ap.func) && !ap.func.empty() &&
@@ -540,7 +544,7 @@ AttachPointParser::State AttachPointParser::lex_attachpoint(
       }
     } else if (raw[idx] == '"') {
       in_quotes = !in_quotes;
-    // Handle escaped characters in a string
+      // Handle escaped characters in a string
     } else if (in_quotes && raw[idx] == '\\' && (idx + 1 < raw.size())) {
       argument += raw[idx + 1];
       ++idx;
@@ -641,14 +645,71 @@ AttachPointParser::State AttachPointParser::benchmark_parser()
   return OK;
 }
 
-AttachPointParser::State AttachPointParser::kprobe_parser(bool allow_offset)
+AttachPointParser::State AttachPointParser::kprobe_parser(bool allow_offset,
+                                                          bool allow_src_loc)
 {
   auto num_parts = parts_.size();
-  if (num_parts != 2 && num_parts != 3) {
+  // kprobe attached by source code location (kprobe@source_file:line[:col])
+  const bool source_location = num_parts > 1 && parts_[1] == "@";
+  if (!source_location && num_parts != 2 && num_parts != 3) {
     if (ap_->ignore_invalid)
       return SKIP;
 
     return argument_count_error(1, 2);
+  }
+
+  if (source_location) {
+    if (!allow_src_loc) {
+      errs_ << "Source code location not allowed" << std::endl;
+      return INVALID;
+    }
+
+    if ((parts_.size() != 4 && parts_.size() != 5) ||
+        (parts_[2].empty() || parts_[3].empty())) {
+      errs_ << "Invalid kprobe arguments, "
+            << "expected format: kprobe:TARGET@FILE:LINE[:COL]" << std::endl;
+      return INVALID;
+    }
+
+    ap_->source_file = parts_[2];
+
+    auto line = util::to_uint(parts_[3]);
+    if (!line) {
+      errs_ << "Invalid line number: " << line.takeError() << std::endl;
+      return INVALID;
+    }
+    ap_->line_num = *line;
+
+    if (parts_.size() == 5) {
+      auto col = util::to_uint(parts_[4]);
+      if (!col) {
+        errs_ << "Invalid column number: " << col.takeError() << std::endl;
+        return INVALID;
+      }
+      ap_->col_num = *col;
+    }
+
+    Dwarf *dwarf = bpftrace_.get_dwarf(*ap_);
+    if (dwarf) {
+      auto address = dwarf->line_to_addr(ap_->source_file,
+                                         ap_->line_num,
+                                         ap_->col_num);
+      if (!address) {
+        errs_ << address.takeError() << std::endl;
+        return INVALID;
+      }
+      if (bpftrace_.safe_mode_) {
+        errs_ << "Probing by source location requires --unsafe" << std::endl;
+        return INVALID;
+      }
+      ap_->address = *address;
+
+      return OK;
+    }
+
+    errs_ << "No DWARF debug info found for kernel, cannot attach "
+          << "by source code location." << std::endl;
+    return INVALID;
   }
 
   auto func_idx = 1;
@@ -709,7 +770,7 @@ AttachPointParser::State AttachPointParser::kprobe_parser(bool allow_offset)
 
 AttachPointParser::State AttachPointParser::kretprobe_parser()
 {
-  return kprobe_parser(false);
+  return kprobe_parser(false, false);
 }
 
 AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,

--- a/src/ast/passes/attachpoint_passes.h
+++ b/src/ast/passes/attachpoint_passes.h
@@ -62,7 +62,7 @@ private:
   State special_parser();
   State test_parser();
   State benchmark_parser();
-  State kprobe_parser(bool allow_offset = true);
+  State kprobe_parser(bool allow_offset = true, bool allow_src_loc = true);
   State kretprobe_parser();
   State uprobe_parser(bool allow_offset = true, bool allow_src_loc = true);
   State uretprobe_parser();

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1442,6 +1442,13 @@ Result<uint64_t> BPFtrace::get_buffer_pages_per_cpu() const
   return get_buffer_pages(true);
 }
 
+Dwarf *BPFtrace::get_kernel_dwarf()
+{
+  if (!kernel_dwarf_)
+    kernel_dwarf_ = Dwarf::GetFromKernel(this, debuginfo_path_);
+  return kernel_dwarf_.get();
+}
+
 Dwarf *BPFtrace::get_dwarf(const std::string &filename)
 {
   auto dwarf = dwarves_.find(filename);
@@ -1457,10 +1464,12 @@ Dwarf *BPFtrace::get_dwarf(const std::string &filename)
 Dwarf *BPFtrace::get_dwarf(const ast::AttachPoint &attachpoint)
 {
   auto probe_type = probetype(attachpoint.provider);
-  if (probe_type != ProbeType::uprobe && probe_type != ProbeType::uretprobe)
-    return nullptr;
+  if (probe_type == ProbeType::uprobe || probe_type == ProbeType::uretprobe)
+    return get_dwarf(attachpoint.target);
+  if (probe_type == ProbeType::kprobe || probe_type == ProbeType::kretprobe)
+    return get_kernel_dwarf();
 
-  return get_dwarf(attachpoint.target);
+  return nullptr;
 }
 
 int BPFtrace::create_pcaps()

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -44,6 +44,9 @@ using util::symbol;
 
 const int timeout_ms = 100;
 
+constexpr auto default_debuginfo_paths =
+    ":.debug:/usr/lib/debug:/lib/debug/boot";
+
 enum class DebugStage;
 
 // globals
@@ -172,6 +175,7 @@ public:
   bool write_pcaps(uint64_t id, uint64_t ns, const OpaqueValue &pkt);
   void parse_module_btf(const std::set<std::string> &modules);
   bool has_btf_data() const;
+  Dwarf *get_kernel_dwarf();
   Dwarf *get_dwarf(const std::string &filename);
   Dwarf *get_dwarf(const ast::AttachPoint &attachpoint);
   std::set<std::string> list_modules(const ast::ASTContext &ctx,
@@ -265,6 +269,7 @@ private:
   uint64_t event_loss_count_ = 0;
 
   std::unordered_map<std::string, std::unique_ptr<Dwarf>> dwarves_;
+  std::unique_ptr<Dwarf> kernel_dwarf_;
 };
 
 } // namespace bpftrace

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -75,6 +75,54 @@ std::unique_ptr<Dwarf> Dwarf::GetFromBinary(BPFtrace *bpftrace,
   return dwarf;
 }
 
+static int kernel_module_section_address(Dwfl_Module *mod,
+                                         void **userdata,
+                                         const char *modname,
+                                         Dwarf_Addr base,
+                                         const char *secname,
+                                         Elf32_Word shndx,
+                                         const GElf_Shdr *shdr,
+                                         Dwarf_Addr *addr)
+{
+  if (std::string_view(secname) == "__versions") {
+    *addr = static_cast<Dwarf_Addr>(-1L);
+    return DWARF_CB_OK;
+  }
+
+  return dwfl_linux_kernel_module_section_address(
+      mod, userdata, modname, base, secname, shndx, shdr, addr);
+}
+
+Dwarf::Dwarf(BPFtrace *bpftrace, std::string debuginfo_path)
+    : bpftrace_(bpftrace),
+      debuginfo_path_(std::move(debuginfo_path)),
+      is_kernel(true)
+{
+  debuginfo_path_cstr_ = debuginfo_path_.c_str();
+  callbacks.find_elf = dwfl_linux_kernel_find_elf;
+  callbacks.find_debuginfo = dwfl_standard_find_debuginfo;
+  // Wrapper callback preventing libdw to mistakenly fail due to missing
+  // __versions section in /sys/module/<name>/sections/ at runtime.
+  callbacks.section_address = kernel_module_section_address;
+  callbacks.debuginfo_path = const_cast<char **>(&debuginfo_path_cstr_);
+  dwfl = dwfl_begin(&callbacks);
+  dwfl_linux_kernel_report_kernel(dwfl);
+  dwfl_linux_kernel_report_modules(dwfl);
+  dwfl_report_end(dwfl, nullptr, nullptr);
+}
+
+std::unique_ptr<Dwarf> Dwarf::GetFromKernel(BPFtrace *bpftrace,
+                                            const std::string &debuginfo_path)
+{
+  std::unique_ptr<Dwarf> dwarf(new Dwarf(bpftrace, debuginfo_path));
+  Dwarf_Addr bias;
+
+  if (dwfl_nextcu(dwarf->dwfl, nullptr, &bias) == nullptr)
+    return nullptr;
+
+  return dwarf;
+}
+
 Dwarf::~Dwarf()
 {
   dwfl_end(dwfl);
@@ -82,8 +130,7 @@ Dwarf::~Dwarf()
 
 bool Dwarf::next_cu_info(CuInfo *cu_info) const
 {
-  Dwarf_Addr cubias;
-  cu_info->cudie = dwfl_nextcu(dwfl, cu_info->cudie, &cubias);
+  cu_info->cudie = dwfl_nextcu(dwfl, cu_info->cudie, &cu_info->mod_bias);
   if (cu_info->cudie == nullptr)
     return false;
 
@@ -605,7 +652,8 @@ Result<uint64_t> Dwarf::line_to_addr(const std::string &source_file,
         (col_num == 0 || col_num == static_cast<size_t>(linecol))) {
       Dwarf_Addr addr;
       if (dwarf_lineaddr(line, &addr) == 0) {
-        return addr;
+        // Add KASLR offset if in kernel mode
+        return is_kernel ? addr + cu->mod_bias : addr;
       }
     }
   }

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -84,7 +84,16 @@ static int kernel_module_section_address(Dwfl_Module *mod,
                                          const GElf_Shdr *shdr,
                                          Dwarf_Addr *addr)
 {
-  if (std::string_view(secname) == "__versions") {
+  const std::string_view section(secname);
+
+  // The kernel does not expose these sections in
+  // /sys/module/<name>/sections after loading. Older libdwfl versions either
+  // do not recognize __versions or check the legacy .data.percpu spelling
+  // instead of the .data..percpu spelling used by affected modules.
+  // A zero-sized section has no runtime contents or address to resolve.
+  if ((shdr != nullptr && shdr->sh_size == 0) ||
+      section == "__versions" ||
+      section == ".data..percpu") {
     *addr = static_cast<Dwarf_Addr>(-1L);
     return DWARF_CB_OK;
   }
@@ -101,8 +110,10 @@ Dwarf::Dwarf(BPFtrace *bpftrace, std::string debuginfo_path)
   debuginfo_path_cstr_ = debuginfo_path_.c_str();
   callbacks.find_elf = dwfl_linux_kernel_find_elf;
   callbacks.find_debuginfo = dwfl_standard_find_debuginfo;
-  // Wrapper callback preventing libdw to mistakenly fail due to missing
-  // __versions section in /sys/module/<name>/sections/ at runtime.
+  // Wrapper callback preventing libdw from failing when a loaded module does
+  // not expose a section that has no runtime contents or address. All other
+  // sections are still handled by the standard libdwfl kernel module
+  // callback.
   callbacks.section_address = kernel_module_section_address;
   callbacks.debuginfo_path = const_cast<char **>(&debuginfo_path_cstr_);
   dwfl = dwfl_begin(&callbacks);

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -54,6 +54,10 @@ public:
       const std::string &file_path,
       const std::string &debuginfo_path);
 
+  static std::unique_ptr<Dwarf> GetFromKernel(
+      BPFtrace *bpftrace,
+      const std::string &debuginfo_path);
+
   std::vector<std::string> get_function_params(
       const std::string &function) const;
   std::shared_ptr<Struct> resolve_args(const std::string &function);
@@ -82,6 +86,8 @@ private:
     // automatically resolves references between the skeleton and split CU.
     std::optional<Dwarf_Die> split_cudie;
 
+    Dwarf_Addr mod_bias = 0;
+
     // Returns split CU DIE if present (skeleton CU), otherwise cudie.
     Dwarf_Die *cu_die()
     {
@@ -92,6 +98,7 @@ private:
   Dwarf(BPFtrace *bpftrace,
         const std::string &file_path,
         std::string debuginfo_path);
+  Dwarf(BPFtrace *bpftrace, std::string debuginfo_path);
 
   bool next_cu_info(CuInfo *cu_info) const;
   std::vector<Dwarf_Die> function_param_dies(const std::string &function) const;
@@ -133,6 +140,7 @@ private:
   // char** to Dwfl_Callbacks.
   std::string debuginfo_path_;
   const char *debuginfo_path_cstr_;
+  bool is_kernel = false;
 };
 
 } // namespace bpftrace
@@ -150,6 +158,14 @@ public:
   static std::unique_ptr<Dwarf> GetFromBinary(BPFtrace *bpftrace
                                               __attribute__((unused)),
                                               const std::string &file_path_
+                                              __attribute__((unused)),
+                                              const std::string &debuginfo_path
+                                              __attribute__((unused)))
+  {
+    return nullptr;
+  }
+
+  static std::unique_ptr<Dwarf> GetFromKernel(BPFtrace *bpftrace
                                               __attribute__((unused)),
                                               const std::string &debuginfo_path
                                               __attribute__((unused)))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -883,7 +883,7 @@ int main(int argc, char* argv[])
   bpftrace.run_tests_ = args.mode == Mode::BPF_TEST;
   bpftrace.run_benchmarks_ = args.mode == Mode::BPF_BENCHMARK;
   bpftrace.probe_filter_ = args.probe_filter;
-  bpftrace.debuginfo_path_ = args.debuginfo_path;
+  bpftrace.debuginfo_path_ = args.debuginfo_path + default_debuginfo_paths;
 
   if (!args.pid_str.empty()) {
     auto maybe_pid = util::to_uint(args.pid_str);

--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -104,6 +104,23 @@ TEST(attachpoint_parser, uprobe_lang)
   test_uprobe_lang("uprobe:cpp:main { 1 }", "cpp");
 }
 
+TEST(attachpoint_parser, kprobe_src_loc)
+{
+  test_error(
+      "kprobe@fs/open.c: { 1 }",
+      R"(Invalid kprobe arguments, expected format: kprobe:TARGET@FILE:LINE[:COL])");
+  test_error(
+      "kprobe@fs/open.c:1077:1:2 { 1 }",
+      R"(Invalid kprobe arguments, expected format: kprobe:TARGET@FILE:LINE[:COL])");
+  test_error("kprobe@fs/open.c:invalid { 1 }",
+             R"(Invalid line number: invalid integer: invalid)");
+  test_error("kprobe@fs/open.c:1077:invalid { 1 }",
+             R"(Invalid column number: invalid integer: invalid)");
+  test_error("kprobe@fs/open.c:1077: { 1 }", R"(Invalid column number:)");
+  test_error("kretprobe@fs/open.c:1077 { 1 }",
+             R"(Source code location not allowed)");
+}
+
 #ifdef HAVE_LIBDW
 
 class attachpoint_parser_dwarf : public test_dwarf {};


### PR DESCRIPTION
This commit introduces support of DWARF debuginfo parsing for kernel and its modules, enabling kprobes to be attached using source location, similiar to the uprobe variant introduced in (#4867)[https://github.com/bpftrace/bpftrace/pull/4867].

If the necessary DWARF files are availabile (`vmlinux` for running kernel, `*.ko`/`*.ko.zst` for loaded modules), kprobes can be attached via the `kprobe@FILE:LINE[:COL]` syntax. Kernel modules must be loaded prior to attachment, as DWARF information is only parsed for currently loaded modules.

Examples:

```
kprobe@br.c:29 {...}
kprobe@fs/vfs_open:1077 {...}
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
