### PR TITLE
stdlib: Add `container_of` macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
   - [#5213](https://github.com/bpftrace/bpftrace/pull/5213)
 - Add support for type expression substitution for macros
   - [#5234](https://github.com/bpftrace/bpftrace/pull/5234)
+- stdlib: add `container_of` mirroring the libbpf macro
+  - [#5236](https://github.com/bpftrace/bpftrace/pull/5236)
 #### Changed
 - List structure with module name in verbose mode
   - [#5212](https://github.com/bpftrace/bpftrace/pull/5212)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -164,6 +164,12 @@ Name of the current thread or the process with the specified PID
 This utilizes the BPF helper `get_current_comm`
 
 
+### container_of
+- `Container* container_of(Member* ptr, Type type, Identifier member)`
+
+Returns a pointer to an object of the passed `type` given a pointer to the `member` of that object.
+
+
 ### cpid
 - `uint32 cpid()`
 - `uint32 cpid`

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -394,6 +395,33 @@ void MacroExpander::visit(Sizeof &sizeof_node)
 void MacroExpander::visit(Offsetof &offsetof_node)
 {
   visit_expr_or_type(offsetof_node.record);
+  if (offsetof_node.field.size() == 1) {
+    if (auto it = passed_exprs_.find(offsetof_node.field.back());
+        it != passed_exprs_.end()) {
+      if (auto *ident = it->second.as<Identifier>()) {
+        offsetof_node.field[0] = ident->ident;
+      } else if (it->second.as<FieldAccess>()) {
+        // A FieldAccess made up entirely of identifiers (e.g. a.b.c) can
+        // replace the single field parameter.
+        std::vector<std::string> fields;
+        Expression expr = it->second;
+        while (auto *field_access = expr.as<FieldAccess>()) {
+          fields.push_back(field_access->field);
+          expr = field_access->expr;
+        }
+        auto *base = expr.as<Identifier>();
+        if (!base) {
+          it->second.node().addError()
+              << "FieldAccess expressions must be made up entirely of idents "
+                 "(e.g. a.b.c) to replace the second argument in `offsetof`";
+          return;
+        }
+        fields.push_back(base->ident);
+        std::ranges::reverse(fields);
+        offsetof_node.field = std::move(fields);
+      }
+    }
+  }
 }
 
 void MacroExpander::visit(Typeof &typeof_node)

--- a/src/stdlib/meta.bt
+++ b/src/stdlib/meta.bt
@@ -84,3 +84,10 @@ macro elf_info()
   assert_userspace_probe("elf_info");
   __builtin_elf_ino
 }
+
+// :variant Container* container_of(Member* ptr, Type type, Identifier member)
+// Returns a pointer to an object of the passed `type` given a pointer to the `member` of that object.
+macro container_of(ptr, type, member) {
+  $vptr = (void *)(ptr);
+  ((type *)($vptr - offsetof(type, member)))
+}

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -317,4 +317,19 @@ TEST(macro_expansion, type_arg)
              "a type parameter");
 }
 
+TEST(macro_expansion, offsetof)
+{
+  test("macro off(t, f) { offsetof(t, f) } "
+       "begin { print(off(typeof(struct Foo), x)); }",
+       "offsetof(struct Foo, x)");
+  test("macro off(t, f) { offsetof(t, f) } "
+       "begin { print(off(typeof(struct Foo), a.b.c)); }",
+       "offsetof(struct Foo, a.b.c)");
+
+  test_error("macro off(t, f) { offsetof(t, f) } "
+             "begin { print(off(typeof(struct Foo), foo().b)); }",
+             "FieldAccess expressions must be made up entirely of idents (e.g. "
+             "a.b.c) to replace the second argument in `offsetof`");
+}
+
 } // namespace bpftrace::test::macro_expansion

--- a/tests/runtime/stdlib
+++ b/tests/runtime/stdlib
@@ -70,3 +70,9 @@ TIMEOUT 5
 NAME strlen
 PROG begin { $a = "hello"; print(strlen($a)); }
 EXPECT 5
+
+NAME container_of
+PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:n_func { $n = (int *)arg0; $foo_ptr = container_of($n, typeof(struct Foo), n); print(*$foo_ptr); }
+EXPECT { .m = 2, .n = 3 }
+TIMEOUT 4
+AFTER ./testprogs/simple_struct

--- a/tests/testprogs/simple_struct.c
+++ b/tests/testprogs/simple_struct.c
@@ -8,11 +8,17 @@ int func(struct Foo *foo)
   return foo->m;
 }
 
+int n_func(int *n)
+{
+  return *n;
+}
+
 int main()
 {
   struct Foo foo;
   foo.m = 2;
   foo.n = 3;
   func(&foo);
+  n_func(&foo.n);
   return 0;
 }


### PR DESCRIPTION
Stacked PRs:
 * __->__#5236
 * #5235


--- --- ---

### stdlib: Add `container_of` macro


This is equivalent to the libbpf macro of the same name.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>