### PR TITLE
stdlib: {pcomm,ppid}: Distinguishing between thread and process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to
 ## Unreleased
 
 #### Breaking Changes
+- stdlib: Change `pcomm` to an alias of task.real_parent.comm instead of task.group_leader.comm.
+  - [#5132](https://github.com/bpftrace/bpftrace/pull/5132)
 #### Added
+- stdlib: add `leader_{tid,comm}` to retrieve the thread group leader.
+  - [#5132](https://github.com/bpftrace/bpftrace/pull/5132)
 - stdlib: add signal_name().
   - [#5098](https://github.com/bpftrace/bpftrace/pull/5098)
 - Add DWARF-based user-space stack unwinding via `dw_ustack()` for x86_64 (requires LLVM >= 21).

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -634,6 +634,26 @@ kprobe:do_nanosleep
 ```
 
 
+### leader_comm
+- `string leader_comm()`
+- `string leader_comm`
+- `string leader_comm(struct task_struct * task)`
+
+Get the thread name of the thread group leader for the passed task or the current task if called without arguments.
+This is an alias for `task.group_leader.comm`, which is different than `task.real_parent.comm`, which you can get from calling `pcomm()`.
+See `pcomm()` for more details.
+
+
+### leader_tid
+- `string leader_tid()`
+- `string leader_tid`
+- `string leader_tid(struct task_struct * task)`
+
+Get the thread id of the thread group leader for the passed task or the current task if called without arguments.
+This is an alias for `task.group_leader.pid`, which is different than `task.real_parent.pid`, which you can get from calling `ppid()`.
+See `ppid()` for more details.
+
+
 ### len
 - `int64 len(map m)`
 - `int64 len(ustack stack)`
@@ -815,7 +835,8 @@ This function can only be used by functions that are allowed to, these functions
 - `string pcomm`
 - `string pcomm(struct task_struct * task)`
 
-Get the name of the process for the passed task or the current task if called without arguments. This is an alias for (task->group_leader->comm).
+Get the name of the parent process for the passed task or the current task if called without arguments.
+This is an alias for `task.real_parent.comm`, which is different than `task.group_leader.comm`, which you can get from calling `leader_comm()`.
 
 
 ### percpu_kaddr
@@ -866,6 +887,7 @@ Defaults to `curr_ns`.
 - `uint32 ppid(struct task_struct * task)`
 
 Get the pid of the parent process for the passed task or the current task if called without arguments.
+This is an alias for `task.real_parent.pid`, which is different than `task.group_leader.pid`, which you can get from calling `leader_tid()`.
 
 
 ### print

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -907,7 +907,9 @@ macro write_user(dst, src, len)
 
 // :variant uint32 ppid()
 // :variant uint32 ppid(struct task_struct * task)
+//
 // Get the pid of the parent process for the passed task or the current task if called without arguments.
+// This is an alias for `task.real_parent.pid`, which is different than `task.group_leader.pid`, which you can get from calling `leader_tid()`.
 macro ppid(task)
 {
   task.real_parent.pid
@@ -918,17 +920,51 @@ macro ppid()
   ppid(curtask)
 }
 
+// :variant string leader_tid()
+// :variant string leader_tid(struct task_struct * task)
+//
+// Get the thread id of the thread group leader for the passed task or the current task if called without arguments.
+// This is an alias for `task.group_leader.pid`, which is different than `task.real_parent.pid`, which you can get from calling `ppid()`.
+// See `ppid()` for more details.
+macro leader_tid(task)
+{
+  task.group_leader.pid
+}
+
+macro leader_tid()
+{
+  leader_tid(curtask)
+}
+
 // :variant string pcomm()
 // :variant string pcomm(struct task_struct * task)
-// Get the name of the process for the passed task or the current task if called without arguments. This is an alias for (task->group_leader->comm).
+//
+// Get the name of the parent process for the passed task or the current task if called without arguments.
+// This is an alias for `task.real_parent.comm`, which is different than `task.group_leader.comm`, which you can get from calling `leader_comm()`.
 macro pcomm(task)
 {
-  task.group_leader.comm
+  task.real_parent.comm
 }
 
 macro pcomm()
 {
   pcomm(curtask)
+}
+
+// :variant string leader_comm()
+// :variant string leader_comm(struct task_struct * task)
+//
+// Get the thread name of the thread group leader for the passed task or the current task if called without arguments.
+// This is an alias for `task.group_leader.comm`, which is different than `task.real_parent.comm`, which you can get from calling `pcomm()`.
+// See `pcomm()` for more details.
+macro leader_comm(task)
+{
+  task.group_leader.comm
+}
+
+macro leader_comm()
+{
+  leader_comm(curtask)
 }
 
 // :function print

--- a/tests/runtime/stdlib
+++ b/tests/runtime/stdlib
@@ -21,6 +21,18 @@ NAME comm from pid
 PROG iter:task { @ = comm(pid); exit() }
 EXPECT @: bpftrace
 
+NAME pcomm and leader_comm for thread
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/multi_threads:stub { printf("%s %s %s\n", comm, pcomm, leader_comm); }'
+EXPECT son-thread multi_threads parent-thread
+EXPECT grandson-thread multi_threads parent-thread
+AFTER ./testprogs/multi_threads
+
+NAME pcomm and leader_comm for process
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/multi_procs:stub { printf("%s %s %s\n", comm, pcomm, leader_comm); }'
+EXPECT son-proc parent-proc son-proc
+EXPECT grandson-proc son-proc grandson-proc
+AFTER ./testprogs/multi_procs
+
 NAME delete map
 PROG begin { @ = 1; @a[1] = 1; @b[1, 2] = 2; if (delete(@)) { printf("ok1\n"); } delete(@a, 1); if (delete(@b, (1, 2))) { printf("ok2\n"); } if (!delete(@b, (5, 6))) { printf("ok3\n"); } }
 EXPECT ok1

--- a/tests/testprogs/multi_procs.c
+++ b/tests/testprogs/multi_procs.c
@@ -1,0 +1,45 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/prctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* could be probed */
+void stub(void)
+{
+}
+
+void set_proc_name(const char *name)
+{
+  if (prctl(PR_SET_NAME, name, 0, 0, 0)) {
+    perror("prctl: failed to set process name");
+    exit(EXIT_FAILURE);
+  }
+}
+
+int main(void)
+{
+  pid_t son;
+
+  set_proc_name("parent-proc");
+
+  son = fork();
+  if (son == 0) {
+    pid_t grandson;
+
+    set_proc_name("son-proc");
+    stub();
+    grandson = fork();
+    if (grandson == 0) {
+      set_proc_name("grandson-proc");
+      stub();
+      exit(0);
+    }
+    waitpid(grandson, NULL, 0);
+    exit(0);
+  }
+
+  waitpid(son, NULL, 0);
+  return 0;
+}

--- a/tests/testprogs/multi_threads.c
+++ b/tests/testprogs/multi_threads.c
@@ -1,0 +1,78 @@
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+/* could be probed in tests */
+void stub(void)
+{
+}
+
+void set_thread_name(const char *name)
+{
+  if (pthread_setname_np(pthread_self(), name)) {
+    perror("pthread_setname_np");
+    exit(EXIT_FAILURE);
+  }
+}
+
+void *grandson_work(void *)
+{
+  set_thread_name("grandson-thread");
+  stub();
+  return NULL;
+}
+
+void *son_work(void *)
+{
+  pthread_t tid;
+
+  set_thread_name("son-thread");
+  stub();
+
+  if (pthread_create(&tid, NULL, grandson_work, 0)) {
+    perror("pthread_create");
+    exit(EXIT_FAILURE);
+  }
+
+  if (pthread_join(tid, NULL)) {
+    perror("pthread_join");
+    exit(EXIT_FAILURE);
+  }
+
+  return NULL;
+}
+
+void real_parent(void)
+{
+  pthread_t tid;
+
+  set_thread_name("parent-thread");
+
+  if (pthread_create(&tid, NULL, son_work, 0)) {
+    perror("pthread_create");
+    exit(EXIT_FAILURE);
+  }
+
+  if (pthread_join(tid, NULL)) {
+    perror("pthread_join");
+    exit(EXIT_FAILURE);
+  }
+  exit(EXIT_SUCCESS);
+}
+
+int main(void)
+{
+  pid_t pid;
+
+  // When testing pcomm, pcomm=$SHELL is uncertain (bash, sh, zsh, etc.), so a
+  // new process needs to be forked first to act as the real_parent.
+  pid = fork();
+  if (pid == 0) {
+    real_parent();
+  }
+
+  waitpid(pid, NULL, 0);
+  return 0;
+}


### PR DESCRIPTION
We cannot use either `group_leader` or `real_parent` to get the parent process's name and PID because they are different for threads and processes.

If a task_struct is the leader of a thread group, then its pid is equal to its tid. We use this to determine whether to use group_leader or real_parent.

I used the [MonoSketch](https://app.monosketch.io/) tool to draw the following diagram.

- Processes

```
                         group_leader
                           ┌──────┐
                           │      │
                           ▼      │
    ┏━━━━━━━━━━┓        ┏━━━━━━━━━┷┓           fork
    ┃   bash   ┃═══════▶┃  parent  ┃═════════════╦════════════════════════════▶
    ┗━━━━━━━━━━┛        ┗━━┯━━━━━━━┛             ║
         ▲                 │    ▲                ║
         │                 │    │                ║
         │  real_parent    │    │                ║
         └─────────────────┘    │                ║
                                │                ▼
                                │           ┏━━━━━━━━━┓       fork
                                └───────────┃   son   ┃═════════╦═════════════▶
                               real_parent  ┗━━━━━┯━━━┛         ║
                                              ▲   │  ▲          ║
                                              └───┘  │          ║
                                      group_leader   │          ║
                                                     │          ║
                                                     │          ▼
                                                     │       ┏━━━━━━━━━━┓
                                                     └───────┃ grandson ┃═════▶
                                              real_parent    ┗━━━━━━━━━┯┛
                                                               ▲       │
                                                               └───────┘
                                                             group_leader
```

- Threads

```
                         group_leader
                           ┌──────┐
                           │      │
                           ▼      │
    ┏━━━━━━━━━━┓        ┏━━━━━━━━━┷┓     pthread_create/clone
    ┃   bash   ┃═══════▶┃  parent  ┃═════════════╦════════════════════════════▶
    ┗━━━━━━━━━━┛        ┗━━┯━━━━━━━┛             ║
       ▲  ▲  ▲             │  ▲  ▲               ║
       │  │  │             │  │  │               ║
       │  │  │ real_parent │  │  │               ║
       │  │  │             │  │  │               ║
       │  │  │             │  │  │               ▼
       │  │  │             │  │  │          ╔═════════╗   pthread_create/clone
       │  │  └─────────────┘  │  └──────────╢   son   ║═════════╦═════════════▶
       │  │                   │ group_leader╚═══════╤═╝         ║
       │  │                   │                     │           ║
       │  │                   │  real_parent        │           ║
       │  └───────────────────┼─────────────────────┘           ║
       │                      │                                 ║
       │                      │                                 ▼
       │                      │               group_leader   ╔══════════╗
       │                      └──────────────────────────────╢ grandson ║═════▶
       │                                                     ╚════╤═════╝
       │                                      real_parent         │
       └──────────────────────────────────────────────────────────┘
```

Fixes: 401c6394bd87 ("tools/{execsnoop,naptime}: Apply stdlib ppid/pcomm (#4744)")
Fixes: c9e6d644104c ("Use group_leader for pcomm (#4795)")
Link: https://github.com/bpftrace/bpftrace/issues/782

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->
