### PR TITLE
Make fentry args test program loop

### DIFF
--- a/tests/testprogs/fentry_args.c
+++ b/tests/testprogs/fentry_args.c
@@ -8,12 +8,13 @@ int main(int argc, char *argv[])
   if (argc != 3) {
     return 1;
   }
-  usleep(1000000);
 
   union bpf_attr attr;
   int cmd = atoi(argv[1]);
   unsigned int size = atoi(argv[2]);
-  syscall(__NR_bpf, cmd, &attr, size);
 
+  while (1) {
+    syscall(__NR_bpf, cmd, &attr, size);
+  }
   return 0;
 }


### PR DESCRIPTION
Fixes #2932

This updates `tests/testprogs/fentry_args.c` to repeatedly invoke the `bpf()` syscall instead of sleeping for one second and invoking it only once.

This avoids relying on a fixed sleep interval before bpftrace has attached the fentry/fexit probe. If attach takes longer than expected, the test program will continue generating events so the probe can still observe them.

Tested:
- `cmake -B build -DCMAKE_BUILD_TYPE=Debug`
- `make -C build -j$(nproc)`
- `timeout 1s ./build/tests/testprogs/fentry_args 1111 2222`

Note:
- The related runtime test fails on my local WSL2 kernel before the test program is exercised:
  `The function __sys_bpf arg1 type STRUCT is unsupported.`