### PR TITLE
Silence hints when warnings are disabled (#5149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Silence warning hints when warnings are disabled (`--no-warnings`)
+  - [#5151](https://github.com/bpftrace/bpftrace/pull/5151)
 - Fix kfunc/fentry probe listing incorrectly showing a `retval` parameter
   - [#5147](https://github.com/bpftrace/bpftrace/pull/5147)
 - stdlib: Fixed strerror() and signal_name() failing BPF verification

--- a/src/ast/diagnostic.cpp
+++ b/src/ast/diagnostic.cpp
@@ -21,6 +21,9 @@ void Diagnostics::emit(std::ostream& out) const
 
 void Diagnostics::emit(std::ostream& out, Severity s) const
 {
+  if (s == Severity::Warning && !Log::get().is_enabled(LogType::WARNING))
+    return;
+
   foreach(s, [this, s, &out](const Diagnostic& d) { emit(out, s, d); });
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(bpftrace_test
   collect_nodes.cpp
   control_flow_analyser.cpp
   deprecated.cpp
+  diagnostic.cpp
   field_analyser.cpp
   fold_literals.cpp
   function_registry.cpp

--- a/tests/diagnostic.cpp
+++ b/tests/diagnostic.cpp
@@ -1,0 +1,54 @@
+#include "ast/diagnostic.h"
+#include "log.h"
+#include "gtest/gtest.h"
+
+namespace bpftrace::test::diagnostic {
+
+TEST(Diagnostics, WarningSilencing)
+{
+  ast::Diagnostics diags;
+  auto &warn = diags.addWarning(ast::Location());
+  warn << "This is a warning";
+  warn.addHint() << "This is a hint";
+
+  // When warnings are enabled
+  {
+    std::stringstream out;
+    diags.emit(out);
+    EXPECT_TRUE(out.str().find("WARNING: This is a warning") !=
+                std::string::npos);
+    EXPECT_TRUE(out.str().find("HINT: This is a hint") != std::string::npos);
+  }
+
+  // When warnings are disabled
+  {
+    DISABLE_LOG(WARNING);
+    std::stringstream out;
+    diags.emit(out);
+    EXPECT_TRUE(out.str().find("WARNING: This is a warning") ==
+                std::string::npos);
+    EXPECT_TRUE(out.str().find("HINT: This is a hint") == std::string::npos);
+    ENABLE_LOG(WARNING);
+  }
+}
+
+TEST(Diagnostics, ErrorNotSilenced)
+{
+  ast::Diagnostics diags;
+  auto &err = diags.addError(ast::Location());
+  err << "This is an error";
+  err.addHint() << "This is an error hint";
+
+  // When warnings are disabled, errors and their hints should still be shown
+  {
+    DISABLE_LOG(WARNING);
+    std::stringstream out;
+    diags.emit(out);
+    EXPECT_TRUE(out.str().find("ERROR: This is an error") != std::string::npos);
+    EXPECT_TRUE(out.str().find("HINT: This is an error hint") !=
+                std::string::npos);
+    ENABLE_LOG(WARNING);
+  }
+}
+
+} // namespace bpftrace::test::diagnostic


### PR DESCRIPTION
Diagnostic hints associated with warnings were still being emitted even when the `--no-warnings` flag was used. This change ensures that both warnings and their associated hints are silenced when `LogType::WARNING` is disabled.

Fixes #5149

##### Checklist
- [x] Language changes are updated (N/A, no language changes)
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests