### PR TITLE
Fix: retval and argX for session probes

### DIFF
--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -210,34 +210,13 @@ std::optional<Expression> Builtins::visit(Builtin &builtin)
       builtin.addError() << "The func builtin can not be used with '"
                          << probe->attach_points[0]->provider << "' probes";
     }
-  } else if (builtin.ident == "__builtin_retval") {
-    auto *probe = get_probe(builtin, builtin.ident);
-    if (probe == nullptr)
-      return std::nullopt;
-    ProbeType type = probe->get_probetype();
-    if (type != ProbeType::kretprobe && type != ProbeType::uretprobe &&
-        type != ProbeType::fentry && type != ProbeType::fexit) {
-      builtin.addError()
-          << "The retval builtin can only be used with 'kretprobe' and "
-          << "'uretprobe' and 'fentry' probes"
-          << (type == ProbeType::tracepoint ? " (try to use args.ret instead)"
-                                            : "");
-    }
   } else if (builtin.is_argx()) {
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)
       return std::nullopt;
     int arg_num = atoi(builtin.ident.substr(3).c_str());
-    ProbeType type = probe->get_probetype();
-    if (type != ProbeType::kprobe && type != ProbeType::uprobe &&
-        type != ProbeType::usdt && type != ProbeType::rawtracepoint) {
-      // N.B. this works for rawtracepoints but it's discouraged
-      builtin.addError() << "The " << builtin.ident
-                         << " builtin can only be used with "
-                         << "'kprobes', 'uprobes' and 'usdt' probes";
-    }
     // argx in USDT probes doesn't need to check against arch::max_arg()
-    if (type != ProbeType::usdt &&
+    if (probe->get_probetype() != ProbeType::usdt &&
         static_cast<size_t>(arg_num) >= arch::Host::arguments().size()) {
       builtin.addError() << arch::Host::Machine << " doesn't support "
                          << builtin.ident;
@@ -319,5 +298,40 @@ Pass CreateBuiltinsPass()
 
   return Pass::create("Builtins", fn);
 };
+
+Pass CreatePreExpansionBuiltinsPass()
+{
+  auto fn = [](ASTContext &ast, BPFtrace &) {
+    for (auto *probe : ast.root->probes) {
+      CollectNodes<Builtin> collector;
+      collector.visit(*probe);
+      for (const Builtin &builtin : collector.nodes()) {
+        for (auto *ap : probe->attach_points) {
+          ProbeType type = probetype(ap->provider);
+          if (builtin.ident == "__builtin_retval") {
+            if (type != ProbeType::kretprobe && type != ProbeType::uretprobe &&
+                type != ProbeType::fentry && type != ProbeType::fexit) {
+              builtin.addError()
+                  << "The retval builtin can only be used with 'kretprobe' "
+                     "and 'uretprobe' and 'fentry' probes"
+                  << (type == ProbeType::tracepoint
+                          ? " (try to use args.ret instead)"
+                          : "");
+            }
+          } else if (builtin.is_argx()) {
+            if (type != ProbeType::kprobe && type != ProbeType::uprobe &&
+                type != ProbeType::usdt && type != ProbeType::rawtracepoint) {
+              builtin.addError() << "The " << builtin.ident
+                                 << " builtin can only be used with "
+                                    "'kprobes', 'uprobes' and 'usdt' probes";
+            }
+          }
+        }
+      }
+    }
+  };
+
+  return Pass::create("BuiltinProbeCheck", fn);
+}
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/builtins.h
+++ b/src/ast/passes/builtins.h
@@ -4,6 +4,10 @@
 
 namespace bpftrace::ast {
 
+// Validate builtins that have probe-type restrictions before probe expansion
+// merges probes (e.g. session expansion merging kprobe + kretprobe).
+Pass CreatePreExpansionBuiltinsPass();
+
 // Fill in the values of all intrinsics.
 Pass CreateBuiltinsPass();
 

--- a/src/ast/passes/parse_passes.h
+++ b/src/ast/passes/parse_passes.h
@@ -52,6 +52,7 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateControlFlowPass());
   passes.emplace_back(CreateMacroExpansionPass());
   passes.emplace_back(CreateParseBTFPass());
+  passes.emplace_back(CreatePreExpansionBuiltinsPass());
   passes.emplace_back(CreateProbeAndApExpansionPass());
   passes.emplace_back(CreateProbePrunePass());
   passes.emplace_back(CreateArgsResolverPass());

--- a/tests/builtins.cpp
+++ b/tests/builtins.cpp
@@ -29,6 +29,7 @@ void test(const std::string& input,
                 .put(get_mock_function_info())
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
+                .add(ast::CreatePreExpansionBuiltinsPass())
                 .add(ast::CreateBuiltinsPass())
                 .run();
 
@@ -260,6 +261,34 @@ fexit:k { __builtin_func }
     test_error(probe + " { __builtin_func }",
                "ERROR: The func builtin can not be used with");
   }
+}
+
+TEST(builtins, retval_in_session_probe)
+{
+  test("kprobe:sys_* { @entry = 1 } kretprobe:sys_* { __builtin_retval }");
+  test("kprobe:sys_read { @entry = 1 } "
+       "kretprobe:sys_read { __builtin_retval }");
+  test_error("kprobe:sys_* { __builtin_retval } kretprobe:sys_* { @exit = 1 }",
+             "ERROR: The retval builtin can only be used with 'kretprobe' and "
+             "'uretprobe' and 'fentry' probes");
+  test_error("kprobe:sys_read { __builtin_retval } "
+             "kretprobe:sys_read { @exit = 1 }",
+             "ERROR: The retval builtin can only be used with 'kretprobe' and "
+             "'uretprobe' and 'fentry' probes");
+}
+
+TEST(builtins, argx_in_session_probe)
+{
+  test("kprobe:sys_* { $x = arg0; } kretprobe:sys_* { @exit = 1 }");
+  test("kprobe:sys_read { $x = arg0; } kretprobe:sys_read { @exit = 1 }");
+  test_error(
+      "kprobe:sys_* { @entry = 1 } kretprobe:sys_* { $x = arg0; }",
+      "ERROR: The arg0 builtin can only be used with 'kprobes', 'uprobes' "
+      "and 'usdt' probes");
+  test_error(
+      "kprobe:sys_read { @entry = 1 } kretprobe:sys_read { $x = arg0; }",
+      "ERROR: The arg0 builtin can only be used with 'kprobes', 'uprobes' "
+      "and 'usdt' probes");
 }
 
 } // namespace bpftrace::test::buitins

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -166,3 +166,11 @@ NAME maps with hidden key fields aligned access
 PROG begin{ @a[(uint8)1] = hist(3,0); @b = count(); }
 EXPECT Attached 1 probe
 TIMEOUT 1
+
+# https://github.com/bpftrace/bpftrace/issues/5194
+NAME session_retval
+RUN {{BPFTRACE}} -e 'kprobe:ksys_read { print("enter"); } kretprobe:ksys_read { print(retval); }'
+AFTER ./testprogs/syscall read
+EXPECT Attached 1 probe
+TIMEOUT 1
+REQUIRES_FEATURE kprobe_session


### PR DESCRIPTION
Stacked PRs:
 * __->__#5195


--- --- ---

### Fix: retval and argX for session probes


There is a bug where we fail valid programs that use `retval` in a return
probe that gets merged into a session probe.

This also adds checking to make sure the argX builtin is not used in return
probes that get merged into a session probe.

This bug has been around for a while but became more noticeable when we
allowed non-wildcard probes to be merged into session probes.

The fix is to move the check for these two builtins before probe expansion.

Fixes: https://github.com/bpftrace/bpftrace/issues/5194

Signed-off-by: Jordan Rome <jordalgo@meta.com>