### PR TITLE
Refactor: extract parsed type funcs from types.cpp

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(ast STATIC
   passes/named_param.cpp
   passes/types/ast_transformer.cpp
   passes/types/cast_creator.cpp
+  passes/types/parsed_type_bridge.cpp
   passes/config_analyser.cpp
   passes/control_flow_analyser.cpp
   passes/deprecated.cpp

--- a/src/ast/passes/types/cast_creator.cpp
+++ b/src/ast/passes/types/cast_creator.cpp
@@ -2,6 +2,7 @@
 #include "ast/ast.h"
 #include "ast/integer_types.h"
 #include "ast/passes/map_sugar.h"
+#include "ast/passes/types/parsed_type_bridge.h"
 #include "ast/passes/types/type_map.h"
 #include "ast/visitor.h"
 #include "bpftrace.h"

--- a/src/ast/passes/types/parsed_type_bridge.cpp
+++ b/src/ast/passes/types/parsed_type_bridge.cpp
@@ -1,0 +1,92 @@
+#include "ast/passes/types/parsed_type_bridge.h"
+
+#include <cassert>
+
+#include "ast/ast.h"
+
+namespace bpftrace {
+
+namespace {
+
+constexpr std::string_view STRUCT_PREFIX = "struct ";
+constexpr std::string_view UNION_PREFIX = "union ";
+
+} // namespace
+
+SizedType parsed_type_to_sized_type(const ast::ParsedType &type)
+{
+  switch (type.kind) {
+    case ast::ParsedType::Kind::Identifier:
+      if (auto bt = ident_to_builtin_type(type.name)) {
+        return *bt;
+      }
+      return CreateCStruct(type.name);
+    case ast::ParsedType::Kind::Struct:
+    case ast::ParsedType::Kind::Union:
+      return CreateCStruct(type.type_name());
+    case ast::ParsedType::Kind::Enum:
+      return CreateEnum(64, type.name);
+    case ast::ParsedType::Kind::Pointer:
+      assert(type.inner);
+      return CreatePointer(parsed_type_to_sized_type(*type.inner));
+    case ast::ParsedType::Kind::Array:
+      assert(type.inner);
+      return normalize_array_to_sized_type(
+          CreateArray(type.array_size, parsed_type_to_sized_type(*type.inner)));
+  }
+
+  return CreateNone();
+}
+
+ast::ParsedType *sized_type_to_parsed_type(ast::ASTContext &ctx,
+                                           const ast::Location &loc,
+                                           const SizedType &type)
+{
+  if (type.IsPtrTy()) {
+    auto *pointee = sized_type_to_parsed_type(ctx, loc, type.GetPointeeTy());
+    return ctx.make_node<ast::ParsedType>(loc, pointee);
+  }
+
+  if (type.IsArrayTy()) {
+    auto *element = sized_type_to_parsed_type(ctx, loc, type.GetElementTy());
+    return ctx.make_node<ast::ParsedType>(loc, type.GetNumElements(), element);
+  }
+
+  if (type.IsStringTy() || type.IsBufferTy() || type.IsInetTy()) {
+    auto *base = ctx.make_node<ast::ParsedType>(
+        loc, ast::ParsedType::Kind::Identifier, typestr(type.GetTy()));
+    if (type.GetSize() == 0) {
+      return base;
+    }
+    return ctx.make_node<ast::ParsedType>(loc, type.GetSize(), base);
+  }
+
+  if (type.IsEnumTy()) {
+    return ctx.make_node<ast::ParsedType>(loc,
+                                          ast::ParsedType::Kind::Enum,
+                                          type.GetName());
+  }
+
+  if (type.IsCStructTy()) {
+    const auto &name = type.GetName();
+    if (name.starts_with(STRUCT_PREFIX)) {
+      return ctx.make_node<ast::ParsedType>(loc,
+                                            ast::ParsedType::Kind::Struct,
+                                            name.substr(STRUCT_PREFIX.size()));
+    }
+    if (name.starts_with(UNION_PREFIX)) {
+      return ctx.make_node<ast::ParsedType>(loc,
+                                            ast::ParsedType::Kind::Union,
+                                            name.substr(UNION_PREFIX.size()));
+    }
+    return ctx.make_node<ast::ParsedType>(loc,
+                                          ast::ParsedType::Kind::Identifier,
+                                          name);
+  }
+
+  return ctx.make_node<ast::ParsedType>(loc,
+                                        ast::ParsedType::Kind::Identifier,
+                                        typestr(type));
+}
+
+} // namespace bpftrace

--- a/src/ast/passes/types/parsed_type_bridge.h
+++ b/src/ast/passes/types/parsed_type_bridge.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "types.h"
+
+namespace bpftrace::ast {
+class ASTContext;
+class ParsedType;
+class LocationChain;
+using Location = std::shared_ptr<LocationChain>;
+} // namespace bpftrace::ast
+
+namespace bpftrace {
+
+SizedType parsed_type_to_sized_type(const ast::ParsedType &type);
+ast::ParsedType *sized_type_to_parsed_type(ast::ASTContext &ctx,
+                                           const ast::Location &loc,
+                                           const SizedType &type);
+
+} // namespace bpftrace

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -10,6 +10,7 @@
 #include "ast/passes/named_param.h"
 #include "ast/passes/types/ast_transformer.h"
 #include "ast/passes/types/cast_creator.h"
+#include "ast/passes/types/parsed_type_bridge.h"
 #include "ast/passes/types/type_checker.h"
 #include "ast/passes/types/type_map.h"
 #include "ast/passes/types/type_system.h"

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2,7 +2,6 @@
 #include <iostream>
 #include <sstream>
 
-#include "ast/ast.h"
 #include "ast/async_event_types.h"
 #include "struct.h"
 #include "types.h"
@@ -962,84 +961,6 @@ std::ostream &operator<<(std::ostream &os, TSeriesAggFunc agg)
   }
 
   return os;
-}
-
-SizedType parsed_type_to_sized_type(const ast::ParsedType &type)
-{
-  switch (type.kind) {
-    case ast::ParsedType::Kind::Identifier:
-      if (auto bt = ident_to_builtin_type(type.name)) {
-        return *bt;
-      }
-      return CreateCStruct(type.name);
-    case ast::ParsedType::Kind::Struct:
-    case ast::ParsedType::Kind::Union:
-      return CreateCStruct(type.type_name());
-    case ast::ParsedType::Kind::Enum:
-      return CreateEnum(64, type.name);
-    case ast::ParsedType::Kind::Pointer: {
-      assert(type.inner);
-      return CreatePointer(parsed_type_to_sized_type(*type.inner));
-    }
-    case ast::ParsedType::Kind::Array: {
-      assert(type.inner);
-      return normalize_array_to_sized_type(
-          CreateArray(type.array_size, parsed_type_to_sized_type(*type.inner)));
-    }
-  }
-
-  return CreateNone();
-}
-
-ast::ParsedType *sized_type_to_parsed_type(ast::ASTContext &ctx,
-                                           const ast::Location &loc,
-                                           const SizedType &type)
-{
-  if (type.IsPtrTy()) {
-    auto *pointee = sized_type_to_parsed_type(ctx, loc, type.GetPointeeTy());
-    return ctx.make_node<ast::ParsedType>(loc, pointee);
-  }
-
-  if (type.IsArrayTy()) {
-    auto *element = sized_type_to_parsed_type(ctx, loc, type.GetElementTy());
-    return ctx.make_node<ast::ParsedType>(loc, type.GetNumElements(), element);
-  }
-
-  if (type.IsStringTy() || type.IsBufferTy() || type.IsInetTy()) {
-    auto *base = ctx.make_node<ast::ParsedType>(
-        loc, ast::ParsedType::Kind::Identifier, typestr(type.GetTy()));
-    if (type.GetSize() == 0) {
-      return base;
-    }
-    return ctx.make_node<ast::ParsedType>(loc, type.GetSize(), base);
-  }
-
-  if (type.IsEnumTy()) {
-    return ctx.make_node<ast::ParsedType>(loc,
-                                          ast::ParsedType::Kind::Enum,
-                                          type.GetName());
-  }
-
-  if (type.IsCStructTy()) {
-    const auto &name = type.GetName();
-    if (name.starts_with(STRUCT_PREFIX)) {
-      return ctx.make_node<ast::ParsedType>(loc,
-                                            ast::ParsedType::Kind::Struct,
-                                            name.substr(STRUCT_PREFIX.size()));
-    }
-    if (name.starts_with(UNION_PREFIX)) {
-      return ctx.make_node<ast::ParsedType>(loc,
-                                            ast::ParsedType::Kind::Union,
-                                            name.substr(UNION_PREFIX.size()));
-    }
-    return ctx.make_node<ast::ParsedType>(loc,
-                                          ast::ParsedType::Kind::Identifier,
-                                          name);
-  }
-
-  return ctx.make_node<ast::ParsedType>(loc,
-                                        ast::ParsedType::Kind::Identifier,
-                                        typestr(type));
 }
 
 } // namespace bpftrace

--- a/src/types.h
+++ b/src/types.h
@@ -618,18 +618,6 @@ std::optional<SizedType> ident_to_builtin_type(const std::string &name);
 // sized-type interpretation to a later stage.
 SizedType normalize_array_to_sized_type(SizedType type);
 
-namespace ast {
-class ASTContext;
-class LocationChain;
-using Location = std::shared_ptr<LocationChain>;
-class ParsedType;
-} // namespace ast
-
-SizedType parsed_type_to_sized_type(const ast::ParsedType &type);
-ast::ParsedType *sized_type_to_parsed_type(ast::ASTContext &ctx,
-                                           const ast::Location &loc,
-                                           const SizedType &type);
-
 std::optional<SizedType> get_promoted_int(const SizedType &currentType,
                                           const SizedType &newType);
 std::optional<SizedType> get_promoted_tuple(const SizedType &currentType,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(bpftrace_test
   opaque.cpp
   output.cpp
   parser.cpp
+  parsed_type_bridge.cpp
   portability_analyser.cpp
   ap_probe_expansion.cpp
   procmon.cpp

--- a/tests/parsed_type_bridge.cpp
+++ b/tests/parsed_type_bridge.cpp
@@ -1,0 +1,270 @@
+#include "ast/passes/types/parsed_type_bridge.h"
+#include "ast/ast.h"
+#include "ast/context.h"
+#include "ast/location.h"
+#include "ast_matchers.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::parsed_type_bridge {
+
+using namespace bpftrace::ast;
+
+namespace {
+
+Location loc(ASTContext &ctx)
+{
+  return ctx.location(SourceLocation{});
+}
+
+} // namespace
+
+TEST(parsed_type_bridge, parsed_type_to_sized_type_builtin_array)
+{
+  ASTContext ctx;
+  auto *elem = ctx.make_node<ast::ParsedType>(loc(ctx),
+                                              ast::ParsedType::Kind::Identifier,
+                                              "string");
+  auto *type = ctx.make_node<ast::ParsedType>(loc(ctx),
+                                              static_cast<uint64_t>(16),
+                                              elem);
+
+  auto sized = parsed_type_to_sized_type(*type);
+
+  EXPECT_EQ(sized, CreateString(16));
+}
+
+TEST(parsed_type_bridge, parsed_type_to_sized_type_builtin_unsized)
+{
+  ASTContext ctx;
+  auto *type = ctx.make_node<ast::ParsedType>(loc(ctx),
+                                              ast::ParsedType::Kind::Identifier,
+                                              "string");
+
+  auto sized = parsed_type_to_sized_type(*type);
+
+  EXPECT_EQ(sized, CreateString(0));
+}
+
+TEST(parsed_type_bridge, parsed_type_to_sized_type_known_builtin_scalars)
+{
+  ASTContext ctx;
+
+  auto *bool_type = ctx.make_node<ast::ParsedType>(
+      loc(ctx), ast::ParsedType::Kind::Identifier, "bool");
+  EXPECT_EQ(parsed_type_to_sized_type(*bool_type), CreateBool());
+
+  auto *int_type = ctx.make_node<ast::ParsedType>(
+      loc(ctx), ast::ParsedType::Kind::Identifier, "int32");
+  EXPECT_EQ(parsed_type_to_sized_type(*int_type), CreateInt32());
+
+  auto *avg_type = ctx.make_node<ast::ParsedType>(
+      loc(ctx), ast::ParsedType::Kind::Identifier, "avg_t");
+  EXPECT_EQ(parsed_type_to_sized_type(*avg_type), CreateAvg(true));
+
+  auto *uavg_type = ctx.make_node<ast::ParsedType>(
+      loc(ctx), ast::ParsedType::Kind::Identifier, "uavg_t");
+  EXPECT_EQ(parsed_type_to_sized_type(*uavg_type), CreateAvg(false));
+}
+
+TEST(parsed_type_bridge, parsed_type_to_sized_type_pointer_to_struct)
+{
+  ASTContext ctx;
+  auto *pointee = ctx.make_node<ast::ParsedType>(loc(ctx),
+                                                 ast::ParsedType::Kind::Struct,
+                                                 "task_struct");
+  auto *type = ctx.make_node<ast::ParsedType>(loc(ctx), pointee);
+
+  auto sized = parsed_type_to_sized_type(*type);
+
+  EXPECT_EQ(sized, CreatePointer(CreateCStruct("struct task_struct")));
+}
+
+TEST(parsed_type_bridge, parsed_type_to_sized_type_array_of_pointer_to_struct)
+{
+  ASTContext ctx;
+  auto *pointee = ctx.make_node<ast::ParsedType>(loc(ctx),
+                                                 ast::ParsedType::Kind::Struct,
+                                                 "task_struct");
+  auto *ptr = ctx.make_node<ast::ParsedType>(loc(ctx), pointee);
+  auto *type = ctx.make_node<ast::ParsedType>(loc(ctx),
+                                              static_cast<uint64_t>(8),
+                                              ptr);
+
+  auto sized = parsed_type_to_sized_type(*type);
+
+  EXPECT_EQ(sized,
+            CreateArray(8, CreatePointer(CreateCStruct("struct task_struct"))));
+}
+
+TEST(parsed_type_bridge, parsed_type_to_sized_type_array_of_pointer_to_typdef)
+{
+  ASTContext ctx;
+  auto *pointee = ctx.make_node<ast::ParsedType>(
+      loc(ctx), ast::ParsedType::Kind::Identifier, "rand_typedef");
+  auto *ptr = ctx.make_node<ast::ParsedType>(loc(ctx), pointee);
+  auto *type = ctx.make_node<ast::ParsedType>(loc(ctx),
+                                              static_cast<uint64_t>(8),
+                                              ptr);
+
+  auto sized = parsed_type_to_sized_type(*type);
+
+  EXPECT_EQ(sized,
+            CreateArray(8, CreatePointer(CreateCStruct("rand_typedef"))));
+}
+
+TEST(parsed_type_bridge, parsed_type_to_sized_type_pointer_to_pointer)
+{
+  ASTContext ctx;
+  auto *base = ctx.make_node<ast::ParsedType>(loc(ctx),
+                                              ast::ParsedType::Kind::Identifier,
+                                              "int64");
+  auto *inner_ptr = ctx.make_node<ast::ParsedType>(loc(ctx), base);
+  auto *type = ctx.make_node<ast::ParsedType>(loc(ctx), inner_ptr);
+
+  auto sized = parsed_type_to_sized_type(*type);
+
+  EXPECT_EQ(sized, CreatePointer(CreatePointer(CreateInt64())));
+}
+
+TEST(parsed_type_bridge, parsed_type_to_sized_type_void)
+{
+  ASTContext ctx;
+  auto *type = ctx.make_node<ast::ParsedType>(loc(ctx),
+                                              ast::ParsedType::Kind::Identifier,
+                                              "void");
+
+  auto sized = parsed_type_to_sized_type(*type);
+
+  EXPECT_EQ(sized, CreateVoid());
+}
+
+TEST(parsed_type_bridge, sized_type_to_parsed_type_preserves_named_types)
+{
+  ASTContext ctx;
+
+  auto *struct_type = sized_type_to_parsed_type(ctx,
+                                                loc(ctx),
+                                                CreateCStruct("struct sock"));
+  EXPECT_EQ(
+      *struct_type,
+      ast::ParsedType(ctx, loc(ctx), ast::ParsedType::Kind::Struct, "sock"));
+
+  auto *union_type = sized_type_to_parsed_type(ctx,
+                                               loc(ctx),
+                                               CreateCStruct("union foo"));
+  EXPECT_EQ(
+      *union_type,
+      ast::ParsedType(ctx, loc(ctx), ast::ParsedType::Kind::Union, "foo"));
+
+  auto *enum_type = sized_type_to_parsed_type(ctx,
+                                              loc(ctx),
+                                              CreateEnum(64, "bar"));
+  EXPECT_EQ(*enum_type,
+            ast::ParsedType(ctx, loc(ctx), ast::ParsedType::Kind::Enum, "bar"));
+}
+
+TEST(parsed_type_bridge, sized_type_to_parsed_type_known_scalars)
+{
+  ASTContext ctx;
+
+  auto *bool_type = sized_type_to_parsed_type(ctx, loc(ctx), CreateBool());
+  EXPECT_EQ(*bool_type,
+            ast::ParsedType(
+                ctx, loc(ctx), ast::ParsedType::Kind::Identifier, "bool"));
+
+  auto *int_type = sized_type_to_parsed_type(ctx, loc(ctx), CreateInt64());
+  EXPECT_EQ(*int_type,
+            ast::ParsedType(
+                ctx, loc(ctx), ast::ParsedType::Kind::Identifier, "int64"));
+
+  auto *avg_type = sized_type_to_parsed_type(ctx, loc(ctx), CreateAvg(true));
+  EXPECT_EQ(*avg_type,
+            ast::ParsedType(
+                ctx, loc(ctx), ast::ParsedType::Kind::Identifier, "avg_t"));
+
+  auto *uavg_type = sized_type_to_parsed_type(ctx, loc(ctx), CreateAvg(false));
+  EXPECT_EQ(*uavg_type,
+            ast::ParsedType(
+                ctx, loc(ctx), ast::ParsedType::Kind::Identifier, "uavg_t"));
+}
+
+TEST(parsed_type_bridge, sized_type_to_parsed_type_void)
+{
+  ASTContext ctx;
+
+  auto *type = sized_type_to_parsed_type(ctx, loc(ctx), CreateVoid());
+  EXPECT_EQ(*type,
+            ast::ParsedType(
+                ctx, loc(ctx), ast::ParsedType::Kind::Identifier, "void"));
+}
+
+TEST(parsed_type_bridge, sized_type_to_parsed_type_preserves_nested_types)
+{
+  ASTContext ctx;
+
+  auto *type = sized_type_to_parsed_type(
+      ctx, loc(ctx), CreatePointer(CreateArray(4, CreateInt8())));
+
+  EXPECT_THAT(*type,
+              bpftrace::test::ParsedType(ast::ParsedType::Kind::Pointer)
+                  .WithInner(
+                      bpftrace::test::ParsedType(ast::ParsedType::Kind::Array)
+                          .WithArraySize(4)
+                          .WithInner(bpftrace::test::ParsedType(
+                              ast::ParsedType::Kind::Identifier, "int8"))));
+}
+
+TEST(parsed_type_bridge, sized_type_to_parsed_type_pointer_to_pointer)
+{
+  ASTContext ctx;
+
+  auto *type = sized_type_to_parsed_type(
+      ctx, loc(ctx), CreatePointer(CreatePointer(CreateInt64())));
+
+  EXPECT_THAT(*type,
+              bpftrace::test::ParsedType(ast::ParsedType::Kind::Pointer)
+                  .WithInner(
+                      bpftrace::test::ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(bpftrace::test::ParsedType(
+                              ast::ParsedType::Kind::Identifier, "int64"))));
+}
+
+TEST(parsed_type_bridge, sized_type_to_parsed_type_array_of_pointer_to_struct)
+{
+  ASTContext ctx;
+
+  auto *type = sized_type_to_parsed_type(
+      ctx,
+      loc(ctx),
+      CreateArray(4, CreatePointer(CreateCStruct("struct task_struct"))));
+
+  EXPECT_THAT(*type,
+              bpftrace::test::ParsedType(ast::ParsedType::Kind::Array)
+                  .WithArraySize(4)
+                  .WithInner(
+                      bpftrace::test::ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(bpftrace::test::ParsedType(
+                              ast::ParsedType::Kind::Struct, "task_struct"))));
+}
+
+TEST(parsed_type_bridge, sized_type_to_parsed_type_array_of_pointer_to_typedef)
+{
+  ASTContext ctx;
+
+  auto *type = sized_type_to_parsed_type(
+      ctx,
+      loc(ctx),
+      CreateArray(4, CreatePointer(CreateCStruct("rand_typedef"))));
+
+  EXPECT_THAT(*type,
+              bpftrace::test::ParsedType(ast::ParsedType::Kind::Array)
+                  .WithArraySize(4)
+                  .WithInner(
+                      bpftrace::test::ParsedType(ast::ParsedType::Kind::Pointer)
+                          .WithInner(bpftrace::test::ParsedType(
+                              ast::ParsedType::Kind::Identifier,
+                              "rand_typedef"))));
+}
+
+} // namespace bpftrace::test::parsed_type_bridge


### PR DESCRIPTION
Stacked PRs:
 * #5128
 * #5127
 * __->__#5126


--- --- ---

### Refactor: extract parsed type funcs from types.cpp


This is a minor refactor that just extracts out `parsed_type_to_sized_type`
and `sized_type_to_parsed_type` into a separate file to not have to pull
the ast.h into types.h.

Also added unit tests for both functions.

No functional changes.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>