### PR TITLE
Fix branch name in release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -24,7 +24,7 @@ For LLVM release schedule, see https://llvm.org/.
 - [ ] Mark the release in [CHANGELOG.md](https://github.com/bpftrace/bpftrace/blob/master/CHANGELOG.md) and create an "Unreleased" section
 - [ ] Set `bpftrace_VERSION_MINOR` to `<minor>` in [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt)
 - [ ] Add `v0.<minor>-rc0` tag to master
-- [ ] Create release branch `release/v0.<minor>.x` (<branching-date>)
+- [ ] Create release branch `release/0.<minor>.x` (<branching-date>)
 - [ ] Add support for LLVM <llvm>
   - [ ] Bump `MAX_LLVM_MAJOR` in [CMakeLists.txt](https://github.com/bpftrace/bpftrace/blob/master/CMakeLists.txt)
   - [ ] Add new Nix target in [flake.nix](https://github.com/bpftrace/bpftrace/blob/master/flake.nix)


### PR DESCRIPTION
We do not use the `v` prefix in the branch name.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
