### PR TITLE
Macros: Add support for typeof args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 #### Added
 - Publish arm64/aarch64 release artifacts alongside x86_64.
   - [#5213](https://github.com/bpftrace/bpftrace/pull/5213)
+- Add support for type expression substitution for macros
+  - [#5234](https://github.com/bpftrace/bpftrace/pull/5234)
 #### Changed
 - List structure with module name in verbose mode
   - [#5212](https://github.com/bpftrace/bpftrace/pull/5212)

--- a/docs/language.md
+++ b/docs/language.md
@@ -747,6 +747,7 @@ A macro's parameter signature specifies how an argument will be used.
 For example `macro test($a, b, @c)` indicates that `$a` needs to be a scratch variable (which might be mutated), that `b` needs to be an expression that will be inserted where ever `b` is used in the macro body, and that `@c` needs to be a map (which might be mutated).
 A valid use of this macro could be `test($x, 1 + 2, @y)`.
 Variables and maps can also be used for ident parameters that expect expressions and would be the same as writing `{ @y }` (Block Expression).
+Type expression substitution is also supported inside of macros but types must be passed into macro calls wrapped in the `typeof` builtin (see below).
 Note: User-defined macros with the same name and signature as a standard library macro will override the standard library version. However, standard library macros nested inside of other standard library macros will never use the user-defined version of the same signature.
 
 Here are some valid usages of macros:
@@ -775,6 +776,10 @@ macro add_two(x) {
   add_one(x) + 1
 }
 
+macro p_cast(a, b) {
+  (a*)b
+}
+
 begin {
   print(one());                   // prints 1
   print(one);                     // prints 1 (bare identifier works if the macro accepts 0 args)
@@ -790,6 +795,10 @@ begin {
   side_effects({ printf("hi") })  // prints hihihi
 
   print(add_two(1));              // prints 3
+
+  print(
+    p_cast(typeof(uint8), -1)
+  );                              // prints 0xff
 }
 ```
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -161,6 +161,7 @@ class None;
 class Identifier;
 class Builtin;
 class ParsedType;
+class TypeArg;
 class Call;
 class Sizeof;
 class Offsetof;
@@ -210,7 +211,8 @@ class Expression : public VariantNode<Integer,
                                       BlockExpr,
                                       Typeinfo,
                                       Comptime,
-                                      Record> {
+                                      Record,
+                                      TypeArg> {
 public:
   using VariantNode::VariantNode;
   Expression() : Expression(static_cast<BlockExpr *>(nullptr)) {};
@@ -734,6 +736,30 @@ public:
   }
 
   ExprOrType record;
+};
+
+class TypeArg : public Node {
+public:
+  explicit TypeArg(ASTContext &ctx, Location &&loc, Typeof *type_of)
+      : Node(ctx, std::move(loc)), type_of(type_of) {};
+  explicit TypeArg(ASTContext &ctx, const Location &loc, const TypeArg &other)
+      : Node(ctx, loc + other.loc), type_of(clone(ctx, loc, other.type_of)) {};
+
+  bool operator==(const TypeArg &other) const
+  {
+    return type_of == other.type_of ||
+           (type_of && other.type_of && *type_of == *other.type_of);
+  }
+  std::strong_ordering operator<=>(const TypeArg &other) const
+  {
+    if (type_of && other.type_of)
+      return *type_of <=> *other.type_of;
+    if (!type_of && !other.type_of)
+      return std::strong_ordering::equal;
+    return type_of ? std::strong_ordering::greater : std::strong_ordering::less;
+  }
+
+  Typeof *type_of;
 };
 
 class Typeinfo : public Node {

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -174,6 +174,7 @@ public:
   void visit(Sizeof &sizeof_node);
   void visit(Offsetof &offsetof_node);
   void visit(Typeof &typeof_node);
+  void visit(TypeArg &type_arg);
 
   void visit_expr_or_type(ExprOrType &record);
 
@@ -262,20 +263,126 @@ void MacroExpander::visit(Map &map)
   }
 }
 
-// Don't expand bare identifiers in type contexts (e.g. casts, sizeof,
-// offsetof). A bare identifier here is intended as a type name, not a macro
-// invocation. Use the call syntax (e.g. sizeof(mymacro())) or typeof wrapper
-// (e.g. (typeof(mymacro()))x) to force macro expansion in type contexts.
+// We are in a possible type context so Macro expansion and type param
+// replacement has special behavior. If `record` is an expression then we only
+// care if it's a bare identifier, which we treat either as a type name or as a
+// target for replacement by a TypeArg (not a possible candidate for macro
+// expansion). If the user wants to expand a macro that has no params in this
+// context then we require the macro calling convention (e.g.
+// `sizeof(mymacro())`). If `record` is a ParsedType and not an expression then
+// we need to see if it's a candidate for replacement by a TypeArg. There are
+// some TypeArg replacements that are not valid (e.g. `macro a(t) {
+// sizeof(struct t) } begin { a(typeof(struct b)) }`, which would yield
+// `sizeof(struct struct b)`).
 void MacroExpander::visit_expr_or_type(ExprOrType &record)
 {
   if (auto *expr = std::get_if<Expression>(&record)) {
     auto *ident = expr->as<Identifier>();
-    if (ident && !passed_exprs_.contains(ident->ident)) {
-      // Bare identifier that isn't a macro expression argument — treat it as
-      // a type name rather than expanding it as a macro.
-      return;
+    if (ident) {
+      if (auto it = passed_exprs_.find(ident->ident);
+          it != passed_exprs_.end()) {
+        auto *type_arg = it->second.as<TypeArg>();
+        if (type_arg) {
+          record = clone(ast_, ident->loc, type_arg->type_of->record);
+          return;
+        }
+      } else {
+        // Bare identifier that isn't a macro expression argument — treat it as
+        // a type name rather than expanding it as a macro.
+        return;
+      }
     }
+
     visit(*expr);
+  } else {
+    auto *parsed_type = std::get<ParsedType *>(record);
+    assert(parsed_type != nullptr);
+    ParsedType *parent = nullptr;
+    while (parsed_type->inner) {
+      parent = parsed_type;
+      parsed_type = parsed_type->inner;
+    }
+    if (auto it = passed_exprs_.find(parsed_type->name);
+        it != passed_exprs_.end()) {
+      auto *type_arg = it->second.as<TypeArg>();
+      auto *ident = it->second.as<Identifier>();
+
+      switch (parsed_type->kind) {
+        case ParsedType::Kind::Struct:
+        case ParsedType::Kind::Union:
+        case ParsedType::Kind::Enum: {
+          // struct enum or struct struct is not supported syntax so unless the
+          // expression is a Identifier or a ParsedType Identifier this is an
+          // error
+          if (ident) {
+            parsed_type->name = ident->ident;
+            return;
+          }
+
+          if (type_arg) {
+            if (auto *pt = std::get_if<ParsedType *>(
+                    &type_arg->type_of->record)) {
+              if ((*pt)->kind == ParsedType::Kind::Identifier) {
+                parsed_type->name = (*pt)->name;
+                return;
+              }
+            } else {
+              auto typeof_expr = std::get<Expression>(
+                  type_arg->type_of->record);
+              ident = typeof_expr.as<Identifier>();
+              if (ident) {
+                parsed_type->name = ident->ident;
+                return;
+              }
+            }
+
+            // Fall through to error below
+          }
+          break;
+        }
+        case ParsedType::Kind::Identifier: {
+          if (ident) {
+            parsed_type->name = ident->ident;
+            return;
+          }
+
+          if (type_arg) {
+            if (!parent) {
+              record = clone(ast_, parsed_type->loc, type_arg->type_of->record);
+              return;
+            }
+
+            if (auto *pt = std::get_if<ParsedType *>(
+                    &type_arg->type_of->record)) {
+              parent->inner = clone(ast_, parsed_type->loc, *pt);
+              return;
+            }
+
+            auto typeof_expr = std::get<Expression>(type_arg->type_of->record);
+            auto *typeof_ident = typeof_expr.as<Identifier>();
+            if (typeof_ident) {
+              parent->inner = ast_.make_node<ParsedType>(
+                  parsed_type->loc,
+                  ParsedType::Kind::Identifier,
+                  typeof_ident->ident);
+              return;
+            }
+          }
+          break;
+        }
+        case ParsedType::Kind::Pointer:
+        case ParsedType::Kind::Array: {
+          LOG(BUG) << "ParsedType bottom can't be a pointer or array";
+          break;
+        }
+      }
+
+      it->second.node().addError()
+          << "Invalid replacement for macro '" << stack_.back()->name
+          << "' type parameter '" << parsed_type->name
+          << "' which makes up the type '"
+          << std::get<ParsedType *>(record)->type_name() << "'";
+    }
   }
 }
 
@@ -292,6 +399,11 @@ void MacroExpander::visit(Offsetof &offsetof_node)
 void MacroExpander::visit(Typeof &typeof_node)
 {
   visit_expr_or_type(typeof_node.record);
+}
+
+void MacroExpander::visit(TypeArg &type_arg)
+{
+  visit_expr_or_type(type_arg.type_of->record);
 }
 
 void MacroExpander::visit(Expression &expr)
@@ -491,6 +603,23 @@ std::optional<BlockExpr *> MacroExpander::expand(const Macro &macro,
   return cloned_block;
 }
 
+class TypeArgCheck : public Visitor<TypeArgCheck> {
+public:
+  explicit TypeArgCheck(ASTContext &ast) : ast_(ast) {};
+
+  using Visitor<TypeArgCheck>::visit;
+  void visit(TypeArg &type_arg);
+
+private:
+  ASTContext &ast_;
+};
+
+void TypeArgCheck::visit(TypeArg &type_arg)
+{
+  type_arg.addError() << "Typeof expression only valid for macro calls that "
+                         "are expecting a type parameter";
+}
+
 void expand_macro(ASTContext &ast,
                   Expression &expr,
                   const MacroRegistry &registry)
@@ -507,6 +636,9 @@ Pass CreateMacroExpansionPass()
     std::vector<const Macro *> stack;
     MacroExpander expander(ast, macros, stack);
     expander.visit(ast.root);
+
+    TypeArgCheck type_arg_check(ast);
+    type_arg_check.visit(ast.root);
 
     // Macros have now been expanded into their call sites, so remove the
     // definitions from the AST. The registry retains its own pointers to the

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -504,6 +504,24 @@ Buffer Formatter::visit(ParsedType& type)
   return visit(static_cast<const ParsedType&>(type));
 }
 
+Buffer Formatter::visit(TypeArg& type_arg)
+{
+  auto& type_of = *type_arg.type_of;
+  if (std::holds_alternative<Expression>(type_of.record)) {
+    // The expression form already prints as `typeof(expr)`.
+    return visit(type_of);
+  }
+  // A direct type must be wrapped in `typeof(...)` so that it parses back as a
+  // type argument rather than being interpreted as an expression.
+  return Buffer()
+      .text("typeof(")
+      .append(format(*std::get<ParsedType*>(type_of.record),
+                     metadata,
+                     max_width - 8,
+                     true))
+      .text(")");
+}
+
 Buffer Formatter::visit(Typeinfo& typeinfo)
 {
   if (std::holds_alternative<Expression>(typeinfo.typeof->record)) {

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -80,6 +80,7 @@ public:
   Buffer visit(Call &call);
   Buffer visit(Sizeof &szof);
   Buffer visit(Offsetof &ofof);
+  Buffer visit(TypeArg &type_arg);
   Buffer visit(Typeof &typeof);
   Buffer visit(Typeinfo &typeinfo);
   Buffer visit(Comptime &comptime);

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -91,6 +91,10 @@ public:
   {
     return visitImpl(ofof.record);
   }
+  R visit([[maybe_unused]] TypeArg &type_arg)
+  {
+    return default_value();
+  }
   R visit(Typeof &typeof)
   {
     return visitImpl(typeof.record);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2556,10 +2556,22 @@ Expression Parser::parse_call_expression(const std::string &name,
 
   ExpressionList args;
   consume_layout();
-  if (peek() != ')') {
+  auto add_expr_or_type_arg = [&, this]() {
+    auto [begin_line, begin_col] = get_current_line_col();
+    if (check_keyword("typeof")) {
+      auto *typeof_node = parse_type_annotation();
+      auto loc = make_loc(begin_line, begin_col, line_, col_);
+      args.emplace_back(ctx_.make_node<TypeArg>(loc, typeof_node));
+      return;
+    }
+
     args.push_back(parse_expression());
+  };
+
+  if (peek() != ')') {
+    add_expr_or_type_arg();
     while (match(',')) {
-      args.push_back(parse_expression());
+      add_expr_or_type_arg();
     }
   }
 

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -17,10 +17,11 @@ macro assert_str(exp)
 {
   if comptime (!is_str(exp)) {
     if comptime is_array(exp) {
-      static_assert(typeinfo(exp[0]) == typeinfo(int8),
+      // wrap exp in parens to force it to be evaluated as an expression
+      static_assert(typeinfo((exp)[0]) == typeinfo(int8),
                     "string-like arrays must contain a char-like type");
     } else if comptime is_ptr(exp) {
-      static_assert(typeinfo(exp[0]) == typeinfo(int8),
+      static_assert(typeinfo((exp)[0]) == typeinfo(int8),
                     "string-like pointers must point to a char-like type");
     } else {
       fail("string-like values must be either strings, arrays or pointers");
@@ -84,7 +85,7 @@ macro strcap(exp)
   if comptime is_str(exp) {
     sizeof(exp)
   } else if comptime is_array(exp) {
-    sizeof(exp) / sizeof(exp[0])
+    sizeof(exp) / sizeof((exp)[0])
   } else {
     strlen(exp) // Pointer, so pass by value.
   }

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -28,7 +28,7 @@ bool MatchWith(const NodeType& node,
                const TargetType& target);
 
 template <typename NodeType>
-auto CheckField(auto NodeType::*member,
+auto CheckField(auto NodeType::* member,
                 const auto& expected,
                 const std::string& name);
 
@@ -49,7 +49,8 @@ public:
     return static_cast<Derived&>(*this);
   }
 
-  const std::vector<PredicateType>& predicates() const {
+  const std::vector<PredicateType>& predicates() const
+  {
     return predicates_;
   }
 
@@ -65,7 +66,9 @@ class NodeMatcher
 public:
   NodeMatcher() = default;
 
-  using PredicateMatcher<Derived, NodeType, std::function<bool(const NodeType&)>>::predicates;
+  using PredicateMatcher<Derived,
+                         NodeType,
+                         std::function<bool(const NodeType&)>>::predicates;
 
   operator Matcher<const NodeType&>() const
   {
@@ -238,7 +241,7 @@ bool MatchWith(const NodeType& node,
 }
 
 template <typename NodeType>
-auto CheckField(auto NodeType::*member,
+auto CheckField(auto NodeType::* member,
                 const auto& expected,
                 const std::string& name)
 {
@@ -417,6 +420,25 @@ inline ParsedTypeMatcher ParsedType(ast::ParsedType::Kind kind,
                                     const std::string& name)
 {
   return ParsedTypeMatcher().WithKind(kind).WithName(name);
+}
+
+class TypeArgMatcher : public NodeMatcher<TypeArgMatcher, ast::TypeArg> {
+public:
+  TypeArgMatcher& WithTypeOf(const Matcher<const ast::Typeof&>& typeof_matcher)
+  {
+    return Where([typeof_matcher](const ast::TypeArg& node) {
+      if (!node.type_of) {
+        node.addError() << "TypeArg has no typeof";
+        return false;
+      }
+      return MatchWith(node, typeof_matcher, *node.type_of);
+    });
+  }
+};
+
+inline TypeArgMatcher TypeArg(const Matcher<const ast::Typeof&>& typeof_matcher)
+{
+  return TypeArgMatcher().WithTypeOf(typeof_matcher);
 }
 
 class ProgramMatcher : public NodeMatcher<ProgramMatcher, ast::Program> {
@@ -978,7 +1000,6 @@ public:
       return MatchWith(node, range_matcher, *node.iterable.as<ast::Range>());
     });
   }
-
 };
 
 inline ForMatcher For(
@@ -1184,7 +1205,8 @@ inline ConfigMatcher Config(
   return ConfigMatcher().WithStatements(statements);
 }
 
-class RootImportMatcher : public NodeMatcher<RootImportMatcher, ast::RootImport> {
+class RootImportMatcher
+    : public NodeMatcher<RootImportMatcher, ast::RootImport> {
 public:
   RootImportMatcher& WithName(const std::string& name)
   {
@@ -1197,7 +1219,8 @@ inline RootImportMatcher RootImport(const std::string& name)
   return RootImportMatcher().WithName(name);
 }
 
-class StatementImportMatcher : public NodeMatcher<StatementImportMatcher, ast::StatementImport> {
+class StatementImportMatcher
+    : public NodeMatcher<StatementImportMatcher, ast::StatementImport> {
 public:
   StatementImportMatcher& WithName(const std::string& name)
   {

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -1,5 +1,6 @@
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/import_scripts.h"
+#include "ast/passes/printer.h"
 #include "ast/passes/resolve_imports.h"
 #include "mocks.h"
 #include "parser.h"
@@ -9,7 +10,11 @@ namespace bpftrace::test::macro_expansion {
 
 using ::testing::HasSubstr;
 
+// Runs the macro expansion pipeline on `input`. When `expected_output` is set,
+// the formatted (expanded) AST is checked to contain it, verifying that the
+// substitution actually happened. Otherwise only diagnostics are checked.
 void test(const std::string& input,
+          const std::string& expected_output = "",
           const std::string& error = "",
           const std::string& warn = "")
 {
@@ -47,6 +52,13 @@ void test(const std::string& input,
 
   if (trimmed_error.empty()) {
     ASSERT_TRUE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
+    if (!expected_output.empty()) {
+      std::stringstream printed;
+      ast::Printer printer(ast, printed);
+      printer.visit(ast.root);
+      EXPECT_THAT(printed.str(), HasSubstr(expected_output))
+          << msg.str() << printed.str();
+    }
     if (!trimmed_warn.empty()) {
       EXPECT_THAT(out.str(), HasSubstr(trimmed_warn)) << msg.str() << out.str();
     }
@@ -58,12 +70,12 @@ void test(const std::string& input,
 
 void test_error(const std::string& input, const std::string& error)
 {
-  test(input, error);
+  test(input, "", error);
 }
 
 void test_warning(const std::string& input, const std::string& warn)
 {
-  test(input, "", warn);
+  test(input, "", "", warn);
 }
 
 TEST(macro_expansion, basic_checks)
@@ -240,6 +252,69 @@ TEST(macro_expansion, stdlib_shadowing)
 
   // User macros should not poison builtin/function calls inside stdlib macros.
   test("macro fail(x) { x } begin { print(strlen(\"hi\")); }");
+}
+
+TEST(macro_expansion, type_arg)
+{
+  test("macro sof(t) { sizeof(t) } begin { print(sof(typeof(struct "
+       "task_struct))); }",
+       "sizeof(struct task_struct)");
+  test("macro sof(t) { sizeof(t) } begin { print(sof(typeof(uint64))); }",
+       "sizeof(uint64)");
+  test("macro sof(t) { sizeof(struct t) } begin { "
+       "print(sof(typeof(task_struct))); }",
+       "sizeof(struct task_struct)");
+  test("macro sof(t) { sizeof(t*) } begin { print(sof(typeof(uint64))); }",
+       "sizeof(uint64*)");
+  test("macro sof(t) { sizeof(t*) } begin { print(sof(typeof(mytype))); }",
+       "sizeof(mytype*)");
+  test("macro sof(a, b) { sizeof(a) + sizeof(b[2]) } "
+       "begin { print(sof(typeof(struct task_struct), typeof(uint64*))); }",
+       "sizeof(struct task_struct) + sizeof(uint64*[2])");
+  test("struct Foo { int x; } macro off(t) { offsetof(t, x) } "
+       "begin { print(off(typeof(struct Foo))); }",
+       "offsetof(struct Foo, x)");
+  test("macro c(t) { (typeof(t))0 } begin { print(c(typeof(uint64*))); }",
+       "(uint64*)0");
+  test("macro lt(t) { let $x: t = 0; } begin { lt(typeof(uint32)); }",
+       ": uint32 = 0;");
+  test("macro cst(t) { (t)0; } begin { print(cst(typeof(uint32*))); }",
+       "(uint32*)0");
+  test("macro ti(t) { typeinfo(t) } begin { print(ti(typeof(struct "
+       "task_struct))); }",
+       "typeinfo(struct task_struct)");
+  test("macro inner(t) { sizeof(t) } macro outer(t) { inner(t) } "
+       "begin { print(outer(typeof(uint64*))); }",
+       "sizeof(uint64*)");
+  test("macro inner(t) { sizeof(t) } macro outer(z) { inner(typeof(z)) } "
+       "begin { print(outer(typeof(uint64*))); }",
+       "sizeof(uint64*)");
+  test("macro out(x) { print(sizeof(x*)); } macro inn(b) { out(typeof(b[2])); "
+       "} begin { inn(typeof(uint64_t)); }",
+       "sizeof(uint64_t[2]*)");
+
+  // Errors
+  test_error("macro m(x) { x + 1 } begin { print(m(typeof(uint64*))); }",
+             "Typeof expression only valid for macro calls that are expecting "
+             "a type parameter");
+
+  test_error(
+      "macro m(t) { sizeof(struct t) } begin { print(m(typeof(uint64*))); }",
+      "Invalid replacement for macro 'm' type parameter 't' which makes up the "
+      "type 'struct t'");
+
+  test_error("macro m(t) { sizeof(struct t) } begin { $x = 1; print(m($x)); }",
+             "Invalid replacement for macro 'm' type parameter 't' which makes "
+             "up the type 'struct t'");
+
+  test_error("begin { print(f(typeof(uint64*))); }",
+             "Typeof expression only valid for macro calls that are expecting "
+             "a type parameter");
+
+  test_error("macro out(x) { print(x); } macro inn(b) { out(typeof(b[2])); } "
+             "begin { inn(typeof(uint64_t)); }",
+             "Typeof expression only valid for macro calls that are expecting "
+             "a type parameter");
 }
 
 } // namespace bpftrace::test::macro_expansion

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -38,6 +38,7 @@ using bpftrace::test::Program;
 
 using bpftrace::test::String;
 using bpftrace::test::Tuple;
+using bpftrace::test::TypeArg;
 using bpftrace::test::Typeof;
 using bpftrace::test::Unop;
 using bpftrace::test::Variable;
@@ -2071,6 +2072,95 @@ TEST(Parser, typeof_unknown_type)
            Probe({ "kprobe:sys_read" },
                  { ExprStatement(
                      Cast(Typeof(Identifier("mytype")), Builtin("arg0"))) })));
+}
+
+TEST(Parser, call_type_arg)
+{
+  test("begin { f(typeof(struct task_struct)); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(Call(
+                     "f",
+                     { TypeArg(Typeof(ParsedType(ast::ParsedType::Kind::Struct,
+                                                 "task_struct"))) })) })));
+
+  test("begin { f(typeof(union my_union)); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(Call(
+                     "f",
+                     { TypeArg(Typeof(ParsedType(ast::ParsedType::Kind::Union,
+                                                 "my_union"))) })) })));
+
+  test("begin { f(typeof(enum my_enum)); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(Call(
+                     "f",
+                     { TypeArg(Typeof(ParsedType(ast::ParsedType::Kind::Enum,
+                                                 "my_enum"))) })) })));
+
+  test("begin { f(typeof(uint64)); }",
+       Program().WithProbe(Probe(
+           { "begin" },
+           { ExprStatement(
+               Call("f",
+                    { TypeArg(Typeof(ParsedType(
+                        ast::ParsedType::Kind::Identifier, "uint64"))) })) })));
+
+  test("begin { f(typeof(uint64*)); }",
+       Program().WithProbe(Probe(
+           { "begin" },
+           { ExprStatement(Call(
+               "f",
+               { TypeArg(Typeof(
+                   ParsedType(ast::ParsedType::Kind::Pointer)
+                       .WithInner(ParsedType(ast::ParsedType::Kind::Identifier,
+                                             "uint64")))) })) })));
+
+  test("begin { f(typeof(uint64[2])); }",
+       Program().WithProbe(Probe(
+           { "begin" },
+           { ExprStatement(Call(
+               "f",
+               { TypeArg(Typeof(
+                   ParsedType(ast::ParsedType::Kind::Array)
+                       .WithArraySize(2)
+                       .WithInner(ParsedType(ast::ParsedType::Kind::Identifier,
+                                             "uint64")))) })) })));
+
+  test("begin { f(typeof(struct task_struct*)); }",
+       Program().WithProbe(Probe(
+           { "begin" },
+           { ExprStatement(
+               Call("f",
+                    { TypeArg(Typeof(
+                        ParsedType(ast::ParsedType::Kind::Pointer)
+                            .WithInner(ParsedType(ast::ParsedType::Kind::Struct,
+                                                  "task_struct")))) })) })));
+
+  test("begin { f(1, typeof(struct task_struct), \"x\"); }",
+       Program().WithProbe(
+           Probe({ "begin" },
+                 { ExprStatement(
+                     Call("f",
+                          { Integer(1),
+                            TypeArg(Typeof(ParsedType(
+                                ast::ParsedType::Kind::Struct, "task_struct"))),
+                            String("x") })) })));
+
+  test("begin { f(foo); }",
+       Program().WithProbe(Probe(
+           { "begin" }, { ExprStatement(Call("f", { Identifier("foo") })) })));
+
+  test_parse_failure("begin { f(struct task_struct*); }", R"(
+stdin:1:18-29: ERROR: syntax: expected ')'
+begin { f(struct task_struct*); }
+                 ~~~~~~~~~~~
+stdin:1:18-29: ERROR: syntax: expected ';'
+begin { f(struct task_struct*); }
+                 ~~~~~~~~~~~
+)");
 }
 
 TEST(Parser, dereference_precedence)

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -58,6 +58,18 @@ NAME it accepts arbitrary expressions with maps
 PROG macro add_one(x) { x + 1 } begin { @a = 1; print(add_one(@a + 1));  }
 EXPECT 3
 
+NAME it accepts typeof expressions
+PROG struct Foo { char m; } macro sof(a, b) { sizeof(a[2]) + sizeof(b*) + sizeof(b) } begin { print(sof(typeof(uint64*), typeof(struct Foo))); }
+EXPECT 25
+
+NAME it accepts typeof expressions with nested calls
+PROG macro m(t) { sizeof(t) + 2 } macro n(z) { print(m(typeof(z))); } begin { n(typeof(uint64*)); }
+EXPECT 10
+
+NAME it accepts typeof expressions for nested casts
+PROG macro cst(a) { (a*)-1 } begin { print(cst(typeof(uint8))); }
+EXPECT 0xff
+
 NAME can call the same macro multiple times
 PROG macro inc($x) { $x += 1; } begin { $a = 1; inc($a); inc($a); inc($a); print($a);  }
 EXPECT 4


### PR DESCRIPTION
Stacked PRs:
 * __->__#5234


--- --- ---

### Macros: Add support for typeof args


This allows us to do type expression substitution in bpftrace macros.
For example:
```
macro sof_double(type_a, type_b) {
  sizeof(type_a) + sizeof(type_b[2])
}

begin {
  print(sof_double(typeof(struct qspinlock), typeof(uint64*)));
}
```
Expands to:
```
begin {
  print(sizeof(struct qspinlock) + sizeof(uint64*[2]));
}
```

This is only valid for macros so if a call signature doesn't match a macro
then a compile time error is issued as `typeof` is not a valid expression.

This wrapping of type expressions in `typeof` is neccessary to prevent a
parsing ambiguity, e.g. `x[2]`. Without a wrapping `typeof` we don't know
if this is an array access or an array of two `x` elements. Inside of a
`typeof` it's always parsed as the latter.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>