### PR TITLE
No error on int mismatch for C func calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to
   - [#5092](https://github.com/bpftrace/bpftrace/pull/5092)
 - The default type for positive integer literals is now `int8`
   - [#5138](https://github.com/bpftrace/bpftrace/pull/5138)
+- Warn instead of error when there is an integer sign mismatch, except for integer literals that are out of range for the destination type
+  - [#5148](https://github.com/bpftrace/bpftrace/pull/5148)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/docs/language.md
+++ b/docs/language.md
@@ -453,9 +453,23 @@ $a = $b; // $a now becomes an int16
 $c = (uint64)1;
 $d = (int64)-1;
 
-$c = $d; // ERROR: type mismatch because there isn't a larger type
-         // that fits both.
+// $c is a int64 below
+// an implicit cast is added to the assignment -> (int64)$d
+// and a warning about the sign mismatch is surfaced
+$c = $d;
 ```
+
+Note: If there is ever an integer sign mismatch that can't be upcast to a type that can hold both, the resulting type is an `int64`.
+This may lead to undefined behavior, or, most likely, a large number being printed as a negative one.
+
+However, implicit casts of integer literals still fail when the literal is outside the
+destination type's range. For example, `let $a: uint16 = -1;` requires an
+explicit cast: `let $a: uint16 = (uint16)-1;`. Though this:
+```
+$b = -1;
+let $a: uint16 = $b;
+```
+only yields a warning.
 
 Additionally, when vmlinux BTF is available, bpftrace supports
 casting to some of the kernel's fixed integer types:

--- a/src/ast/passes/types/cast_creator.cpp
+++ b/src/ast/passes/types/cast_creator.cpp
@@ -4,8 +4,10 @@
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/types/parsed_type_bridge.h"
 #include "ast/passes/types/type_map.h"
+#include "ast/passes/types/type_system.h"
 #include "ast/visitor.h"
 #include "bpftrace.h"
+#include "btf/compat.h"
 #include "log.h"
 #include "types.h"
 
@@ -298,6 +300,7 @@ class CastCreator : public Visitor<CastCreator> {
 public:
   explicit CastCreator(ASTContext &ast,
                        BPFtrace &bpftrace,
+                       TypeMetadata &type_metadata,
                        const TypeMap &type_map);
 
   using Visitor<CastCreator>::visit;
@@ -321,14 +324,19 @@ private:
 
   ASTContext &ctx_;
   BPFtrace &bpftrace_;
+  TypeMetadata &type_metadata_;
   const TypeMap &type_map_;
   std::variant<std::monostate, Probe *, Subprog *> top_level_node_;
 };
 
 CastCreator::CastCreator(ASTContext &ast,
                          BPFtrace &bpftrace,
+                         TypeMetadata &type_metadata,
                          const TypeMap &type_map)
-    : ctx_(ast), bpftrace_(bpftrace), type_map_(type_map)
+    : ctx_(ast),
+      bpftrace_(bpftrace),
+      type_metadata_(type_metadata),
+      type_map_(type_map)
 {
 }
 
@@ -449,6 +457,47 @@ void CastCreator::visit(Call &call)
       cast_expression(call.vargs.at(0),
                       type_map_.type(call.vargs.at(0)),
                       CreateUInt64());
+    }
+  } else {
+    // All these errors below will be surfaced in type_checker
+    auto maybe_func = type_metadata_.global.lookup<btf::Function>(call.func);
+    if (!maybe_func) {
+      consumeError(std::move(maybe_func));
+      return;
+    }
+
+    const auto &func = *maybe_func;
+    auto proto = func.type();
+    if (!proto) {
+      consumeError(std::move(proto));
+      return;
+    }
+
+    auto argument_types = proto->argument_types();
+    if (!argument_types) {
+      consumeError(argument_types.takeError());
+      return;
+    }
+
+    if (argument_types->size() != call.vargs.size()) {
+      return;
+    }
+
+    for (size_t i = 0; i < argument_types->size(); i++) {
+      auto compat_arg_type = getCompatType(argument_types->at(i).second);
+      if (!compat_arg_type) {
+        consumeError(compat_arg_type.takeError());
+        continue;
+      }
+
+      auto &arg = call.vargs.at(i);
+      const auto &arg_type = type_map_.type(arg);
+      if (!arg_type.IsIntegerTy() || !compat_arg_type->IsIntegerTy()) {
+        continue;
+      }
+
+      // Cast integers and issue warnings if neccessary
+      cast_expression(arg, arg_type, *compat_arg_type);
     }
   }
 }
@@ -581,9 +630,10 @@ void CastCreator::visit(Subprog &subprog)
 
 void RunCastCreator(ASTContext &ast,
                     BPFtrace &bpftrace,
+                    TypeMetadata &type_metadata,
                     const TypeMap &type_map)
 {
-  CastCreator(ast, bpftrace, type_map).visit(ast.root);
+  CastCreator(ast, bpftrace, type_metadata, type_map).visit(ast.root);
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/cast_creator.cpp
+++ b/src/ast/passes/types/cast_creator.cpp
@@ -206,7 +206,11 @@ static std::optional<SizedType> try_int_cast(ASTContext &ctx,
 
   if (!expr_type.FitsInto(target_type) && !expr_type.IsCastableMapTy() &&
       !exp.is<Integer>() && !exp.is<NegativeInteger>()) {
-    return std::nullopt;
+    auto &warning = exp.node().addWarning();
+    warning << "Expression of type: " << expr_type
+            << " being cast to type: " << target_type
+            << ". This may cause unexpected results. Use an explicit cast to "
+               "suppress this warning.";
   }
 
   auto *typeof_r = ctx.make_node<Typeof>(

--- a/src/ast/passes/types/cast_creator.h
+++ b/src/ast/passes/types/cast_creator.h
@@ -13,6 +13,7 @@ namespace bpftrace::ast {
 class ASTContext;
 class Expression;
 class TypeMap;
+class TypeMetadata;
 struct Program;
 
 std::optional<SizedType> try_tuple_cast(ASTContext &ctx,
@@ -27,6 +28,7 @@ std::optional<SizedType> try_record_cast(ASTContext &ctx,
 
 void RunCastCreator(ASTContext &ast,
                     BPFtrace &bpftrace,
+                    TypeMetadata &type_metadata,
                     const TypeMap &type_map);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -2723,7 +2723,7 @@ Pass CreateTypeResolverPass()
 
         // Apply casts in parts of the AST where we want the left and right
         // sides to have the same type.
-        RunCastCreator(ast, b, type_map);
+        RunCastCreator(ast, b, types, type_map);
 
         // Re-resolve types for nodes created by CastCreator. This is just
         // easier than having CastCreator update resolved_types

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -193,12 +193,21 @@ public:
       // referencing a single type for an AST Map node is not correct
       const auto &current_type = types_[type_rule.output];
 
+      // Types can become not sign flexible but not the other way around
+      bool ignore_sign_flexible = (current_type.IsSignFlexible() ==
+                                   result_type.IsSignFlexible()) ||
+                                  (!current_type.IsSignFlexible() &&
+                                   result_type.IsSignFlexible());
+
       // TODO: further investigate and fix this weirdness with address space and
       // ctx access
-      if (current_type == result_type &&
-          current_type.IsCtxAccess() == result_type.IsCtxAccess() &&
-          (current_type.GetAS() == result_type.GetAS() ||
-           current_type.GetAS() != AddrSpace::none)) {
+      bool ignore_address_space = (current_type.GetAS() ==
+                                       result_type.GetAS() ||
+                                   current_type.GetAS() != AddrSpace::none);
+
+      if (current_type == result_type && ignore_sign_flexible &&
+          ignore_address_space &&
+          current_type.IsCtxAccess() == result_type.IsCtxAccess()) {
         continue;
       }
 
@@ -492,33 +501,6 @@ SizedType get_binop_int(Binop &binop,
       }
       return CreateUInt64();
     }
-  }
-
-  bool show_warning = false;
-  bool mismatched_sign = right_type.IsSigned() != left_type.IsSigned();
-  // N.B. all castable map values are 64 bits
-  if (left_type.IsCastableMapTy()) {
-    if (right_type.IsCastableMapTy()) {
-      show_warning = mismatched_sign;
-    } else {
-      if (!get_promoted_type(right_type,
-                             CreateInteger(64, left_type.IsSigned()))) {
-        show_warning = true;
-      }
-    }
-  } else if (right_type.IsCastableMapTy()) {
-    if (!get_promoted_type(left_type,
-                           CreateInteger(64, right_type.IsSigned()))) {
-      show_warning = true;
-    }
-  } else if (!get_promoted_type(left_type, right_type)) {
-    show_warning = true;
-  }
-
-  if (show_warning && is_comparison) {
-    binop.addWarning() << "comparison of integers of different signs: '" << lht
-                       << "' and '" << rht << "'"
-                       << " can lead to undefined behavior";
   }
 
   if (is_comparison) {
@@ -2526,7 +2508,8 @@ SizedType TypeRuleCollector::get_locked_node(const TypeVariable &node,
 {
   if (auto found_locked = locked_nodes_.find(node);
       found_locked != locked_nodes_.end()) {
-    if (!type.FitsInto(found_locked->second)) {
+    auto promoted = get_promoted_type(found_locked->second, type);
+    if (!promoted || *promoted != found_locked->second) {
       error_node.addError()
           << "Type mismatch for " << name << ": "
           << "this type has been locked because it was used "

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -141,22 +141,6 @@ bool SizedType::IsCompatible(const SizedType &t) const
   if (IsPtrTy())
     return GetPointeeTy().IsCompatible(t.GetPointeeTy());
 
-  if (IsIntegerTy()) {
-    if (IsSigned() == t.IsSigned()) {
-      return true;
-    }
-    if (IsSignFlexible() || t.IsSignFlexible()) {
-      return true;
-    }
-    // If the signs don't match then the unsigned side
-    // can't be promoted anymore if it's already the largest int
-    if (!t.IsSigned()) {
-      return t.GetSize() != 8;
-    } else { // t is signed
-      return GetSize() != 8;
-    }
-  }
-
   if (IsTupleTy()) {
     if (GetFieldCount() != t.GetFieldCount())
       return false;
@@ -686,7 +670,8 @@ std::optional<SizedType> get_promoted_int(const SizedType &currentType,
     // If one side has flexible sign (from a non-negative integer literal),
     // adapt it to match the other side's sign and promote by size.
     if (currentType.IsSignFlexible() || newType.IsSignFlexible()) {
-      bool sign = currentType.IsSignFlexible() ? newSigned : currentSigned;
+      bool sign = (!currentType.IsSignFlexible() && currentSigned) ||
+                  (!newType.IsSignFlexible() && newSigned);
       size_t promoted_size = std::max(currentSize, newSize);
       auto result = CreateInteger(promoted_size * 8, sign);
       result.SetSignFlexible(result_flexible);
@@ -701,7 +686,9 @@ std::optional<SizedType> get_promoted_int(const SizedType &currentType,
 
     size_t promoted_size = std::max(currentSize, newSize) * 2;
     if (promoted_size > 8) {
-      return std::nullopt;
+      // If both are 64 bits default to signed, which will yield a warning to
+      // the user.
+      return CreateInt64();
     } else {
       return CreateInteger(promoted_size * 8, true);
     }

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -5226,6 +5226,8 @@ TEST_F(TypeCheckerTest, external_function)
   ast::TypeMetadata types;
 
   // Build some basic types.
+  auto uint64 = types.global.add<btf::Integer>("uint64", 8, 0);
+  ASSERT_TRUE(bool(uint64));
   auto int32 = types.global.add<btf::Integer>("int32", 4, 1);
   ASSERT_TRUE(bool(int32));
   auto int64 = types.global.add<btf::Integer>("int64", 8, 1);
@@ -5242,9 +5244,56 @@ TEST_F(TypeCheckerTest, external_function)
       "foo", btf::Function::Linkage::Global, *add_proto);
   ASSERT_TRUE(bool(add_func));
 
+  std::vector<std::pair<std::string, btf::ValueType>> cast_args = {
+    { "a", btf::ValueType(*int64) }
+  };
+  auto cast_proto = types.global.add<btf::FunctionProto>(btf::ValueType(*int64),
+                                                         cast_args);
+  ASSERT_TRUE(bool(cast_proto));
+  auto cast_func = types.global.add<btf::Function>(
+      "bar", btf::Function::Linkage::Global, *cast_proto);
+  ASSERT_TRUE(bool(cast_func));
+
   // Test that calling this function works.
   test("kprobe:f { foo((int32)1, (int64)2); }", Types{ types });
   test("kprobe:f { print(foo((int32)1, (int64)2)); }", Types{ types });
+  // Cast int arguments to a different sign
+  test("kprobe:f { print(bar((uint64)1)); }",
+       Types{ types },
+       Warning{ "being cast to type" },
+       ExpectedAST{ Program().WithProbe(Probe(
+           { "kprobe:f" },
+           { ExprStatement(Block(
+               { ExprStatement(Call(
+                     "print",
+                     { Call("bar",
+                            { Cast(Typeof(ParsedType(
+                                       ast::ParsedType::Kind::Identifier,
+                                       "int64")),
+                                   (Cast(Typeof(ParsedType(
+                                             ast::ParsedType::Kind::Identifier,
+                                             "uint64")),
+                                         Integer(1)))) }) })),
+                 Jump(ast::JumpType::RETURN) })) })) });
+  // Cast int arguments to a smaller int
+  test("kprobe:f { print(foo((int64)1, (int64)2)); }",
+       Types{ types },
+       Warning{ "being cast to type" },
+       ExpectedAST{ Program().WithProbe(Probe(
+           { "kprobe:f" },
+           { ExprStatement(Block(
+               { ExprStatement(Call(
+                     "print",
+                     { Call("foo",
+                            { Cast(Typeof(ParsedType(
+                                       ast::ParsedType::Kind::Identifier,
+                                       "int32")),
+                                   (Cast(Typeof(ParsedType(
+                                             ast::ParsedType::Kind::Identifier,
+                                             "int64")),
+                                         Integer(1)))),
+                              _ }) })),
+                 Jump(ast::JumpType::RETURN) })) })) });
 
   // Test that calling with the wrong number of arguments fails.
   test("kprobe:f { foo((int32)1); }", Types{ types }, Error{ R"(
@@ -5253,15 +5302,10 @@ kprobe:f { foo((int32)1); }
            ~~~~~~~~~~~~~
 )" });
 
-  // Test that calling with the wrong types fails.
-  test("kprobe:f { foo((int64)1, (int64)2); }", Types{ types }, Error{ R"(
-stdin:1:16-23: ERROR: Expected int32 for argument `a` got int64
-kprobe:f { foo((int64)1, (int64)2); }
-               ~~~~~~~
-stdin:1:12-35: ERROR: Function `foo` requires arguments (int32, int64)
-kprobe:f { foo((int64)1, (int64)2); }
-           ~~~~~~~~~~~~~~~~~~~~~~~
-)" });
+  // Non-integer mismatches should still fail.
+  test("kprobe:f { foo(\"hi\", (int64)2); }",
+       Types{ types },
+       Error{ "Expected int32 for argument `a` got string[3]" });
 
   // Test that the return type is well-understood.
   test("kprobe:f { $x = (int32*)0; $x = foo((int32)1, (int64)2); }",

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -2657,27 +2657,98 @@ enum named { a = 1, b } kprobe:f { $a = "str"; print((enum named)$a); }
 )" });
 }
 
-TEST_F(TypeCheckerTest, signed_int_comparison_warnings)
+TEST_F(TypeCheckerTest, implicit_int_cast_warnings)
 {
-  std::string cmp_sign = "comparison of integers of different signs";
-  test("kretprobe:f /-1 < retval/ {}", Warning{ cmp_sign });
-  test("kretprobe:f /-1 > retval/ {}", Warning{ cmp_sign });
-  test("kretprobe:f /-1 >= retval/ {}", Warning{ cmp_sign });
-  test("kretprobe:f /-1 <= retval/ {}", Warning{ cmp_sign });
-  test("kretprobe:f /-1 != retval/ {}", Warning{ cmp_sign });
-  test("kretprobe:f /-1 == retval/ {}", Warning{ cmp_sign });
-  test("kretprobe:f /retval > -1/ {}", Warning{ cmp_sign });
-  test("kretprobe:f /retval < -1/ {}", Warning{ cmp_sign });
+  std::string cast_warn = "being cast to type";
 
-  // These should not trigger a warning
-  test("kretprobe:f /(uint64)1 < retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /(uint64)1 > retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /(uint64)1 >= retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /(uint64)1 <= retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /(uint64)1 != retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /(uint64)1 == retval/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /retval > (uint64)1/ {}", NoWarning{ cmp_sign });
-  test("kretprobe:f /retval < (uint64)1/ {}", NoWarning{ cmp_sign });
+  test("begin { $a = (uint64)1; $a = (int64)2; }", Warning{ cast_warn });
+  test("begin { $a = (int64)1; $a = (uint64)2; }", Warning{ cast_warn });
+  test("begin { $a = -1; $a = (uint64)2; }", Warning{ cast_warn });
+  test("begin { $a = 1; $a = -1; $a = (uint64)2; }", Warning{ cast_warn });
+
+  test("begin { $a = (uint32)1; $a = (int32)2; }", NoWarning{ cast_warn });
+  test("begin { $a = (uint16)1; $a = (int16)2; }", NoWarning{ cast_warn });
+  test("begin { $a = 1; $a = (uint64)2; }", NoWarning{ cast_warn });
+  test("begin { $a = 1; $a = (int64)2; }", NoWarning{ cast_warn });
+
+  test("begin { @a = (uint64)1; @a = (int64)2; }", Warning{ cast_warn });
+  test("begin { @a = (int64)1; @a = (uint64)2; }", Warning{ cast_warn });
+  test("begin { @a = -1; @a = (uint64)2; }", Warning{ cast_warn });
+
+  test("begin { @a = (uint32)1; @a = (int32)2; }", NoWarning{ cast_warn });
+  test("begin { @a = 1; @a = (uint64)2; }", NoWarning{ cast_warn });
+  test("begin { @a = 0; @a--; @a++; }", NoWarning{ cast_warn });
+
+  test("begin { @a[(uint64)1] = 1; @a[(int64)2] = 1; }", Warning{ cast_warn });
+  test("begin { @a[(int64)1] = 1; @a[(uint64)2] = 1; }", Warning{ cast_warn });
+  test("begin { @a[-1] = 1; @a[(uint64)2] = 1; }", Warning{ cast_warn });
+
+  test("begin { @a[(uint32)1] = 1; @a[(int32)2] = 1; }",
+       NoWarning{ cast_warn });
+  test("begin { @a[1] = 1; @a[(uint64)2] = 1; }", NoWarning{ cast_warn });
+
+  test("begin { print(if (1) { (uint64)1 } else { (int64)2 }); }",
+       Warning{ cast_warn });
+  test("begin { print(if (1) { (int64)1 } else { (uint64)2 }); }",
+       Warning{ cast_warn });
+
+  test("begin { print(if (1) { (uint32)1 } else { (int32)2 }); }",
+       NoWarning{ cast_warn });
+  test("begin { print(if (1) { 1 } else { (uint64)2 }); }",
+       NoWarning{ cast_warn });
+
+  test("begin { let $a: uint64 = (int64)1; }", Warning{ cast_warn });
+  test("begin { let $a: int64 = (uint64)1; }", Warning{ cast_warn });
+
+  test("begin { let $a: uint64 = 1; }", NoWarning{ cast_warn });
+  test("begin { let $a: int32 = (uint32)1; }", Warning{ cast_warn });
+  // Smoke test for explict bad casting
+  test("begin { let $a: uint16 = (uint16)-1; }", NoWarning{ cast_warn });
+
+  test("begin { $a = (uint64)1 + (int64)2; }", Warning{ cast_warn });
+  test("begin { $a = (uint64)1 - 1; }", Warning{ cast_warn });
+  test("begin { $a = (uint64)1 == (int64)-1; }", Warning{ cast_warn });
+  test("begin { @a = sum(-1); $a = (uint64)1 == @a; }", Warning{ cast_warn });
+  test("begin { @a = sum(-1); $a = @a == (uint64)1; }", Warning{ cast_warn });
+
+  test("begin { $a = (uint32)1 + (int32)2; }", NoWarning{ cast_warn });
+  test("begin { $a = (int64)(uint64)1 - 1; }", NoWarning{ cast_warn });
+  test("begin { $a = 1 == -1; }", NoWarning{ cast_warn });
+  test("begin { $a = 1 == (int64)-1; }", NoWarning{ cast_warn });
+  test("begin { $a = (uint32)1 == (int32)-1; }", NoWarning{ cast_warn });
+  test("begin { @a = sum(-1); $a = 1 == @a; }", NoWarning{ cast_warn });
+  test("begin { @a = sum(-1); $a = @a == 1; }", NoWarning{ cast_warn });
+  test("begin { @a = sum(1); $a = @a == (uint16)1; }", NoWarning{ cast_warn });
+  test("begin { @a = sum(-1); $a = @a == (uint16)1; }", NoWarning{ cast_warn });
+  test("begin { @a = sum((uint64)1); @b = count(); $a = @a == @b; }",
+       NoWarning{ cast_warn });
+
+  test(R"(begin { $a = ((uint64)1, "hi"); $a = ((int64)2, "hello"); })",
+       Warning{ cast_warn });
+  test(R"(begin { $a = (x=(uint64)1, y="hi"); $a = (x=(int64)2, y="hello"); })",
+       Warning{ cast_warn });
+  test(
+      R"(begin { $a = (1, ("hi", (uint64)2)); $a = (1, ("hello", (int64)3)); })",
+      Warning{ cast_warn });
+
+  test(R"(begin { $a = ((uint32)1, "hi"); $a = ((int32)2, "hello"); })",
+       NoWarning{ cast_warn });
+  test(R"(begin { $a = (1, "hi"); $a = ((uint64)2, "hello"); })",
+       NoWarning{ cast_warn });
+  test(R"(begin { $a = (x=(uint32)1, y="hi"); $a = (x=(int32)2, y="hello"); })",
+       NoWarning{ cast_warn });
+  test(R"(begin { $a = (x=1, y="hi"); $a = (x=(uint64)2, y="hello"); })",
+       NoWarning{ cast_warn });
+  test(
+      R"(begin { $a = (1, ("hi", (uint32)2)); $a = (1, ("hello", (int32)3)); })",
+      NoWarning{ cast_warn });
+}
+
+TEST_F(TypeCheckerTest, implicit_int_cast_literal_errors)
+{
+  test("begin { let $a: uint16 = -1; }", Error{});
+  test("begin { let $a: uint8 = 10000000; }", Error{});
+  test("fn f(): uint8 { return 10000000; }", Error{});
 }
 
 TEST_F(TypeCheckerTest, unsigned_literal_arithmetic_warnings)
@@ -3020,17 +3091,12 @@ TEST_F(TypeCheckerTest, mixed_int_var_assignments)
   test("kprobe:f { $x = (int16)1; $x = 100000; }");
   test("kprobe:f { $a = (uint16)5; $x = (uint8)0; $x = $a; }");
   test("kprobe:f { $a = (int8)-1; $x = (uint8)0; $x = $a; }");
+  test("kprobe:f { $a = -1; $a = (uint64)2; }");
+  test("kprobe:f { $a = (int64)1; $a = (uint64)2; }");
+  test("kprobe:f { $a = 9223372036854775807; $a = -2147483648 }");
 
-  // Errors
-  test("begin { $a = -1; $a = (uint64)2; }", Error{});
-  test("begin { $a = (int64)1; $a = (uint64)2; }", Error{});
-  test("begin { $a = -1; $a = 9223372036854775808; }", Error{});
-  test("begin { $a = 9223372036854775807; $a = -2147483648 }");
-  test("kprobe:f { $x = -1; $x = 10223372036854775807; }", Error{ R"(
-stdin:1:21-46: ERROR: Type mismatch for $x: trying to assign value of type 'uint64' when variable already has a type 'int8'
-kprobe:f { $x = -1; $x = 10223372036854775807; }
-                    ~~~~~~~~~~~~~~~~~~~~~~~~~
-)" });
+  // We can prove statically that these don't fit in the same type
+  test("kprobe:f { $a = -1; $a = 9223372036854775808; }", Error{});
 
   test("begin { $x = (int8)1; $x = 5; }",
        ExpectedAST{ Program().WithProbe(
@@ -3085,25 +3151,10 @@ TEST_F(TypeCheckerTest, mixed_int_like_map_assignments)
   test("kprobe:f { @x = max((uint32)1); @x = max(-1); }");
   test("kprobe:f { @x = stats(1); @x = stats(-1); }");
   test("kprobe:f { @x = stats((uint32)1); @x = stats(-1); }");
-
-  test("kprobe:f { @x = sum((uint64)1); @x = sum(-1); }", Error{ R"(
-ERROR: Type mismatch for sum: trying to call function with type 'int8' when it already has a type 'uint64'
-)" });
-  test("kprobe:f { @x = min((uint64)1); @x = min(-1); }", Error{ R"(
-ERROR: Type mismatch for min: trying to call function with type 'int8' when it already has a type 'uint64'
-)" });
-  test("kprobe:f { @x = max((uint64)1); @x = max(-1); }", Error{ R"(
-ERROR: Type mismatch for max: trying to call function with type 'int8' when it already has a type 'uint64'
-)" });
-  test("kprobe:f { @x = avg((uint64)1); @x = avg(-1); }", Error{ R"(
-ERROR: Type mismatch for avg: trying to call function with type 'int8' when it already has a type 'uint64'
-)" });
-  // One errror test to validate the source location
-  test("kprobe:f { @x = stats((uint64)1); @x = stats(-1); }", Error{ R"(
-ERROR: Type mismatch for stats: trying to call function with type 'int8' when it already has a type 'uint64'
-kprobe:f { @x = stats((uint64)1); @x = stats(-1); }
-                                       ~~~~~~~~~
-)" });
+  test("kprobe:f { @x = sum((uint64)1); @x = sum(-1); }");
+  test("kprobe:f { @x = min((uint64)1); @x = min(-1); }");
+  test("kprobe:f { @x = max((uint64)1); @x = max(-1); }");
+  test("kprobe:f { @x = avg((uint64)1); @x = avg(-1); }");
 }
 
 TEST_F(TypeCheckerTest, mixed_int_map_access)
@@ -3115,55 +3166,21 @@ TEST_F(TypeCheckerTest, mixed_int_map_access)
   test("kprobe:f { @x[(uint16)1] = 1; @x[(uint64)2] }");
   test("kprobe:f { @x[(uint64)1] = 1; @x[(uint16)2] }");
   test("kprobe:f { @x[(uint16)1] = 1; @x[2] }");
+  test("kprobe:f { @x[(uint8)1] = 1; @x[10000000] }");
   test("kprobe:f { @x[(uint16)1] = 1; @x[10223372036854775807] }");
   test("kprobe:f { @x[1] = 1; @x[9223372036854775807] }");
   test("kprobe:f { @x[1] = 1; @x[-9223372036854775808] }");
   test("kprobe:f { @x[(uint8)1] = 1; @x[(uint64)1] }");
   test("kprobe:f { @x[(uint32)-1] = 1; @x[1] }");
   test("kprobe:f { @x[-1] = 1; @x[(uint32)1] }");
+  test("kprobe:f { @x[(uint64)1] = 1; @x[-1] }");
+  test("kprobe:f { @x[-1] = 1; @x[(uint64)1] }");
 
-  test("kprobe:f { @x[-1] = 1; @x[10223372036854775807] }", Error{ R"(
-ERROR: Argument mismatch for @x: trying to access with arguments: 'uint64' when map expects arguments: 'int8'
-kprobe:f { @x[-1] = 1; @x[10223372036854775807] }
-                       ~~~~~~~~~~~~~~~~~~~~~~~~
-)" });
-  test("kprobe:f { @x[(uint64)1] = 1; @x[-1] }", Error{ R"(
-ERROR: Argument mismatch for @x: trying to access with arguments: 'int8' when map expects arguments: 'uint64'
-kprobe:f { @x[(uint64)1] = 1; @x[-1] }
-                              ~~~~~~
-)" });
-  test("kretprobe:f { @x[-1] = 1; @x[(uint64)1] }", Error{ R"(
-ERROR: Argument mismatch for @x: trying to access with arguments: 'uint64' when map expects arguments: 'int8'
-)" });
+  test("kprobe:f { @x[-1] = 1; @x[10223372036854775807] }", Error{});
 }
 
 TEST_F(TypeCheckerTest, mixed_int_like_binop)
 {
-  test("kprobe:f { $a = 1 == -1; }", NoWarning{ "comparison of integers" });
-  test("kprobe:f { $a = 1 == (int64)-1; }",
-       NoWarning{ "comparison of integers" });
-  test("kprobe:f { $a = (uint32)1 == (int32)-1; }",
-       NoWarning{ "comparison of integers" });
-  test("kprobe:f { @a = sum(-1); $a = 1 == @a; }",
-       NoWarning{ "comparison of integers" });
-  test("kprobe:f { @a = sum(-1); $a = @a == 1; }",
-       NoWarning{ "comparison of integers" });
-  test("kprobe:f { @a = sum(1); $a = @a == (uint16)1; }",
-       NoWarning{ "comparison of integers" });
-  test("kprobe:f { @a = sum(-1); $a = @a == (uint16)1; }",
-       NoWarning{ "comparison of integers" });
-  test("kprobe:f { @a = sum((uint64)1); @b = count(); $a = @a == @b; }",
-       NoWarning{ "comparison of integers" });
-
-  test("kprobe:f { $a = (uint64)1 == (int64)-1; }",
-       Warning{ "comparison of integers" });
-  test("kprobe:f { @a = sum(-1); $a = (uint64)1 == @a; }",
-       Warning{ "comparison of integers" });
-  test("kprobe:f { @a = sum(-1); $a = @a == (uint64)1; }",
-       Warning{ "comparison of integers" });
-  test("kprobe:f { @a = sum(-1); @b = count(); $a = @a == @b; }",
-       Warning{ "comparison of integers" });
-
   // Both are additionally casted to int16
   test("kprobe:f { $a = (uint8)1 == (int8)-1; }",
        ExpectedAST{ Program().WithProbe(Probe(
@@ -3729,12 +3746,7 @@ TEST_F(TypeCheckerTest, tuple)
 
   test(R"(begin { $t = (1, (2, 3)); $t = (4, ((int64)5, 6)); })");
 
-  test(R"(begin { $t = (1, ((int8)2, 3)); $t = (4, ((uint64)5, 6)); })",
-       Error{ R"(
-stdin:1:33-57: ERROR: Type mismatch for $t: trying to assign value of type '(int8,(uint64,int8))' when variable already has a type '(int8,(int8,int8))'
-begin { $t = (1, ((int8)2, 3)); $t = (4, ((uint64)5, 6)); }
-                                ~~~~~~~~~~~~~~~~~~~~~~~~
-)" });
+  test(R"(begin { $t = (1, ((int8)2, 3)); $t = (4, ((uint64)5, 6)); })");
 
   test(R"(begin { $t = ((uint8)1, (2, 3)); $t = (4, (5, 6)); })");
   test(R"(begin { @t = (1, 2, "hi"); @t = (3, 4, "hellolongstr"); })");
@@ -3827,15 +3839,11 @@ TEST_F(TypeCheckerTest, mixed_tuple)
   test(
       R"(begin { print(if (pid == 1) { ((int16)1, "hi") } else { ((uint16)2, "hellostr") }); })");
 
-  test(R"(begin { $a = ((int64)1, "hi"); $a = ((uint64)2, "hellostr"); })",
-       Error{});
-  test(R"(begin { @a[(int64)1, "hi"] = 1; @a[(uint64)2, "hellostr"] = 2; })",
-       Error{});
-  test(R"(begin { @a = ((int64)1, "hi"); @a = ((uint64)2, "hellostr"); })",
-       Error{});
+  test(R"(begin { $a = ((int64)1, "hi"); $a = ((uint64)2, "hellostr"); })");
+  test(R"(begin { @a[(int64)1, "hi"] = 1; @a[(uint64)2, "hellostr"] = 2; })");
+  test(R"(begin { @a = ((int64)1, "hi"); @a = ((uint64)2, "hellostr"); })");
   test(
-      R"(begin { print(if (pid == 1) { ((int64)1, "hi") } else { ((uint64)2, "hellostr") }); })",
-      Error{});
+      R"(begin { print(if (pid == 1) { ((int64)1, "hi") } else { ((uint64)2, "hellostr") }); })");
 
   // Test inserted casts
   test(R"(begin { $a = ((int16)1, "hi"); $a = ((uint16)2, "hellostr"); })",
@@ -4283,7 +4291,7 @@ TEST_F(TypeCheckerTest, subprog_builtin)
 {
   test("fn f(): void { print(\"Hello world\"); }");
   test("fn f(): uint64 { return nsecs; }");
-  test("fn f(): uint8 { return (uint64)2; }", Error{});
+  test("fn f(): uint8 { return \"bob\"; }", Error{});
 }
 
 TEST_F(TypeCheckerTest, subprog_builtin_disallowed)
@@ -4881,36 +4889,16 @@ TEST_F(TypeCheckerTest, variable_declarations)
   test("struct x { int a; } begin { let $a: struct x[10]; }");
   test("begin { if (pid) { let $x = 1; } $x = 2; }");
   test("begin { if (pid) { let $x = 1; } else { let $x = 1; } let $x = 1; }");
+  // Explicit casts, are allowed for typed declarations.
+  test("begin { let $a: uint16 = (uint16)-1; }");
+  test("begin { let $a: uint8 = (uint8)10000; }");
 
-  test("begin { let $a: uint16; $a = -1; }", Error{ R"(
-ERROR: Type mismatch for $a: trying to assign value of type 'int8' when variable already has a type 'uint16'
-begin { let $a: uint16; $a = -1; }
-                        ~~~~~~~
-)" });
-
-  test("begin { let $a: uint8 = (uint8)1; $a = 10000; }", Error{ R"(
-stdin:1:35-45: ERROR: Type mismatch for $a: trying to assign value of type 'int16' when variable already has a type 'uint8'
-begin { let $a: uint8 = (uint8)1; $a = 10000; }
-                                  ~~~~~~~~~~
-)" });
-
-  test("begin { let $a: int8 = 1; $a = -10000; }", Error{ R"(
-stdin:1:27-38: ERROR: Type mismatch for $a: trying to assign value of type 'int16' when variable already has a type 'int8'
-begin { let $a: int8 = 1; $a = -10000; }
-                          ~~~~~~~~~~~
-)" });
-
-  test("begin { let $a: int8; $a = 10000; }", Error{ R"(
-ERROR: Type mismatch for $a: trying to assign value of type 'int16' when variable already has a type 'int8'
-begin { let $a: int8; $a = 10000; }
-                      ~~~~~~~~~~
-)" });
-
-  test("begin { let $a: uint16 = -1; }", Error{ R"(
-ERROR: Type mismatch for $a: trying to assign value of type 'int8' when variable already has a type 'uint16'
-begin { let $a: uint16 = -1; }
-        ~~~~~~~~~~~~~~~~~~~
-)" });
+  // Out-of-range integer literals still require an explicit cast.
+  test("begin { let $a: uint16; $a = -1; }", Error{});
+  test("begin { let $a: uint8 = (uint8)1; $a = 10000; }", Error{});
+  test("begin { let $a: int8 = 1; $a = -10000; }", Error{});
+  test("begin { let $a: int8; $a = 10000; }", Error{});
+  test("begin { let $a: uint16 = -1; }", Error{});
 
   test(R"(begin { let $a: sum_t; })", Error{ R"(
 stdin:1:17-22: ERROR: Invalid variable declaration type: sum_t
@@ -5332,18 +5320,18 @@ TEST_F(TypeCheckerTest, typeof_decls)
   test("begin { let $a: int32 = 0; }");
   test(
       R"(begin { @a["hi", 2] = 1; let $x: typeof(@a) = ("hello", (int16)1); @a["hello", (int32)2] = 2; })");
+  // Integer types will be cast to the declaration type
+  test("begin { let $a: int8 = 1; $a = (int32)1; }");
+  test("begin { let $a: uint8; $a = (int8)1; }");
+  test("begin { $y = (int8)1; let $a: uint8; $a = $y; }");
+  test(
+      R"(begin { @a["hi", 2] = 1; let $x: typeof(@a) = ("hello",
+        (uint64)1); @a["hello", (int32)2] = 2; })");
 
   // These types should be enforced.
-  test("begin { let $a: int8 = 1; $a = (int32)1; }", Error{});
-  test("begin { let $a: uint8; $a = (int8)1; }", Error{});
-  test("begin { $y = (int8)1; let $a: uint8; $a = $y; }", Error{});
   test("begin { let $a: uint8; $a = -1; }", Error{});
   test(R"(kprobe:f { let $x: string[3] = "helloooooo"; })", Error{});
   test(R"(kprobe:f { let $x: string[3] = "hi"; $x = "helloooooo"; })", Error{});
-  test(
-      R"(begin { @a["hi", 2] = 1; let $x: typeof(@a) = ("hello",
-        (uint64)1); @a["hello", (int32)2] = 2; })",
-      Error{});
 
   test(R"(kprobe:f { $a = (1, "hi"); let $x: typeof($a) = (1, "helllooo");
     })",
@@ -5626,19 +5614,14 @@ TEST_F(TypeCheckerTest, record_mixed_types)
       R"(begin { print(if (pid == 1) { (x=(int32)1, y="hi") } else { (x=(uint16)2, y="hellostr") }); })");
   test(
       R"(begin { $a = (y="hi", x=(a=(uint8)1, b=(uint32)2)); $a = (x=(b=(uint8)3, a=(int16)5), y="hellostr"); })");
-
   test(
-      R"(begin { $a = (x=(int64)1, y="hi"); $a = (x=(uint64)2, y="hellostr"); })",
-      Error{});
+      R"(begin { $a = (x=(int64)1, y="hi"); $a = (x=(uint64)2, y="hellostr"); })");
   test(
-      R"(begin { @a[(x=(int64)1, y="hi")] = 1; @a[(x=(uint64)2, y="hellostr")] = 2; })",
-      Error{});
+      R"(begin { @a[(x=(int64)1, y="hi")] = 1; @a[(x=(uint64)2, y="hellostr")] = 2; })");
   test(
-      R"(begin { @a = (x=(int64)1, y="hi"); @a = (x=(uint64)2, y="hellostr"); })",
-      Error{});
+      R"(begin { @a = (x=(int64)1, y="hi"); @a = (x=(uint64)2, y="hellostr"); })");
   test(
-      R"(begin { print(if (pid == 1) { (x=(int64)1, y="hi") } else { (x=(uint64)2, y="hellostr") }); })",
-      Error{});
+      R"(begin { print(if (pid == 1) { (x=(int64)1, y="hi") } else { (x=(uint64)2, y="hellostr") }); })");
 
   // Test inserted casts
   test(

--- a/tests/type_resolver.cpp
+++ b/tests/type_resolver.cpp
@@ -145,11 +145,27 @@ TEST_F(TypeResolverTest, variable_promotion_integers)
     EXPECT_EQ(var_type(result, "$a"), CreateInt32());
   }
   {
+    auto result = test(R"(begin { $a = -1; $a = (uint64)2 })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = 1; $a = -1; $a = (uint64)2 })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+  }
+  {
     auto result = test(R"(begin { $a = (int8)1; $a = (uint8)2; })");
     EXPECT_EQ(var_type(result, "$a"), CreateInt16());
   }
   {
     auto result = test(R"(begin { $a = (uint32)1; $a = (int32)2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = (uint64)1; $a = (int64)2; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+  }
+  {
+    auto result = test(R"(begin { $a = (int64)1; $a = (uint64)2; })");
     EXPECT_EQ(var_type(result, "$a"), CreateInt64());
   }
   {
@@ -161,13 +177,6 @@ TEST_F(TypeResolverTest, variable_promotion_integers)
     EXPECT_EQ(var_type(result, "$a"), CreateInt8());
     EXPECT_EQ(var_type(result, "$v"), CreateInt8());
   }
-
-  // Errors
-  test(R"(begin { $a = (uint64)1; $a = (int64)2 })", Error{});
-  // Negative literal pins sign; can't promote to uint64
-  test(R"(begin { $a = -1; $a = (uint64)2 })", Error{});
-  // Multiple literals where negative pins sign
-  test(R"(begin { $a = 1; $a = -1; $a = (uint64)2 })", Error{});
 }
 
 TEST_F(TypeResolverTest, variable_promotion_strings)
@@ -203,6 +212,13 @@ TEST_F(TypeResolverTest, variable_promotion_tuples)
   }
   {
     auto result = test(
+        R"(begin { $a = ((uint64)1, "str"); $a = ((int64)1, "longer"); })");
+    EXPECT_EQ(var_type(result, "$a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateInt64(), CreateString(7) })));
+  }
+  {
+    auto result = test(
         R"(begin { $a = ((uint32)1, "str"); $a = (1, "longer"); $a = ((int64)1, "a"); })");
     EXPECT_EQ(var_type(result, "$a"),
               CreateTuple(
@@ -228,6 +244,15 @@ TEST_F(TypeResolverTest, variable_promotion_tuples)
   }
   {
     auto result = test(
+        R"(begin { $a = ((uint32)1, (x="str", y=(int64)2)); $a = (1, (x="longer", y=(uint64)2)); })");
+    auto nested_record = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt64() }, { "x", "y" }));
+    EXPECT_EQ(var_type(result, "$a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_record })));
+  }
+  {
+    auto result = test(
         R"(begin { $b = ("str", (int16)2); $a = ((uint32)1, $b); $c = ("longer", (uint16)2); $a = (1, $c); })");
     auto nested_tuple = CreateTuple(
         Struct::CreateTuple({ CreateString(7), CreateInt32() }));
@@ -242,14 +267,6 @@ TEST_F(TypeResolverTest, variable_promotion_tuples)
               CreateTuple(
                   Struct::CreateTuple({ CreateString(7), CreateUInt16() })));
   }
-
-  // Errors
-  test(
-      R"(begin { $a = ((uint64)1, "str"); $a = (1, "longer"); $a = ((int64)1, "a"); })",
-      Error{});
-  test(
-      R"(begin { $a = (1, ("str", (uint64)2)); $a = (1, ("longer", (int64)2)); })",
-      Error{});
 }
 
 TEST_F(TypeResolverTest, variable_promotion_records)
@@ -266,6 +283,13 @@ TEST_F(TypeResolverTest, variable_promotion_records)
     EXPECT_EQ(var_type(result, "$a"),
               CreateRecord(Struct::CreateRecord(
                   { CreateUInt32(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto result = test(
+        R"(begin { $a = (x = (uint64)1, y = "str"); $a = (x = (int64)1, y = "longer"); })");
+    EXPECT_EQ(var_type(result, "$a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(), CreateString(7) }, { "x", "y" })));
   }
   {
     auto result = test(
@@ -292,12 +316,31 @@ TEST_F(TypeResolverTest, variable_promotion_records)
   }
   {
     auto result = test(
+        R"(begin { $a = (x = (uint32)1, y = (s = "str", n = (int64)2)); $a = (x = 1, y = (s = "longer", n = (uint64)2)); })");
+    auto nested = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt64() }, { "s", "n" }));
+    EXPECT_EQ(var_type(result, "$a"),
+              CreateRecord(Struct::CreateRecord({ CreateUInt32(), nested },
+                                                { "x", "y" })));
+  }
+  {
+    auto result = test(
         R"(begin { $a = (x = (uint32)1, y = ("str", (int16)2)); $a = (x = (int32)1, y = ("longer", (uint16)2)); })");
     EXPECT_EQ(var_type(result, "$a"),
               CreateRecord(Struct::CreateRecord(
                   { CreateInt64(),
                     CreateTuple(Struct::CreateTuple(
                         { CreateString(7), CreateInt32() })) },
+                  { "x", "y" })));
+  }
+  {
+    auto result = test(
+        R"(begin { $a = (x = (uint32)1, y = ("str", (int64)2)); $a = (x = (int32)1, y = ("longer", (uint64)2)); })");
+    EXPECT_EQ(var_type(result, "$a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(),
+                    CreateTuple(Struct::CreateTuple(
+                        { CreateString(7), CreateInt64() })) },
                   { "x", "y" })));
   }
   {
@@ -316,14 +359,6 @@ TEST_F(TypeResolverTest, variable_promotion_records)
               CreateRecord(Struct::CreateRecord(
                   { CreateString(7), CreateUInt16() }, { "s", "n" })));
   }
-
-  // Errors
-  test(
-      R"(begin { $a = (x = (uint64)1, y = "str"); $a = (x = 1, y = "longer"); $a = (x = (int64)1, y = "a"); })",
-      Error{});
-  test(
-      R"(begin { $a = (x = 1, y = (s = "str", n = (uint64)2)); $a = (x = 1, y = (s = "longer", n = (int64)2)); })",
-      Error{});
 }
 
 TEST_F(TypeResolverTest, variable_castable_maps)
@@ -345,6 +380,11 @@ TEST_F(TypeResolverTest, variable_castable_maps)
     EXPECT_EQ(var_type(result, "$a"), CreateInt64());
   }
   {
+    auto result = test(
+        R"(begin { @a = sum((uint64)1); @a = sum((int64)-1); $a = @a; })");
+    EXPECT_EQ(var_type(result, "$a"), CreateInt64());
+  }
+  {
     auto result = test(R"(begin { @a = sum(-1); $a = (int16)2; $a = @a; })");
     EXPECT_EQ(var_type(result, "$a"), CreateInt64());
   }
@@ -353,7 +393,6 @@ TEST_F(TypeResolverTest, variable_castable_maps)
         R"(begin { @a = sum((uint64)1); $a = (uint8)1; $a = @a; })");
     EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
   }
-
   {
     auto result = test(R"(begin { @a = sum((uint64)1); $a = 1; $a = @a; })");
     EXPECT_EQ(var_type(result, "$a"), CreateUInt64());
@@ -383,6 +422,14 @@ TEST_F(TypeResolverTest, map_value_promotion_integers)
     EXPECT_EQ(map_val_type(result, "@a"), CreateUInt64());
   }
   {
+    auto result = test(R"(begin { @a = (int64)1; @a = (uint64)2; })");
+    EXPECT_EQ(map_val_type(result, "@a"), CreateInt64());
+  }
+  {
+    auto result = test(R"(begin { @a = (uint64)1; @a = (int64)2; })");
+    EXPECT_EQ(map_val_type(result, "@a"), CreateInt64());
+  }
+  {
     // Multiple positive literals then unsigned: all adapt
     auto result = test(R"(begin { @a = 1; @a = 2; @a = (uint32)3; })");
     EXPECT_EQ(map_val_type(result, "@a"), CreateUInt32());
@@ -409,13 +456,6 @@ TEST_F(TypeResolverTest, map_value_promotion_integers)
     EXPECT_EQ(map_val_type(result, "@a"), CreateInt8());
     EXPECT_EQ(var_type(result, "$v"), CreateInt8());
   }
-
-  // Errors
-  test(R"(begin { @a = (uint64)1; @a = (int64)2 })", Error{});
-  // Negative literal pins sign; can't promote to uint64
-  test(R"(begin { @a = -1; @a = (uint64)2 })", Error{});
-  // Multiple literals where negative pins sign
-  test(R"(begin { @a = 1; @a = -1; @a = (uint64)2 })", Error{});
 }
 
 TEST_F(TypeResolverTest, map_value_promotion_strings)
@@ -467,9 +507,27 @@ TEST_F(TypeResolverTest, map_value_promotion_tuples)
   }
   {
     auto result = test(
+        R"(begin { @a = ((uint64)1, ("str", (int64)2)); @a = ((int64)1, ("longer", (uint64)2)); })");
+    auto nested_tuple = CreateTuple(
+        Struct::CreateTuple({ CreateString(7), CreateInt64() }));
+    EXPECT_EQ(map_val_type(result, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateInt64(), nested_tuple })));
+  }
+  {
+    auto result = test(
         R"(begin { @a = ((uint32)1, (x="str", y=(int16)2)); @a = (1, (x="longer", y=(uint16)2)); })");
     auto nested_record = CreateRecord(
         Struct::CreateRecord({ CreateString(7), CreateInt32() }, { "x", "y" }));
+    EXPECT_EQ(map_val_type(result, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateUInt32(), nested_record })));
+  }
+  {
+    auto result = test(
+        R"(begin { @a = ((uint32)1, (x="str", y=(int64)2)); @a = (1, (x="longer", y=(uint64)2)); })");
+    auto nested_record = CreateRecord(
+        Struct::CreateRecord({ CreateString(7), CreateInt64() }, { "x", "y" }));
     EXPECT_EQ(map_val_type(result, "@a"),
               CreateTuple(
                   Struct::CreateTuple({ CreateUInt32(), nested_record })));
@@ -490,14 +548,6 @@ TEST_F(TypeResolverTest, map_value_promotion_tuples)
               CreateTuple(
                   Struct::CreateTuple({ CreateString(7), CreateUInt16() })));
   }
-
-  // Errors
-  test(
-      R"(begin { @a = ((uint64)1, "str"); @a = (1, "longer"); @a = ((int64)1, "a"); })",
-      Error{});
-  test(
-      R"(begin { @a = (1, ("str", (uint64)2)); @a = (1, ("longer", (int64)2)); })",
-      Error{});
 }
 
 TEST_F(TypeResolverTest, map_value_promotion_records)
@@ -518,6 +568,13 @@ TEST_F(TypeResolverTest, map_value_promotion_records)
   {
     auto result = test(
         R"(begin { @a = (x = (uint32)1, y = "str"); @a = (y = "longer", x = (int32)1); })");
+    EXPECT_EQ(map_val_type(result, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto result = test(
+        R"(begin { @a = (x = (uint64)1, y = "str"); @a = (y = "longer", x = (int64)1); })");
     EXPECT_EQ(map_val_type(result, "@a"),
               CreateRecord(Struct::CreateRecord(
                   { CreateInt64(), CreateString(7) }, { "x", "y" })));
@@ -580,14 +637,6 @@ TEST_F(TypeResolverTest, map_value_promotion_records)
               CreateRecord(Struct::CreateRecord(
                   { CreateString(7), CreateUInt16() }, { "s", "n" })));
   }
-
-  // Errors
-  test(
-      R"(begin { @a = (x = (uint64)1, y = "str"); @a = (x = 1, y = "longer"); @a = (x = (int64)1, y = "a"); })",
-      Error{});
-  test(
-      R"(begin { @a = (x = 1, y = (s = "str", n = (uint64)2)); @a = (x = 1, y = (s = "longer", n = (int64)2)); })",
-      Error{});
 }
 
 TEST_F(TypeResolverTest, map_value_castable_maps)
@@ -604,11 +653,15 @@ TEST_F(TypeResolverTest, map_value_castable_maps)
     auto result = test(R"(begin { @a = sum(1); @a = sum(-1); })");
     EXPECT_EQ(map_val_type(result, "@a"), CreateSum(true));
   }
+  {
+    auto result = test(
+        R"(begin { @a = sum((uint64)1); @a = sum((int64)-1); })");
+    EXPECT_EQ(map_val_type(result, "@a"), CreateSum(true));
+  }
 
   // Errors
   test(R"(begin { @a = sum(1); @a = avg(-1); })", Error{});
   test(R"(begin { @a = sum(1); @a = 1; })", Error{});
-  test(R"(begin { @a = sum((uint64)1); @a = sum((int64)-1); })", Error{});
 }
 
 TEST_F(TypeResolverTest, map_key_promotion_integers)
@@ -630,6 +683,14 @@ TEST_F(TypeResolverTest, map_key_promotion_integers)
     EXPECT_EQ(map_key_type(result, "@a"), CreateUInt64());
   }
   {
+    auto result = test(R"(begin { @a[(int64)1] = 1; @a[(uint64)2] = 1; })");
+    EXPECT_EQ(map_key_type(result, "@a"), CreateInt64());
+  }
+  {
+    auto result = test(R"(begin { @a[(uint64)1] = 1; @a[(int64)2] = 1; })");
+    EXPECT_EQ(map_key_type(result, "@a"), CreateInt64());
+  }
+  {
     auto result = test(R"(begin { @a[(int8)1] = 1; @a[(uint8)2] = 1; })");
     EXPECT_EQ(map_key_type(result, "@a"), CreateInt16());
   }
@@ -642,10 +703,6 @@ TEST_F(TypeResolverTest, map_key_promotion_integers)
         R"(begin { @a[(uint32)1] = 1; $b = (int32)2; @a[$b] = 1; })");
     EXPECT_EQ(map_key_type(result, "@a"), CreateInt64());
   }
-
-  // Errors
-  test(R"(begin { @a[(uint64)1] = 1; @a[(int64)2] = 1 })", Error{});
-  test(R"(begin { @a[-1] = 1; @a[(uint64)2] = 1 })", Error{});
 }
 
 TEST_F(TypeResolverTest, map_key_promotion_strings)
@@ -689,6 +746,13 @@ TEST_F(TypeResolverTest, map_key_promotion_tuples)
   }
   {
     auto result = test(
+        R"(begin { @a[((uint64)1, "str")] = 1; @a[(1, "longer")] = 1; @a[((int64)1, "a")] = 1; })");
+    EXPECT_EQ(map_key_type(result, "@a"),
+              CreateTuple(
+                  Struct::CreateTuple({ CreateInt64(), CreateString(7) })));
+  }
+  {
+    auto result = test(
         R"(begin { @a[((uint32)1, ("str", (int16)2))] = 1; @a[(1, ("longer", (uint16)2))] = 1; })");
     auto nested_tuple = CreateTuple(
         Struct::CreateTuple({ CreateString(7), CreateInt32() }));
@@ -721,14 +785,6 @@ TEST_F(TypeResolverTest, map_key_promotion_tuples)
               CreateTuple(
                   Struct::CreateTuple({ CreateString(7), CreateUInt16() })));
   }
-
-  // Errors
-  test(
-      R"(begin { @a[((uint64)1, "str")] = 1; @a[(1, "longer")] = 1; @a[((int64)1, "a")] = 1; })",
-      Error{});
-  test(
-      R"(begin { @a[(1, ("str", (uint64)2))] = 1; @a[(1, ("longer", (int64)2))] = 1; })",
-      Error{});
 }
 
 TEST_F(TypeResolverTest, map_key_promotion_records)
@@ -749,6 +805,13 @@ TEST_F(TypeResolverTest, map_key_promotion_records)
   {
     auto result = test(
         R"(begin { @a[(x = (uint32)1, y = "str")] = 1; @a[(y = "longer", x = (int32)1)] = 1; })");
+    EXPECT_EQ(map_key_type(result, "@a"),
+              CreateRecord(Struct::CreateRecord(
+                  { CreateInt64(), CreateString(7) }, { "x", "y" })));
+  }
+  {
+    auto result = test(
+        R"(begin { @a[(x = (uint64)1, y = "str")] = 1; @a[(y = "longer", x = (int64)1)] = 1; })");
     EXPECT_EQ(map_key_type(result, "@a"),
               CreateRecord(Struct::CreateRecord(
                   { CreateInt64(), CreateString(7) }, { "x", "y" })));
@@ -811,14 +874,6 @@ TEST_F(TypeResolverTest, map_key_promotion_records)
               CreateRecord(Struct::CreateRecord(
                   { CreateString(7), CreateUInt16() }, { "s", "n" })));
   }
-
-  // Errors
-  test(
-      R"(begin { @a[(x = (uint64)1, y = "str")] = 1; @a[(x = 1, y = "longer")] = 1; @a[(x = (int64)1, y = "a")] = 1; })",
-      Error{});
-  test(
-      R"(begin { @a[(x = 1, y = (s = "str", n = (uint64)2))] = 1; @a[(x = 1, y = (s = "longer", n = (int64)2))] = 1; })",
-      Error{});
 }
 
 TEST_F(TypeResolverTest, variable_no_type)
@@ -969,8 +1024,17 @@ TEST_F(TypeResolverTest, locked_types)
       R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a[(uint32)2] = 2; } @a[(uint32)1] = 1; })");
   test(
       R"(begin { let $c; if comptime (typeinfo($c).full_type == "uint32") { $c = (uint16)2; } $c = (uint32)1; })");
+  // This signed mismatch is ok because the variable's type doesn't change
+  test(
+      R"(begin { let $c; if comptime (typeinfo($c).full_type == "int64") { $c = (uint64)2; } $c = (int64)1; })");
   test(
       R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a = 1; } @a = (uint32)2; })");
+  test(
+      R"(begin { if comptime (typeinfo(@a).base_type == "string") { @a = "a"; } @a = "muchlongerstr"; })");
+  test(
+      R"(begin { if comptime (typeinfo(@a).base_type == "tuple") { @a = ((uint8)2, "b"); } @a = ((int64)1, "a"); })");
+  test(
+      R"(begin { if comptime (typeinfo(@a).base_type == "record") { @a = (a=(uint8)2, b="b"); } @a = (a=(int64)1, b="a"); })");
 
   // Errors
   test(
@@ -979,6 +1043,10 @@ TEST_F(TypeResolverTest, locked_types)
 
   test(
       R"(begin { if comptime (typeinfo(@a).full_type == "uint32") { @a = (uint64)2; } @a = (uint32)1; })",
+      Error{});
+
+  test(
+      R"(begin { if comptime (typeinfo(@a).full_type == "uint64") { @a = (int64)2; } @a = (uint64)1; })",
       Error{});
 
   test(
@@ -999,6 +1067,13 @@ begin { if comptime (typeinfo(@a).full_type == "uint32") { $a = 1; if comptime (
   // Sign-flexible literal too large for locked type
   test(
       R"(begin { if comptime (typeinfo(@a).full_type == "uint8") { @a = 200; } @a = (uint8)2; })",
+      Error{});
+
+  test(
+      R"(begin { if comptime (typeinfo(@a).base_type == "tuple") { @a = ((int64)2, "b"); } @a = ((uint64)1, "a"); })",
+      Error{});
+  test(
+      R"(begin { if comptime (typeinfo(@a).base_type == "record") { @a = (a=(int64)2, b="b"); } @a = (a=(uint64)1, b="a"); })",
       Error{});
 }
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#5152
 * #5148


--- --- ---

### No error on int mismatch for C func calls


This follows the same behavior for how integer mismatches are handled for
bpftrace scratch variables and map values/keys.

Follow up from:
https://github.com/bpftrace/bpftrace/pull/5148

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>