### PR TITLE
Remove arithmetic mixed sign warning

### DIFF
--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -409,7 +409,9 @@ private:
   SizedType get_stack_type(Call &call, bool kernel);
 };
 
-SizedType binop_ptr(Binop &binop, const SizedType &lht, const SizedType &rht)
+SizedType get_binop_ptr(Binop &binop,
+                        const SizedType &lht,
+                        const SizedType &rht)
 {
   bool left_is_ptr = lht.IsPtrTy();
   const auto &ptr = left_is_ptr ? lht : rht;
@@ -466,7 +468,9 @@ SizedType binop_ptr(Binop &binop, const SizedType &lht, const SizedType &rht)
   }
 }
 
-SizedType binop_int(Binop &binop, const SizedType &lht, const SizedType &rht)
+SizedType get_binop_int(Binop &binop,
+                        const SizedType &lht,
+                        const SizedType &rht)
 {
   auto is_comparison = is_comparison_op(binop.op);
   if (lht == rht) {
@@ -499,30 +503,10 @@ SizedType binop_int(Binop &binop, const SizedType &lht, const SizedType &rht)
     show_warning = true;
   }
 
-  if (show_warning) {
-    switch (binop.op) {
-      case Operator::EQ:
-      case Operator::NE:
-      case Operator::LE:
-      case Operator::GE:
-      case Operator::LT:
-      case Operator::GT:
-        binop.addWarning() << "comparison of integers of different signs: '"
-                           << lht << "' and '" << rht << "'"
-                           << " can lead to undefined behavior";
-        break;
-      case Operator::PLUS:
-      case Operator::MINUS:
-      case Operator::MUL:
-      case Operator::DIV:
-      case Operator::MOD:
-        binop.addWarning() << "arithmetic on integers of different signs: '"
-                           << lht << "' and '" << rht << "'"
-                           << " can lead to undefined behavior";
-        break;
-      default:
-        break;
-    }
+  if (show_warning && is_comparison) {
+    binop.addWarning() << "comparison of integers of different signs: '" << lht
+                       << "' and '" << rht << "'"
+                       << " can lead to undefined behavior";
   }
 
   if (is_comparison) {
@@ -576,7 +560,7 @@ SizedType get_binop_type(Binop &binop,
   }
 
   if (lht.IsPtrTy() || rht.IsPtrTy()) {
-    return binop_ptr(binop, lht, rht);
+    return get_binop_ptr(binop, lht, rht);
   }
 
   auto result_type = is_comparison ? CreateBool()
@@ -601,7 +585,7 @@ SizedType get_binop_type(Binop &binop,
   }
 
   if (is_int_binop) {
-    auto int_type = binop_int(binop, lht, rht);
+    auto int_type = get_binop_int(binop, lht, rht);
     int_type.SetAS(result_type.GetAS());
     return int_type;
   }

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -2698,22 +2698,6 @@ kprobe:f { $x = "foo"; printf("%c is the fifth letter", $x[4]); }
 )" });
 }
 
-TEST_F(TypeCheckerTest, signed_int_arithmetic_warnings)
-{
-  // Test type warnings for arithmetic
-  std::string msg = "arithmetic on integers of different signs";
-
-  test("kprobe:f { @ = -1 - arg0 }", Warning{ msg });
-  test("kprobe:f { @ = -1 + arg0 }", Warning{ msg });
-  test("kprobe:f { @ = -1 * arg0 }", Warning{ msg });
-  test("kprobe:f { @ = -1 / arg0 }", Warning{ msg });
-
-  test("kprobe:f { @ = arg0 + 1 }", NoWarning{ msg });
-  test("kprobe:f { @ = arg0 - 1 }", NoWarning{ msg });
-  test("kprobe:f { @ = arg0 * 1 }", NoWarning{ msg });
-  test("kprobe:f { @ = arg0 / 1 }", NoWarning{ msg });
-}
-
 TEST_F(TypeCheckerTest, signed_int_division_warnings)
 {
   std::string msg = "signed operands";
@@ -3159,31 +3143,6 @@ TEST_F(TypeCheckerTest, mixed_int_like_binop)
        Warning{ "comparison of integers" });
   test("kprobe:f { @a = sum(-1); @b = count(); $a = @a == @b; }",
        Warning{ "comparison of integers" });
-
-  test("kprobe:f { $a = 1 + -1; }", NoWarning{ "arithmetic on integers" });
-  test("kprobe:f { $a = 1 + (int64)-1; }",
-       NoWarning{ "arithmetic on integers" });
-  test("kprobe:f { $a = (uint32)1 + (int32)-1; }",
-       NoWarning{ "arithmetic on integers" });
-  test("kprobe:f { @a = sum(-1); $a = 1 + @a; }",
-       NoWarning{ "arithmetic on integers" });
-  test("kprobe:f { @a = sum(-1); $a = @a + 1; }",
-       NoWarning{ "arithmetic on integers" });
-  test("kprobe:f { @a = sum(1); $a = @a + (uint16)1; }",
-       NoWarning{ "arithmetic on integers" });
-  test("kprobe:f { @a = sum(-1); $a = @a + (uint16)1; }",
-       NoWarning{ "arithmetic on integers" });
-  test("kprobe:f { @a = sum(1); @b = count(); $a = @a + @b; }",
-       NoWarning{ "arithmetic on integers" });
-
-  test("kprobe:f { $a = (uint64)1 + (int64)-1; }",
-       Warning{ "arithmetic on integers" });
-  test("kprobe:f { @a = sum(-1); $a = (uint64)1 + @a; }",
-       Warning{ "arithmetic on integers" });
-  test("kprobe:f { @a = sum(-1); $a = @a + (uint64)1; }",
-       Warning{ "arithmetic on integers" });
-  test("kprobe:f { @a = sum(-1); @b = count(); $a = @a + @b; }",
-       Warning{ "arithmetic on integers" });
 
   // Both are additionally casted to int16
   test("kprobe:f { $a = (uint8)1 == (int8)-1; }",


### PR DESCRIPTION
Stacked PRs:
 * #5138
 * __->__#5139


--- --- ---

### Remove arithmetic mixed sign warning


This is a warning that is hard to get right so I think it's best to just
remove it rather than it being noisy and sometimes valueable.

Take this example:
```
$a = (uint64)arg0 + (-10);
```

$a becomes an int64, which in most cases is probably fine.
The only time it's not, and the warning is helpful, is if arg0 is larger
than the largest positive int64 then we're going to get a negative number.

Additionally, because we upcast for binops, and unop decrement/increment
this whole evaluation of safeness is more fragile and context sensitive.

Fixes: https://github.com/bpftrace/bpftrace/issues/5137

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>