### PR TITLE
Fix ASAN container-overflow in ap_probe_expansion

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -440,7 +440,7 @@ public:
 class Builtin : public Node {
 public:
   explicit Builtin(ASTContext &ctx, Location &&loc, std::string ident)
-      : Node(ctx, std::move(loc)), ident(std::move(ident)) {};
+      : Node(ctx, std::move(loc)), ident(std::move(ident)), probe_id(-1) {};
   explicit Builtin(ASTContext &ctx, const Location &loc, const Builtin &other)
       : Node(ctx, loc + other.loc),
         ident(other.ident),

--- a/src/ast/passes/ap_probe_expansion.cpp
+++ b/src/ast/passes/ap_probe_expansion.cpp
@@ -135,6 +135,7 @@ public:
   }
 
   using Visitor<SessionExpander>::visit;
+  void visit(Program &prog);
   void visit(Probe &probe);
 
   Probe expand(Probe &entry, Probe &exit);
@@ -145,6 +146,7 @@ private:
   ASTContext &ast_;
   const BPFtrace &bpftrace_;
   ExpansionResult &expansion_result_;
+  ProbeList probes_to_erase_;
 };
 
 Probe *SessionExpander::find_matching_retprobe(Probe &probe)
@@ -155,6 +157,7 @@ Probe *SessionExpander::find_matching_retprobe(Probe &probe)
   // - has a single kretprobe attach point
   // - attaches to the same target and function as probe
   // - is multi-expanded (session expansion uses the same attach mechanism)
+  // - is not already scheduled for erasure
   std::ranges::copy_if(
       ast_.root->probes, std::back_inserter(retprobes), [&](Probe *other) {
         return other->attach_points.size() == 1 &&
@@ -163,14 +166,16 @@ Probe *SessionExpander::find_matching_retprobe(Probe &probe)
                expansion_result_.get_expansion(*other->attach_points[0]) ==
                    ExpansionType::MULTI &&
                other->attach_points[0]->target == ap->target &&
-               other->attach_points[0]->func == ap->func;
+               other->attach_points[0]->func == ap->func &&
+               std::ranges::find(probes_to_erase_, other) ==
+                   probes_to_erase_.end();
       });
 
   // If there's not exactly one match, we don't know how to do session expansion
-  if (retprobes.size() == 1)
-    return retprobes[0];
-
-  return nullptr;
+  if (retprobes.size() != 1) {
+    return nullptr;
+  }
+  return retprobes[0];
 }
 
 void SessionExpander::visit(Probe &probe)
@@ -206,7 +211,15 @@ void SessionExpander::visit(Probe &probe)
     expansion_result_.set_expansion(*probe.attach_points[0],
                                     ExpansionType::SESSION);
 
-    std::erase(ast_.root->probes, retprobe);
+    probes_to_erase_.push_back(retprobe);
+  }
+}
+
+void SessionExpander::visit(Program &prog)
+{
+  Visitor<SessionExpander>::visit(prog);
+  for (auto *retprobe : probes_to_erase_) {
+    std::erase(prog.probes, retprobe);
   }
 }
 

--- a/tests/ap_probe_expansion.cpp
+++ b/tests/ap_probe_expansion.cpp
@@ -389,4 +389,19 @@ TEST(ap_probe_expansion_btf, kprobe_session)
        true);
 }
 
+TEST(ap_probe_expansion_btf, kprobe_session_duplicate_kprobe)
+{
+  auto funcs = std::set<std::string>{ "func_1",
+                                      "func_2",
+                                      "func_3",
+                                      "func_anon_struct",
+                                      "func_array_with_compound_data",
+                                      "func_arrays" };
+  test("kprobe:func_* {} kprobe:func_* {} kretprobe:func_* {}",
+       { "kprobe:func_*", "kprobe:func_*" },
+       { funcs, funcs },
+       _,
+       true);
+}
+
 } // namespace bpftrace::test::ap_probe_expansion


### PR DESCRIPTION
Defer erasure of probes in `SessionExpander` to avoid modifying `ast_.root->probes` while iterating over it.

Previously, `SessionExpander::visit(Probe &)` would call `std::erase` on `ast_.root->probes` immediately when a matching retprobe was found. Since this visitation happens during an iteration over `ast_.root->probes` in the base `Visitor`, modifying the vector invalidated iterators and led to a sanitizer detected `container-overflow` when the range-based for loop continued to its cached end.

Now, `SessionExpander` collects probes to be erased and performs the erasure in an overridden `visit(Program &)` method after the base visitation completes.

Co-developed-by: Gemini

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
