### PR TITLE
Fix symbolication for UserSymbolCacheType::per_pid

### DIFF
--- a/src/usyms.cpp
+++ b/src/usyms.cpp
@@ -1,6 +1,7 @@
 #include "types.h"
 #include <bcc/bcc_elf.h>
 #include <bcc/bcc_syms.h>
+#include <fstream>
 #include <sstream>
 
 #include "config.h"
@@ -369,11 +370,23 @@ std::vector<std::string> Usyms::resolve_blazesym_impl(
     return str_syms;
   }
 
+  // We check that /proc/<pid>/maps has content rather than that /proc/<pid>
+  // merely exists: a process that has exited but not yet been reaped lingers
+  // as a zombie with an empty maps file and no usable map_files entries.
+  // See blazesym docs why setting no_map_files to true is discouraged.
+  bool no_map_files = false;
+  if (cache_type == UserSymbolCacheType::per_pid) {
+    std::ifstream maps("/proc/" + std::to_string(pid) + "/maps");
+    no_map_files = !maps.good() ||
+                   maps.peek() == std::ifstream::traits_type::eof();
+  }
+
   blaze_symbolize_src_process src = {
     .type_size = sizeof(src),
     .pid = static_cast<uint32_t>(pid),
     .debug_syms = show_debug_info,
     .perf_map = true,
+    .no_map_files = no_map_files,
   };
 
   const blaze_syms *syms = blaze_symbolize_process_abs_addrs(

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -80,14 +80,14 @@ EXPECT_REGEX ^func: 'test'$|^func: '0'$
 AFTER ./testprogs/uprobe_symres
 REQUIRES_FEATURE get_func_ip
 
-# Disabled, since BCC code it depends on is prone to race condition,
+# This requires Blazesym since BCC code it depends on is prone to race condition,
 # (https://github.com/iovisor/bcc/pull/4319#issuecomment-1321731687)
 NAME func_uprobe_symcache_preload
 ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PID
-PROG uprobe:./testprogs/uprobe_symres_exited_process:test { print(func); exit(); }
-EXPECT test
+PROG uprobe:./testprogs/uprobe_symres_exited_process:test { @a[func] = 1; } i:5s { exit(); }
+EXPECT @a[test]: 1
 BEFORE ./testprogs/uprobe_symres_exited_process
-REQUIRES bash -c "exit 1"
+REQUIRES_FEATURE blazesym
 
 NAME func_uprobe_elf_symtable
 ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -166,6 +166,7 @@ class Runner(object):
         bpffeature["jiffies64"] = output.find("jiffies64: yes") != -1
         bpffeature["lookup_percpu_elem"] = output.find("lookup_percpu_elem: yes") != -1
         bpffeature["dwunwind"] = output.find("dwunwind (DWARF stack unwinding): yes") != -1
+        bpffeature["blazesym"] = output.find("blazesym (advanced symbolization): yes") != -1
         return bpffeature
 
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#5215


--- --- ---

### Fix symbolication for UserSymbolCacheType::per_pid


When the UserSymbolCacheType is per_pid and the target process has exited
then we need to set no_map_files in blaze_symbolize_src_process to true so
blazesym doesn't attempt to use the map files. This is stated in the
blazesym documentation when utilizing VMA caching, which we do for per_pid.

Fixes the issue mentioend in: https://github.com/bpftrace/bpftrace/discussions/3108#discussioncomment-17242216

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>