### PR TITLE
Consolidate struct, union, and enum prefix strings

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -351,7 +351,7 @@ std::optional<std::string> Probe::args_typename() const
   if (!name) {
     return std::nullopt;
   }
-  return "struct " + *name + "_args";
+  return std::string(STRUCT_PREFIX) + *name + "_args";
 }
 
 int Probe::index() const

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -299,12 +299,10 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype)
 {
   if (stype.IsCStructTy()) {
     std::string name = stype.GetName();
-    static constexpr std::string_view struct_prefix = "struct ";
-    static constexpr std::string_view union_prefix = "union ";
-    if (name.starts_with(struct_prefix))
-      name = name.substr(struct_prefix.length());
-    else if (name.starts_with(union_prefix))
-      name = name.substr(union_prefix.length());
+    if (name.starts_with(STRUCT_PREFIX))
+      name = name.substr(STRUCT_PREFIX.length());
+    else if (name.starts_with(UNION_PREFIX))
+      name = name.substr(UNION_PREFIX.length());
 
     return createStructType(file,
                             name,

--- a/src/ast/helpers.cpp
+++ b/src/ast/helpers.cpp
@@ -2,6 +2,7 @@
 
 #include "ast/helpers.h"
 #include "log.h"
+#include "types.h"
 
 namespace bpftrace {
 
@@ -32,8 +33,8 @@ bool is_supported_lang(const std::string &lang)
 
 bool is_type_name(std::string_view str)
 {
-  return str.starts_with("struct ") || str.starts_with("union ") ||
-         str.starts_with("enum ");
+  return str.starts_with(STRUCT_PREFIX) || str.starts_with(UNION_PREFIX) ||
+         str.starts_with(ENUM_PREFIX);
 }
 
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -2130,7 +2130,7 @@ Value *IRBuilderBPF::CreateUprobeArgsRecord(Value *ctx,
 llvm::Type *IRBuilderBPF::UprobeArgsType(const SizedType &args_type)
 {
   auto type_name = args_type.GetName();
-  type_name.erase(0, strlen("struct "));
+  type_name.erase(0, STRUCT_PREFIX.length());
 
   std::vector<llvm::Type *> arg_types;
   for (auto &arg : args_type.GetFields())

--- a/src/ast/passes/clang_parser.cpp
+++ b/src/ast/passes/clang_parser.cpp
@@ -268,7 +268,7 @@ static SizedType get_sized_type(CXType clang_type, StructManager &structs)
     case CXType_Enum: {
       // The pretty printed type name contains `enum` prefix. That's not
       // helpful for us, so remove it. We have our own metadata.
-      static std::regex re("enum ");
+      static std::regex re{ std::string{ ENUM_PREFIX } };
       auto enum_name = std::regex_replace(typestr, re, "");
       return CreateEnum(size, enum_name);
     }

--- a/src/ast/passes/types/parsed_type_bridge.cpp
+++ b/src/ast/passes/types/parsed_type_bridge.cpp
@@ -6,13 +6,6 @@
 
 namespace bpftrace {
 
-namespace {
-
-constexpr std::string_view STRUCT_PREFIX = "struct ";
-constexpr std::string_view UNION_PREFIX = "union ";
-
-} // namespace
-
 SizedType parsed_type_to_sized_type(const ast::ParsedType &type)
 {
   switch (type.kind) {

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -218,25 +218,25 @@ static std::string full_type_str(const struct btf *btf,
   const char *str = btf_str(btf, type->name_off);
 
   if (BTF_INFO_KIND(type->info) == BTF_KIND_STRUCT)
-    return std::string("struct ") + str;
+    return std::string(STRUCT_PREFIX) + str;
 
   if (BTF_INFO_KIND(type->info) == BTF_KIND_UNION)
-    return std::string("union ") + str;
+    return std::string(UNION_PREFIX) + str;
 
   if (BTF_INFO_KIND(type->info) == BTF_KIND_ENUM)
-    return std::string("enum ") + str;
+    return std::string(ENUM_PREFIX) + str;
 
   return str;
 }
 
 static std::string_view btf_type_str(std::string_view type)
 {
-  if (type.starts_with("struct "))
-    return type.substr("struct "sv.length());
-  if (type.starts_with("union "))
-    return type.substr("union "sv.length());
-  if (type.starts_with("enum "))
-    return type.substr("enum "sv.length());
+  if (type.starts_with(STRUCT_PREFIX))
+    return type.substr(STRUCT_PREFIX.length());
+  if (type.starts_with(UNION_PREFIX))
+    return type.substr(UNION_PREFIX.length());
+  if (type.starts_with(ENUM_PREFIX))
+    return type.substr(ENUM_PREFIX.length());
   return type;
 }
 
@@ -503,7 +503,7 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
     }
   } else if (btf_is_composite(t)) {
     bool is_anon = false;
-    std::string recprefix = btf_is_struct(t) ? "struct " : "union ";
+    std::string recprefix(btf_is_struct(t) ? STRUCT_PREFIX : UNION_PREFIX);
     std::string rname = btf_str(btf_id.btf, t->name_off);
 
     if (is_anon_btf_typename(rname)) {

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -199,11 +199,11 @@ std::string Dwarf::get_type_name(Dwarf_Die &type_die) const
     case DW_TAG_enumeration_type: {
       std::string prefix;
       if (tag == DW_TAG_structure_type)
-        prefix = "struct ";
+        prefix = STRUCT_PREFIX;
       else if (tag == DW_TAG_union_type)
-        prefix = "union ";
+        prefix = UNION_PREFIX;
       else
-        prefix = "enum ";
+        prefix = ENUM_PREFIX;
 
       if (dwarf_hasattr(&type_die, DW_AT_name))
         return prefix + get_die_name(&type_die);
@@ -269,7 +269,9 @@ SizedType Dwarf::get_stype(Dwarf_Die &type_die, bool resolve_structs) const
     case DW_TAG_structure_type:
     case DW_TAG_union_type: {
       std::string name = get_die_name(&type_die);
-      name = (tag == DW_TAG_structure_type ? "struct " : "union ") + name;
+      name = std::string(tag == DW_TAG_structure_type ? STRUCT_PREFIX
+                                                      : UNION_PREFIX) +
+             name;
       auto result = CreateCStruct(
           name, bpftrace_->structs.LookupOrAdd(name, bit_size / 8));
       if (resolve_structs)
@@ -304,8 +306,8 @@ SizedType Dwarf::get_stype(Dwarf_Die &type_die, bool resolve_structs) const
 SizedType Dwarf::get_stype(const std::string &type_name) const
 {
   std::string name = type_name;
-  if (name.starts_with("struct "))
-    name = name.substr(strlen("struct "));
+  if (name.starts_with(STRUCT_PREFIX))
+    name = name.substr(STRUCT_PREFIX.length());
 
   auto type_die = find_type(name);
   if (!type_die)
@@ -351,8 +353,8 @@ void Dwarf::resolve_fields(const SizedType &type) const
     return;
 
   std::string type_name = type.GetName();
-  if (type_name.starts_with("struct "))
-    type_name = type_name.substr(strlen("struct "));
+  if (type_name.starts_with(STRUCT_PREFIX))
+    type_name = type_name.substr(STRUCT_PREFIX.length());
   auto type_die = find_type(type_name);
   if (!type_die)
     return;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -9,9 +9,6 @@
 
 namespace bpftrace {
 
-static constexpr std::string_view STRUCT_PREFIX = "struct ";
-static constexpr std::string_view UNION_PREFIX = "union ";
-
 std::ostream &operator<<(std::ostream &os, Type type)
 {
   os << typestr(type);
@@ -35,7 +32,7 @@ std::string typestr(const SizedType &type)
   switch (type.GetTy()) {
     case Type::integer:
       if (type.IsEnumTy()) {
-        return "enum " + type.GetName();
+        return std::string(ENUM_PREFIX) + type.GetName();
       }
       return (type.is_signed_ ? "int" : "uint") +
              std::to_string(8 * type.GetSize());

--- a/src/types.h
+++ b/src/types.h
@@ -11,6 +11,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <string_view>
 #include <sys/types.h>
 #include <unistd.h>
 #include <unordered_set>
@@ -21,6 +22,10 @@
 #include "util/result.h"
 
 namespace bpftrace {
+
+inline constexpr std::string_view STRUCT_PREFIX = "struct ";
+inline constexpr std::string_view UNION_PREFIX = "union ";
+inline constexpr std::string_view ENUM_PREFIX = "enum ";
 
 enum class Type : uint8_t {
   // clang-format off


### PR DESCRIPTION
Stacked PRs:
 * #5128
 * __->__#5127


--- --- ---

### Consolidate struct, union, and enum prefix strings


Small refactor to keep these same strings in one place as constexpr.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>