### PR TITLE
tests/self: migrate basic runtime tests

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -283,20 +283,10 @@ EXPECT_NONE @: 0
 EXPECT_NONE @a[1]: 1
 TIMEOUT 1
 
-NAME increment/decrement map
-PROG begin { @x = 10; printf("%d", @x++); printf(" %d", ++@x); printf(" %d", @x--); printf(" %d\n", --@x); delete(@x); }
-EXPECT 10 12 12 10
-TIMEOUT 1
-
 NAME parallel map access
 RUN {{BPFTRACE}} runtime/scripts/parallel_map_access.bt --no-warnings
 EXPECT SUCCESS
 TIMEOUT 10
-
-NAME increment/decrement variable
-PROG begin { $x = 10; printf("%d", $x++); printf(" %d", ++$x); printf(" %d", $x--); printf(" %d\n", --$x);  }
-EXPECT 10 12 12 10
-TIMEOUT 1
 
 NAME spawn child
 RUN {{BPFTRACE}} -e 'i:ms:500 { printf("%d\n", cpid); }' --cmd './testprogs/syscall nanosleep 1e9'
@@ -332,16 +322,6 @@ EXPECT stdin:1:15-35: ERROR: Failed to resolve kernel symbol: asdfzzzzzzz
 TIMEOUT 1
 WILL_FAIL
 
-NAME variable strings are memset
-PROG begin { $x = "xxxxx"; $x = "a"; @[$x] = 1; $y = "yyyyy"; $y = "a"; @[$y] = 1; printf("len: %d\n", len(@));  }
-EXPECT len: 1
-TIMEOUT 1
-
-NAME map strings are memset
-PROG begin { @x = "xxxxx"; @x = "a"; @[@x] = 1; @y = "yyyyy"; @y = "a"; @[@y] = 1; printf("len: %d\n", len(@));  }
-EXPECT len: 1
-TIMEOUT 1
-
 NAME print_per_cpu_map_vals
 REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @a = avg(5); @c = count(); @s = sum(5); @mn = min(1); @mx = max(-1); print((@a, @c, @s, @mn, @mx));  }
@@ -349,7 +329,7 @@ EXPECT (5, 1, 5, 1, -1)
 TIMEOUT 3
 
 NAME print large int
-PROG begin { $a = 10223372036854775807; print(($a));  }
+PROG begin { $a = 10223372036854775807; print(($a)); }
 EXPECT 10223372036854775807
 TIMEOUT 1
 
@@ -372,10 +352,6 @@ PROG begin { exit(69); }
 RETURN_CODE 69
 TIMEOUT 1
 
-NAME block expression
-PROG begin { let $a = { let $b = 1; $b }; print($a);  }
-EXPECT 1
-
 NAME print block expression with print
 PROG begin { print({ $x = 1; print ("bob"); $x > 1 }); }
 EXPECT bob
@@ -384,18 +360,6 @@ EXPECT false
 NAME block expression with condition
 PROG begin { if ({ let $a = true; $a }) { print ("bob"); } }
 EXPECT bob
-
-NAME block expression complex
-PROG begin { $x = { $y = { $z = 10; $z + 5 }; $y * 2 }; print($x); }
-EXPECT 30
-
-NAME logical and with different types
-PROG begin { $x = 5; $y = true; if ($x && $y) { print("ok"); } }
-EXPECT ok
-
-NAME logical or with different types
-PROG begin { $x = 0; $y = true; if ($x || $y) { print("ok"); } }
-EXPECT ok
 
 NAME bitshift
 PROG begin { @x = 1 << 10; @y = 1024 >> 9; }

--- a/tests/self/basic.bt
+++ b/tests/self/basic.bt
@@ -1,3 +1,96 @@
 test:noop
 {
 }
+
+test:increment_decrement_map {
+  @x = 10;
+
+  if (@x++ != 10) { return 1; }
+  if (++@x != 12) { return 1; }
+  if (@x-- != 12) { return 1; }
+  if (--@x != 10) { return 1; }
+
+  _ = delete(@x);
+}
+
+test:increment_decrement_variable {
+  $x = 10;
+
+  if ($x++ != 10) { return 1; }
+  if (++$x != 12) { return 1; }
+  if ($x-- != 12) { return 1; }
+  if (--$x != 10) { return 1; }
+}
+
+test:variable_strings_are_memset {
+  $x = "xxxxx";
+  $x = "a";
+
+  @variable_strings_are_memset[$x] = 1;
+  $y = "yyyyy";
+  $y = "a";
+
+  @variable_strings_are_memset[$y] = 1;
+
+  if (len(@variable_strings_are_memset) != 1) {
+    return 1;
+  }
+}
+
+test:map_strings_are_memset {
+  @map_strings_are_memset_x = "xxxxx";
+  @map_strings_are_memset_x = "a";
+  @map_strings_are_memset[@map_strings_are_memset_x] = 1;
+  @map_strings_are_memset_y = "yyyyy";
+  @map_strings_are_memset_y = "a";
+  @map_strings_are_memset[@map_strings_are_memset_y] = 1;
+
+  if (len(@map_strings_are_memset) != 1) {
+    return 1;
+  }
+
+  _ = delete(@map_strings_are_memset_x);
+  _ = delete(@map_strings_are_memset_y);
+}
+
+test:block_expression {
+ let $a = {
+   let $b = 1;
+   $b
+ };
+ if ($a != 1) {
+   return 1;
+ }
+}
+
+test:block_expression_complex {
+  $x = {
+    $y = {
+      $z = 10;
+      $z + 5
+    };
+    $y * 2
+  };
+
+  if ($x != 30) {
+    return 1;
+  }
+}
+
+test:logical_and_with_different_types {
+  $x = 5;
+  $y = true;
+
+  if (!($x && $y)) {
+    return 1;
+  }
+}
+
+test:logical_or_with_different_types {
+  $x = 0;
+  $y = true;
+
+  if (!($x || $y)) {
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary

Migrate several simple runtime tests from `tests/runtime/basic` to self tests in `tests/self/basic.bt`.

Migrated tests:

* increment/decrement map
* increment/decrement variable
* variable strings are memset
* map strings are memset
* print large int
* block expression
* block expression complex
* logical and/or with different types

## Testing

```bash
cmake --build build --target self_test_files
sudo ./build/tests/self-tests.sh --filter basic
```
