### PR TITLE
Support arg replacement for offsetof's 2nd param

### DIFF
--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -394,6 +395,33 @@ void MacroExpander::visit(Sizeof &sizeof_node)
 void MacroExpander::visit(Offsetof &offsetof_node)
 {
   visit_expr_or_type(offsetof_node.record);
+  if (offsetof_node.field.size() == 1) {
+    if (auto it = passed_exprs_.find(offsetof_node.field.back());
+        it != passed_exprs_.end()) {
+      if (auto *ident = it->second.as<Identifier>()) {
+        offsetof_node.field[0] = ident->ident;
+      } else if (it->second.as<FieldAccess>()) {
+        // A FieldAccess made up entirely of identifiers (e.g. a.b.c) can
+        // replace the single field parameter.
+        std::vector<std::string> fields;
+        Expression expr = it->second;
+        while (auto *field_access = expr.as<FieldAccess>()) {
+          fields.push_back(field_access->field);
+          expr = field_access->expr;
+        }
+        auto *base = expr.as<Identifier>();
+        if (!base) {
+          it->second.node().addError()
+              << "FieldAccess expressions must be made up entirely of idents "
+                 "(e.g. a.b.c) to replace the second argument in `offsetof`";
+          return;
+        }
+        fields.push_back(base->ident);
+        std::ranges::reverse(fields);
+        offsetof_node.field = std::move(fields);
+      }
+    }
+  }
 }
 
 void MacroExpander::visit(Typeof &typeof_node)

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -317,4 +317,19 @@ TEST(macro_expansion, type_arg)
              "a type parameter");
 }
 
+TEST(macro_expansion, offsetof)
+{
+  test("macro off(t, f) { offsetof(t, f) } "
+       "begin { print(off(typeof(struct Foo), x)); }",
+       "offsetof(struct Foo, x)");
+  test("macro off(t, f) { offsetof(t, f) } "
+       "begin { print(off(typeof(struct Foo), a.b.c)); }",
+       "offsetof(struct Foo, a.b.c)");
+
+  test_error("macro off(t, f) { offsetof(t, f) } "
+             "begin { print(off(typeof(struct Foo), foo().b)); }",
+             "FieldAccess expressions must be made up entirely of idents (e.g. "
+             "a.b.c) to replace the second argument in `offsetof`");
+}
+
 } // namespace bpftrace::test::macro_expansion


### PR DESCRIPTION
Stacked PRs:
 * #5236
 * __->__#5235


--- --- ---

### Support arg replacement for offsetof's 2nd param


If someone creates a macro that utilizes a macro param for the second
argument to `offsetof` then we should support it.

For example:
```
macro off(t, f) { offsetof(t, f)

print(off(typeof(struct Foo), a.b.c));
```

However, there is a restriction in that it only supports bare idents or
FieldAccess expressions that are only composed of idents to mimic the
parser restriction.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>