### PR TITLE
stdlib: support get current working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- stdlib: add `abspath()` get file absolute path
+  - [#5231](https://github.com/bpftrace/bpftrace/pull/5231)
+- stdlib: add `str_{append,prepend}` function
+  - [#5231](https://github.com/bpftrace/bpftrace/pull/5231)
 #### Changed
 - List structure with module name in verbose mode
   - [#5212](https://github.com/bpftrace/bpftrace/pull/5212)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -13,6 +13,22 @@ Basically all functions or macros that don't have arguments or have default argu
 
 ## Helpers
 
+### abspath
+- `void abspath(string path, uint64 max_path_depth);`
+
+Takes a string-like variable, and converts to an absolute path.
+
+
+In fact, this function concatenates the program's current working directory and the filename to form the absolute path of the file. If an empty string is passed in, the current working directory can be obtained.
+
+For example:
+```
+let $cwd : string[256];
+abspath($cwd, 32);
+printf("%s\n", $cwd);
+```
+
+
 ### assert
 - `void assert(bool condition, string message)`
 
@@ -352,6 +368,14 @@ kprobe:dummy {
   }
 }
 ```
+
+
+### fs_root
+- `struct fs_struct *fs_root();`
+- `struct fs_struct *fs_root;`
+
+Get task filesystem root.
+
 
 
 ### func
@@ -1276,6 +1300,22 @@ The maximum string length is limited by the `BPFTRACE_MAX_STRLEN` env variable, 
 In case the string is longer than the specified length only `length - 1` bytes are copied and a NULL byte is appended at the end.
 
 bpftrace will automatically use the `kernel` or `user` variant of `probe_read_{kernel,user}_str` based on the address space of `data`, see [Address-spaces](./language.md#address-spaces) for more information.
+
+
+### str_append
+- `void str_append(string dst, string src);`
+- `void str_append(string dst, char src[]);`
+
+Appends another string or const char* to an existing string variable.
+
+
+
+### str_prepend
+- `void str_prepend(string dst, string src);`
+- `void str_prepend(string dst, char src[]);`
+
+Prepends another string or const char* to an existing string variable.
+
 
 
 ### strcap

--- a/src/stdlib/path.bt
+++ b/src/stdlib/path.bt
@@ -1,0 +1,71 @@
+// Path helpers.
+
+// Get task filesystem root.
+//
+// :function fs_root
+// :variant struct fs_struct *fs_root();
+macro fs_root() {
+  curtask->fs
+}
+
+// Takes a string-like variable, and converts to an absolute path.
+//
+// :function abspath
+// :variant void abspath(string path, uint64 max_path_depth);
+//
+// In fact, this function concatenates the program's current working directory and the filename to form the absolute path of the file. If an empty string is passed in, the current working directory can be obtained.
+//
+// For example:
+// ```
+// let $cwd : string[256];
+// abspath($cwd, 32);
+// printf("%s\n", $cwd);
+// ```
+macro abspath($path, $max_path_depth)
+{
+  $fs = fs_root;
+  $dentry = $fs->pwd.dentry;
+  $vfsmnt = $fs->pwd.mnt;
+  $mnt = (struct mount *)(((uint64)$vfsmnt) - offsetof(struct mount, mnt));
+  $mnt_root = $vfsmnt.mnt_root;
+
+  for $j : ((uint64)0)..((uint64)$max_path_depth) {
+
+    $d_name = str($dentry.d_name.name);
+    $parent_dentry = $dentry.d_parent;
+
+    if ($dentry == $parent_dentry || $dentry == $mnt_root) {
+      $mnt_parent = (struct mount *)$mnt.mnt_parent;
+
+      // Real root directory
+      if ($mnt == $mnt_parent) {
+        break;
+      }
+
+      $dentry = $mnt.mnt_mountpoint;
+      $mnt = $mnt_parent;
+      $mnt_root = $mnt.mnt.mnt_root;
+      continue;
+    }
+
+    // Sometimes, $d_name will be equal to "/" or start with "/", such as in a
+    // mount point directory.
+    if ($d_name[0] != "/"[0]) {
+      str_prepend($path, "/");
+    }
+    str_prepend($path, $d_name);
+
+    $dentry = $parent_dentry;
+  }
+
+  // Normally, the root directory will be missing a '/'.
+  if ($path[0] != "/"[0]) {
+    str_prepend($path, "/");
+  }
+}
+
+macro abspath($path, max_path_depth)
+{
+  let $max_path_depth = max_path_depth;
+  abspath($path, $max_path_depth);
+}

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -134,6 +134,48 @@ macro strcontains(haystack, needle)
   strstr(haystack, needle) >= 0
 }
 
+// Appends another string or const char* to an existing string variable.
+//
+// :function str_append
+// :variant void str_append(string dst, string src);
+// :variant void str_append(string dst, char src[]);
+macro str_append($dst, $src) {
+  assert_str($dst);
+  assert_str($src);
+  let $dst_size = strcap($dst);
+  let $src_size = strcap($src);
+  if ($src_size > 0) {
+    __bpf_str_append((int8 *)&$dst, (uint64)$dst_size, (int8 *)&$src,
+                     (uint64)$src_size);
+  }
+}
+
+macro str_append($dst, src) {
+  let $src = src;
+  str_append($dst, $src);
+}
+
+// Prepends another string or const char* to an existing string variable.
+//
+// :function str_prepend
+// :variant void str_prepend(string dst, string src);
+// :variant void str_prepend(string dst, char src[]);
+macro str_prepend($dst, $src) {
+  assert_str($dst);
+  assert_str($src);
+  let $dst_size = strcap($dst);
+  let $src_size = strcap($src);
+  if ($src_size > 0) {
+    __bpf_str_prepend((int8 *)&$dst, (uint64)$dst_size, (int8 *)&$src,
+                      (uint64)$src_size);
+  }
+}
+
+macro str_prepend($dst, src) {
+  let $src = src;
+  str_prepend($dst, $src);
+}
+
 // :variant string strerror(int error)
 //
 // Convert errno code to string.

--- a/src/stdlib/strings/strings.bpf.c
+++ b/src/stdlib/strings/strings.bpf.c
@@ -67,6 +67,48 @@ int __bpf_strnstr(const char *haystack,
   return -1;
 }
 
+size_t __bpf_str_append(char *dst, size_t dst_sz, const char *src,
+                        size_t src_sz)
+{
+  __u8 i, j;
+  size_t dst_len = __bpf_strnlen(dst, dst_sz);
+  size_t src_len = __bpf_strnlen(src, src_sz);
+
+  // Provide sufficient conditions for the BPF Verifier
+  for (i = dst_len, j = 0; i < dst_sz - 1 && j < src_sz - 1 && src[j] != '\0';
+       j++, i++)
+    dst[i] = src[j];
+
+  dst[i] = '\0';
+
+  return j;
+}
+
+size_t __bpf_str_prepend(char *dst, size_t dst_sz, const char *src,
+                         size_t src_sz)
+{
+  __u8 i;
+  const __u8 dst_len = __bpf_strnlen(dst, dst_sz);
+  const __u8 src_len = __bpf_strnlen(src, src_sz);
+
+  if (dst_len + src_len > dst_sz - 1) {
+    return 0;
+  }
+
+  for (i = 0; i < dst_len && dst[i] != '\0'; i++) {
+    __u8 idx = dst_len - i - 1;
+    dst[src_len + idx] = dst[idx];
+  }
+  dst[src_len + dst_len] = '\0';
+
+  // Provide sufficient conditions for the BPF Verifier
+  for (i = 0; i < src_len && i < dst_sz && i < src_sz && src[i] != '\0'; i++) {
+    dst[i] = src[i];
+  }
+
+  return src_len;
+}
+
 int __strerror(int errno, err_str *out) {
   if (errno < 0) {
     errno = -errno;

--- a/tests/runtime/stdlib
+++ b/tests/runtime/stdlib
@@ -70,3 +70,15 @@ TIMEOUT 5
 NAME strlen
 PROG begin { $a = "hello"; print(strlen($a)); }
 EXPECT 5
+
+NAME string append
+PROG begin { let $s : string[64]; $s = "hello"; str_append($s, " world"); printf("%s\n", $s); }
+EXPECT hello world
+
+NAME string prepend
+PROG begin { let $s : string[64]; $s = "world"; str_prepend($s, "hello "); printf("%s\n", $s); }
+EXPECT hello world
+
+NAME abspath
+RUN mkdir -p /root/tmpdir-xyz/; pushd /root/tmpdir-xyz/; {{BPFTRACE}} -e 'begin { let $cwd : string[256]; abspath($cwd, 32); printf("%s\n", $cwd); }'; popd; rmdir /root/tmpdir-xyz/
+EXPECT /root/tmpdir-xyz/

--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -35,6 +35,7 @@
 //
 // 08-Sep-2018	Brendan Gregg	Created this.
 // 16-Sep-2025	Rong Tao	Support fullpath of file.
+// 26-Jun-2026	Rong Tao	Move fullpath function to stdlib.
 
 config = {
   missing_probes = warn;
@@ -69,65 +70,16 @@ tracepoint:syscalls:sys_enter_openat2
   @filename[tid] = args.filename;
 }
 
-macro getcwd(@paths)
-{
-  $dentry = curtask.fs.pwd.dentry;
-  $vfsmnt = curtask.fs.pwd.mnt;
-  $mnt = (struct mount *)(((uint64)$vfsmnt) - offsetof(struct mount, mnt));
-  $mnt_root = $vfsmnt.mnt_root;
-
-  for $j : ((uint64)0)..((uint64)max_path_depth) {
-
-    @paths[tid,$j] = str($dentry.d_name.name);
-    $parent_dentry = $dentry.d_parent;
-
-    if ($dentry == $parent_dentry || $dentry == $mnt_root) {
-      $mnt_parent = (struct mount *)$mnt.mnt_parent;
-
-      // Real root directory
-
-      if ($mnt == $mnt_parent) {
-        break;
-      }
-
-      $dentry = $mnt.mnt_mountpoint;
-      $mnt = $mnt_parent;
-      $mnt_root = $mnt.mnt.mnt_root;
-      continue;
-    }
-
-    $dentry = $parent_dentry;
-  }
-}
-
-macro printcwd(@paths)
-{
-  for $j : ((uint64)0)..((uint64)max_path_depth) {
-    let $key = (tid,(uint64)((max_path_depth() - $j) - 1));
-    let $name = @paths[$key];
-    // If it is a mount point, there will be a '/', because
-    // the '/' will be added below, so just skip this '/'.
-    //
-    // And, if @paths don't have the $key, just skip the
-    // empty string.
-    if ($name == "/" || $name == "") {
-      continue;
-    }
-    printf("/%s", $name);
-    delete(@paths, $key);
-  }
-  printf("/");
-}
-
-macro sys_exit(ret, @filename, @paths)
+macro sys_exit(ret, $abspath)
 {
   $ret = ret;
   $fd = ($ret >= 0) ? $ret : (-1);
   $errno = ($ret >= 0) ? 0 : (-$ret);
 
-  getcwd(@paths);
-
-  $path = str(@filename[tid]);
+  // Skip display cwd if path start with '/'.
+  if ($abspath[0] != "/"[0]) {
+    abspath($abspath, max_path_depth);
+  }
 
   printf("%-6d %-16s %4d", pid, comm, $fd);
 
@@ -136,13 +88,7 @@ macro sys_exit(ret, @filename, @paths)
   } else {
     printf(" %3d ", $errno);
   }
-
-  // Skip display cwd if path start with '/'.
-  if ($path[0] != "/"[0]) {
-    printcwd(@paths);
-  }
-  printf("%s\n", str(@filename[tid]));
-  delete(@filename, tid);
+  printf("%s\n", $abspath);
 }
 
 tracepoint:syscalls:sys_exit_open,
@@ -150,11 +96,13 @@ tracepoint:syscalls:sys_exit_openat,
 tracepoint:syscalls:sys_exit_openat2
 /@filename[tid]/
 {
-  sys_exit(args.ret, @filename, @paths);
+  let $abspath : string[1024];
+  $abspath = str(@filename[tid]);
+  sys_exit(args.ret, $abspath);
+  delete(@filename, tid);
 }
 
 END
 {
   clear(@filename);
-  clear(@paths);
 }


### PR DESCRIPTION
In PR [1], opensnoop.bt support full-path of file, this PR moves the functionality to retrieve absolute paths to stdlib. Also, instead of using @map to store each level of the path, it uses the string prepend to assemble an absolute path.

Added stdlib bpftrace function, see [1]:

    fs_root();
    str_append(dst, src);
    str_prepend(dst, src);
    abspath(path);

Added stdlib bpf C interop function:

    __bpf_str_append()
    __bpf_str_prepend()

Usage:

    let $dst : string[256];
    let $src = "##";

    $dst = "abc";

    str_prepend($dst, "/home/rongtao/");
    str_prepend($dst, $src);
    str_append($dst, $src);
    str_append($dst, "/os-release");

[1] https://github.com/bpftrace/bpftrace/pull/4601
    commit 89ac7c69f7c5 ("tools/opensnoop: support full path (#4601)")

And, apply to opensnoop.bt.

@amscanne @jordalgo Please review ;)