### PR TITLE
Fix for-loop variable scoping

### DIFF
--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -1593,9 +1593,12 @@ void TypeRuleCollector::visit(For &f)
     return false;
   });
 
-  visit(f.decl);
-
-  ScopedVariable scoped_var = std::make_pair(scope_stack_.back(), decl_name);
+  ScopedVariable scoped_var = std::make_pair(&f, decl_name);
+  variables_[&f].insert({ decl_name, CreateNone() });
+  resolver_.add_pass_through(scoped_var, f.decl);
+  if (introspection_level_ > 0) {
+    introspected_nodes_.insert(scoped_var);
+  }
 
   if (auto *map = f.iterable.as<Map>()) {
     visit(map);

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -26,14 +26,12 @@ PROG begin { @map[16] = 32; @map[64] = 128; for ($kv : @map) { @new[$kv.1] = $kv
 EXPECT @new[32]: 16
 EXPECT @new[128]: 64
 
-# TODO: make these maps different types.
-# https://github.com/bpftrace/bpftrace/issues/5142
 NAME map multiple loops
-PROG begin { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 40; @mapB[65] = 41; for ($kv : @mapA) { print($kv); } for ($kv : @mapB) { print($kv); }  }
+PROG begin { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = "aa"; @mapB[65] = "bb"; for ($kv : @mapA) { print($kv); } for ($kv : @mapB) { print($kv); }  }
 EXPECT (16, 32)
 EXPECT (17, 33)
-EXPECT (64, 40)
-EXPECT (65, 41)
+EXPECT (64, aa)
+EXPECT (65, bb)
 
 NAME map multiple probes
 PROG begin { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); }  } end { for ($kv : @mapB) { print($kv); } }

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -4478,6 +4478,35 @@ TEST_F(TypeCheckerTest, for_loop_map)
   test("begin {@map1[@map2] = 1; @map2 = 1; for ($kv : @map1) {print($kv);}}");
 }
 
+TEST_F(TypeCheckerTest, for_loop_map_reused_variable_name)
+{
+  auto result = test(R"(
+    begin {
+      @mapA[16] = 32;
+      @mapB[64] = "value";
+      for ($kv : @mapA) {
+        print($kv.1);
+      }
+      for ($kv : @mapB) {
+        print($kv.1);
+      }
+    })");
+
+  auto *first_loop =
+      result.ast.root->probes.at(0)->block->stmts.at(2).as<ast::For>();
+  auto *second_loop =
+      result.ast.root->probes.at(0)->block->stmts.at(3).as<ast::For>();
+  ASSERT_NE(first_loop, nullptr);
+  ASSERT_NE(second_loop, nullptr);
+
+  const auto &first_decl_type = result.type_map.type(first_loop->decl);
+  const auto &second_decl_type = result.type_map.type(second_loop->decl);
+  ASSERT_TRUE(first_decl_type.IsTupleTy());
+  ASSERT_TRUE(second_decl_type.IsTupleTy());
+  EXPECT_TRUE(first_decl_type.GetField(1).type.IsIntTy());
+  EXPECT_TRUE(second_decl_type.GetField(1).type.IsStringTy());
+}
+
 TEST_F(TypeCheckerTest, for_loop_map_declared_after)
 {
   // Regression test: What happens with


### PR DESCRIPTION
## Summary

Fix loop variable type resolution for sibling `for` loops that reuse the same variable name.

The type resolver was keying the loop declaration by the surrounding scope before entering the loop scope, while pre-type-check and codegen treat the loop declaration as scoped to the `For` node. That allowed two loops such as `for ($kv : @mapA)` and `for ($kv : @mapB)` to share the same scoped type variable and leak the first map element type into the second loop.

This keys the loop declaration type by the `For` node scope and keeps iterable/range expressions resolved outside that scope.

Closes #5142.

## Testing

- Added a type checker regression for two sibling map loops reusing `$kv` with different value types.
- Updated the runtime `map multiple loops` case to use maps with different value types.
- `git diff --check`

Not run locally:

- `./build/tests/bpftrace_test --gtest_filter=TypeCheckerTest.for_loop_map_reused_variable_name` because this environment does not have a completed bpftrace build available.
