### PR TITLE
Run clang-format on src/

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -94,7 +94,7 @@ public:
   template <typename T>
   VariantNode(T *value)
     requires(std::is_same_v<T, Ts> || ...)
-      : value(value){};
+      : value(value) {};
 
   template <typename T>
   bool is() const
@@ -275,9 +275,7 @@ public:
                    Location &&loc,
                    uint64_t n,
                    std::optional<std::string> &&original = std::nullopt)
-      : Node(ctx, std::move(loc)),
-        value(n),
-        original(std::move(original)) {};
+      : Node(ctx, std::move(loc)), value(n), original(std::move(original)) {};
   explicit Integer(ASTContext &ctx, const Location &loc, const Integer &other)
       : Node(ctx, loc + other.loc),
         value(other.value),
@@ -307,7 +305,7 @@ public:
 
   bool operator==(const NegativeInteger &other) const
   {
-     return value == other.value;
+    return value == other.value;
   }
   std::strong_ordering operator<=>(const NegativeInteger &other) const
   {
@@ -397,11 +395,9 @@ public:
 class String : public Node {
 public:
   explicit String(ASTContext &ctx, Location &&loc, std::string str)
-      : Node(ctx, std::move(loc)),
-        value(std::move(str)) {};
+      : Node(ctx, std::move(loc)), value(std::move(str)) {};
   explicit String(ASTContext &ctx, const Location &loc, const String &other)
-      : Node(ctx, loc + other.loc),
-        value(other.value) {};
+      : Node(ctx, loc + other.loc), value(other.value) {};
 
   bool operator==(const String &other) const
   {
@@ -422,8 +418,7 @@ public:
   explicit Identifier(ASTContext &ctx,
                       const Location &loc,
                       const Identifier &other)
-      : Node(ctx, loc + other.loc),
-        ident(other.ident) {};
+      : Node(ctx, loc + other.loc), ident(other.ident) {};
 
   bool operator==(const Identifier &other) const
   {
@@ -705,8 +700,7 @@ public:
   explicit Map(ASTContext &ctx, Location &&loc, std::string ident)
       : Node(ctx, std::move(loc)), ident(std::move(ident)) {};
   explicit Map(ASTContext &ctx, const Location &loc, const Map &other)
-      : Node(ctx, loc + other.loc),
-        ident(other.ident) {};
+      : Node(ctx, loc + other.loc), ident(other.ident) {};
 
   bool operator==(const Map &other) const
   {
@@ -826,8 +820,7 @@ public:
   explicit Variable(ASTContext &ctx, Location &&loc, std::string ident)
       : Node(ctx, std::move(loc)), ident(std::move(ident)) {};
   explicit Variable(ASTContext &ctx, const Location &loc, const Variable &other)
-      : Node(ctx, loc + other.loc),
-        ident(other.ident) {};
+      : Node(ctx, loc + other.loc), ident(other.ident) {};
 
   bool operator==(const Variable &other) const
   {
@@ -848,8 +841,7 @@ public:
   explicit VariableAddr(ASTContext &ctx,
                         const Location &loc,
                         const VariableAddr &other)
-      : Node(ctx, loc + other.loc),
-        var(clone(ctx, loc, other.var)) {};
+      : Node(ctx, loc + other.loc), var(clone(ctx, loc, other.var)) {};
 
   bool operator==(const VariableAddr &other) const
   {
@@ -868,8 +860,7 @@ public:
   explicit MapAddr(ASTContext &ctx, Location &&loc, Map *map)
       : Node(ctx, std::move(loc)), map(map) {};
   explicit MapAddr(ASTContext &ctx, const Location &loc, const MapAddr &other)
-      : Node(ctx, loc + other.loc),
-        map(clone(ctx, loc, other.map)) {};
+      : Node(ctx, loc + other.loc), map(clone(ctx, loc, other.map)) {};
 
   bool operator==(const MapAddr &other) const
   {
@@ -1073,7 +1064,7 @@ public:
 
   bool operator==(const Cast &other) const
   {
-    return *typeof == *other.typeof && expr == other.expr;
+    return *typeof == *other.typeof &&expr == other.expr;
   }
   std::strong_ordering operator<=>(const Cast &other) const
   {
@@ -1091,8 +1082,7 @@ public:
   explicit Tuple(ASTContext &ctx, Location &&loc, ExpressionList &&elems)
       : Node(ctx, std::move(loc)), elems(std::move(elems)) {};
   explicit Tuple(ASTContext &ctx, const Location &loc, const Tuple &other)
-      : Node(ctx, loc + other.loc),
-        elems(clone(ctx, loc, other.elems)) {};
+      : Node(ctx, loc + other.loc), elems(clone(ctx, loc, other.elems)) {};
 
   bool operator==(const Tuple &other) const
   {
@@ -1112,7 +1102,9 @@ public:
                          Location &&loc,
                          std::string name,
                          Expression expr)
-      : Node(ctx, std::move(loc)), name(std::move(name)), expr(std::move(expr)) {};
+      : Node(ctx, std::move(loc)),
+        name(std::move(name)),
+        expr(std::move(expr)) {};
   explicit NamedArgument(ASTContext &ctx,
                          const Location &loc,
                          const NamedArgument &other)
@@ -1139,18 +1131,20 @@ using NamedArgumentList = std::vector<NamedArgument *>;
 
 class Record : public Node {
 public:
-  explicit Record(ASTContext &ctx, Location &&loc, NamedArgumentList &&named_args)
+  explicit Record(ASTContext &ctx,
+                  Location &&loc,
+                  NamedArgumentList &&named_args)
       : Node(ctx, std::move(loc)), elems(std::move(named_args)) {};
   explicit Record(ASTContext &ctx, const Location &loc, const Record &other)
-      : Node(ctx, loc + other.loc),
-        elems(clone(ctx, loc, other.elems)) {};
+      : Node(ctx, loc + other.loc), elems(clone(ctx, loc, other.elems)) {};
 
   bool operator==(const Record &other) const
   {
-    return std::ranges::equal(
-               elems,
-               other.elems,
-               [](const auto *a, const auto *b) { return *a == *b; });
+    return std::ranges::equal(elems,
+                              other.elems,
+                              [](const auto *a, const auto *b) {
+                                return *a == *b;
+                              });
   }
   std::strong_ordering operator<=>(const Record &other) const
   {
@@ -1417,15 +1411,12 @@ public:
 
 class DiscardExpr : public Node {
 public:
-  explicit DiscardExpr(ASTContext &ctx,
-                              Location &&loc,
-                              Expression expr)
+  explicit DiscardExpr(ASTContext &ctx, Location &&loc, Expression expr)
       : Node(ctx, std::move(loc)), expr(std::move(expr)) {};
   explicit DiscardExpr(ASTContext &ctx,
-                              const Location &loc,
-                              const DiscardExpr &other)
-      : Node(ctx, loc + other.loc),
-        expr(clone(ctx, loc, other.expr)) {};
+                       const Location &loc,
+                       const DiscardExpr &other)
+      : Node(ctx, loc + other.loc), expr(clone(ctx, loc, other.expr)) {};
 
   bool operator==(const DiscardExpr &other) const
   {
@@ -1682,7 +1673,8 @@ public:
            target == other.target && lang == other.lang && ns == other.ns &&
            func == other.func && pin == other.pin && freq == other.freq &&
            len == other.len && mode == other.mode && address == other.address &&
-           func_offset == other.func_offset && ignore_invalid == other.ignore_invalid;
+           func_offset == other.func_offset &&
+           ignore_invalid == other.ignore_invalid;
   }
   std::strong_ordering operator<=>(const AttachPoint &other) const
   {
@@ -1739,8 +1731,8 @@ public:
   std::string pin;
   symbols::usdt_probe_entry usdt; // resolved USDT entry
   int64_t freq = 0;
-  uint64_t len = 0;   // for watchpoint probes, the width of watched addr
-  std::string mode;   // for watchpoint probes, the watch mode
+  uint64_t len = 0; // for watchpoint probes, the width of watched addr
+  std::string mode; // for watchpoint probes, the watch mode
 
   uint64_t address = 0;
   uint64_t func_offset = 0;
@@ -1891,7 +1883,9 @@ class RootImport : public Node {
 public:
   explicit RootImport(ASTContext &ctx, Location &&loc, std::string name)
       : Node(ctx, std::move(loc)), name(std::move(name)) {};
-  explicit RootImport(ASTContext &ctx, const Location &loc, const RootImport &other)
+  explicit RootImport(ASTContext &ctx,
+                      const Location &loc,
+                      const RootImport &other)
       : Node(ctx, loc + other.loc), name(other.name) {};
 
   bool operator==(const RootImport &other) const
@@ -1910,7 +1904,9 @@ class StatementImport : public Node {
 public:
   explicit StatementImport(ASTContext &ctx, Location &&loc, std::string name)
       : Node(ctx, std::move(loc)), name(std::move(name)) {};
-  explicit StatementImport(ASTContext &ctx, const Location &loc, const StatementImport &other)
+  explicit StatementImport(ASTContext &ctx,
+                           const Location &loc,
+                           const StatementImport &other)
       : Node(ctx, loc + other.loc), name(other.name) {};
 
   bool operator==(const StatementImport &other) const
@@ -2078,8 +2074,8 @@ std::string opstr(const Unop &unop);
 std::string opstr(const Jump &jump);
 bool is_comparison_op(Operator op);
 
-Record* make_record(ASTContext &ctx,
+Record *make_record(ASTContext &ctx,
                     const Location &loc,
-                    std::vector<std::pair<std::string, Expression>>&& args);
+                    std::vector<std::pair<std::string, Expression>> &&args);
 
 } // namespace bpftrace::ast

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -19,8 +19,8 @@ inline bool shouldBeInBpfMemoryAlready(const SizedType &type)
 {
   return type.IsStringTy() || type.IsBufferTy() || type.IsInetTy() ||
          type.IsUsymTy() || type.IsKstackTy() || type.IsUstackTy() ||
-         type.IsTupleTy() || type.IsRecordTy() || type.IsTimestampTy() || type.IsMacAddressTy() ||
-         type.IsCgroupPathTy();
+         type.IsTupleTy() || type.IsRecordTy() || type.IsTimestampTy() ||
+         type.IsMacAddressTy() || type.IsCgroupPathTy();
 }
 
 inline bool inBpfMemory(const SizedType &type)

--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -72,8 +72,7 @@ private:
     size_t amount;
   };
   using InternalMap =
-      std::map<SourceLocation,
-               std::variant<CommentSentinel, VspaceSentinel>>;
+      std::map<SourceLocation, std::variant<CommentSentinel, VspaceSentinel>>;
   MetadataIndex(std::shared_ptr<ASTSource> source, InternalMap other)
       : source_(std::move(source)), map_(std::move(other)) {};
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -118,7 +118,7 @@ public:
   CallInst *CreateGetRandom(const Location &loc);
   CallInst *CreateGetStack(Value *ctx,
                            Value *buf,
-                           const StackType& stack_type,
+                           const StackType &stack_type,
                            const Location &loc);
   CallInst *CreateGetFuncIp(Value *ctx, const Location &loc);
   CallInst *CreatePerCpuPtr(Value *var, Value *cpu, const Location &loc);
@@ -131,11 +131,11 @@ public:
                                           const std::string &name,
                                           const Location &loc);
   Value *CreateAnonStructAllocation(const SizedType &tuple_type,
-                               const std::string &name,
-                               const Location &loc);
+                                    const std::string &name,
+                                    const Location &loc);
   Value *CreateCallStackAllocation(const SizedType &stack_type,
-                               const std::string &name,
-                               const Location &loc);
+                                   const std::string &name,
+                                   const Location &loc);
   Value *CreateJoinAllocation(const Location &loc);
   Value *CreateWriteMapValueAllocation(const SizedType &value_type,
                                        const std::string &name,
@@ -183,7 +183,7 @@ public:
   void CreateHelperErrorCond(Value *return_value,
                              bpf_func_id func_id,
                              const Location &loc);
-  StructType *GetStackStructType(const StackType& stack_type);
+  StructType *GetStackStructType(const StackType &stack_type);
   StructType *GetStructType(const std::string &name,
                             const std::vector<llvm::Type *> &elements,
                             bool packed = false);

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -540,7 +540,7 @@ AttachPointParser::State AttachPointParser::lex_attachpoint(
       }
     } else if (raw[idx] == '"') {
       in_quotes = !in_quotes;
-    // Handle escaped characters in a string
+      // Handle escaped characters in a string
     } else if (in_quotes && raw[idx] == '\\' && (idx + 1 < raw.size())) {
       argument += raw[idx + 1];
       ++idx;

--- a/src/ast/passes/macro_expansion.h
+++ b/src/ast/passes/macro_expansion.h
@@ -46,7 +46,9 @@ private:
   std::map<std::string, std::vector<Macro *>> macros_;
 };
 
-void expand_macro(ASTContext &ast, Expression &expr, const MacroRegistry &registry);
+void expand_macro(ASTContext &ast,
+                  Expression &expr,
+                  const MacroRegistry &registry);
 
 // Expand all possible macros. Macros can be defined recursively, and in these
 // cases they are not expanded recursively. Instead, it is the responsibility

--- a/src/ast/passes/map_sugar.h
+++ b/src/ast/passes/map_sugar.h
@@ -26,8 +26,8 @@ public:
   std::unordered_set<Node *> bad_iterator;
 };
 
-const std::unordered_set<std::string>& getAssignRewriteFuncs();
-const std::unordered_set<std::string>& getRawMapArgFuncs();
+const std::unordered_set<std::string> &getAssignRewriteFuncs();
+const std::unordered_set<std::string> &getRawMapArgFuncs();
 
 Pass CreateMapSugarPass();
 

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -120,7 +120,7 @@ public:
   Buffer visit(Statement &stmt);
   Buffer visit(RootStatement &root);
   Buffer visit(CStatement &cstmt);
-  Buffer visit(NamedArgument& named_arg);
+  Buffer visit(NamedArgument &named_arg);
   Buffer visit(const ParsedType &type);
 
 private:
@@ -166,7 +166,8 @@ public:
   void visit(T &value)
   {
     MetadataIndex metadata = ast_.metadata();
-    out_ << Formatter(mode_, metadata, max_width_, true, type_map_).visit(value);
+    out_
+        << Formatter(mode_, metadata, max_width_, true, type_map_).visit(value);
   }
 
 private:

--- a/src/ast/passes/types/type_resolver.h
+++ b/src/ast/passes/types/type_resolver.h
@@ -13,8 +13,9 @@ namespace bpftrace::ast {
 
 using ScopedVariable = std::pair<Node *, std::string>;
 // Node * is a pointer to an AST node
-// ScopedVariable is for tracking the type of a scratch variable referenced in many AST nodes
-// std::string is for map key and value names as these are often resolved separately by different statements/expressions
+// ScopedVariable is for tracking the type of a scratch variable referenced in
+// many AST nodes std::string is for map key and value names as these are often
+// resolved separately by different statements/expressions
 using TypeVariable = std::variant<Node *, ScopedVariable, std::string>;
 
 struct ScopedVariableHash {
@@ -46,7 +47,8 @@ struct TypeVariableHash {
   }
 };
 
-using ResolvedTypes = std::unordered_map<TypeVariable, SizedType, TypeVariableHash>;
+using ResolvedTypes =
+    std::unordered_map<TypeVariable, SizedType, TypeVariableHash>;
 
 inline std::string get_map_value_name(const std::string &ident)
 {

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -21,9 +21,10 @@ namespace bpftrace {
 // General load error with a specific message.
 class BpfLoadError : public ErrorInfo<BpfLoadError> {
 public:
-  BpfLoadError(std::string msg) : msg_(std::move(msg)){};
+  BpfLoadError(std::string msg) : msg_(std::move(msg)) {};
   static char ID;
-  void log(llvm::raw_ostream& OS) const override;
+  void log(llvm::raw_ostream &OS) const override;
+
 private:
   std::string msg_;
 };
@@ -34,8 +35,12 @@ public:
   HelperVerifierError(std::string msg, bpf_func_id func_id_)
       : msg_(std::move(msg)), func_id_(func_id_) {};
   static char ID;
-  void log(llvm::raw_ostream& OS) const override;
-  bpf_func_id func_id() const { return func_id_; }
+  void log(llvm::raw_ostream &OS) const override;
+  bpf_func_id func_id() const
+  {
+    return func_id_;
+  }
+
 private:
   std::string msg_;
   bpf_func_id func_id_;
@@ -60,9 +65,9 @@ public:
                           globalvars::GlobalVarMap &&global_var_vals);
   uint64_t get_event_loss_counter(BPFtrace &bpftrace, int max_cpu_id);
   Result<> load_progs(const RequiredResources &resources,
-                  const BTF &btf,
-                  BPFfeature &feature,
-                  const Config &config);
+                      const BTF &btf,
+                      BPFfeature &feature,
+                      const Config &config);
   void attach_external();
 
   const BpfProgram &getProgramForProbe(const Probe &probe) const;

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -128,7 +128,6 @@ bpf_map_type get_bpf_map_type(const SizedType &val_type);
 std::optional<bpf_map_type> get_bpf_map_type(const std::string &name);
 std::string get_bpf_map_type_str(bpf_map_type map_type);
 void add_bpf_map_types_hint(std::stringstream &hint);
-bool bpf_map_types_compatible(const SizedType &val_type,
-                              bpf_map_type kind);
+bool bpf_map_types_compatible(const SizedType &val_type, bpf_map_type kind);
 
 } // namespace bpftrace

--- a/src/btf.h
+++ b/src/btf.h
@@ -102,7 +102,8 @@ public:
   std::string c_def(const std::unordered_set<std::string>& set = {});
 
   std::map<std::string, std::set<std::string>> get_all_structs() const;
-  std::unique_ptr<std::istream> get_all_traceable_funcs(const symbols::KernelInfo &kernel_func_info) const;
+  std::unique_ptr<std::istream> get_all_traceable_funcs(
+      const symbols::KernelInfo& kernel_func_info) const;
   std::unordered_set<std::string> get_all_iters() const;
   std::unique_ptr<std::istream> get_all_raw_tracepoints();
   FuncParamLists get_params(const std::set<std::string>& funcs) const;
@@ -112,10 +113,9 @@ public:
   FuncParamLists get_rawtracepoint_params(
       const std::set<std::string>& rawtracepoints) const;
 
-  Result<std::shared_ptr<Struct>> resolve_args(
-      std::string_view func,
-      bool ret,
-      bool skip_first_arg);
+  Result<std::shared_ptr<Struct>> resolve_args(std::string_view func,
+                                               bool ret,
+                                               bool skip_first_arg);
   Result<std::shared_ptr<Struct>> resolve_raw_tracepoint_args(
       std::string_view func);
   void resolve_fields(const SizedType& type);
@@ -138,7 +138,9 @@ private:
 
   std::string dump_defs_from_btf(const struct btf* btf,
                                  std::unordered_set<std::string>& types) const;
-  std::string get_all_traceable_funcs_from_btf(const symbols::KernelInfo &kernel_func_info, const BTFObj& btf_obj) const;
+  std::string get_all_traceable_funcs_from_btf(
+      const symbols::KernelInfo& kernel_func_info,
+      const BTFObj& btf_obj) const;
   std::string get_all_raw_tracepoints_from_btf(const BTFObj& btf_obj) const;
   FuncParamLists get_params_impl(
       const std::set<std::string>& funcs,
@@ -164,8 +166,8 @@ private:
 
   __u32 start_id(const struct btf* btf) const;
 
-  BTFId parse_anon_btf_name(const std::string &name);
-  std::string create_anon_btf_name(BTFId &btf_id);
+  BTFId parse_anon_btf_name(const std::string& name);
+  std::string create_anon_btf_name(BTFId& btf_id);
 
   struct btf* vmlinux_btf = nullptr;
   __u32 vmlinux_btf_size;

--- a/src/btf/btf.h
+++ b/src/btf/btf.h
@@ -68,7 +68,10 @@ public:
   static char ID;
   ParseError(int err) : err_(err >= 0 ? err : -err) {};
   void log(llvm::raw_ostream &OS) const override;
-  int error_code() const { return err_; }
+  int error_code() const
+  {
+    return err_;
+  }
 
 private:
   int err_;
@@ -80,7 +83,10 @@ public:
   static char ID;
   TypeError(int err) : err_(err >= 0 ? err : -err) {};
   void log(llvm::raw_ostream &OS) const override;
-  int error_code() const { return err_; }
+  int error_code() const
+  {
+    return err_;
+  }
 
 private:
   int err_;
@@ -296,10 +302,12 @@ public:
       : Type<Integer, BTF_KIND_INT>(std::move(handle), type_id) {};
 
   size_t bytes() const;
-  bool is_bool() const {
+  bool is_bool() const
+  {
     return btf_int_encoding(btf_type()) & BTF_INT_BOOL;
   }
-  bool is_signed() const {
+  bool is_signed() const
+  {
     return btf_int_encoding(btf_type()) & BTF_INT_SIGNED;
   }
 
@@ -639,7 +647,7 @@ public:
   template <typename U>
   VariantType(const U &value)
     requires((std::is_same_v<U, Ts> || ...))
-      : value_(value){};
+      : value_(value) {};
 
   // Allow conversion between types as long as one is strictly a subset of the
   // other. In general, this allows `ValueType` to `AnyType` implicit
@@ -648,7 +656,7 @@ public:
   VariantType(VariantType<Us...> other)
       : VariantType(
             std::visit([](const auto &v) -> std::variant<Ts...> { return v; },
-                       other.value())){};
+                       other.value())) {};
 
   // Checks to see if this is the given kind.
   template <typename T>
@@ -825,7 +833,8 @@ public:
   Types(const Types &base)
       : handle_(std::make_shared<detail::Handle>(base.handle_)) {};
   Types(struct btf *btf) : handle_(std::make_shared<detail::Handle>(btf)) {};
-  Types(struct btf *btf, const Types &base) : handle_(std::make_shared<detail::Handle>(btf, base.handle_)) {};
+  Types(struct btf *btf, const Types &base)
+      : handle_(std::make_shared<detail::Handle>(btf, base.handle_)) {};
   Types(Types &&other) = default;
   Types &operator=(Types &&other) = default;
 

--- a/src/btf/compat.h
+++ b/src/btf/compat.h
@@ -37,33 +37,48 @@ struct compatTypeFor {
 
 template <typename... Ts>
 struct compatTypeFor<VariantType<Ts...>> {
-  Result<SizedType> operator()(const VariantType<Ts...> &type, CompatTypeCache &type_cache)
+  Result<SizedType> operator()(const VariantType<Ts...> &type,
+                               CompatTypeCache &type_cache)
   {
-    return std::visit([&](const auto &v) { return getCompatType(v, type_cache); },
-                      type.value());
+    return std::visit(
+        [&](const auto &v) { return getCompatType(v, type_cache); },
+        type.value());
   }
 };
 
 Result<SizedType> getCompatType(const Void &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const Integer &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const Pointer &type, CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const Integer &type,
+                                CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const Pointer &type,
+                                CompatTypeCache &type_cache);
 Result<SizedType> getCompatType(const Array &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const Struct &type, CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const Struct &type,
+                                CompatTypeCache &type_cache);
 Result<SizedType> getCompatType(const Union &type, CompatTypeCache &type_cache);
 Result<SizedType> getCompatType(const Enum &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const Enum64 &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const TypeTag &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const DeclTag &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const Typedef &type, CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const Enum64 &type,
+                                CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const TypeTag &type,
+                                CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const DeclTag &type,
+                                CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const Typedef &type,
+                                CompatTypeCache &type_cache);
 Result<SizedType> getCompatType(const Const &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const Volatile &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const Restrict &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const Function &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const FunctionProto &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const DataSection &type, CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const Volatile &type,
+                                CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const Restrict &type,
+                                CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const Function &type,
+                                CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const FunctionProto &type,
+                                CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const DataSection &type,
+                                CompatTypeCache &type_cache);
 Result<SizedType> getCompatType(const Float &type, CompatTypeCache &type_cache);
 Result<SizedType> getCompatType(const Var &type, CompatTypeCache &type_cache);
-Result<SizedType> getCompatType(const ForwardDecl &type, CompatTypeCache &type_cache);
+Result<SizedType> getCompatType(const ForwardDecl &type,
+                                CompatTypeCache &type_cache);
 
 template <typename T>
 Result<SizedType> getCompatType(const T &type, CompatTypeCache &type_cache)

--- a/src/config.h
+++ b/src/config.h
@@ -20,7 +20,8 @@ enum class ConfigUnstable {
   error,
 };
 
-// Taken from here: https://elixir.bootlin.com/linux/v5.16/source/include/linux/license.h
+// Taken from here:
+// https://elixir.bootlin.com/linux/v5.16/source/include/linux/license.h
 enum CompatibleBPFLicense {
   GPL,
   GPL_V2,

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -139,8 +139,10 @@ constexpr std::string_view CHILD_PID = "__bt__child_pid";
 constexpr std::string_view RO_SECTION_NAME = ".rodata";
 constexpr std::string_view FMT_STRINGS_BUFFER_SECTION_NAME =
     ".data.fmt_str_buf";
-constexpr std::string_view ANON_STRUCT_BUFFER_SECTION_NAME = ".data.anon_struct_buf";
-constexpr std::string_view CALL_STACK_BUFFER_SECTION_NAME = ".data.call_stack_buf";
+constexpr std::string_view ANON_STRUCT_BUFFER_SECTION_NAME =
+    ".data.anon_struct_buf";
+constexpr std::string_view CALL_STACK_BUFFER_SECTION_NAME =
+    ".data.call_stack_buf";
 constexpr std::string_view GET_STR_BUFFER_SECTION_NAME = ".data.get_str_buf";
 constexpr std::string_view READ_MAP_VALUE_BUFFER_SECTION_NAME =
     ".data.read_map_val_buf";
@@ -150,8 +152,7 @@ constexpr std::string_view VARIABLE_BUFFER_SECTION_NAME = ".data.var_buf";
 constexpr std::string_view MAP_KEY_BUFFER_SECTION_NAME = ".data.map_key_buf";
 constexpr std::string_view EVENT_LOSS_COUNTER_SECTION_NAME =
     ".data.event_loss_counter";
-constexpr std::string_view JOIN_BUFFER_SECTION_NAME =
-    ".data.join_buf";
+constexpr std::string_view JOIN_BUFFER_SECTION_NAME = ".data.join_buf";
 
 struct GlobalVarConfig {
   std::string section;
@@ -175,16 +176,20 @@ private:
 const std::unordered_map<std::string_view, GlobalVarConfig>
     GLOBAL_VAR_CONFIGS = {
       { NUM_CPUS,
-        { .section = std::string(RO_SECTION_NAME), .type = GlobalVarConfig::opt_unsigned } },
+        { .section = std::string(RO_SECTION_NAME),
+          .type = GlobalVarConfig::opt_unsigned } },
       { MAX_CPU_ID,
-        { .section = std::string(RO_SECTION_NAME), .type = GlobalVarConfig::opt_unsigned } },
+        { .section = std::string(RO_SECTION_NAME),
+          .type = GlobalVarConfig::opt_unsigned } },
       { EVENT_LOSS_COUNTER,
         { .section = std::string(EVENT_LOSS_COUNTER_SECTION_NAME),
           .type = GlobalVarConfig::opt_unsigned } },
       { FMT_STRINGS_BUFFER,
         { .section = std::string(FMT_STRINGS_BUFFER_SECTION_NAME) } },
-      { ANON_STRUCT_BUFFER, { .section = std::string(ANON_STRUCT_BUFFER_SECTION_NAME) } },
-      { CALL_STACK_BUFFER, { .section = std::string(CALL_STACK_BUFFER_SECTION_NAME) } },
+      { ANON_STRUCT_BUFFER,
+        { .section = std::string(ANON_STRUCT_BUFFER_SECTION_NAME) } },
+      { CALL_STACK_BUFFER,
+        { .section = std::string(CALL_STACK_BUFFER_SECTION_NAME) } },
       { GET_STR_BUFFER,
         { .section = std::string(GET_STR_BUFFER_SECTION_NAME) } },
       { READ_MAP_VALUE_BUFFER,
@@ -195,10 +200,10 @@ const std::unordered_map<std::string_view, GlobalVarConfig>
         { .section = std::string(VARIABLE_BUFFER_SECTION_NAME) } },
       { MAP_KEY_BUFFER,
         { .section = std::string(MAP_KEY_BUFFER_SECTION_NAME) } },
-      { JOIN_BUFFER,
-        { .section = std::string(JOIN_BUFFER_SECTION_NAME) } },
+      { JOIN_BUFFER, { .section = std::string(JOIN_BUFFER_SECTION_NAME) } },
       { CHILD_PID,
-        { .section = std::string(RO_SECTION_NAME), .type = GlobalVarConfig::opt_unsigned } },
+        { .section = std::string(RO_SECTION_NAME),
+          .type = GlobalVarConfig::opt_unsigned } },
     };
 
 class GlobalVars {
@@ -221,7 +226,9 @@ public:
   SizedType get_sized_type(const std::string &global_var_name,
                            const RequiredResources &resources,
                            const Config &bpftrace_config) const;
-  void check_index(const std::string &global_var_name, const RequiredResources &resources, size_t index) const;
+  void check_index(const std::string &global_var_name,
+                   const RequiredResources &resources,
+                   size_t index) const;
 
   const std::unordered_map<std::string, GlobalVarConfig> &global_var_map() const
   {

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -64,7 +64,7 @@ struct Primitive {
   template <typename T>
   Primitive(T&& t)
     requires std::constructible_from<Variant, T>
-      : variant(std::forward<T>(t)){};
+      : variant(std::forward<T>(t)) {};
 
   auto operator<=>(const Primitive& other) const = default;
   bool operator==(const Primitive& other) const = default;
@@ -124,7 +124,7 @@ struct Value {
   template <typename T>
   Value(T&& t)
     requires std::constructible_from<Variant, T>
-      : variant(std::forward<T>(t)){};
+      : variant(std::forward<T>(t)) {};
 
   Variant variant;
 };

--- a/src/probe_types.h
+++ b/src/probe_types.h
@@ -114,8 +114,8 @@ struct Probe {
   uint64_t log_size = 1000000;
   int index = 0;
   int freq = 0;
-  uint64_t len = 0;   // for watchpoint probes, size of region
-  std::string mode;   // for watchpoint probes, watch mode (rwx)
+  uint64_t len = 0; // for watchpoint probes, size of region
+  std::string mode; // for watchpoint probes, watch mode (rwx)
   uint64_t address = 0;
   uint64_t func_offset = 0;
   uint64_t bpf_prog_id = 0;

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -169,26 +169,26 @@ public:
   std::vector<
       std::tuple<FormatString, std::vector<Field>, PrintfSeverity, SourceInfo>>
       printf_args;
-  std::unordered_map<ast::Call* , size_t> printf_args_id_map;
+  std::unordered_map<ast::Call *, size_t> printf_args_id_map;
   std::vector<std::tuple<FormatString, std::vector<Field>>> system_args;
-  std::unordered_map<ast::Call* , size_t> system_args_id_map;
+  std::unordered_map<ast::Call *, size_t> system_args_id_map;
   // fmt strings for BPF helpers (bpf_seq_printf, bpf_trace_printk)
   std::vector<FormatString> bpf_print_fmts;
-  std::unordered_map<ast::Call* , size_t> bpf_print_fmts_id_map;
+  std::unordered_map<ast::Call *, size_t> bpf_print_fmts_id_map;
   std::vector<std::tuple<FormatString, std::vector<Field>>> cat_args;
-  std::unordered_map<ast::Call* , size_t> cat_args_id_map;
+  std::unordered_map<ast::Call *, size_t> cat_args_id_map;
   std::vector<std::string> join_args;
-  std::unordered_map<ast::Call* , size_t> join_args_id_map;
+  std::unordered_map<ast::Call *, size_t> join_args_id_map;
   std::vector<std::string> time_args;
-  std::unordered_map<ast::Call* , size_t> time_args_id_map;
+  std::unordered_map<ast::Call *, size_t> time_args_id_map;
   std::vector<std::string> strftime_args;
-  std::unordered_map<ast::Call* , size_t> strftime_args_id_map;
+  std::unordered_map<ast::Call *, size_t> strftime_args_id_map;
   std::vector<std::string> cgroup_path_args;
-  std::unordered_map<ast::Call* , size_t> cgroup_path_args_id_map;
+  std::unordered_map<ast::Call *, size_t> cgroup_path_args_id_map;
   std::vector<SizedType> non_map_print_args;
-  std::unordered_map<ast::Call* , size_t> non_map_print_args_id_map;
+  std::unordered_map<ast::Call *, size_t> non_map_print_args_id_map;
   std::vector<std::tuple<std::string, long>> skboutput_args_;
-  std::unordered_map<ast::Call* , size_t> skboutput_args_id_map;
+  std::unordered_map<ast::Call *, size_t> skboutput_args_id_map;
   // While max fmtstring args size is not used at runtime, the size
   // calculation requires taking into account struct alignment semantics,
   // and that is tricky enough that we want to minimize repetition of

--- a/src/symbols/elf_parser.h
+++ b/src/symbols/elf_parser.h
@@ -1,13 +1,13 @@
 #pragma once
 
-#include <string>
-#include <string_view>
-#include <utility>
-#include <vector>
-#include <unistd.h>
 #include <elf.h>
 #include <gelf.h>
 #include <libelf.h>
+#include <string>
+#include <string_view>
+#include <unistd.h>
+#include <utility>
+#include <vector>
 
 #include "util/result.h"
 
@@ -19,7 +19,7 @@ constexpr std::string_view USDT_NOTE_NAME = "stapsdt";
 
 class ELFParseError : public ErrorInfo<ELFParseError> {
 public:
-  ELFParseError(std::string&& msg) : msg_(std::move(msg)){};
+  ELFParseError(std::string&& msg) : msg_(std::move(msg)) {};
   ELFParseError() = default;
   static char ID;
   void log(llvm::raw_ostream& OS) const override;
@@ -60,9 +60,7 @@ struct usdt_probe_entry {
       : provider(std::move(provider)),
         name(std::move(name)),
         sema_addr(sema_addr),
-        sema_offset(sema_offset)
-  {
-  };
+        sema_offset(sema_offset) {};
 
   bool operator==(const usdt_probe_entry& other) const = default;
   auto operator<=>(const usdt_probe_entry& other) const = default;

--- a/src/symbols/kernel.h
+++ b/src/symbols/kernel.h
@@ -2,15 +2,15 @@
 
 #include <cstdint>
 #include <fstream>
-#include <optional>
-#include <string>
 #include <map>
+#include <optional>
 #include <set>
+#include <string>
 #include <vector>
 
+#include "btf/btf.h"
 #include "util/result.h"
 #include "util/symbols.h"
-#include "btf/btf.h"
 
 namespace bpftrace::symbols {
 
@@ -31,16 +31,20 @@ public:
   virtual ~KernelInfo() = default;
 
   // Returns the set of available modules.
-  virtual ModuleSet get_modules(const std::optional<std::string> &mod_name = std::nullopt) const = 0;
+  virtual ModuleSet get_modules(
+      const std::optional<std::string> &mod_name = std::nullopt) const = 0;
 
   // Returns all traceable functions.
-  virtual ModulesFuncsMap get_traceable_funcs(const std::optional<std::string> &mod_name = std::nullopt) const = 0;
+  virtual ModulesFuncsMap get_traceable_funcs(
+      const std::optional<std::string> &mod_name = std::nullopt) const = 0;
 
   // Returns all raw tracepoints.
-  virtual ModulesFuncsMap get_raw_tracepoints(const std::optional<std::string> &mod_name = std::nullopt) const = 0;
+  virtual ModulesFuncsMap get_raw_tracepoints(
+      const std::optional<std::string> &mod_name = std::nullopt) const = 0;
 
   // Returns all known tracepoints.
-  virtual ModulesFuncsMap get_tracepoints(const std::optional<std::string> &category_name = std::nullopt) const = 0;
+  virtual ModulesFuncsMap get_tracepoints(
+      const std::optional<std::string> &category_name = std::nullopt) const = 0;
 
   // Returns all currently running BPF programs as (id, function_name) pairs.
   virtual std::vector<std::pair<uint32_t, std::string>> get_bpf_progs()
@@ -48,7 +52,8 @@ public:
 
   // Returns the set of modules (or "vmlinux") where the function appears.
   virtual ModuleSet get_func_modules(
-      const std::string &func_name, const std::optional<std::string> &mod_name = std::nullopt) const = 0;
+      const std::string &func_name,
+      const std::optional<std::string> &mod_name = std::nullopt) const = 0;
 
   // Loads the BTF for the given modules.
   virtual Result<btf::Types> load_btf(const std::string &mod_name) const = 0;
@@ -56,8 +61,9 @@ public:
   // Returns true if the given function is traceable.
   //
   // This is a simple convenience method.
-  virtual bool is_traceable(const std::string &func_name,
-                            const std::optional<std::string> &mod_name = std::nullopt) const = 0;
+  virtual bool is_traceable(
+      const std::string &func_name,
+      const std::optional<std::string> &mod_name = std::nullopt) const = 0;
 
   // Returns true iff the given module is loaded (has anything traceable).
   //
@@ -65,9 +71,8 @@ public:
   virtual bool is_module_loaded(const std::string &mod_name) const = 0;
 
   // This may be used by derived classes to implement core methods.
-  static ModulesFuncsMap filter(
-    const ModulesFuncsMap &source,
-    const std::optional<std::string> &mod_name);
+  static ModulesFuncsMap filter(const ModulesFuncsMap &source,
+                                const std::optional<std::string> &mod_name);
 };
 
 // Implements the all the basic helpers.
@@ -77,7 +82,8 @@ template <typename T>
 class KernelInfoBase : public KernelInfo {
 public:
   ModuleSet get_func_modules(
-    const std::string &func_name, const std::optional<std::string> &mod_name = std::nullopt) const override
+      const std::string &func_name,
+      const std::optional<std::string> &mod_name = std::nullopt) const override
   {
     const auto *impl = static_cast<const T *>(this);
     ModuleSet result;
@@ -89,16 +95,19 @@ public:
     return result;
   }
 
-  bool is_traceable(const std::string &func_name,
-                    const std::optional<std::string> &mod_name = std::nullopt) const override {
-                      const auto *impl = static_cast<const T *>(this);
-                      auto funcs = impl->get_traceable_funcs(mod_name);
-                      return std::ranges::any_of(funcs, [&func_name](const auto &pair) {
-                        return pair.second->contains(func_name);
-                      });
-                    }
+  bool is_traceable(
+      const std::string &func_name,
+      const std::optional<std::string> &mod_name = std::nullopt) const override
+  {
+    const auto *impl = static_cast<const T *>(this);
+    auto funcs = impl->get_traceable_funcs(mod_name);
+    return std::ranges::any_of(funcs, [&func_name](const auto &pair) {
+      return pair.second->contains(func_name);
+    });
+  }
 
-  bool is_module_loaded(const std::string &mod_name) const override {
+  bool is_module_loaded(const std::string &mod_name) const override
+  {
     const auto *impl = static_cast<const T *>(this);
     return !impl->get_modules(mod_name).empty();
   }
@@ -107,17 +116,23 @@ public:
 // Implementation that reads available functions from the kernel.
 class KernelInfoImpl : public KernelInfoBase<KernelInfoImpl> {
 public:
-  static Result<KernelInfoImpl> open(const std::string &traceable_functions_file);
+  static Result<KernelInfoImpl> open(
+      const std::string &traceable_functions_file);
   KernelInfoImpl(const KernelInfoImpl &other) = delete;
   KernelInfoImpl &operator=(const KernelInfoImpl &other) = delete;
   KernelInfoImpl(KernelInfoImpl &&other) = default;
   KernelInfoImpl &operator=(KernelInfoImpl &&other) = default;
   ~KernelInfoImpl() override = default;
 
-  ModuleSet get_modules(const std::optional<std::string> &mod_name = std::nullopt) const override;
-  ModulesFuncsMap get_traceable_funcs(const std::optional<std::string> &mod_name = std::nullopt) const override;
-  ModulesFuncsMap get_raw_tracepoints(const std::optional<std::string> &mod_name = std::nullopt) const override;
-  ModulesFuncsMap get_tracepoints(const std::optional<std::string> &category_name = std::nullopt) const override;
+  ModuleSet get_modules(
+      const std::optional<std::string> &mod_name = std::nullopt) const override;
+  ModulesFuncsMap get_traceable_funcs(
+      const std::optional<std::string> &mod_name = std::nullopt) const override;
+  ModulesFuncsMap get_raw_tracepoints(
+      const std::optional<std::string> &mod_name = std::nullopt) const override;
+  ModulesFuncsMap get_tracepoints(
+      const std::optional<std::string> &category_name =
+          std::nullopt) const override;
   Result<btf::Types> load_btf(const std::string &mod_name) const override;
 
   std::vector<std::pair<uint32_t, std::string>> get_bpf_progs() const override;
@@ -125,9 +140,13 @@ public:
 private:
   KernelInfoImpl() = default;
 
-  void add_function(const std::string &func_name, const std::string &mod_name) const;
-  void populate_lazy(const std::optional<std::string> &mod_name = std::nullopt) const;
-  ModulesFuncsMap filter_funcs(const ModulesFuncsMap &source, const std::optional<std::string> &mod_name = std::nullopt) const;
+  void add_function(const std::string &func_name,
+                    const std::string &mod_name) const;
+  void populate_lazy(
+      const std::optional<std::string> &mod_name = std::nullopt) const;
+  ModulesFuncsMap filter_funcs(
+      const ModulesFuncsMap &source,
+      const std::optional<std::string> &mod_name = std::nullopt) const;
 
   mutable std::ifstream available_filter_functions_;
   mutable std::string last_checked_line_;

--- a/src/symbols/user.h
+++ b/src/symbols/user.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <map>
 #include <set>
 #include <string>
-#include <map>
 
 #include "symbols/elf_parser.h"
 #include "util/result.h"
@@ -65,17 +65,16 @@ public:
   UserInfoImpl() = default;
   ~UserInfoImpl() override = default;
 
- Result<BinaryFuncMap> func_symbols_for_pid(int pid) const override;
- Result<FunctionSet> func_symbols_for_path(
-    const std::string &path) const override;
+  Result<BinaryFuncMap> func_symbols_for_pid(int pid) const override;
+  Result<FunctionSet> func_symbols_for_path(
+      const std::string &path) const override;
   Result<BinaryUSDTMap> usdt_probes_for_pid(int pid) const override;
   Result<BinaryUSDTMap> usdt_probes_for_all_pids() const override;
-  Result<USDTSet> usdt_probes_for_path(
-      const std::string &path) const override;
+  Result<USDTSet> usdt_probes_for_path(const std::string &path) const override;
 
 private:
   Result<> read_probes_for_pid(int pid) const;
-  Result<> read_probes_for_path(const std::string& path) const;
+  Result<> read_probes_for_path(const std::string &path) const;
 
   // Maps a pid to a set of paths for its probes.
   mutable std::unordered_map<int, std::set<std::string>> pid_to_paths_;

--- a/src/types.h
+++ b/src/types.h
@@ -78,12 +78,7 @@ enum class UserSymbolCacheType {
   none,
 };
 
-enum class StackMode : uint8_t {
-  bpftrace,
-  perf,
-  raw,
-  build_id
-};
+enum class StackMode : uint8_t { bpftrace, perf, raw, build_id };
 
 const std::map<StackMode, std::string> STACK_MODE_NAME_MAP = {
   { StackMode::bpftrace, "bpftrace" },
@@ -105,17 +100,19 @@ struct ConfigParser<StackMode> {
         return OK();
       }
     }
-    return make_error<ParseError>(key,
-                                  "Invalid value for stack_mode: valid "
-                                  "values are bpftrace, raw, perf, and build_id.");
+    return make_error<ParseError>(
+        key,
+        "Invalid value for stack_mode: valid "
+        "values are bpftrace, raw, perf, and build_id.");
   }
   Result<OK> parse(const std::string &key,
                    [[maybe_unused]] StackMode *target,
                    [[maybe_unused]] uint64_t v)
   {
-    return make_error<ParseError>(key,
-                                  "Invalid value for stack_mode: valid "
-                                  "values are bpftrace, raw, perf, and build_id.");
+    return make_error<ParseError>(
+        key,
+        "Invalid value for stack_mode: valid "
+        "values are bpftrace, raw, perf, and build_id.");
   }
 };
 
@@ -152,10 +149,10 @@ struct StackType {
            std::to_string(limit);
   }
 
-  size_t elem_size() const {
-    return mode == StackMode::build_id
-                              ? sizeof(bpf_stack_build_id)
-                              : sizeof(uint64_t);
+  size_t elem_size() const
+  {
+    return mode == StackMode::build_id ? sizeof(bpf_stack_build_id)
+                                       : sizeof(uint64_t);
   }
 
 private:
@@ -296,8 +293,7 @@ public:
 
   bool IsPrintableTy() const
   {
-    return type_ != Type::none &&
-           type_ != Type::timestamp_mode &&
+    return type_ != Type::none && type_ != Type::timestamp_mode &&
            (!IsCtxAccess() || is_funcarg); // args builtin is printable
   }
 
@@ -336,9 +332,9 @@ public:
     assert(IsIntTy());
     // Truncate integers too large to fit in BPF registers (64-bits).
     bits = std::min<size_t>(bits, 64);
-    // Zero sized integers are not usually valid. However, during type resolution the first pass may not have
-    // enough information to figure out the exact size of the integer. Later
-    // passes infer the exact size.
+    // Zero sized integers are not usually valid. However, during type
+    // resolution the first pass may not have enough information to figure out
+    // the exact size of the integer. Later passes infer the exact size.
     assert(bits == 0 || bits == 1 || bits == 8 || bits == 16 || bits == 32 ||
            bits == 64);
     size_bits_ = bits;
@@ -590,7 +586,7 @@ public:
   friend SizedType CreateCStruct(const std::string &name);
   friend SizedType CreateCStruct(std::shared_ptr<Struct> &&record);
   friend SizedType CreateCStruct(const std::string &name,
-                                std::weak_ptr<Struct> record);
+                                 std::weak_ptr<Struct> record);
   friend SizedType CreateInteger(size_t bits, bool is_signed);
   friend SizedType CreateTuple(std::shared_ptr<Struct> &&tuple);
   friend SizedType CreateRecord(std::shared_ptr<Struct> &&record);

--- a/src/util/bpf_names.h
+++ b/src/util/bpf_names.h
@@ -8,9 +8,8 @@ namespace bpftrace::util {
 std::string sanitise_bpf_program_name(const std::string &name);
 
 // Generate object file function name for a given probe
-inline std::string get_function_name_for_probe(
-    const std::string &probe_name,
-    int index)
+inline std::string get_function_name_for_probe(const std::string &probe_name,
+                                               int index)
 {
   return sanitise_bpf_program_name(probe_name) + "_" + std::to_string(index);
 }

--- a/src/util/gfp_flags.h
+++ b/src/util/gfp_flags.h
@@ -1,45 +1,46 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace bpftrace::util {
 
 // GFP flag bit definitions (from linux/gfp_types.h)
 enum {
-	___GFP_DMA_BIT,
-	___GFP_HIGHMEM_BIT,
-	___GFP_DMA32_BIT,
-	___GFP_MOVABLE_BIT,
-	___GFP_RECLAIMABLE_BIT,
-	___GFP_HIGH_BIT,
-	___GFP_IO_BIT,
-	___GFP_FS_BIT,
-	___GFP_ZERO_BIT,
-	___GFP_UNUSED_BIT,	/* 0x200u unused */
-	___GFP_DIRECT_RECLAIM_BIT,
-	___GFP_KSWAPD_RECLAIM_BIT,
-	___GFP_WRITE_BIT,
-	___GFP_NOWARN_BIT,
-	___GFP_RETRY_MAYFAIL_BIT,
-	___GFP_NOFAIL_BIT,
-	___GFP_NORETRY_BIT,
-	___GFP_MEMALLOC_BIT,
-	___GFP_COMP_BIT,
-	___GFP_NOMEMALLOC_BIT,
-	___GFP_HARDWALL_BIT,
-	___GFP_THISNODE_BIT,
-	___GFP_ACCOUNT_BIT,
-	___GFP_ZEROTAGS_BIT,
-	___GFP_SKIP_ZERO_BIT,
-	___GFP_SKIP_KASAN_BIT,
-	___GFP_NO_OBJ_EXT_BIT,
-	___GFP_LAST_BIT
+  ___GFP_DMA_BIT,
+  ___GFP_HIGHMEM_BIT,
+  ___GFP_DMA32_BIT,
+  ___GFP_MOVABLE_BIT,
+  ___GFP_RECLAIMABLE_BIT,
+  ___GFP_HIGH_BIT,
+  ___GFP_IO_BIT,
+  ___GFP_FS_BIT,
+  ___GFP_ZERO_BIT,
+  ___GFP_UNUSED_BIT, /* 0x200u unused */
+  ___GFP_DIRECT_RECLAIM_BIT,
+  ___GFP_KSWAPD_RECLAIM_BIT,
+  ___GFP_WRITE_BIT,
+  ___GFP_NOWARN_BIT,
+  ___GFP_RETRY_MAYFAIL_BIT,
+  ___GFP_NOFAIL_BIT,
+  ___GFP_NORETRY_BIT,
+  ___GFP_MEMALLOC_BIT,
+  ___GFP_COMP_BIT,
+  ___GFP_NOMEMALLOC_BIT,
+  ___GFP_HARDWALL_BIT,
+  ___GFP_THISNODE_BIT,
+  ___GFP_ACCOUNT_BIT,
+  ___GFP_ZEROTAGS_BIT,
+  ___GFP_SKIP_ZERO_BIT,
+  ___GFP_SKIP_KASAN_BIT,
+  ___GFP_NO_OBJ_EXT_BIT,
+  ___GFP_LAST_BIT
 };
 
 template <typename T = uint64_t>
-constexpr T BIT(int nr) {
+constexpr T BIT(int nr)
+{
   return static_cast<T>(1) << nr;
 }
 
@@ -60,8 +61,10 @@ private:
   static constexpr uint64_t __GFP_IO = BIT(___GFP_IO_BIT);
   static constexpr uint64_t __GFP_FS = BIT(___GFP_FS_BIT);
   static constexpr uint64_t __GFP_ZERO = BIT(___GFP_ZERO_BIT);
-  static constexpr uint64_t __GFP_DIRECT_RECLAIM = BIT(___GFP_DIRECT_RECLAIM_BIT);
-  static constexpr uint64_t __GFP_KSWAPD_RECLAIM = BIT(___GFP_KSWAPD_RECLAIM_BIT);
+  static constexpr uint64_t __GFP_DIRECT_RECLAIM = BIT(
+      ___GFP_DIRECT_RECLAIM_BIT);
+  static constexpr uint64_t __GFP_KSWAPD_RECLAIM = BIT(
+      ___GFP_KSWAPD_RECLAIM_BIT);
   static constexpr uint64_t __GFP_WRITE = BIT(___GFP_WRITE_BIT);
   static constexpr uint64_t __GFP_NOWARN = BIT(___GFP_NOWARN_BIT);
   static constexpr uint64_t __GFP_RETRY_MAYFAIL = BIT(___GFP_RETRY_MAYFAIL_BIT);
@@ -78,22 +81,31 @@ private:
   static constexpr uint64_t __GFP_SKIP_KASAN = BIT(___GFP_SKIP_KASAN_BIT);
   static constexpr uint64_t __GFP_NO_OBJ_EXT = BIT(___GFP_NO_OBJ_EXT_BIT);
 
-  static constexpr uint64_t __GFP_RECLAIM = (__GFP_DIRECT_RECLAIM | __GFP_KSWAPD_RECLAIM);
+  static constexpr uint64_t __GFP_RECLAIM = (__GFP_DIRECT_RECLAIM |
+                                             __GFP_KSWAPD_RECLAIM);
 
   // Compound GFP flags (common combinations) - calculated at compile time
   static constexpr uint64_t GFP_ATOMIC = (__GFP_HIGH | __GFP_KSWAPD_RECLAIM);
-  static constexpr uint64_t GFP_KERNEL = (__GFP_DIRECT_RECLAIM | __GFP_KSWAPD_RECLAIM | __GFP_IO | __GFP_FS);
+  static constexpr uint64_t GFP_KERNEL = (__GFP_DIRECT_RECLAIM |
+                                          __GFP_KSWAPD_RECLAIM | __GFP_IO |
+                                          __GFP_FS);
   static constexpr uint64_t GFP_KERNEL_ACCOUNT = (GFP_KERNEL | __GFP_ACCOUNT);
   static constexpr uint64_t GFP_NOWAIT = (__GFP_KSWAPD_RECLAIM | __GFP_NOWARN);
-  static constexpr uint64_t GFP_NOIO = (__GFP_DIRECT_RECLAIM | __GFP_KSWAPD_RECLAIM);
+  static constexpr uint64_t GFP_NOIO = (__GFP_DIRECT_RECLAIM |
+                                        __GFP_KSWAPD_RECLAIM);
   static constexpr uint64_t GFP_NOFS = (GFP_NOIO | __GFP_IO);
   static constexpr uint64_t GFP_USER = (GFP_NOFS | __GFP_FS | __GFP_HARDWALL);
   static constexpr uint64_t GFP_DMA = __GFP_DMA;
   static constexpr uint64_t GFP_DMA32 = __GFP_DMA32;
   static constexpr uint64_t GFP_HIGHUSER = (GFP_USER | __GFP_HIGHMEM);
-  static constexpr uint64_t GFP_HIGHUSER_MOVABLE = (GFP_HIGHUSER | __GFP_MOVABLE | __GFP_SKIP_KASAN);
-  static constexpr uint64_t GFP_TRANSHUGE_LIGHT = (GFP_HIGHUSER_MOVABLE | __GFP_COMP | __GFP_NOMEMALLOC | __GFP_NOWARN) & ~__GFP_RECLAIM;
-  static constexpr uint64_t GFP_TRANSHUGE = (GFP_TRANSHUGE_LIGHT | __GFP_DIRECT_RECLAIM);
+  static constexpr uint64_t GFP_HIGHUSER_MOVABLE = (GFP_HIGHUSER |
+                                                    __GFP_MOVABLE |
+                                                    __GFP_SKIP_KASAN);
+  static constexpr uint64_t GFP_TRANSHUGE_LIGHT =
+      (GFP_HIGHUSER_MOVABLE | __GFP_COMP | __GFP_NOMEMALLOC | __GFP_NOWARN) &
+      ~__GFP_RECLAIM;
+  static constexpr uint64_t GFP_TRANSHUGE = (GFP_TRANSHUGE_LIGHT |
+                                             __GFP_DIRECT_RECLAIM);
 
   static const std::vector<std::pair<uint64_t, std::string>> flag_names;
 };

--- a/src/util/proc.h
+++ b/src/util/proc.h
@@ -73,7 +73,8 @@ public:
   // Get termination signal, if any. This should only be called when the child
   // has finished (i.e. when is_alive() returns false).
   //
-  // \return A signal ID or -1 if the child hasn't been terminated (by a signal).
+  // \return A signal ID or -1 if the child hasn't been terminated (by a
+  // signal).
   std::optional<int> term_signal()
   {
     return term_signal_;
@@ -88,6 +89,7 @@ protected:
 Result<std::unique_ptr<Proc>> create_proc(pid_t pid);
 
 // Create a concrete implementation of ChildProc.
-Result<std::unique_ptr<ChildProc>> create_child(const std::string &cmd, bool suppress_stdio = false);
+Result<std::unique_ptr<ChildProc>> create_child(const std::string& cmd,
+                                                bool suppress_stdio = false);
 
 } // namespace bpftrace::util


### PR DESCRIPTION
Run clang-format on src/ so that diffs for functional changes aren't muddied by clang-format.