### PR TITLE
Conditionally import stdlib bt files

### DIFF
--- a/src/ast/passes/clang_build.cpp
+++ b/src/ast/passes/clang_build.cpp
@@ -45,7 +45,7 @@ static Result<BitcodeModules::Result> build(
                llvm::MemoryBuffer::getMemBufferCopy(obj.data(), "main"));
 
   const std::string asm_dir = "include/asm/" + arch::Host::asm_arch() + "/";
-  for (const auto &[name, other] : stdlib::Stdlib::files) {
+  for (const auto &[name, other] : stdlib::Stdlib::c_files) {
     // If this include file is an arch-specific assembly file, then we
     // skip if it does not match the current architecture. If it *does*
     // match the current architecture, then we remap it as the `asm`

--- a/src/ast/passes/clang_parser.cpp
+++ b/src/ast/passes/clang_parser.cpp
@@ -131,7 +131,7 @@ const std::vector<CXUnsavedFile> &getDefaultHeaders()
   static auto cached = [] {
     std::vector<std::string> names;
     std::vector<CXUnsavedFile> unsaved_files;
-    for (const auto &[name, view] : stdlib::Stdlib::files) {
+    for (const auto &[name, view] : stdlib::Stdlib::c_files) {
       if (!name.ends_with(".h")) {
         continue; // Inlucde only headers.
       }

--- a/src/ast/passes/resolve_imports.cpp
+++ b/src/ast/passes/resolve_imports.cpp
@@ -1,9 +1,11 @@
 #include <filesystem>
 #include <fstream>
+#include <optional>
 #include <sstream>
 
 #include "ast/passes/resolve_imports.h"
 #include "ast/visitor.h"
+#include "log.h"
 #include "parser.h"
 #include "stdlib/stdlib.h"
 #include "util/result.h"
@@ -13,6 +15,8 @@
 namespace bpftrace::ast {
 
 using bpftrace::stdlib::Stdlib;
+
+static constexpr auto INTERNAL_BT = "stdlib/internal.bt";
 
 class ResolveRootImports : public Visitor<ResolveRootImports> {
 public:
@@ -25,6 +29,26 @@ public:
 
 private:
   Imports &imports_;
+  const std::vector<std::filesystem::path> &paths_;
+};
+
+class ResolveStdlibMacroImports : public Visitor<ResolveStdlibMacroImports> {
+public:
+  ResolveStdlibMacroImports(
+      Imports &imports,
+      std::optional<std::string> source_macro_name,
+      const std::vector<std::filesystem::path> &paths = {})
+      : imports_(imports),
+        source_macro_name_(std::move(source_macro_name)),
+        paths_(paths) {};
+
+  using Visitor<ResolveStdlibMacroImports>::visit;
+  void visit(Expression &expr);
+  void visit(Macro &macro);
+
+private:
+  Imports &imports_;
+  std::optional<std::string> source_macro_name_;
   const std::vector<std::filesystem::path> &paths_;
 };
 
@@ -60,6 +84,36 @@ static bool check_permissions(const std::filesystem::path &path)
   }
 }
 
+// Parses a script into the scripts map and returns a pointer to its
+// ASTContext, or nullptr if already imported.
+static Result<ASTContext *> import_bt_file(
+    Node &node,
+    const std::string &name,
+    std::string data,
+    bool internal,
+    std::map<std::string, ScriptObject> &scripts)
+{
+  if (scripts.contains(name)) {
+    return nullptr;
+  }
+
+  auto [it, added] = scripts.emplace(
+      name, ScriptObject(node, ASTContext(name, std::move(data)), internal));
+  assert(added);
+  auto &ast = it->second.ast;
+
+  PassManager pm;
+  pm.put(ast);
+  pm.add(CreateParsePass());
+
+  auto ok = pm.run();
+  if (!ok) {
+    return ok.takeError();
+  }
+
+  return &ast;
+}
+
 static Result<OK> import_script(Node &node,
                                 Imports &imports,
                                 const std::string &name,
@@ -68,27 +122,14 @@ static Result<OK> import_script(Node &node,
                                 std::map<std::string, ScriptObject> &contents,
                                 bool internal)
 {
-  if (contents.contains(name)) {
-    return OK(); // Already added.
+  auto result = import_bt_file(node, name, data, internal, contents);
+  if (!result) {
+    return result.takeError();
   }
-
-  // Construct our context.
-  auto [it, added] = contents.emplace(
-      name, ScriptObject(node, ASTContext(name, data), internal));
-  assert(added);
-  auto &ast = it->second.ast;
-
-  // Perform the basic parse pass. Note that this parse is done extremely
-  // early, and does zero expansion or parsing of attachpoints, etc.
-  PassManager pm;
-  pm.put(ast);
-  pm.add(CreateParsePass());
-
-  // Attempt to parse the source.
-  auto ok = pm.run();
-  if (!ok) {
-    return ok.takeError();
+  if (*result == nullptr) {
+    return OK();
   }
+  auto &ast = **result;
 
   // Disallow `config` blocks as they cannot be merged.
   if (ast.root != nullptr && ast.root->config != nullptr &&
@@ -99,6 +140,10 @@ static Result<OK> import_script(Node &node,
   // Recursively visit the parsed tree.
   ResolveRootImports resolver(imports, paths);
   resolver.visit(ast.root);
+
+  // Check for stdlib macro references in the imported script.
+  ResolveStdlibMacroImports macro_resolver(imports, std::nullopt, paths);
+  macro_resolver.visit(ast.root);
 
   return OK();
 }
@@ -247,6 +292,48 @@ Result<OK> Imports::import_any(Node &node,
   return OK();
 }
 
+Result<OK> Imports::import_stdlib(
+    Node &node,
+    const std::string &name,
+    const std::string_view &data,
+    const std::string &macro_name,
+    const std::vector<std::filesystem::path> &paths)
+{
+  if (has_external_stdlib_override_ && name != INTERNAL_BT) {
+    return OK();
+  }
+
+  if (seen_stdlib_macros_.contains(macro_name)) {
+    return OK();
+  }
+
+  seen_stdlib_macros_.insert(macro_name);
+
+  auto result = import_bt_file(node, name, std::string(data), true, scripts);
+  if (!result) {
+    return result.takeError();
+  }
+
+  if (*result == nullptr) {
+    // Even though we imported and parsed the stdlib file, we may still need to
+    // resolve other nested macros
+    auto found = scripts.find(name);
+    if (found != scripts.end()) {
+      ResolveStdlibMacroImports resolver(*this, macro_name, paths);
+      auto &ast = found->second.ast;
+      resolver.visit(ast.root);
+    }
+
+    return OK();
+  }
+  auto &ast = **result;
+
+  ResolveStdlibMacroImports resolver(*this, macro_name, paths);
+  resolver.visit(ast.root);
+
+  return OK();
+}
+
 Result<OK> Imports::import_any(Node &node,
                                const std::string &name,
                                const std::vector<std::filesystem::path> &paths)
@@ -286,8 +373,12 @@ Result<OK> Imports::import_any(Node &node,
   // expansion here, importing anything that is matching as a path.
   bool found = false;
   std::vector<std::string> similar;
-  for (const auto &[internal_path, s] : Stdlib::files) {
+  // This automatically imports c files from the stdlib but not bpftrace (bt)
+  // files so we don't have to always re-parse the entire stdlib library for
+  // every script invocation
+  for (const auto &[internal_path, s] : Stdlib::c_files) {
     auto path = std::filesystem::path(internal_path);
+
     if (path.string() == name) {
       return import_any(node, name, s, paths, false);
     } else if (path.parent_path().string() == name) {
@@ -329,13 +420,6 @@ void ResolveStatementImports::visit(StatementImport &imp)
     imp.addError() << import_error;
   } else if (path.extension() == ".bt") {
     imp.addError() << import_error;
-  } else {
-    for (const auto &[internal_path, s] : Stdlib::files) {
-      auto path = std::filesystem::path(internal_path);
-      if (path.parent_path().string() == imp.name) {
-        imp.addError() << import_error;
-      }
-    }
   }
   auto ok = imports_.import_any(imp, imp.name, paths_);
   if (!ok) {
@@ -345,9 +429,74 @@ void ResolveStatementImports::visit(StatementImport &imp)
 
 void ResolveRootImports::visit(RootImport &imp)
 {
+  if (imp.name == "stdlib") {
+    // If an explicit root import resolves to a filesystem stdlib package,
+    // treat it as an override before importing its files so later
+    // conditional stdlib bt imports do not mix in embedded stdlib scripts.
+    for (const auto &import_path : paths_) {
+      auto path = import_path / imp.name;
+      std::error_code ec;
+      if (!std::filesystem::exists(path, ec)) {
+        continue;
+      }
+      if (!check_permissions(path)) {
+        continue;
+      }
+      if (std::filesystem::is_directory(path)) {
+        imports_.mark_external_stdlib_override();
+      }
+      break;
+    }
+  }
+
   auto ok = imports_.import_any(imp, imp.name, paths_);
   if (!ok) {
     imp.addError() << "import error: " << ok.takeError();
+  }
+}
+
+void ResolveStdlibMacroImports::visit(Macro &macro)
+{
+  if (!source_macro_name_ || macro.name == *source_macro_name_) {
+    visit(macro.block);
+  }
+}
+
+void ResolveStdlibMacroImports::visit(Expression &expr)
+{
+  auto *ident = expr.as<Identifier>();
+  auto *call = expr.as<Call>();
+
+  if (!ident && !call) {
+    Visitor<ResolveStdlibMacroImports>::visit(expr);
+    return;
+  }
+
+  if (call) {
+    visit(call->vargs);
+  }
+
+  const std::string &possible_macro_name = ident ? ident->ident : call->func;
+  auto found = Stdlib::macro_to_file.find(possible_macro_name);
+
+  if (found == Stdlib::macro_to_file.end()) {
+    return;
+  }
+
+  auto found_files_entry = Stdlib::bt_files.find(found->second);
+
+  if (found_files_entry == Stdlib::bt_files.end()) {
+    LOG(BUG) << found->second << " should be also in Stdlib::bt_files";
+    return;
+  }
+
+  auto ok = imports_.import_stdlib(expr.node(),
+                                   found->second,
+                                   found_files_entry->second,
+                                   possible_macro_name,
+                                   paths_);
+  if (!ok) {
+    LOG(BUG) << "import error: " << ok.takeError();
   }
 }
 
@@ -370,6 +519,13 @@ Pass CreateResolveRootImportsPass(std::vector<std::string> &&import_paths)
                         ResolveRootImports analyser(imports, updated_paths);
                         analyser.visit(ast.root);
 
+                        // Let's pull in stdlib bt files as needed by the script
+                        // itself
+                        ResolveStdlibMacroImports macro_analyser(imports,
+                                                                 std::nullopt,
+                                                                 updated_paths);
+                        macro_analyser.visit(ast.root);
+
                         // Ensure that the essential part of the standard
                         // library is imported. All other parts of the standard
                         // library are conditionally imported based on inlined
@@ -381,6 +537,22 @@ Pass CreateResolveRootImportsPass(std::vector<std::string> &&import_paths)
                         if (!ok) {
                           return ok.takeError();
                         }
+
+                        // This is the only stdlib bt script we import
+                        // unconditionally because it contains macro calls that
+                        // are created in future passes
+                        auto internal = Stdlib::bt_files.find(INTERNAL_BT);
+                        if (internal != Stdlib::bt_files.end()) {
+                          ok = imports.import_stdlib(*ast.root,
+                                                     INTERNAL_BT,
+                                                     internal->second,
+                                                     INTERNAL_BT,
+                                                     updated_paths);
+                          if (!ok) {
+                            return ok.takeError();
+                          }
+                        }
+
                         return imports;
                       });
 }

--- a/src/ast/passes/resolve_imports.h
+++ b/src/ast/passes/resolve_imports.h
@@ -77,10 +77,21 @@ public:
   std::map<std::string, ExternalObject> objects;
   std::map<std::string, ScriptObject> scripts;
 
-  // Public import call.
+  // Public import calls.
   Result<OK> import_any(Node &node,
                         const std::string &name,
                         const std::vector<std::filesystem::path> &paths = {});
+
+  Result<OK> import_stdlib(Node &node,
+                           const std::string &name,
+                           const std::string_view &data,
+                           const std::string &macro_name,
+                           const std::vector<std::filesystem::path> &paths);
+
+  void mark_external_stdlib_override()
+  {
+    has_external_stdlib_override_ = true;
+  }
 
 private:
   Result<OK> import_any(Node &node,
@@ -99,6 +110,12 @@ private:
   // Record full packages/directories that have been imported separately from
   // the specific modules, in order to avoid re-importing these paths.
   std::unordered_set<std::string> packages_;
+  std::unordered_set<std::string> seen_stdlib_macros_;
+  // An explicit `import "stdlib"` should suppress conditional
+  // imports from the embedded stdlib bt files.
+  // This is a way for users or developers to override the internal stdlib
+  // entirely
+  bool has_external_stdlib_override_ = false;
 };
 
 // This pass resolves imports from the AST itself.

--- a/src/stdlib/CMakeLists.txt
+++ b/src/stdlib/CMakeLists.txt
@@ -40,9 +40,17 @@ function(add_stdlib_source PREFIX FILENAME)
   # Set globals that are used to configure the template.
   set(STDLIB_INCLUDES "${STDLIB_INCLUDES}
 #include \"${PREFIX}/${header_name}.h\"" PARENT_SCOPE)
-  set(STDLIB_FILES "${STDLIB_FILES}
+
+  get_filename_component(ext "${FILENAME}" EXT)
+  if(ext STREQUAL ".bt")
+    set(STDLIB_BT_FILES "${STDLIB_BT_FILES}
   { \"${PREFIX}/${name}\", make_view(${rule_name}, sizeof(${rule_name})) },"
-  PARENT_SCOPE)
+    PARENT_SCOPE)
+  else()
+    set(STDLIB_C_FILES "${STDLIB_C_FILES}
+  { \"${PREFIX}/${name}\", make_view(${rule_name}, sizeof(${rule_name})) },"
+    PARENT_SCOPE)
+  endif()
 endfunction()
 
 foreach(filename ${STDLIB_SOURCES})
@@ -59,6 +67,24 @@ foreach(filename ${BPF_HEADERS})
   string(REGEX REPLACE "^${LIBBPF_INCLUDE_DIRS}/" "" suffix "${filename}")
   get_filename_component(prefix "include/${suffix}" DIRECTORY)
   add_stdlib_source("${prefix}" "${filename}")
+endforeach()
+
+# Extract macro names from .bt files and build a macro-name-to-filename map.
+file(GLOB STDLIB_BT_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.bt")
+set(STDLIB_MACROS "")
+set(SEEN_MACROS "")
+foreach(bt_file ${STDLIB_BT_SOURCES})
+  get_filename_component(bt_name "${bt_file}" NAME)
+  file(READ "${bt_file}" bt_content)
+  string(REGEX MATCHALL "(^|\n)[ \t]*macro [a-zA-Z_][a-zA-Z0-9_]*\\(" macro_matches "${bt_content}")
+  foreach(match ${macro_matches})
+    string(REGEX REPLACE "(^|\n)[ \t]*macro ([a-zA-Z_][a-zA-Z0-9_]*)\\(" "\\2" macro_name "${match}")
+    if(NOT "${macro_name}" IN_LIST SEEN_MACROS)
+      list(APPEND SEEN_MACROS "${macro_name}")
+      string(APPEND STDLIB_MACROS
+        "\n  { \"${macro_name}\", \"stdlib/${bt_name}\" },")
+    endif()
+  endforeach()
 endforeach()
 
 configure_file(stdlib.cpp.in stdlib.cpp)

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -649,45 +649,6 @@ macro len(e)
 //  */
 // ```
 
-// :variant int memcmp(left, right, uint64 count)
-// Compares the first 'count' bytes of two expressions.
-// 0 is returned if they are the same.
-// negative value if the first differing byte in left is less
-// than the corresponding byte in right.
-//
-macro memcmp($left, $right, count)
-{
-  __memcmp((int8*)(&$left), (int8*)(&$right), (uint64)count)
-}
-
-macro memcmp($left, right, count)
-{
-  $right = right;
-  memcmp($left, $right, count)
-}
-
-macro memcmp(left, $right, count)
-{
-  $left = left;
-  memcmp($left, $right, count)
-}
-
-macro memcmp(left, right, count)
-{
-  $left = left;
-  $right = right;
-  memcmp($left, $right, count)
-}
-
-macro memcmp_record(left, right, count)
-{
-  let $left = left;
-  // This ensures that the $right variable type has fields
-  // in the exact same order as the $left
-  let $right: typeof($left) = right;
-  memcmp($left, $right, count)
-}
-
 // :variant uint64 ncpus()
 // Number of CPUs
 macro ncpus()

--- a/src/stdlib/internal.bt
+++ b/src/stdlib/internal.bt
@@ -1,0 +1,47 @@
+// Only add macros to this file if calls to these macros are
+// created by an AST pass that happens after ResolveRootImports
+// This is the only stdlib bt file that always gets imported
+
+// :variant int memcmp(left, right, uint64 count)
+// Compares the first 'count' bytes of two expressions.
+// 0 is returned if they are the same.
+// negative value if the first differing byte in left is less
+// than the corresponding byte in right.
+//
+macro memcmp($left, $right, count)
+{
+  __memcmp((int8*)(&$left), (int8*)(&$right), (uint64)count)
+}
+
+macro memcmp($left, right, count)
+{
+  $right = right;
+  memcmp($left, $right, count)
+}
+
+macro memcmp(left, $right, count)
+{
+  $left = left;
+  memcmp($left, $right, count)
+}
+
+macro memcmp(left, right, count)
+{
+  $left = left;
+  $right = right;
+  memcmp($left, $right, count)
+}
+
+macro memcmp_record(left, right, count)
+{
+  let $left = left;
+  // This ensures that the $right variable type has fields
+  // in the exact same order as the $left
+  let $right: typeof($left) = right;
+  memcmp($left, $right, count)
+}
+
+macro usdt_arg(x)
+{
+  __usdt_arg((void *)ctx, (int64)x)
+}

--- a/src/stdlib/meta.bt
+++ b/src/stdlib/meta.bt
@@ -66,11 +66,6 @@ macro is_literal(expr)
   __builtin_is_literal(expr)
 }
 
-macro usdt_arg(x)
-{
-  __usdt_arg((void *)ctx, (int64)x)
-}
-
 macro assert_userspace_probe(func) {
   if comptime (probetype != "uprobe" && probetype != "uretprobe" &&
                probetype != "usdt") {

--- a/src/stdlib/stdlib.cpp.in
+++ b/src/stdlib/stdlib.cpp.in
@@ -9,9 +9,16 @@ inline std::string_view make_view(const unsigned char *v, size_t sz)
   return { reinterpret_cast<const char *>(v), sz };
 }
 
-const std::map<std::string, std::string_view> Stdlib::files = {
-    ${STDLIB_FILES}
+const std::map<std::string, std::string_view> Stdlib::c_files = {
+    ${STDLIB_C_FILES}
+};
+
+const std::map<std::string, std::string_view> Stdlib::bt_files = {
+    ${STDLIB_BT_FILES}
+};
+
+const std::map<std::string, std::string> Stdlib::macro_to_file = {
+    ${STDLIB_MACROS}
 };
 
 } // namespace bpftrace::stdlib
-

--- a/src/stdlib/stdlib.h
+++ b/src/stdlib/stdlib.h
@@ -7,10 +7,10 @@ namespace bpftrace::stdlib {
 
 class Stdlib {
 public:
-  // files is the set of files embedded in the standard library.
-  //
   // This is constructed automatically from a generated `stdlib.cpp`.
-  static const std::map<std::string, std::string_view> files;
+  static const std::map<std::string, std::string_view> c_files;
+  static const std::map<std::string, std::string_view> bt_files;
+  static const std::map<std::string, std::string> macro_to_file;
 };
 
 } // namespace bpftrace::stdlib

--- a/tests/imports.cpp
+++ b/tests/imports.cpp
@@ -133,11 +133,89 @@ TEST_F(ImportTest, stdlib_implicit_rules)
     EXPECT_FALSE(imports.scripts.contains("stdlib/base.bt"));
   });
 
-  // Without the explicit import, it should use the builtin one.
+  // An explicit filesystem stdlib import should continue to override the
+  // embedded stdlib, even when the script references a macro with the same
+  // name as one of the embedded stdlib macros.
+  ASSERT_TRUE(create_file(*dir, "stdlib/cpu.bt", R"(macro cpu() { 123 })"));
+  test(R"(import "stdlib"; begin { print(cpu()); })",
+       { dir->path() },
+       [](Imports &imports) {
+         EXPECT_TRUE(imports.scripts.contains("stdlib/foo.bt"));
+         EXPECT_TRUE(imports.scripts.contains("stdlib/cpu.bt"));
+         EXPECT_FALSE(imports.scripts.contains("stdlib/base.bt"));
+         EXPECT_FALSE(imports.scripts.contains("stdlib/meta.bt"));
+       });
+
+  // Without the explicit import, stdlib .bt files are only imported
+  // if the script references macros from them.
   test(R"(begin {})", { dir->path() }, [](Imports &imports) {
     EXPECT_FALSE(imports.scripts.contains("stdlib/foo.bt"));
+    EXPECT_FALSE(imports.scripts.contains("stdlib/base.bt"));
+  });
+
+  // Referencing a macro from base.bt should import it.
+  test(R"(begin { print(cpu()); })", { dir->path() }, [](Imports &imports) {
+    EXPECT_FALSE(imports.scripts.contains("stdlib/strings.bt"));
+    EXPECT_FALSE(imports.scripts.contains("stdlib/meta.bt"));
     EXPECT_TRUE(imports.scripts.contains("stdlib/base.bt"));
   });
+
+  // This test is to illustrate something that can be improved later. The `cpu`
+  // macro takes no arguments but the call to `cpu` in this test passes
+  // arguments meaning that if another `cpu` marco is defined by the user that
+  // does take arguments we are unneccesarily importing part of the stdlib. One
+  // potential fix is having cmake count the number of arguments and adding this
+  // to the macro_to_file map and then comparing this number to the actual ast
+  // Call argument count.
+  test(R"(macro cpu(x, y) { x + y } begin { print(cpu(1, 2)); })",
+       { dir->path() },
+       [](Imports &imports) {
+         EXPECT_FALSE(imports.scripts.contains("stdlib/strings.bt"));
+         EXPECT_FALSE(imports.scripts.contains("stdlib/meta.bt"));
+         EXPECT_TRUE(imports.scripts.contains("stdlib/base.bt"));
+       });
+
+  // Referencing a macro from base.bt inside another macro should import it.
+  test(R"(macro get_cpu() { cpu } begin { print(get_cpu()); })",
+       { dir->path() },
+       [](Imports &imports) {
+         EXPECT_FALSE(imports.scripts.contains("stdlib/strings.bt"));
+         EXPECT_FALSE(imports.scripts.contains("stdlib/meta.bt"));
+         EXPECT_TRUE(imports.scripts.contains("stdlib/base.bt"));
+       });
+
+  // Referencing a macro from base.bt that references a macro in another stdlib
+  // file
+  test(R"(begin { @a[1,2] = 1; $b = !has_key(@a, (1,2)); })",
+       { dir->path() },
+       [](Imports &imports) {
+         EXPECT_FALSE(imports.scripts.contains("stdlib/strings.bt"));
+         EXPECT_TRUE(imports.scripts.contains("stdlib/base.bt"));
+         EXPECT_TRUE(imports.scripts.contains("stdlib/meta.bt"));
+       });
+
+  // Imported .bt files that reference stdlib macros should also trigger
+  // stdlib imports.
+  ASSERT_TRUE(create_file(*dir, "mylib.bt", R"(macro myfunc() { cpu() })"));
+  test(R"(import "mylib.bt"; begin { print(myfunc()); })",
+       { dir->path() },
+       [](Imports &imports) {
+         EXPECT_TRUE(imports.scripts.contains("mylib.bt"));
+         EXPECT_TRUE(imports.scripts.contains("stdlib/base.bt"));
+         EXPECT_FALSE(imports.scripts.contains("stdlib/meta.bt"));
+       });
+
+  // Referencing a macro from base.bt that references a macro in another stdlib
+  // file from a manuallys imported bt file
+  ASSERT_TRUE(
+      create_file(*dir, "mylib2.bt", R"(macro myfunc(@a) { has_key(@a, 1) })"));
+  test(R"(import "mylib2.bt"; begin { @b[1] = 2; print(myfunc(@b)); })",
+       { dir->path() },
+       [](Imports &imports) {
+         EXPECT_TRUE(imports.scripts.contains("mylib2.bt"));
+         EXPECT_TRUE(imports.scripts.contains("stdlib/base.bt"));
+         EXPECT_TRUE(imports.scripts.contains("stdlib/meta.bt"));
+       });
 }
 
 TEST_F(ImportTest, world_writable_ignored)


### PR DESCRIPTION
Stacked PRs:
 * __->__#5131


--- --- ---

### Conditionally import stdlib bt files


This will reduce unnecessary importing and parsing. It also allows us to
let the stdlib bt files get larger and more numerous without having to
worry about script bloat.

It works by recursively checking idents and calls to see if they are part
of the stdlib macros and then only importing those stdlib bt files.

For macros that call other macros in other stdlib files, we make sure to
only check against the macros that were referenced by the base script or
scripts that were imported explicitly.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>