### PR TITLE
Macros: Add support for ParsedType expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to
 ## Unreleased
 
 #### Breaking Changes
+- Array access for bare identifiers only valid in type expression contexts
+  - [#5217](https://github.com/bpftrace/bpftrace/pull/5217)
 #### Added
+- Add support for type expression substitution for macros
+  - [#5217](https://github.com/bpftrace/bpftrace/pull/5217)
 #### Changed
 - List structure with module name in verbose mode
   - [#5212](https://github.com/bpftrace/bpftrace/pull/5212)

--- a/docs/language.md
+++ b/docs/language.md
@@ -111,7 +111,7 @@ bpftrace supports accessing one-dimensional arrays like those found in `C`.
 Constructing arrays from scratch, like `int a[] = {1,2,3}` in `C`, is not supported.
 They can only be read into a variable from a pointer.
 
-The `[]` operator is used to access elements.
+The `[]` operator is used to access elements on variables, maps, or parenthesized expressions (e.g. `(expr)[1]` - a bare identifier followed by brackets, `expr[1]`, is parsed as a type).
 
 ```
 struct MyStruct {
@@ -747,6 +747,7 @@ A macro's parameter signature specifies how an argument will be used.
 For example `macro test($a, b, @c)` indicates that `$a` needs to be a scratch variable (which might be mutated), that `b` needs to be an expression that will be inserted where ever `b` is used in the macro body, and that `@c` needs to be a map (which might be mutated).
 A valid use of this macro could be `test($x, 1 + 2, @y)`.
 Variables and maps can also be used for ident parameters that expect expressions and would be the same as writing `{ @y }` (Block Expression).
+Type expression substitution is also supported inside of macros (see below).
 Note: User-defined macros with the same name and signature as a standard library macro will override the standard library version. However, standard library macros nested inside of other standard library macros will never use the user-defined version of the same signature.
 
 Here are some valid usages of macros:
@@ -775,6 +776,10 @@ macro add_two(x) {
   add_one(x) + 1
 }
 
+macro custom_cast(a, b) {
+  (a*)b
+}
+
 begin {
   print(one());                   // prints 1
   print(one);                     // prints 1 (bare identifier works if the macro accepts 0 args)
@@ -790,6 +795,8 @@ begin {
   side_effects({ printf("hi") })  // prints hihihi
 
   print(add_two(1));              // prints 3
+
+  print(custom_cast(uint8, -1));  // prints 0xff
 }
 ```
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -161,6 +161,7 @@ class None;
 class Identifier;
 class Builtin;
 class ParsedType;
+class TypeArg;
 class Call;
 class Sizeof;
 class Offsetof;
@@ -210,7 +211,8 @@ class Expression : public VariantNode<Integer,
                                       BlockExpr,
                                       Typeinfo,
                                       Comptime,
-                                      Record> {
+                                      Record,
+                                      TypeArg> {
 public:
   using VariantNode::VariantNode;
   Expression() : Expression(static_cast<BlockExpr *>(nullptr)) {};
@@ -639,6 +641,33 @@ inline std::strong_ordering expr_or_type_compare(const ExprOrType &lhs,
   }
   return std::get<Expression>(lhs) <=> std::get<Expression>(rhs);
 }
+
+class TypeArg : public Node {
+public:
+  explicit TypeArg(ASTContext &ctx, Location &&loc, ParsedType *type)
+      : Node(ctx, std::move(loc)), parsed_type(type) {};
+  explicit TypeArg(ASTContext &ctx, const Location &loc, const TypeArg &other)
+      : Node(ctx, loc + other.loc),
+        parsed_type(clone(ctx, loc, other.parsed_type)) {};
+
+  bool operator==(const TypeArg &other) const
+  {
+    return parsed_type == other.parsed_type ||
+           (parsed_type && other.parsed_type &&
+            *parsed_type == *other.parsed_type);
+  }
+  std::strong_ordering operator<=>(const TypeArg &other) const
+  {
+    if (parsed_type && other.parsed_type)
+      return *parsed_type <=> *other.parsed_type;
+    if (!parsed_type && !other.parsed_type)
+      return std::strong_ordering::equal;
+    return parsed_type ? std::strong_ordering::greater
+                       : std::strong_ordering::less;
+  }
+
+  ParsedType *parsed_type;
+};
 
 class Sizeof : public Node {
 public:

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -270,12 +270,95 @@ void MacroExpander::visit_expr_or_type(ExprOrType &record)
 {
   if (auto *expr = std::get_if<Expression>(&record)) {
     auto *ident = expr->as<Identifier>();
-    if (ident && !passed_exprs_.contains(ident->ident)) {
-      // Bare identifier that isn't a macro expression argument — treat it as
-      // a type name rather than expanding it as a macro.
-      return;
+    if (ident) {
+      if (auto it = passed_exprs_.find(ident->ident);
+          it != passed_exprs_.end()) {
+        auto *type_arg = it->second.as<TypeArg>();
+        if (type_arg) {
+          record = clone(ast_, ident->loc, type_arg->parsed_type);
+          return;
+        }
+      } else {
+        // Bare identifier that isn't a macro expression argument — treat it as
+        // a type name rather than expanding it as a macro.
+        return;
+      }
     }
+
     visit(*expr);
+  } else {
+    auto *parsed_type = std::get<ParsedType *>(record);
+    ParsedType *parent = nullptr;
+    while (parsed_type->inner) {
+      parent = parsed_type;
+      parsed_type = parsed_type->inner;
+    }
+    if (auto it = passed_exprs_.find(parsed_type->name);
+        it != passed_exprs_.end()) {
+      auto *type_arg = it->second.as<TypeArg>();
+      auto *ident = it->second.as<Identifier>();
+
+      switch (parsed_type->kind) {
+        case ParsedType::Kind::Struct:
+        case ParsedType::Kind::Union:
+        case ParsedType::Kind::Enum: {
+          // struct enum or struct struct is not supported syntax so unless the
+          // expression is a Identifier or a ParsedType Identifier this is an
+          // error
+          if (ident) {
+            parsed_type->name = ident->ident;
+            return;
+          }
+
+          if (type_arg) {
+            if (type_arg->parsed_type->kind == ParsedType::Kind::Identifier) {
+              parsed_type->name = type_arg->parsed_type->name;
+            } else {
+              auto &error = parsed_type->addError();
+              error << "Source type template '" << parsed_type->type_name()
+                    << "' is incompatible with replacement type arg '"
+                    << type_arg->parsed_type->type_name() << "'";
+              if (!type_arg->parsed_type->inner) {
+                error.addHint() << "Try just passing the raw ident: '"
+                                << type_arg->parsed_type->name << "'";
+              }
+            }
+            return;
+          }
+
+          break;
+        }
+        case ParsedType::Kind::Identifier: {
+          if (ident) {
+            parsed_type->name = ident->ident;
+            return;
+          }
+
+          if (type_arg) {
+            if (!parent) {
+              record = clone(ast_, parsed_type->loc, type_arg->parsed_type);
+            } else {
+              parent->inner = clone(ast_,
+                                    parsed_type->loc,
+                                    type_arg->parsed_type);
+            }
+            return;
+          }
+
+          break;
+        }
+        case ParsedType::Kind::Pointer:
+        case ParsedType::Kind::Array: {
+          LOG(BUG) << "ParsedType bottom can't be a pointer or array";
+          break;
+        }
+      }
+
+      it->second.node().addError()
+          << "Macro '" << stack_.back()->name
+          << "' is expecting a ParsedType or Identifier to replace '"
+          << parsed_type->name << "'";
+    }
   }
 }
 
@@ -491,6 +574,23 @@ std::optional<BlockExpr *> MacroExpander::expand(const Macro &macro,
   return cloned_block;
 }
 
+class TypeArgCheck : public Visitor<TypeArgCheck> {
+public:
+  explicit TypeArgCheck(ASTContext &ast) : ast_(ast) {};
+
+  using Visitor<TypeArgCheck>::visit;
+  void visit(TypeArg &type_arg);
+
+private:
+  ASTContext &ast_;
+};
+
+void TypeArgCheck::visit(TypeArg &type_arg)
+{
+  type_arg.addError()
+      << "Type expression only valid for macro calls expecting type parameters";
+}
+
 void expand_macro(ASTContext &ast,
                   Expression &expr,
                   const MacroRegistry &registry)
@@ -507,6 +607,9 @@ Pass CreateMacroExpansionPass()
     std::vector<const Macro *> stack;
     MacroExpander expander(ast, macros, stack);
     expander.visit(ast.root);
+
+    TypeArgCheck type_arg_check(ast);
+    type_arg_check.visit(ast.root);
     return macros;
   };
 

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -504,6 +504,11 @@ Buffer Formatter::visit(ParsedType& type)
   return visit(static_cast<const ParsedType&>(type));
 }
 
+Buffer Formatter::visit(TypeArg& type_arg)
+{
+  return visit(static_cast<const ParsedType&>(*type_arg.parsed_type));
+}
+
 Buffer Formatter::visit(Typeinfo& typeinfo)
 {
   if (std::holds_alternative<Expression>(typeinfo.typeof->record)) {
@@ -713,6 +718,11 @@ Buffer Formatter::visit(FieldAccess& acc)
 Buffer Formatter::visit(ArrayAccess& arr)
 {
   auto expr = format(arr.expr, metadata, max_width - 1);
+  // A bare identifier followed by `[` is parsed as a type-array, so it must be
+  // parenthesized to round-trip as a value being indexed (e.g. `(x)[0]`).
+  if (arr.expr.is<Identifier>()) {
+    expr = Buffer().text("(").append(std::move(expr)).text(")");
+  }
   auto indexpr = format(arr.indexpr, metadata, max_width - kIndentWidth);
   if (expr.width() + indexpr.width() + 2 > max_width) {
     return Buffer()

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -80,6 +80,7 @@ public:
   Buffer visit(Call &call);
   Buffer visit(Sizeof &szof);
   Buffer visit(Offsetof &ofof);
+  Buffer visit(TypeArg &type_arg);
   Buffer visit(Typeof &typeof);
   Buffer visit(Typeinfo &typeinfo);
   Buffer visit(Comptime &comptime);

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -91,6 +91,10 @@ public:
   {
     return visitImpl(ofof.record);
   }
+  R visit([[maybe_unused]] TypeArg &type_arg)
+  {
+    return default_value();
+  }
   R visit(Typeof &typeof)
   {
     return visitImpl(typeof.record);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1611,6 +1611,11 @@ std::optional<std::variant<Expression, ParsedType *>> Parser::
     return std::nullopt;
   }
 
+  if (ident == "true" || ident == "false") {
+    sp.restore();
+    return std::nullopt;
+  }
+
   auto matches_terminator = [&](size_t end_pos) {
     char next = char_at(scan_layout(end_pos));
     return next != '\0' && end_chars.find(next) != std::string_view::npos;
@@ -2270,6 +2275,20 @@ Expression Parser::parse_primary()
       auto *builtin = ctx_.make_node<Builtin>(name_loc, std::move(*name));
       return { builtin };
     }
+    // A bare identifier cannot be indexed as a value. The `name[N]` form is
+    // reserved for type-array syntax. To index a value use a variable, map, or
+    // parenthesize the expression: `$x[N]`, `@x[N]`, `(x)[N]`.
+    if (peek() == '[') {
+      advance();
+      parse_expression();
+      expect(']');
+      error("cannot index the bare identifier '" + *name +
+                "'; index a variable, map, or parenthesized expression",
+            begin_line,
+            begin_col,
+            line_,
+            col_);
+    }
     // Just an identifier.
     auto *ident = ctx_.make_node<Identifier>(name_loc, std::move(*name));
     return { ident };
@@ -2556,10 +2575,24 @@ Expression Parser::parse_call_expression(const std::string &name,
 
   ExpressionList args;
   consume_layout();
-  if (peek() != ')') {
-    args.push_back(parse_expression());
-    while (match(',')) {
+  auto add_expr_or_type_arg = [&, this]() {
+    auto [begin_line, begin_col] = get_current_line_col();
+    if (auto type_ref = try_parse_type_reference(",)")) {
+      auto loc = make_loc(begin_line, begin_col, line_, col_);
+      if (auto *type = std::get_if<ParsedType *>(&*type_ref)) {
+        args.emplace_back(ctx_.make_node<TypeArg>(loc, *type));
+      } else {
+        args.push_back(std::move(std::get<Expression>(*type_ref)));
+      }
+    } else {
       args.push_back(parse_expression());
+    }
+  };
+
+  if (peek() != ')') {
+    add_expr_or_type_arg();
+    while (match(',')) {
+      add_expr_or_type_arg();
     }
   }
 

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -17,10 +17,12 @@ macro assert_str(exp)
 {
   if comptime (!is_str(exp)) {
     if comptime is_array(exp) {
-      static_assert(typeinfo(exp[0]) == typeinfo(int8),
+      $a = exp;
+      static_assert(typeinfo($a[0]) == typeinfo(int8),
                     "string-like arrays must contain a char-like type");
     } else if comptime is_ptr(exp) {
-      static_assert(typeinfo(exp[0]) == typeinfo(int8),
+      $a = exp;
+      static_assert(typeinfo($a[0]) == typeinfo(int8),
                     "string-like pointers must point to a char-like type");
     } else {
       fail("string-like values must be either strings, arrays or pointers");
@@ -84,7 +86,7 @@ macro strcap(exp)
   if comptime is_str(exp) {
     sizeof(exp)
   } else if comptime is_array(exp) {
-    sizeof(exp) / sizeof(exp[0])
+    sizeof(exp) / sizeof((exp)[0])
   } else {
     strlen(exp) // Pointer, so pass by value.
   }

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -28,7 +28,7 @@ bool MatchWith(const NodeType& node,
                const TargetType& target);
 
 template <typename NodeType>
-auto CheckField(auto NodeType::*member,
+auto CheckField(auto NodeType::* member,
                 const auto& expected,
                 const std::string& name);
 
@@ -49,7 +49,8 @@ public:
     return static_cast<Derived&>(*this);
   }
 
-  const std::vector<PredicateType>& predicates() const {
+  const std::vector<PredicateType>& predicates() const
+  {
     return predicates_;
   }
 
@@ -65,7 +66,9 @@ class NodeMatcher
 public:
   NodeMatcher() = default;
 
-  using PredicateMatcher<Derived, NodeType, std::function<bool(const NodeType&)>>::predicates;
+  using PredicateMatcher<Derived,
+                         NodeType,
+                         std::function<bool(const NodeType&)>>::predicates;
 
   operator Matcher<const NodeType&>() const
   {
@@ -238,7 +241,7 @@ bool MatchWith(const NodeType& node,
 }
 
 template <typename NodeType>
-auto CheckField(auto NodeType::*member,
+auto CheckField(auto NodeType::* member,
                 const auto& expected,
                 const std::string& name)
 {
@@ -417,6 +420,25 @@ inline ParsedTypeMatcher ParsedType(ast::ParsedType::Kind kind,
                                     const std::string& name)
 {
   return ParsedTypeMatcher().WithKind(kind).WithName(name);
+}
+
+class TypeArgMatcher : public NodeMatcher<TypeArgMatcher, ast::TypeArg> {
+public:
+  TypeArgMatcher& WithType(const Matcher<const ast::ParsedType&>& type_matcher)
+  {
+    return Where([type_matcher](const ast::TypeArg& node) {
+      if (!node.parsed_type) {
+        node.addError() << "TypeArg has no parsed_type";
+        return false;
+      }
+      return MatchWith(node, type_matcher, *node.parsed_type);
+    });
+  }
+};
+
+inline TypeArgMatcher TypeArg(const Matcher<const ast::ParsedType&>& type)
+{
+  return TypeArgMatcher().WithType(type);
 }
 
 class ProgramMatcher : public NodeMatcher<ProgramMatcher, ast::Program> {
@@ -978,7 +1000,6 @@ public:
       return MatchWith(node, range_matcher, *node.iterable.as<ast::Range>());
     });
   }
-
 };
 
 inline ForMatcher For(
@@ -1184,7 +1205,8 @@ inline ConfigMatcher Config(
   return ConfigMatcher().WithStatements(statements);
 }
 
-class RootImportMatcher : public NodeMatcher<RootImportMatcher, ast::RootImport> {
+class RootImportMatcher
+    : public NodeMatcher<RootImportMatcher, ast::RootImport> {
 public:
   RootImportMatcher& WithName(const std::string& name)
   {
@@ -1197,7 +1219,8 @@ inline RootImportMatcher RootImport(const std::string& name)
   return RootImportMatcher().WithName(name);
 }
 
-class StatementImportMatcher : public NodeMatcher<StatementImportMatcher, ast::StatementImport> {
+class StatementImportMatcher
+    : public NodeMatcher<StatementImportMatcher, ast::StatementImport> {
 public:
   StatementImportMatcher& WithName(const std::string& name)
   {

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -1,5 +1,6 @@
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/import_scripts.h"
+#include "ast/passes/printer.h"
 #include "ast/passes/resolve_imports.h"
 #include "mocks.h"
 #include "parser.h"
@@ -9,7 +10,11 @@ namespace bpftrace::test::macro_expansion {
 
 using ::testing::HasSubstr;
 
+// Runs the macro expansion pipeline on `input`. When `expected_output` is set,
+// the formatted (expanded) AST is checked to contain it, verifying that the
+// substitution actually happened. Otherwise only diagnostics are checked.
 void test(const std::string& input,
+          const std::string& expected_output = "",
           const std::string& error = "",
           const std::string& warn = "")
 {
@@ -47,6 +52,13 @@ void test(const std::string& input,
 
   if (trimmed_error.empty()) {
     ASSERT_TRUE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+    if (!expected_output.empty()) {
+      std::stringstream printed;
+      ast::Printer printer(ast, printed);
+      printer.visit(ast.root);
+      EXPECT_THAT(printed.str(), HasSubstr(expected_output))
+          << msg.str() << printed.str();
+    }
     if (!trimmed_warn.empty()) {
       EXPECT_THAT(out.str(), HasSubstr(trimmed_warn)) << msg.str() << out.str();
     }
@@ -58,12 +70,12 @@ void test(const std::string& input,
 
 void test_error(const std::string& input, const std::string& error)
 {
-  test(input, error);
+  test(input, "", error);
 }
 
 void test_warning(const std::string& input, const std::string& warn)
 {
-  test(input, "", warn);
+  test(input, "", "", warn);
 }
 
 TEST(macro_expansion, basic_checks)
@@ -240,6 +252,57 @@ TEST(macro_expansion, stdlib_shadowing)
 
   // User macros should not poison builtin/function calls inside stdlib macros.
   test("macro fail(x) { x } begin { print(strlen(\"hi\")); }");
+}
+
+TEST(macro_expansion, type_arg)
+{
+  test("macro sof(t) { sizeof(t) } begin { print(sof(struct task_struct)); }",
+       "sizeof(struct task_struct)");
+  test("macro sof(t) { sizeof(t) } begin { print(sof(uint64)); }",
+       "sizeof(uint64)");
+  test("macro sof(t) { sizeof(struct t) } begin { print(sof(task_struct)); }",
+       "sizeof(struct task_struct)");
+  test("macro sof(t) { sizeof(t*) } begin { print(sof(uint64)); }",
+       "sizeof(uint64*)");
+  test("macro sof(a, b) { sizeof(a) + sizeof(b[2]) } "
+       "begin { print(sof(struct task_struct, uint64*)); }",
+       "sizeof(struct task_struct) + sizeof(uint64*[2])");
+  test("struct Foo { int x; } macro off(t) { offsetof(t, x) } "
+       "begin { print(off(struct Foo)); }",
+       "offsetof(struct Foo, x)");
+  test("macro c(t) { (typeof(t))0 } begin { print(c(uint64*)); }",
+       "(uint64*)0");
+  test("macro lt(t) { let $x: t = 0; } begin { lt(uint32); }", ": uint32 = 0;");
+  test("macro cst(t) { (t)0; } begin { print(cst(uint32*)); }", "(uint32*)0");
+  test("macro ti(t) { typeinfo(t) } begin { print(ti(struct task_struct)); }",
+       "typeinfo(struct task_struct)");
+  test("macro inner(t) { sizeof(t) } macro outer(t) { inner(t) } "
+       "begin { print(outer(uint64*)); }",
+       "sizeof(uint64*)");
+
+  // Errors
+  test_error(
+      "macro m(x) { x + 1 } begin { print(m(uint64*)); }",
+      "Type expression only valid for macro calls expecting type parameters");
+
+  test_error("macro m(t) { sizeof(struct t) } begin { print(m(uint64*)); }",
+             "Source type template 'struct t' is incompatible with replacement "
+             "type arg 'uint64*'");
+
+  test_error("macro m(t) { sizeof(struct t) } begin { print(m(struct foo)); }",
+             "Try just passing the raw ident: 'foo'");
+
+  test_error(
+      "macro cst(t) { sizeof((t)[0]) } begin { print(cst(uint32*)); }",
+      "Type expression only valid for macro calls expecting type parameters");
+
+  test_error(
+      "macro m(t) { sizeof(struct t) } begin { $x = 1; print(m($x)); }",
+      "Macro 'm' is expecting a ParsedType or Identifier to replace 't'");
+
+  test_error(
+      "begin { print(f(uint64*)); }",
+      "Type expression only valid for macro calls expecting type parameters");
 }
 
 } // namespace bpftrace::test::macro_expansion

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -38,6 +38,7 @@ using bpftrace::test::Program;
 
 using bpftrace::test::String;
 using bpftrace::test::Tuple;
+using bpftrace::test::TypeArg;
 using bpftrace::test::Typeof;
 using bpftrace::test::Unop;
 using bpftrace::test::Variable;
@@ -705,6 +706,20 @@ TEST(Parser, booleans)
        Program().WithProbe(
            Probe({ "kprobe:do_nanosleep" },
                  { AssignVarStatement(Variable("$x"), Boolean(false)) })));
+
+  // A boolean literal passed as a call argument must parse as a Boolean node,
+  // not be swallowed as a bare identifier by the type-argument path.
+  test("begin { getopt(\"cc\", true); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(
+                     Call("getopt", { String("cc"), Boolean(true) })) })));
+
+  test("begin { getopt(\"cc\", false); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(
+                     Call("getopt", { String("cc"), Boolean(false) })) })));
 }
 
 TEST(Parser, map_key)
@@ -2073,6 +2088,86 @@ TEST(Parser, typeof_unknown_type)
                      Cast(Typeof(Identifier("mytype")), Builtin("arg0"))) })));
 }
 
+TEST(Parser, call_type_arg)
+{
+  test("begin { f(struct task_struct); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(
+                     Call("f",
+                          { TypeArg(ParsedType(ast::ParsedType::Kind::Struct,
+                                               "task_struct")) })) })));
+
+  test("begin { f(union my_union); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(
+                     Call("f",
+                          { TypeArg(ParsedType(ast::ParsedType::Kind::Union,
+                                               "my_union")) })) })));
+
+  test("begin { f(enum my_enum); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(
+                     Call("f",
+                          { TypeArg(ParsedType(ast::ParsedType::Kind::Enum,
+                                               "my_enum")) })) })));
+
+  test("begin { f(uint64); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(Call(
+                     "f",
+                     { TypeArg(ParsedType(ast::ParsedType::Kind::Identifier,
+                                          "uint64")) })) })));
+
+  test("begin { f(uint64*); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(
+                     Call("f",
+                          { TypeArg(ParsedType(ast::ParsedType::Kind::Pointer)
+                                        .WithInner(ParsedType(
+                                            ast::ParsedType::Kind::Identifier,
+                                            "uint64"))) })) })));
+
+  test("begin { f(uint64[2]); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(
+                     Call("f",
+                          { TypeArg(ParsedType(ast::ParsedType::Kind::Array)
+                                        .WithArraySize(2)
+                                        .WithInner(ParsedType(
+                                            ast::ParsedType::Kind::Identifier,
+                                            "uint64"))) })) })));
+
+  test(
+      "begin { f(struct task_struct*); }",
+      Program().WithProbe(Probe(
+          { "begin" },
+          { ExprStatement(Call(
+              "f",
+              { TypeArg(ParsedType(ast::ParsedType::Kind::Pointer)
+                            .WithInner(ParsedType(ast::ParsedType::Kind::Struct,
+                                                  "task_struct"))) })) })));
+
+  test("begin { f(1, struct task_struct, \"x\"); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(
+                     Call("f",
+                          { Integer(1),
+                            TypeArg(ParsedType(ast::ParsedType::Kind::Struct,
+                                               "task_struct")),
+                            String("x") })) })));
+
+  test("begin { f(foo); }",
+       Program().WithProbe(Probe(
+           { "begin" }, { ExprStatement(Call("f", { Identifier("foo") })) })));
+}
+
 TEST(Parser, dereference_precedence)
 {
   test("kprobe:sys_read { *@x+1 }",
@@ -2157,18 +2252,31 @@ TEST(Parser, field_access_sized_type)
 
 TEST(Parser, array_access)
 {
-  test("kprobe:sys_read { x[index]; }",
-       Program().WithProbe(
-           Probe({ "kprobe:sys_read" },
-                 { ExprStatement(
-                     ArrayAccess(Identifier("x"), Identifier("index"))) })));
+  // Array access on a variable, map, or parenthesized expression is fine.
+  test("kprobe:sys_read { $x[index]; }",
+       Program().WithProbe(Probe({ "kprobe:sys_read" },
+                                 { ExprStatement(ArrayAccess(
+                                     Variable("$x"), Identifier("index"))) })));
 
-  test("kprobe:sys_read { $val = x[index]; }",
+  test("kprobe:sys_read { (x)[0]; }",
        Program().WithProbe(
            Probe({ "kprobe:sys_read" },
-                 { AssignVarStatement(Variable("$val"),
-                                      ArrayAccess(Identifier("x"),
-                                                  Identifier("index"))) })));
+                 { ExprStatement(ArrayAccess(Identifier("x"), Integer(0))) })));
+
+  // A bare identifier cannot be indexed as a value: `name[N]` is reserved for
+  // type-array syntax. Users must index a variable, map, or parenthesized
+  // expression instead.
+  test_parse_failure("kprobe:sys_read { x[index]; }", R"(
+stdin:1:19-27: ERROR: syntax: cannot index the bare identifier 'x'; index a variable, map, or parenthesized expression
+kprobe:sys_read { x[index]; }
+                  ~~~~~~~~
+)");
+
+  test_parse_failure("kprobe:sys_read { $val = x[index]; }", R"(
+stdin:1:26-34: ERROR: syntax: cannot index the bare identifier 'x'; index a variable, map, or parenthesized expression
+kprobe:sys_read { $val = x[index]; }
+                         ~~~~~~~~
+)");
 }
 
 TEST(Parser, cstruct)

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -58,6 +58,18 @@ NAME it accepts arbitrary expressions with maps
 PROG macro add_one(x) { x + 1 } begin { @a = 1; print(add_one(@a + 1));  }
 EXPECT 3
 
+NAME it accepts type expressions
+PROG struct Foo { char m; } macro sof(a, b) { sizeof(a[2]) + sizeof(b*) + sizeof(b) } begin { print(sof(uint64*, struct Foo)); }
+EXPECT 25
+
+NAME it accepts type expressions with nested calls
+PROG macro m(t) { sizeof(t) + 2 } macro n(z) { print(m(z)); } begin { n(uint64*); }
+EXPECT 10
+
+NAME it accepts type expressions for nested casts
+PROG macro cst(a) { (a*)-1 } begin { print(cst(uint8)); }
+EXPECT 0xff
+
 NAME can call the same macro multiple times
 PROG macro inc($x) { $x += 1; } begin { $a = 1; inc($a); inc($a); inc($a); print($a);  }
 EXPECT 4


### PR DESCRIPTION
Stacked PRs:
 * __->__#5217


--- --- ---

### Macros: Add support for ParsedType expressions


This allows us to do type expression substitution in bpftrace macros.
For example:
```
macro sof_double(type_a, type_b) {
  sizeof(type_a) + sizeof(type_b[2])
}

begin {
  print(sof_double(struct qspinlock, uint64*));
}
```

Expands to:
```
begin {
  print(sizeof(struct qspinlock) + sizeof(uint64*[2]));
}
```

This is only valid for macros so if a call signature doesn't match a macro
then a compile time error is issued.

In order to resolve an ambiguity with bare identifier array access, this
change also disallows (at the parser level) this in a non type context. For
example: `$a = x[5];` is not legal but `$a = (x)[5];` and `$a =
sizeof(x[5])` are legal.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>