### PR TITLE
stdlib: docs: Fix the declaration of the func()

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -355,8 +355,10 @@ kprobe:dummy {
 
 
 ### func
-- `string func()`
-- `string func`
+- `ksym_t func()`
+- `ksym_t func`
+- `usym_t func()`
+- `usym_t func`
 
 Name of the current function being traced (kprobes,uprobes,fentry)
 

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -381,7 +381,8 @@ macro find(@map, key, $var) {
   }
 }
 
-// :variant string func()
+// :variant ksym_t func()
+// :variant usym_t func()
 // Name of the current function being traced (kprobes,uprobes,fentry)
 macro func()
 {


### PR DESCRIPTION
The return value of the func function is ksym_t or usym_t, not string.

see also PR https://github.com/bpftrace/bpftrace/pull/5202

