### PR TITLE
Publish arm64 release artifacts alongside x86_64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,17 @@ on:
 
 jobs:
   build-upload:
-    runs-on: ubuntu-latest
+    name: build-upload (${{ matrix.runner }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Only the x86_64 runner builds the arch-independent assets
+          - runner: ubuntu-latest
+            build_shared: "1"
+          - runner: ubuntu-24.04-arm
+            build_shared: "0"
+    runs-on: ${{ matrix.runner }}
     permissions:
       # For flakehub cache
       id-token: write
@@ -30,7 +40,7 @@ jobs:
         determinate: true
     - uses: DeterminateSystems/flakehub-cache-action@v2
     - name: Build artifacts
-      run: nix develop --command bash -c "OUT=./assets ./scripts/create-assets.sh"
+      run: nix develop --command bash -c "OUT=./assets BUILD_SHARED_ASSETS=${{ matrix.build_shared }} ./scripts/create-assets.sh"
 
     - name: Upload artifacts
       if: ${{ !inputs.dry_run }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,15 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- Publish arm64/aarch64 release artifacts alongside x86_64.
+  - [#5213](https://github.com/bpftrace/bpftrace/pull/5213)
 #### Changed
 - List structure with module name in verbose mode
   - [#5212](https://github.com/bpftrace/bpftrace/pull/5212)
 - Warn if casting to the exact same type
   - [#5208](https://github.com/bpftrace/bpftrace/pull/5208)
+- Release assets are now suffixed with the architecture
+  - [#5213](https://github.com/bpftrace/bpftrace/pull/5213)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/scripts/create-assets.sh
+++ b/scripts/create-assets.sh
@@ -6,8 +6,17 @@
 #         ./scripts/create-assets.sh
 #         OUT=../out-dir ./scripts/create-assets.sh
 #
+# Arch-specific assets (the binary and the bundle) are suffixed with the host
+# architecture
+#
+# Tools and man pages are only built when BUILD_SHARED_ASSETS=1.
+#
 
 ZSTDFLAGS="-19"
+ARCH="$(uname -m)"
+
+# Whether to also build the arch-independent archives (tools, man pages).
+: "${BUILD_SHARED_ASSETS:=1}"
 
 function err() {
   echo >&2 "$(tput setaf 1)ERROR: $*$(tput sgr0)"
@@ -30,31 +39,38 @@ echo "Using '$OUT' as assert dir"
 
 set -e
 
-info "Creating tools archive"
+info "Staging tools"
 
 # bit of copying to avoid confusing tar flags not great but works
 mkdir -p "$TMP/bin"
 
 cp tools/*.bt "$TMP/bin"
 chmod +x "$TMP/bin/"*.bt
-tar --xz -cf "$OUT/tools.tar.xz" -C "$TMP/bin" "."
 
-info "Creating man archive"
+info "Staging man pages"
 mkdir -p "$TMP/share/man/man8"
 cp man/man8/*.8 "$TMP/share//man/man8/"
 gzip -n "$TMP/share/man/man8/"*
 asciidoctor man/adoc/bpftrace.adoc  -b manpage -o - | gzip -n - > "$TMP/share/man/man8/bpftrace.8.gz"
-tar --xz -cf "$OUT/man.tar.xz" -C "$TMP/share" man
+
+# The tools and man archives are arch-independent, so only one runner needs to
+# build them for a multi-arch release.
+if [[ "$BUILD_SHARED_ASSETS" == "1" ]]; then
+  info "Creating tools archive"
+  tar --xz -cf "$OUT/tools.tar.xz" -C "$TMP/bin" "."
+  info "Creating man archive"
+  tar --xz -cf "$OUT/man.tar.xz" -C "$TMP/share" man
+fi
 
 info "Building bpftrace appimage"
 nix build .?submodules=1#appimage
 
 info "Creating bundle"
-cp ./result "$OUT/bpftrace"
+cp ./result "$OUT/bpftrace-$ARCH"
 cp ./result "$TMP/bin/bpftrace"
-tar -cf "$OUT/binary_tools_man-bundle.tar" -C "$TMP" bin share
-zstd $ZSTDFLAGS -q -k "$OUT/binary_tools_man-bundle.tar"
-xz "$OUT/binary_tools_man-bundle.tar"
+tar -cf "$OUT/binary_tools_man-bundle-$ARCH.tar" -C "$TMP" bin share
+zstd $ZSTDFLAGS -q -k "$OUT/binary_tools_man-bundle-$ARCH.tar"
+xz "$OUT/binary_tools_man-bundle-$ARCH.tar"
 
 echo "All assets created in $OUT"
 [[ -d "$TMP" ]] && rm -rf "$TMP"


### PR DESCRIPTION
Stacked PRs:
 * __->__#5213


--- --- ---

### Publish arm64 release artifacts alongside x86_64


To avoid asset-name collisions when both runners upload to the same
release, create-assets.sh now suffixes the arch-specific assets (the
appimage binary and the bundle) with the host architecture, and only
builds the arch-independent tools/man archives when BUILD_SHARED_ASSETS=1
(set on the x86_64 runner only).

This renames the existing 'bpftrace' and 'binary_tools_man-bundle.*'
release assets to include the '-x86_64' suffix.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>