### PR TITLE
Update CHANGELOG for the 0.26.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,17 @@ and this project adheres to
 #### Docs
 #### Tools
 
-## [0.26.0] 2026-06-26
+## [0.26.1] 2026-06-02
+
+#### Fixed
+- Fix reval and argX for session probes
+  - [#5195](https://github.com/bpftrace/bpftrace/pull/5195)
+- Fix self probe listing
+  - [#5200](https://github.com/bpftrace/bpftrace/pull/5200)
+- Fix statement probes for some compiler versions
+  - [#5201](https://github.com/bpftrace/bpftrace/pull/5201)
+
+## [0.26.0] 2026-05-26
 
 #### Breaking Changes
 - stdlib: Change `pcomm` to an alias of task.real_parent.comm instead of task.group_leader.comm.


### PR DESCRIPTION
Add CHANGELOG entries for the backported fixes.

Also a drive-by fix of the 0.26.0 release date.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
