### PR TITLE
Docker: Add OpenSUSE Dockerfile

### DIFF
--- a/.github/workflows/distros.yml
+++ b/.github/workflows/distros.yml
@@ -20,6 +20,7 @@ jobs:
         - docker/Dockerfile.alpine
         - docker/Dockerfile.debian
         - docker/Dockerfile.fedora
+        - docker/Dockerfile.opensuse
         - docker/Dockerfile.ubuntu
 
     steps:

--- a/docker/Dockerfile.opensuse
+++ b/docker/Dockerfile.opensuse
@@ -1,0 +1,41 @@
+# This Dockerfile is used to both document and test building bpftrace on the
+# latest version of OpenSUSE Tumbleweed. We attempt to catch bugs as early as
+# possible which is why we are using latest.
+
+FROM opensuse/tumbleweed:latest
+
+RUN zypper install --no-recommends -y \
+        awk \
+        bcc-devel \
+        bison \
+        binutils-devel \
+        bpftool \
+        cereal-devel \
+        clang-devel \
+        cmake \
+        elfutils \
+        flex \
+        gcc \
+        gcc-c++ \
+        libpcap-devel \
+        libbpf-devel \
+        libbpf-devel-static \
+        libzstd-devel \
+        llvm-devel \
+        make \
+        pahole \
+        xxd \
+        zip \
+        zlib-devel
+
+COPY . /src
+WORKDIR /src
+
+# Use CMAKE_BUILD_TYPE=Release if you don't plan on developing bpftrace
+# We set USE_SYSTEM_LIBBPF=On to test that bpftrace can build with system libbpf
+# (i.e. not using libbpf from the submodule)
+RUN cmake -B /build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug  -DUSE_SYSTEM_LIBBPF=On
+RUN make -C /build -j$(nproc)
+
+ENTRYPOINT ["/build/src/bpftrace"]
+


### PR DESCRIPTION
Stacked PRs:
 * __->__#5167
 * #5166


--- --- ---

### Docker: Add OpenSUSE Dockerfile


OpenSUSE has some specifics in library packaging, especially libbfd.
We've already had to fix some CMake/linker errors that only happened
there so add a new Dockerfile and CI job to catch these earlier.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>