### PR TITLE
Structures support using __attribute__ after the closing curly brace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 - Subtraction and decrement ops now produce an int64 instead of a uint64.
   - [#5138](https://github.com/bpftrace/bpftrace/pull/5138)
 #### Added
+- User defined C structs support using `__attribute__`s after the closing curly brace.
+  - [#5153](https://github.com/bpftrace/bpftrace/pull/5153)
 - stdlib: add `leader_{tid,comm}` to retrieve the thread group leader.
   - [#5132](https://github.com/bpftrace/bpftrace/pull/5132)
 - stdlib: add signal_name().

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -313,6 +313,23 @@ CStatement *Parser::parse_c_definition()
   while (!def.empty() && std::isspace(def.back())) {
     def.pop_back();
   }
+  // Consume attribute, like __attribute__((packed, aligned(1))),
+  // supports specifying __attribute__ multiple times.
+  size_t attr_pos = pos_;
+  while (match("__attribute__")) {
+    consume_layout();
+    // match __attribute__'s '(('
+    if (peek() == '(' && peek(1) == '(') {
+      size_t after = scan_balanced(pos_, '(', ')');
+      if (after == pos_ || char_at(after - 1) != ')') {
+        error("__attribute__ syntax error, mismatched '(' and ')'");
+      }
+      def += view(attr_pos, after);
+      attr_pos = pos_ = after;
+    } else {
+      error("__attribute__ syntax error, expected '(('");
+    }
+  }
   // Ensure trailing semicolon.
   if (!def.empty() && def.back() != ';') {
     def += ";";
@@ -3373,7 +3390,7 @@ bool Parser::looks_like_c_definition() const
   // Skip keyword (struct/union/enum), then accept an arbitrary sequence of
   // identifiers and balanced (...) / [...] groups before the opening brace.
   // This covers declarations like:
-  //   struct Foo __attribute__((packed)) {
+  //   struct __attribute__((packed)) Foo {
   // while still rejecting attach points such as:
   //   struct:probe { ... }
   p = scan_identifier_end(p);

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -884,4 +884,59 @@ TEST(clang_parser, redefined_types)
   parse("struct a {int a;}; struct a {int a; short b;};", bpftrace, false);
 }
 
+TEST(clang_parser, attribute)
+{
+  BPFtrace bpftrace;
+  parse("struct Foo { "
+        "  int x; char y; int z; "
+        "} __attribute__((packed, aligned(1))) "
+        "struct Bar { "
+        " int x; char y; int z; "
+        "} __attribute__((packed)) __attribute__((aligned(1)))",
+        bpftrace);
+
+  ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
+  ASSERT_TRUE(bpftrace.structs.Has("struct Bar"));
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
+  auto bar = bpftrace.structs.Lookup("struct Bar").lock();
+
+  // Foo
+  EXPECT_EQ(foo->size, 9);
+  ASSERT_EQ(foo->fields.size(), 3U);
+  ASSERT_EQ(foo->HasField("x"), true);
+  ASSERT_EQ(foo->HasField("y"), true);
+  ASSERT_EQ(foo->HasField("z"), true);
+
+  EXPECT_TRUE(foo->GetField("x").type.IsIntTy());
+  EXPECT_EQ(foo->GetField("x").type.GetSize(), 4U);
+  EXPECT_EQ(foo->GetField("x").offset, 0);
+
+  EXPECT_TRUE(foo->GetField("y").type.IsIntTy());
+  EXPECT_EQ(foo->GetField("y").type.GetSize(), 1U);
+  EXPECT_EQ(foo->GetField("y").offset, 4);
+
+  EXPECT_TRUE(foo->GetField("z").type.IsIntTy());
+  EXPECT_EQ(foo->GetField("z").type.GetSize(), 4U);
+  EXPECT_EQ(foo->GetField("z").offset, 5);
+
+  // Bar
+  EXPECT_EQ(bar->size, 9);
+  ASSERT_EQ(bar->fields.size(), 3U);
+  ASSERT_EQ(bar->HasField("x"), true);
+  ASSERT_EQ(bar->HasField("y"), true);
+  ASSERT_EQ(bar->HasField("z"), true);
+
+  EXPECT_TRUE(bar->GetField("x").type.IsIntTy());
+  EXPECT_EQ(bar->GetField("x").type.GetSize(), 4U);
+  EXPECT_EQ(bar->GetField("x").offset, 0);
+
+  EXPECT_TRUE(bar->GetField("y").type.IsIntTy());
+  EXPECT_EQ(bar->GetField("y").type.GetSize(), 1U);
+  EXPECT_EQ(bar->GetField("y").offset, 4);
+
+  EXPECT_TRUE(bar->GetField("z").type.IsIntTy());
+  EXPECT_EQ(bar->GetField("z").type.GetSize(), 4U);
+  EXPECT_EQ(bar->GetField("z").offset, 5);
+}
+
 } // namespace bpftrace::test::clang_parser

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -3776,4 +3776,42 @@ TEST(Parser, discard)
   test("kprobe:f { _ = 1; }",
        Program().WithProbe(Probe({ "kprobe:f" }, { DiscardExpr(Integer(1)) })));
 }
+
+TEST(Parser, struct_attribute)
+{
+  test("struct Foo { } __attribute__ ((packed))",
+       Program().WithCStatements(
+           { CStatement("struct Foo { } __attribute__ ((packed));") }));
+  test("struct Foo { } __attribute__ ((packed, aligend(1)))",
+       Program().WithCStatements({ CStatement(
+           "struct Foo { } __attribute__ ((packed, aligend(1)));") }));
+  test("struct Foo { } __attribute__ ((packed)) __attribute__ ((aligend(1)))",
+       Program().WithCStatements(
+           { CStatement("struct Foo { } __attribute__ ((packed)) "
+                        "__attribute__ ((aligend(1)));") }));
+  test_parse_failure("struct foo {} __attribute__ begin {}",
+                     R"(
+stdin:1:29-34: ERROR: syntax: __attribute__ syntax error, expected '(('
+struct foo {} __attribute__ begin {}
+                            ~~~~~
+)");
+  test_parse_failure("struct foo {} __attribute__ (packed) begin {}",
+                     R"(
+stdin:1:29-30: ERROR: syntax: __attribute__ syntax error, expected '(('
+struct foo {} __attribute__ (packed) begin {}
+                            ~
+)");
+  test_parse_failure("struct foo {} __attribute__ ( (packed)) begin {}",
+                     R"(
+stdin:1:29-30: ERROR: syntax: __attribute__ syntax error, expected '(('
+struct foo {} __attribute__ ( (packed)) begin {}
+                            ~
+)");
+  test_parse_failure("struct foo {} __attribute__ ((packed) begin {}",
+                     R"(
+stdin:1:29-30: ERROR: syntax: __attribute__ syntax error, mismatched '(' and ')'
+struct foo {} __attribute__ ((packed) begin {}
+                            ~
+)");
+}
 } // namespace bpftrace::test::parser

--- a/tests/runtime/struct
+++ b/tests/runtime/struct
@@ -50,3 +50,12 @@ NAME struct with bitfield
 PROG struct foo { unsigned long long x_0:1; unsigned long long x_1:1; unsigned long long x_2:2; } begin { $val = (uint64)0x1e; $f = *(struct foo *)(&$val); print($f); }
 EXPECT { .x_0 = 0, .x_1 = 1, .x_2 = 3 }
 
+NAME struct with attribute
+PROG struct foo { int x; char y; int z; } struct bar { int x; char y; int z; } __attribute__((packed)) struct bar2 { int x; char y; int z; } __attribute__((packed)) __attribute__((aligned(1))) begin { print(sizeof(struct foo)); print(sizeof(struct bar)); print(sizeof(struct bar2)); }
+EXPECT 12
+EXPECT 9
+EXPECT 9
+
+NAME struct with attribute and comment
+PROG struct foo { int x; char y; int z; } /**/ __attribute__ /**/ ((packed)) /**/ begin { print(sizeof(struct foo)); }
+EXPECT 9


### PR DESCRIPTION
This is a breaking modification, struct/union/enum definitions MUST end with a semicolon. The `__attribute__` at the end of the structure is discarded because the structure is determined by the '}' symbol, like:

    struct s { int a; char b, int c; } __attribute__((packed))

or

    #define PACKED __attribute__((packed))
    struct s { int a; char b, int c; } PACKED

To solve this problem, the content after the `}` must be parsed. However, if the semicolon `;` can be ignored, the end of the structure cannot be obtained. Therefore, like in C, the structure must end with a semicolon `;`.

- todo: I only modified some of the unit tests rightnow; let's decide whether to proceed this way first ;)