### PR TITLE
tests: fix char signedness assumptions for LoongArch64

### DIFF
--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -3539,7 +3539,8 @@ TEST_F(TypeCheckerTest, type_ctx)
   EXPECT_TRUE(result.type_map.type(var).IsPtrTy());
 
   class SizedType chartype;
-  if (arch::Host::Machine == arch::Machine::X86_64) {
+  if (arch::Host::Machine == arch::Machine::X86_64 ||
+      arch::Host::Machine == arch::Machine::LOONGARCH64) {
     chartype = CreateInt8();
   } else {
     chartype = CreateUInt8();


### PR DESCRIPTION
The type_ctx test hardcodes the signedness of the C `char` type per architecture, but only accounted for x86_64 having signed char. On LoongArch64, `char` is also signed by default.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests

This fixes the following test failures on LoongArch64:

       [  FAILED  ] TypeCheckerTest.type_ctx
       Expected equality of these values:
         chartype
           Which is: uint8
         result.type_map.type(assignment->var())
           Which is: int8
       .....