### PR TITLE
Update CHANGELOG for the 0.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-#### Breaking Changes
-#### Added
-#### Deprecated
-#### Removed
-#### Fixed
-#### Security
-#### Docs
-#### Tools
-
-## [0.26.0] TBD
+## [0.26.0] 2026-06-26
 
 #### Breaking Changes
 - stdlib: Change `pcomm` to an alias of task.real_parent.comm instead of task.group_leader.comm.
@@ -56,8 +45,6 @@ and this project adheres to
   - [#5184](https://github.com/bpftrace/bpftrace/pull/5184)
 - Stabilize address-of operator `&` (remove 'unstable_addr' flag)
   - [#5185](https://github.com/bpftrace/bpftrace/pull/5185)
-#### Deprecated
-#### Removed
 #### Fixed
 - Silence warning hints when warnings are disabled (`--no-warnings`)
   - [#5151](https://github.com/bpftrace/bpftrace/pull/5151)
@@ -81,8 +68,6 @@ and this project adheres to
   - [#5104](https://github.com/bpftrace/bpftrace/pull/5104)
 - Fix un-aligned map key access for hist/lhist/tseries map types
   - [#5181](https://github.com/bpftrace/bpftrace/pull/5181)
-#### Security
-#### Docs
 #### Tools
 - naptime.bt: Filter out failed calls and add clock_nanosleep support
   - [#5117](https://github.com/bpftrace/bpftrace/pull/5117)


### PR DESCRIPTION
List of highlights to be included in the release description (for review):
- Stabilize imports of other bpfscript files and BPF C sources
- Stabilize address-of operator (`&`)
- DWARF-based stack unwinding for user-space
- Statement probes (`uprobe:binary@file:line[:column]`)
- New builtin `write_user(dst, src, len)` to write to user-space memory
- Fix subtraction and decrement ops not producing the correct type