### PR TITLE
Fix preamble ordering

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -1,13 +1,36 @@
 # The bpftrace Language
 
-The `bpftrace` (`bt`) language is inspired by the D language used by `dtrace` and uses the same program structure.
-Each script consists of a [Preamble](#preamble) and one or more [Action Blocks](#action-blocks).
+The `bpftrace` (`bt`) language is inspired by the D language used by `dtrace` and uses a similar program structure.
+Each section is optional but must appear in this order:
+
+1. **[C Definitions](#structs)** — `#include` directives, `#define` macros, and
+   `struct`/`union`/`enum` type definitions. Must come before everything else
+   (aside from a shebang line).
+2. **[Config Block](#config-block) and Imports** — a `config` block and any `import` statements.
+   These can appear in any order relative to each other, but must appear after
+   C definitions and before action blocks, map declarations, and macros.
+3. **[Action Blocks](#action-blocks), [Macros](#macros), and [Map Declarations](#map-declarations)** — the main body of the
+   script. These can appear in any order relative to each other.
+
+For example:
 
 ```
-preamble
+#include <linux/socket.h>
+#define RED "\033[31m"
 
-actionblock1
-actionblock2
+struct S {
+  int x;
+}
+
+config = {
+    stack_mode=perf
+}
+
+let @a = lruhash(100);
+
+macro greet { print("hi"); }
+
+kprobe:do_nanosleep { greet!(); }
 ```
 
 ## Action Blocks
@@ -196,7 +219,7 @@ if (condition) {
 ## Config Block
 
 To improve script portability, you can set bpftrace [Config Variables](#config-variables) via the config block,
-which can only be placed at the top of the script (in the [preamble](#preamble)) before any action blocks.
+which can only be placed at the top of the script before any action blocks, macros, or map declarations.
 
 ```
 config = {
@@ -835,41 +858,6 @@ The warning can also be silenced by utilizing the Discard Expression:
 
 ```
 _ = has_key(@a, 1); // No Warning
-```
-
-## Program Structure
-
-A bpftrace script has the following top-level structure, where each section is
-optional but must appear in this order:
-
-1. **Config block and imports** — a `config` block and any `import` statements.
-   These can appear in any order relative to each other, but must come before
-   everything else (aside from a shebang line).
-2. **C definitions** — `#include` directives, `#define` macros, and
-   `struct`/`union`/`enum` type definitions. Must appear after config/imports
-   and before probes, functions, and macros.
-3. **Probes, macros, and map declarations** — the main body of the
-   script. These can appear in any order relative to each other.
-
-For example:
-
-```
-config = {
-    stack_mode=perf
-}
-
-#include <linux/socket.h>
-#define RED "\033[31m"
-
-struct S {
-  int x;
-}
-
-let @a = lruhash(100);
-
-macro greet { print("hi"); }
-
-kprobe:do_nanosleep { greet!(); }
 ```
 
 ## Probes
@@ -1691,7 +1679,7 @@ Fields are accessed with the `.` operator.
 If the `.` is used on a pointer, it is automatically dereferenced.
 The legacy `->` operator may be used, but is purely an alias for the `.` operator.
 
-Custom structs can be defined in the preamble.
+Custom structs can be defined at the top of the program.
 
 Constructing structs from scratch, like `struct X var = {.f1 = 1}` in `C`, is not supported.
 They can only be read into a variable from a pointer.

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -79,9 +79,30 @@ Program *Parser::parse_program()
     consume_layout();
   }
 
-  // Preamble: config and imports must appear after the header but they can be
-  // in any order relative to each other.
+  // C definitions: #include, struct/union/enum definitions.
+  // Must appear after header but before config/imports/probes.
   CStatementList c_stmts;
+  consume_layout();
+  while (!at_end() && !has_errors()) {
+    // C preprocessor directives: #include, #define, etc.
+    if (peek() == '#' && peek(1) != '!') {
+      c_stmts.push_back(parse_c_preprocessor());
+      consume_layout();
+      continue;
+    }
+    // C struct/union/enum definitions: struct Name { ... }
+    auto kw = peek_keyword();
+    if ((kw == "struct" || kw == "union" || kw == "enum") &&
+        looks_like_c_definition()) {
+      c_stmts.push_back(parse_c_definition());
+      consume_layout();
+      continue;
+    }
+    break;
+  }
+
+  // Config and imports: must appear after c_definitions but they can be
+  // in any order relative to each other.
   Config *config = nullptr;
 
   while (!at_end() && !has_errors()) {
@@ -102,27 +123,6 @@ Program *Parser::parse_program()
       if (imp) {
         imports.push_back(imp);
       }
-      consume_layout();
-      continue;
-    }
-    break;
-  }
-
-  // C definitions: #include, struct/union/enum definitions.
-  // Must appear after config/imports but before probes/macros/functions.
-  consume_layout();
-  while (!at_end() && !has_errors()) {
-    // C preprocessor directives: #include, #define, etc.
-    if (peek() == '#' && peek(1) != '!') {
-      c_stmts.push_back(parse_c_preprocessor());
-      consume_layout();
-      continue;
-    }
-    // C struct/union/enum definitions: struct Name { ... }
-    auto kw = peek_keyword();
-    if ((kw == "struct" || kw == "union" || kw == "enum") &&
-        looks_like_c_definition()) {
-      c_stmts.push_back(parse_c_definition());
       consume_layout();
       continue;
     }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2778,6 +2778,12 @@ TEST(Parser, config)
 
   test("config = {} begin {}",
        Program().WithConfig(Config({})).WithProbe(Probe({ "begin" }, {})));
+
+  test("#include <stdio.h>\nconfig = { blah = 5 } begin {}",
+       Program()
+           .WithCStatements({ CStatement("#include <stdio.h>") })
+           .WithConfig(Config({ AssignConfigVarStatement("blah", 5UL) }))
+           .WithProbe(Probe({ "begin" }, {})));
 }
 
 TEST(Parser, config_error)
@@ -2842,6 +2848,13 @@ config { BPFTRACE_STACK_MODE=perf } i:s:1 { exit(); }
 stdin:1:27-28: ERROR: syntax: expected '{'
 BPFTRACE_STACK_MODE=perf; i:s:1 { exit(); }
                           ~
+)");
+
+  test_parse_failure("config = { blah = 5 }\n#include <stdio.h>\nbegin {}",
+                     R"(
+stdin:2-3: ERROR: syntax: C definitions must appear before probes and functions
+#include <stdio.h>
+begin {}
 )");
 }
 


### PR DESCRIPTION
Prior to the replacement of flex/bison with a recursive descent parser C preprocessor directives were supposed to appear before config blocks and imports. The change of the ordering seemed intentional but this is a breaking change (I happened to notice in some older scripts).

Instead of just documenting this breaking change, let's just switch back to the prior behavior as C preprocessor directives are mostly getting phased out as we lean into BTF.

Also added tests and fixed up the language doc.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
