### PR TITLE
CMake: Fix circular static library dependencies

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,7 +102,7 @@ target_link_options(bpftrace BEFORE PRIVATE
 
 target_link_libraries(runtime debugfs output symbols tracefs util)
 target_link_libraries(runtime ${LIBBPF_LIBRARIES} ${ZLIB_LIBRARIES})
-target_link_libraries(libbpftrace runtime symbols aot ast arch util cxxdemangler_llvm)
+target_link_libraries(libbpftrace "-Wl,--start-group" runtime symbols aot ast arch util cxxdemangler_llvm "-Wl,--end-group")
 
 if(LIBPCAP_FOUND)
   target_link_libraries(libbpftrace ${LIBPCAP_LIBRARIES})


### PR DESCRIPTION
Stacked PRs:
 * #5167
 * __->__#5166


--- --- ---

### CMake: Fix circular static library dependencies


Some internal static libraries may have subtle circular dependencies.
In particular:
- attachpoint_passes.cpp uses Dwarf from dwarf_parser.cpp
- attachpoint_passes.cpp is in the `ast` target which is normally linked
  *after* the `runtime` target

This may lead to the following linker error:

    /usr/bin/ld.bfd: ast/libast.a(attachpoint_passes.cpp.o): [...]
    [...] undefined reference to `bpftrace::DwarfParseError::ID'

Fix the issue by wrapping the linked libraries with `--start-group` and
`--end-group`, which allows the linker to resolve the dependencies
properly.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>