### PR TITLE
Fix self probe listing

### DIFF
--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -602,6 +602,12 @@ std::vector<std::string> ProbeMatcher::get_probes_for_listing(
   }
 
   for (const auto& probe_type_str : probe_types) {
+    if (probe_type_str == "self") {
+      auto self_probes = get_self_probes_for_listing(search_suffix);
+      results.insert(results.end(), self_probes.begin(), self_probes.end());
+      continue;
+    }
+
     auto probe_type = probetype(probe_type_str);
     if (probe_type == ProbeType::invalid)
       continue;
@@ -660,6 +666,23 @@ std::vector<std::string> ProbeMatcher::get_probes_for_listing(
 
     auto param_lists = get_params_for_matches(probe_type, matches);
     format_matches_for_listing(probe_type, matches, param_lists, results);
+  }
+  return results;
+}
+
+std::vector<std::string> ProbeMatcher::get_self_probes_for_listing(
+    const std::string& search_input)
+{
+  std::string probes;
+  for (const auto& signal : SIGNALS) {
+    probes += "signal:" + signal + "\n";
+  }
+
+  std::istringstream probe_stream(probes);
+  std::vector<std::string> results;
+  auto search = search_input.empty() ? "*" : search_input;
+  for (const auto& match : get_matches_in_stream(search, probe_stream, false)) {
+    results.push_back("self:" + match);
   }
   return results;
 }

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -99,9 +99,12 @@ private:
       bool demangle_symbols);
   std::set<std::string> get_matches_in_set(const std::string &search_input,
                                            const std::set<std::string> &set);
+  std::vector<std::string> get_self_probes_for_listing(
+      const std::string &search_input);
 
   virtual std::unique_ptr<std::istream> get_symbols_from_traceable_funcs(
-      bool with_modules = false, std::optional<std::string> module = std::nullopt) const;
+      bool with_modules = false,
+      std::optional<std::string> module = std::nullopt) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_list(
       const std::vector<ProbeListItem> &probes_list) const;
   virtual std::unique_ptr<std::istream> get_fentry_symbols(

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -807,6 +807,28 @@ static std::set<std::string> list_modules(std::string_view ap)
   return bpftrace->list_modules(ast, probe_matcher);
 }
 
+static std::vector<std::string> list_probes(std::string_view pattern)
+{
+  auto bpftrace = get_mock_bpftrace();
+  auto &func_info = get_mock_function_info();
+  ProbeMatcher probe_matcher(bpftrace.get(),
+                             func_info.kernel_info(),
+                             func_info.user_info());
+  return probe_matcher.get_probes_for_listing(std::string(pattern));
+}
+
+TEST(bpftrace, list_self_probe)
+{
+  EXPECT_THAT(list_probes("self:*"),
+              ::testing::ElementsAre("self:signal:SIGUSR1"));
+  EXPECT_THAT(list_probes("self:signal:*"),
+              ::testing::ElementsAre("self:signal:SIGUSR1"));
+  EXPECT_THAT(list_probes("self:signal:SIG*"),
+              ::testing::ElementsAre("self:signal:SIGUSR1"));
+  EXPECT_THAT(list_probes("self:*:*"),
+              ::testing::ElementsAre("self:signal:SIGUSR1"));
+}
+
 // Test modules are extracted when module is not explicit in attachpoint
 TEST(bpftrace, list_modules_kprobe_implicit)
 {


### PR DESCRIPTION
Fixes #4388.

Reopened from #5196 with the same changes but a different commit hash, as requested.

Updates probe listing so explicit self probe patterns list the supported self signal probe instead of falling through to the generic special-probe path.

Covered patterns:
- `self:*`
- `self:signal:*`
- `self:signal:SIG*`
- `self:*:*`

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests