### PR TITLE
dwarf: restore default debuginfo paths

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -80,15 +80,15 @@ For example, you could add the predicate `/pid == cpid/` to probes with userspac
 Enable debug mode.
 For more details see the <<Debug Output>> section.
 
-=== *--debuginfo* _DIR_
+=== *--debuginfo* _DIR[:DIR]_
 
 Add the directory DIR to the search path for DWARF debug information.
 Paths may be absolute or relative to the traced binary's location.
-Multiple paths can be specified by separating them with a colon (`:`), for example `--debuginfo=/bin/debug:./debug:..`.
-Files found in these paths are validated using the build ID.
-Alternatively, CRC32 checksum validation can be enabled by prefixing a path with `+`.
+Specify multiple paths either by separating them with a colon (`:`) or by repeating the option,
+e.g. `--debuginfo=/bin/debug:./lib/debug:..` and `--debuginfo=/bin/debug --debuginfo=./lib/debug`, respectively.
+Debug files in these paths are matched by build ID when available; prefix a path with `+` to enable CRC32 validation when needed.
 Files that do not match are skipped.
-By default, bpftrace searches standard debug paths or attempts to query available debuginfod servers.
+By default, bpftrace searches under standard debug paths, including `.debug` relative to the traced binary and `/usr/lib/debug`; it may also query available debuginfod servers.
 
 Split debuginfo format (`.dwo`, `.dwp`) is not yet supported for this option, but continues to work with the default probe binary path.
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,6 +110,8 @@ enum Options {
 
 constexpr auto FULL_SEARCH = "*:*";
 
+constexpr auto DEFAULT_DEBUG_INFO_PATHS = ":.debug:/usr/lib/debug";
+
 } // namespace
 
 void usage(std::ostream& out)
@@ -154,8 +156,8 @@ void usage(std::ostream& out)
   out << "                   only run probes whose name matches REGEX" << std::endl;
   out << "    --traceable-functions FILE" << std::endl;
   out << "                   load the list of traceable kernel functions from FILE" << std::endl;
-  out << "    --debuginfo DIR" << std::endl;
-  out << "                   add one or more directory to the debug info search path" << std::endl;
+  out << "    --debuginfo DIR[:DIR]" << std::endl;
+  out << "                   add directories to the debug info search path" << std::endl;
   out << std::endl;
   out << "TROUBLESHOOTING OPTIONS:" << std::endl;
   out << "    -v, --verbose           verbose messages" << std::endl;
@@ -687,7 +689,8 @@ Args parse_args(int argc, char* argv[])
       case Options::BTF:
         break;
       case Options::DEBUGINFO:
-        args.debuginfo_path = optarg;
+        args.debuginfo_path += optarg;
+        args.debuginfo_path += ":";
         break;
       case 'h':
       case Options::HELP:
@@ -917,7 +920,7 @@ int main(int argc, char* argv[])
   bpftrace.run_tests_ = args.mode == Mode::BPF_TEST;
   bpftrace.run_benchmarks_ = args.mode == Mode::BPF_BENCHMARK;
   bpftrace.probe_filter_ = args.probe_filter;
-  bpftrace.debuginfo_path_ = args.debuginfo_path;
+  bpftrace.debuginfo_path_ = args.debuginfo_path + DEFAULT_DEBUG_INFO_PATHS;
 
   if (!args.pid_str.empty()) {
     auto pid = parse_pid(args.pid_str);

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -106,61 +106,74 @@ TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME parse stripped debuginfo - list args
-RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test-stripped:main' --debuginfo=./debug
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test-stripped:main' --debuginfo=./external_debug
 EXPECT int argc
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME parse stripped debuginfo - arg by name
-RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_test-stripped:uprobeFunction1 { printf("%c\n", args.c); exit(); }' --debuginfo=./debug
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_test-stripped:uprobeFunction1 { printf("%c\n", args.c); exit(); }' --debuginfo=./external_debug
 EXPECT x
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test-stripped
 
 NAME parse stripped debuginfo - attach by source line
-RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_test-stripped@uprobe_test.c:22 { print("ok"); exit(); }' --debuginfo=./debug
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_test-stripped@uprobe_test.c:22 { print("ok"); exit(); }' --debuginfo=./external_debug
 EXPECT ok
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test-stripped
 
+NAME parse stripped debuginfo - search multiple paths
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test-stripped:main' --debuginfo=./external_debug/dwo --debuginfo=./external_debug/dwp --debuginfo=./external_debug
+EXPECT int argc
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+
+NAME parse stripped debuginfo - search standard .debug path
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_separate_debug-stripped:fn'
+EXPECT int n
+EXPECT const char* str
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+
 NAME parse DWO debuginfo - list args
-RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/debug/dwo/uprobe_test-split:main'
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/external_debug/dwo/uprobe_test-split:main'
 EXPECT int argc
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME parse DWO debuginfo - arg by name
-RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwo/uprobe_test-split:uprobeFunction1 { printf("%c\n", args.c); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/external_debug/dwo/uprobe_test-split:uprobeFunction1 { printf("%c\n", args.c); exit(); }'
 EXPECT x
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
-BEFORE ./testprogs/debug/dwo/uprobe_test-split
+BEFORE ./testprogs/external_debug/dwo/uprobe_test-split
 
 NAME parse DWO debuginfo - attach by source line
-RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwo/uprobe_test-split@uprobe_test.c:22 { printf("ok"); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/external_debug/dwo/uprobe_test-split@uprobe_test.c:22 { printf("ok"); exit(); }'
 EXPECT ok
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
-BEFORE ./testprogs/debug/dwo/uprobe_test-split
+BEFORE ./testprogs/external_debug/dwo/uprobe_test-split
 
 NAME parse DWP debuginfo - list args
-RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/debug/dwp/uprobe_test-split:main'
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/external_debug/dwp/uprobe_test-split:main'
 EXPECT int argc
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME parse DWP debuginfo - arg by name
-RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwp/uprobe_test-split:uprobeFunction1 { printf("%c\n", args.c); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/external_debug/dwp/uprobe_test-split:uprobeFunction1 { printf("%c\n", args.c); exit(); }'
 EXPECT x
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
-BEFORE ./testprogs/debug/dwp/uprobe_test-split
+BEFORE ./testprogs/external_debug/dwp/uprobe_test-split
 
 NAME parse DWP debuginfo - attach by source line
-RUN {{BPFTRACE}} -e 'uprobe:./testprogs/debug/dwp/uprobe_test-split@uprobe_test.c:22 { printf("ok"); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/external_debug/dwp/uprobe_test-split@uprobe_test.c:22 { printf("ok"); exit(); }'
 EXPECT ok
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
-BEFORE ./testprogs/debug/dwp/uprobe_test-split
+BEFORE ./testprogs/external_debug/dwp/uprobe_test-split

--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -102,52 +102,71 @@ add_custom_command(
 )
 list(APPEND testprogtargets archive.zip)
 
-# Make debug subdirs to test parsing of external DWARF debug formats. 
+# Make debug subdirs to test parsing of external DWARF debug formats.
+set(EXTERNAL_DEBUG_DIR ${CMAKE_CURRENT_BINARY_DIR}/external_debug)
 file(MAKE_DIRECTORY
-  ${CMAKE_CURRENT_BINARY_DIR}/debug
-  ${CMAKE_CURRENT_BINARY_DIR}/debug/dwo
-  ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp
+  ${EXTERNAL_DEBUG_DIR}
+  ${EXTERNAL_DEBUG_DIR}/dwo
+  ${EXTERNAL_DEBUG_DIR}/dwp
+  ${CMAKE_CURRENT_BINARY_DIR}/.debug
 )
 
 # Create a stripped binary with a separate .debug file, placed in a subdir; used to verify
-# loading and parsing of external debuginfo.
+# searching and parsing of external debuginfo via --debuginfo option.
 add_custom_command(
   OUTPUT 
     ${CMAKE_CURRENT_BINARY_DIR}/uprobe_test-stripped
-    ${CMAKE_CURRENT_BINARY_DIR}/debug/uprobe_test-stripped.debug
-  COMMAND ${LLVM_OBJCOPY} --only-keep-debug $<TARGET_FILE:uprobe_test> ${CMAKE_CURRENT_BINARY_DIR}/debug/uprobe_test-stripped.debug
+    ${EXTERNAL_DEBUG_DIR}/uprobe_test-stripped.debug
+  COMMAND ${LLVM_OBJCOPY} --only-keep-debug $<TARGET_FILE:uprobe_test> ${EXTERNAL_DEBUG_DIR}/uprobe_test-stripped.debug
   COMMAND ${LLVM_OBJCOPY} --strip-debug $<TARGET_FILE:uprobe_test> ${CMAKE_CURRENT_BINARY_DIR}/uprobe_test-stripped
   DEPENDS uprobe_test
 )
 list(APPEND testprogtargets
   ${CMAKE_CURRENT_BINARY_DIR}/uprobe_test-stripped
-  ${CMAKE_CURRENT_BINARY_DIR}/debug/uprobe_test-stripped.debug)
+  ${EXTERNAL_DEBUG_DIR}/uprobe_test-stripped.debug)
+
+# Second stripped binary (distinct build-id), with its .debug placed in the standard ./.debug/ subdir;
+# used to verify default build-id-based lookup.
+add_custom_command(
+  OUTPUT 
+    ${CMAKE_CURRENT_BINARY_DIR}/uprobe_separate_debug-stripped
+    ${CMAKE_CURRENT_BINARY_DIR}/.debug/uprobe_separate_debug-stripped.debug
+  COMMAND ${LLVM_OBJCOPY} --only-keep-debug $<TARGET_FILE:uprobe_separate_debug> ${CMAKE_CURRENT_BINARY_DIR}/.debug/uprobe_separate_debug-stripped.debug
+  COMMAND ${LLVM_OBJCOPY} --strip-debug $<TARGET_FILE:uprobe_separate_debug> ${CMAKE_CURRENT_BINARY_DIR}/uprobe_separate_debug-stripped
+  COMMAND ${LLVM_OBJCOPY}
+    --add-gnu-debuglink=${CMAKE_CURRENT_BINARY_DIR}/.debug/uprobe_separate_debug-stripped.debug
+    ${CMAKE_CURRENT_BINARY_DIR}/uprobe_separate_debug-stripped
+  DEPENDS uprobe_separate_debug
+)
+list(APPEND testprogtargets
+  ${CMAKE_CURRENT_BINARY_DIR}/uprobe_separate_debug-stripped
+  ${CMAKE_CURRENT_BINARY_DIR}/.debug/uprobe_separate_debug-stripped.debug)
 
 # Build a binary with split DWARF (.dwo files) to verify parsing of the split debug info format.
 add_custom_command(
   OUTPUT
-    ${CMAKE_CURRENT_BINARY_DIR}/debug/dwo/uprobe_test-split
-    ${CMAKE_CURRENT_BINARY_DIR}/debug/dwo/uprobe_test-split-uprobe_test.dwo
-  COMMAND ${CMAKE_C_COMPILER} -g -O0 -gsplit-dwarf ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c -o ${CMAKE_CURRENT_BINARY_DIR}/debug/dwo/uprobe_test-split
+    ${EXTERNAL_DEBUG_DIR}/dwo/uprobe_test-split
+    ${EXTERNAL_DEBUG_DIR}/dwo/uprobe_test-split-uprobe_test.dwo
+  COMMAND ${CMAKE_C_COMPILER} -g -O0 -gsplit-dwarf ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c -o ${EXTERNAL_DEBUG_DIR}/dwo/uprobe_test-split
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c
 )
-list(APPEND testprogtargets ${CMAKE_CURRENT_BINARY_DIR}/debug/dwo/uprobe_test-split)
+list(APPEND testprogtargets ${EXTERNAL_DEBUG_DIR}/dwo/uprobe_test-split)
 
 # Build a binary with split debuginfo and bundle the .dwo files into a DWARF Package (.dwp)
 # archive; to verify parsing of the packaged format.
 find_program(LLVM_DWP llvm-dwp REQUIRED)
 add_custom_command(
   OUTPUT
-    ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split
-    ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split.dwp
-  COMMAND ${CMAKE_C_COMPILER} -g -O0 -gsplit-dwarf ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c -o ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split
-  COMMAND ${LLVM_DWP} -e ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split -o ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split.dwp
-  COMMAND ${CMAKE_COMMAND} -E rm -f ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/*.dwo
+    ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split
+    ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split.dwp
+  COMMAND ${CMAKE_C_COMPILER} -g -O0 -gsplit-dwarf ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c -o ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split
+  COMMAND ${LLVM_DWP} -e ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split -o ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split.dwp
+  COMMAND ${CMAKE_COMMAND} -E rm -f ${EXTERNAL_DEBUG_DIR}/dwp/*.dwo
   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c
 )
 list(APPEND testprogtargets
-  ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split
-  ${CMAKE_CURRENT_BINARY_DIR}/debug/dwp/uprobe_test-split.dwp)
+  ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split
+  ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split.dwp)
 
 add_custom_target(testprogs ALL DEPENDS ${testprogtargets})
 

--- a/tests/testprogs/uprobe_separate_debug.c
+++ b/tests/testprogs/uprobe_separate_debug.c
@@ -1,0 +1,7 @@
+int __attribute__((noinline)) fn(int n, const char *str __attribute__((unused))) {
+    return n * n;
+}
+
+int main(void) {
+    return fn(123, "Hello world!");
+}


### PR DESCRIPTION
This restores the standard debug info search paths when resolving DWARF. Passing a path string caused libdwfl to skip the default paths, which regressed the debuginfo lookup.

Additionally, `--debuginfo` is now additive by allowing the option to be specified multiple times. For example, `--debuginfo=/bin/debug:./lib/debug` can also be specified as `--debuginfo=/bin/debug --debuginfo=./lib/debug`.

The repeated options are joined into the colon-separated format expected by the library, while preserving the default paths.

Fixes #5154

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
