### PR TITLE
Fix kfunc probe listing incorrectly showing retval parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix kfunc/fentry probe listing incorrectly showing a `retval` parameter
+  - [#5147](https://github.com/bpftrace/bpftrace/pull/5147)
 - stdlib: Fixed strerror() and signal_name() failing BPF verification
   - [#5145](https://github.com/bpftrace/bpftrace/pull/5145)
 - Fix boolean to integer cast on big-endian architectures

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -462,7 +462,18 @@ FuncParamLists ProbeMatcher::get_params_for_matches(
   switch (probe_type) {
     case ProbeType::tracepoint:
       return get_tracepoints_params(matches);
-    case ProbeType::fentry:
+    case ProbeType::fentry: {
+      auto params = bpftrace_->btf_->get_params(matches);
+      // fentry (kfunc) does not have a return value, so strip the retval
+      // entry that get_params() unconditionally appends. Inspect the last
+      // element rather than blindly popping so a future change in
+      // get_params() can't silently drop a real parameter.
+      for (auto& [name, p] : params) {
+        if (!p.empty() && p.back().ends_with(" retval"))
+          p.pop_back();
+      }
+      return params;
+    }
     case ProbeType::fexit:
       return bpftrace_->btf_->get_params(matches);
     case ProbeType::rawtracepoint:


### PR DESCRIPTION
## fix: remove incorrect retval from kfunc probe listing

Probe listing (`-lv`) for `kfunc` (fentry) probes incorrectly showed a `retval` parameter. `get_params()` unconditionally appends the return type as "retval" for all functions, but fentry probes fire at function entry where no return value exists.

This change splits the `fentry`/`fexit` cases in `get_params_for_matches()` so that `fentry` removes the trailing `retval`, while `fexit` remains unchanged.

Before:
```
$ bpftrace -lv kfunc:vmlinux:tcp_sendmsg
fentry:vmlinux:tcp_sendmsg
    struct sock * sk
    struct msghdr * msg
    size_t size
    int retval              <-- should not be here
```

After:
```
$ bpftrace -lv kfunc:vmlinux:tcp_sendmsg
fentry:vmlinux:tcp_sendmsg
    struct sock * sk
    struct msghdr * msg
    size_t size
```

Closes https://github.com/bpftrace/bpftrace/issues/3059

test scripts:

```bash
  BPFTRACE="sudo bpftrace"                                                       
  # BPFTRACE="sudo /my/bpftrace/build/src/bpftrace"                          
  echo "1. kfunc listing (should not have retval)"                              
  $BPFTRACE -lv 'kfunc:vmlinux:tcp_sendmsg'
       
  echo "2. kretfunc listing (with retval)"
  $BPFTRACE -lv 'kretfunc:vmlinux:tcp_sendmsg' 

  echo "3. kfunc with args.retval (error)" 
  $BPFTRACE -e 'kfunc:vmlinux:tcp_sendmsg { print(args.retval) }' 2>&1 | head -5 
  
  echo "4. kretfunc  args (with retval)"
  $BPFTRACE -e 'kretfunc:vmlinux:tcp_sendmsg { print(args); exit() }' 2>&1 | head -5  
```


##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
