### PR TITLE
tests: migrate more tuple runtime tests to selftest

### DIFF
--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -6,48 +6,6 @@ NAME basic tuple map
 PROG begin { $v = 99; @t = (0, 1, "str"); printf("%d %d %s\n", @t.0, @t.1, @t.2);  }
 EXPECT 0 1 str
 
-NAME mixed int tuple map
-PROG begin { @ = ( (int32) -100, (int8) 10, 50 ); }
-EXPECT @: (-100, 10, 50)
-
-NAME mixed int tuple map 2
-PROG begin { @ = ( -100, (int8) 10, (int32) 50 ); }
-EXPECT @: (-100, 10, 50)
-
-NAME mixed int tuple map 3
-PROG begin { @ = ( -100, (int8) 10, (int32) 50, 100 ); }
-EXPECT @: (-100, 10, 50, 100)
-
-NAME tuple map key
-PROG begin { @[(1, "hello")] = 1; }
-EXPECT @[1, hello]: 1
-
-NAME tuple map key and value
-PROG begin { @[(1, 2)] = (3, 4); }
-EXPECT @[1, 2]: (3, 4)
-
-NAME implicit conversion of multi map key to tuple
-PROG begin { @["abcd", 2] = (3, 4, 5); }
-EXPECT @[abcd, 2]: (3, 4, 5)
-
-NAME tuple map key same as assoc array
-PROG begin { @[(1, "hello")] = 1;  @[2, "hello"] = 2; delete(@, (1, "hello")); }
-EXPECT @[2, hello]: 2
-
-NAME tuple map key variable
-PROG begin { $a = (1, "hello"); @[(1, "hello")] = 1; @[$a] = 2; }
-EXPECT @[1, hello]: 2
-
-NAME tuple map key string resize
-PROG begin { @a["hellotherelongstr", 4] = 1; @a["by", 6] = 2;  }
-EXPECT @a[hellotherelongstr, 4]: 1
-EXPECT @a[by, 6]: 2
-
-NAME tuple map key compatible int sizes
-PROG begin { $a = (1,(123,(uint64)1234)); $b = (4,(1234,(uint8)123)); @a[$a] = 1; @a[$b] = 2;  }
-EXPECT @a[1, (123, 1234)]: 1
-EXPECT @a[4, (1234, 123)]: 2
-
 NAME complex tuple 1
 PROG begin { print(((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555));  }
 EXPECT (-100, 100, abcdef, 3, 1, -10, 10, -555)
@@ -125,13 +83,3 @@ EXPECT Attached 1 probe
 NAME kstack in tuple
 PROG begin { print((kstack, "a"));  }
 EXPECT Attached 1 probe
-
-NAME tuple binop equals
-PROG begin { $x = ("hello", -6); $y = ("hello", -6); $a = (1, true, $x); @b = (1, true, $y); if ($a == @b) { printf("ok\n"); } if ($a == (1, true, ("ello", -6))) { printf("nok\n"); } }
-EXPECT ok
-EXPECT_NONE nok
-
-NAME tuple binop not equals
-PROG begin { $x = ("hello", -6); $y = ("hello", -6); $a = (1, true, $x); @b = (1, true, $y); if ($a != @b) { printf("nok\n"); } if ($a != (1, true, ("ello", -6))) { printf("ok\n"); } }
-EXPECT ok
-EXPECT_NONE nok

--- a/tests/self/tuple.bt
+++ b/tests/self/tuple.bt
@@ -1,0 +1,143 @@
+test:tuple_binop_equals {
+  $x = ("hello", -6);
+  $y = ("hello", -6);
+  $a = (1, true, $x);
+  @b = (1, true, $y);
+
+  if (!($a == @b)) {
+    return 1;
+  }
+
+  if ($a == (1, true, ("ello", -6))) {
+    return 1;
+  }
+
+  if ($a != @b) {
+    return 1;
+  }
+
+  if (!($a != (1, true, ("ello", -6)))) {
+    return 1;
+  }
+}
+
+test:mixed_int_tuple_map {
+  @mixed_int_tuple_map_a = ((int32) -100, (int8) 10, 50);
+  @mixed_int_tuple_map_b = (-100, (int8) 10, (int32) 50);
+  @mixed_int_tuple_map_c = (-100, (int8) 10, (int32) 50, 100);
+
+  if (@mixed_int_tuple_map_a.0 != -100) {
+    return 1;
+  }
+  if (@mixed_int_tuple_map_a.1 != 10) {
+    return 1;
+  }
+  if (@mixed_int_tuple_map_a.2 != 50) {
+    return 1;
+  }
+
+  if (@mixed_int_tuple_map_b.0 != -100) {
+    return 1;
+  }
+  if (@mixed_int_tuple_map_b.1 != 10) {
+    return 1;
+  }
+  if (@mixed_int_tuple_map_b.2 != 50) {
+    return 1;
+  }
+
+  if (@mixed_int_tuple_map_c.0 != -100) {
+    return 1;
+  }
+  if (@mixed_int_tuple_map_c.1 != 10) {
+    return 1;
+  }
+  if (@mixed_int_tuple_map_c.2 != 50) {
+    return 1;
+  }
+  if (@mixed_int_tuple_map_c.3 != 100) {
+    return 1;
+  }
+}
+
+test:tuple_map_key {
+  @tuple_map_key_a[(1, "hello")] = 1;
+
+  if (@tuple_map_key_a[1, "hello"] != 1) {
+    return 1;
+ }
+}
+
+test:tuple_map_key_and_value {
+  @tuple_map_key_and_value_a[(1, 2)] = (3, 4);
+
+  if (@tuple_map_key_and_value_a[(1, 2)] != (3, 4)) {
+    return 1;
+  }
+}
+
+test:tuple_map_key_same_as_assoc_array {
+  @tuple_map_key_same_as_assoc_array_a[(1, "hello")] = 1;
+  @tuple_map_key_same_as_assoc_array_a[2, "hello"] = 2;
+
+  if (!delete(@tuple_map_key_same_as_assoc_array_a, (1, "hello"))) {
+    return 1;
+  }
+
+  if (@tuple_map_key_same_as_assoc_array_a[2, "hello"] != 2) {
+    return 1;
+  }
+}
+
+test:implicit_conversion_of_multi_map_key_to_tuple {
+  @implicit_conversion_of_multi_map_key_to_tuple_a["abcd", 2] = (3, 4, 5);
+
+  for ($kv : @implicit_conversion_of_multi_map_key_to_tuple_a) {
+    if ($kv.0 != ("abcd", 2)) {
+      return 1;
+    }
+
+    if ($kv.1 != (3, 4, 5)) {
+      return 1;
+    }
+  }
+}
+
+test:tuple_map_key_variable {
+  $a = (1, "hello");
+  @tuple_map_key_variable_a[(1, "hello")] = 1;
+  @tuple_map_key_variable_a[$a] = 2;
+
+  if (@tuple_map_key_variable_a[(1, "hello")] != 2) {
+    return 1;
+  }
+}
+
+test:tuple_map_key_string_resize {
+  @tuple_map_key_string_resize_a["hellotherelongstr", 4] = 1;
+  @tuple_map_key_string_resize_a["by", 6] = 2;
+
+  if (@tuple_map_key_string_resize_a["hellotherelongstr", 4] != 1) {
+    return 1;
+  }
+
+  if (@tuple_map_key_string_resize_a["by", 6] != 2) {
+    return 1;
+  }
+}
+
+test:tuple_map_key_compatible_int_size {
+  $a = (1, (123, (uint64) 1234));
+  $b = (4, (1234, (uint8) 123));
+
+  @tuple_map_key_compatible_int_size_a[$a] = 1;
+  @tuple_map_key_compatible_int_size_a[$b] = 2;
+
+  if (@tuple_map_key_compatible_int_size_a[1, (123, 1234)] != 1) {
+    return 1;
+  }
+
+  if (@tuple_map_key_compatible_int_size_a[4, (1234, 123)] != 2) {
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary

Move additional tuple runtime tests to selftests.

This migrates tuple equality checks and tuple map key/value cases from
`tests/runtime/tuples` to `tests/self/tuple.bt`.

## Testing

* `./build/tests/self-tests.sh --filter tuple`
* `./build/tests/runtime-tests.sh --filter tuples`
