### PR TITLE
Use mock BTF for attachpoint_checker test

### DIFF
--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -339,7 +339,9 @@ TEST(attachpoint_checker, tracepoint)
   test("tracepoint:category:event { 1 }");
 }
 
-TEST(attachpoint_checker, rawtracepoint)
+class attachpoint_checker_btf : public test_btf {};
+
+TEST_F(attachpoint_checker_btf, rawtracepoint)
 {
   test("rawtracepoint:event_rt { 1 }");
   test("rawtracepoint:event_rt { arg0 }");


### PR DESCRIPTION
Stacked PRs:
 * __->__#5223


--- --- ---

### Use mock BTF for attachpoint_checker test


This test was failing when system BTF wasn't available.

Co-authored-by: Holger Hoffstätte <holger@applied-asynchrony.com>

Signed-off-by: Jordan Rome <jordalgo@meta.com>