### PR TITLE
stdlib: strings: Use a mask to control access scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- stdlib: Fixed strerror() and signal_name() failing BPF verification
+  - [#5145](https://github.com/bpftrace/bpftrace/pull/5145)
 - Fix boolean to integer cast on big-endian architectures
   - [#5143](https://github.com/bpftrace/bpftrace/pull/5143)
 - Fix per-cpu map aggregation on big-endian architectures

--- a/src/stdlib/strings/errors.h
+++ b/src/stdlib/strings/errors.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "strings.h"
 #include <linux/types.h>
 
 typedef char err_str[64];
@@ -139,6 +140,7 @@ static err_str errors[] = {
   [ENOTRECOVERABLE] = "State not recoverable",
   [ERFKILL] = "Operation not possible due to RF-kill",
   [EHWPOISON] = "Memory page has hardware error",
+  [ERROR_INDEX_MASK] = "",
 };
 
 static err_str unknown_error = "Unknown error";

--- a/src/stdlib/strings/signal.h
+++ b/src/stdlib/strings/signal.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "strings.h"
+
 typedef char sig_str[64];
 
 // See strsignal(3)
@@ -69,6 +71,7 @@ static sig_str signals[] = {
   [62] = "Real-time signal 28",
   [63] = "Real-time signal 29",
   [64] = "Real-time signal 30", // SIGRTMAX
+  [SIGNAL_INDEX_MASK] = "",
 };
 
 static sig_str unknown_signal = "N/A";

--- a/src/stdlib/strings/strings.bpf.c
+++ b/src/stdlib/strings/strings.bpf.c
@@ -71,7 +71,9 @@ int __strerror(int errno, err_str *out) {
   if (errno < 0) {
     errno = -errno;
   }
-  if (errno >= 0 && errno <= EHWPOISON) {
+  if (errno >= 0 && errno < ERROR_INDEX_MASK) {
+    errno &= ERROR_INDEX_MASK;
+
     // The array 'errors' is not fully populated, skip the empty 'errno'.
     //
     // There is another benefit to doing this. BPF 512-byte stack limit.
@@ -95,7 +97,9 @@ int __strerror(int errno, err_str *out) {
 }
 
 void __signal_name(int sig, sig_str *out) {
-  if (sig >= 0 && sig <= 64) {
+  if (sig >= 0 && sig < SIGNAL_INDEX_MASK) {
+    sig &= SIGNAL_INDEX_MASK;
+
     if (signals[sig][0] == '\0') {
       __builtin_memcpy(out, &unknown_signal, sizeof(*out));
     } else {
@@ -107,11 +111,8 @@ void __signal_name(int sig, sig_str *out) {
 }
 
 int __syscall_name(int n, syscall_str *out) {
-  if (n >= 0 && n < NR_SYSCALL_ALIGN_BITS) {
-    // To resolve the verifier's complaint that the off range is too large,
-    // resulting in "possible" access beyond the range of syscall_names[],
-    // we use a constant value to constrain n to help the verifier.
-    n &= NR_SYSCALL_ALIGN_BITS;
+  if (n >= 0 && n < SYSCALL_INDEX_MASK) {
+    n &= SYSCALL_INDEX_MASK;
 
     // System call numbers are not sequential, so when syscall_names is empty,
     // we return "unknown system call".

--- a/src/stdlib/strings/strings.h
+++ b/src/stdlib/strings/strings.h
@@ -1,0 +1,13 @@
+#pragma once
+
+// A constant whose low-order bits are all 1 and is greater than the maximum
+// index number. To resolve the verifier's complaint that the off range is too
+// large, resulting in "possible" access beyond the range of ARRAY[], we use a
+// constant value to constrain `index` to help the verifier.
+// Maximum value is EHWPOISON 133 (1000 0101), mask 1111 1111 = 0xff
+#define ERROR_INDEX_MASK 0xff
+// SIGRTMAX 64 (0100 0000), mask 0111 1111 = 0x7f
+#define SIGNAL_INDEX_MASK 0x7f
+// sys_pwritev64v2 547 (0010 0010 0011), mask 0011 1111 1111 = 0x3ff
+// see linux::arch/x86/entry/syscalls/syscall_64.tbl
+#define SYSCALL_INDEX_MASK 0x3ff

--- a/src/stdlib/strings/syscall.h
+++ b/src/stdlib/strings/syscall.h
@@ -1,12 +1,9 @@
 #pragma once
 
+#include "strings.h"
 #include <linux/types.h>
 
 typedef char syscall_str[64];
-
-// A constant whose low-order bits are all 1 and is greater than the maximum
-// syscall number.
-#define NR_SYSCALL_ALIGN_BITS 0x3ff
 
 // Syscall table for Linux x86_64.
 #ifdef __TARGET_ARCH_x86
@@ -429,7 +426,7 @@ static syscall_str syscall_names[] = {
   [545] = "execveat",
   [546] = "preadv2",
   [547] = "pwritev2",
-  [NR_SYSCALL_ALIGN_BITS] = "",
+  [SYSCALL_INDEX_MASK] = "",
 };
 #elif defined(__TARGET_ARCH_arm)
 static syscall_str syscall_names[] = {
@@ -867,7 +864,7 @@ static syscall_str syscall_names[] = {
   [467] = "open_tree_attr",
   [468] = "file_getattr",
   [469] = "file_setattr",
-  [NR_SYSCALL_ALIGN_BITS] = "",
+  [SYSCALL_INDEX_MASK] = "",
 };
 #elif defined(__TARGET_ARCH_mips)
 static syscall_str syscall_names[] = {
@@ -1244,7 +1241,7 @@ static syscall_str syscall_names[] = {
   [467] = "open_tree_attr",
   [468] = "file_getattr",
   [469] = "file_setattr",
-  [NR_SYSCALL_ALIGN_BITS] = "",
+  [SYSCALL_INDEX_MASK] = "",
 };
 #elif defined(__TARGET_ARCH_powerpc)
 static syscall_str syscall_names[] = {
@@ -1796,7 +1793,7 @@ static syscall_str syscall_names[] = {
   [467] = "open_tree_attr",
   [468] = "file_getattr",
   [469] = "file_setattr",
-  [NR_SYSCALL_ALIGN_BITS] = "",
+  [SYSCALL_INDEX_MASK] = "",
 };
 #elif defined(__TARGET_ARCH_s390)
 static syscall_str syscall_names[] = {
@@ -2263,7 +2260,7 @@ static syscall_str syscall_names[] = {
   [467] = "open_tree_attr",
   [468] = "file_getattr",
   [469] = "file_setattr",
-  [NR_SYSCALL_ALIGN_BITS] = "",
+  [SYSCALL_INDEX_MASK] = "",
 };
 #elif defined(__TARGET_ARCH_arm64) || defined(__TARGET_ARCH_riscv) ||          \
     defined(__TARGET_ARCH_loongarch)
@@ -2598,13 +2595,13 @@ static syscall_str syscall_names[] = {
   [467] = "open_tree_attr",
   [468] = "file_getattr",
   [469] = "file_setattr",
-  [NR_SYSCALL_ALIGN_BITS] = "",
+  [SYSCALL_INDEX_MASK] = "",
 };
 #else
 // All architectures supported by bpftrace are listed above. If the architecture
 // is still not supported, the unknown system call will be returned.
 static syscall_str syscall_names[] = {
-  [NR_SYSCALL_ALIGN_BITS] = "",
+  [SYSCALL_INDEX_MASK] = "",
 };
 #endif
 


### PR DESCRIPTION
On fedora 44 amd64 llvm 22.1.4, `strerror()` and `signal_name()` cannot pass the verifier's validation, `syscall_name()` works fine, for example strerror:

    tracepoint:syscalls:sys_exit_openat,
    tracepoint:syscalls:sys_exit_openat2
    {
        $errno = args.ret;
        @[strerror($errno)] = count();
        exit();
    }

Error: `errors[var_off=(0x0; 0x3fffffffc0)]` failed:

    ;  @ strings.bpf.c:86
    30: (bf) r1 = r2                      ; R1=scalar(id=3) R2=scalar(id=3)
    31: (57) r1 &= 255                    ; R1=scalar(smin=smin32=0,smax=umax=smax32=umax32=255,var_off=(0x0; 0xff))
    32: (15) if r1 == 0x3a goto pc+1      ; R1=scalar(smin=smin32=0,smax=umax=smax32=umax32=255,var_off=(0x0; 0xff))
    33: (55) if r1 != 0x29 goto pc+139 173: R0=scalar(smin=smin32=0,smax=umax=smax32=umax32=11,var_off=(0x0; 0xf)) R1=scalar(smin=smin32=0,smax=umax=smax32=umax32=255,var_off=(0x0; 0xff)) R2=scalar(id=3) R3=scalar(smin=smin32=0,smax=umax=smax32=umax32=133,var_off=(0x0; 0xff)) R6=map_value(map=.data.var_buf,ks=4,vs=2048,smin=smin32=0,smax=umax=smax32=umax32=1408,var_off=(0x0; 0x780)) R7=ctx() R8=scalar(id=1,smin=smin32=0,smax=umax=smax32=umax32=11,var_off=(0x0; 0xf)) R10=fp0
    173: (67) r2 <<= 32                   ; R2=scalar(smax=0x7fffffff00000000,umax=0xffffffff00000000,smin32=0,smax32=umax32=0,var_off=(0x0; 0xffffffff00000000))
    174: (77) r2 >>= 32                   ; R2=scalar(smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
    175: (67) r2 <<= 6                    ; R2=scalar(smin=0,smax=umax=0x3fffffffc0,smax32=0x7fffffc0,umax32=0xffffffc0,var_off=(0x0; 0x3fffffffc0))
    176: (18) r1 = 0xffffd016cf169010     ; R1=map_value(map=38213820.rodata,ks=4,vs=8656,off=16)
    178: (0f) r1 += r2                    ; R1=map_value(map=38213820.rodata,ks=4,vs=8656,off=16,smin=0,smax=umax=0x3fffffffc0,smax32=0x7fffffc0,umax32=0xffffffc0,var_off=(0x0; 0x3fffffffc0)) R2=scalar(smin=0,smax=umax=0x3fffffffc0,smax32=0x7fffffc0,umax32=0xffffffc0,var_off=(0x0; 0x3fffffffc0))
    ;  @ strings.bpf.c:89
    179: (71) r2 = *(u8 *)(r1 +63)
    R1 unbounded memory access, make sure to bounds check any such access

Using a mask to control the range of array access can solve this problem.

The max errno is EHWPOISON (1000 0101), then mask will be `0xff`.

I tried several methods, but I could never pass the verifier in both Fedora [1] and Ubuntu [2] environments at the same time. Only this method using a mask can support various kernel and LLVM versions simultaneously.

[1] Fedora 44 kernel 6.19.14-300.fc44.x86_64, llvm 22.1.4
[2] Ubuntu 24.04.4 kernel 6.17.0-1014-nvidia, llvm 18.1.3
