### PR TITLE
tests/runtime: tighten clear map expectations

### DIFF
--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -213,22 +213,22 @@ AFTER ./testprogs/uprobe_loop
 
 NAME lhist can be cleared
 PROG begin{ @[1] = lhist(3,0,10,1); clear(@); exit() }
-EXPECT_REGEX .*
+EXPECT_REGEX_NONE @
 TIMEOUT 1
 
 NAME hist can be cleared
 PROG begin{ @[1] = hist(1); clear(@); exit() }
-EXPECT_REGEX .*
+EXPECT_REGEX_NONE @
 TIMEOUT 1
 
 NAME stats can be cleared
 PROG begin{ @[1] = stats(1); clear(@); exit() }
-EXPECT_REGEX .*
+EXPECT_REGEX_NONE @
 TIMEOUT 1
 
 NAME avg can be cleared
 PROG begin{ @[1] = avg(1); clear(@); exit() }
-EXPECT_REGEX .*
+EXPECT_REGEX_NONE @
 TIMEOUT 1
 
 NAME tseries can be cleared


### PR DESCRIPTION
## Description

Tighten a few overly broad runtime test expectations in `tests/runtime/other`.

Some `clear(@)` tests used `EXPECT_REGEX .*`, which matched any output and therefore did not verify that the map was actually cleared. This changes them to `EXPECT_REGEX_NONE @`, matching the existing `tseries can be cleared` test.

Addresses part of #2993.

## Testing

- `sudo --preserve-env=PATH --preserve-env=PYTHONPATH ./build/tests/runtime-tests.sh --filter="other.*can be cleared"`