### PR TITLE
Fix: un-aligned key access for hist/lhist/tseries (#5181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to
   - [#5169](https://github.com/bpftrace/bpftrace/pull/5169)
 - Enable session probes for kprobes with exact function names (not only wildcards)
   - [#5104](https://github.com/bpftrace/bpftrace/pull/5104)
+- Fix un-aligned map key access for hist/lhist/tseries map types
+  - [#5181](https://github.com/bpftrace/bpftrace/pull/5181)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3632,7 +3632,6 @@ ScopedExpr CodegenLLVM::getMultiMapKey(Map &map,
   auto *key_type = ArrayType::get(b_.getInt8Ty(), size);
 
   int offset = 0;
-  bool aligned = true;
   // Construct a map key in the stack
   Value *offset_val = b_.CreateGEP(key_type,
                                    key,
@@ -3640,18 +3639,16 @@ ScopedExpr CodegenLLVM::getMultiMapKey(Map &map,
   size_t map_key_size = type_map_.map_key_type(map.ident).GetSize();
   size_t expr_size = type_map_.type(key_expr).GetSize();
 
+  bool aligned = (map_key_size % 8) == 0;
+
   if (inBpfMemory(type_map_.type(key_expr))) {
     b_.CreateMemcpyBPF(offset_val, scoped_expr.value(), expr_size);
-    if ((map_key_size % 8) != 0)
-      aligned = false;
   } else {
     if (type_map_.type(key_expr).IsArrayTy() ||
         type_map_.type(key_expr).IsCTypeTy()) {
       // Read the array/struct into the key
       b_.CreateProbeRead(
           offset_val, type_map_.type(key_expr), scoped_expr.value(), map.loc);
-      if ((map_key_size % 8) != 0)
-        aligned = false;
     } else {
       if (aligned)
         b_.CreateStore(scoped_expr.value(), offset_val);

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -160,3 +160,9 @@ NAME probe specific arguments
 PROG fentry:vmlinux:vfs_write { print(args.file); exit(); } t:syscalls:sys_enter_execve { print(args.filename); exit(); }
 EXPECT Attached 2 probes
 TIMEOUT 1
+
+# https://github.com/bpftrace/bpftrace/issues/5180
+NAME maps with hidden key fields aligned access
+PROG begin{ @a[(uint8)1] = hist(3,0); @b = count(); }
+EXPECT Attached 1 probe
+TIMEOUT 1


### PR DESCRIPTION
In the case of hist, lhist, and teries, we add additional metadata into the map keys for bookkeeping. When the user-set map key size is not 8-byte aligned then we do a specifically aligned store. However, we weren't doing that in the case of integers or booleans, which are 1 byte, and this was causing a verifier error.

This was caused by 817faee42 — "Remove automatic integer promotion (#4768)". Before that the keys were automatically promoted to 8 bytes.

The fix is to check the map_key_size size for the right alignment regardless of its type.

Fixes: https://github.com/bpftrace/bpftrace/issues/5180

stack-info: PR: https://github.com/bpftrace/bpftrace/pull/5181, branch: user/jordalgo/issue_5180/1


(cherry picked from commit 59cc61cfab285ebc524cbc6f4018f21e2a86b8c2)

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
