### PR TITLE
tests: Handle kernel renaming `do_filp_open`

### DIFF
--- a/tests/runtime/stdlib
+++ b/tests/runtime/stdlib
@@ -57,8 +57,11 @@ PROG begin { @a[1] = 1; $x = delete(@a, 2); $y = delete(@a, 1); if ($x == false 
 EXPECT SUCCESS
 TIMEOUT 1
 
+# Kernel commit 541003b576c3 ("rename do_filp_open() to do_file_open()") renamed
+# do_filp_open to do_file_open since version 7.0 so use wildcard below to handle
+# both names.
 NAME is_err
-PROG fexit:do_filp_open { if (is_err(retval)) { printf("is_err: %ld\n", (int64)retval); exit(); } }
+PROG fexit:do_fil*_open { if (is_err(retval)) { printf("is_err: %ld\n", (int64)retval); exit(); } }
 EXPECT_REGEX is_err: -[0-9]{1,4}$
 AFTER cat /tmp/bpftrace_nonexistent_file
 REQUIRES_FEATURE btf


### PR DESCRIPTION
Kernel patch [541003b576c3](https://github.com/torvalds/linux/commit/541003b576c3) ("rename do_filp_open() to do_file_open()") renamed `do_filp_open()` to `do_file_open()` since Linux 7.0. Adjust the test attaching to this function to use a wildcard, so that it handles both names.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
