### PR TITLE
Add urgent ringbuf (#5114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to
 - Subtraction and decrement ops now produce an int64 instead of a uint64.
   - [#5138](https://github.com/bpftrace/bpftrace/pull/5138)
 #### Added
+- Add urgent ringbuf to handle async runtime errors, and use sync action on clear and zero
+  - [#5114](https://github.com/bpftrace/bpftrace/issues/5114)
 - User defined C structs support using `__attribute__`s after the closing curly brace.
   - [#5153](https://github.com/bpftrace/bpftrace/pull/5153)
 - stdlib: add `leader_{tid,comm}` to retrieve the thread group leader.

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1887,17 +1887,22 @@ CallInst *IRBuilderBPF::CreateGetSocketCookie(Value *var, const Location &loc)
                           loc);
 }
 
-void IRBuilderBPF::CreateOutput(Value *data, size_t size, const Location &loc)
+void IRBuilderBPF::CreateOutput(Value *data,
+                                size_t size,
+                                const Location &loc,
+                                bool urgent)
 {
   assert(data && data->getType()->isPointerTy());
-  CreateRingbufOutput(data, size, loc);
+  CreateRingbufOutput(data, size, loc, urgent);
 }
 
 void IRBuilderBPF::CreateRingbufOutput(Value *data,
                                        size_t size,
-                                       const Location &loc)
+                                       const Location &loc,
+                                       bool urgent)
 {
-  Value *map_ptr = GetMapVar(to_string(MapType::Ringbuf));
+  auto rb_map = urgent ? RingbufMap::Urgent : RingbufMap::Normal;
+  Value *map_ptr = GetMapVar(get_bpf_ringbuf_map_str(rb_map));
 
   // long bpf_ringbuf_output(void *ringbuf, void *data, u64 size, u64 flags)
   FunctionType *ringbuf_output_func_type = FunctionType::get(
@@ -2243,7 +2248,7 @@ void IRBuilderBPF::CreateRuntimeError(RuntimeErrorId rte_id,
 
   const auto &layout = module_.getDataLayout();
   auto struct_size = layout.getTypeAllocSize(runtime_error_struct);
-  CreateOutput(buf, struct_size, loc);
+  CreateOutput(buf, struct_size, loc, true);
   CreateLifetimeEnd(buf);
 }
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -787,6 +787,24 @@ Value *IRBuilderBPF::CreateMapLookupElem(const std::string &map_name,
   return ret;
 }
 
+void IRBuilderBPF::CreateMapDeleteElem(const std::string &map_ident,
+                                       Value *key,
+                                       const Location &loc)
+{
+  Value *map_ptr = GetMapVar(map_ident);
+
+  FunctionType *delete_func_type = FunctionType::get(
+      getInt64Ty(), { map_ptr->getType(), key->getType() }, false);
+  PointerType *delete_func_ptr_type = PointerType::get(getContext(), 0);
+  Constant *delete_func = ConstantExpr::getCast(Instruction::IntToPtr,
+                                                getInt64(
+                                                    BPF_FUNC_map_delete_elem),
+                                                delete_func_ptr_type);
+  CallInst *call = createCall(
+      delete_func_type, delete_func, { map_ptr, key }, "delete_elem");
+  CreateHelperErrorCond(call, BPF_FUNC_map_delete_elem, loc);
+}
+
 Value *IRBuilderBPF::CreatePerCpuMapAggElems(Map &map,
                                              Value *key,
                                              const SizedType &type,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -58,6 +58,9 @@ public:
                            Value *val,
                            const Location &loc,
                            int64_t flags = 0);
+  void CreateMapDeleteElem(const std::string &map_ident,
+                           Value *key,
+                           const Location &loc);
   Value *CreateForRange(Value *iters,
                         Value *callback,
                         Value *callback_ctx,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -118,7 +118,7 @@ public:
   CallInst *CreateGetRandom(const Location &loc);
   CallInst *CreateGetStack(Value *ctx,
                            Value *buf,
-                           const StackType& stack_type,
+                           const StackType &stack_type,
                            const Location &loc);
   CallInst *CreateGetFuncIp(Value *ctx, const Location &loc);
   CallInst *CreatePerCpuPtr(Value *var, Value *cpu, const Location &loc);
@@ -131,11 +131,11 @@ public:
                                           const std::string &name,
                                           const Location &loc);
   Value *CreateAnonStructAllocation(const SizedType &tuple_type,
-                               const std::string &name,
-                               const Location &loc);
+                                    const std::string &name,
+                                    const Location &loc);
   Value *CreateCallStackAllocation(const SizedType &stack_type,
-                               const std::string &name,
-                               const Location &loc);
+                                   const std::string &name,
+                                   const Location &loc);
   Value *CreateJoinAllocation(const Location &loc);
   Value *CreateWriteMapValueAllocation(const SizedType &value_type,
                                        const std::string &name,
@@ -159,7 +159,10 @@ public:
                        ArrayRef<Value *> args,
                        const Twine &Name);
   void CreateGetCurrentComm(AllocaInst *buf, size_t size, const Location &loc);
-  void CreateOutput(Value *data, size_t size, const Location &loc);
+  void CreateOutput(Value *data,
+                    size_t size,
+                    const Location &loc,
+                    bool urgent = false);
   void CreateIncEventLossCounter(const Location &loc);
   void CreatePerCpuMapElemInit(const std::string &map_ident,
                                Value *key,
@@ -183,7 +186,7 @@ public:
   void CreateHelperErrorCond(Value *return_value,
                              bpf_func_id func_id,
                              const Location &loc);
-  StructType *GetStackStructType(const StackType& stack_type);
+  StructType *GetStackStructType(const StackType &stack_type);
   StructType *GetStructType(const std::string &name,
                             const std::vector<llvm::Type *> &elements,
                             bool packed = false);
@@ -300,7 +303,10 @@ private:
                              size_t key);
   bpf_func_id selectProbeReadHelper(AddrSpace as, bool str);
 
-  void CreateRingbufOutput(Value *data, size_t size, const Location &loc);
+  void CreateRingbufOutput(Value *data,
+                           size_t size,
+                           const Location &loc,
+                           bool urgent);
 
   void createPerCpuSum(AllocaInst *ret, CallInst *call, const SizedType &type);
   void createPerCpuMinMax(AllocaInst *ret,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1901,30 +1901,79 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     AllocaInst *buf = b_.CreateAllocaBPF(event_struct,
                                          call.func + "_" + map.ident);
 
-    auto *aa_ptr = b_.CreateGEP(event_struct,
-                                buf,
-                                { b_.getInt64(0), b_.getInt32(0) });
-    if (call.func == "clear")
-      b_.CreateStore(b_.GetIntSameSize(static_cast<int64_t>(
-                                           async_action::AsyncAction::clear),
-                                       elements.at(0)),
-                     aa_ptr);
-    else
-      b_.CreateStore(b_.GetIntSameSize(static_cast<int64_t>(
-                                           async_action::AsyncAction::zero),
-                                       elements.at(0)),
-                     aa_ptr);
+    auto saved_ip = b_.saveIP();
 
-    int id = bpftrace_.resources.maps_info.at(map.ident).id;
-    if (id == -1) {
-      LOG(BUG) << "map id for map \"" << map.ident << "\" not found";
+    std::array<llvm::Type *, 4> callback_args = {
+      b_.getPtrTy(), // map
+      b_.getPtrTy(), // key
+      b_.getPtrTy(), // value
+      b_.getPtrTy()  // ctx
+    };
+
+    // All callbacks in BPF will be generated with a standard integer return.
+    FunctionType *callback_type = FunctionType::get(b_.getInt64Ty(),
+                                                    callback_args,
+                                                    false);
+    auto *callback = llvm::Function::Create(
+        callback_type,
+        llvm::Function::LinkageTypes::InternalLinkage,
+        call.func + "_callback_" + map.ident,
+        module_.get());
+    callback->setDSOLocal(true);
+    callback->setVisibility(llvm::GlobalValue::DefaultVisibility);
+    callback->setSection(".text");
+    callback->addFnAttr(Attribute::NoUnwind);
+
+    // Add the debug information.
+    Struct debug_args;
+    debug_args.AddField("map", CreatePointer(CreateInt8()));
+    debug_args.AddField("key", CreatePointer(CreateInt8()));
+    debug_args.AddField("value", CreatePointer(CreateInt8()));
+    debug_args.AddField("ctx", CreatePointer(CreateInt8()));
+    scope_ = debug_.createFunctionDebugInfo(*callback,
+                                            CreateInt64(),
+                                            debug_args);
+
+    // Start our basic function block.
+    auto *entry = BasicBlock::Create(module_->getContext(),
+                                     "for_body",
+                                     callback);
+    b_.SetInsertPoint(entry);
+
+    if (call.func == "clear") {
+      // delete the element
+      Value *key_ptr = callback->getArg(1);
+      b_.CreateMapDeleteElem(map.ident, key_ptr, call.loc);
+    } else {
+      // Get value pointer (3rd argument)
+      Value *value_ptr = callback->getArg(2);
+
+      // Get map value
+      auto map_info = bpftrace_.resources.maps_info.find(map.ident);
+      if (map_info == bpftrace_.resources.maps_info.end()) {
+        LOG(BUG) << "map name not found";
+      }
+      auto &val_type = map_info->second.value_type;
+      auto value_size = val_type.GetSize();
+
+      // per-cpu map handling
+      bool is_per_cpu = (map_info->second.bpf_type ==
+                             BPF_MAP_TYPE_PERCPU_ARRAY ||
+                         map_info->second.bpf_type ==
+                             BPF_MAP_TYPE_LRU_PERCPU_HASH);
+      if (is_per_cpu) {
+        value_size *= bpftrace_.ncpus_;
+      }
+
+      b_.CreateMemSet(value_ptr, b_.getInt8(0), value_size, MaybeAlign(1));
     }
-    auto *ident_ptr = b_.CreateGEP(event_struct,
-                                   buf,
-                                   { b_.getInt64(0), b_.getInt32(1) });
-    b_.CreateStore(b_.GetIntSameSize(id, elements.at(1)), ident_ptr);
 
-    b_.CreateOutput(buf, getStructSize(event_struct), call.loc, true);
+    b_.CreateRet(b_.getInt64(0));
+
+    b_.restoreIP(saved_ip);
+
+    b_.CreateForEachMapElem(map, callback, nullptr, call.loc);
+
     return ScopedExpr(buf, [this, buf] { b_.CreateLifetimeEnd(buf); });
   } else if (call.func == "stack_len") {
     auto &arg = call.vargs.at(0);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1924,7 +1924,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                                    { b_.getInt64(0), b_.getInt32(1) });
     b_.CreateStore(b_.GetIntSameSize(id, elements.at(1)), ident_ptr);
 
-    b_.CreateOutput(buf, getStructSize(event_struct), call.loc);
+    b_.CreateOutput(buf, getStructSize(event_struct), call.loc, true);
     return ScopedExpr(buf, [this, buf] { b_.CreateLifetimeEnd(buf); });
   } else if (call.func == "stack_len") {
     auto &arg = call.vargs.at(0);
@@ -4345,6 +4345,8 @@ void CodegenLLVM::generate_maps(const RequiredResources &required_resources)
                         CreateInt32(),
                         CreateInt32());
   }
+
+  // Create ring buffers for kernel/user interactions
   auto num_pages = bpftrace_.get_buffer_pages();
   // The default value exists just to prevent a segfault.
   // The program should terminate as we're adding an error to the ast root
@@ -4360,9 +4362,15 @@ void CodegenLLVM::generate_maps(const RequiredResources &required_resources)
     buffer_size = *num_pages * sysconf(_SC_PAGE_SIZE);
   }
 
-  createMapDefinition(to_string(MapType::Ringbuf),
+  createMapDefinition(get_bpf_ringbuf_map_str(RingbufMap::Normal),
                       BPF_MAP_TYPE_RINGBUF,
                       buffer_size,
+                      CreateNone(),
+                      CreateNone());
+
+  createMapDefinition(get_bpf_ringbuf_map_str(RingbufMap::Urgent),
+                      BPF_MAP_TYPE_RINGBUF,
+                      sysconf(_SC_PAGE_SIZE), // single page
                       CreateNone(),
                       CreateNone());
 }

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -228,4 +228,41 @@ Result<> AsyncHandlers::printf(const OpaqueValue &data)
   return OK();
 }
 
+std::ostream &operator<<(std::ostream &os, const AsyncAction &action)
+{
+  static std::unordered_map<AsyncAction, std::string> names = {
+    { AsyncAction::printf, "printf" },
+    { AsyncAction::syscall, "syscall" },
+    { AsyncAction::cat, "cat" },
+    { AsyncAction::exit, "exit" },
+    { AsyncAction::print, "print" },
+    { AsyncAction::clear, "clear" },
+    { AsyncAction::zero, "zero" },
+    { AsyncAction::time, "time" },
+    { AsyncAction::join, "join" },
+    { AsyncAction::runtime_error, "runtime_error" },
+    { AsyncAction::print_non_map, "print_non_map" },
+    { AsyncAction::strftime, "strftime" },
+    { AsyncAction::skboutput, "skboutput" },
+  };
+
+  if (action >= AsyncAction::printf && action <= AsyncAction::printf_end) {
+    os << names[AsyncAction::printf];
+  } else if (action >= AsyncAction::syscall &&
+             action <= AsyncAction::syscall_end) {
+    os << names[AsyncAction::syscall];
+  } else if (action >= AsyncAction::cat && action <= AsyncAction::cat_end) {
+    os << names[AsyncAction::cat];
+  } else {
+    auto it = names.find(action);
+    if (it != names.end()) {
+      os << it->second;
+    } else {
+      os << "unknown (" << static_cast<uint32_t>(action) << ")";
+    }
+  }
+
+  return os;
+}
+
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -27,6 +27,8 @@ enum class AsyncAction {
   // clang-format on
 };
 
+std::ostream &operator<<(std::ostream &os, const AsyncAction &action);
+
 class AsyncHandlers {
 public:
   const static size_t MAX_TIME_STR_LEN = 64;

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -15,6 +15,12 @@ const std::unordered_map<std::string, bpf_map_type> BPF_MAP_TYPES = {
   { "percpulruhash", BPF_MAP_TYPE_LRU_PERCPU_HASH }
 };
 
+// ringbuf maps
+const std::unordered_map<RingbufMap, std::string> BPF_RINGBUF_MAP_NAMES = {
+  { RingbufMap::Normal, "ringbuf" },
+  { RingbufMap::Urgent, "ringbuf_urg" }
+};
+
 int BpfMap::fd() const
 {
   return bpf_map__fd(bpf_map_);
@@ -297,6 +303,15 @@ bool bpf_map_types_compatible(const SizedType &val_type, bpf_map_type kind)
   }
 
   return false;
+}
+
+std::string get_bpf_ringbuf_map_str(const RingbufMap &rb_map)
+{
+  auto found = BPF_RINGBUF_MAP_NAMES.find(rb_map);
+  if (found == BPF_RINGBUF_MAP_NAMES.end()) {
+    return "unknown";
+  }
+  return found->second;
 }
 
 } // namespace bpftrace

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -106,6 +106,9 @@ enum class MapType {
 
 std::string to_string(MapType t);
 
+// Ringbuf maps
+enum class RingbufMap { Normal, Urgent };
+
 // BPF maps do not accept "@" in name so we replace it by "AT_".
 // The below two functions do the translations.
 inline std::string bpf_map_name(std::string_view bpftrace_map_name)
@@ -128,7 +131,7 @@ bpf_map_type get_bpf_map_type(const SizedType &val_type);
 std::optional<bpf_map_type> get_bpf_map_type(const std::string &name);
 std::string get_bpf_map_type_str(bpf_map_type map_type);
 void add_bpf_map_types_hint(std::stringstream &hint);
-bool bpf_map_types_compatible(const SizedType &val_type,
-                              bpf_map_type kind);
+bool bpf_map_types_compatible(const SizedType &val_type, bpf_map_type kind);
+std::string get_bpf_ringbuf_map_str(const RingbufMap &rb_map);
 
 } // namespace bpftrace

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -244,10 +244,6 @@ static Result<> event_printer(void *cb_cookie,
     return ctx->handlers.print_map(data);
   } else if (printf_id == async_action::AsyncAction::print_non_map) {
     return ctx->handlers.print_non_map(data);
-  } else if (printf_id == async_action::AsyncAction::clear) {
-    return ctx->handlers.clear_map(data);
-  } else if (printf_id == async_action::AsyncAction::zero) {
-    return ctx->handlers.zero_map(data);
   } else if (printf_id == async_action::AsyncAction::time) {
     return ctx->handlers.time(data);
   } else if (printf_id == async_action::AsyncAction::join) {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -209,7 +209,10 @@ struct PerfEventContext {
   output::Output &output;
 };
 
-static Result<> event_printer(void *cb_cookie, void *raw_data, int size)
+static Result<> event_printer(void *cb_cookie,
+                              void *raw_data,
+                              int size,
+                              const std::string &prefix)
 {
   auto *ctx = static_cast<PerfEventContext *>(cb_cookie);
 
@@ -232,6 +235,9 @@ static Result<> event_printer(void *cb_cookie, void *raw_data, int size)
 
   // async actions
   auto printf_id = async_action::AsyncAction(data.bitcast<uint64_t>());
+
+  LOG(V1) << "[" << prefix << "] Event print async action " << printf_id;
+
   if (printf_id == async_action::AsyncAction::exit) {
     return ctx->handlers.exit(data);
   } else if (printf_id == async_action::AsyncAction::print) {
@@ -265,13 +271,27 @@ static Result<> event_printer(void *cb_cookie, void *raw_data, int size)
   }
 }
 
-static int ringbuf_printer(void *cb_cookie, void *data, size_t size)
+static int ringbuf_printer_helper(RingbufMap rb,
+                                  void *cb_cookie,
+                                  void *data,
+                                  size_t size)
 {
-  auto ok = event_printer(cb_cookie, data, size);
+  auto ok = event_printer(
+      cb_cookie, data, size, rb == RingbufMap::Normal ? "NORMAL" : "URGENT");
   if (!ok) {
     LOG(ERROR) << ok.takeError();
   }
   return 0;
+}
+
+static int ringbuf_printer(void *cb_cookie, void *data, size_t size)
+{
+  return ringbuf_printer_helper(RingbufMap::Normal, cb_cookie, data, size);
+}
+
+static int ringbuf_urg_printer(void *cb_cookie, void *data, size_t size)
+{
+  return ringbuf_printer_helper(RingbufMap::Urgent, cb_cookie, data, size);
 }
 
 static void skb_output_printer(void *ctx,
@@ -279,7 +299,7 @@ static void skb_output_printer(void *ctx,
                                void *data,
                                __u32 size)
 {
-  auto ok = event_printer(ctx, data, size);
+  auto ok = event_printer(ctx, data, size, "SKB");
   if (!ok) {
     LOG(ERROR) << ok.takeError();
   }
@@ -953,22 +973,34 @@ int BPFtrace::setup_skboutput_perf_buffer(void *ctx)
 void BPFtrace::setup_ringbuf(void *ctx)
 {
   ringbuf_ = ring_buffer__new(
-      bytecode_.getMap(MapType::Ringbuf).fd(), ringbuf_printer, ctx, nullptr);
+      bytecode_.getMap(get_bpf_ringbuf_map_str(RingbufMap::Normal)).fd(),
+      ringbuf_printer,
+      ctx,
+      nullptr);
+
+  ringbuf_urg_ = ring_buffer__new(
+      bytecode_.getMap(get_bpf_ringbuf_map_str(RingbufMap::Urgent)).fd(),
+      ringbuf_urg_printer,
+      ctx,
+      nullptr);
 }
 
 void BPFtrace::teardown_output()
 {
   ring_buffer__free(ringbuf_);
+  ring_buffer__free(ringbuf_urg_);
 
   if (resources.using_skboutput)
     perf_buffer__free(skb_perfbuf_);
 }
 
-void BPFtrace::poll_output(output::Output &out, bool drain)
+bool BPFtrace::poll_buf_helper(void *buf,
+                               bool is_ringbuf,
+                               bool drain,
+                               bool do_retry,
+                               bool &do_poll)
 {
   int ready;
-  bool poll_skboutput = resources.using_skboutput;
-  bool do_poll_ringbuf = true;
   auto should_retry = [](int ready) {
     // epoll_wait will set errno to EINTR if an interrupt received, it is
     // retryable if not caused by SIGINT. ring_buffer__poll does not set
@@ -986,33 +1018,57 @@ void BPFtrace::poll_output(output::Output &out, bool drain)
            (ready == 0 && (drain || finalize_));
   };
 
+  if (do_poll) {
+    if (is_ringbuf) {
+      ready = ring_buffer__poll(static_cast<struct ring_buffer *>(buf),
+                                timeout_ms);
+    } else {
+      ready = perf_buffer__poll(static_cast<struct perf_buffer *>(buf),
+                                timeout_ms);
+    }
+    if (should_retry(ready)) {
+      if (do_retry)
+        return true;
+    }
+    if (should_stop(ready)) {
+      do_poll = false;
+    }
+  }
+  return false;
+}
+
+void BPFtrace::poll_output(output::Output &out, bool drain)
+{
+  bool poll_skboutput = resources.using_skboutput;
+  bool do_poll_ringbuf = true;
+  bool do_poll_ringbuf_urg = true;
+  bool retry;
+
   while (true) {
     if (poll_skboutput) {
-      ready = perf_buffer__poll(skb_perfbuf_, timeout_ms);
-      if (should_retry(ready)) {
-        if (!do_poll_ringbuf)
-          continue;
-      }
-      if (should_stop(ready)) {
-        poll_skboutput = false;
-      }
+      retry = poll_buf_helper(skb_perfbuf_,
+                              false,
+                              drain,
+                              !do_poll_ringbuf && !do_poll_ringbuf_urg,
+                              poll_skboutput);
+      if (retry)
+        continue;
     }
 
     // Handle lost events, if any
     poll_event_loss(out);
 
-    if (do_poll_ringbuf) {
-      ready = ring_buffer__poll(ringbuf_, timeout_ms);
-      if (should_retry(ready)) {
-        continue;
-      }
-      if (should_stop(ready)) {
-        do_poll_ringbuf = false;
-      }
-    }
-    if (!poll_skboutput && !do_poll_ringbuf) {
+    retry = poll_buf_helper(
+        ringbuf_urg_, true, drain, !do_poll_ringbuf, do_poll_ringbuf_urg);
+    if (retry)
+      continue;
+
+    retry = poll_buf_helper(ringbuf_, true, drain, true, do_poll_ringbuf);
+    if (retry)
+      continue;
+
+    if (!poll_skboutput && !do_poll_ringbuf && !do_poll_ringbuf_urg)
       return;
-    }
 
     // If we are tracing a specific pid and it has exited, we should exit
     // as well b/c otherwise we'd be tracing nothing.

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -252,6 +252,11 @@ private:
                                               bool perf_mode,
                                               bool show_debug_info);
   void teardown_output();
+  bool poll_buf_helper(void *buf,
+                       bool is_ringbuf,
+                       bool drain,
+                       bool do_retry,
+                       bool &do_poll);
   void poll_output(output::Output &out, bool drain = false);
   void poll_event_loss(output::Output &out);
   static uint64_t read_address_from_output(std::string output);
@@ -262,6 +267,7 @@ private:
                        std::set<std::string> expanded_funcs);
   bool has_iter_ = false;
   struct ring_buffer *ringbuf_ = nullptr;
+  struct ring_buffer *ringbuf_urg_ = nullptr; // urgent ringbuf
   struct perf_buffer *skb_perfbuf_ = nullptr;
   uint64_t event_loss_count_ = 0;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,6 +47,7 @@ add_executable(bpftrace_test
   resource_analyser.cpp
   result.cpp
   required_resources.cpp
+  ringbuf.cpp
   scopeguard.cpp
   type_checker.cpp
   type_resolver.cpp

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 
+#include "async_action.h"
 #include "log.h"
 #include "gtest/gtest.h"
 
@@ -117,6 +118,23 @@ TEST(Log, disable_log_type)
   Log::get().enable(LogType::WARNING);
   LOG(WARNING, ss) << content;
   EXPECT_EQ(ss.str(), "WARNING: " + content + "\n");
+  ss.str({});
+}
+
+TEST(Log, log_async_action)
+{
+  std::ostringstream ss;
+  LOG(ERROR, ss) << bpftrace::async_action::AsyncAction::printf;
+  EXPECT_EQ(ss.str(), "ERROR: printf\n");
+  ss.str({});
+  LOG(ERROR, ss) << bpftrace::async_action::AsyncAction::print_non_map;
+  EXPECT_EQ(ss.str(), "ERROR: print_non_map\n");
+  ss.str({});
+  LOG(ERROR, ss) << bpftrace::async_action::AsyncAction::clear;
+  EXPECT_EQ(ss.str(), "ERROR: clear\n");
+  ss.str({});
+  LOG(ERROR, ss) << bpftrace::async_action::AsyncAction(50000);
+  EXPECT_EQ(ss.str(), "ERROR: unknown (50000)\n");
   ss.str({});
 }
 

--- a/tests/ringbuf.cpp
+++ b/tests/ringbuf.cpp
@@ -1,0 +1,14 @@
+#include "bpfmap.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::ringbuf {
+
+TEST(ringbuf, name)
+{
+  auto s1 = get_bpf_ringbuf_map_str(RingbufMap::Normal);
+  EXPECT_EQ(s1, "ringbuf");
+  auto s2 = get_bpf_ringbuf_map_str(RingbufMap::Urgent);
+  EXPECT_EQ(s2, "ringbuf_urg");
+}
+
+} // namespace bpftrace::test::ringbuf

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -416,7 +416,7 @@ LOCALIZE_TIMESTAMPS 0
 
 NAME tseries zigzag
 ENV BPFTRACE_DUMMY_TS_MAP=@ts
-PROG BEGIN { @dir = 1; @c = -5; @ts = (uint64)100ms; } i:ms:1 { $i = 0; while ($i < 20) { @ = tseries(@c, 100ms, 20); @ts += 100ms; @c += @dir; $i++; if (@c > 5) { @dir = -1; @c = 4 } else if (@c < -5) { @dir = 1; @c = -4; } } clear(@ts); clear(@c); clear(@dir); exit(); }
+PROG BEGIN { @dir = 1; @c = -5; @ts = (uint64)100ms; } i:ms:1 { $i = 0; while ($i < 20) { @ = tseries(@c, 100ms, 20); @ts += 100ms; @c += @dir; $i++; if (@c > 5) { @dir = -1; @c = 4 } else if (@c < -5) { @dir = 1; @c = -4; } } } end { clear(@ts); clear(@c); clear(@dir); exit(); }
 EXPECT_FILE runtime/outputs/tseries_zigzag.txt
 LOCALIZE_TIMESTAMPS 0
 
@@ -609,22 +609,22 @@ EXPECT 1.000123
 TIMEOUT 1
 
 NAME print_avg_map_args
-PROG begin { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@);  }
+PROG begin { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); } end { clear(@); }
 EXPECT_FILE  runtime/outputs/print_avg_map_args.txt
 TIMEOUT 1
 
 NAME print_avg_map_with_large_top
-PROG begin { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@);  }
+PROG begin { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); } end { clear(@); }
 EXPECT_FILE runtime/outputs/print_avg_map_with_large_top.txt
 TIMEOUT 1
 
 NAME print_hist_with_top_arg
-PROG begin { print("begin"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); print("end"); clear(@);  }
+PROG begin { print("begin"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); print("end"); } end { clear(@); }
 EXPECT_REGEX begin\n@\[2\]:(.*\n)+@\[3\]:(.*\n)+end
 TIMEOUT 1
 
 NAME print_hist_with_large_top_arg
-PROG begin { print("begin"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); print("end"); clear(@);  }
+PROG begin { print("begin"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); print("end"); } end { clear(@); }
 EXPECT_REGEX begin\n@\[1\]:(.*\n)+@\[2\]:(.*\n)+@\[3\]:(.*\n)+end
 TIMEOUT 1
 

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -166,22 +166,22 @@ EXPECT {"type": "value", "data": {"y": {"m": [2]}, "a": {"n": 3}}}
 AFTER ./testprogs/simple_struct
 
 NAME print_avg_map_args
-RUN {{BPFTRACE}} -q -f json -e 'begin { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@);  }'
+RUN {{BPFTRACE}} -q -f json -e 'begin { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); } end { clear(@); }'
 EXPECT {"type": "stats", "data": {"@": {"c": 3, "d": 4}}}
 TIMEOUT 1
 
 NAME print_avg_map_with_large_top
-RUN {{BPFTRACE}} -q -f json -e 'begin { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@);  }'
+RUN {{BPFTRACE}} -q -f json -e 'begin { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); } end { clear(@); }'
 EXPECT {"type": "stats", "data": {"@": {"a": 1, "b": 2, "c": 3, "d": 4}}}
 TIMEOUT 1
 
 NAME print_hist_with_top_arg
-RUN {{BPFTRACE}} -q -f json -e 'begin { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); clear(@);  }'
+RUN {{BPFTRACE}} -q -f json -e 'begin { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); } end { clear(@); }'
 EXPECT {"type": "hist", "data": {"@": {"2": [{"min": 16, "max": 31, "count": 1}], "3": [{"min": 16, "max": 31, "count": 1}]}}}
 TIMEOUT 1
 
 NAME print_hist_with_large_top_arg
-RUN {{BPFTRACE}} -q -f json -e 'begin { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); clear(@);  }'
+RUN {{BPFTRACE}} -q -f json -e 'begin { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); } end { clear(@); }'
 EXPECT {"type": "hist", "data": {"@": {"1": [{"min": 8, "max": 15, "count": 1}], "2": [{"min": 16, "max": 31, "count": 1}], "3": [{"min": 16, "max": 31, "count": 1}]}}}
 TIMEOUT 1
 

--- a/tests/runtime/ringbuf
+++ b/tests/runtime/ringbuf
@@ -2,14 +2,6 @@ NAME normal ringbuf
 RUN {{BPFTRACE}} -v -e 'begin { print(0); }'
 EXPECT_REGEX .*\[NORMAL\] Event print async action print_non_map
 
-NAME clear uses urgent ringbuf
-RUN {{BPFTRACE}} -v -e 'begin { @m=1; } end { clear(@m); }'
-EXPECT_REGEX .*\[URGENT\] Event print async action clear
-
-NAME zero uses urgent ringbuf
-RUN {{BPFTRACE}} -v -e 'begin { @m=1; } end { zero(@m); }'
-EXPECT_REGEX .*\[URGENT\] Event print async action zero
-
 NAME runtime error uses urgent ringbuf
 RUN {{BPFTRACE}} -v -e 'begin { $zero = 0; $x = 1 / $zero; }'
 EXPECT_REGEX .*\[URGENT\] Event print async action runtime_error

--- a/tests/runtime/ringbuf
+++ b/tests/runtime/ringbuf
@@ -1,0 +1,15 @@
+NAME normal ringbuf
+RUN {{BPFTRACE}} -v -e 'begin { print(0); }'
+EXPECT_REGEX .*\[NORMAL\] Event print async action print_non_map
+
+NAME clear uses urgent ringbuf
+RUN {{BPFTRACE}} -v -e 'begin { @m=1; } end { clear(@m); }'
+EXPECT_REGEX .*\[URGENT\] Event print async action clear
+
+NAME zero uses urgent ringbuf
+RUN {{BPFTRACE}} -v -e 'begin { @m=1; } end { zero(@m); }'
+EXPECT_REGEX .*\[URGENT\] Event print async action zero
+
+NAME runtime error uses urgent ringbuf
+RUN {{BPFTRACE}} -v -e 'begin { $zero = 0; $x = 1 / $zero; }'
+EXPECT_REGEX .*\[URGENT\] Event print async action runtime_error


### PR DESCRIPTION
Use another ringbuf for "urgent" async actions that has side effects or errors. These include "clear", "zero", and runtime errors.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
