### PR TITLE
Release/0.26.x backports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to
   - [#5138](https://github.com/bpftrace/bpftrace/pull/5138)
 - Warn instead of error when there is an integer sign mismatch, except for integer literals that are out of range for the destination type
   - [#5148](https://github.com/bpftrace/bpftrace/pull/5148)
+- Stabilize root imports (remove 'unstable_import' flag)
+  - [#5184](https://github.com/bpftrace/bpftrace/pull/5184)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to
   - [#5148](https://github.com/bpftrace/bpftrace/pull/5148)
 - Stabilize root imports (remove 'unstable_import' flag)
   - [#5184](https://github.com/bpftrace/bpftrace/pull/5184)
+- Stabilize address-of operator `&` (remove 'unstable_addr' flag)
+  - [#5185](https://github.com/bpftrace/bpftrace/pull/5185)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/docs/language.md
+++ b/docs/language.md
@@ -745,6 +745,7 @@ A macro's parameter signature specifies how an argument will be used.
 For example `macro test($a, b, @c)` indicates that `$a` needs to be a scratch variable (which might be mutated), that `b` needs to be an expression that will be inserted where ever `b` is used in the macro body, and that `@c` needs to be a map (which might be mutated).
 A valid use of this macro could be `test($x, 1 + 2, @y)`.
 Variables and maps can also be used for ident parameters that expect expressions and would be the same as writing `{ @y }` (Block Expression).
+Note: User-defined macros with the same name and signature as a standard library macro will override the standard library version. However, standard library macros nested inside of other standard library macros will never use the user-defined version of the same signature.
 
 Here are some valid usages of macros:
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -395,7 +395,6 @@ Controls whether maps are printed on exit. Set to `false` in order to change the
 
 These are the list of unstable features:
 - `unstable_tseries` - feature flag for time series map type
-- `unstable_addr` - feature flag for address of operator (&)
 - `unstable_dw_ustack` - feature flag for DWARF-based user-space stack unwinding
 
 All of these accept the following options:
@@ -1769,6 +1768,7 @@ $b = (buffer[256])arg0;   // buffer of 256 bytes
 ### Pointers
 
 Pointers in bpftrace are similar to those found in `C`.
+You can also get the pointer to a bpftrace scratch variable or map using the address-of operator (`&`), e.g. `$a = 1; $b = &$a;`.
 
 ### Structs
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -6,7 +6,7 @@ Each section is optional but must appear in this order:
 1. **[C Definitions](#structs)** — `#include` directives, `#define` macros, and
    `struct`/`union`/`enum` type definitions. Must come before everything else
    (aside from a shebang line).
-2. **[Config Block](#config-block) and Imports** — a `config` block and any `import` statements.
+2. **[Config Block](#config-block) and [Imports](#imports)** — a `config` block and any `import` statements.
    These can appear in any order relative to each other, but must appear after
    C definitions and before action blocks, map declarations, and macros.
 3. **[Action Blocks](#action-blocks), [Macros](#macros), and [Map Declarations](#map-declarations)** — the main body of the
@@ -502,6 +502,78 @@ kprobe:vfs_read /comm == "bash"/ {
 ## Floating-point
 
 Floating-point numbers are not supported by BPF and therefore not by bpftrace.
+
+## Imports
+
+Root-level imports allow you to import other files into your script using the `import` statement.
+
+### Syntax
+
+```
+import "<path>";
+```
+
+Import statements must appear after [C definitions](#structs) but before any [action blocks](#action-blocks), [macros](#macros), or [map declarations](#map-declarations).
+
+### Supported file types
+
+| Extension | Description |
+|-----------|-------------|
+| `.bt` | bpftrace script — probes, macros, and map declarations are merged into the importing script |
+| `.h` | C header — type definitions are made available to the importing script |
+| `.bpf.c` | BPF C source — compiled and linked into the BPF program. These are checked by the BPF verifier. |
+
+If a directory is specified instead of a file, all supported files in that directory (non-recursive) are imported.
+
+### Path resolution
+
+The import path is resolved relative to the directory containing the script that has the `import` statement. For example, if `/home/user/script.bt` contains `import "helpers.bt";`, bpftrace looks for `/home/user/helpers.bt`.
+
+As a security measure, bpftrace refuses to import from world-writable directories.
+
+### Examples
+
+Importing a bpftrace script:
+
+```
+// helpers.bt
+macro greet { print("hello"); }
+```
+
+```
+import "helpers.bt";
+
+begin { greet!(); } // prints "hello"
+```
+
+Importing a C file:
+
+```
+// my_c_lib.bpf.c
+int __add_one(int val) { return 1 + val; }
+```
+
+```
+import "my_c_lib.bpf.c";
+
+begin {
+  print(__add_one(1)); // prints 2
+}
+```
+
+Importing a directory of files:
+
+```
+import "my_lib";
+```
+
+This imports all supported files in the `my_lib/` directory.
+
+### Behavior notes
+
+- Each import path is only imported once. Duplicate imports of the same path are silently ignored.
+- Imported `.bt` scripts can themselves contain `import` statements.
+- An imported `.bt` script cannot contain a `config` block. Only one config block is allowed in the root script.
 
 ## Identifiers
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1942,7 +1942,8 @@ public:
       : Node(ctx, loc + other.loc),
         name(other.name),
         vargs(clone(ctx, loc, other.vargs)),
-        block(clone(ctx, loc, other.block)) {};
+        block(clone(ctx, loc, other.block)),
+        is_stdlib(other.is_stdlib) {};
 
   bool operator==(const Macro &other) const
   {
@@ -1950,11 +1951,15 @@ public:
       return false;
     if (vargs != other.vargs)
       return false;
+    if (is_stdlib != other.is_stdlib)
+      return false;
     return *block == *other.block;
   }
   std::strong_ordering operator<=>(const Macro &other) const
   {
     if (auto cmp = name <=> other.name; cmp != 0)
+      return cmp;
+    if (auto cmp = is_stdlib <=> other.is_stdlib; cmp != 0)
       return cmp;
     if (vargs.size() != other.vargs.size())
       return vargs.size() <=> other.vargs.size();
@@ -1968,6 +1973,7 @@ public:
   std::string name;
   ExpressionList vargs;
   BlockExpr *block = nullptr;
+  bool is_stdlib = false;
 };
 using MacroList = std::vector<Macro *>;
 

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -22,6 +22,7 @@ static bool validate(Macro *macro)
 {
   std::unordered_set<std::string> seen_mvars;
   std::unordered_set<std::string> seen_mmaps;
+  std::unordered_set<std::string> seen_idents;
   for (const auto &arg : macro->vargs) {
     if (auto *mvar = arg.as<Variable>()) {
       auto inserted = seen_mvars.insert(mvar->ident);
@@ -36,6 +37,13 @@ static bool validate(Macro *macro)
       if (!inserted.second) {
         mmap->addError() << "Map for macro argument has already been used: "
                          << mmap->ident;
+        return false;
+      }
+    } else if (auto *ident = arg.as<Identifier>()) {
+      auto inserted = seen_idents.insert(ident->ident);
+      if (!inserted.second) {
+        ident->addError() << "Ident for macro argument has already been used: "
+                          << ident->ident;
         return false;
       }
     }
@@ -56,7 +64,7 @@ MacroRegistry MacroRegistry::create(ASTContext &ast)
     // However we explicitly allow this, as long as they are added in such a way
     // that they will match with the most precise macros first. The newest macro
     // definition must not match with any existing macro definition.
-    auto exists = registry.lookup(macro->name, macro->vargs);
+    auto exists = registry.lookup(macro->name, macro->vargs, macro->is_stdlib);
     if (exists) {
       auto &err = macro->addError();
       err << "Redefinition of macro: " << macro->name;
@@ -91,9 +99,9 @@ static size_t distance(const Macro *macro, const std::vector<Expression> &args)
   return d;
 }
 
-Result<const Macro *> MacroRegistry::lookup(
-    const std::string &name,
-    const std::vector<Expression> &args) const
+Result<const Macro *> MacroRegistry::lookup(const std::string &name,
+                                            const std::vector<Expression> &args,
+                                            std::optional<bool> is_stdlib) const
 {
   const auto it = macros_.find(name);
   if (it == macros_.end()) {
@@ -106,10 +114,23 @@ Result<const Macro *> MacroRegistry::lookup(
   }
   size_t min_distance = std::numeric_limits<size_t>::max();
   std::vector<const Macro *> closest;
+  const Macro *exact_stdlib_match = nullptr;
+  const Macro *exact_user_match = nullptr;
   for (const auto *m : it->second) {
+    // When a lookup explicitly targets stdlib or user-defined macros, treat
+    // the other class as invisible. This avoids turning unrelated builtin or
+    // function calls into macro mismatch errors.
+    if (is_stdlib && m->is_stdlib != *is_stdlib) {
+      continue;
+    }
+
     size_t d = distance(m, args);
     if (d == 0) {
-      return m; // Matched.
+      if (m->is_stdlib && !exact_stdlib_match) {
+        exact_stdlib_match = m;
+      } else if (!m->is_stdlib && !exact_user_match) {
+        exact_user_match = m;
+      }
     }
     if (d < min_distance) {
       min_distance = d;
@@ -119,6 +140,16 @@ Result<const Macro *> MacroRegistry::lookup(
       closest.push_back(m);
     }
   }
+
+  // When both user and stdlib definitions match, prefer the user-defined
+  // macro. Filtered lookups only populate one of these pointers.
+  if (exact_user_match) {
+    return exact_user_match;
+  }
+  if (exact_stdlib_match) {
+    return exact_stdlib_match;
+  }
+
   return make_error<MacroLookupError>(name, std::move(closest));
 }
 
@@ -294,7 +325,13 @@ void MacroExpander::visit(Expression &expr)
   const std::string &name = ident ? ident->ident : call->func;
   const std::vector<Expression> &args = ident ? empty : call->vargs;
 
-  auto result = registry_.lookup(name, args);
+  // If we're being called from a stdlib macro then only expand other stdlib
+  // macros not user-defined macros that also happen to match
+  std::optional<bool> restrict_to_stdlib = std::nullopt;
+  if (!stack_.empty() && stack_.back()->is_stdlib) {
+    restrict_to_stdlib = true;
+  }
+  auto result = registry_.lookup(name, args, restrict_to_stdlib);
   if (!result) {
     auto done = handleErrors(
         std::move(result), [&](const MacroLookupError &lookupErr) {

--- a/src/ast/passes/macro_expansion.h
+++ b/src/ast/passes/macro_expansion.h
@@ -33,11 +33,13 @@ public:
   // This may add errors to conflicting macros.
   static MacroRegistry create(ASTContext &ast);
 
-  // Lookup a macro based on a name and set of arguments.
+  // Lookup a macro based on a name, set of arguments, and if it's stdlib
   //
   // If no matching macro is found, `nullptr` is returned.
-  Result<const Macro *> lookup(const std::string &name,
-                               const std::vector<Expression> &args) const;
+  Result<const Macro *> lookup(
+      const std::string &name,
+      const std::vector<Expression> &args,
+      std::optional<bool> is_stdlib = std::nullopt) const;
 
 private:
   // This holds the definitions for all discovered macros.

--- a/src/ast/passes/resolve_imports.cpp
+++ b/src/ast/passes/resolve_imports.cpp
@@ -292,6 +292,17 @@ Result<OK> Imports::import_any(Node &node,
   return OK();
 }
 
+static void mark_stdlib_macros(ASTContext &ast)
+{
+  if (!ast.root) {
+    return;
+  }
+
+  for (auto *macro : ast.root->macros) {
+    macro->is_stdlib = true;
+  }
+}
+
 Result<OK> Imports::import_stdlib(
     Node &node,
     const std::string &name,
@@ -327,6 +338,7 @@ Result<OK> Imports::import_stdlib(
     return OK();
   }
   auto &ast = **result;
+  mark_stdlib_macros(ast);
 
   ResolveStdlibMacroImports resolver(*this, macro_name, paths);
   resolver.visit(ast.root);

--- a/src/ast/passes/unstable_feature.cpp
+++ b/src/ast/passes/unstable_feature.cpp
@@ -44,7 +44,6 @@ public:
   using Visitor<UnstableFeature>::visit;
   void visit(MapAddr &map_addr);
   void visit(VariableAddr &var_addr);
-  void visit(RootImport &imp);
   void visit(StatementImport &imp);
   void visit(Call &call);
   void visit(Typeinfo &typeinfo);
@@ -80,20 +79,6 @@ void UnstableFeature::visit(StatementImport &imp)
       !warned_features.contains(UNSTABLE_IMPORT_STATEMENT)) {
     LOG(WARNING) << get_warning(IMPORT_STATEMENTS, UNSTABLE_IMPORT_STATEMENT);
     warned_features.insert(UNSTABLE_IMPORT_STATEMENT);
-  }
-}
-
-void UnstableFeature::visit(RootImport &imp)
-{
-  if (bpftrace_.config_->unstable_import == ConfigUnstable::error) {
-    imp.addError() << get_error(IMPORTS, UNSTABLE_IMPORT);
-    return;
-  }
-
-  if (bpftrace_.config_->unstable_import == ConfigUnstable::warn &&
-      !warned_features.contains(UNSTABLE_IMPORT)) {
-    LOG(WARNING) << get_warning(IMPORTS, UNSTABLE_IMPORT);
-    warned_features.insert(UNSTABLE_IMPORT);
   }
 }
 

--- a/src/ast/passes/unstable_feature.cpp
+++ b/src/ast/passes/unstable_feature.cpp
@@ -42,8 +42,6 @@ public:
   explicit UnstableFeature(BPFtrace &bpftrace) : bpftrace_(bpftrace) {};
 
   using Visitor<UnstableFeature>::visit;
-  void visit(MapAddr &map_addr);
-  void visit(VariableAddr &var_addr);
   void visit(StatementImport &imp);
   void visit(Call &call);
   void visit(Typeinfo &typeinfo);
@@ -53,7 +51,6 @@ private:
   // This set is so we don't warn multiple times for the same feature.
   std::unordered_set<std::string> warned_features;
 
-  void check_unstable_addr(Node &node);
   void check_unstable_tseries(Node &node);
   void check_unstable_dw_ustack(Node &node);
 };
@@ -103,20 +100,6 @@ void UnstableFeature::visit(Typeinfo &typeinfo)
   }
 }
 
-void UnstableFeature::check_unstable_addr(Node &node)
-{
-  if (bpftrace_.config_->unstable_addr == ConfigUnstable::error) {
-    node.addError() << get_error(ADDR, UNSTABLE_ADDR);
-    return;
-  }
-
-  if (bpftrace_.config_->unstable_addr == ConfigUnstable::warn &&
-      !warned_features.contains(UNSTABLE_ADDR)) {
-    LOG(WARNING) << get_warning(ADDR, UNSTABLE_ADDR);
-    warned_features.insert(UNSTABLE_ADDR);
-  }
-}
-
 void UnstableFeature::check_unstable_tseries(Node &node)
 {
   if (bpftrace_.config_->unstable_tseries == ConfigUnstable::error) {
@@ -148,16 +131,6 @@ void UnstableFeature::check_unstable_dw_ustack(Node &node)
     warned_features.insert(UNSTABLE_DW_USTACK);
   }
 #endif // HAVE_DW_UNWIND
-}
-
-void UnstableFeature::visit(MapAddr &map_addr)
-{
-  check_unstable_addr(map_addr);
-}
-
-void UnstableFeature::visit(VariableAddr &var_addr)
-{
-  check_unstable_addr(var_addr);
 }
 
 Pass CreateUnstableFeaturePass()

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -328,7 +328,6 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { "show_debug_info", CONFIG_FIELD_PARSER(show_debug_info) },
   { UNSTABLE_IMPORT_STATEMENT, CONFIG_FIELD_PARSER(unstable_import_statement) },
   { UNSTABLE_TSERIES, CONFIG_FIELD_PARSER(unstable_tseries) },
-  { UNSTABLE_ADDR, CONFIG_FIELD_PARSER(unstable_addr) },
   { UNSTABLE_TYPEINFO, CONFIG_FIELD_PARSER(unstable_typeinfo) },
   { UNSTABLE_DW_USTACK, CONFIG_FIELD_PARSER(unstable_dw_ustack) },
 };

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -326,7 +326,6 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { "print_maps_on_exit", CONFIG_FIELD_PARSER(print_maps_on_exit) },
   { "use_blazesym", CONFIG_FIELD_PARSER(use_blazesym) },
   { "show_debug_info", CONFIG_FIELD_PARSER(show_debug_info) },
-  { UNSTABLE_IMPORT, CONFIG_FIELD_PARSER(unstable_import) },
   { UNSTABLE_IMPORT_STATEMENT, CONFIG_FIELD_PARSER(unstable_import_statement) },
   { UNSTABLE_TSERIES, CONFIG_FIELD_PARSER(unstable_tseries) },
   { UNSTABLE_ADDR, CONFIG_FIELD_PARSER(unstable_addr) },

--- a/src/config.h
+++ b/src/config.h
@@ -32,16 +32,12 @@ enum CompatibleBPFLicense {
 
 static const auto UNSTABLE_IMPORT_STATEMENT = "unstable_import_statement";
 static const auto UNSTABLE_TSERIES = "unstable_tseries";
-static const auto UNSTABLE_ADDR = "unstable_addr";
 static const auto UNSTABLE_TYPEINFO = "unstable_typeinfo";
 static const auto UNSTABLE_DW_USTACK = "unstable_dw_ustack";
 
 static std::unordered_set<std::string> DEPRECATED_CONFIGS = {
-  "symbol_source",
-  "max_type_res_iterations",
-  "unstable_import",
-  "unstable_macro",
-  "unstable_map_decl"
+  "symbol_source",   "max_type_res_iterations", "unstable_addr",
+  "unstable_import", "unstable_macro",          "unstable_map_decl"
 };
 
 class Config {
@@ -66,7 +62,6 @@ public:
   bool print_maps_on_exit = true;
   ConfigUnstable unstable_import_statement = ConfigUnstable::error;
   ConfigUnstable unstable_tseries = ConfigUnstable::warn;
-  ConfigUnstable unstable_addr = ConfigUnstable::warn;
   ConfigUnstable unstable_typeinfo = ConfigUnstable::error;
   ConfigUnstable unstable_dw_ustack = ConfigUnstable::warn;
 #ifdef HAVE_BLAZESYM

--- a/src/config.h
+++ b/src/config.h
@@ -30,7 +30,6 @@ enum CompatibleBPFLicense {
   DUAL_MPL_GPL
 };
 
-static const auto UNSTABLE_IMPORT = "unstable_import";
 static const auto UNSTABLE_IMPORT_STATEMENT = "unstable_import_statement";
 static const auto UNSTABLE_TSERIES = "unstable_tseries";
 static const auto UNSTABLE_ADDR = "unstable_addr";
@@ -40,6 +39,7 @@ static const auto UNSTABLE_DW_USTACK = "unstable_dw_ustack";
 static std::unordered_set<std::string> DEPRECATED_CONFIGS = {
   "symbol_source",
   "max_type_res_iterations",
+  "unstable_import",
   "unstable_macro",
   "unstable_map_decl"
 };
@@ -64,7 +64,6 @@ public:
   bool cpp_demangle = true;
   bool lazy_symbolication = true;
   bool print_maps_on_exit = true;
-  ConfigUnstable unstable_import = ConfigUnstable::warn;
   ConfigUnstable unstable_import_statement = ConfigUnstable::error;
   ConfigUnstable unstable_tseries = ConfigUnstable::warn;
   ConfigUnstable unstable_addr = ConfigUnstable::warn;

--- a/tests/imports.cpp
+++ b/tests/imports.cpp
@@ -83,7 +83,6 @@ void test(const std::string &input,
           std::variant<checkFn, std::string> check)
 {
   BPFtrace bpftrace;
-  bpftrace.config_->unstable_import = ConfigUnstable::enable;
   ast::ASTContext ast("stdin", input);
   std::stringstream msg;
   msg << "\nInput:\n" << input << "\n\nOutput:\n";

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -1,4 +1,6 @@
 #include "ast/passes/macro_expansion.h"
+#include "ast/passes/import_scripts.h"
+#include "ast/passes/resolve_imports.h"
 #include "mocks.h"
 #include "parser.h"
 #include "gtest/gtest.h"
@@ -24,6 +26,8 @@ void test(const std::string& input,
                 .put(ast)
                 .put(bpftrace)
                 .add(CreateParsePass())
+                .add(ast::CreateResolveRootImportsPass({}))
+                .add(ast::CreateImportInternalScriptsPass())
                 .add(ast::CreateMacroExpansionPass())
                 .run();
 
@@ -91,6 +95,10 @@ TEST(macro_expansion, basic_checks)
              "1 but got 2");
   test_error("macro set($x, $x) { $x += 1; $x } begin { $a = 1; set($a, 1); }",
              "Variable for macro argument has already been used: $x");
+  test_error("macro set(@x, @x) { @x } begin { @a = 1; set(@a, @a); }",
+             "Map for macro argument has already been used: @x");
+  test_error("macro set(x, x) { x } begin { set(1, 1); }",
+             "Ident for macro argument has already been used: x");
   test_error("macro set($x) { $x += 1; $x } macro set($x) { $x } begin { $a = "
              "1; set($a, 1); }",
              "Redefinition of macro: set");
@@ -211,6 +219,27 @@ stdin:1:12-15: ERROR: syntax: builtin 'pid' can't be used as a macro argument
 macro test(pid) { } begin { }
            ~~~
 )");
+}
+
+TEST(macro_expansion, stdlib_shadowing)
+{
+  // User macro with same name and signature shadows the stdlib version.
+  test("macro cpu() { 42 } begin { print(cpu()); }");
+
+  // User macro with same name but different signature coexists with stdlib.
+  // cpu(x) is user-defined, cpu() is from stdlib — both should work.
+  test("macro cpu(x) { x } begin { print(cpu(1)); print(cpu()); }");
+
+  // User macro shadows matching stdlib overload but non-matching stdlib
+  // overloads remain available. comm() has multiple stdlib overloads.
+  test("macro comm() { \"me\" } begin { print(comm()); }");
+
+  // User-to-user redefinitions should still error.
+  test_error("macro cpu() { 1 } macro cpu() { 2 } begin { print(cpu()); }",
+             "Redefinition of macro: cpu");
+
+  // User macros should not poison builtin/function calls inside stdlib macros.
+  test("macro fail(x) { x } begin { print(strlen(\"hi\")); }");
 }
 
 } // namespace bpftrace::test::macro_expansion

--- a/tests/runtime/interop
+++ b/tests/runtime/interop
@@ -1,3 +1,3 @@
 NAME interop return types
-PROG config = { unstable_import=true; } import "stdlib/test"; begin { print(__always_true()); exit(); }
+PROG import "stdlib/test"; begin { print(__always_true()); exit(); }
 EXPECT 1

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -188,3 +188,20 @@ ARCH x86_64
 NAME builtin wrapper username
 PROG begin { if (__builtin_username == username() && __builtin_username == username) { printf("SUCCESS %s\n", username); } }
 EXPECT_REGEX SUCCESS .*
+
+NAME user macros override stdlib
+PROG macro cpu() { "hi" } begin { printf(cpu()); }
+EXPECT_REGEX hi
+
+NAME user macros don't override stdlib if different signature
+PROG macro cpu(x) { x } begin { print(cpu("hi")); printf("SUCCESS %llu\n", cpu()); }
+EXPECT_REGEX hi
+EXPECT_REGEX SUCCESS [0-9]+
+
+NAME user macros don't override indirect stdlib macros
+PROG macro assert_str(exp) { fail("boom") } begin { print(strlen("hi")); }
+EXPECT 2
+
+NAME user macros don't poison stdlib builtin calls
+PROG macro fail(x) { x } begin { print(strlen("hi")); }
+EXPECT 2

--- a/tests/unstable_feature.cpp
+++ b/tests/unstable_feature.cpp
@@ -50,17 +50,6 @@ TEST(unstable_feature, check_error)
       "tseries feature is not enabled by default. To enable this unstable "
       "feature, set the config flag to enable. unstable_tseries=enable");
 
-  test("config = { unstable_addr=warn } begin { $x = 1; &$x; }");
-  test_error("config = { unstable_addr=error } begin { $x = 1; &$x; }",
-             "address-of operator (&) feature is not enabled by default. To "
-             "enable this unstable "
-             "feature, set the config flag to enable. unstable_addr=enable");
-  test("config = { unstable_addr=warn } begin { @x = 1; &@x; }");
-  test_error("config = { unstable_addr=error } begin { @x = 1; &@x; }",
-             "address-of operator (&) feature is not enabled by default. To "
-             "enable this unstable "
-             "feature, set the config flag to enable. unstable_addr=enable");
-
 #ifdef HAVE_DW_UNWIND
   test("config = { unstable_dw_ustack=warn } uprobe:./a:main "
        "{ @ = dw_ustack(); }");


### PR DESCRIPTION
3 commits

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
