### PR TITLE
Allow user-defined macros to override stdlib

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -674,6 +674,7 @@ A macro's parameter signature specifies how an argument will be used.
 For example `macro test($a, b, @c)` indicates that `$a` needs to be a scratch variable (which might be mutated), that `b` needs to be an expression that will be inserted where ever `b` is used in the macro body, and that `@c` needs to be a map (which might be mutated).
 A valid use of this macro could be `test($x, 1 + 2, @y)`.
 Variables and maps can also be used for ident parameters that expect expressions and would be the same as writing `{ @y }` (Block Expression).
+Note: User-defined macros with the same name and signature as a standard library macro will override the standard library version. However, standard library macros nested inside of other standard library macros will never use the user-defined version of the same signature.
 
 Here are some valid usages of macros:
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1942,7 +1942,8 @@ public:
       : Node(ctx, loc + other.loc),
         name(other.name),
         vargs(clone(ctx, loc, other.vargs)),
-        block(clone(ctx, loc, other.block)) {};
+        block(clone(ctx, loc, other.block)),
+        is_stdlib(other.is_stdlib) {};
 
   bool operator==(const Macro &other) const
   {
@@ -1950,11 +1951,15 @@ public:
       return false;
     if (vargs != other.vargs)
       return false;
+    if (is_stdlib != other.is_stdlib)
+      return false;
     return *block == *other.block;
   }
   std::strong_ordering operator<=>(const Macro &other) const
   {
     if (auto cmp = name <=> other.name; cmp != 0)
+      return cmp;
+    if (auto cmp = is_stdlib <=> other.is_stdlib; cmp != 0)
       return cmp;
     if (vargs.size() != other.vargs.size())
       return vargs.size() <=> other.vargs.size();
@@ -1968,6 +1973,7 @@ public:
   std::string name;
   ExpressionList vargs;
   BlockExpr *block = nullptr;
+  bool is_stdlib = false;
 };
 using MacroList = std::vector<Macro *>;
 

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -22,6 +22,7 @@ static bool validate(Macro *macro)
 {
   std::unordered_set<std::string> seen_mvars;
   std::unordered_set<std::string> seen_mmaps;
+  std::unordered_set<std::string> seen_idents;
   for (const auto &arg : macro->vargs) {
     if (auto *mvar = arg.as<Variable>()) {
       auto inserted = seen_mvars.insert(mvar->ident);
@@ -36,6 +37,13 @@ static bool validate(Macro *macro)
       if (!inserted.second) {
         mmap->addError() << "Map for macro argument has already been used: "
                          << mmap->ident;
+        return false;
+      }
+    } else if (auto *ident = arg.as<Identifier>()) {
+      auto inserted = seen_idents.insert(ident->ident);
+      if (!inserted.second) {
+        ident->addError() << "Ident for macro argument has already been used: "
+                          << ident->ident;
         return false;
       }
     }
@@ -56,7 +64,7 @@ MacroRegistry MacroRegistry::create(ASTContext &ast)
     // However we explicitly allow this, as long as they are added in such a way
     // that they will match with the most precise macros first. The newest macro
     // definition must not match with any existing macro definition.
-    auto exists = registry.lookup(macro->name, macro->vargs);
+    auto exists = registry.lookup(macro->name, macro->vargs, macro->is_stdlib);
     if (exists) {
       auto &err = macro->addError();
       err << "Redefinition of macro: " << macro->name;
@@ -91,9 +99,9 @@ static size_t distance(const Macro *macro, const std::vector<Expression> &args)
   return d;
 }
 
-Result<const Macro *> MacroRegistry::lookup(
-    const std::string &name,
-    const std::vector<Expression> &args) const
+Result<const Macro *> MacroRegistry::lookup(const std::string &name,
+                                            const std::vector<Expression> &args,
+                                            std::optional<bool> is_stdlib) const
 {
   const auto it = macros_.find(name);
   if (it == macros_.end()) {
@@ -106,10 +114,23 @@ Result<const Macro *> MacroRegistry::lookup(
   }
   size_t min_distance = std::numeric_limits<size_t>::max();
   std::vector<const Macro *> closest;
+  const Macro *exact_stdlib_match = nullptr;
+  const Macro *exact_user_match = nullptr;
   for (const auto *m : it->second) {
+    // When a lookup explicitly targets stdlib or user-defined macros, treat
+    // the other class as invisible. This avoids turning unrelated builtin or
+    // function calls into macro mismatch errors.
+    if (is_stdlib && m->is_stdlib != *is_stdlib) {
+      continue;
+    }
+
     size_t d = distance(m, args);
     if (d == 0) {
-      return m; // Matched.
+      if (m->is_stdlib && !exact_stdlib_match) {
+        exact_stdlib_match = m;
+      } else if (!m->is_stdlib && !exact_user_match) {
+        exact_user_match = m;
+      }
     }
     if (d < min_distance) {
       min_distance = d;
@@ -119,6 +140,16 @@ Result<const Macro *> MacroRegistry::lookup(
       closest.push_back(m);
     }
   }
+
+  // When both user and stdlib definitions match, prefer the user-defined
+  // macro. Filtered lookups only populate one of these pointers.
+  if (exact_user_match) {
+    return exact_user_match;
+  }
+  if (exact_stdlib_match) {
+    return exact_stdlib_match;
+  }
+
   return make_error<MacroLookupError>(name, std::move(closest));
 }
 
@@ -294,7 +325,13 @@ void MacroExpander::visit(Expression &expr)
   const std::string &name = ident ? ident->ident : call->func;
   const std::vector<Expression> &args = ident ? empty : call->vargs;
 
-  auto result = registry_.lookup(name, args);
+  // If we're being called from a stdlib macro then only expand other stdlib
+  // macros not user-defined macros that also happen to match
+  std::optional<bool> restrict_to_stdlib = std::nullopt;
+  if (!stack_.empty() && stack_.back()->is_stdlib) {
+    restrict_to_stdlib = true;
+  }
+  auto result = registry_.lookup(name, args, restrict_to_stdlib);
   if (!result) {
     auto done = handleErrors(
         std::move(result), [&](const MacroLookupError &lookupErr) {

--- a/src/ast/passes/macro_expansion.h
+++ b/src/ast/passes/macro_expansion.h
@@ -33,11 +33,13 @@ public:
   // This may add errors to conflicting macros.
   static MacroRegistry create(ASTContext &ast);
 
-  // Lookup a macro based on a name and set of arguments.
+  // Lookup a macro based on a name, set of arguments, and if it's stdlib
   //
   // If no matching macro is found, `nullptr` is returned.
-  Result<const Macro *> lookup(const std::string &name,
-                               const std::vector<Expression> &args) const;
+  Result<const Macro *> lookup(
+      const std::string &name,
+      const std::vector<Expression> &args,
+      std::optional<bool> is_stdlib = std::nullopt) const;
 
 private:
   // This holds the definitions for all discovered macros.

--- a/src/ast/passes/resolve_imports.cpp
+++ b/src/ast/passes/resolve_imports.cpp
@@ -292,6 +292,17 @@ Result<OK> Imports::import_any(Node &node,
   return OK();
 }
 
+static void mark_stdlib_macros(ASTContext &ast)
+{
+  if (!ast.root) {
+    return;
+  }
+
+  for (auto *macro : ast.root->macros) {
+    macro->is_stdlib = true;
+  }
+}
+
 Result<OK> Imports::import_stdlib(
     Node &node,
     const std::string &name,
@@ -327,6 +338,7 @@ Result<OK> Imports::import_stdlib(
     return OK();
   }
   auto &ast = **result;
+  mark_stdlib_macros(ast);
 
   ResolveStdlibMacroImports resolver(*this, macro_name, paths);
   resolver.visit(ast.root);

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -1,4 +1,6 @@
 #include "ast/passes/macro_expansion.h"
+#include "ast/passes/import_scripts.h"
+#include "ast/passes/resolve_imports.h"
 #include "mocks.h"
 #include "parser.h"
 #include "gtest/gtest.h"
@@ -24,6 +26,8 @@ void test(const std::string& input,
                 .put(ast)
                 .put(bpftrace)
                 .add(CreateParsePass())
+                .add(ast::CreateResolveRootImportsPass({}))
+                .add(ast::CreateImportInternalScriptsPass())
                 .add(ast::CreateMacroExpansionPass())
                 .run();
 
@@ -91,6 +95,10 @@ TEST(macro_expansion, basic_checks)
              "1 but got 2");
   test_error("macro set($x, $x) { $x += 1; $x } begin { $a = 1; set($a, 1); }",
              "Variable for macro argument has already been used: $x");
+  test_error("macro set(@x, @x) { @x } begin { @a = 1; set(@a, @a); }",
+             "Map for macro argument has already been used: @x");
+  test_error("macro set(x, x) { x } begin { set(1, 1); }",
+             "Ident for macro argument has already been used: x");
   test_error("macro set($x) { $x += 1; $x } macro set($x) { $x } begin { $a = "
              "1; set($a, 1); }",
              "Redefinition of macro: set");
@@ -211,6 +219,27 @@ stdin:1:12-15: ERROR: syntax: builtin 'pid' can't be used as a macro argument
 macro test(pid) { } begin { }
            ~~~
 )");
+}
+
+TEST(macro_expansion, stdlib_shadowing)
+{
+  // User macro with same name and signature shadows the stdlib version.
+  test("macro cpu() { 42 } begin { print(cpu()); }");
+
+  // User macro with same name but different signature coexists with stdlib.
+  // cpu(x) is user-defined, cpu() is from stdlib — both should work.
+  test("macro cpu(x) { x } begin { print(cpu(1)); print(cpu()); }");
+
+  // User macro shadows matching stdlib overload but non-matching stdlib
+  // overloads remain available. comm() has multiple stdlib overloads.
+  test("macro comm() { \"me\" } begin { print(comm()); }");
+
+  // User-to-user redefinitions should still error.
+  test_error("macro cpu() { 1 } macro cpu() { 2 } begin { print(cpu()); }",
+             "Redefinition of macro: cpu");
+
+  // User macros should not poison builtin/function calls inside stdlib macros.
+  test("macro fail(x) { x } begin { print(strlen(\"hi\")); }");
 }
 
 } // namespace bpftrace::test::macro_expansion

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -188,3 +188,20 @@ ARCH x86_64
 NAME builtin wrapper username
 PROG begin { if (__builtin_username == username() && __builtin_username == username) { printf("SUCCESS %s\n", username); } }
 EXPECT_REGEX SUCCESS .*
+
+NAME user macros override stdlib
+PROG macro cpu() { "hi" } begin { printf(cpu()); }
+EXPECT_REGEX hi
+
+NAME user macros don't override stdlib if different signature
+PROG macro cpu(x) { x } begin { print(cpu("hi")); printf("SUCCESS %llu\n", cpu()); }
+EXPECT_REGEX hi
+EXPECT_REGEX SUCCESS [0-9]+
+
+NAME user macros don't override indirect stdlib macros
+PROG macro assert_str(exp) { fail("boom") } begin { print(strlen("hi")); }
+EXPECT 2
+
+NAME user macros don't poison stdlib builtin calls
+PROG macro fail(x) { x } begin { print(strlen("hi")); }
+EXPECT 2


### PR DESCRIPTION
Stacked PRs:
 * __->__#5187


--- --- ---

### Allow user-defined macros to override stdlib


If the user provides a macro with the same signature as a stdlib macro then
silently use the user-defined macro and don't error.

This allows us to add more macros in the future without the risk of
breaking existing scripts.

However, this change also makes sure not to override indirect stdlib macro
calls with user-defined macros, which would cause unexpected and confusing
behavior. We make sure that if we're expanding from a stdlib macro that we
only expand other stdlib macros.

Also includes a drive-by update to make sure macros don't have duplicate
arg idents.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>