### PR TITLE
Stabilize address-of operator (`&`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to
   - [#5148](https://github.com/bpftrace/bpftrace/pull/5148)
 - Stabilize root imports (remove 'unstable_import' flag)
   - [#5184](https://github.com/bpftrace/bpftrace/pull/5184)
+- Stabilize address-of operator `&` (remove 'unstable_addr' flag)
+  - [#5185](https://github.com/bpftrace/bpftrace/pull/5185)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/docs/language.md
+++ b/docs/language.md
@@ -395,7 +395,6 @@ Controls whether maps are printed on exit. Set to `false` in order to change the
 
 These are the list of unstable features:
 - `unstable_tseries` - feature flag for time series map type
-- `unstable_addr` - feature flag for address of operator (&)
 - `unstable_dw_ustack` - feature flag for DWARF-based user-space stack unwinding
 
 All of these accept the following options:
@@ -1798,6 +1797,7 @@ $b = (buffer[256])arg0;   // buffer of 256 bytes
 ### Pointers
 
 Pointers in bpftrace are similar to those found in `C`.
+You can also get the pointer to a bpftrace scratch variable or map using the address-of operator (`&`), e.g. `$a = 1; $b = &$a;`.
 
 ### Structs
 

--- a/src/ast/passes/unstable_feature.cpp
+++ b/src/ast/passes/unstable_feature.cpp
@@ -42,8 +42,6 @@ public:
   explicit UnstableFeature(BPFtrace &bpftrace) : bpftrace_(bpftrace) {};
 
   using Visitor<UnstableFeature>::visit;
-  void visit(MapAddr &map_addr);
-  void visit(VariableAddr &var_addr);
   void visit(StatementImport &imp);
   void visit(Call &call);
   void visit(Typeinfo &typeinfo);
@@ -53,7 +51,6 @@ private:
   // This set is so we don't warn multiple times for the same feature.
   std::unordered_set<std::string> warned_features;
 
-  void check_unstable_addr(Node &node);
   void check_unstable_tseries(Node &node);
   void check_unstable_dw_ustack(Node &node);
 };
@@ -103,20 +100,6 @@ void UnstableFeature::visit(Typeinfo &typeinfo)
   }
 }
 
-void UnstableFeature::check_unstable_addr(Node &node)
-{
-  if (bpftrace_.config_->unstable_addr == ConfigUnstable::error) {
-    node.addError() << get_error(ADDR, UNSTABLE_ADDR);
-    return;
-  }
-
-  if (bpftrace_.config_->unstable_addr == ConfigUnstable::warn &&
-      !warned_features.contains(UNSTABLE_ADDR)) {
-    LOG(WARNING) << get_warning(ADDR, UNSTABLE_ADDR);
-    warned_features.insert(UNSTABLE_ADDR);
-  }
-}
-
 void UnstableFeature::check_unstable_tseries(Node &node)
 {
   if (bpftrace_.config_->unstable_tseries == ConfigUnstable::error) {
@@ -148,16 +131,6 @@ void UnstableFeature::check_unstable_dw_ustack(Node &node)
     warned_features.insert(UNSTABLE_DW_USTACK);
   }
 #endif // HAVE_DW_UNWIND
-}
-
-void UnstableFeature::visit(MapAddr &map_addr)
-{
-  check_unstable_addr(map_addr);
-}
-
-void UnstableFeature::visit(VariableAddr &var_addr)
-{
-  check_unstable_addr(var_addr);
 }
 
 Pass CreateUnstableFeaturePass()

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -328,7 +328,6 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { "show_debug_info", CONFIG_FIELD_PARSER(show_debug_info) },
   { UNSTABLE_IMPORT_STATEMENT, CONFIG_FIELD_PARSER(unstable_import_statement) },
   { UNSTABLE_TSERIES, CONFIG_FIELD_PARSER(unstable_tseries) },
-  { UNSTABLE_ADDR, CONFIG_FIELD_PARSER(unstable_addr) },
   { UNSTABLE_TYPEINFO, CONFIG_FIELD_PARSER(unstable_typeinfo) },
   { UNSTABLE_DW_USTACK, CONFIG_FIELD_PARSER(unstable_dw_ustack) },
 };

--- a/src/config.h
+++ b/src/config.h
@@ -32,16 +32,12 @@ enum CompatibleBPFLicense {
 
 static const auto UNSTABLE_IMPORT_STATEMENT = "unstable_import_statement";
 static const auto UNSTABLE_TSERIES = "unstable_tseries";
-static const auto UNSTABLE_ADDR = "unstable_addr";
 static const auto UNSTABLE_TYPEINFO = "unstable_typeinfo";
 static const auto UNSTABLE_DW_USTACK = "unstable_dw_ustack";
 
 static std::unordered_set<std::string> DEPRECATED_CONFIGS = {
-  "symbol_source",
-  "max_type_res_iterations",
-  "unstable_import",
-  "unstable_macro",
-  "unstable_map_decl"
+  "symbol_source",   "max_type_res_iterations", "unstable_addr",
+  "unstable_import", "unstable_macro",          "unstable_map_decl"
 };
 
 class Config {
@@ -66,7 +62,6 @@ public:
   bool print_maps_on_exit = true;
   ConfigUnstable unstable_import_statement = ConfigUnstable::error;
   ConfigUnstable unstable_tseries = ConfigUnstable::warn;
-  ConfigUnstable unstable_addr = ConfigUnstable::warn;
   ConfigUnstable unstable_typeinfo = ConfigUnstable::error;
   ConfigUnstable unstable_dw_ustack = ConfigUnstable::warn;
 #ifdef HAVE_BLAZESYM

--- a/tests/unstable_feature.cpp
+++ b/tests/unstable_feature.cpp
@@ -50,17 +50,6 @@ TEST(unstable_feature, check_error)
       "tseries feature is not enabled by default. To enable this unstable "
       "feature, set the config flag to enable. unstable_tseries=enable");
 
-  test("config = { unstable_addr=warn } begin { $x = 1; &$x; }");
-  test_error("config = { unstable_addr=error } begin { $x = 1; &$x; }",
-             "address-of operator (&) feature is not enabled by default. To "
-             "enable this unstable "
-             "feature, set the config flag to enable. unstable_addr=enable");
-  test("config = { unstable_addr=warn } begin { @x = 1; &@x; }");
-  test_error("config = { unstable_addr=error } begin { @x = 1; &@x; }",
-             "address-of operator (&) feature is not enabled by default. To "
-             "enable this unstable "
-             "feature, set the config flag to enable. unstable_addr=enable");
-
 #ifdef HAVE_DW_UNWIND
   test("config = { unstable_dw_ustack=warn } uprobe:./a:main "
        "{ @ = dw_ustack(); }");


### PR DESCRIPTION
Stacked PRs:
 * __->__#5185


--- --- ---

### Stabilize address-of operator (`&`)


This is needed to support the use of C-interop

Closes: https://github.com/bpftrace/bpftrace/issues/4460

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>