### PR TITLE
Types: distinguish structs, typedefs, and unions

### DIFF
--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -292,20 +292,14 @@ DIType *DIBuilderBPF::CreateByteArrayType(uint64_t num_bytes)
 /// programs (see IRBuilderBPF::GetType for details).
 ///
 /// As opposed to IRBuilderBPF::GetType we need to emit proper struct type
-/// info for the c_struct SizedType whose BTF must exactly match the kernel
+/// info for the c_type SizedType whose BTF must exactly match the kernel
 /// BTF (e.g. kernel functions ("kfunc") prototypes). For debug info the name
 /// and size need to at least be correct but the fields are not necessary.
 DIType *DIBuilderBPF::GetType(const SizedType &stype)
 {
-  if (stype.IsCStructTy()) {
-    std::string name = stype.GetName();
-    if (name.starts_with(STRUCT_PREFIX))
-      name = name.substr(STRUCT_PREFIX.length());
-    else if (name.starts_with(UNION_PREFIX))
-      name = name.substr(UNION_PREFIX.length());
-
+  if (stype.IsCTypeTy()) {
     return createStructType(file,
-                            name,
+                            std::string(stype.GetBaseName()),
                             file,
                             0,
                             stype.GetSize() * 8,

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -376,11 +376,11 @@ llvm::ConstantInt *IRBuilderBPF::GetIntSameSize(uint64_t C, llvm::Value *expr)
 /// Convert internal SizedType to a corresponding LLVM type.
 ///
 /// Only one type is not converted directly into an LLVM type:
-/// - C structs (c_struct) are represented as byte arrays
+/// - C types (c_type) are represented as byte arrays
 llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
 {
   llvm::Type *ty;
-  if (stype.IsByteArray() || stype.IsCStructTy()) {
+  if (stype.IsByteArray() || stype.IsCTypeTy()) {
     ty = ArrayType::get(getInt8Ty(), stype.GetSize());
   } else if (stype.IsArrayTy()) {
     ty = ArrayType::get(GetType(stype.GetElementTy()), stype.GetNumElements());
@@ -2108,7 +2108,7 @@ Value *IRBuilderBPF::CreateRawTracepointArg(Value *ctx,
 Value *IRBuilderBPF::CreateUprobeArgsRecord(Value *ctx,
                                             const SizedType &args_type)
 {
-  assert(args_type.IsCStructTy());
+  assert(args_type.IsCTypeTy());
 
   auto *args_t = UprobeArgsType(args_type);
   AllocaInst *result = CreateAllocaBPF(args_t, "args");
@@ -2129,13 +2129,10 @@ Value *IRBuilderBPF::CreateUprobeArgsRecord(Value *ctx,
 
 llvm::Type *IRBuilderBPF::UprobeArgsType(const SizedType &args_type)
 {
-  auto type_name = args_type.GetName();
-  type_name.erase(0, STRUCT_PREFIX.length());
-
   std::vector<llvm::Type *> arg_types;
   for (auto &arg : args_type.GetFields())
     arg_types.push_back(GetType(arg.type));
-  return GetStructType(type_name, arg_types, false);
+  return GetStructType(std::string(args_type.GetBaseName()), arg_types, false);
 }
 
 Value *IRBuilderBPF::CreateRegisterRead(Value *ctx, const std::string &builtin)

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2158,10 +2158,9 @@ ScopedExpr CodegenLLVM::visit(MapAddr &map_addr)
 
 ScopedExpr CodegenLLVM::visit(Variable &var)
 {
-  // Arrays and structs are not memcopied for local variables
+  // Arrays and c-types are not memcopied for local variables
   if (needMemcpy(type_map_.type(&var)) &&
-      !(type_map_.type(&var).IsArrayTy() ||
-        type_map_.type(&var).IsCStructTy())) {
+      !(type_map_.type(&var).IsArrayTy() || type_map_.type(&var).IsCTypeTy())) {
     return ScopedExpr(getVariable(var.ident).value);
   } else {
     auto &var_llvm = getVariable(var.ident);
@@ -2653,7 +2652,7 @@ ScopedExpr CodegenLLVM::visit(FieldAccess &acc)
   const SizedType &type = type_map_.type(acc.expr);
   auto scoped_arg = visit(acc.expr);
 
-  assert(type.IsRecordTy() || type.IsCStructTy());
+  assert(type.IsRecordTy() || type.IsCTypeTy());
 
   if (type.IsRecordTy()) {
     return createAnonStructAccess(type,
@@ -3023,7 +3022,7 @@ Value *CodegenLLVM::createAnonStruct(
 
     if (inBpfMemory(type))
       b_.CreateMemcpyBPF(dst, val, type.GetSize());
-    else if (type.IsArrayTy() || type.IsCStructTy())
+    else if (type.IsArrayTy() || type.IsCTypeTy())
       b_.CreateProbeRead(dst, type, val, vloc);
     else
       b_.CreateStore(val, dst);
@@ -3128,7 +3127,7 @@ void CodegenLLVM::maybeAllocVariable(const std::string &var_ident,
   // Arrays and structs need not to be copied when assigned to local variables
   // since they are treated as read-only - it is sufficient to assign
   // the pointer and do the memcpy/proberead later when necessary
-  if (var_type.IsArrayTy() || var_type.IsCStructTy()) {
+  if (var_type.IsArrayTy() || var_type.IsCTypeTy()) {
     const auto &pointee_type = var_type.IsArrayTy() ? var_type.GetElementTy()
                                                     : var_type;
     alloca_type = CreatePointer(pointee_type, var_type.GetAS());
@@ -3200,7 +3199,7 @@ void CodegenLLVM::createVariableStore(const SizedType &src_type,
     return;
   }
 
-  if (dst_type.IsArrayTy() || dst_type.IsCStructTy()) {
+  if (dst_type.IsArrayTy() || dst_type.IsCTypeTy()) {
     b_.CreateStore(b_.CreatePtrToInt(src, b_.getInt64Ty()), dst);
   } else if (needMemcpy(dst_type)) {
     b_.CreateMemcpyBPF(dst, src, src_type.GetSize());
@@ -3228,7 +3227,7 @@ ScopedExpr CodegenLLVM::visit(AssignVarStatement &assignment)
 
   maybeAllocVariable(var.ident, type_map_.type(&var), var.loc);
 
-  if (type_map_.type(&var).IsArrayTy() || type_map_.type(&var).IsCStructTy()) {
+  if (type_map_.type(&var).IsArrayTy() || type_map_.type(&var).IsCTypeTy()) {
     // For arrays and structs, only the pointer is stored. However, this means
     // that we cannot release the underlying memory for any of these types. We
     // just disarm the scoped expression, and therefore never free any of these
@@ -3575,7 +3574,7 @@ void CodegenLLVM::createMapBufferStore(const SizedType &src_type,
     return;
   }
 
-  if (dst_type.IsArrayTy() || dst_type.IsCStructTy()) {
+  if (dst_type.IsArrayTy() || dst_type.IsCTypeTy()) {
     // src currently contains a pointer to the struct or array
     // We now want to read the entire struct/array in so we can save it
     b_.CreateProbeRead(dst, dst_type, src, loc, src_type.GetAS());
@@ -3650,7 +3649,7 @@ ScopedExpr CodegenLLVM::getMultiMapKey(Map &map,
       aligned = false;
   } else {
     if (type_map_.type(key_expr).IsArrayTy() ||
-        type_map_.type(key_expr).IsCStructTy()) {
+        type_map_.type(key_expr).IsCTypeTy()) {
       // Read the array/struct into the key
       b_.CreateProbeRead(
           offset_val, type_map_.type(key_expr), scoped_expr.value(), map.loc);
@@ -4450,9 +4449,9 @@ ScopedExpr CodegenLLVM::probereadDatastructElem(ScopedExpr &&scoped_src,
   // to cast the pointer to the expected value.
   Value *src = b_.CreateSafeGEP(b_.getInt8Ty(), scoped_src.value(), offset);
 
-  if (elem_type.IsCStructTy() || elem_type.IsArrayTy()) {
-    // For nested arrays and structs, just pass the pointer along and
-    // dereference it later when necessary. We just need to extend lifetime
+  if (elem_type.IsCTypeTy() || elem_type.IsArrayTy()) {
+    // For nested arrays, structs, unions, typedefs just pass the pointer along
+    // and dereference it later when necessary. We just need to extend lifetime
     // of the source pointer.
     return ScopedExpr(src, std::move(scoped_src));
   } else if (elem_type.IsStringTy() || elem_type.IsBufferTy()) {

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -134,7 +134,7 @@ void FieldAnalyser::visit(FieldAccess &acc)
       sized_type_ = arg->type;
 
     has_builtin_args_ = false;
-  } else if (sized_type_.IsCStructTy()) {
+  } else if (sized_type_.IsCTypeTy()) {
     SizedType field_type = CreateNone();
     if (sized_type_.HasField(acc.field))
       field_type = sized_type_.GetField(acc.field).type;
@@ -222,7 +222,7 @@ void FieldAnalyser::visit(Unop &unop)
 
 void FieldAnalyser::resolve_fields(SizedType &type)
 {
-  if (!type.IsCStructTy())
+  if (!type.IsCTypeTy())
     return;
 
   if (probe_) {

--- a/src/ast/passes/types/ast_transformer.cpp
+++ b/src/ast/passes/types/ast_transformer.cpp
@@ -194,25 +194,25 @@ std::optional<Expression> AstTransformer::visit(FieldAccess &acc)
 
 std::optional<Expression> AstTransformer::visit(Offsetof &offof)
 {
-  SizedType cstruct;
+  SizedType c_type;
   if (std::holds_alternative<ParsedType *>(offof.record)) {
-    cstruct = get_type(std::get<ParsedType *>(offof.record));
+    c_type = get_type(std::get<ParsedType *>(offof.record));
   } else {
-    cstruct = get_type(&std::get<Expression>(offof.record).node());
+    c_type = get_type(&std::get<Expression>(offof.record).node());
   }
 
-  if (cstruct.IsNoneTy()) {
+  if (c_type.IsNoneTy()) {
     return std::nullopt;
   }
 
   size_t offset = 0;
   for (const auto &field : offof.field) {
-    if (!cstruct.IsCStructTy() || !cstruct.HasField(field)) {
+    if (!c_type.IsCTypeTy() || !c_type.HasField(field)) {
       return std::nullopt;
     }
-    const auto &f = cstruct.GetField(field);
+    const auto &f = c_type.GetField(field);
     offset += f.offset;
-    cstruct = f.type;
+    c_type = f.type;
   }
 
   return ast_.make_node<Integer>(Location(offof.loc), offset);

--- a/src/ast/passes/types/parsed_type_bridge.cpp
+++ b/src/ast/passes/types/parsed_type_bridge.cpp
@@ -60,21 +60,20 @@ ast::ParsedType *sized_type_to_parsed_type(ast::ASTContext &ctx,
                                           type.GetName());
   }
 
+  if (type.IsCUnionTy()) {
+    return ctx.make_node<ast::ParsedType>(loc,
+                                          ast::ParsedType::Kind::Union,
+                                          std::string(type.GetBaseName()));
+  }
   if (type.IsCStructTy()) {
-    const auto &name = type.GetName();
-    if (name.starts_with(STRUCT_PREFIX)) {
-      return ctx.make_node<ast::ParsedType>(loc,
-                                            ast::ParsedType::Kind::Struct,
-                                            name.substr(STRUCT_PREFIX.size()));
-    }
-    if (name.starts_with(UNION_PREFIX)) {
-      return ctx.make_node<ast::ParsedType>(loc,
-                                            ast::ParsedType::Kind::Union,
-                                            name.substr(UNION_PREFIX.size()));
-    }
+    return ctx.make_node<ast::ParsedType>(loc,
+                                          ast::ParsedType::Kind::Struct,
+                                          std::string(type.GetBaseName()));
+  }
+  if (type.IsCTypedefTy()) {
     return ctx.make_node<ast::ParsedType>(loc,
                                           ast::ParsedType::Kind::Identifier,
-                                          name);
+                                          type.GetName());
   }
 
   return ctx.make_node<ast::ParsedType>(loc,

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -221,7 +221,7 @@ static bool IsValidVarDeclType(const SizedType &ty)
     case Type::pointer:
     case Type::array:
     case Type::mac_address:
-    case Type::c_struct:
+    case Type::c_type:
     case Type::tuple:
     case Type::record:
     case Type::cgroup_path_t:
@@ -450,9 +450,8 @@ void TypeChecker::visit(Call &call)
     // member, like: path(args.filp->f_path))
     auto &arg = call.vargs.at(0);
     const auto &arg_type = type_map_.type(arg);
-    if (arg_type.GetTy() != Type::c_struct &&
-        arg_type.GetTy() != Type::pointer) {
-      call.addError() << "path() only supports pointer or record argument ("
+    if (!arg_type.IsCTypeTy() && !arg_type.IsPtrTy()) {
+      call.addError() << "path() only supports pointer or C type argument ("
                       << arg_type.GetTy() << " provided)";
     }
   } else if (call.func == "kptr" || call.func == "uptr") {
@@ -506,7 +505,7 @@ void TypeChecker::visit(Call &call)
     };
 
     const auto &type = type_map_.type(call.vargs.at(0));
-    if (!type.IsPtrTy() || !type.GetPointeeTy().IsCStructTy()) {
+    if (!type.IsPtrTy() || !type.GetPointeeTy().IsCTypeTy()) {
       logError(type.GetTy());
       return;
     }
@@ -867,7 +866,7 @@ void TypeChecker::visit(FieldAccess &acc)
     type = type.GetPointeeTy();
   }
 
-  if (!type.IsCStructTy() && !type.IsTupleTy() && !type.IsRecordTy()) {
+  if (!type.IsCTypeTy() && !type.IsTupleTy() && !type.IsRecordTy()) {
     return;
   }
 
@@ -939,8 +938,8 @@ void TypeChecker::visit(Cast &cast)
   }
 
   auto rhs = type_map_.type(cast.expr);
-  if (rhs.IsCStructTy()) {
-    cast.addError() << "Cannot cast from struct type \"" << rhs << "\"";
+  if (rhs.IsCTypeTy()) {
+    cast.addError() << "Cannot cast from C type \"" << rhs << "\"";
     return;
   } else if (rhs.IsNoneTy()) {
     cast.addError() << "Cannot cast from \"" << rhs << "\" type";
@@ -960,7 +959,7 @@ void TypeChecker::visit(Cast &cast)
 
   if (!ty.IsIntTy() && !ty.IsPtrTy() && !ty.IsBoolTy() &&
       (!ty.IsPtrTy() || ty.GetElementTy().IsIntTy() ||
-       ty.GetElementTy().IsCStructTy()) &&
+       ty.GetElementTy().IsCTypeTy()) &&
       // we support casting integers to int arrays
       !(ty.IsArrayTy() && ty.GetElementTy().IsBoolTy()) &&
       !(ty.IsArrayTy() && ty.GetElementTy().IsIntTy())) {

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -384,7 +384,7 @@ private:
 
   std::optional<SizedType> resolve_parsed_type(ParsedType *type, Node &node);
   bool resolve_external_type(SizedType &type, Node &node);
-  bool check_offsetof_type(Offsetof &offof, SizedType cstruct);
+  bool check_offsetof_type(Offsetof &offof, SizedType c_type);
 
   SizedType get_var_type(const ScopedVariable &scoped_var,
                          const SizedType &type,
@@ -609,24 +609,25 @@ SizedType get_binop_type(Binop &binop,
   return result_type;
 }
 
-bool TypeRuleCollector::check_offsetof_type(Offsetof &offof, SizedType cstruct)
+bool TypeRuleCollector::check_offsetof_type(Offsetof &offof, SizedType c_type)
 {
   // Check if all sub-fields are present.
   for (const auto &field : offof.field) {
-    if (!cstruct.IsCStructTy()) {
-      offof.addError() << "'" << cstruct << "' " << "is not a c_struct type.";
+    if (!c_type.IsCTypeTy()) {
+      offof.addError() << "'" << c_type << "' "
+                       << "is not a C type.";
       return false;
-    } else if (!bpftrace_.structs.Has(cstruct.GetName())) {
-      offof.addError() << "'" << cstruct.GetName() << "' does not exist.";
+    } else if (!bpftrace_.structs.Has(c_type.GetName())) {
+      offof.addError() << "'" << c_type.GetName() << "' does not exist.";
       return false;
-    } else if (!cstruct.HasField(field)) {
-      offof.addError() << "'" << cstruct.GetName() << "' "
+    } else if (!c_type.HasField(field)) {
+      offof.addError() << "'" << c_type.GetName() << "' "
                        << "has no field named " << "'" << field << "'";
       return false;
     } else {
       // Get next sub-field
-      const auto &f = cstruct.GetField(field);
-      cstruct = f.type;
+      const auto &f = c_type.GetField(field);
+      c_type = f.type;
     }
   }
   return true;
@@ -1482,7 +1483,7 @@ void TypeRuleCollector::visit(FieldAccess &acc)
 
         SizedType result_type = CreateNone();
 
-        if (!expr_type.IsCStructTy() && !expr_type.IsRecordTy()) {
+        if (!expr_type.IsCTypeTy() && !expr_type.IsRecordTy()) {
           acc.addError() << "Can not access field '" << acc.field
                          << "' on expression of type '" << expr_type << "'";
           return CreateNone();
@@ -1544,8 +1545,7 @@ void TypeRuleCollector::visit(FieldAccess &acc)
           }
 
           result_type = field.type;
-          if (is_ctx &&
-              (result_type.IsArrayTy() || result_type.IsCStructTy())) {
+          if (is_ctx && (result_type.IsArrayTy() || result_type.IsCTypeTy())) {
             // e.g., ((struct bpf_perf_event_data*)ctx)->regs.ax
             result_type.MarkCtxAccess();
           }
@@ -2238,7 +2238,7 @@ void TypeRuleCollector::visit(Unop &unop)
               result.MarkCtxAccess();
             result.is_internal = type.is_internal;
             result.SetAS(type.GetAS());
-          } else if (type.IsCStructTy()) {
+          } else if (type.IsCTypeTy()) {
             // We allow dereferencing "args" with no effect (for backwards
             // compat)
             if (type.IsCtxAccess()) {
@@ -2373,7 +2373,7 @@ bool TypeRuleCollector::resolve_external_type(SizedType &type, Node &node)
     return true;
   }
 
-  if (type.IsCStructTy() && !type.GetStruct()) {
+  if (type.IsCTypeTy() && !type.GetStruct()) {
     auto struct_type = bpftrace_.structs.Lookup(type.GetName()).lock();
     if (struct_type) {
       type = CreateCStruct(type.GetName(), struct_type);
@@ -2447,7 +2447,7 @@ SizedType TypeRuleCollector::get_map_value_type(const std::string &map_name,
   if (promoted) {
     // Data stored in a BPF map is internal (managed by BPF runtime), so
     // structs and arrays should be marked as such.
-    if (promoted->IsCStructTy() || promoted->IsArrayTy()) {
+    if (promoted->IsCTypeTy() || promoted->IsArrayTy()) {
       promoted->is_internal = true;
     }
 

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -1210,7 +1210,7 @@ void BTF::resolve_fields(const SizedType &type)
 {
   BTFId type_id;
 
-  if (!type.IsCStructTy())
+  if (!type.IsCTypeTy())
     return;
 
   auto const &name = type.GetName();
@@ -1221,7 +1221,7 @@ void BTF::resolve_fields(const SizedType &type)
   if (type.IsAnonTy()) {
     type_id = parse_anon_btf_name(name);
   } else {
-    __u32 kind = name.starts_with("struct") ? BTF_KIND_STRUCT : BTF_KIND_UNION;
+    __u32 kind = type.IsCStructTy() ? BTF_KIND_STRUCT : BTF_KIND_UNION;
     auto type_name = btf_type_str(name);
 
     type_id = find_id(type_name, kind);

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -345,17 +345,14 @@ std::optional<Bitfield> Dwarf::resolve_bitfield(Dwarf_Die &field_die) const
 
 void Dwarf::resolve_fields(const SizedType &type) const
 {
-  if (!type.IsCStructTy())
+  if (!type.IsCTypeTy())
     return;
 
   auto str = bpftrace_->structs.Lookup(type.GetName()).lock();
   if (str->HasFields())
     return;
 
-  std::string type_name = type.GetName();
-  if (type_name.starts_with(STRUCT_PREFIX))
-    type_name = type_name.substr(STRUCT_PREFIX.length());
-  auto type_die = find_type(type_name);
+  auto type_die = find_type(std::string(type.GetBaseName()));
   if (!type_die)
     return;
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -49,7 +49,7 @@ std::string typestr(const SizedType &type)
     case Type::array:
       return typestr(type.GetElementTy()) + "[" +
              std::to_string(type.GetNumElements()) + "]";
-    case Type::c_struct: {
+    case Type::c_type: {
       if (!type.IsAnonTy())
         return type.GetName();
 
@@ -135,7 +135,7 @@ bool SizedType::IsCompatible(const SizedType &t) const
   if (t.GetTy() != type_)
     return false;
 
-  if (IsCStructTy())
+  if (IsCTypeTy())
     return t.GetName() == GetName();
 
   if (IsPtrTy())
@@ -214,7 +214,7 @@ std::strong_ordering SizedType::operator<=>(const SizedType &t) const
   if (auto cmp = type_ <=> t.type_; cmp != 0)
     return cmp;
 
-  if (IsCStructTy()) {
+  if (IsCTypeTy()) {
     if (auto cmp = GetName() <=> t.GetName(); cmp != 0)
       return cmp;
     return GetSize() <=> t.GetSize();
@@ -284,7 +284,7 @@ bool SizedType::IsByteArray() const
 
 bool SizedType::IsAggregate() const
 {
-  return IsArrayTy() || IsByteArray() || IsTupleTy() || IsCStructTy() ||
+  return IsArrayTy() || IsByteArray() || IsTupleTy() || IsCTypeTy() ||
          IsStack() || IsRecordTy();
 }
 
@@ -318,7 +318,7 @@ std::string typestr(Type t)
     case Type::voidtype: return "void";     break;
     case Type::integer:  return "int";  break;
     case Type::pointer:  return "pointer";  break;
-    case Type::c_struct:   return "c_struct";   break;
+    case Type::c_type:   return "c_type";   break;
     case Type::hist_t:     return "hist_t";     break;
     case Type::lhist_t:    return "lhist_t";    break;
     case Type::tseries_t:    return "tseries_t";    break;
@@ -456,7 +456,7 @@ SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as)
 SizedType CreateCStruct(const std::string &name)
 {
   assert(!name.empty());
-  auto ty = SizedType(Type::c_struct, 0);
+  auto ty = SizedType(Type::c_type, 0);
   ty.name_ = name;
   return ty;
 }
@@ -465,7 +465,7 @@ SizedType CreateCStruct(std::shared_ptr<Struct> &&record)
 {
   // A local anonymous record.
   assert(record);
-  auto ty = SizedType(Type::c_struct, record->size);
+  auto ty = SizedType(Type::c_type, record->size);
   ty.inner_struct_ = std::move(record);
   return ty;
 }
@@ -474,7 +474,7 @@ SizedType CreateCStruct(const std::string &name, std::weak_ptr<Struct> record)
 {
   // A named type, stored in the `StructManager`.
   assert(!name.empty() && !record.expired());
-  auto ty = SizedType(Type::c_struct, record.lock()->size);
+  auto ty = SizedType(Type::c_type, record.lock()->size);
   ty.name_ = name;
   ty.inner_struct_ = std::move(record);
   return ty;
@@ -801,13 +801,13 @@ bool SizedType::IsSigned() const
 
 std::vector<Field> &SizedType::GetFields() const
 {
-  assert(IsTupleTy() || IsCStructTy() || IsRecordTy());
+  assert(IsTupleTy() || IsCTypeTy() || IsRecordTy());
   return inner_struct()->fields;
 }
 
 Field &SizedType::GetField(ssize_t n) const
 {
-  assert(IsTupleTy() || IsCStructTy() || IsRecordTy());
+  assert(IsTupleTy() || IsCTypeTy() || IsRecordTy());
   if (n >= GetFieldCount())
     throw util::FatalUserException("Getfield(): out of bounds");
   return inner_struct()->fields[n];
@@ -821,7 +821,7 @@ size_t SizedType::GetFieldIdx(const std::string &name) const
 
 ssize_t SizedType::GetFieldCount() const
 {
-  assert(IsTupleTy() || IsCStructTy() || IsRecordTy());
+  assert(IsTupleTy() || IsCTypeTy() || IsRecordTy());
   return inner_struct()->fields.size();
 }
 
@@ -840,7 +840,7 @@ ssize_t SizedType::GetInTupleAlignment() const
   if (IsByteArray())
     return 1;
 
-  if (IsTupleTy() || IsCStructTy() || IsRecordTy())
+  if (IsTupleTy() || IsCTypeTy() || IsRecordTy())
     return inner_struct()->align;
 
   if (GetSize() <= 2)
@@ -855,19 +855,19 @@ ssize_t SizedType::GetInTupleAlignment() const
 
 bool SizedType::HasField(const std::string &name) const
 {
-  assert(IsCStructTy() || IsRecordTy() || IsTupleTy());
+  assert(IsCTypeTy() || IsRecordTy() || IsTupleTy());
   return inner_struct()->HasField(name);
 }
 
 const Field &SizedType::GetField(const std::string &name) const
 {
-  assert(IsCStructTy() || IsRecordTy() || IsTupleTy());
+  assert(IsCTypeTy() || IsRecordTy() || IsTupleTy());
   return inner_struct()->GetField(name);
 }
 
 std::shared_ptr<Struct> SizedType::inner_struct() const
 {
-  assert(IsCStructTy() || IsTupleTy() || IsRecordTy());
+  assert(IsCTypeTy() || IsTupleTy() || IsRecordTy());
   return std::visit(
       [](const auto &v) {
         if constexpr (std::is_same_v<std::decay_t<decltype(v)>,
@@ -882,7 +882,7 @@ std::shared_ptr<Struct> SizedType::inner_struct() const
 
 std::shared_ptr<const Struct> SizedType::GetStruct() const
 {
-  assert(IsCStructTy() || IsTupleTy() || IsRecordTy());
+  assert(IsCTypeTy() || IsTupleTy() || IsRecordTy());
   return inner_struct();
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -34,7 +34,7 @@ enum class Type : uint8_t {
   integer, // int is a protected keyword
   boolean,
   pointer,
-  c_struct, // struct/union from external c programs or the kernel
+  c_type, // struct/union/typedef from external C programs or the kernel
   hist_t,
   lhist_t,
   tseries_t,
@@ -354,15 +354,25 @@ public:
     return name_;
   }
 
+  std::string_view GetBaseName() const
+  {
+    std::string_view name = name_;
+    if (name.starts_with(STRUCT_PREFIX))
+      return name.substr(STRUCT_PREFIX.length());
+    if (name.starts_with(UNION_PREFIX))
+      return name.substr(UNION_PREFIX.length());
+    return name;
+  }
+
   bool IsAnonTy() const
   {
-    assert(IsCStructTy());
+    assert(IsCTypeTy());
     return is_anon_;
   }
 
   void SetAnon()
   {
-    assert(IsCStructTy());
+    assert(IsCTypeTy());
     is_anon_ = true;
   }
 
@@ -486,9 +496,21 @@ public:
   {
     return type_ == Type::array;
   };
+  bool IsCTypeTy() const
+  {
+    return type_ == Type::c_type;
+  };
   bool IsCStructTy() const
   {
-    return type_ == Type::c_struct;
+    return IsCTypeTy() && name_.starts_with(STRUCT_PREFIX);
+  };
+  bool IsCUnionTy() const
+  {
+    return IsCTypeTy() && name_.starts_with(UNION_PREFIX);
+  };
+  bool IsCTypedefTy() const
+  {
+    return IsCTypeTy() && !IsCStructTy() && !IsCUnionTy();
   };
   bool IsBufferTy() const
   {

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -152,7 +152,7 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
       }
       return array;
     }
-    case Type::c_struct:
+    case Type::c_type:
     case Type::record: {
       output::Primitive::Record record;
       for (auto &field : type.GetFields()) {

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -272,7 +272,7 @@ TEST(clang_parser, nested_struct_named)
   ASSERT_TRUE(foo->HasField("bar"));
 
   const auto &bar = foo->GetField("bar");
-  EXPECT_TRUE(bar.type.IsCStructTy());
+  EXPECT_TRUE(bar.type.IsCTypeTy());
   EXPECT_EQ(bar.type.GetName(), "struct Bar");
   EXPECT_EQ(bar.type.GetSize(), 4U);
   EXPECT_EQ(bar.offset, 0);
@@ -293,7 +293,7 @@ TEST(clang_parser, nested_struct_ptr_named)
 
   const auto &bar = foo->GetField("bar");
   EXPECT_TRUE(bar.type.IsPtrTy());
-  EXPECT_TRUE(bar.type.GetPointeeTy().IsCStructTy());
+  EXPECT_TRUE(bar.type.GetPointeeTy().IsCTypeTy());
   EXPECT_EQ(bar.type.GetPointeeTy().GetName(), "struct Bar");
   EXPECT_EQ(bar.type.GetPointeeTy().GetSize(), sizeof(int));
   EXPECT_EQ(bar.offset, 0);
@@ -340,12 +340,12 @@ TEST(clang_parser, nested_struct_no_type)
 
   {
     const auto &bar_field = foo->GetField("bar");
-    EXPECT_TRUE(bar_field.type.IsCStructTy());
+    EXPECT_TRUE(bar_field.type.IsCTypeTy());
     EXPECT_EQ(bar_field.type.GetSize(), sizeof(int));
     EXPECT_EQ(bar_field.offset, 0);
 
     const auto &baz_field = foo->GetField("baz");
-    EXPECT_TRUE(baz_field.type.IsCStructTy());
+    EXPECT_TRUE(baz_field.type.IsCTypeTy());
     EXPECT_EQ(baz_field.type.GetSize(), sizeof(int));
     EXPECT_EQ(baz_field.offset, 4);
   }
@@ -707,7 +707,7 @@ TEST_F(clang_parser_btf, btf)
   EXPECT_EQ(foo2->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo2->GetField("a").offset, 0);
 
-  EXPECT_TRUE(foo2->GetField("f").type.IsCStructTy());
+  EXPECT_TRUE(foo2->GetField("f").type.IsCTypeTy());
   EXPECT_EQ(foo2->GetField("f").type.GetSize(), 16U);
   EXPECT_EQ(foo2->GetField("f").offset, 8);
 
@@ -870,10 +870,10 @@ TEST(clang_parser, struct_qualifiers)
   EXPECT_EQ(SB->fields.size(), 2U);
 
   EXPECT_TRUE(SB->GetField("a").type.IsPtrTy());
-  EXPECT_TRUE(SB->GetField("a").type.GetPointeeTy().IsCStructTy());
+  EXPECT_TRUE(SB->GetField("a").type.GetPointeeTy().IsCTypeTy());
   EXPECT_EQ(SB->GetField("a").type.GetPointeeTy().GetName(), "struct a");
 
-  EXPECT_TRUE(SB->GetField("a2").type.IsCStructTy());
+  EXPECT_TRUE(SB->GetField("a2").type.IsCTypeTy());
   EXPECT_EQ(SB->GetField("a2").type.GetName(), "struct a");
 }
 

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -98,7 +98,7 @@ TEST_F(field_analyser_btf, btf_types)
   EXPECT_EQ(foo2->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo2->GetField("a").offset, 0);
 
-  EXPECT_TRUE(foo2->GetField("f").type.IsCStructTy());
+  EXPECT_TRUE(foo2->GetField("f").type.IsCTypeTy());
   EXPECT_EQ(foo2->GetField("f").type.GetSize(), 16U);
   EXPECT_EQ(foo2->GetField("f").offset, 8);
 
@@ -238,14 +238,14 @@ void test_arrays_compound_data(BPFtrace &bpftrace)
   ASSERT_TRUE(foo3_ptr_type.IsPtrTy());
 
   const auto &foo3_type = foo3_ptr_type.GetPointeeTy();
-  ASSERT_TRUE(foo3_type.IsCStructTy());
+  ASSERT_TRUE(foo3_type.IsCTypeTy());
   ASSERT_TRUE(foo3_type.HasField("foo1"));
 
   const auto &foo1_ptr_type = foo3_type.GetField("foo1").type;
   ASSERT_TRUE(foo1_ptr_type.IsPtrTy());
 
   const auto &foo1_type = foo1_ptr_type.GetPointeeTy();
-  ASSERT_TRUE(foo1_type.IsCStructTy());
+  ASSERT_TRUE(foo1_type.IsCTypeTy());
   ASSERT_TRUE(foo1_type.HasField("a"));
 }
 
@@ -326,7 +326,7 @@ TEST_F(field_analyser_btf, btf_types_anon_structs)
   EXPECT_TRUE(typedefarray.IsArrayTy());
   EXPECT_EQ(typedefarray.GetNumElements(), 8);
   EXPECT_EQ(typedefarray.GetSize(), 32);
-  EXPECT_TRUE(typedefarray.GetElementTy().IsCStructTy());
+  EXPECT_TRUE(typedefarray.GetElementTy().IsCTypeTy());
   EXPECT_TRUE(typedefarray.GetElementTy().IsAnonTy());
   EXPECT_TRUE(typedefarray.GetElementTy().HasField("a"));
 
@@ -335,7 +335,7 @@ TEST_F(field_analyser_btf, btf_types_anon_structs)
   EXPECT_TRUE(typedefarray.IsArrayTy());
   EXPECT_EQ(structarray.GetSize(), 96);
   EXPECT_EQ(structarray.GetNumElements(), 4);
-  EXPECT_TRUE(structarray.GetElementTy().IsCStructTy());
+  EXPECT_TRUE(structarray.GetElementTy().IsCTypeTy());
   EXPECT_TRUE(structarray.GetElementTy().IsAnonTy());
   EXPECT_TRUE(structarray.GetElementTy().HasField("a"));
   EXPECT_TRUE(structarray.GetElementTy().HasField("b"));
@@ -343,7 +343,7 @@ TEST_F(field_analyser_btf, btf_types_anon_structs)
   ASSERT_TRUE(structarray.GetElementTy().HasField("AnonSubArray"));
   auto subarray = structarray.GetElementTy().GetField("AnonSubArray").type;
   EXPECT_EQ(subarray.GetNumElements(), 2);
-  EXPECT_TRUE(subarray.GetElementTy().IsCStructTy());
+  EXPECT_TRUE(subarray.GetElementTy().IsCTypeTy());
   EXPECT_TRUE(subarray.GetElementTy().IsAnonTy());
   EXPECT_TRUE(subarray.GetElementTy().HasField("c"));
   EXPECT_TRUE(subarray.GetElementTy().HasField("d"));

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -2353,7 +2353,7 @@ TEST_F(TypeCheckerTest, cast_struct)
   test("struct mytype { int field; }\n"
        "begin { $s = (struct mytype *)cpu; (uint32)*$s; }",
        Error{ R"(
-stdin:2:36-44: ERROR: Cannot cast from struct type "struct mytype"
+stdin:2:36-44: ERROR: Cannot cast from C type "struct mytype"
 begin { $s = (struct mytype *)cpu; (uint32)*$s; }
                                    ~~~~~~~~
 )" });
@@ -3544,7 +3544,7 @@ TEST_F(TypeCheckerTest, type_ctx)
   fieldaccess = assignment->expr.as<ast::FieldAccess>();
   EXPECT_EQ(chartype, result.type_map.type(fieldaccess));
   unop = fieldaccess->expr.as<ast::Unop>();
-  EXPECT_TRUE(result.type_map.type(unop).IsCStructTy());
+  EXPECT_TRUE(result.type_map.type(unop).IsCTypeTy());
   fieldaccess = unop->expr.as<ast::FieldAccess>();
   EXPECT_TRUE(result.type_map.type(fieldaccess).IsPtrTy());
   unop = fieldaccess->expr.as<ast::Unop>();
@@ -3612,7 +3612,7 @@ TEST_F(TypeCheckerTest, double_pointer_struct)
   ASSERT_TRUE(result.type_map.type(assignment->var())
                   .GetPointeeTy()
                   .GetPointeeTy()
-                  .IsCStructTy());
+                  .IsCTypeTy());
   EXPECT_EQ(result.type_map.type(assignment->var())
                 .GetPointeeTy()
                 .GetPointeeTy()
@@ -3623,7 +3623,7 @@ TEST_F(TypeCheckerTest, double_pointer_struct)
   assignment = stmts.at(1).as<ast::AssignVarStatement>();
   ASSERT_TRUE(result.type_map.type(assignment->var()).IsPtrTy());
   ASSERT_TRUE(
-      result.type_map.type(assignment->var()).GetPointeeTy().IsCStructTy());
+      result.type_map.type(assignment->var()).GetPointeeTy().IsCTypeTy());
   EXPECT_EQ(result.type_map.type(assignment->var()).GetPointeeTy().GetName(),
             "struct Foo");
 
@@ -4116,7 +4116,7 @@ TEST_F(TypeCheckerTest, call_offsetof)
   test("struct Foo { struct Bar { int a; } *bar; } \
               begin { @x = offsetof(struct Foo, bar.a); }",
        Error{ R"(
-stdin:1:71-98: ERROR: 'struct Bar *' is not a c_struct type.
+stdin:1:71-98: ERROR: 'struct Bar *' is not a C type.
 struct Foo { struct Bar { int a; } *bar; }               begin { @x = offsetof(struct Foo, bar.a); }
                                                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -4135,7 +4135,7 @@ stdin:1:70-117: ERROR: 'struct Bar' has no field named '__notexist_subfield__'
 struct Foo { struct Bar { int a; } bar; }               begin { @x = offsetof(struct Foo, bar.__notexist_subfield__); }
                                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
-  // Not exist c_struct
+  // Non-existent type
   test("begin { @x = offsetof(__passident__, x); }", Error{});
   test("begin { @x = offsetof(__passident__, x.y.z); }", Error{});
   test("begin { @x = offsetof(struct __notexiststruct__, x); }", Error{});
@@ -4576,7 +4576,7 @@ TEST_F(TypeCheckerTest, for_loop_variables_read_only)
       result.ast.root->probes.at(0)->block->stmts.at(2).as<ast::For>();
   ASSERT_NE(for_node, nullptr);
   const auto &ctx_type = result.type_map.type(for_node);
-  EXPECT_TRUE(ctx_type.IsCStructTy());
+  EXPECT_TRUE(ctx_type.IsCTypeTy());
   ASSERT_EQ(ctx_type.GetFields().size(), 1U);
   EXPECT_EQ(ctx_type.GetFields()[0].name, "$var");
   EXPECT_TRUE(ctx_type.GetFields()[0].type.IsPtrTy());
@@ -4619,7 +4619,7 @@ TEST_F(TypeCheckerTest, for_loop_variables_modified_during_loop)
       result.ast.root->probes.at(0)->block->stmts.at(2).as<ast::For>();
   ASSERT_NE(for_node, nullptr);
   const auto &ctx_type = result.type_map.type(for_node);
-  EXPECT_TRUE(ctx_type.IsCStructTy());
+  EXPECT_TRUE(ctx_type.IsCTypeTy());
   ASSERT_EQ(ctx_type.GetFields().size(), 1U);
   EXPECT_EQ(ctx_type.GetFields()[0].name, "$var");
   EXPECT_TRUE(ctx_type.GetFields()[0].type.IsPtrTy());
@@ -4690,7 +4690,7 @@ TEST_F(TypeCheckerTest, for_loop_variables_multiple)
       result.ast.root->probes.at(0)->block->stmts.at(4).as<ast::For>();
   ASSERT_NE(for_node, nullptr);
   const auto &ctx_type = result.type_map.type(for_node);
-  EXPECT_TRUE(ctx_type.IsCStructTy());
+  EXPECT_TRUE(ctx_type.IsCTypeTy());
   ASSERT_EQ(ctx_type.GetFields().size(), 2U);
   EXPECT_EQ(ctx_type.GetFields()[0].name, "$var1");
   EXPECT_TRUE(ctx_type.GetFields()[0].type.IsPtrTy());


### PR DESCRIPTION
Stacked PRs:
 * __->__#5128


--- --- ---

### Types: distinguish structs, typedefs, and unions


Small refactor to better distinguish between these three types in SizedType
and consolidate around the term "CType" instead of the misnamed "CStruct".

No functional changes.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>