### PR TITLE
probe_matcher: Fix fentry listing without module

### DIFF
--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -626,15 +626,27 @@ std::vector<std::string> ProbeMatcher::get_probes_for_listing(
         break;
       }
       case ProbeType::kprobe:
-      case ProbeType::kretprobe:
-      case ProbeType::fentry:
-      case ProbeType::fexit:
-      case ProbeType::rawtracepoint: {
+      case ProbeType::kretprobe: {
         // These can be target:func or just func.
         if (parts.size() > 2) {
           target = parts[1];
         }
         search_input = search_suffix;
+        break;
+      }
+      case ProbeType::fentry:
+      case ProbeType::fexit:
+      case ProbeType::rawtracepoint: {
+        // These can be target:func or just func. For the latter, we have to
+        // explicitly add the "*:" prefix to search_input since symbols
+        // extracted from BTF have the "module:func" form.
+        if (parts.size() > 2) {
+          target = parts[1];
+          search_input = search_suffix;
+        } else {
+          target = "*";
+          search_input = "*:" + search_suffix;
+        }
         break;
       }
       default:

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -69,6 +69,12 @@ EXPECT_REGEX fentry:.*
 REQUIRES_FEATURE btf
 TIMEOUT 1
 
+NAME it lists fentry without module
+RUN {{BPFTRACE}} -l 'fentry:vfs_*'
+EXPECT_REGEX fentry:vmlinux:vfs_.*
+REQUIRES_FEATURE btf
+TIMEOUT 1
+
 NAME regression for #4162
 RUN {{BPFTRACE}} -l 'fentry:*'
 EXPECT_REGEX fentry:.*


### PR DESCRIPTION
Commit ff45058e ("passes: remove `listing` mode from passes, use `ProbeMatcher` directly") introduced a regression by removing setting of the default wildcard target ("*") from AttachPointParser.

This broke listing fentry probes when no explicit module was given, as the ProbeMatcher would not prepend the required "*:" to the search:

    # bpftrace -l 'fentry:vfs_*' | wc -l
    0

Fix the issue in ProbeMatcher::get_probes_for_listing() by prepending "*:" to the search input and setting target to "*" before passing them to ProbeMatcher::get_matches_for_probetype().

Fixes: ff45058e ("passes: remove `listing` mode from passes, use `ProbeMatcher` directly")

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
