### PR TITLE
Fix `typeof` usage inconsistency

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1457,6 +1457,19 @@ Unlike `strftime()` `time()` doesn’t send a timestamp from the probe, instead 
 bpftrace uses the `strftime(3)` function for formatting time and supports the same format specifiers.
 
 
+### typeof
+- `TYPE typeof(TYPE)`
+- `TYPE typeof(EXPRESSION)`
+
+This is a special builtin that can only be used in the following contexts:
+- variable declarations e.g. `let $a: typeof($b);`
+- cast expressions e.g. `$a = (typeof($b))2;`
+- macro expansion calls to pass a type parameter e.g. `my_macro(typeof(uint64 *));`
+- type accepting builtins: `sizeof`, `offsetof`, `typeinfo`
+
+This builtin evaluates to the static type of either the parsed TYPE or the raw EXPRESSION parameter.
+
+
 ### uaddr
 - `T * uaddr(const string sym)`
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -642,80 +642,6 @@ inline std::strong_ordering expr_or_type_compare(const ExprOrType &lhs,
   return std::get<Expression>(lhs) <=> std::get<Expression>(rhs);
 }
 
-class Sizeof : public Node {
-public:
-  explicit Sizeof(ASTContext &ctx, Location &&loc, ParsedType *type)
-      : Node(ctx, std::move(loc)), record(std::move(type)) {};
-  explicit Sizeof(ASTContext &ctx, Location &&loc, Expression expr)
-      : Node(ctx, std::move(loc)), record(expr) {};
-  explicit Sizeof(ASTContext &ctx, const Location &loc, const Sizeof &other)
-      : Node(ctx, loc + other.loc), record(clone(ctx, loc, other.record)) {};
-
-  bool operator==(const Sizeof &other) const
-  {
-    return expr_or_type_equal(record, other.record);
-  }
-  std::strong_ordering operator<=>(const Sizeof &other) const
-  {
-    return expr_or_type_compare(record, other.record);
-  }
-
-  ExprOrType record;
-};
-
-class Offsetof : public Node {
-public:
-  explicit Offsetof(ASTContext &ctx,
-                    Location &&loc,
-                    ParsedType *record,
-                    std::vector<std::string> field)
-      : Node(ctx, std::move(loc)),
-        record(std::move(record)),
-        field(std::move(field)) {};
-  explicit Offsetof(ASTContext &ctx,
-                    Location &&loc,
-                    Expression expr,
-                    std::vector<std::string> field)
-      : Node(ctx, std::move(loc)), record(expr), field(std::move(field)) {};
-  explicit Offsetof(ASTContext &ctx, const Location &loc, const Offsetof &other)
-      : Node(ctx, loc + other.loc),
-        record(clone(ctx, loc + other.loc, other.record)),
-        field(other.field) {};
-
-  bool operator==(const Offsetof &other) const
-  {
-    return expr_or_type_equal(record, other.record) && field == other.field;
-  }
-  std::strong_ordering operator<=>(const Offsetof &other) const
-  {
-    if (auto cmp = expr_or_type_compare(record, other.record); cmp != 0)
-      return cmp;
-    return field <=> other.field;
-  }
-
-  ExprOrType record;
-  std::vector<std::string> field;
-};
-
-class Map : public Node {
-public:
-  explicit Map(ASTContext &ctx, Location &&loc, std::string ident)
-      : Node(ctx, std::move(loc)), ident(std::move(ident)) {};
-  explicit Map(ASTContext &ctx, const Location &loc, const Map &other)
-      : Node(ctx, loc + other.loc), ident(other.ident) {};
-
-  bool operator==(const Map &other) const
-  {
-    return ident == other.ident;
-  }
-  std::strong_ordering operator<=>(const Map &other) const
-  {
-    return ident <=> other.ident;
-  }
-
-  std::string ident;
-};
-
 class Typeof : public Node {
 public:
   explicit Typeof(ASTContext &ctx, Location &&loc, ParsedType *record)
@@ -736,6 +662,72 @@ public:
   }
 
   ExprOrType record;
+};
+
+class Sizeof : public Node {
+public:
+  explicit Sizeof(ASTContext &ctx, Location &&loc, Typeof *type_of)
+      : Node(ctx, std::move(loc)), type_of(type_of) {};
+  explicit Sizeof(ASTContext &ctx, const Location &loc, const Sizeof &other)
+      : Node(ctx, loc + other.loc),
+        type_of(clone(ctx, loc + other.loc, other.type_of)) {};
+
+  bool operator==(const Sizeof &other) const
+  {
+    return *type_of == *other.type_of;
+  }
+  std::strong_ordering operator<=>(const Sizeof &other) const
+  {
+    return *type_of <=> *other.type_of;
+  }
+
+  Typeof *type_of = nullptr;
+};
+
+class Offsetof : public Node {
+public:
+  explicit Offsetof(ASTContext &ctx,
+                    Location &&loc,
+                    Typeof *type_of,
+                    std::vector<std::string> field)
+      : Node(ctx, std::move(loc)), type_of(type_of), field(std::move(field)) {};
+  explicit Offsetof(ASTContext &ctx, const Location &loc, const Offsetof &other)
+      : Node(ctx, loc + other.loc),
+        type_of(clone(ctx, loc + other.loc, other.type_of)),
+        field(other.field) {};
+
+  bool operator==(const Offsetof &other) const
+  {
+    return *type_of == *other.type_of && field == other.field;
+  }
+  std::strong_ordering operator<=>(const Offsetof &other) const
+  {
+    if (auto cmp = *type_of <=> *other.type_of; cmp != 0)
+      return cmp;
+    return field <=> other.field;
+  }
+
+  Typeof *type_of = nullptr;
+  std::vector<std::string> field;
+};
+
+class Map : public Node {
+public:
+  explicit Map(ASTContext &ctx, Location &&loc, std::string ident)
+      : Node(ctx, std::move(loc)), ident(std::move(ident)) {};
+  explicit Map(ASTContext &ctx, const Location &loc, const Map &other)
+      : Node(ctx, loc + other.loc), ident(other.ident) {};
+
+  bool operator==(const Map &other) const
+  {
+    return ident == other.ident;
+  }
+  std::strong_ordering operator<=>(const Map &other) const
+  {
+    return ident <=> other.ident;
+  }
+
+  std::string ident;
 };
 
 class TypeArg : public Node {

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -173,20 +173,12 @@ void FieldAnalyser::visit(MapAccess &acc)
 
 void FieldAnalyser::visit(Sizeof &szof)
 {
-  if (auto *const *type = std::get_if<ParsedType *>(&szof.record)) {
-    resolve_type(**type);
-  } else {
-    visit(szof.record);
-  }
+  visit(*szof.type_of);
 }
 
 void FieldAnalyser::visit(Offsetof &offof)
 {
-  if (auto *const *type = std::get_if<ParsedType *>(&offof.record)) {
-    resolve_type(**type);
-  } else {
-    visit(offof.record);
-  }
+  visit(*offof.type_of);
 }
 
 void FieldAnalyser::visit(Typeof &typeof)

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -389,12 +389,12 @@ void MacroExpander::visit_expr_or_type(ExprOrType &record)
 
 void MacroExpander::visit(Sizeof &sizeof_node)
 {
-  visit_expr_or_type(sizeof_node.record);
+  visit(*sizeof_node.type_of);
 }
 
 void MacroExpander::visit(Offsetof &offsetof_node)
 {
-  visit_expr_or_type(offsetof_node.record);
+  visit(*offsetof_node.type_of);
   if (offsetof_node.field.size() == 1) {
     if (auto it = passed_exprs_.find(offsetof_node.field.back());
         it != passed_exprs_.end()) {
@@ -644,8 +644,9 @@ private:
 
 void TypeArgCheck::visit(TypeArg &type_arg)
 {
-  type_arg.addError() << "Typeof expression only valid for macro calls that "
-                         "are expecting a type parameter";
+  type_arg.addError()
+      << "When used as a call argument, `typeof` builtin only valid for macro "
+         "calls that are expecting a type parameter";
 }
 
 void expand_macro(ASTContext &ast,

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -462,7 +462,7 @@ Buffer Formatter::visit(Sizeof& szof)
       .text("sizeof(")
       .append(std::visit(
           [&](auto& v) { return format(v, metadata, max_width - 8, true); },
-          szof.record))
+          szof.type_of->record))
       .text(")");
 }
 
@@ -476,7 +476,7 @@ Buffer Formatter::visit(Offsetof& ofof)
     }
     fields = fields.text(ofof.field[i]);
   }
-  auto expr = format(ofof.record, metadata, max_width);
+  auto expr = format(ofof.type_of->record, metadata, max_width);
   return Buffer()
       .text("offsetof(")
       .append(std::move(expr))

--- a/src/ast/passes/types/ast_transformer.cpp
+++ b/src/ast/passes/types/ast_transformer.cpp
@@ -194,12 +194,7 @@ std::optional<Expression> AstTransformer::visit(FieldAccess &acc)
 
 std::optional<Expression> AstTransformer::visit(Offsetof &offof)
 {
-  SizedType c_type;
-  if (std::holds_alternative<ParsedType *>(offof.record)) {
-    c_type = get_type(std::get<ParsedType *>(offof.record));
-  } else {
-    c_type = get_type(&std::get<Expression>(offof.record).node());
-  }
+  SizedType c_type = get_type(offof.type_of);
 
   if (c_type.IsNoneTy()) {
     return std::nullopt;
@@ -220,22 +215,12 @@ std::optional<Expression> AstTransformer::visit(Offsetof &offof)
 
 std::optional<Expression> AstTransformer::visit(Sizeof &szof)
 {
-  size_t size = 0;
-  if (std::holds_alternative<ParsedType *>(szof.record)) {
-    const auto &ty = get_type(std::get<ParsedType *>(szof.record));
-    if (ty.IsNoneTy()) {
-      return std::nullopt;
-    }
-    size = ty.GetSize();
-  } else {
-    const auto &ty = get_type(&std::get<Expression>(szof.record).node());
-    if (ty.IsNoneTy()) {
-      return std::nullopt;
-    }
-    size = ty.GetSize();
+  const auto &ty = get_type(szof.type_of);
+  if (ty.IsNoneTy()) {
+    return std::nullopt;
   }
 
-  return ast_.make_node<Integer>(Location(szof.loc), size);
+  return ast_.make_node<Integer>(Location(szof.loc), ty.GetSize());
 }
 
 std::optional<Expression> AstTransformer::visit(Typeinfo &typeinfo)

--- a/src/ast/passes/types/pre_type_check.cpp
+++ b/src/ast/passes/types/pre_type_check.cpp
@@ -363,12 +363,12 @@ public:
 
 void MapCheck::visit(Offsetof &offof)
 {
-  AssignMapDisallowed<"offsetof">().visit(offof.record);
+  AssignMapDisallowed<"offsetof">().visit(offof.type_of->record);
 }
 
 void MapCheck::visit(Sizeof &szof)
 {
-  AssignMapDisallowed<"sizeof">().visit(szof.record);
+  AssignMapDisallowed<"sizeof">().visit(szof.type_of->record);
 }
 
 void MapCheck::visit(Typeof &typeof)

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -1868,33 +1868,22 @@ void TypeRuleCollector::visit(PositionalParameterCount &param)
 
 void TypeRuleCollector::visit(Offsetof &offof)
 {
+  visit(*offof.type_of);
   // This type will change later depending on what integer literal it resolves
   // to in AstTransformer but for now set it to the smallest uint
-  if (std::holds_alternative<ParsedType *>(offof.record)) {
-    auto ty = resolve_parsed_type(std::get<ParsedType *>(offof.record), offof);
-    if (!ty || !check_offsetof_type(offof, *ty)) {
-      return;
-    }
-    resolver_.set_type(&offof, CreateUInt8());
-  } else {
-    auto &expr = std::get<Expression>(offof.record);
-    ++introspection_level_;
-    visit(expr);
-    --introspection_level_;
-    resolver_.add_type_rule({
-        .output = &offof,
-        .inputs = { &expr.node() },
-        .resolve = [this,
-                    &offof](const std::vector<SizedType> &inputs) -> SizedType {
-          auto local_type = inputs[0];
-          resolve_external_type(local_type, offof);
-          if (!check_offsetof_type(offof, local_type)) {
-            return CreateNone();
-          }
-          return CreateUInt8();
-        },
-    });
-  }
+  resolver_.add_type_rule({
+      .output = &offof,
+      .inputs = { offof.type_of },
+      .resolve = [this,
+                  &offof](const std::vector<SizedType> &inputs) -> SizedType {
+        auto local_type = inputs[0];
+        resolve_external_type(local_type, offof);
+        if (!check_offsetof_type(offof, local_type)) {
+          return CreateNone();
+        }
+        return CreateUInt8();
+      },
+  });
 }
 
 void TypeRuleCollector::visit(Probe &probe)
@@ -1929,27 +1918,16 @@ void TypeRuleCollector::visit(Record &record)
 
 void TypeRuleCollector::visit(Sizeof &szof)
 {
+  visit(*szof.type_of);
   // This type will change later depending on what integer literal it resolves
   // to for now set it to the smallest uint
-  if (std::holds_alternative<ParsedType *>(szof.record)) {
-    auto ty = resolve_parsed_type(std::get<ParsedType *>(szof.record), szof);
-    if (!ty) {
-      return;
-    }
-    resolver_.set_type(&szof, CreateUInt8());
-  } else {
-    auto &expr = std::get<Expression>(szof.record);
-    ++introspection_level_;
-    visit(expr);
-    --introspection_level_;
-    resolver_.add_type_rule({
-        .output = &szof,
-        .inputs = { &expr.node() },
-        .resolve = [&szof](const std::vector<SizedType> &) -> SizedType {
-          return CreateUInt8();
-        },
-    });
-  }
+  resolver_.add_type_rule({
+      .output = &szof,
+      .inputs = { szof.type_of },
+      .resolve = [](const std::vector<SizedType> &) -> SizedType {
+        return CreateUInt8();
+      },
+  });
 }
 
 void TypeRuleCollector::visit(String &str)

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -85,11 +85,11 @@ public:
   }
   R visit(Sizeof &szof)
   {
-    return visitImpl(szof.record);
+    return visitImpl(szof.type_of);
   }
   R visit(Offsetof &ofof)
   {
-    return visitImpl(ofof.record);
+    return visitImpl(ofof.type_of);
   }
   R visit([[maybe_unused]] TypeArg &type_arg)
   {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2172,54 +2172,22 @@ Expression Parser::parse_primary()
   // sizeof(type_or_expr)
   if (match("sizeof")) {
     expect('(');
-    consume_layout();
-
-    if (auto type_ref = try_parse_type_reference(")")) {
-      expect(')');
-      auto loc = make_loc(begin_line, begin_col, line_, col_);
-      if (auto *type = std::get_if<ParsedType *>(&*type_ref)) {
-        auto *s = ctx_.make_node<Sizeof>(loc, *type);
-        return { s };
-      }
-      auto *s = ctx_.make_node<Sizeof>(
-          loc, std::move(std::get<Expression>(*type_ref)));
-      return { s };
-    }
-    auto expr = parse_expression();
+    auto *typeof_node = parse_type_annotation();
     expect(')');
     auto loc = make_loc(begin_line, begin_col, line_, col_);
-    auto *s = ctx_.make_node<Sizeof>(loc, std::move(expr));
+    auto *s = ctx_.make_node<Sizeof>(loc, typeof_node);
     return { s };
   }
 
-  // offsetof(type, field.field...)
+  // offsetof(type_or_expr, field.field...)
   if (match("offsetof")) {
     expect('(');
-    consume_layout();
-
-    // Try type first (struct Name)
-    auto sp = save_point();
-    auto ident = consume_identifier().value_or("");
-    bool is_struct_type = (ident == "struct" || ident == "union" ||
-                           ident == "enum");
-    sp.restore();
-
-    if (is_struct_type) {
-      auto *type = parse_type();
-      expect(',');
-      auto fields = parse_field_access();
-      expect(')');
-      auto loc = make_loc(begin_line, begin_col, line_, col_);
-      auto *o = ctx_.make_node<Offsetof>(loc, type, std::move(fields));
-      return { o };
-    }
-    // Expression form: offsetof(expr, field)
-    auto expr = parse_expression();
+    auto *typeof_node = parse_type_annotation();
     expect(',');
     auto fields = parse_field_access();
     expect(')');
     auto loc = make_loc(begin_line, begin_col, line_, col_);
-    auto *o = ctx_.make_node<Offsetof>(loc, std::move(expr), std::move(fields));
+    auto *o = ctx_.make_node<Offsetof>(loc, typeof_node, std::move(fields));
     return { o };
   }
 

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -1400,6 +1400,18 @@ macro signal_thread(expr)
 //
 // bpftrace uses the `strftime(3)` function for formatting time and supports the same format specifiers.
 
+// :function typeof
+// :variant TYPE typeof(TYPE)
+// :variant TYPE typeof(EXPRESSION)
+//
+// This is a special builtin that can only be used in the following contexts:
+// - variable declarations e.g. `let $a: typeof($b);`
+// - cast expressions e.g. `$a = (typeof($b))2;`
+// - macro expansion calls to pass a type parameter e.g. `my_macro(typeof(uint64 *));`
+// - type accepting builtins: `sizeof`, `offsetof`, `typeinfo`
+//
+// This builtin evaluates to the static type of either the parsed TYPE or the raw EXPRESSION parameter.
+
 // :variant T * uaddr(const string sym)
 //
 // **Supported probes**

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -161,12 +161,21 @@ std::vector<Sizeof *> variants<Sizeof>(ASTContext &c, SourceLocation l)
   Expression expr = c.make_node<Integer>(l, 42UL);
   return {
     c.make_node<Sizeof>(
-        l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int32")),
+        l,
+        c.make_node<Typeof>(
+            l,
+            c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int32"))),
     c.make_node<Sizeof>(
-        l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int64")),
+        l,
+        c.make_node<Typeof>(
+            l,
+            c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "int64"))),
     c.make_node<Sizeof>(
-        l, c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint32")),
-    c.make_node<Sizeof>(l, std::move(expr))
+        l,
+        c.make_node<Typeof>(l,
+                            c.make_node<ParsedType>(
+                                l, ParsedType::Kind::Identifier, "uint32"))),
+    c.make_node<Sizeof>(l, c.make_node<Typeof>(l, std::move(expr)))
   };
 }
 
@@ -185,14 +194,21 @@ std::vector<Offsetof *> variants<Offsetof>(ASTContext &c, SourceLocation l)
   return {
     c.make_node<Offsetof>(
         l,
-        c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint32"),
+        c.make_node<Typeof>(
+            l,
+            c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint32")),
         field1),
     c.make_node<Offsetof>(
         l,
-        c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint64"),
+        c.make_node<Typeof>(
+            l,
+            c.make_node<ParsedType>(l, ParsedType::Kind::Identifier, "uint64")),
         field2),
-    c.make_node<Offsetof>(l, c.make_node<ParsedType>(l, 64, string), field3),
-    c.make_node<Offsetof>(l, std::move(expr), field4)
+    c.make_node<Offsetof>(
+        l,
+        c.make_node<Typeof>(l, c.make_node<ParsedType>(l, 64, string)),
+        field3),
+    c.make_node<Offsetof>(l, c.make_node<Typeof>(l, std::move(expr)), field4)
   };
 }
 

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -1414,24 +1414,26 @@ public:
   SizeofMatcher& WithExpr(const Matcher<const ast::Expression&>& expr_matcher)
   {
     return Where([expr_matcher](const ast::Sizeof& node) {
-      if (!std::holds_alternative<ast::Expression>(node.record)) {
+      if (!node.type_of ||
+          !std::holds_alternative<ast::Expression>(node.type_of->record)) {
         node.addError() << "record is not an expression";
         return false;
       }
       return MatchWith(node,
                        expr_matcher,
-                       std::get<ast::Expression>(node.record));
+                       std::get<ast::Expression>(node.type_of->record));
     });
   }
 
   SizeofMatcher& WithType(const Matcher<const ast::ParsedType&>& type_matcher)
   {
     return Where([type_matcher](const ast::Sizeof& node) {
-      if (!std::holds_alternative<ast::ParsedType*>(node.record)) {
+      if (!node.type_of ||
+          !std::holds_alternative<ast::ParsedType*>(node.type_of->record)) {
         node.addError() << "record is not a ParsedType";
         return false;
       }
-      const auto* type = std::get<ast::ParsedType*>(node.record);
+      const auto* type = std::get<ast::ParsedType*>(node.type_of->record);
       return type && MatchWith(node, type_matcher, *type);
     });
   }
@@ -1452,24 +1454,26 @@ public:
   OffsetofMatcher& WithExpr(const Matcher<const ast::Expression&>& expr_matcher)
   {
     return Where([expr_matcher](const ast::Offsetof& node) {
-      if (!std::holds_alternative<ast::Expression>(node.record)) {
+      if (!node.type_of ||
+          !std::holds_alternative<ast::Expression>(node.type_of->record)) {
         node.addError() << "record is not an expression";
         return false;
       }
       return MatchWith(node,
                        expr_matcher,
-                       std::get<ast::Expression>(node.record));
+                       std::get<ast::Expression>(node.type_of->record));
     });
   }
 
   OffsetofMatcher& WithType(const Matcher<const ast::ParsedType&>& type_matcher)
   {
     return Where([type_matcher](const ast::Offsetof& node) {
-      if (!std::holds_alternative<ast::ParsedType*>(node.record)) {
+      if (!node.type_of ||
+          !std::holds_alternative<ast::ParsedType*>(node.type_of->record)) {
         node.addError() << "record is not a ParsedType";
         return false;
       }
-      const auto* type = std::get<ast::ParsedType*>(node.record);
+      const auto* type = std::get<ast::ParsedType*>(node.type_of->record);
       return type && MatchWith(node, type_matcher, *type);
     });
   }

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -295,8 +295,8 @@ TEST(macro_expansion, type_arg)
 
   // Errors
   test_error("macro m(x) { x + 1 } begin { print(m(typeof(uint64*))); }",
-             "Typeof expression only valid for macro calls that are expecting "
-             "a type parameter");
+             "When used as a call argument, `typeof` builtin only valid for "
+             "macro calls that are expecting a type parameter");
 
   test_error(
       "macro m(t) { sizeof(struct t) } begin { print(m(typeof(uint64*))); }",
@@ -308,13 +308,13 @@ TEST(macro_expansion, type_arg)
              "up the type 'struct t'");
 
   test_error("begin { print(f(typeof(uint64*))); }",
-             "Typeof expression only valid for macro calls that are expecting "
-             "a type parameter");
+             "When used as a call argument, `typeof` builtin only valid for "
+             "macro calls that are expecting a type parameter");
 
   test_error("macro out(x) { print(x); } macro inn(b) { out(typeof(b[2])); } "
              "begin { inn(typeof(uint64_t)); }",
-             "Typeof expression only valid for macro calls that are expecting "
-             "a type parameter");
+             "When used as a call argument, `typeof` builtin only valid for "
+             "macro calls that are expecting a type parameter");
 }
 
 TEST(macro_expansion, offsetof)

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1967,6 +1967,14 @@ TEST(Parser, sizeof_type)
            Probe({ "kprobe:sys_read" },
                  { ExprStatement(Sizeof(ParsedType(
                      ast::ParsedType::Kind::Identifier, "int32"))) })));
+  test("kprobe:sys_read { sizeof(typeof(int32)); }",
+       Program().WithProbe(
+           Probe({ "kprobe:sys_read" },
+                 { ExprStatement(Sizeof(ParsedType(
+                     ast::ParsedType::Kind::Identifier, "int32"))) })));
+  test("kprobe:sys_read { sizeof(typeof(arg0)); }",
+       Program().WithProbe(Probe({ "kprobe:sys_read" },
+                                 { ExprStatement(Sizeof(Builtin("arg0"))) })));
 }
 
 TEST(Parser, offsetof_type)
@@ -1989,6 +1997,15 @@ TEST(Parser, offsetof_type)
                      { ExprStatement(Offsetof(
                          ParsedType(ast::ParsedType::Kind::Struct, "Foo"),
                          { "bar", "x" })) })));
+  test("struct Foo { int x; } begin { offsetof(typeof(struct Foo), x); }",
+       Program()
+           .WithCStatements({ CStatement("struct Foo { int x; };") })
+           .WithProbe(
+               Probe({ "begin" },
+                     { ExprStatement(Offsetof(
+                         ParsedType(ast::ParsedType::Kind::Struct, "Foo"),
+                         { "x" })) })));
+
   test_parse_failure("struct Foo { struct Bar { int x; } *bar; } "
                      "begin { offsetof(struct Foo, bar->x); }",
                      R"(

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -4158,6 +4158,14 @@ TEST_F(TypeCheckerTest, int_ident)
   test("begin { sizeof(int32) }");
 }
 
+TEST_F(TypeCheckerTest, sizeof_offsetof_typeof)
+{
+  test("begin { sizeof(typeof(int32)) }");
+  test("begin { $x = (int64)1; sizeof(typeof($x)) }");
+  test("struct Foo { int x; long l; } \
+        begin { @x = offsetof(typeof(struct Foo), l); }");
+}
+
 TEST_F(TypeCheckerTest, string_size)
 {
   // Size of the variable should be the size of the larger string (incl. null)


### PR DESCRIPTION
Stacked PRs:
 * #5238
 * __->__#5237


--- --- ---

### Fix `typeof` usage inconsistency


Allow `typeof` to be used inside of `sizeof` and `offsetof` matching the
behavior of casts, `typeinfo`, and TypeArg.

This allows us to reduce some repeated logic in some of the passes.

This also adds `typeof` to the standard library docs.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>