### PR TITLE
tests: Remove test on handling percpu_kaddr verifier errors

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -816,13 +816,6 @@ NAME percpu_kaddr field access
 PROG begin { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); if ($runq != 0) { printf("nr_running: %d\n", $runq.nr_running) } exit() }
 EXPECT_REGEX nr_running: [0-9]+
 
-NAME percpu_kaddr field access no NULL check
-PROG begin { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); printf("nr_running: %d\n", $runq.nr_running); exit() }
-EXPECT stdin:1:31-59: ERROR: helper bpf_per_cpu_ptr: result needs to be null-checked before accessing fields
-       begin { $runq = ((struct rq *)percpu_kaddr("runqueues", 0)); printf("nr_running: %d\n", $runq.nr_running); exit() }
-                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-WILL_FAIL
-
 NAME clear on scalar map prevents printing
 PROG begin { @xx = 5; clear(@xx); exit() }
 EXPECT_NONE @xx: 5


### PR DESCRIPTION
The percpu_kaddr builin calls the bpf_per_cpu_ptr() helper under the hood. That helper may return NULL, which may cause a verifier error if a NULL check is not provided afterwards. bpftrace catches such errors and displays them in a user-friendly way.

However, it looks like the recent versions of the verifier got smart enough not to require such a check, at least not for the test case that we have. Let's just drop that test case since it just checks that we can propagate the verifier error.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
