### PR TITLE
Print macros in debug output

### DIFF
--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -507,6 +507,13 @@ Pass CreateMacroExpansionPass()
     std::vector<const Macro *> stack;
     MacroExpander expander(ast, macros, stack);
     expander.visit(ast.root);
+
+    // Macros have now been expanded into their call sites, so remove the
+    // definitions from the AST. The registry retains its own pointers to the
+    // (arena-owned) macro nodes, so this only affects later AST traversals and
+    // debug dumps, which should no longer see the consumed definitions.
+    ast.root->macros.clear();
+
     return macros;
   };
 

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -1262,13 +1262,8 @@ Buffer Formatter::visit(Program& program)
     auto pre_metadata = metadata.before(entry.node().loc->current.begin);
     auto local_buffer = format(entry, metadata, max_width);
 
-    // Macros are only included during full mode, which is effectively
-    // formatting the AST. Otherwise, it is for debug purposes, including
-    // all types, etc. and we only care about macros post-expansion.
-    if (mode == FormatMode::Full || !entry.is<Macro>()) {
-      buffer = buffer.metadata(std::move(pre_metadata), 0)
-                   .append(std::move(local_buffer));
-    }
+    buffer = buffer.metadata(std::move(pre_metadata), 0)
+                 .append(std::move(local_buffer));
   }
 
   // It's possible that there are trailing comments, not associated with any


### PR DESCRIPTION
Stacked PRs:
 * __->__#5222


--- --- ---

### Print macros in debug output


To properly show the AST we should print macros as normal before macro
expansion and just remove them afterward as they are unused.

This allows us to properly test macros in the parser tests.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>