### PR TITLE
probe_matcher: fix probe listing for -p

### DIFF
--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -123,15 +123,19 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
         }
         return symbols::BinaryFuncMap();
       }();
-      // Expand to the full set of possible matching paths.
-      auto paths = util::resolve_binary_path(target,
-                                             bpftrace_->pid(),
-                                             bpftrace_->safe_mode_);
-      for (const auto& path : paths) {
-        auto ok = user_func_info_.func_symbols_for_path(path);
-        if (ok) {
-          for (const auto& sym : *ok) {
-            result[path].insert(sym);
+      // Expand to the full set of possible matching paths, unless a pid is
+      // given with -p and target is '*'. In that case, we already have
+      // the full set of symbols.
+      if (!bpftrace_->pid() || target != "*") {
+        auto paths = util::resolve_binary_path(target,
+                                               bpftrace_->pid(),
+                                               bpftrace_->safe_mode_);
+        for (const auto& path : paths) {
+          auto ok = user_func_info_.func_symbols_for_path(path);
+          if (ok) {
+            for (const auto& sym : *ok) {
+              result[path].insert(sym);
+            }
           }
         }
       }

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -30,6 +30,10 @@ BEFORE ./testprogs/uprobe_test
 NAME uprobes - list probes by pid; uprobes only
 RUN {{BPFTRACE}} -l 'uprobe:*' -p {{BEFORE_PID}}
 EXPECT_REGEX uprobe:.*/testprogs/uprobe_test:uprobeFunction1
+# Ensure that no probes from other binaries are listed. If bpftrace_test is
+# listed, unwanted globbing took place. bpftrace_test sits in the runtime
+# test runner's cwd (build/tests/).
+EXPECT_REGEX_NONE ^uprobe:bpftrace_test:
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - list probes by pid in separate mount namespace


### PR DESCRIPTION
bpftrace -l -p <pid> with target "*" is supposed to list only probes from the running pid.
With 4a3b4dec this changed, so that currently all binaries from $PATH are enumerated. Add back the restriction.

Fixes: 4a3b4dec ("cleanup: aggregate function info into mockable interfaces")
