### PR TITLE
docs: add variable form of nsecs to stdlib.md

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -704,6 +704,7 @@ Number of CPUs
 
 ### nsecs
 - `timestamp nsecs([TimestampMode mode])`
+- `timestamp nsecs`
 - `nsecs(monotonic) - nanosecond timestamp since boot, exclusive of time the system spent suspended (CLOCK_MONOTONIC)`
 - `nsecs(boot) - nanoseconds since boot, inclusive of time the system spent suspended (CLOCK_BOOTTIME)`
 - `nsecs(tai) - TAI timestamp in nanoseconds (CLOCK_TAI)`


### PR DESCRIPTION
Fixes #5232

Added the missing `timestamp nsecs` variable form entry to the nsecs section.