### PR TITLE
Issue a warning if casting to the same type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+#### Changed
+- Warn if casting to the exact same type
+  - [#000](https://github.com/bpftrace/bpftrace/pull/0000)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -939,11 +939,18 @@ void TypeChecker::visit(Cast &cast)
   }
 
   auto rhs = type_map_.type(cast.expr);
+
   if (rhs.IsCTypeTy()) {
     cast.addError() << "Cannot cast from C type \"" << rhs << "\"";
     return;
   } else if (rhs.IsNoneTy()) {
     cast.addError() << "Cannot cast from \"" << rhs << "\" type";
+    return;
+  }
+
+  if (ty == rhs) {
+    cast.addWarning() << "Unnecessary cast: expression is already of type "
+                      << rhs;
     return;
   }
 

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -2411,6 +2411,19 @@ TEST_F(TypeCheckerTest, cast_string)
   test("kprobe:f { $a = (string)5; }", Error{});
 }
 
+TEST_F(TypeCheckerTest, cast_same_type)
+{
+  std::string warn = "Unnecessary cast";
+
+  test("kprobe:f { $a = (uint64)(uint64)1; }", Warning{ warn });
+  test("kprobe:f { $a = (uint8[4])pton(\"127.0.0.1\"); }", Warning{ warn });
+  test("kprobe:f { $a = (string[6])\"hello\"; }", Warning{ warn });
+  test("kprobe:f { $b = true; $a = (bool)$b; }", Warning{ warn });
+
+  test("kprobe:f { $a = (uint64)(int64)1; }", NoWarning{ warn });
+  test("kprobe:f { $a = (string[10])\"hello\"; }", NoWarning{ warn });
+}
+
 TEST_F(TypeCheckerTest, field_access)
 {
   std::string structs = "struct type1 { int field; }";


### PR DESCRIPTION
Stacked PRs:
 * __->__#5208


--- --- ---

### Issue a warning if casting to the same type


Aside from the errors that occur when the right hand side type is a C type
or a None type, simply issue a warning if attempting to cast an expression
to the exact same type.

Previously we would silently allow this for types like integers and error
for types like bool.

This change helps improve scripts by both making users aware of
unnecessary casts and not erroring out for a benign issue.

Signed-off-by: Jordan Rome <jordalgo@meta.com>