### PR TITLE
tests/self: migrate bool runtime tests

### DIFF
--- a/tests/runtime/bool
+++ b/tests/runtime/bool
@@ -3,34 +3,9 @@ PROG begin { print((true, false));  }
 EXPECT (true, false)
 TIMEOUT 1
 
-NAME bool in conditional
-PROG begin { if (true) { print(1); } if (false) { print(2); }  }
-EXPECT 1
-EXPECT_NONE 2
-TIMEOUT 1
-
 NAME bool as map keys and values
 PROG begin { @a[true] = false;  }
 EXPECT @a[true]: false
-TIMEOUT 1
-
-NAME bool as a variable
-PROG begin { $b = true; $c = false; print(($b, $c));  }
-EXPECT (true, false)
-
-NAME cast int to bool
-PROG begin{ print(((bool)1, (bool)0)); exit(); }
-EXPECT (true, false)
-TIMEOUT 1
-
-NAME cast string to bool
-PROG begin{ print(((bool)"hello", (bool)"")); exit(); }
-EXPECT (true, false)
-TIMEOUT 1
-
-NAME cast ptr to bool
-PROG begin { $a = (int64*)0; $b = (int64*)1; print(((bool)$b, (bool)$a));  }
-EXPECT (true, false)
 TIMEOUT 1
 
 NAME cast castable map to bool
@@ -38,28 +13,7 @@ PROG begin{ @a = count(); @b = sum(0); print(((bool)@a, (bool)@b)); exit(); }
 EXPECT (true, false)
 TIMEOUT 1
 
-NAME cast bool to int
-PROG begin{ print(((int64)true, (int64)false)); exit(); }
-EXPECT (1, 0)
-TIMEOUT 1
-
 NAME bool array
 PROG begin { @a = (bool[2])(uint16)1;  }
 EXPECT @a: [true,false]
-TIMEOUT 1
-
-NAME bool logical not
-PROG begin{ $x = 0; print((!0, !10, !$x)); exit(); }
-EXPECT (true, false, true)
-TIMEOUT 1
-
-NAME bool in resized tuples
-PROG begin { @a[false, 1, true] = 1; @a[true, (int32)2, false] = 2;  }
-EXPECT @a[false, 1, true]: 1
-EXPECT @a[true, 2, false]: 2
-TIMEOUT 1
-
-NAME complex bool logical
-PROG BEGIN { $a = 100000; $b = 0; $c = $a > $b; $d = $a && $b; $e = $c || $d; $f = (uint64)$c; print(($c, $d, $e, $f)); }
-EXPECT (true, false, true, 1)
 TIMEOUT 1

--- a/tests/self/bool.bt
+++ b/tests/self/bool.bt
@@ -1,0 +1,136 @@
+test:bool_in_conditional {
+  $x = 0;
+
+  if (true) {
+    $x = 1;
+  }
+
+  if (false) {
+    $x = 2;
+  }
+
+  if ($x != 1) {
+    return 1;
+  }
+}
+
+test:bool_as_a_variable {
+  $b = true;
+  $c = false;
+
+  $t = ($b, $c);
+
+  if (!$t.0) {
+    return 1;
+  }
+
+  if ($t.1) {
+    return 1;
+  }
+}
+
+test:cast_int_to_bool {
+  $t = ((bool)1, (bool)0);
+
+  if (!$t.0) {
+    return 1;
+  }
+  if ($t.1) {
+    return 1;
+  }
+}
+
+test:cast_string_to_bool {
+  $t = ((bool)"hello", (bool)"");
+
+  if (!$t.0) {
+    return 1;
+  }
+
+  if ($t.1) {
+    return 1;
+  }
+}
+
+test:cast_ptr_to_bool {
+  $a = (int64*)0;
+  $b = (int64*)1;
+
+  $t = ((bool)$b, (bool)$a);
+
+  if (!$t.0) {
+    return 1;
+  }
+
+  if ($t.1) {
+    return 1;
+  }
+}
+
+test:cast_bool_to_int {
+  $t = ((int64)true, (int64)false);
+
+  if ($t.0 != 1) {
+    return 1;
+  }
+
+  if ($t.1 != 0) {
+    return 1;
+  }
+}
+
+test:bool_logical_not {
+  $x = 0;
+
+  $t = (!0, !10, !$x);
+
+  if (!$t.0) {
+    return 1;
+  }
+
+  if ($t.1) {
+    return 1;
+  }
+
+  if (!$t.2) {
+    return 1;
+  }
+}
+
+test:bool_in_resized_tuples {
+  @bool_in_resized_tuples_a[false, 1, true] = 1;
+  @bool_in_resized_tuples_a[true, (int32)2, false] = 2;
+
+  if (@bool_in_resized_tuples_a[false, 1, true] != 1) {
+    return 1;
+  }
+
+  if (@bool_in_resized_tuples_a[true, 2, false] != 2) {
+    return 1;
+  }
+}
+
+test:complex_bool_logical {
+  $a = 100000;
+  $b = 0;
+  $c = $a > $b;
+  $d = $a && $b;
+  $e = $c || $d;
+  $f = (uint64)$c;
+
+  if (!$c) {
+    return 1;
+  }
+
+  if ($d) {
+    return 1;
+  }
+
+  if (!$e) {
+    return 1;
+  }
+
+  if ($f != 1) {
+    return 1;
+  }
+}


### PR DESCRIPTION
Migrate several bool runtime tests to self tests.

The migrated tests cover:

bool values
bool in conditional
bool as map keys and values
bool as a variable
int/string/pointer casts to bool
bool to int casts
logical not
bools in resized tuples
complex bool logical expressions