### PR TITLE
Skip rawtracepoint test when BTF is not available

### DIFF
--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -341,6 +341,10 @@ TEST(attachpoint_checker, tracepoint)
 
 TEST(attachpoint_checker, rawtracepoint)
 {
+  auto bpftrace = get_mock_bpftrace();
+  if (!bpftrace->has_btf_data())
+    GTEST_SKIP();
+
   test("rawtracepoint:event_rt { 1 }");
   test("rawtracepoint:event_rt { arg0 }");
   test("rawtracepoint:vmlinux:event_rt { arg0 }");


### PR DESCRIPTION
Even though a working system configuration should be checked up front, we should still properly skip this test instead of failing it.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests

None of the above apply.
