### PR TITLE
tools/xfsdist: Solving the problem of missing xfs module

### DIFF
--- a/tools/xfsdist.bt
+++ b/tools/xfsdist.bt
@@ -74,6 +74,8 @@ config = {
 BEGIN
 {
   printf("Tracing XFS operation latency... Hit Ctrl-C to end.\n");
+  @name[0] = ksym(0);
+  @start[0] = 0;
 }
 
 kprobe:xfs_file_read_iter,


### PR DESCRIPTION
When the XFS file system is not in use and the XFS module is not loaded, the following error will occur: `ERROR: Undefined map: @start`.

```
$ lsblk -o +fstype
NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS                         FSTYPE
nvme0n1     259:0    0   3.7T  0 disk                                     
├─nvme0n1p1 259:1    0   298M  0 part /boot/efi                           vfat
└─nvme0n1p2 259:2    0   3.7T  0 part /                                   ext4
```

```
$ sudo bpftrace xfsdist.bt 
xfsdist.bt:101:9-15: ERROR: Undefined map: @start
  clear(@start);
        ~~~~~~
xfsdist.bt:102:9-14: ERROR: Undefined map: @name
  clear(@name);
        ~~~~~
```

Since we have already delete() the corresponding @start and @name in kretprobe, we can omit clear() in END. After testing, this method works (When the program terminates with `Ctrl-C`, `@start` and `@name` are not printed).
