### PR TITLE
TypeResolver: fix for-loop variable scope causing type merging across loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to
   - [#2801](https://github.com/bpftrace/bpftrace/issues/2801)
 - Fix subtraction and decrement ops not producing the correct type
   - [#5138](https://github.com/bpftrace/bpftrace/pull/5138)
+- Fix for-loop variable scope causing type merging across loops
+  - [#5157](https://github.com/bpftrace/bpftrace/pull/5157)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -1611,6 +1611,8 @@ void TypeRuleCollector::visit(For &f)
     return false;
   });
 
+  scope_stack_.push_back(&f);
+
   visit(f.decl);
 
   ScopedVariable scoped_var = std::make_pair(scope_stack_.back(), decl_name);
@@ -1644,8 +1646,6 @@ void TypeRuleCollector::visit(For &f)
         },
     });
   }
-
-  scope_stack_.push_back(&f);
 
   visit(f.block);
 

--- a/tests/type_resolver.cpp
+++ b/tests/type_resolver.cpp
@@ -1286,4 +1286,62 @@ TEST_F(TypeResolverTest, macro_not_expanded_in_type_context)
   }
 }
 
+TEST_F(TypeResolverTest, for_loop_variable_scope)
+{
+  {
+    auto result = test(
+        R"(begin { @mapA[0] = (uint8)1; @mapB[0] = (uint16)1;
+           for ($kv : @mapA) { print($kv); }
+           for ($kv : @mapB) { print($kv); } })");
+
+    EXPECT_EQ(map_val_type(result, "@mapA"), CreateUInt8());
+    EXPECT_EQ(map_val_type(result, "@mapB"), CreateUInt16());
+
+    ast::CollectNodes<ast::Variable> collector;
+    collector.visit(*result.ast.root,
+                    [&](const ast::Variable &v) { return v.ident == "$kv"; });
+    ASSERT_EQ(collector.nodes().size(), 4);
+
+    auto kv_a_type = result.type_map.type(&collector.nodes().front().get());
+    auto kv_b_type = result.type_map.type(&collector.nodes().at(2).get());
+
+    EXPECT_EQ(kv_a_type,
+              CreateTuple(
+                  Struct::CreateTuple({ map_key_type(result, "@mapA"),
+                                        map_val_type(result, "@mapA") })));
+    EXPECT_EQ(kv_b_type,
+              CreateTuple(
+                  Struct::CreateTuple({ map_key_type(result, "@mapB"),
+                                        map_val_type(result, "@mapB") })));
+  }
+  {
+    // Reverse order: the for-loop for @mapB comes first. Each $kv
+    // should still bind to its own loop's scope.
+    auto result = test(
+        R"(begin { @mapA[0] = (uint8)1; @mapB[0] = (uint16)1;
+           for ($kv : @mapB) { print($kv); }
+           for ($kv : @mapA) { print($kv); } })");
+
+    EXPECT_EQ(map_val_type(result, "@mapA"), CreateUInt8());
+    EXPECT_EQ(map_val_type(result, "@mapB"), CreateUInt16());
+
+    ast::CollectNodes<ast::Variable> collector;
+    collector.visit(*result.ast.root,
+                    [&](const ast::Variable &v) { return v.ident == "$kv"; });
+    ASSERT_EQ(collector.nodes().size(), 4);
+
+    auto kv_b_type = result.type_map.type(&collector.nodes().front().get());
+    auto kv_a_type = result.type_map.type(&collector.nodes().at(2).get());
+
+    EXPECT_EQ(kv_b_type,
+              CreateTuple(
+                  Struct::CreateTuple({ map_key_type(result, "@mapB"),
+                                        map_val_type(result, "@mapB") })));
+    EXPECT_EQ(kv_a_type,
+              CreateTuple(
+                  Struct::CreateTuple({ map_key_type(result, "@mapA"),
+                                        map_val_type(result, "@mapA") })));
+  }
+}
+
 } // namespace bpftrace::test::type_resolver


### PR DESCRIPTION
… loops

When multiple for-loops with the same variable name appear in the same probe, the type resolver incorrectly merged their types because the for-loop scope (push_stack) happened after the ScopedVariable was created using the parent scope.

Move scope_stack_.push_back(&f) before visit(f.decl) so that each for-loop variable binds to its own scope, preventing type merging.

Example of the bug:
  for ($kv : @mapA) { print($kv); }
  for ($kv : @mapB) { print($kv); }

Where @mapA value_size=1 and @mapB value_size=2, both $kv variables would be merged to the wider type (int16), causing the callback for @mapA to emit a u16 load exceeding the map's 1-byte value—rejected by the BPF verifier.

Fixes: https://github.com/bpftrace/bpftrace/issues/5142

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
