### PR TITLE
Add a dry_run option to the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip uploading artifacts (for testing the workflow)'
+        type: boolean
+        default: true
 
 jobs:
   build-upload:
@@ -27,6 +33,7 @@ jobs:
       run: nix develop --command bash -c "OUT=./assets ./scripts/create-assets.sh"
 
     - name: Upload artifacts
+      if: ${{ !inputs.dry_run }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: gh release upload ${{ github.ref_name }} ./assets/*


### PR DESCRIPTION
Currently, it is pretty difficult to test changes in the build system, a problem further compounded by lack of access to non-x86 machines. This adds a `dry_run` option to the release workflow, which can just be toggled from the GitHub UI when running the action.