### PR TITLE
Enable xz feature in blazesym

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,7 @@
           # Build blazesym
           blazesym_c = naersk.lib.${system}.buildPackage {
             root = blazesym;
-            cargoBuildOptions = x: x ++ [ "-p" "blazesym-c" ];
+            cargoBuildOptions = x: x ++ [ "-p" "blazesym-c" "--features" "blazesym/xz" ];
             copyLibs = true;
             postInstall = ''
               # Export C headers


### PR DESCRIPTION
With xz enabled, blazesym also pulls symbols from the ELF .gnu_debugdata section. This enables stack symbolication especially in redhat-based-environments.

Not sure if we need a test for this here, as it is covered by a test in blazesym.

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [?] The new behaviour is covered by tests
