### PR TITLE
struct listing: Fix BTF dump parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to
   - [#5138](https://github.com/bpftrace/bpftrace/pull/5138)
 - Fix for-loop variable scope causing type merging across loops
   - [#5157](https://github.com/bpftrace/bpftrace/pull/5157)
+- Fix verbose listing of some kernel struct types
+  - [#5169](https://github.com/bpftrace/bpftrace/pull/5169)
 #### Security
 #### Docs
 #### Tools

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -1099,7 +1099,10 @@ std::set<std::string> BTF::get_all_structs_from_btf(const struct btf *btf) const
           type.clear();
           in_def = false;
         }
-      } else if (!line.empty() && line.back() == '{') {
+      } else if ((line.starts_with(STRUCT_PREFIX) ||
+                  line.starts_with(UNION_PREFIX) ||
+                  line.starts_with(ENUM_PREFIX)) &&
+                 line.back() == '{') {
         // start of type definition
         type += line + "\n";
         in_def = true;


### PR DESCRIPTION
When doing verbose struct listing, we use libbpf's btf_dump to dump all kernel types in C format to a giant string and then split it to individual types. The splitting logic is as follows:
- a type starts on a line ending with '{'
- a type ends on a line containing just "};"

This logic has a flaw, since it would squash the following two type defs into a single entry, effectively preventing us from listing another_type_t:

    typedef struct {
        ...
    } type_name_t;

    type another_type_t {
        ...
    };

Fix the type start detection to require a line starting with "struct". Types defined with `typedef ...` are left unsupported for now.

This fixes two failing tests from #5158. The reason they started failing on newer kernels is that they print `struct type`, which has been moved after a `typedef`ed type in BTF and exposed this bug.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
