### PR TITLE
codegen_llvm: Fix endianness bug in bool to int casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix boolean to integer cast on big-endian architectures
+  - [#5143](https://github.com/bpftrace/bpftrace/pull/5143)
 - Fix per-cpu map aggregation on big-endian architectures
   - [#5130](https://github.com/bpftrace/bpftrace/pull/5130)
 - Add bitfield support when printing full structure using "print()"

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2919,9 +2919,6 @@ ScopedExpr CodegenLLVM::visit(Cast &cast)
       return ScopedExpr(b_.CreateLoad(int_ty, array, true /*volatile*/));
     } else if (type_map_.type(cast.expr).IsPtrTy()) {
       return ScopedExpr(b_.CreatePtrToInt(scoped_expr.value(), int_ty));
-    } else if (type_map_.type(cast.expr).IsBoolTy()) {
-      return ScopedExpr(
-          b_.CreateIntCast(scoped_expr.value(), b_.getInt1Ty(), false, "cast"));
     } else {
       return ScopedExpr(b_.CreateIntCast(scoped_expr.value(),
                                          b_.getIntNTy(ty.GetIntBitWidth()),


### PR DESCRIPTION
bpftrace -e 'BEGIN { print((int64)true); }' fails on big endian. Attached 1 probe
72057594037927936

The visit(Cast) bool to integer special case returned an i1 value instead of properly extending to the target integer type.

As a result, createPrintNonMapCall() stored a single byte into an 8‑byte buffer, making the observed value dependent on endianness.

On little‑endian, this happened to read back as 1, while on big‑endian, it is interpreted as 0x0100000000000000.

Fix this by removing the special bool cast handling and letting the generic integer cast logic perform proper integer extension.

Reviewed-by: Ilya Leoshkevich <iii@linux.ibm.com>
Signed-off-by: Sumanth Korikkar <sumanthk@linux.ibm.com>
