### PR TITLE
Fix kprobe session eligibility for exact function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ and this project adheres to
   - [#5157](https://github.com/bpftrace/bpftrace/pull/5157)
 - Fix verbose listing of some kernel struct types
   - [#5169](https://github.com/bpftrace/bpftrace/pull/5169)
+- Enable session probes for kprobes with exact function names (not only wildcards)
+  - [#5104](https://github.com/bpftrace/bpftrace/pull/5104)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/ap_probe_expansion.cpp
+++ b/src/ast/passes/ap_probe_expansion.cpp
@@ -141,6 +141,8 @@ public:
   Probe expand(Probe &entry, Probe &exit);
 
 private:
+  bool is_session_attach_point(AttachPoint &ap);
+
   Probe *find_matching_retprobe(Probe &probe);
 
   ASTContext &ast_;
@@ -148,6 +150,21 @@ private:
   ExpansionResult &expansion_result_;
   ProbeList probes_to_erase_;
 };
+
+bool SessionExpander::is_session_attach_point(AttachPoint &ap)
+{
+  auto provider = probetype(ap.provider);
+  if (provider != ProbeType::kprobe && provider != ProbeType::kretprobe)
+    return false;
+
+  auto expansion = expansion_result_.get_expansion(ap);
+  if (expansion == ExpansionType::MULTI)
+    return true;
+
+  return expansion == ExpansionType::NONE &&
+         bpftrace_.feature_->has_kprobe_multi() && ap.target.empty() &&
+         ap.func_offset == 0 && ap.address == 0 && !util::has_wildcard(ap.func);
+}
 
 Probe *SessionExpander::find_matching_retprobe(Probe &probe)
 {
@@ -158,13 +175,13 @@ Probe *SessionExpander::find_matching_retprobe(Probe &probe)
   // - attaches to the same target and function as probe
   // - is multi-expanded (session expansion uses the same attach mechanism)
   // - is not already scheduled for erasure
+  // - is eligible for session expansion
   std::ranges::copy_if(
       ast_.root->probes, std::back_inserter(retprobes), [&](Probe *other) {
         return other->attach_points.size() == 1 &&
                probetype(other->attach_points[0]->provider) ==
                    ProbeType::kretprobe &&
-               expansion_result_.get_expansion(*other->attach_points[0]) ==
-                   ExpansionType::MULTI &&
+               is_session_attach_point(*other->attach_points[0]) &&
                other->attach_points[0]->target == ap->target &&
                other->attach_points[0]->func == ap->func &&
                std::ranges::find(probes_to_erase_, other) ==
@@ -180,12 +197,13 @@ Probe *SessionExpander::find_matching_retprobe(Probe &probe)
 
 void SessionExpander::visit(Probe &probe)
 {
-  // If the probe has a single multi-expanded kprobe attach point, check if
-  // there's another probe with a single multi-expanded kretprobe attach point
-  // with the same target. If so, perform session expansion by merging the two
-  // probes together.
+  // If the probe has a single session-eligible kprobe attach point, check if
+  // there's another probe with a single session-eligible kretprobe attach
+  // point with the same target. If so, perform session expansion by merging
+  // the two probes together.
   if (probe.attach_points.size() == 1 &&
-      probetype(probe.attach_points[0]->provider) == ProbeType::kprobe) {
+      probetype(probe.attach_points[0]->provider) == ProbeType::kprobe &&
+      is_session_attach_point(*probe.attach_points[0])) {
     Probe *retprobe = find_matching_retprobe(probe);
     if (!retprobe)
       return;

--- a/tests/ap_probe_expansion.cpp
+++ b/tests/ap_probe_expansion.cpp
@@ -170,6 +170,31 @@ TEST(ap_probe_expansion, kprobe_module_function_wildcard)
        true);
 }
 
+TEST(ap_probe_expansion, kprobe_multi_exact)
+{
+  // Exact function names start with NONE expansion but get promoted to SESSION
+  // when merged with a matching kretprobe.
+  test("kprobe:sys_read { @entry = 1 } kretprobe:sys_read { @exit = 1 }",
+       { "kprobe:sys_read" },
+       { { "sys_read" } },
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(
+               If(Call("__session_is_return", {}),
+                  Block({ AssignScalarMapStatement(Map("@exit"), Integer(1)) },
+                        None()),
+                  Block({ AssignScalarMapStatement(Map("@entry"), Integer(1)) },
+                        None()))) })),
+       true);
+}
+
+TEST(ap_probe_expansion, kprobe_offset_no_multi)
+{
+  // kprobe_multi does not support non-zero offsets, so even with
+  // kprobe_multi enabled, an offset probe must not use multi expansion.
+  test("kprobe:sys_read+10 {}", { "kprobe:sys_read+10" }, { {} }, _, true);
+}
+
 TEST(ap_probe_expansion, uprobe_wildcard)
 {
   // Disabled uprobe_multi - should get full expansion

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -91,7 +91,6 @@ void check_kprobe(Probe &p,
   EXPECT_EQ(attach_point, p.attach_point);
   EXPECT_EQ(kprobe_name(attach_point, target, func_offset), p.name);
   EXPECT_EQ(func_offset, p.func_offset);
-  EXPECT_TRUE(p.funcs.empty());
 }
 
 void check_uprobe(Probe &p,

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -285,6 +285,14 @@ EXPECT links: 1
 REQUIRES bpftool
 REQUIRES_FEATURE kprobe_session
 
+NAME kprobe_session_exact
+RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_read { @entry = 1; printf("progs: "); system("bpftool prog | grep kprobe | grep ksys_read | wc -l"); } kretprobe:ksys_read { printf("links: "); system("bpftool link | grep kprobe_multi | wc -l"); if (@entry == 1) { exit() } }'
+AFTER ./testprogs/syscall read
+EXPECT progs: 1
+EXPECT links: 1
+REQUIRES bpftool
+REQUIRES_FEATURE kprobe_session
+
 NAME uprobe
 PROG uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}
 EXPECT_REGEX arg0: [0-9]*


### PR DESCRIPTION
Session probes previously only worked with wildcard kprobe attach points because find_matching_retprobe() required MULTI expansion. Exact function names (e.g. kprobe:ksys_read) get NONE expansion, so they were excluded from session probe merging.

Add is_session_attach_point() to SessionExpander that checks whether an attach point is eligible for session probes based on: (1) it already has MULTI expansion, or (2) it has NONE expansion but kprobe_multi is available, no module is specified, no offset, no address, and no wildcards in the function name.

This enables session probes (merged kprobe + kretprobe) for exact function names, reducing the number of BPF programs needed.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
