### PR TITLE
List structure with module name in verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 #### Breaking Changes
 #### Added
 #### Changed
+- List structure with module name in verbose mode
+  - [#5212](https://github.com/bpftrace/bpftrace/pull/5212)
 - Warn if casting to the exact same type
   - [#000](https://github.com/bpftrace/bpftrace/pull/0000)
 #### Deprecated

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -376,7 +376,7 @@ uprobe:/bin/bash:rl_set_prompt
     const char *prompt
 
 # bpftrace -lv 'struct css_task_iter'
-struct css_task_iter {
+vmlinux: struct css_task_iter {
         struct cgroup_subsys *ss;
         unsigned int flags;
         struct list_head *cset_pos;

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -1115,14 +1115,23 @@ std::set<std::string> BTF::get_all_structs_from_btf(const struct btf *btf) const
   return struct_set;
 }
 
-std::set<std::string> BTF::get_all_structs() const
+std::map<std::string, std::set<std::string>> BTF::get_all_structs() const
 {
-  std::set<std::string> structs;
+  // Save the structure definition and module name list.
+  // For example: { "struct task_struct", { "vmlinux", "kvm" } }
+  std::map<std::string, std::set<std::string>> structs_map;
   for (const auto &btf_obj : btf_objects) {
-    auto mod_structs = get_all_structs_from_btf(btf_obj.btf);
-    structs.insert(mod_structs.begin(), mod_structs.end());
+    for (const auto &s : get_all_structs_from_btf(btf_obj.btf)) {
+      auto it = structs_map.find(s);
+      // The same structure (name) can appear in different BTFs.
+      if (it != structs_map.end()) {
+        it->second.insert(btf_obj.name);
+      } else {
+        structs_map.insert({ s, { btf_obj.name } });
+      }
+    }
   }
-  return structs;
+  return structs_map;
 }
 
 std::unordered_set<std::string> BTF::get_all_iters_from_btf(

--- a/src/btf.h
+++ b/src/btf.h
@@ -101,7 +101,7 @@ public:
   // will be generated.
   std::string c_def(const std::unordered_set<std::string>& set = {});
 
-  std::set<std::string> get_all_structs() const;
+  std::map<std::string, std::set<std::string>> get_all_structs() const;
   std::unique_ptr<std::istream> get_all_traceable_funcs(const symbols::KernelInfo &kernel_func_info) const;
   std::unordered_set<std::string> get_all_iters() const;
   std::unique_ptr<std::istream> get_all_raw_tracepoints();

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -794,15 +794,36 @@ std::vector<std::string> ProbeMatcher::get_structs_for_listing(
     const std::string& search)
 {
   std::vector<std::string> results;
-  auto structs = bpftrace_->btf_->get_all_structs();
+  std::set<std::string> structs;
+  auto structmap = bpftrace_->btf_->get_all_structs();
 
   std::string search_input = search;
   // If verbose is on, structs will contain full definitions
   if (bt_verbose)
     search_input += " *{*}*";
 
-  for (const auto& match : get_matches_in_set(search_input, structs))
-    results.push_back(match);
+  for (const auto& s : structmap) {
+    structs.insert(s.first);
+  }
+
+  for (const auto& match : get_matches_in_set(search_input, structs)) {
+    auto sm = structmap.find(match);
+    // If in verbose mode, display module information.
+    if (sm != structmap.end() && bt_verbose) {
+      // The exact same structure definition may appear in multiple BTFs. If
+      // the structure is defined in vmlinux, then it does not need to be
+      // printed in other BTFs.
+      if (sm->second.contains("vmlinux")) {
+        results.push_back(std::string("vmlinux: ") + match);
+      } else {
+        for (const auto& mod : sm->second) {
+          results.push_back(mod + std::string(": ") + match);
+        }
+      }
+    } else {
+      results.push_back(match);
+    }
+  }
   return results;
 }
 } // namespace bpftrace

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -204,14 +204,14 @@ EXPECT tracepoint:xdp:mem_connect
 
 NAME it lists struct definitions
 RUN {{BPFTRACE}} -lv 'struct task_struct'
-EXPECT struct task_struct {
+EXPECT vmlinux: struct task_struct {
 TIMEOUT 2
 
 NAME it lists multiple struct definitions
 RUN {{BPFTRACE}} -lv 'struct task_struct,struct file,struct fd'
-EXPECT struct task_struct {
-EXPECT struct file {
-EXPECT struct fd {
+EXPECT vmlinux: struct task_struct {
+EXPECT vmlinux: struct file {
+EXPECT vmlinux: struct fd {
 TIMEOUT 2
 
 NAME it lists probes in a given file
@@ -223,7 +223,7 @@ EXPECT interval:us:
 NAME it lists misc in verbose mode
 RUN {{BPFTRACE}} -lv 'kprobe:vfs_read,struct file'
 EXPECT kprobe:vfs_read
-EXPECT struct file {
+EXPECT vmlinux: struct file {
 TIMEOUT 2
 
 NAME warning on non existent file


### PR DESCRIPTION
The same struct name may have different definitions in different modules, which can cause confusion when writing code, making it difficult to know which definition to use.

This patch prints the module name along with the structure definition.

For example, Both cxgb3 and cxgb4 driver have a structure called adapter, but they are defined completely differently.

    $ sudo modprobe cxgb3
    $ sudo modprobe cxgb4
    $ sudo bpftrace -lv 'struct adapter'
    struct adapter {
    	struct t3cdev tdev;
    	struct list_head adapter_list;
    	...
    };
    struct adapter {
    	void *regs;
    	void *bar2;
    	...
    };

    $ grep t3_sge_cqcntxt_op /proc/kallsyms
    ...
    0000000000000000 t t3_sge_cqcntxt_op	[cxgb3]

    $ sudo bpftrace -lv kprobe:cxgb3:t3_sge_cqcntxt_op
    kprobe:cxgb3:t3_sge_cqcntxt_op
        struct adapter * arg0   <<< don't know which struct it is
        unsigned int arg1
        unsigned int arg2
        unsigned int arg3

After:

    $ sudo bpftrace -lv 'struct adapter'
    cxgb3: struct adapter {
    	struct t3cdev tdev;
    	struct list_head adapter_list;
    	...
    };

    cxgb4: struct adapter {
    	void *regs;
    	void *bar2;
    	...
    };
