### PR TITLE
Update integer and arithmetic type resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 #### Breaking Changes
 - stdlib: Change `pcomm` to an alias of task.real_parent.comm instead of task.group_leader.comm.
   - [#5132](https://github.com/bpftrace/bpftrace/pull/5132)
+- Subtraction and decrement ops now produce an int64 instead of a uint64.
+  - [#5138](https://github.com/bpftrace/bpftrace/pull/5138)
 #### Added
 - stdlib: add `leader_{tid,comm}` to retrieve the thread group leader.
   - [#5132](https://github.com/bpftrace/bpftrace/pull/5132)
@@ -33,6 +35,8 @@ and this project adheres to
 #### Changed
 - Improved disambiguation for cast and typeof-style expressions
   - [#5092](https://github.com/bpftrace/bpftrace/pull/5092)
+- The default type for positive integer literals is now `int8`
+  - [#5138](https://github.com/bpftrace/bpftrace/pull/5138)
 #### Deprecated
 #### Removed
 #### Fixed
@@ -44,6 +48,8 @@ and this project adheres to
   - [#5130](https://github.com/bpftrace/bpftrace/pull/5130)
 - Add bitfield support when printing full structure using "print()"
   - [#2801](https://github.com/bpftrace/bpftrace/issues/2801)
+- Fix subtraction and decrement ops not producing the correct type
+  - [#5138](https://github.com/bpftrace/bpftrace/pull/5138)
 #### Security
 #### Docs
 #### Tools

--- a/docs/language.md
+++ b/docs/language.md
@@ -434,12 +434,19 @@ begin { $x = 1<<16; printf("%d %d\n", (uint16)$x, $x); }
 ```
 
 Integers are by default represented as the smallest possible
-type, e.g. `1` is a `uint8` and `-1` is an `int8`. However integers,
-scratch variables, and map keys/values will be automatically upcast
-when necessary, e.g.
-
+signed type, e.g. `0`, `1`, and `-1` are all `int8`.
+If an integer literal exceeds the largest `int64` then it's a `uint64`.
+Positive integer literals are flexible though.
+For this code:
 ```
-$a = 1; // starts as uint8
+$a = 1;
+$a = (uint64)2;
+```
+`$a` ends up being a `uint64` as bpftrace can determine this statically.
+
+Scratch variables and map keys/values will be automatically upcast when necessary, e.g.
+```
+$a = 1; // starts as int8
 $b = -1000; // starts as int16
 $a = $b; // $a now becomes an int16
 
@@ -742,13 +749,18 @@ The following operators are available for integer arithmetic:
 
 Operations between a signed and an unsigned integer are allowed providing
 bpftrace can statically prove a safe conversion is possible. If safe conversion
-is not guaranteed, the operation is undefined behavior and a corresponding
-warning will be emitted.
+is not guaranteed, the operation is undefined behavior.
 
 If the two operands are different size, the smaller integer is implicitly
 promoted to the size of the larger one. Sign is preserved in the promotion.
 For example, `(uint32)5 + (uint8)3` is converted to `(uint32)5 + (uint32)3`
 which results in `(uint32)8`.
+
+Subtraction (as well as decrement below) always yields a signed integer type
+as this is equivalent to addition with a signed (negative) integer, e.g.
+these two assignments yield the same type (`int64`):
+`$a = (uint64)1 - (uint64)2; $b = (uint64)1 + (-2)`.
+To maintain an unsigned type, cast the result, e.g. `$a = (uint64)((uint64)1 - (uint64)2);`.
 
 Pointers may be used with arithmetic operators but only for addition and
 subtraction. For subtraction, the pointer must appear on the left side of the

--- a/src/ast/integer_types.cpp
+++ b/src/ast/integer_types.cpp
@@ -8,16 +8,25 @@ namespace bpftrace::ast {
 
 SizedType get_integer_type(uint64_t n)
 {
-  // Make the smallest possible sizedType based on n
-  if (n <= std::numeric_limits<uint8_t>::max()) {
-    return CreateUInt8();
-  } else if (n <= std::numeric_limits<uint16_t>::max()) {
-    return CreateUInt16();
-  } else if (n <= std::numeric_limits<uint32_t>::max()) {
-    return CreateUInt32();
+  // Make the smallest possible signed sizedType based on n
+  // or an unsigned SizedType if it exceeds the largest int64
+  SizedType ty;
+  if (n <= std::numeric_limits<int8_t>::max()) {
+    ty = CreateInt8();
+  } else if (n <= std::numeric_limits<int16_t>::max()) {
+    ty = CreateInt16();
+  } else if (n <= std::numeric_limits<int32_t>::max()) {
+    ty = CreateInt32();
+  } else if (n <= std::numeric_limits<int64_t>::max()) {
+    ty = CreateInt64();
   } else {
     return CreateUInt64();
   }
+  // Non-negative literals that fit in a signed type can be treated as
+  // either signed or unsigned. Values exceeding INT64_MAX require
+  // unsigned representation and are not flexible.
+  ty.SetSignFlexible(true);
+  return ty;
 }
 
 std::optional<SizedType> get_signed_integer_type(uint64_t n)

--- a/src/ast/passes/types/cast_creator.cpp
+++ b/src/ast/passes/types/cast_creator.cpp
@@ -9,11 +9,73 @@
 #include "log.h"
 #include "types.h"
 
+#include <cassert>
+#include <climits>
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <variant>
 
 namespace bpftrace::ast {
+
+static bool integer_fits_in_type(uint64_t val, const SizedType &type)
+{
+  assert(type.IsIntegerTy());
+
+  auto size = type.GetSize();
+  if (type.IsSigned()) {
+    switch (size) {
+      case 1:
+        return val <= std::numeric_limits<int8_t>::max();
+      case 2:
+        return val <= std::numeric_limits<int16_t>::max();
+      case 4:
+        return val <= std::numeric_limits<int32_t>::max();
+      case 8:
+        return val <= std::numeric_limits<int64_t>::max();
+      default:
+        return false;
+    }
+  } else {
+    switch (size) {
+      case 1:
+        return val <= std::numeric_limits<uint8_t>::max();
+      case 2:
+        return val <= std::numeric_limits<uint16_t>::max();
+      case 4:
+        return val <= std::numeric_limits<uint32_t>::max();
+      case 8:
+        return true;
+      default:
+        return false;
+    }
+  }
+}
+
+static bool integer_fits_in_type(int64_t val, const SizedType &type)
+{
+  assert(type.IsIntegerTy());
+  if (!type.IsSigned()) {
+    return false;
+  }
+
+  auto size = type.GetSize();
+  switch (size) {
+    case 1:
+      return val >= std::numeric_limits<int8_t>::min() &&
+             val <= std::numeric_limits<int8_t>::max();
+    case 2:
+      return val >= std::numeric_limits<int16_t>::min() &&
+             val <= std::numeric_limits<int16_t>::max();
+    case 4:
+      return val >= std::numeric_limits<int32_t>::min() &&
+             val <= std::numeric_limits<int32_t>::max();
+    case 8:
+      return true;
+    default:
+      return false;
+  }
+}
 
 static std::optional<SizedType> try_expression_cast(
     ASTContext &ctx,
@@ -133,27 +195,11 @@ static std::optional<SizedType> try_int_cast(ASTContext &ctx,
                                              const SizedType &target_type)
 {
   if (auto *integer = exp.as<Integer>()) {
-    if (target_type.IsSigned()) {
-      auto signed_ty = get_signed_integer_type(integer->value);
-      if (!signed_ty || !signed_ty->FitsInto(target_type)) {
-        // The integer is too large
-        return std::nullopt;
-      }
-    } else {
-      auto unsigned_ty = ast::get_integer_type(integer->value);
-      if (!unsigned_ty.FitsInto(target_type)) {
-        // The integer is too large
-        return std::nullopt;
-      }
-    }
-  } else if (auto *negative_integer = exp.as<NegativeInteger>()) {
-    if (!target_type.IsSigned()) {
+    if (!integer_fits_in_type(integer->value, target_type)) {
       return std::nullopt;
     }
-
-    auto signed_ty = get_signed_integer_type(negative_integer->value);
-    if (!signed_ty.FitsInto(target_type)) {
-      // The integer is too large
+  } else if (auto *negative_integer = exp.as<NegativeInteger>()) {
+    if (!integer_fits_in_type(negative_integer->value, target_type)) {
       return std::nullopt;
     }
   }

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -723,9 +723,10 @@ void TypeChecker::visit(ArrayAccess &arr)
     }
   } else {
     const auto &idx_type = type_map_.type(arr.indexpr);
-    if (!idx_type.IsIntTy() || idx_type.IsSigned()) {
+    if (!idx_type.IsIntTy() ||
+        (idx_type.IsSigned() && !idx_type.IsSignFlexible())) {
       arr.addError() << "The array index operator [] only "
-                        "accepts positive (unsigned) integer indices. Got: "
+                        "accepts non-negative integer indices. Got: "
                      << idx_type;
     }
   }

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -208,13 +208,14 @@ public:
 
     // There are some map expressions that self initialize, e.g. `@a++` or `@a
     // +=1` and there are no other assignments to them. Treat these as holding
-    // an int64 value type and try again to resolve them
+    // an int8 value type, as this is equivalent to a default 0 assignment, and
+    // then try again to resolve
     bool had_unresolved_map_values = false;
     for (const auto &name : map_value_names) {
       const auto &current_type = get_type(name);
       if (current_type.IsNoneTy()) {
         had_unresolved_map_values = true;
-        set_type(name, CreateInt64());
+        set_type(name, CreateInt8());
       }
     }
     if (had_unresolved_map_values) {
@@ -398,7 +399,6 @@ private:
   SizedType get_map_key_type(const std::string &map_name,
                              const SizedType &type,
                              Node &error_node);
-  void check_unresolved_maps();
   Node *find_variable_scope(const std::string &var_ident, bool safe = true);
   SizedType get_locked_node(const TypeVariable &node,
                             const SizedType &type,
@@ -472,12 +472,22 @@ SizedType get_binop_int(Binop &binop,
                         const SizedType &lht,
                         const SizedType &rht)
 {
+  auto left_type = lht;
+  auto right_type = rht;
+
+  if (left_type.IsSignFlexible() && !right_type.IsSignFlexible()) {
+    left_type.SetSign(right_type.IsSigned());
+    left_type.SetSignFlexible(false);
+  } else if (right_type.IsSignFlexible() && !left_type.IsSignFlexible()) {
+    right_type.SetSign(left_type.IsSigned());
+    right_type.SetSignFlexible(false);
+  }
   auto is_comparison = is_comparison_op(binop.op);
-  if (lht == rht) {
+  if (left_type == right_type) {
     if (is_comparison) {
       return CreateBool();
     } else {
-      if (lht.IsSigned()) {
+      if (left_type.IsSigned() || binop.op == Operator::MINUS) {
         return CreateInt64();
       }
       return CreateUInt64();
@@ -485,21 +495,23 @@ SizedType get_binop_int(Binop &binop,
   }
 
   bool show_warning = false;
-  bool mismatched_sign = rht.IsSigned() != lht.IsSigned();
+  bool mismatched_sign = right_type.IsSigned() != left_type.IsSigned();
   // N.B. all castable map values are 64 bits
-  if (lht.IsCastableMapTy()) {
-    if (rht.IsCastableMapTy()) {
+  if (left_type.IsCastableMapTy()) {
+    if (right_type.IsCastableMapTy()) {
       show_warning = mismatched_sign;
     } else {
-      if (!get_promoted_type(rht, CreateInteger(64, lht.IsSigned()))) {
+      if (!get_promoted_type(right_type,
+                             CreateInteger(64, left_type.IsSigned()))) {
         show_warning = true;
       }
     }
-  } else if (rht.IsCastableMapTy()) {
-    if (!get_promoted_type(lht, CreateInteger(64, rht.IsSigned()))) {
+  } else if (right_type.IsCastableMapTy()) {
+    if (!get_promoted_type(left_type,
+                           CreateInteger(64, right_type.IsSigned()))) {
       show_warning = true;
     }
-  } else if (!get_promoted_type(lht, rht)) {
+  } else if (!get_promoted_type(left_type, right_type)) {
     show_warning = true;
   }
 
@@ -519,13 +531,14 @@ SizedType get_binop_int(Binop &binop,
   // in kernel sources
   if (binop.op == Operator::DIV || binop.op == Operator::MOD) {
     // If they're still signed, we have to warn
-    if (lht.IsSigned() || rht.IsSigned()) {
+    if (left_type.IsSigned() || right_type.IsSigned()) {
       binop.addWarning() << "signed operands for '" << opstr(binop)
                          << "' can lead to undefined behavior "
                          << "(cast to unsigned to silence warning)";
     }
   }
-  if (lht.IsSigned() || rht.IsSigned()) {
+  if (left_type.IsSigned() || right_type.IsSigned() ||
+      binop.op == Operator::MINUS) {
     return CreateInt64();
   }
 
@@ -2095,14 +2108,17 @@ void TypeRuleCollector::visit(Unop &unop)
 {
   visit(unop.expr);
 
-  bool is_inc_dec_op = false;
+  bool is_inc_op = false;
+  bool is_dec_op = false;
 
   switch (unop.op) {
     case Operator::PRE_INCREMENT:
-    case Operator::PRE_DECREMENT:
     case Operator::POST_INCREMENT:
+      is_inc_op = true;
+      break;
+    case Operator::PRE_DECREMENT:
     case Operator::POST_DECREMENT:
-      is_inc_dec_op = true;
+      is_dec_op = true;
       break;
     default:;
   }
@@ -2113,7 +2129,7 @@ void TypeRuleCollector::visit(Unop &unop)
   // chain that attemps to assign this integer type to the stored map value or
   // variable. This enables us to get error messages on the correct node if we
   // attempt to increment a string or some other invalid type.
-  if (is_inc_dec_op) {
+  if (is_inc_op || is_dec_op) {
     if (auto *acc = unop.expr.as<MapAccess>()) {
       auto map_name = acc->map->ident;
 
@@ -2135,9 +2151,10 @@ void TypeRuleCollector::visit(Unop &unop)
       resolver_.add_type_rule({
           .output = &unop,
           .inputs = { &unop.expr.node() },
-          .resolve =
-              [&unop](const std::vector<SizedType> &inputs) -> SizedType {
-            return inputs[0].IsSigned() ? CreateInt64() : CreateUInt64();
+          .resolve = [&unop, is_dec_op](
+                         const std::vector<SizedType> &inputs) -> SizedType {
+            return (inputs[0].IsSigned() || is_dec_op) ? CreateInt64()
+                                                       : CreateUInt64();
           },
       });
 
@@ -2168,7 +2185,7 @@ void TypeRuleCollector::visit(Unop &unop)
       resolver_.add_type_rule({
           .output = &unop,
           .inputs = { &unop.expr.node() },
-          .resolve = [this, &unop, scoped_var](
+          .resolve = [this, &unop, scoped_var, is_dec_op](
                          const std::vector<SizedType> &inputs) -> SizedType {
             const auto &type = inputs[0];
             const auto &current_type = resolver_.get_type(scoped_var);
@@ -2177,7 +2194,8 @@ void TypeRuleCollector::visit(Unop &unop)
               return current_type;
             }
 
-            return type.IsSigned() ? CreateInt64() : CreateUInt64();
+            return (type.IsSigned() || is_dec_op) ? CreateInt64()
+                                                  : CreateUInt64();
           },
       });
 

--- a/src/stdlib/process.bt
+++ b/src/stdlib/process.bt
@@ -1,7 +1,7 @@
 macro __signal(expr, is_tid)
 {
   import "stdlib/process/process.bpf.c";
-  let $sig : uint64 = 0;
+  let $sig : uint32 = 0;
 
   if comptime (probetype != "kprobe" && probetype != "kretprobe" &&
                probetype != "uprobe" && probetype != "uretprobe" &&
@@ -23,17 +23,17 @@ macro __signal(expr, is_tid)
         fail("%s accepts a string literal or an integer between 1 and 64 (inclusive)",
              is_tid ? "signal_thread()" : "signal()");
       } else {
-        $sig = expr;
+        $sig = (uint32)expr;
       }
     } else {
       fail("%s accepts a string literal or a positive integer",
            is_tid ? "signal_thread()" : "signal()");
     }
-  } else if comptime (!is_unsigned_integer(expr)) {
-    fail("%s accepts a string literal or a unsigned integer",
+  } else if comptime (!is_integer(expr)) {
+    fail("%s accepts a string literal or an integer",
          is_tid ? "signal_thread()" : "signal()");
   } else {
-    $sig = expr;
+    $sig = (uint32)expr;
   }
 
   if ($sig == 0 || $sig > 64) {
@@ -41,8 +41,8 @@ macro __signal(expr, is_tid)
            is_tid ? "signal_thread()" : "signal()", $sig);
   } else {
     $ret = comptime is_tid
-           ? __signal_thread((uint32)$sig)
-           : __signal_process((uint32)$sig);
+           ? __signal_thread($sig)
+           : __signal_process($sig);
     if ($ret != 0) {
       warnf("signal call failed with error %d", $ret);
     }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -145,7 +145,10 @@ bool SizedType::IsCompatible(const SizedType &t) const
     if (IsSigned() == t.IsSigned()) {
       return true;
     }
-    // If the signs don't match then then unsigned side
+    if (IsSignFlexible() || t.IsSignFlexible()) {
+      return true;
+    }
+    // If the signs don't match then the unsigned side
     // can't be promoted anymore if it's already the largest int
     if (!t.IsSigned()) {
       return t.GetSize() != 8;
@@ -676,8 +679,20 @@ std::optional<SizedType> get_promoted_int(const SizedType &currentType,
   bool newSigned = newType.IsSigned();
   auto currentSize = currentType.GetSize();
   auto newSize = newType.GetSize();
+  bool result_flexible = currentType.IsSignFlexible() &&
+                         newType.IsSignFlexible();
 
   if (currentSigned != newSigned) {
+    // If one side has flexible sign (from a non-negative integer literal),
+    // adapt it to match the other side's sign and promote by size.
+    if (currentType.IsSignFlexible() || newType.IsSignFlexible()) {
+      bool sign = currentType.IsSignFlexible() ? newSigned : currentSigned;
+      size_t promoted_size = std::max(currentSize, newSize);
+      auto result = CreateInteger(promoted_size * 8, sign);
+      result.SetSignFlexible(result_flexible);
+      return result;
+    }
+
     if (currentSigned && currentSize > newSize) {
       return CreateInteger(currentSize * 8, true);
     } else if (newSigned && newSize > currentSize) {
@@ -694,7 +709,9 @@ std::optional<SizedType> get_promoted_int(const SizedType &currentType,
 
   // Same sign - return the larger of the two
   size_t promoted_size = std::max(currentSize, newSize);
-  return CreateInteger(promoted_size * 8, currentSigned);
+  auto result = CreateInteger(promoted_size * 8, currentSigned);
+  result.SetSignFlexible(result_flexible);
+  return result;
 }
 
 std::optional<SizedType> get_promoted_castable_map(const SizedType &currentType,
@@ -895,7 +912,7 @@ bool SizedType::FitsInto(const SizedType &t) const
     return GetSize() <= t.GetSize();
 
   if (IsIntegerTy()) {
-    if (IsSigned() == t.IsSigned())
+    if (IsSigned() == t.IsSigned() || IsSignFlexible())
       return GetSize() <= t.GetSize();
 
     // Unsigned into signed requires the destination to be bigger than the

--- a/src/types.h
+++ b/src/types.h
@@ -208,6 +208,7 @@ private:
                      // owned by the `StructManager`.
   AddrSpace as_ = AddrSpace::none;
   bool is_signed_ = false;
+  bool sign_flexible_ = false;
   bool is_anon_ = false;
   bool ctx_ = false;                              // Is bpf program context
   std::unordered_set<std::string> btf_type_tags_; // Only populated for
@@ -306,6 +307,16 @@ public:
   }
 
   bool IsSigned() const;
+
+  void SetSignFlexible(bool flexible)
+  {
+    sign_flexible_ = flexible;
+  }
+
+  bool IsSignFlexible() const
+  {
+    return sign_flexible_;
+  }
 
   size_t GetSize() const
   {

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -358,7 +358,7 @@ WILL_FAIL
 
 NAME has_key error type mismatch
 PROG begin { @g[1, "hi"] = 2; if (has_key(@g, (1, 2))) { printf("ok\n"); }  }
-EXPECT_REGEX .* ERROR: Argument mismatch for @g: trying to access with arguments: '\(uint8,uint8\)' when map expects arguments: '\(uint8,string\[3\]\)'.*
+EXPECT_REGEX .* ERROR: Argument mismatch for @g: trying to access with arguments: '\(int8,int8\)' when map expects arguments: '\(int8,string\[3\]\)'.*
 WILL_FAIL
 
 NAME exit code

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -26,12 +26,14 @@ PROG begin { @map[16] = 32; @map[64] = 128; for ($kv : @map) { @new[$kv.1] = $kv
 EXPECT @new[32]: 16
 EXPECT @new[128]: 64
 
+# TODO: make these maps different types.
+# https://github.com/bpftrace/bpftrace/issues/5142
 NAME map multiple loops
-PROG begin { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); } for ($kv : @mapB) { print($kv); }  }
+PROG begin { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 40; @mapB[65] = 41; for ($kv : @mapA) { print($kv); } for ($kv : @mapB) { print($kv); }  }
 EXPECT (16, 32)
 EXPECT (17, 33)
-EXPECT (64, 128)
-EXPECT (65, 129)
+EXPECT (64, 40)
+EXPECT (65, 41)
 
 NAME map multiple probes
 PROG begin { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); }  } end { for ($kv : @mapB) { print($kv); } }

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -337,8 +337,8 @@ PROG enum { ONE = 1, TWO = 2 }; begin { @[ONE+1] = TWO-1;  }
 EXPECT @[2]: 1
 
 NAME no symbolize enum after arithmetic mixed
-PROG enum { ONE = 1, TWO = 2 }; begin { @[ONE+1] = TWO-1; @[ONE] = ONE;  }
-EXPECT @[2]: 1
+PROG enum { ONE = 1, TWO = 2 }; begin { @[ONE+1] = TWO+1; @[ONE] = ONE;  }
+EXPECT @[2]: 3
 EXPECT @[1]: 1
 
 NAME symbolize enum in scratch variable

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -36,6 +36,31 @@ PROG begin { printf("%lu\n", (uint64)(-4095)); }
 EXPECT 18446744073709547521
 TIMEOUT 1
 
+NAME subtraction produces negative
+PROG begin { $a = (uint8)1 - 2; printf("%d\n", $a); }
+EXPECT -1
+TIMEOUT 1
+
+NAME decrement map below zero
+PROG begin { @x = 0; --@x; printf("%d\n", @x); }
+EXPECT -1
+TIMEOUT 1
+
+NAME increment then decrement map below zero
+PROG begin { @x = 0; ++@x; --@x; --@x; printf("%d\n", @x); }
+EXPECT -1
+TIMEOUT 1
+
+NAME uint64 subtraction stays unsigned with cast
+PROG begin { $a = (uint64)((uint64)5 - (uint64)3); printf("%lu\n", $a); }
+EXPECT 2
+TIMEOUT 1
+
+NAME uint64 subtraction underflow with cast
+PROG begin { $a = (uint64)3 - (uint64)5; printf("%d %lu\n", $a, $a); }
+EXPECT -2 18446744073709551614
+TIMEOUT 1
+
 NAME mixed values
 PROG begin { printf("%d %d %d %d\n", (int8) -10, -5555, (int16)-123, 100);  }
 EXPECT -10 -5555 -123 100

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -331,7 +331,7 @@ TEST_F(TypeCheckerTest, consistent_map_values)
   test(
       R"(begin { $a = (3, "hello"); @m[1] = $a; $a = (1,"aaaaaaaaaa"); @m[2] = $a; })");
   test("kprobe:f { @x = 0; @x = \"a\"; }", Error{ R"(
-stdin:1:20-28: ERROR: Type mismatch for @x: trying to assign value of type 'string[2]' when map already has a type 'uint8'
+stdin:1:20-28: ERROR: Type mismatch for @x: trying to assign value of type 'string[2]' when map already has a type 'int8'
 kprobe:f { @x = 0; @x = "a"; }
                    ~~~~~~~~
 )" });
@@ -361,12 +361,12 @@ begin { @x[1] = 0; @x; }
   test("begin { @x[1, ((int8)2, ((int16)3, 4))] = 0; @x[5, (6, (7, 8))]; }");
 
   test("begin { @x[1,2] = 0; @x[3]; }", Error{ R"(
-ERROR: Argument mismatch for @x: trying to access with arguments: '(uint8,uint8)' when map expects arguments: 'uint8'
+ERROR: Argument mismatch for @x: trying to access with arguments: '(int8,int8)' when map expects arguments: 'int8'
 begin { @x[1,2] = 0; @x[3]; }
         ~~~~~~~
 )" });
   test("begin { @x[1] = 0; @x[2,3]; }", Error{ R"(
-ERROR: Argument mismatch for @x: trying to access with arguments: '(uint8,uint8)' when map expects arguments: 'uint8'
+ERROR: Argument mismatch for @x: trying to access with arguments: '(int8,int8)' when map expects arguments: 'int8'
 begin { @x[1] = 0; @x[2,3]; }
                    ~~~~~~~
 )" });
@@ -379,7 +379,7 @@ begin { @x[1] = 0; @x[2,3]; }
       @x["b", 2, kstack];
     })",
        Error{ R"(
-ERROR: Argument mismatch for @x: trying to access with arguments: '(string[2],uint8,kstack_bpftrace_127)' when map expects arguments: '(uint8,string[2],kstack_bpftrace_127)'
+ERROR: Argument mismatch for @x: trying to access with arguments: '(string[2],int8,kstack_bpftrace_127)' when map expects arguments: '(int8,string[2],kstack_bpftrace_127)'
       @x["b", 2, kstack];
       ~~~~~~~~~~~~~~~~~~
 )" });
@@ -388,7 +388,7 @@ ERROR: Argument mismatch for @x: trying to access with arguments: '(string[2],ui
 
   test(R"(begin { @map[1, 2] = 1; for ($kv : @map) { @map[$kv.0.0] = 2; } })",
        Error{ R"(
-ERROR: Argument mismatch for @map: trying to access with arguments: 'uint8' when map expects arguments: '(uint8,uint8)'
+ERROR: Argument mismatch for @map: trying to access with arguments: 'int8' when map expects arguments: '(int8,int8)'
 begin { @map[1, 2] = 1; for ($kv : @map) { @map[$kv.0.0] = 2; } }
                                            ~~~~~~~~~~~~~
 )" });
@@ -494,25 +494,25 @@ TEST_F(TypeCheckerTest, ternary_expressions)
   // Error location is incorrect: #3063
   test("kprobe:f { $x = pid < 10000 ? 3 : cat(\"/proc/uptime\"); exit(); }",
        Error{ R"(
-stdin:1:17-54: ERROR: Branches must return the same type or compatible types: have 'uint8' and 'void'
+stdin:1:17-54: ERROR: Branches must return the same type or compatible types: have 'int8' and 'void'
 kprobe:f { $x = pid < 10000 ? 3 : cat("/proc/uptime"); exit(); }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? 1 : \"high\" }", Error{ R"(
-stdin:1:17-41: ERROR: Branches must return the same type or compatible types: have 'uint8' and 'string[5]'
+stdin:1:17-41: ERROR: Branches must return the same type or compatible types: have 'int8' and 'string[5]'
 kprobe:f { @x = pid < 10000 ? 1 : "high" }
                 ~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? \"lo\" : 2 }", Error{ R"(
-stdin:1:17-39: ERROR: Branches must return the same type or compatible types: have 'string[3]' and 'uint8'
+stdin:1:17-39: ERROR: Branches must return the same type or compatible types: have 'string[3]' and 'int8'
 kprobe:f { @x = pid < 10000 ? "lo" : 2 }
                 ~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? (1, 2) : (\"a\", 4) }", Error{ R"(
-stdin:1:17-48: ERROR: Branches must return the same type or compatible types: have '(uint8,uint8)' and '(string[2],uint8)'
+stdin:1:17-48: ERROR: Branches must return the same type or compatible types: have '(int8,int8)' and '(string[2],int8)'
 kprobe:f { @x = pid < 10000 ? (1, 2) : ("a", 4) }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -545,7 +545,7 @@ kprobe:f { $x = nonsense; $y = true ? $x : 1; exit(); }
 TEST_F(TypeCheckerTest, mismatched_call_types)
 {
   test("kprobe:f { @x = 1; @x = count(); }", Error{ R"(
-stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'count_t' when map already has a type 'uint8'
+stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'count_t' when map already has a type 'int8'
 kprobe:f { @x = 1; @x = count(); }
                         ~~~~~~~
 )" });
@@ -557,7 +557,7 @@ kprobe:f { @x = count(); @x = sum(pid); }
                               ~~~~~~~~
 )" });
   test("kprobe:f { @x = 1; @x = hist(0); }", Error{ R"(
-stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'hist_t' when map already has a type 'uint8'
+stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'hist_t' when map already has a type 'int8'
 kprobe:f { @x = 1; @x = hist(0); }
                         ~~~~~~~
 )" });
@@ -872,7 +872,7 @@ TEST_F(TypeCheckerTest, call_delete)
   test("kprobe:f { @y[(3, 4, 5)] = "
        "5; delete(@y, (1, 2)); }",
        Error{ R"(
-ERROR: Argument mismatch for @y: trying to access with arguments: '(uint8,uint8)' when map expects arguments: '(uint8,uint8,uint8)'
+ERROR: Argument mismatch for @y: trying to access with arguments: '(int8,int8)' when map expects arguments: '(int8,int8,int8)'
 )" },
        Types{ types });
 
@@ -903,7 +903,7 @@ ERROR: call to delete() with two arguments expects a map with explicit keys (non
 
   test(R"(kprobe:f { @x[1, "hi"] = 1; delete(@x["hi", 1]); })",
        Error{ R"(
-ERROR: Argument mismatch for @x: trying to access with arguments: '(string[3],uint8)' when map expects arguments: '(uint8,string[3])'
+ERROR: Argument mismatch for @x: trying to access with arguments: '(string[3],int8)' when map expects arguments: '(int8,string[3])'
 )" },
        Types{ types });
 
@@ -966,7 +966,7 @@ TEST_F(TypeCheckerTest, call_print_map_item)
   test("begin { print(@x[2]); }");
 
   test("begin { @x[1] = 1; print(@x[\"asdf\"]); }", Error{ R"(
-ERROR: Argument mismatch for @x: trying to access with arguments: 'string[5]' when map expects arguments: 'uint8'
+ERROR: Argument mismatch for @x: trying to access with arguments: 'string[5]' when map expects arguments: 'int8'
 begin { @x[1] = 1; print(@x["asdf"]); }
                          ~~~~~~~~~~
 )" });
@@ -1569,7 +1569,7 @@ TEST_F(TypeCheckerTest, variable_reassignment)
 
   test(R"(kprobe:f { $b = "hi"; $b = @b; } kprobe:func_1 { @b = 1; })",
        Error{ R"(
-stdin:1:23-30: ERROR: Type mismatch for $b: trying to assign value of type 'uint8' when variable already has a type 'string[3]'
+stdin:1:23-30: ERROR: Type mismatch for $b: trying to assign value of type 'int8' when variable already has a type 'string[3]'
 kprobe:f { $b = "hi"; $b = @b; } kprobe:func_1 { @b = 1; }
                       ~~~~~~~
 )" });
@@ -1595,6 +1595,8 @@ TEST_F(TypeCheckerTest, variables_are_local)
 
 TEST_F(TypeCheckerTest, array_access)
 {
+  test(R"(begin { $i = 1; $s = "ab"; $a = $s[$i]; })");
+  test(R"(begin { $i = -1; $s = "ab"; $a = $s[$i]; })", Error{});
   test("kprobe:f { $s = arg0; @x = $s->y[0];}", Error{});
   test("kprobe:f { $s = 0; @x = $s->y[0];}", Error{});
   test("struct MyStruct { int y[4]; } "
@@ -1611,7 +1613,7 @@ TEST_F(TypeCheckerTest, array_access)
        Error{});
   test("struct MyStruct { int y[4]; } "
        "kprobe:f { $s = (struct MyStruct *) "
-       "arg0; $idx = 0; @x = $s->y[$idx];}");
+       "arg0; $idx = (uint32)0; @x = $s->y[$idx];}");
   test("struct MyStruct { int y[4]; } "
        "kprobe:f { $s = (struct MyStruct *) "
        "arg0; $idx = -1; @x = $s->y[$idx];}",
@@ -1750,7 +1752,7 @@ TEST_F(TypeCheckerTest, array_compare)
 TEST_F(TypeCheckerTest, variable_type)
 {
   auto result = test("kprobe:f { $x = 1 }");
-  auto st = CreateUInt8();
+  auto st = CreateInt8();
   auto *assignment = result.ast.root->probes.at(0)
                          ->block->stmts.at(0)
                          .as<ast::AssignVarStatement>();
@@ -2161,25 +2163,35 @@ TEST_F(TypeCheckerTest, map_aggregations_implicit_cast)
                 std::forward<decltype(expr)>(expr));
   };
   auto CastVal = [](auto &&expr) {
+    return Cast(Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "int64")),
+                std::forward<decltype(expr)>(expr));
+  };
+  auto CastUInt8 = [](auto &&expr) {
+    return Cast(Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "uint8")),
+                std::forward<decltype(expr)>(expr));
+  };
+  auto CastValU = [](auto &&expr) {
     return Cast(Typeof(ParsedType(ast::ParsedType::Kind::Identifier, "uint64")),
                 std::forward<decltype(expr)>(expr));
   };
-  test("kprobe:f { @x = 1; @y = count(); @x = @y; }",
+  test("kprobe:f { @x = (uint8)1; @y = count(); @x = @y; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
-           { AssignMapStatement(
-                 Map("@x"), CastKey(Integer(0)), CastVal(Integer(1))),
+           { AssignMapStatement(Map("@x"),
+                                CastKey(Integer(0)),
+                                CastValU(CastUInt8(Integer(1)))),
              DiscardExpr(Call("count", { Map("@y"), CastKey(Integer(0)) })),
              AssignMapStatement(Map("@x"),
                                 CastKey(Integer(0)),
-                                CastVal(
+                                CastValU(
                                     MapAccess(Map("@y"), CastKey(Integer(0))))),
              Jump(ast::JumpType::RETURN) })) });
-  test("kprobe:f { @x = 1; @y = sum(5); @x = @y; }",
+  test("kprobe:f { @x = (uint8)1; @y = sum(5); @x = @y; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
-           { AssignMapStatement(
-                 Map("@x"), CastKey(Integer(0)), CastVal(Integer(1))),
+           { AssignMapStatement(Map("@x"),
+                                CastKey(Integer(0)),
+                                CastVal(CastUInt8(Integer(1)))),
              DiscardExpr(
                  Call("sum", { Map("@y"), CastKey(Integer(0)), Integer(5) })),
              AssignMapStatement(Map("@x"),
@@ -2187,11 +2199,12 @@ TEST_F(TypeCheckerTest, map_aggregations_implicit_cast)
                                 CastVal(
                                     MapAccess(Map("@y"), CastKey(Integer(0))))),
              Jump(ast::JumpType::RETURN) })) });
-  test("kprobe:f { @x = 1; @y = min(5); @x = @y; }",
+  test("kprobe:f { @x = (uint8)1; @y = min(5); @x = @y; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
-           { AssignMapStatement(
-                 Map("@x"), CastKey(Integer(0)), CastVal(Integer(1))),
+           { AssignMapStatement(Map("@x"),
+                                CastKey(Integer(0)),
+                                CastVal(CastUInt8(Integer(1)))),
              DiscardExpr(
                  Call("min", { Map("@y"), CastKey(Integer(0)), Integer(5) })),
              AssignMapStatement(Map("@x"),
@@ -2199,11 +2212,12 @@ TEST_F(TypeCheckerTest, map_aggregations_implicit_cast)
                                 CastVal(
                                     MapAccess(Map("@y"), CastKey(Integer(0))))),
              Jump(ast::JumpType::RETURN) })) });
-  test("kprobe:f { @x = 1; @y = max(5); @x = @y; }",
+  test("kprobe:f { @x = (uint8)1; @y = max(5); @x = @y; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
-           { AssignMapStatement(
-                 Map("@x"), CastKey(Integer(0)), CastVal(Integer(1))),
+           { AssignMapStatement(Map("@x"),
+                                CastKey(Integer(0)),
+                                CastVal(CastUInt8(Integer(1)))),
              DiscardExpr(
                  Call("max", { Map("@y"), CastKey(Integer(0)), Integer(5) })),
              AssignMapStatement(Map("@x"),
@@ -2211,11 +2225,12 @@ TEST_F(TypeCheckerTest, map_aggregations_implicit_cast)
                                 CastVal(
                                     MapAccess(Map("@y"), CastKey(Integer(0))))),
              Jump(ast::JumpType::RETURN) })) });
-  test("kprobe:f { @x = 1; @y = avg(5); @x = @y; }",
+  test("kprobe:f { @x = (uint8)1; @y = avg(5); @x = @y; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
-           { AssignMapStatement(
-                 Map("@x"), CastKey(Integer(0)), CastVal(Integer(1))),
+           { AssignMapStatement(Map("@x"),
+                                CastKey(Integer(0)),
+                                CastVal(CastUInt8(Integer(1)))),
              DiscardExpr(
                  Call("avg", { Map("@y"), CastKey(Integer(0)), Integer(5) })),
              AssignMapStatement(Map("@x"),
@@ -2243,36 +2258,36 @@ kprobe:f { @y = count(); @x = @y; }
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )" });
   test("kprobe:f { @y = sum(5); @x = @y; }", Error{ R"(
-stdin:1:25-32: ERROR: Map value 'usum_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = sum(retval);`.
+stdin:1:25-32: ERROR: Map value 'sum_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = sum(retval);`.
 kprobe:f { @y = sum(5); @x = @y; }
                         ~~~~~~~
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )" });
   test("kprobe:f { @y = min(5); @x = @y; }", Error{ R"(
-stdin:1:25-32: ERROR: Map value 'umin_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = min(retval);`.
+stdin:1:25-32: ERROR: Map value 'min_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = min(retval);`.
 kprobe:f { @y = min(5); @x = @y; }
                         ~~~~~~~
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )" });
   test("kprobe:f { @y = max(5); @x = @y; }", Error{ R"(
-stdin:1:25-32: ERROR: Map value 'umax_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = max(retval);`.
+stdin:1:25-32: ERROR: Map value 'max_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = max(retval);`.
 kprobe:f { @y = max(5); @x = @y; }
                         ~~~~~~~
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )" });
   test("kprobe:f { @y = avg(5); @x = @y; }", Error{ R"(
-stdin:1:25-32: ERROR: Map value 'uavg_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = avg(retval);`.
+stdin:1:25-32: ERROR: Map value 'avg_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = avg(retval);`.
 kprobe:f { @y = avg(5); @x = @y; }
                         ~~~~~~~
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )" });
   test("kprobe:f { @y = stats(5); @x = @y; }", Error{ R"(
-stdin:1:27-34: ERROR: Map value 'ustats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
+stdin:1:27-34: ERROR: Map value 'stats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
 kprobe:f { @y = stats(5); @x = @y; }
                           ~~~~~~~
 )" });
   test("kprobe:f { @x = 1; @y = stats(5); @x = @y; }", Error{ R"(
-stdin:1:35-42: ERROR: Map value 'ustats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
+stdin:1:35-42: ERROR: Map value 'stats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
 kprobe:f { @x = 1; @y = stats(5); @x = @y; }
                                   ~~~~~~~
 )" });
@@ -2284,13 +2299,13 @@ kprobe:f { @x = 1; @y = stats(5); @x = @y; }
   test("kprobe:f { @ = avg(5); if (@ > 0) { print((1)); } }");
 
   test("kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }", Error{ R"(
-stdin:1:29-34: ERROR: Type mismatch for '>': comparing hist_t with uint8
+stdin:1:29-34: ERROR: Type mismatch for '>': comparing hist_t with int8
 kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
                             ~~~~~
 stdin:1:29-30: ERROR: left (hist_t)
 kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
                             ~
-stdin:1:33-34: ERROR: right (uint8)
+stdin:1:33-34: ERROR: right (int8)
 kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
                                 ~
 )" });
@@ -2536,7 +2551,7 @@ begin { @x = tseries(10, 1s, 10); @y[@x] = 1; }
 )" });
 
   test("begin { @x = stats(10); @y[@x] = 1; }", Error{ R"(
-ERROR: Value 'ustats_t' cannot be used as a map key.
+ERROR: Value 'stats_t' cannot be used as a map key.
 begin { @x = stats(10); @y[@x] = 1; }
                         ~~~~~~
 )" });
@@ -2655,14 +2670,22 @@ TEST_F(TypeCheckerTest, signed_int_comparison_warnings)
   test("kretprobe:f /retval < -1/ {}", Warning{ cmp_sign });
 
   // These should not trigger a warning
-  test("kretprobe:f /1 < retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /1 > retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /1 >= retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /1 <= retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /1 != retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /1 == retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /retval > 1/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /retval < 1/ {}", NoWarning{ cmp_sign });
+  test("kretprobe:f /(uint64)1 < retval/ {}", NoWarning{ cmp_sign });
+  test("kretprobe:f /(uint64)1 > retval/ {}", NoWarning{ cmp_sign });
+  test("kretprobe:f /(uint64)1 >= retval/ {}", NoWarning{ cmp_sign });
+  test("kretprobe:f /(uint64)1 <= retval/ {}", NoWarning{ cmp_sign });
+  test("kretprobe:f /(uint64)1 != retval/ {}", NoWarning{ cmp_sign });
+  test("kretprobe:f /(uint64)1 == retval/ {}", NoWarning{ cmp_sign });
+  test("kretprobe:f /retval > (uint64)1/ {}", NoWarning{ cmp_sign });
+  test("kretprobe:f /retval < (uint64)1/ {}", NoWarning{ cmp_sign });
+}
+
+TEST_F(TypeCheckerTest, unsigned_literal_arithmetic_warnings)
+{
+  test(R"(begin { $a = (uint64)10 / 2; })",
+       NoWarning{ "signed operands for '/'" });
+  test(R"(begin { $a = (uint64)10 % 2; })",
+       NoWarning{ "signed operands for '%'" });
 }
 
 TEST_F(TypeCheckerTest, string_comparison)
@@ -2701,26 +2724,26 @@ kprobe:f { $x = "foo"; printf("%c is the fifth letter", $x[4]); }
 TEST_F(TypeCheckerTest, signed_int_division_warnings)
 {
   std::string msg = "signed operands";
-  test("kprobe:f { @x = -1; @y = @x / 1 }", Warning{ msg });
+  test("kprobe:f { @x = (uint64)1; @y = -1 / @x }", Warning{ msg });
   test("kprobe:f { @x = (uint64)1; @y = @x / -1 }", Warning{ msg });
 
   // These should not trigger a warning.
   // Note that we need to assign to a map in
   // order to ensure that they are typed.
   // Literals are not yet typed.
-  test("kprobe:f { @x = (uint64)1; @y = @x / 1 }", NoWarning{ msg });
-  test("kprobe:f { @x = (uint64)1; @y = -(@x / 1) }", NoWarning{ msg });
+  test("kprobe:f { @x = (uint64)1; @y = @x / (uint64)1 }", NoWarning{ msg });
+  test("kprobe:f { @x = (uint64)1; @y = -(@x / (uint64)1) }", NoWarning{ msg });
 }
 
 TEST_F(TypeCheckerTest, signed_int_modulo_warnings)
 {
   std::string msg = "signed operands";
-  test("kprobe:f { @x = -1; @y = @x % 1 }", Warning{ msg });
+  test("kprobe:f { @x = (uint64)1; @y = -1 % @x }", Warning{ msg });
   test("kprobe:f { @x = (uint64)1; @y = @x % -1 }", Warning{ msg });
 
   // These should not trigger a warning. See above re: types.
-  test("kprobe:f { @x = (uint64)1; @y = @x % 1 }", NoWarning{ msg });
-  test("kprobe:f { @x = (uint64)1; @y = -(@x % 1) }", NoWarning{ msg });
+  test("kprobe:f { @x = (uint64)1; @y = @x % (uint64)1 }", NoWarning{ msg });
+  test("kprobe:f { @x = (uint64)1; @y = -(@x % (uint64)1) }", NoWarning{ msg });
 }
 
 TEST_F(TypeCheckerTest, map_as_lookup_table)
@@ -2787,6 +2810,7 @@ TEST_F(TypeCheckerTest, binop_arithmetic)
 
   std::string arithmetic_operators[] = { "+", "-", "/", "*" };
   for (std::string op : arithmetic_operators) {
+    bool is_subtract = op == "-";
     std::string prog = prog_pre + "$varA = $t->l " + op +
                        " $t->l; "
                        "$varB = $t->ul " +
@@ -2816,11 +2840,13 @@ TEST_F(TypeCheckerTest, binop_arithmetic)
     auto *varC = result.ast.root->probes.at(0)
                      ->block->stmts.at(3)
                      .as<ast::AssignVarStatement>();
-    EXPECT_EQ(CreateUInt64(), result.type_map.type(varC->var()));
+    EXPECT_EQ(is_subtract ? CreateInt64() : CreateUInt64(),
+              result.type_map.type(varC->var()));
     auto *varD = result.ast.root->probes.at(0)
                      ->block->stmts.at(4)
                      .as<ast::AssignVarStatement>();
-    EXPECT_EQ(CreateUInt64(), result.type_map.type(varD->var()));
+    EXPECT_EQ(is_subtract ? CreateInt64() : CreateUInt64(),
+              result.type_map.type(varD->var()));
     // This one is not like the others
     auto *varE = result.ast.root->probes.at(0)
                      ->block->stmts.at(5)
@@ -2999,7 +3025,7 @@ TEST_F(TypeCheckerTest, mixed_int_var_assignments)
   test("begin { $a = -1; $a = (uint64)2; }", Error{});
   test("begin { $a = (int64)1; $a = (uint64)2; }", Error{});
   test("begin { $a = -1; $a = 9223372036854775808; }", Error{});
-  test("begin { $a = 9223372036854775807; $a = -2147483648 }", Error{});
+  test("begin { $a = 9223372036854775807; $a = -2147483648 }");
   test("kprobe:f { $x = -1; $x = 10223372036854775807; }", Error{ R"(
 stdin:1:21-46: ERROR: Type mismatch for $x: trying to assign value of type 'uint64' when variable already has a type 'int8'
 kprobe:f { $x = -1; $x = 10223372036854775807; }
@@ -3007,21 +3033,15 @@ kprobe:f { $x = -1; $x = 10223372036854775807; }
 )" });
 
   test("begin { $x = (int8)1; $x = 5; }",
-       ExpectedAST{ Program().WithProbe(Probe(
-           { "begin" },
-           { AssignVarStatement(
-                 Variable("$x"),
-                 Cast(Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
-                                        "int16")),
-                      Cast(Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
-                                             "int8")),
-                           Integer(1)))),
-             AssignVarStatement(
-                 Variable("$x"),
-                 Cast(Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
-                                        "int16")),
-                      Integer(5))),
-             Jump(ast::JumpType::RETURN) })) });
+       ExpectedAST{ Program().WithProbe(
+           Probe({ "begin" },
+                 { AssignVarStatement(
+                       Variable("$x"),
+                       Cast(Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
+                                              "int8")),
+                            Integer(1))),
+                   AssignVarStatement(Variable("$x"), Integer(5)),
+                   Jump(ast::JumpType::RETURN) })) });
   test("begin { $x = (int8)1; $x = (uint8)5; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "begin" },
@@ -3054,7 +3074,7 @@ TEST_F(TypeCheckerTest, mixed_int_like_map_assignments)
   test("kprobe:f { @x = 1; @x = 9223372036854775807; }");
   test("kprobe:f { @x = 1; @x = -9223372036854775808; }");
   test("kprobe:f { @x = (uint8)1; @x = -1; }");
-  test("kprobe:f { @x = 1; @x = 10223372036854775807; }");
+  test("kprobe:f { @x = (uint8)1; @x = 10223372036854775807; }");
   test("kprobe:f { @x = sum(1); @x = sum(-1); }");
   test("kprobe:f { @x = sum((uint32)1); @x = sum(-1); }");
   test("kprobe:f { @x = avg(1); @x = avg(-1); }");
@@ -3098,7 +3118,7 @@ TEST_F(TypeCheckerTest, mixed_int_map_access)
   test("kprobe:f { @x[(uint16)1] = 1; @x[10223372036854775807] }");
   test("kprobe:f { @x[1] = 1; @x[9223372036854775807] }");
   test("kprobe:f { @x[1] = 1; @x[-9223372036854775808] }");
-  test("kprobe:f { @x[1] = 1; @x[(uint64)1] }");
+  test("kprobe:f { @x[(uint8)1] = 1; @x[(uint64)1] }");
   test("kprobe:f { @x[(uint32)-1] = 1; @x[1] }");
   test("kprobe:f { @x[-1] = 1; @x[(uint32)1] }");
 
@@ -3132,7 +3152,7 @@ TEST_F(TypeCheckerTest, mixed_int_like_binop)
        NoWarning{ "comparison of integers" });
   test("kprobe:f { @a = sum(-1); $a = @a == (uint16)1; }",
        NoWarning{ "comparison of integers" });
-  test("kprobe:f { @a = sum(1); @b = count(); $a = @a == @b; }",
+  test("kprobe:f { @a = sum((uint64)1); @b = count(); $a = @a == @b; }",
        NoWarning{ "comparison of integers" });
 
   test("kprobe:f { $a = (uint64)1 == (int64)-1; }",
@@ -3221,19 +3241,29 @@ TEST_F(TypeCheckerTest, signal)
   for (const auto &signal :
        std::vector<std::string>{ "signal", "signal_thread" }) {
     // int literals
-    test("k:f {" + signal + "(1); }", UnsafeMode::Enable, Types{ types });
-    test("k:f {" + signal + "(1); }", UnsafeMode::Enable, Types{ types });
-    test("kr:f {" + signal + "(1); }", UnsafeMode::Enable, Types{ types });
-    test("u:/bin/sh:f {" + signal + "(11); }",
+    test("k:f {" + signal + "((uint64)1); }",
          UnsafeMode::Enable,
          Types{ types });
-    test("ur:/bin/sh:f {" + signal + "(11); }",
+    test("k:f {" + signal + "((uint64)1); }",
          UnsafeMode::Enable,
          Types{ types });
-    test("p:hz:1 {" + signal + "(1); }", UnsafeMode::Enable, Types{ types });
+    test("kr:f {" + signal + "((uint64)1); }",
+         UnsafeMode::Enable,
+         Types{ types });
+    test("u:/bin/sh:f {" + signal + "((uint64)11); }",
+         UnsafeMode::Enable,
+         Types{ types });
+    test("ur:/bin/sh:f {" + signal + "((uint64)11); }",
+         UnsafeMode::Enable,
+         Types{ types });
+    test("p:hz:1 {" + signal + "((uint64)1); }",
+         UnsafeMode::Enable,
+         Types{ types });
 
     // vars
-    test("k:f { @=1;" + signal + "(@); }", UnsafeMode::Enable, Types{ types });
+    test("k:f { @=(uint8)1;" + signal + "(@); }",
+         UnsafeMode::Enable,
+         Types{ types });
     test("k:f { " + signal + "((uint64)arg0); }",
          UnsafeMode::Enable,
          Types{ types });
@@ -3701,7 +3731,7 @@ TEST_F(TypeCheckerTest, tuple)
 
   test(R"(begin { $t = (1, ((int8)2, 3)); $t = (4, ((uint64)5, 6)); })",
        Error{ R"(
-stdin:1:33-57: ERROR: Type mismatch for $t: trying to assign value of type '(uint8,(uint64,uint8))' when variable already has a type '(uint8,(int8,uint8))'
+stdin:1:33-57: ERROR: Type mismatch for $t: trying to assign value of type '(int8,(uint64,int8))' when variable already has a type '(int8,(int8,int8))'
 begin { $t = (1, ((int8)2, 3)); $t = (4, ((uint64)5, 6)); }
                                 ~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -3733,7 +3763,7 @@ TEST_F(TypeCheckerTest, tuple_indexing)
 TEST_F(TypeCheckerTest, tuple_assign_var)
 {
   class SizedType ty = CreateTuple(
-      Struct::CreateTuple({ CreateUInt8(), CreateString(6) }));
+      Struct::CreateTuple({ CreateInt8(), CreateString(6) }));
   auto result = test(R"(begin { $t = (1, "str"); $t = (4, "other"); })");
   auto &stmts = result.ast.root->probes.at(0)->block->stmts;
 
@@ -3755,14 +3785,14 @@ TEST_F(TypeCheckerTest, tuple_assign_map)
   // $t = (1, 3, 3, 7);
   auto *assignment = stmts.at(0).as<ast::AssignMapStatement>();
   class SizedType ty = CreateTuple(Struct::CreateTuple(
-      { CreateUInt8(), CreateUInt8(), CreateUInt8(), CreateUInt8() }));
+      { CreateInt8(), CreateInt8(), CreateInt8(), CreateInt8() }));
   EXPECT_EQ(ty,
             result.type_map.map_value_type(assignment->map_access->map->ident));
 
   // $t = (0, 0, 0, 0);
   assignment = stmts.at(1).as<ast::AssignMapStatement>();
   ty = CreateTuple(Struct::CreateTuple(
-      { CreateUInt8(), CreateUInt8(), CreateUInt8(), CreateUInt8() }));
+      { CreateInt8(), CreateInt8(), CreateInt8(), CreateInt8() }));
   EXPECT_EQ(ty,
             result.type_map.map_value_type(assignment->map_access->map->ident));
 }
@@ -3771,9 +3801,9 @@ TEST_F(TypeCheckerTest, tuple_assign_map)
 TEST_F(TypeCheckerTest, tuple_nested)
 {
   class SizedType ty_inner = CreateTuple(
-      Struct::CreateTuple({ CreateUInt8(), CreateUInt8() }));
+      Struct::CreateTuple({ CreateInt8(), CreateInt8() }));
   class SizedType ty = CreateTuple(
-      Struct::CreateTuple({ CreateUInt8(), ty_inner }));
+      Struct::CreateTuple({ CreateInt8(), ty_inner }));
   auto result = test(R"(begin { $t = (1,(1,2)); })");
   auto &stmts = result.ast.root->probes.at(0)->block->stmts;
 
@@ -4195,11 +4225,11 @@ TEST_F(TypeCheckerTest, call_pid_tid)
 TEST_F(TypeCheckerTest, subprog_return)
 {
   test("fn f(): void { return; }");
-  test("fn f(): uint8 { return 1; }");
+  test("fn f(): uint8 { return (uint8)1; }");
 
   // Error location is incorrect: #3063
   test("fn f(): void { return 1; }", Error{ R"(
-stdin:1:16-25: ERROR: Function f is of type void, cannot return uint8
+stdin:1:16-25: ERROR: Function f is of type void, cannot return int8
 fn f(): void { return 1; }
                ~~~~~~~~~
 )" });
@@ -4244,9 +4274,9 @@ fn f($a : int64): string { return $a; }
 TEST_F(TypeCheckerTest, subprog_map)
 {
   test("fn f(): void { @a = 0; }");
-  test("fn f(): uint64 { @a = 0; return @a + 1; }");
+  test("fn f(): int64 { @a = 0; return @a + 1; }");
   test("fn f(): void { @a[0] = 0; }");
-  test("fn f(): uint64 { @a[0] = 0; return @a[0] + 1; }");
+  test("fn f(): int64 { @a[0] = 0; return @a[0] + 1; }");
 }
 
 TEST_F(TypeCheckerTest, subprog_builtin)
@@ -4498,7 +4528,7 @@ begin { @map[0] = tseries(10, 10s, 10); for ($kv : @map) { } }
                                                    ~~~~
 )" });
   test("begin { @map[0] = stats(10); for ($kv : @map) { } }", Error{ R"(
-stdin:1:41-45: ERROR: Loop expression does not support type: ustats_t
+stdin:1:41-45: ERROR: Loop expression does not support type: stats_t
 begin { @map[0] = stats(10); for ($kv : @map) { } }
                                         ~~~~
 )" });
@@ -4560,7 +4590,7 @@ TEST_F(TypeCheckerTest, for_loop_variables_modified_during_loop)
               AssignVarStatement(
                   Variable("$var"),
                   Cast(Typeof(ParsedType(ast::ParsedType::Kind::Identifier,
-                                         "uint64")),
+                                         "int64")),
                        Integer(0))),
               AssignMapStatement(Map("@map"), Integer(0), Integer(1)),
               For(Variable("$kv"),
@@ -4772,12 +4802,12 @@ begin { @a = count(); $b = @a; }
                            ~~
 )" });
 
-  test("begin { @a = count(); @b = 1; @b = @a; }",
+  test("begin { @a = count(); @b = (uint8)1; @b = @a; }",
        NoFeatures::Enable,
        Error{ R"(
-stdin:1:36-38: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a = count(); @b = 1; @b = @a; }
-                                   ~~
+stdin:1:43-45: ERROR: Missing required kernel feature: map_lookup_percpu_elem
+begin { @a = count(); @b = (uint8)1; @b = @a; }
+                                          ~~
 )" });
 }
 
@@ -4835,9 +4865,9 @@ TEST_F(TypeCheckerTest, variable_declarations)
   test("begin { let $a; $a = 1; }");
   test("begin { let $a: int16; $a = 1; }");
   test("begin { let $a = 1; }");
-  test("begin { let $a: uint16 = 1; }");
+  test("begin { let $a: uint16 = (uint16)1; }");
   test("begin { let $a: int16 = 1; }");
-  test("begin { let $a: uint8 = 1; $a = 100; }");
+  test("begin { let $a: uint8 = (uint8)1; $a = (uint8)100; }");
   test("begin { let $a: int8 = 1; $a = -100; }");
   test(R"(begin { let $a: string; $a = "hiya"; })");
   test("begin { let $a: int16; print($a); }");
@@ -4858,10 +4888,10 @@ begin { let $a: uint16; $a = -1; }
                         ~~~~~~~
 )" });
 
-  test("begin { let $a: uint8 = 1; $a = 10000; }", Error{ R"(
-stdin:1:28-38: ERROR: Type mismatch for $a: trying to assign value of type 'uint16' when variable already has a type 'uint8'
-begin { let $a: uint8 = 1; $a = 10000; }
-                           ~~~~~~~~~~
+  test("begin { let $a: uint8 = (uint8)1; $a = 10000; }", Error{ R"(
+stdin:1:35-45: ERROR: Type mismatch for $a: trying to assign value of type 'int16' when variable already has a type 'uint8'
+begin { let $a: uint8 = (uint8)1; $a = 10000; }
+                                  ~~~~~~~~~~
 )" });
 
   test("begin { let $a: int8 = 1; $a = -10000; }", Error{ R"(
@@ -4871,7 +4901,7 @@ begin { let $a: int8 = 1; $a = -10000; }
 )" });
 
   test("begin { let $a: int8; $a = 10000; }", Error{ R"(
-ERROR: Type mismatch for $a: trying to assign value of type 'uint16' when variable already has a type 'int8'
+ERROR: Type mismatch for $a: trying to assign value of type 'int16' when variable already has a type 'int8'
 begin { let $a: int8; $a = 10000; }
                       ~~~~~~~~~~
 )" });
@@ -5045,7 +5075,7 @@ begin { @a = tseries(10, 10s, 1); let $b = @a; }
 )" });
 
   test("begin { @a = stats(10); let $b = @a; }", Error{ R"(
-stdin:1:25-36: ERROR: Value 'ustats_t' cannot be assigned to a scratch variable.
+stdin:1:25-36: ERROR: Value 'stats_t' cannot be assigned to a scratch variable.
 begin { @a = stats(10); let $b = @a; }
                         ~~~~~~~~~~~
 )" });
@@ -5069,7 +5099,7 @@ begin { @a = tseries(10, 10s, 1); @b = @a; }
 )" });
 
   test("begin { @a = stats(10); @b = @a; }", Error{ R"(
-stdin:1:25-32: ERROR: Map value 'ustats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@b = stats(arg2);`.
+stdin:1:25-32: ERROR: Map value 'stats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@b = stats(arg2);`.
 begin { @a = stats(10); @b = @a; }
                         ~~~~~~~
 )" });
@@ -5146,7 +5176,7 @@ TEST_F(TypeCheckerTest, macros)
   test("macro set($x) { $x = 1; $x } begin { $a = \"string\"; set($a); }",
        Mock{ *bpftrace },
        Error{ R"(
-stdin:1:17-23: ERROR: Type mismatch for $a: trying to assign value of type 'uint8' when variable already has a type 'string[7]'
+stdin:1:17-23: ERROR: Type mismatch for $a: trying to assign value of type 'int8' when variable already has a type 'string[7]'
 macro set($x) { $x = 1; $x } begin { $a = "string"; set($a); }
                 ~~~~~~
 stdin:1:53-60: ERROR: expanded from
@@ -5159,13 +5189,13 @@ macro set($x) { $x = 1; $x } begin { $a = "string"; set($a); }
        "begin { $a = \"string\"; add1($a); }",
        Mock{ *bpftrace },
        Error{ R"(
-stdin:1:18-24: ERROR: Type mismatch for '+': comparing string[7] with uint8
+stdin:1:18-24: ERROR: Type mismatch for '+': comparing string[7] with int8
 macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add1($a); }
                  ~~~~~~
 stdin:1:18-20: ERROR: left (string[7])
 macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add1($a); }
                  ~~
-stdin:1:23-24: ERROR: right (uint8)
+stdin:1:23-24: ERROR: right (int8)
 macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add1($a); }
                       ~
 stdin:1:44-52: ERROR: expanded from
@@ -5290,10 +5320,10 @@ kprobe:f { if (false) { fail("always false"); } }
 
 TEST_F(TypeCheckerTest, typeof_decls)
 {
-  test("kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = 2; }");
+  test("kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = (uint8)2; }");
   test(R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = "bar"; })");
   test(R"(kprobe:f { let $y : string = "hi"; $y = "muchmuchlongerstr"; })");
-  test("begin { let $a: uint32 = 1; }");
+  test("begin { let $a: uint32 = (uint32)1; }");
   test("begin { let $a: uint32; $a = (uint8)1; }");
   test("begin { let $a: int8; $a = 1; }");
   test("begin { let $a; $a = (int32)1; }");
@@ -5331,12 +5361,13 @@ kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = "foo"; }
   test(
       R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = 2; })",
       Error{
-          R"(ERROR: Type mismatch for $y: trying to assign value of type 'uint8' when variable already has a type 'string[4]'
+          R"(ERROR: Type mismatch for $y: trying to assign value of type 'int8' when variable already has a type 'string[4]'
 kprobe:f { $x = "foo"; let $y : typeof($x); $y = 2; }
                                             ~~~~~~)" });
 
   // But ordering should not matter, as long as the scope is the same.
-  test("kprobe:f { let $x; let $y : typeof($x); $y = 2; $x = (uint8)1; }");
+  test("kprobe:f { let $x; let $y : typeof($x); $y = (uint8)2; $x = (uint8)1; "
+       "}");
   test(R"(kprobe:f { let $x; let $y : typeof($x); $y = "bar"; $x = "foo"; })");
 }
 
@@ -5373,7 +5404,7 @@ TEST_F(TypeCheckerTest, typeof_casts)
   test(
       R"(struct foo { int x; } kprobe:f { $x = (struct foo*)0; $y = (typeof(*$x))0; })",
       Error{ R"(
-stdin:1:60-73: ERROR: Cannot cast from "uint8" to "struct foo"
+stdin:1:60-73: ERROR: Cannot cast from "int8" to "struct foo"
 struct foo { int x; } kprobe:f { $x = (struct foo*)0; $y = (typeof(*$x))0; }
                                                            ~~~~~~~~~~~~~
 )" });
@@ -5531,7 +5562,7 @@ TEST_F(TypeCheckerTest, record)
   test(
       R"(begin { $t = (a=1, b=(x=2, y=3)); $t = (a=4, b=(x=(int64)5, y="hi")); })",
       Error{ R"(
-stdin:1:35-69: ERROR: Type mismatch for $t: trying to assign value of type 'record { .a = uint8, .b = record { .x = int64, .y = string[3] } }' when variable already has a type 'record { .a = uint8, .b = record { .x = uint8, .y = uint8 } }'
+stdin:1:35-69: ERROR: Type mismatch for $t: trying to assign value of type 'record { .a = int8, .b = record { .x = int64, .y = string[3] } }' when variable already has a type 'record { .a = int8, .b = record { .x = int8, .y = int8 } }'
 begin { $t = (a=1, b=(x=2, y=3)); $t = (a=4, b=(x=(int64)5, y="hi")); }
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -5561,7 +5592,7 @@ TEST_F(TypeCheckerTest, record_field_access)
 TEST_F(TypeCheckerTest, record_assign_var)
 {
   class SizedType ty = CreateRecord(
-      Struct::CreateRecord({ CreateUInt8(), CreateString(6) }, { "a", "b" }));
+      Struct::CreateRecord({ CreateInt8(), CreateString(6) }, { "a", "b" }));
   auto result = test(
       R"(begin { $t = (a=1, b="str"); $t = (b="other", a=4); })");
   auto &stmts = result.ast.root->probes.at(0)->block->stmts;

--- a/tests/type_resolver.cpp
+++ b/tests/type_resolver.cpp
@@ -116,15 +116,33 @@ TEST_F(TypeResolverTest, variable_promotion_integers)
 {
   {
     auto result = test(R"(begin { $a = 1; })");
-    EXPECT_EQ(var_type(result, "$a"), CreateUInt8());
+    EXPECT_EQ(var_type(result, "$a"), CreateInt8());
   }
   {
     auto result = test(R"(begin { $a = -1; })");
     EXPECT_EQ(var_type(result, "$a"), CreateInt8());
   }
   {
+    auto result = test(R"(begin { $a = 10446744073709551615; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
+  {
     auto result = test(R"(begin { $a = 1; $a = (uint32)2; })");
     EXPECT_EQ(var_type(result, "$a"), CreateUInt32());
+  }
+  {
+    auto result = test(R"(begin { $a = 1; $a = (uint64)2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
+  {
+    // Multiple positive literals then unsigned: all adapt
+    auto result = test(R"(begin { $a = 1; $a = 2; $a = (uint64)3; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
+  {
+    // Negative literal pins sign, positive literals follow
+    auto result = test(R"(begin { $a = 1; $a = -1; $a = (int32)3; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt32());
   }
   {
     auto result = test(R"(begin { $a = (int8)1; $a = (uint8)2; })");
@@ -140,12 +158,16 @@ TEST_F(TypeResolverTest, variable_promotion_integers)
   }
   {
     auto result = test(R"(begin { let $v; $a = $v; $v = 10; })");
-    EXPECT_EQ(var_type(result, "$a"), CreateUInt8());
-    EXPECT_EQ(var_type(result, "$v"), CreateUInt8());
+    EXPECT_EQ(var_type(result, "$a"), CreateInt8());
+    EXPECT_EQ(var_type(result, "$v"), CreateInt8());
   }
 
   // Errors
   test(R"(begin { $a = (uint64)1; $a = (int64)2 })", Error{});
+  // Negative literal pins sign; can't promote to uint64
+  test(R"(begin { $a = -1; $a = (uint64)2 })", Error{});
+  // Multiple literals where negative pins sign
+  test(R"(begin { $a = 1; $a = -1; $a = (uint64)2 })", Error{});
 }
 
 TEST_F(TypeResolverTest, variable_promotion_strings)
@@ -170,7 +192,7 @@ TEST_F(TypeResolverTest, variable_promotion_tuples)
     auto result = test(R"(begin { $a = (1, "str"); })");
     EXPECT_EQ(var_type(result, "$a"),
               CreateTuple(
-                  Struct::CreateTuple({ CreateUInt8(), CreateString(4) })));
+                  Struct::CreateTuple({ CreateInt8(), CreateString(4) })));
   }
   {
     auto result = test(
@@ -236,7 +258,7 @@ TEST_F(TypeResolverTest, variable_promotion_records)
     auto result = test(R"(begin { $a = (x = 1, y = "str"); })");
     EXPECT_EQ(var_type(result, "$a"),
               CreateRecord(Struct::CreateRecord(
-                  { CreateUInt8(), CreateString(4) }, { "x", "y" })));
+                  { CreateInt8(), CreateString(4) }, { "x", "y" })));
   }
   {
     auto result = test(
@@ -308,11 +330,15 @@ TEST_F(TypeResolverTest, variable_castable_maps)
 {
   {
     auto result = test(R"(begin { @a = sum(1); $a = @a; })");
-    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
   }
   {
     auto result = test(R"(begin { @a = sum(-1); $a = @a; })");
     EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+  }
+  {
+    auto result = test(R"(begin { @a = sum((uint64)1); $a = @a; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
   }
   {
     auto result = test(R"(begin { @a = sum(1); @a = sum(-1); $a = @a; })");
@@ -322,24 +348,49 @@ TEST_F(TypeResolverTest, variable_castable_maps)
     auto result = test(R"(begin { @a = sum(-1); $a = (int16)2; $a = @a; })");
     EXPECT_EQ(var_type(result, "$a"), CreateInt64());
   }
+  {
+    auto result = test(
+        R"(begin { @a = sum((uint64)1); $a = (uint8)1; $a = @a; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
 
-  // Errors
-  test(R"(begin { @a = sum(1); $a = (int64)1; $a = @a; })", Error{});
+  {
+    auto result = test(R"(begin { @a = sum((uint64)1); $a = 1; $a = @a; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
 }
 
 TEST_F(TypeResolverTest, map_value_promotion_integers)
 {
   {
     auto result = test(R"(begin { @a = 1; })");
-    EXPECT_EQ(map_val_type(result, "@a"), CreateUInt8());
+    EXPECT_EQ(map_val_type(result, "@a"), CreateInt8());
   }
   {
     auto result = test(R"(begin { @a = -1; })");
     EXPECT_EQ(map_val_type(result, "@a"), CreateInt8());
   }
   {
+    auto result = test(R"(begin { @a = 10446744073709551615; })");
+    EXPECT_EQ(map_val_type(result, "@a"), CreateUInt64());
+  }
+  {
     auto result = test(R"(begin { @a = 1; @a = (uint32)2; })");
     EXPECT_EQ(map_val_type(result, "@a"), CreateUInt32());
+  }
+  {
+    auto result = test(R"(begin { @a = 1; @a = (uint64)2; })");
+    EXPECT_EQ(map_val_type(result, "@a"), CreateUInt64());
+  }
+  {
+    // Multiple positive literals then unsigned: all adapt
+    auto result = test(R"(begin { @a = 1; @a = 2; @a = (uint32)3; })");
+    EXPECT_EQ(map_val_type(result, "@a"), CreateUInt32());
+  }
+  {
+    // Negative literal pins sign, positive literals follow
+    auto result = test(R"(begin { @a = 1; @a = -1; @a = (int32)3; })");
+    EXPECT_EQ(map_val_type(result, "@a"), CreateInt32());
   }
   {
     auto result = test(R"(begin { @a = (int8)1; @a = (uint8)2; })");
@@ -355,12 +406,16 @@ TEST_F(TypeResolverTest, map_value_promotion_integers)
   }
   {
     auto result = test(R"(begin { let $v; @a = $v; $v = 10; })");
-    EXPECT_EQ(map_val_type(result, "@a"), CreateUInt8());
-    EXPECT_EQ(var_type(result, "$v"), CreateUInt8());
+    EXPECT_EQ(map_val_type(result, "@a"), CreateInt8());
+    EXPECT_EQ(var_type(result, "$v"), CreateInt8());
   }
 
   // Errors
   test(R"(begin { @a = (uint64)1; @a = (int64)2 })", Error{});
+  // Negative literal pins sign; can't promote to uint64
+  test(R"(begin { @a = -1; @a = (uint64)2 })", Error{});
+  // Multiple literals where negative pins sign
+  test(R"(begin { @a = 1; @a = -1; @a = (uint64)2 })", Error{});
 }
 
 TEST_F(TypeResolverTest, map_value_promotion_strings)
@@ -385,7 +440,7 @@ TEST_F(TypeResolverTest, map_value_promotion_tuples)
     auto result = test(R"(begin { @a = (1, "str"); })");
     EXPECT_EQ(map_val_type(result, "@a"),
               CreateTuple(
-                  Struct::CreateTuple({ CreateUInt8(), CreateString(4) })));
+                  Struct::CreateTuple({ CreateInt8(), CreateString(4) })));
   }
   {
     auto result = test(
@@ -451,7 +506,7 @@ TEST_F(TypeResolverTest, map_value_promotion_records)
     auto result = test(R"(begin { @a = (x = 1, y = "str"); })");
     EXPECT_EQ(map_val_type(result, "@a"),
               CreateRecord(Struct::CreateRecord(
-                  { CreateUInt8(), CreateString(4) }, { "x", "y" })));
+                  { CreateInt8(), CreateString(4) }, { "x", "y" })));
   }
   {
     auto result = test(
@@ -539,7 +594,7 @@ TEST_F(TypeResolverTest, map_value_castable_maps)
 {
   {
     auto result = test(R"(begin { @a = sum(1); })");
-    EXPECT_EQ(map_val_type(result, "@a"), CreateSum(false));
+    EXPECT_EQ(map_val_type(result, "@a"), CreateSum(true));
   }
   {
     auto result = test(R"(begin { @a = sum(-1); })");
@@ -560,7 +615,7 @@ TEST_F(TypeResolverTest, map_key_promotion_integers)
 {
   {
     auto result = test(R"(begin { @a[1] = 1; })");
-    EXPECT_EQ(map_key_type(result, "@a"), CreateUInt8());
+    EXPECT_EQ(map_key_type(result, "@a"), CreateInt8());
   }
   {
     auto result = test(R"(begin { @a[-1] = 1; })");
@@ -569,6 +624,10 @@ TEST_F(TypeResolverTest, map_key_promotion_integers)
   {
     auto result = test(R"(begin { @a[1] = 1; @a[(uint32)2] = 1; })");
     EXPECT_EQ(map_key_type(result, "@a"), CreateUInt32());
+  }
+  {
+    auto result = test(R"(begin { @a[1] = 1; @a[(uint64)2] = 1; })");
+    EXPECT_EQ(map_key_type(result, "@a"), CreateUInt64());
   }
   {
     auto result = test(R"(begin { @a[(int8)1] = 1; @a[(uint8)2] = 1; })");
@@ -586,6 +645,7 @@ TEST_F(TypeResolverTest, map_key_promotion_integers)
 
   // Errors
   test(R"(begin { @a[(uint64)1] = 1; @a[(int64)2] = 1 })", Error{});
+  test(R"(begin { @a[-1] = 1; @a[(uint64)2] = 1 })", Error{});
 }
 
 TEST_F(TypeResolverTest, map_key_promotion_strings)
@@ -611,7 +671,7 @@ TEST_F(TypeResolverTest, map_key_promotion_tuples)
     auto result = test(R"(begin { @a[(1, "str")] = 1; })");
     EXPECT_EQ(map_key_type(result, "@a"),
               CreateTuple(
-                  Struct::CreateTuple({ CreateUInt8(), CreateString(4) })));
+                  Struct::CreateTuple({ CreateInt8(), CreateString(4) })));
   }
   {
     auto result = test(
@@ -677,7 +737,7 @@ TEST_F(TypeResolverTest, map_key_promotion_records)
     auto result = test(R"(begin { @a[(x = 1, y = "str")] = 1; })");
     EXPECT_EQ(map_key_type(result, "@a"),
               CreateRecord(Struct::CreateRecord(
-                  { CreateUInt8(), CreateString(4) }, { "x", "y" })));
+                  { CreateInt8(), CreateString(4) }, { "x", "y" })));
   }
   {
     auto result = test(
@@ -778,7 +838,7 @@ begin { let $z; $a = 1; $b = typeinfo($z); }
 TEST_F(TypeResolverTest, variable_with_type_decl)
 {
   {
-    auto result = test(R"(begin { let $a: uint32 = 1; })");
+    auto result = test(R"(begin { let $a: uint32 = (uint32)1; })");
     EXPECT_EQ(var_type(result, "$a"), CreateUInt32());
   }
   {
@@ -799,10 +859,10 @@ TEST_F(TypeResolverTest, variable_map_promotion)
 {
   {
     auto result = test(
-        R"(begin { $a = 1; @x = (uint32)1; $a = @x; @y = $a; } end { @x = (uint64)2; })");
-    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
-    EXPECT_EQ(map_val_type(result, "@x"), CreateUInt64());
-    EXPECT_EQ(map_val_type(result, "@y"), CreateUInt64());
+        R"(begin { $a = 1; @x = (uint32)1; $a = @x; @y = $a; } end { @x = (int64)2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+    EXPECT_EQ(map_val_type(result, "@x"), CreateInt64());
+    EXPECT_EQ(map_val_type(result, "@y"), CreateInt64());
   }
   {
     auto result = test(
@@ -820,9 +880,9 @@ TEST_F(TypeResolverTest, typeof)
   }
   {
     auto result = test(
-        R"(begin { let $b; $a = (typeof($b))1; $b = 1; $b = (uint64)2; })");
-    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
-    EXPECT_EQ(var_type(result, "$b"), CreateUInt64());
+        R"(begin { let $b; $a = (typeof($b))1; $b = 1; $b = (int64)2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+    EXPECT_EQ(var_type(result, "$b"), CreateInt64());
   }
   {
     auto result = test(
@@ -845,8 +905,8 @@ TEST_F(TypeResolverTest, typeof)
   {
     auto result = test(
         R"(begin { @x[(int16)1] = 1; $a = (typeof({ print(1); @x[0] }))1; })");
-    EXPECT_EQ(map_val_type(result, "@x"), CreateUInt8());
-    EXPECT_EQ(var_type(result, "$a"), CreateUInt8());
+    EXPECT_EQ(map_val_type(result, "@x"), CreateInt8());
+    EXPECT_EQ(var_type(result, "$a"), CreateInt8());
   }
 }
 
@@ -854,24 +914,24 @@ TEST_F(TypeResolverTest, comptime)
 {
   {
     auto result = test(
-        R"(begin { let $c; $a = 1; if comptime (typeinfo($a).full_type == "uint64") { $c = (int64)2; } $a = (uint64)2; })");
+        R"(begin { let $c; $a = 1; if comptime (typeinfo($a).full_type == "int64") { $c = (int64)2; } $a = (int64)2; })");
     EXPECT_EQ(var_type(result, "$c"), CreateInt64());
-    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
   }
   {
     auto result = test(
-        R"(begin { let $c; $a = 1; if comptime (typeinfo(sizeof($a)).base_type == "int") { $c = (int64)2; } $a = (uint64)2; })");
+        R"(begin { let $c; $a = 1; if comptime (typeinfo(sizeof($a)).base_type == "int") { $c = (int64)2; } $a = (int64)2; })");
     EXPECT_EQ(var_type(result, "$c"), CreateInt64());
-    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
   }
   {
     auto result = test(
-        R"(begin { let $c; $a = 1; if comptime (typeinfo($a).full_type == "uint64") { let $d; if comptime (typeinfo($d).full_type == "int64") { $c = (int16)3; } $d = (int64)2; } $a = (uint64)2; })");
+        R"(begin { let $c; $a = 1; if comptime (typeinfo($a).full_type == "int64") { let $d; if comptime (typeinfo($d).full_type == "int64") { $c = (int16)3; } $d = (int64)2; } $a = (int64)2; })");
     EXPECT_EQ(var_type(result, "$c"), CreateInt16());
   }
   {
     auto result = test(
-        R"(begin { let $c; let $e; let $d; $a = 1; if comptime (typeinfo($a).full_type == "uint64") { if comptime (typeinfo($d).full_type == "int64") { $c = (int16)3; } $e = (int32)1; } $a = (uint64)2; if comptime (typeinfo($e).full_type == "int32") { $d = (int64)3; } })");
+        R"(begin { let $c; let $e; let $d; $a = 1; if comptime (typeinfo($a).full_type == "int64") { if comptime (typeinfo($d).full_type == "int64") { $c = (int16)3; } $e = (int32)1; } $a = (int64)2; if comptime (typeinfo($e).full_type == "int32") { $d = (int64)3; } })");
     EXPECT_EQ(var_type(result, "$c"), CreateInt16());
   }
   {
@@ -883,7 +943,7 @@ TEST_F(TypeResolverTest, comptime)
   {
     auto result = test(
         R"(begin { @x = 1; if comptime (typeinfo(@y[1]).full_type != "uint64") { @x = (int32)2; } } end { @y[1] = (uint64)2; })");
-    EXPECT_EQ(map_val_type(result, "@x"), CreateUInt8());
+    EXPECT_EQ(map_val_type(result, "@x"), CreateInt8());
     EXPECT_EQ(map_val_type(result, "@y"), CreateUInt64());
   }
 
@@ -904,11 +964,13 @@ begin { let $c; if comptime (typeinfo($c).base_type == "int") { 1 } }
 TEST_F(TypeResolverTest, locked_types)
 {
   test(
-      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a = 2; } @a = (uint32)1; })");
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a = (uint32)2; } @a = (uint32)1; })");
   test(
-      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a[2] = 2; } @a[(uint32)1] = 1; })");
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a[(uint32)2] = 2; } @a[(uint32)1] = 1; })");
   test(
       R"(begin { let $c; if comptime (typeinfo($c).full_type == "uint32") { $c = (uint16)2; } $c = (uint32)1; })");
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a = 1; } @a = (uint32)2; })");
 
   // Errors
   test(
@@ -928,12 +990,16 @@ begin { if comptime (typeinfo(@a).full_type == "uint32") { @a[(uint64)2] = 2; } 
 )" });
 
   test(
-      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { $a = 1; if comptime (typeinfo($a).full_type == "uint8") { @a[(uint64)2] = 2; } } @a[(uint32)1] = 1; })",
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { $a = 1; if comptime (typeinfo($a).full_type == "int8") { @a[(uint64)2] = 2; } } @a[(uint32)1] = 1; })",
       Error{ R"(
 ERROR: Type mismatch for @a: this type has been locked because it was used in another part of the type graph that was already resolved (e.g. `sizeof`, `typeinfo`, etc.). The new type 'uint64' doesn't fit into the locked type 'uint32'
-begin { if comptime (typeinfo(@a).full_type == "uint32") { $a = 1; if comptime (typeinfo($a).full_type == "uint8") { @a[(uint64)2] = 2; } } @a[(uint32)1] = 1; }
-                                                                                                                     ~~~~~~~~~~~~~
+begin { if comptime (typeinfo(@a).full_type == "uint32") { $a = 1; if comptime (typeinfo($a).full_type == "int8") { @a[(uint64)2] = 2; } } @a[(uint32)1] = 1; }
+                                                                                                                    ~~~~~~~~~~~~~
 )" });
+  // Sign-flexible literal too large for locked type
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint8") { @a = 200; } @a = (uint8)2; })",
+      Error{});
 }
 
 TEST_F(TypeResolverTest, unop)
@@ -943,8 +1009,17 @@ TEST_F(TypeResolverTest, unop)
     EXPECT_EQ(map_val_type(result, "@a"), CreateInt64());
   }
   {
+    auto result = test(R"(begin { ++@a; --@b; })");
+    EXPECT_EQ(map_val_type(result, "@a"), CreateInt64());
+    EXPECT_EQ(map_val_type(result, "@b"), CreateInt64());
+  }
+  {
+    auto result = test(R"(begin { @a = 0; ++@a; --@a; })");
+    EXPECT_EQ(map_val_type(result, "@a"), CreateInt64());
+  }
+  {
     auto result = test(R"(begin { @a = 0; ++@a; $b = @a; })");
-    EXPECT_EQ(var_type(result, "$b"), CreateUInt64());
+    EXPECT_EQ(var_type(result, "$b"), CreateInt64());
   }
   {
     auto result = test(R"(begin { ++@a; $b = @a; })");
@@ -956,8 +1031,17 @@ TEST_F(TypeResolverTest, unop)
   }
   {
     auto result = test(R"(begin { $a = 1; $c = ++$a; })");
-    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
-    EXPECT_EQ(var_type(result, "$c"), CreateUInt64());
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+    EXPECT_EQ(var_type(result, "$c"), CreateInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = 1; $c = --$a; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+    EXPECT_EQ(var_type(result, "$c"), CreateInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = 0; --$a; ++$a; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
   }
   {
     auto result = test(R"(begin { let $a: int16; $c = ++$a; $b = $a; })");
@@ -992,8 +1076,51 @@ TEST_F(TypeResolverTest, binop)
     EXPECT_EQ(var_type(result, "$a"), CreateInt64());
   }
   {
+    auto result = test(R"(begin { $a = (uint32)1 * (uint32)2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = (uint8)1 / (uint8)2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = (uint64)10 + 2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = (uint64)10 * 2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = (uint64)10 / 2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = (uint64)10 % 2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = (uint32)2 - (uint32)1; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+  }
+  {
     auto result = test(R"(begin { $a = (int8)1 * 2; })");
     EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+  }
+  {
+    // Literal adapts to signed when other side is signed
+    auto result = test(R"(begin { $a = (int64)10 + 2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+  }
+  {
+    // Negative literal stays signed, makes result signed
+    auto result = test(R"(begin { $a = (uint64)10 + (-1); })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+  }
+  {
+    // Literal adapts to unsigned for comparison
+    auto result = test(R"(begin { $a = ((uint32)1 == 2); })");
+    EXPECT_EQ(var_type(result, "$a"), CreateBool());
   }
   {
     auto result = test(R"(begin { $a = (uint8)1 * sizeof(uint64 *); })");
@@ -1057,11 +1184,11 @@ TEST_F(TypeResolverTest, binop)
   }
   {
     auto result = test(R"(begin { $pv = 1; $p = &$pv; $a = $p + 1; })");
-    EXPECT_EQ(var_type(result, "$a"), CreatePointer(CreateUInt8()));
+    EXPECT_EQ(var_type(result, "$a"), CreatePointer(CreateInt8()));
   }
   {
     auto result = test(R"(begin { $pv = 1; $p = &$pv; $a = $p - 1; })");
-    EXPECT_EQ(var_type(result, "$a"), CreatePointer(CreateUInt8()));
+    EXPECT_EQ(var_type(result, "$a"), CreatePointer(CreateInt8()));
   }
   {
     auto result = test(
@@ -1149,13 +1276,13 @@ TEST_F(TypeResolverTest, macro_not_expanded_in_type_context)
     // sizeof: call syntax forces macro expansion.
     auto result = test(
         R"(macro mytype() { 1 } begin { $x = sizeof(mytype()); })");
-    EXPECT_EQ(var_type(result, "$x"), CreateUInt8());
+    EXPECT_EQ(var_type(result, "$x"), CreateInt8());
   }
   {
     // cast: typeof wrapper with call syntax forces macro expansion.
     auto result = test(
         R"(macro mytype() { 1 } begin { $x = (typeof(mytype()))1; })");
-    EXPECT_EQ(var_type(result, "$x"), CreateUInt8());
+    EXPECT_EQ(var_type(result, "$x"), CreateInt8());
   }
 }
 

--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -103,7 +103,7 @@ macro getcwd(@paths)
 macro printcwd(@paths)
 {
   for $j : ((uint64)0)..((uint64)max_path_depth) {
-    let $key = (tid,((((uint64)max_path_depth) - $j) - 1));
+    let $key = (tid,(uint64)((max_path_depth() - $j) - 1));
     let $name = @paths[$key];
     // If it is a mount point, there will be a '/', because
     // the '/' will be added below, so just skip this '/'.


### PR DESCRIPTION
Stacked PRs:
 * __->__#5138


--- --- ---

### Update integer and arithmetic type resolution


In an attempt to fix type resolution for binop subtraction as well as unary
decrement, I ran into several larger problems with integer types.

Firstly, the issue with subtraction and decrement was that they weren't
yielding signed integer values:

```
$a = (uint8)1 + (-1); // int64
$b = (uint8)1 - 1;    // uint64

@c = 0; --@c;         // uint64
```

In an attempt to apply logic at the binop and unop call sites in the type
resolver I ran into an issue in a runtime test:
```
@d = 0; ++@d; --@d;
```
This was producing an error because 0 is a `uint8`, the first increment
makes `@d` a `uint64`, and then the decrement tries to make `@d` a `int64`
which is a mismatch error.

After exploring a bit and talking with AI, we agreed that three changes were
required:

1. Make all integer literals default to their smallest SIGNED type. Meaning
   that `0` and `1` will be int8 (not uint8). Only resort to unsigned if
   the literal value is larger than the largest int64. This apparently
   mirrors C behavior. This also means that most arithmetic binops will
   produce an `int64` instead of a `uint64`.

2. Add a sign_flexible_ flag to SizedType, which will be used for positive
   integer literals. This will be used when determining compatible integer
   types. All of the following examples are now valid:
   `$a = 1; $a = (uint64)2;`
   `$a = (uint64)2; $a = 1;`
   `$b = (uint8)1 - 1; $b = -2;`

3. If we can't resolve a map type because we only have a unop, e.g.
   `++@a;` then set the initial type to a `int8`, which is the equivalent
   of inserting a 0 initialization (`@a = 0;`). The unop will turn the map
   into a `int64` but this makes the initial type more flexible.

Tests and docs have been updated with this change.

It will hopefully not cause any user-facing issues but rather fix some
lingering weirdness for integer types.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>