### PR TITLE
Macros: Add support for type params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- Add type parameters for macros
+  - [#5220](https://github.com/bpftrace/bpftrace/pull/5220)
 #### Changed
 - List structure with module name in verbose mode
   - [#5212](https://github.com/bpftrace/bpftrace/pull/5212)

--- a/docs/language.md
+++ b/docs/language.md
@@ -745,6 +745,8 @@ A macro's parameter signature specifies how an argument will be used.
 For example `macro test($a, b, @c)` indicates that `$a` needs to be a scratch variable (which might be mutated), that `b` needs to be an expression that will be inserted where ever `b` is used in the macro body, and that `@c` needs to be a map (which might be mutated).
 A valid use of this macro could be `test($x, 1 + 2, @y)`.
 Variables and maps can also be used for ident parameters that expect expressions and would be the same as writing `{ @y }` (Block Expression).
+Additionally, macros and macro calls support type paramaters that allow replacing in static type contexts (casts, `sizeof`, variable declarations, etc.).
+For example: `macro szof_mult[a](x) { sizeof(a) * x }` and the call `szof_mult[uint32](5)`.
 Note: User-defined macros with the same name and signature as a standard library macro will override the standard library version. However, standard library macros nested inside of other standard library macros will never use the user-defined version of the same signature.
 
 Here are some valid usages of macros:
@@ -773,6 +775,10 @@ macro add_two(x) {
   add_one(x) + 1
 }
 
+macro szof_two[a]() {
+  sizeof(a[2])
+}
+
 begin {
   print(one());                   // prints 1
   print(one);                     // prints 1 (bare identifier works if the macro accepts 0 args)
@@ -788,6 +794,7 @@ begin {
   side_effects({ printf("hi") })  // prints hihihi
 
   print(add_two(1));              // prints 3
+  print(szof_two[uint32]());      // prints 8
 }
 ```
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -218,6 +218,8 @@ public:
   bool is_literal() const;
 };
 using ExpressionList = std::vector<Expression>;
+using TypeList = std::vector<ParsedType *>;
+using IdentList = std::vector<Identifier *>;
 
 class ExprStatement;
 class VarDeclStatement;
@@ -481,50 +483,6 @@ public:
   int probe_id;
 };
 
-class Call : public Node {
-public:
-  explicit Call(ASTContext &ctx,
-                Location &&loc,
-                std::string func,
-                ExpressionList &&vargs)
-      : Node(ctx, std::move(loc)),
-        func(std::move(func)),
-        vargs(std::move(vargs)) {};
-  explicit Call(ASTContext &ctx, const Location &loc, const Call &other)
-      : Node(ctx, loc + other.loc),
-        func(other.func),
-        vargs(clone(ctx, loc, other.vargs)),
-        injected_args(other.injected_args) {};
-
-  bool operator==(const Call &other) const
-  {
-    return func == other.func && vargs == other.vargs &&
-           injected_args == other.injected_args;
-  }
-  std::strong_ordering operator<=>(const Call &other) const
-  {
-    if (auto cmp = func <=> other.func; cmp != 0)
-      return cmp;
-    if (vargs.size() != other.vargs.size())
-      return vargs.size() <=> other.vargs.size();
-    for (size_t i = 0; i < vargs.size(); ++i) {
-      if (auto cmp = vargs[i] <=> other.vargs[i]; cmp != 0)
-        return cmp;
-    }
-    return injected_args <=> other.injected_args;
-  }
-
-  std::string func;
-  ExpressionList vargs;
-
-  // Some passes may inject new arguments to the call, which is always
-  // done at the beginning (in order to support variadic arguments) for
-  // later passes. This is a result of "desugaring" some syntax. When this
-  // happens, this number is increased so that later error reporting can
-  // correctly account for this.
-  size_t injected_args = 0;
-};
-
 class ParsedType : public Node {
 public:
   enum class Kind {
@@ -616,6 +574,81 @@ public:
   std::string name;
   uint64_t array_size = 0;
   ParsedType *inner = nullptr;
+};
+
+class Call : public Node {
+public:
+  explicit Call(ASTContext &ctx,
+                Location &&loc,
+                std::string func,
+                ExpressionList &&vargs)
+      : Node(ctx, std::move(loc)),
+        func(std::move(func)),
+        vargs(std::move(vargs)) {};
+  explicit Call(ASTContext &ctx,
+                Location &&loc,
+                std::string func,
+                ExpressionList &&vargs,
+                TypeList &&type_args)
+      : Node(ctx, std::move(loc)),
+        func(std::move(func)),
+        vargs(std::move(vargs)),
+        type_args(std::move(type_args)) {};
+  explicit Call(ASTContext &ctx, const Location &loc, const Call &other)
+      : Node(ctx, loc + other.loc),
+        func(other.func),
+        vargs(clone(ctx, loc, other.vargs)),
+        type_args(clone(ctx, loc, other.type_args)),
+        injected_args(other.injected_args) {};
+
+  bool operator==(const Call &other) const
+  {
+    if (func != other.func || vargs != other.vargs ||
+        injected_args != other.injected_args) {
+      return false;
+    }
+
+    if (type_args.size() != other.type_args.size()) {
+      return false;
+    }
+
+    for (size_t i = 0; i < type_args.size(); ++i) {
+      if (*type_args[i] != *other.type_args[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+  std::strong_ordering operator<=>(const Call &other) const
+  {
+    if (auto cmp = func <=> other.func; cmp != 0)
+      return cmp;
+    if (vargs.size() != other.vargs.size())
+      return vargs.size() <=> other.vargs.size();
+    for (size_t i = 0; i < vargs.size(); ++i) {
+      if (auto cmp = vargs[i] <=> other.vargs[i]; cmp != 0)
+        return cmp;
+    }
+    if (type_args.size() != other.type_args.size())
+      return type_args.size() <=> other.type_args.size();
+    for (size_t i = 0; i < type_args.size(); ++i) {
+      if (auto cmp = *type_args[i] <=> *other.type_args[i]; cmp != 0)
+        return cmp;
+    }
+    return injected_args <=> other.injected_args;
+  }
+
+  std::string func;
+  ExpressionList vargs;
+  TypeList type_args; // Only valid for macro calls
+
+  // Some passes may inject new arguments to the call, which is always
+  // done at the beginning (in order to support variadic arguments) for
+  // later passes. This is a result of "desugaring" some syntax. When this
+  // happens, this number is increased so that later error reporting can
+  // correctly account for this.
+  size_t injected_args = 0;
 };
 
 using ExprOrType = std::variant<Expression, ParsedType *>;
@@ -1938,18 +1971,30 @@ public:
         name(std::move(name)),
         vargs(std::move(vargs)),
         block(block) {};
+  Macro(ASTContext &ctx,
+        Location &&loc,
+        std::string name,
+        ExpressionList &&vargs,
+        BlockExpr *block,
+        IdentList &&type_params)
+      : Node(ctx, std::move(loc)),
+        name(std::move(name)),
+        vargs(std::move(vargs)),
+        block(block),
+        type_params(std::move(type_params)) {};
   explicit Macro(ASTContext &ctx, const Location &loc, const Macro &other)
       : Node(ctx, loc + other.loc),
         name(other.name),
         vargs(clone(ctx, loc, other.vargs)),
         block(clone(ctx, loc, other.block)),
+        type_params(clone(ctx, loc, other.type_params)),
         is_stdlib(other.is_stdlib) {};
 
   bool operator==(const Macro &other) const
   {
     if (name != other.name || vargs != other.vargs)
       return false;
-    if (vargs != other.vargs)
+    if (type_params != other.type_params)
       return false;
     if (is_stdlib != other.is_stdlib)
       return false;
@@ -1967,12 +2012,19 @@ public:
       if (auto cmp = vargs[i] <=> other.vargs[i]; cmp != 0)
         return cmp;
     }
+    if (type_params.size() != other.type_params.size())
+      return type_params.size() <=> other.type_params.size();
+    for (size_t i = 0; i < type_params.size(); ++i) {
+      if (auto cmp = *type_params[i] <=> *other.type_params[i]; cmp != 0)
+        return cmp;
+    }
     return *block <=> *other.block;
   }
 
   std::string name;
   ExpressionList vargs;
   BlockExpr *block = nullptr;
+  IdentList type_params;
   bool is_stdlib = false;
 };
 using MacroList = std::vector<Macro *>;

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -23,6 +23,18 @@ static bool validate(Macro *macro)
   std::unordered_set<std::string> seen_mvars;
   std::unordered_set<std::string> seen_mmaps;
   std::unordered_set<std::string> seen_idents;
+  std::unordered_set<std::string> seen_type_params;
+
+  for (const auto &ident : macro->type_params) {
+    auto inserted = seen_type_params.insert(ident->ident);
+    if (!inserted.second) {
+      ident->addError()
+          << "Type param for macro argument has already been used: "
+          << ident->ident;
+      return false;
+    }
+  }
+
   for (const auto &arg : macro->vargs) {
     if (auto *mvar = arg.as<Variable>()) {
       auto inserted = seen_mvars.insert(mvar->ident);
@@ -45,9 +57,15 @@ static bool validate(Macro *macro)
         ident->addError() << "Ident for macro argument has already been used: "
                           << ident->ident;
         return false;
+      } else if (seen_type_params.contains(ident->ident)) {
+        ident->addError() << "Ident for macro argument has already been used "
+                             "as a type param: "
+                          << ident->ident;
+        return false;
       }
     }
   }
+
   return true;
 }
 
@@ -64,7 +82,8 @@ MacroRegistry MacroRegistry::create(ASTContext &ast)
     // However we explicitly allow this, as long as they are added in such a way
     // that they will match with the most precise macros first. The newest macro
     // definition must not match with any existing macro definition.
-    auto exists = registry.lookup(macro->name, macro->vargs, macro->is_stdlib);
+    auto exists = registry.lookup(
+        macro->name, macro->vargs, macro->type_params.size(), macro->is_stdlib);
     if (exists) {
       auto &err = macro->addError();
       err << "Redefinition of macro: " << macro->name;
@@ -81,7 +100,9 @@ MacroRegistry MacroRegistry::create(ASTContext &ast)
   return registry;
 }
 
-static size_t distance(const Macro *macro, const std::vector<Expression> &args)
+static size_t distance(const Macro *macro,
+                       const std::vector<Expression> &args,
+                       size_t num_types)
 {
   // Any missing arguments either way are wrong; these dominate the other
   // differences by far, so we ensure that these are the least close macros.
@@ -90,6 +111,11 @@ static size_t distance(const Macro *macro, const std::vector<Expression> &args)
   size_t d = 1024 * static_cast<size_t>(
                         std::abs(static_cast<long>(macro->vargs.size()) -
                                  static_cast<long>(args.size())));
+  // A differing number of type parameters means a different macro signature,
+  // so this dominates just like a differing number of arguments.
+  d += 1024 * static_cast<size_t>(
+                  std::abs(static_cast<long>(macro->type_params.size()) -
+                           static_cast<long>(num_types)));
   for (size_t i = 0; i < macro->vargs.size() && i < args.size(); i++) {
     if ((macro->vargs[i].is<Map>() && !args[i].is<Map>()) ||
         (macro->vargs[i].is<Variable>() && !args[i].is<Variable>())) {
@@ -101,6 +127,7 @@ static size_t distance(const Macro *macro, const std::vector<Expression> &args)
 
 Result<const Macro *> MacroRegistry::lookup(const std::string &name,
                                             const std::vector<Expression> &args,
+                                            size_t num_types,
                                             std::optional<bool> is_stdlib) const
 {
   const auto it = macros_.find(name);
@@ -124,7 +151,7 @@ Result<const Macro *> MacroRegistry::lookup(const std::string &name,
       continue;
     }
 
-    size_t d = distance(m, args);
+    size_t d = distance(m, args, num_types);
     if (d == 0) {
       if (m->is_stdlib && !exact_stdlib_match) {
         exact_stdlib_match = m;
@@ -176,6 +203,7 @@ public:
   void visit(Typeof &typeof_node);
 
   void visit_expr_or_type(ExprOrType &record);
+  void substitute_type_param(ParsedType *&type);
 
   std::optional<BlockExpr *> expand(const Macro &macro, Call &call);
   std::optional<BlockExpr *> expand(const Macro &macro, Identifier &ident);
@@ -194,6 +222,7 @@ private:
   std::unordered_map<std::string, std::string> vars_;
   std::unordered_set<std::string> renamed_vars_;
   std::unordered_map<std::string, Expression> passed_exprs_;
+  std::unordered_map<std::string, ParsedType *> type_params_;
 };
 
 void MacroExpander::visit(AssignVarStatement &assignment)
@@ -270,12 +299,75 @@ void MacroExpander::visit_expr_or_type(ExprOrType &record)
 {
   if (auto *expr = std::get_if<Expression>(&record)) {
     auto *ident = expr->as<Identifier>();
-    if (ident && !passed_exprs_.contains(ident->ident)) {
-      // Bare identifier that isn't a macro expression argument — treat it as
-      // a type name rather than expanding it as a macro.
-      return;
+    if (ident) {
+      if (auto it = type_params_.find(ident->ident); it != type_params_.end()) {
+        record = clone(ast_, ident->loc, it->second);
+        return;
+      } else if (!passed_exprs_.contains(ident->ident)) {
+        // Bare identifier that isn't a macro expression argument — treat it as
+        // a type name rather than expanding it as a macro.
+        return;
+      }
     }
     visit(*expr);
+  } else {
+    auto *parsed_type = std::get<ParsedType *>(record);
+    substitute_type_param(parsed_type);
+    record = parsed_type;
+  }
+}
+
+// Replace a type parameter referenced within `type` with the type argument it
+// was bound to. The replacement happens at the innermost (leaf) type so that
+// any pointer/array wrappers around the type parameter are preserved, e.g. a
+// type param `b` bound to `uint64*` used as `b*` becomes `uint64**`.
+void MacroExpander::substitute_type_param(ParsedType *&type)
+{
+  ParsedType *parsed_type = type;
+  ParsedType *parent = nullptr;
+  while (parsed_type->inner) {
+    parent = parsed_type;
+    parsed_type = parsed_type->inner;
+  }
+  auto it = type_params_.find(parsed_type->name);
+  if (it == type_params_.end()) {
+    return;
+  }
+  auto *type_param = it->second;
+  assert(type_param != nullptr);
+
+  switch (parsed_type->kind) {
+    case ParsedType::Kind::Struct:
+    case ParsedType::Kind::Union:
+    case ParsedType::Kind::Enum: {
+      // struct enum or struct struct is not supported syntax
+      if (type_param->kind == ParsedType::Kind::Identifier) {
+        parsed_type->name = type_param->name;
+      } else {
+        auto &error = parsed_type->addError();
+        error << "Type arg '" << type_param->type_name()
+              << "' is incompatible with how the type param is used in the "
+                 "macro body.";
+        if (!type_param->inner) {
+          error.addHint() << "Try just passing the raw ident: '"
+                          << type_param->name << "'";
+        }
+      }
+      return;
+    }
+    case ParsedType::Kind::Identifier: {
+      if (!parent) {
+        type = clone(ast_, parsed_type->loc, type_param);
+      } else {
+        parent->inner = clone(ast_, parsed_type->loc, type_param);
+      }
+      return;
+    }
+    case ParsedType::Kind::Pointer:
+    case ParsedType::Kind::Array: {
+      LOG(BUG) << "ParsedType bottom can't be a pointer or array";
+      break;
+    }
   }
 }
 
@@ -319,11 +411,15 @@ void MacroExpander::visit(Expression &expr)
   }
   if (call) {
     visit(call->vargs);
+    for (auto *&type : call->type_args) {
+      substitute_type_param(type);
+    }
   }
 
   std::vector<Expression> empty;
   const std::string &name = ident ? ident->ident : call->func;
   const std::vector<Expression> &args = ident ? empty : call->vargs;
+  const size_t num_types = ident ? 0 : call->type_args.size();
 
   // If we're being called from a stdlib macro then only expand other stdlib
   // macros not user-defined macros that also happen to match
@@ -331,7 +427,7 @@ void MacroExpander::visit(Expression &expr)
   if (!stack_.empty() && stack_.back()->is_stdlib) {
     restrict_to_stdlib = true;
   }
-  auto result = registry_.lookup(name, args, restrict_to_stdlib);
+  auto result = registry_.lookup(name, args, num_types, restrict_to_stdlib);
   if (!result) {
     auto done = handleErrors(
         std::move(result), [&](const MacroLookupError &lookupErr) {
@@ -354,6 +450,15 @@ void MacroExpander::visit(Expression &expr)
                 << "() has a different number of arguments. "
                 << "Expected: " << macro->vargs.size() << " but got "
                 << args.size();
+            return;
+          }
+
+          if (macro->type_params.size() != num_types) {
+            err.addContext(macro->loc)
+                << "The closest definition of " << macro->name
+                << "() has a different number of type parameters. "
+                << "Expected: " << macro->type_params.size() << " but got "
+                << num_types;
             return;
           }
 
@@ -446,7 +551,8 @@ std::string MacroExpander::get_new_var_ident(std::string original_ident)
 
 std::optional<BlockExpr *> MacroExpander::expand(const Macro &macro, Call &call)
 {
-  if (macro.vargs.size() != call.vargs.size()) {
+  if (macro.vargs.size() != call.vargs.size() ||
+      macro.type_params.size() != call.type_args.size()) {
     return std::nullopt;
   }
 
@@ -471,6 +577,14 @@ std::optional<BlockExpr *> MacroExpander::expand(const Macro &macro, Call &call)
     }
   }
 
+  for (size_t i = 0; i < macro.type_params.size(); i++) {
+    auto *mident = macro.type_params.at(i);
+    assert(mident != nullptr); // Required by lookup.
+    auto *type = call.type_args.at(i);
+    assert(type != nullptr); // Required by lookup.
+    type_params_[mident->ident] = type;
+  }
+
   auto *cloned_block = clone(ast_, call.loc, macro.block);
   visit(cloned_block);
   return cloned_block;
@@ -491,6 +605,25 @@ std::optional<BlockExpr *> MacroExpander::expand(const Macro &macro,
   return cloned_block;
 }
 
+class TypeParamCheck : public Visitor<TypeParamCheck> {
+public:
+  explicit TypeParamCheck(ASTContext &ast) : ast_(ast) {};
+
+  using Visitor<TypeParamCheck>::visit;
+  void visit(Call &call);
+
+private:
+  ASTContext &ast_;
+};
+
+void TypeParamCheck::visit(Call &call)
+{
+  if (!call.type_args.empty()) {
+    call.addError()
+        << "Type args are not supported for function calls only macros";
+  }
+}
+
 void expand_macro(ASTContext &ast,
                   Expression &expr,
                   const MacroRegistry &registry)
@@ -507,6 +640,10 @@ Pass CreateMacroExpansionPass()
     std::vector<const Macro *> stack;
     MacroExpander expander(ast, macros, stack);
     expander.visit(ast.root);
+
+    TypeParamCheck type_param_check(ast);
+    type_param_check.visit(ast.root);
+
     return macros;
   };
 

--- a/src/ast/passes/macro_expansion.h
+++ b/src/ast/passes/macro_expansion.h
@@ -33,12 +33,14 @@ public:
   // This may add errors to conflicting macros.
   static MacroRegistry create(ASTContext &ast);
 
-  // Lookup a macro based on a name, set of arguments, and if it's stdlib
+  // Lookup a macro based on a name, set of arguments, number of type
+  // parameters, and if it's stdlib
   //
   // If no matching macro is found, `nullptr` is returned.
   Result<const Macro *> lookup(
       const std::string &name,
       const std::vector<Expression> &args,
+      size_t num_types,
       std::optional<bool> is_stdlib = std::nullopt) const;
 
 private:
@@ -46,7 +48,9 @@ private:
   std::map<std::string, std::vector<Macro *>> macros_;
 };
 
-void expand_macro(ASTContext &ast, Expression &expr, const MacroRegistry &registry);
+void expand_macro(ASTContext &ast,
+                  Expression &expr,
+                  const MacroRegistry &registry);
 
 // Expand all possible macros. Macros can be defined recursively, and in these
 // cases they are not expanded recursively. Instead, it is the responsibility

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -429,8 +429,21 @@ Buffer Formatter::format_list(std::vector<U>& exprs,
 
 Buffer Formatter::visit(Call& call)
 {
+  // Build the call name, including the optional type list of a macro call:
+  //
+  //    foo[uint64, struct Bar](a, b)
+  //
+  Buffer name = Buffer().text(call.func);
+  size_t name_width = call.func.size();
+  if (!call.type_args.empty()) {
+    auto type_args = format_list(
+        call.type_args, ", ", metadata, max_width, true);
+    name_width += type_args.width() + 2; // account for the '[' and ']'
+    name = std::move(name).text("[").append(std::move(type_args)).text("]");
+  }
+
   auto args = format_list(
-      call.vargs, ", ", metadata, max_width - (call.func.size() + 2), true);
+      call.vargs, ", ", metadata, max_width - (name_width + 2), true);
   if (args.width() > max_width) {
     // Return with the newline break style.
     //
@@ -439,7 +452,8 @@ Buffer Formatter::visit(Call& call)
     //      b
     //    );
     return Buffer()
-        .text(call.func + "(")
+        .append(std::move(name))
+        .text("(")
         .append(std::move(args), kIndentWidth)
         .text(")");
   } else {
@@ -451,7 +465,11 @@ Buffer Formatter::visit(Call& call)
     //        b,
     //        c);
     //
-    return Buffer().text(call.func + "(").append(std::move(args)).text(")");
+    return Buffer()
+        .append(std::move(name))
+        .text("(")
+        .append(std::move(args))
+        .text(")");
   }
 }
 
@@ -1279,12 +1297,18 @@ Buffer Formatter::visit(Program& program)
 
 Buffer Formatter::visit(Macro& macro)
 {
+  Buffer name = Buffer().text(macro.name);
+  if (!macro.type_params.empty()) {
+    auto type_params = format_list(
+        macro.type_params, ", ", metadata, max_width - 10, true);
+    name = std::move(name).text("[").append(std::move(type_params)).text("]");
+  }
   auto args = format_list(macro.vargs, ", ", metadata, max_width - 10, true);
   auto block_metadata = metadata.before(macro.block->loc->current.begin);
   auto block = format(*macro.block, metadata, max_width - kIndentWidth);
   return Buffer()
       .text("macro ")
-      .text(macro.name)
+      .append(std::move(name))
       .text("(")
       .append(std::move(args))
       .text(")")

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -489,6 +489,44 @@ Macro *Parser::parse_macro()
   }
   auto name_loc = make_loc(begin_line, begin_col, line_, col_);
 
+  IdentList type_params;
+
+  if (peek() == '[') {
+    size_t after = scan_balanced(pos_, '[', ']');
+    if (after != pos_ && char_at(after - 1) == ']' &&
+        char_at(scan_layout(after)) == '(') {
+      expect('[');
+
+      auto add_type_ident = [&, this]() -> bool {
+        consume_layout();
+        auto [ident_line, ident_col] = get_current_line_col();
+        auto parsed_ident = consume_identifier("expected type param ident");
+        if (!parsed_ident) {
+          return false;
+        }
+        auto loc = make_loc(ident_line, ident_col, line_, col_);
+        type_params.emplace_back(
+            ctx_.make_node<Identifier>(loc, std::move(*parsed_ident)));
+        return true;
+      };
+
+      bool ok = true;
+      if (peek() != ']') {
+        ok = add_type_ident();
+        while (ok && match(',')) {
+          ok = add_type_ident();
+        }
+      }
+
+      if (!ok) {
+        return nullptr;
+      }
+      expect(']');
+    } else {
+      return nullptr;
+    }
+  }
+
   if (!expect('(')) {
     return nullptr;
   }
@@ -512,8 +550,11 @@ Macro *Parser::parse_macro()
     return nullptr;
   }
 
-  return ctx_.make_node<Macro>(
-      name_loc, std::move(*name), std::move(args), block);
+  return ctx_.make_node<Macro>(name_loc,
+                               std::move(*name),
+                               std::move(args),
+                               block,
+                               std::move(type_params));
 }
 
 Expression Parser::parse_macro_arg()
@@ -1592,7 +1633,7 @@ std::optional<size_t> Parser::scan_type_suffixes(size_t pos,
 }
 
 std::optional<std::variant<Expression, ParsedType *>> Parser::
-    try_parse_type_reference(std::string_view end_chars)
+    try_parse_type_reference(std::string_view end_chars, bool parsed_type_only)
 {
   auto sp = save_point();
   consume_layout();
@@ -1648,6 +1689,14 @@ std::optional<std::variant<Expression, ParsedType *>> Parser::
     return std::nullopt;
   }
   auto loc = make_loc(begin_line, begin_col, line_, col_);
+
+  // TODO - Investigate doing this by default
+  if (parsed_type_only) {
+    return ctx_.make_node<ParsedType>(loc,
+                                      ParsedType::Kind::Identifier,
+                                      *parsed_ident);
+  }
+
   auto *id = ctx_.make_node<Identifier>(loc, std::move(*parsed_ident));
   return Expression(id);
 }
@@ -2263,9 +2312,18 @@ Expression Parser::parse_primary()
     }
 
     consume_layout();
+    if (peek() == '[') {
+      size_t after = scan_balanced(pos_, '[', ']');
+      if (after != pos_ && char_at(after - 1) == ']' &&
+          char_at(scan_layout(after)) == '(') {
+        return parse_typed_call_expression(*name, name_loc);
+      }
+    }
+
     if (peek() == '(') {
       return parse_call_expression(*name, name_loc);
     }
+
     if (is_builtin(*name)) {
       auto *builtin = ctx_.make_node<Builtin>(name_loc, std::move(*name));
       return { builtin };
@@ -2556,6 +2614,7 @@ Expression Parser::parse_call_expression(const std::string &name,
 
   ExpressionList args;
   consume_layout();
+
   if (peek() != ')') {
     args.push_back(parse_expression());
     while (match(',')) {
@@ -2568,6 +2627,64 @@ Expression Parser::parse_call_expression(const std::string &name,
   auto loc = make_loc(
       start_loc.begin.line, start_loc.begin.column, line_, col_);
   auto *call = ctx_.make_node<Call>(loc, std::string(name), std::move(args));
+  return { call };
+}
+
+Expression Parser::parse_typed_call_expression(const std::string &name,
+                                               const SourceLocation &start_loc)
+{
+  expect('[');
+
+  TypeList type_args;
+  consume_layout();
+  auto add_parsed_type = [&, this]() -> bool {
+    auto [begin_line, begin_col] = get_current_line_col();
+    if (auto type_ref = try_parse_type_reference(",]", true)) {
+      auto loc = make_loc(begin_line, begin_col, line_, col_);
+      if (auto *type = std::get_if<ParsedType *>(&*type_ref)) {
+        type_args.emplace_back(std::move(*type));
+        return true;
+      }
+    }
+    return false;
+  };
+
+  bool ok = true;
+  if (peek() != ']') {
+    ok = add_parsed_type();
+    while (ok && match(',')) {
+      ok = add_parsed_type();
+    }
+  }
+
+  if (!ok) {
+    error("expected type expression");
+    // return this simple expression to avoid cascading failures
+    auto loc = make_loc(
+        start_loc.begin.line, start_loc.begin.column, line_, col_);
+    auto *junk = ctx_.make_node<Identifier>(loc, "");
+    return { junk };
+  }
+
+  expect(']');
+  expect('(');
+
+  ExpressionList args;
+  consume_layout();
+
+  if (peek() != ')') {
+    args.push_back(parse_expression());
+    while (match(',')) {
+      args.push_back(parse_expression());
+    }
+  }
+
+  expect(')');
+
+  auto loc = make_loc(
+      start_loc.begin.line, start_loc.begin.column, line_, col_);
+  auto *call = ctx_.make_node<Call>(
+      loc, std::string(name), std::move(args), std::move(type_args));
   return { call };
 }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -64,7 +64,8 @@ private:
   ast::Typeof *parse_type_annotation(bool type_only = false);
   std::optional<size_t> scan_type_suffixes(size_t pos, bool &saw_suffix) const;
   std::optional<std::variant<ast::Expression, ast::ParsedType *>> try_parse_type_reference(
-      std::string_view end_chars);
+      std::string_view end_chars,
+      bool parsed_type_only = false);
 
   // Expression grammar
   ast::Expression parse_expression();
@@ -76,6 +77,9 @@ private:
   ast::Expression parse_primary();
   ast::Expression parse_call_expression(const std::string &name,
                                         const ast::SourceLocation &start_loc);
+  ast::Expression parse_typed_call_expression(
+      const std::string &name,
+      const ast::SourceLocation &start_loc);
   ast::Expression parse_paren_expr();
   std::optional<ast::Expression> try_parse_record(int begin_line,
                                                   int begin_col);

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -28,7 +28,7 @@ bool MatchWith(const NodeType& node,
                const TargetType& target);
 
 template <typename NodeType>
-auto CheckField(auto NodeType::*member,
+auto CheckField(auto NodeType::* member,
                 const auto& expected,
                 const std::string& name);
 
@@ -49,7 +49,8 @@ public:
     return static_cast<Derived&>(*this);
   }
 
-  const std::vector<PredicateType>& predicates() const {
+  const std::vector<PredicateType>& predicates() const
+  {
     return predicates_;
   }
 
@@ -65,7 +66,9 @@ class NodeMatcher
 public:
   NodeMatcher() = default;
 
-  using PredicateMatcher<Derived, NodeType, std::function<bool(const NodeType&)>>::predicates;
+  using PredicateMatcher<Derived,
+                         NodeType,
+                         std::function<bool(const NodeType&)>>::predicates;
 
   operator Matcher<const NodeType&>() const
   {
@@ -238,7 +241,7 @@ bool MatchWith(const NodeType& node,
 }
 
 template <typename NodeType>
-auto CheckField(auto NodeType::*member,
+auto CheckField(auto NodeType::* member,
                 const auto& expected,
                 const std::string& name)
 {
@@ -645,6 +648,14 @@ public:
       return CheckList(call, call.vargs, args_matchers, "arguments");
     });
   }
+
+  CallMatcher& WithTypes(
+      const std::vector<Matcher<const ast::ParsedType&>>& type_matchers)
+  {
+    return Where([type_matchers](const ast::Call& call) {
+      return CheckList(call, call.type_args, type_matchers, "type arguments");
+    });
+  }
 };
 
 inline CallMatcher Call(
@@ -652,6 +663,14 @@ inline CallMatcher Call(
     const std::vector<Matcher<const ast::Expression&>>& args)
 {
   return CallMatcher().WithFunction(name).WithArgs(args);
+}
+
+inline CallMatcher Call(
+    const std::string& name,
+    const std::vector<Matcher<const ast::Expression&>>& args,
+    const std::vector<Matcher<const ast::ParsedType&>>& types)
+{
+  return CallMatcher().WithFunction(name).WithArgs(args).WithTypes(types);
 }
 
 class MapMatcher : public NodeMatcher<MapMatcher, ast::Map> {};
@@ -978,7 +997,6 @@ public:
       return MatchWith(node, range_matcher, *node.iterable.as<ast::Range>());
     });
   }
-
 };
 
 inline ForMatcher For(
@@ -1184,7 +1202,8 @@ inline ConfigMatcher Config(
   return ConfigMatcher().WithStatements(statements);
 }
 
-class RootImportMatcher : public NodeMatcher<RootImportMatcher, ast::RootImport> {
+class RootImportMatcher
+    : public NodeMatcher<RootImportMatcher, ast::RootImport> {
 public:
   RootImportMatcher& WithName(const std::string& name)
   {
@@ -1197,7 +1216,8 @@ inline RootImportMatcher RootImport(const std::string& name)
   return RootImportMatcher().WithName(name);
 }
 
-class StatementImportMatcher : public NodeMatcher<StatementImportMatcher, ast::StatementImport> {
+class StatementImportMatcher
+    : public NodeMatcher<StatementImportMatcher, ast::StatementImport> {
 public:
   StatementImportMatcher& WithName(const std::string& name)
   {
@@ -1258,6 +1278,15 @@ public:
       return MatchWith(node, block_matcher, *node.block);
     });
   }
+
+  MacroMatcher& WithTypeParams(
+      const std::vector<Matcher<const ast::Identifier&>>& type_param_matchers)
+  {
+    return Where([type_param_matchers](const ast::Macro& node) {
+      return CheckList(
+          node, node.type_params, type_param_matchers, "type parameters");
+    });
+  }
 };
 
 inline MacroMatcher Macro(
@@ -1266,6 +1295,19 @@ inline MacroMatcher Macro(
     const Matcher<const ast::BlockExpr&>& block)
 {
   return MacroMatcher().WithName(name).WithArgs(args).WithBlock(block);
+}
+
+inline MacroMatcher Macro(
+    const std::string& name,
+    const std::vector<Matcher<const ast::Identifier&>>& type_params,
+    const std::vector<Matcher<const ast::Expression&>>& args,
+    const Matcher<const ast::BlockExpr&>& block)
+{
+  return MacroMatcher()
+      .WithName(name)
+      .WithTypeParams(type_params)
+      .WithArgs(args)
+      .WithBlock(block);
 }
 
 class SubprogArgMatcher

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -1,5 +1,6 @@
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/import_scripts.h"
+#include "ast/passes/printer.h"
 #include "ast/passes/resolve_imports.h"
 #include "mocks.h"
 #include "parser.h"
@@ -10,6 +11,7 @@ namespace bpftrace::test::macro_expansion {
 using ::testing::HasSubstr;
 
 void test(const std::string& input,
+          const std::string& expected_output = "",
           const std::string& error = "",
           const std::string& warn = "")
 {
@@ -47,6 +49,13 @@ void test(const std::string& input,
 
   if (trimmed_error.empty()) {
     ASSERT_TRUE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+    if (!expected_output.empty()) {
+      std::stringstream printed;
+      ast::Printer printer(ast, printed);
+      printer.visit(ast.root);
+      EXPECT_THAT(printed.str(), HasSubstr(expected_output))
+          << msg.str() << printed.str();
+    }
     if (!trimmed_warn.empty()) {
       EXPECT_THAT(out.str(), HasSubstr(trimmed_warn)) << msg.str() << out.str();
     }
@@ -58,12 +67,12 @@ void test(const std::string& input,
 
 void test_error(const std::string& input, const std::string& error)
 {
-  test(input, error);
+  test(input, "", error);
 }
 
 void test_warning(const std::string& input, const std::string& warn)
 {
-  test(input, "", warn);
+  test(input, "", "", warn);
 }
 
 TEST(macro_expansion, basic_checks)
@@ -240,6 +249,53 @@ TEST(macro_expansion, stdlib_shadowing)
 
   // User macros should not poison builtin/function calls inside stdlib macros.
   test("macro fail(x) { x } begin { print(strlen(\"hi\")); }");
+}
+
+TEST(macro_expansion, type_params)
+{
+  test("macro sz[T]() { sizeof(T) } begin { print(sz[uint64]()); }",
+       "sizeof(uint64)");
+  test("macro sz[T]() { sizeof(T) } begin { print(sz[struct task_struct]()); }",
+       "sizeof(struct task_struct)");
+  test("macro sz[T]() { sizeof(T*) } begin { print(sz[uint64]()); }",
+       "sizeof(uint64*)");
+  test("macro sz[T]() { sizeof(T*[5]) } begin { print(sz[uint64]()); }",
+       "sizeof(uint64*[5])");
+  test("macro sz[T]() { let $x: T = 1 } begin { print(sz[uint32]()); }",
+       ": uint32 = 1");
+  test("macro two[T, U]() { sizeof(T) + sizeof(U) } "
+       "begin { print(two[uint64, uint32]()); }",
+       "sizeof(uint64) + sizeof(uint32)");
+  test("macro foo() { 1 } macro foo[T]() { sizeof(T) } "
+       "begin { print(foo()); print(foo[uint64]()); }",
+       "sizeof(uint64)");
+  test("macro foo[T]() { (T)1 } macro foo[T, U]() { sizeof(U) } "
+       "begin { print(foo[uint64]()); print(foo[uint32, int8]()); }",
+       "sizeof(int8)");
+  test("macro inner[b](t) { sizeof(b*) } macro outer[a](t) { inner[a*](t) } "
+       "begin { print(outer[uint64*](1)); }",
+       "sizeof(uint64***)");
+
+  test_error("macro foo[T]($x) { $x } "
+             "begin { $y = 1; foo[uint64, uint32]($y); }",
+             "The closest definition of foo() has a different number of type "
+             "parameters. Expected: 1 but got 2");
+  test_error("macro foo[T]($x) { $x } begin { $y = 1; foo($y); }",
+             "The closest definition of foo() has a different number of type "
+             "parameters. Expected: 1 but got 0");
+  test_error("macro foo[T]($x) { $x } macro foo[U]($x) { $x } "
+             "begin { $y = 1; foo[uint64]($y); }",
+             "Redefinition of macro: foo");
+  test_error("macro sz[T]() { sizeof(struct T) } begin { print(sz[struct "
+             "task_struct]()); }",
+             "Type arg 'struct task_struct' is incompatible with how the type "
+             "param is used in the macro body.");
+  test_error("macro sz[T]() { sizeof(enum T) } begin { print(sz[struct "
+             "task_struct]()); }",
+             "Type arg 'struct task_struct' is incompatible with how the type "
+             "param is used in the macro body.");
+  test_error("begin { $y = 1; foo[uint64, uint32]($y); }",
+             "Type args are not supported for function calls only macros");
 }
 
 } // namespace bpftrace::test::macro_expansion

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -153,6 +153,31 @@ void test(const std::string &input, const MatcherT &matcher)
   test(bpftrace, input, matcher);
 }
 
+// Macros are not emitted by the formatter (they are expanded away before
+// printing), so they cannot be round-tripped through the printer like other
+// top-level constructs. This variant parses and checks the matcher without
+// the format/reparse step.
+template <typename MatcherT>
+void test_macro(const std::string &input, const MatcherT &matcher)
+{
+  std::ostringstream out;
+  BPFtrace bpftrace;
+  ast::ASTContext ast("stdin", input);
+  auto ok = ast::PassManager()
+                .put(ast)
+                .put(bpftrace)
+                .put(get_mock_function_info())
+                .add(CreateParsePass())
+                .add(ast::CreateParseAttachpointsPass())
+                .run();
+  ASSERT_TRUE(bool(ok));
+
+  ast.diagnostics().emit(out);
+  ASSERT_TRUE(ast.diagnostics().ok()) << out.str() << input;
+
+  EXPECT_THAT(ast, matcher) << input;
+}
+
 TEST(Parser, builtin_variables)
 {
   test("kprobe:sys_read { pid }",
@@ -2046,6 +2071,82 @@ TEST(Parser, sizeof_macro_call)
        Program().WithProbe(
            Probe({ "kprobe:sys_read" },
                  { ExprStatement(Sizeof(Call("mymacro", {}))) })));
+}
+
+TEST(Parser, typed_call)
+{
+  test("kprobe:sys_read { foo[uint64](1); }",
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Call("foo",
+                                { Integer(1) },
+                                { ParsedType(ast::ParsedType::Kind::Identifier,
+                                             "uint64") })) })));
+
+  test("kprobe:sys_read { foo[uint64, struct Foo](1, 2); }",
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(
+               Call("foo",
+                    { Integer(1), Integer(2) },
+                    { ParsedType(ast::ParsedType::Kind::Identifier, "uint64"),
+                      ParsedType(ast::ParsedType::Kind::Struct, "Foo") })) })));
+
+  test("kprobe:sys_read { foo[uint64*](); }",
+       Program().WithProbe(Probe(
+           { "kprobe:sys_read" },
+           { ExprStatement(Call(
+               "foo",
+               {},
+               { ParsedType(ast::ParsedType::Kind::Pointer)
+                     .WithInner(ParsedType(ast::ParsedType::Kind::Identifier,
+                                           "uint64")) })) })));
+
+  // Errors
+  test_parse_failure("kprobe:sys_read { foo[uint64,](1); }", R"(
+stdin:1:30-31: ERROR: syntax: expected type expression
+kprobe:sys_read { foo[uint64,](1); }
+                             ~
+stdin:1:30-31: ERROR: syntax: expected ';'
+kprobe:sys_read { foo[uint64,](1); }
+                             ~
+)");
+  test_parse_failure("kprobe:sys_read { foo[123](1); }", R"(
+stdin:1:23-26: ERROR: syntax: expected type expression
+kprobe:sys_read { foo[123](1); }
+                      ~~~
+stdin:1:23-26: ERROR: syntax: expected ';'
+kprobe:sys_read { foo[123](1); }
+                      ~~~
+)");
+}
+
+TEST(Parser, macro_type_params)
+{
+  test_macro("macro foo[T]($x) {}",
+             Program().WithMacros({ Macro(
+                 "foo", { Identifier("T") }, { Variable("$x") }, Block({})) }));
+
+  test_macro("macro foo[T, U]($x, $y) {}",
+             Program().WithMacros({ Macro("foo",
+                                          { Identifier("T"), Identifier("U") },
+                                          { Variable("$x"), Variable("$y") },
+                                          Block({})) }));
+  test_macro("macro foo[T]() {}",
+             Program().WithMacros(
+                 { Macro("foo", { Identifier("T") }, {}, Block({})) }));
+
+  // Errors
+  test_parse_failure("macro foo[T,]($x) {}", R"(
+stdin:1:13-14: ERROR: syntax: expected type param ident
+macro foo[T,]($x) {}
+            ~
+)");
+  test_parse_failure("macro foo[123]($x) {}", R"(
+stdin:1:11-14: ERROR: syntax: expected type param ident
+macro foo[123]($x) {}
+          ~~~
+)");
 }
 
 TEST(Parser, typeinfo_unknown_type)

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -58,6 +58,18 @@ NAME it accepts arbitrary expressions with maps
 PROG macro add_one(x) { x + 1 } begin { @a = 1; print(add_one(@a + 1));  }
 EXPECT 3
 
+NAME it accepts type params
+PROG struct Foo { char m; } macro sof[a, b]() { sizeof(a[2]) + sizeof(b*) + sizeof(b) } begin { print(sof[uint64*, struct Foo]()); }
+EXPECT 25
+
+NAME it accepts type params for nested casts
+PROG macro cst[a]() { (a*)-1 } begin { print(cst[uint8]()); }
+EXPECT 0xff
+
+NAME it accepts type params for nested macros
+PROG macro cstA[a]() { (a*)-1 } macro cstB[b]() { cstA[b]() } begin { print(cstB[uint8]()); }
+EXPECT 0xff
+
 NAME can call the same macro multiple times
 PROG macro inc($x) { $x += 1; } begin { $a = 1; inc($a); inc($a); inc($a); print($a);  }
 EXPECT 4


### PR DESCRIPTION
Stacked PRs:
 * #5222
 * __->__#5220


--- --- ---

### Macros: Add support for type params


This allows us to do type expression substitution in bpftrace macros.
For example:
```
macro sof_double[type_a, type_b]() {
  sizeof(type_a) + sizeof(type_b[2])
}

begin {
  print(sof_double[struct qspinlock, uint64*]());
}
```

This is only valid for macros so if a call signature doesn't match a macro
then a compile time error is issued.

Also used brackets `[]` instead of `<>` to prevent parsing ambiguity with
less than/greater than operators.

This paves the way to implement the `container_of` macro in addition to a
lot of other cool things with types.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>