### PR TITLE
Fix print output for empty scalar maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Print zero values for empty scalar maps
+  - [#5239](https://github.com/bpftrace/bpftrace/pull/5239)
 #### Security
 #### Docs
 #### Tools

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -1,6 +1,7 @@
 #include <fstream>
 #include <memory>
 #include <string>
+#include <variant>
 
 #include "ast/async_event_types.h"
 #include "async_action.h"
@@ -109,10 +110,48 @@ Result<> AsyncHandlers::print_map(const OpaqueValue &data)
 {
   auto print = data.bitcast<AsyncEvent::Print>();
   const auto &map = bpftrace.bytecode_.getMap(print.mapid);
+  const auto &map_info = bpftrace.resources.maps_info.at(map.name());
 
   auto res = format(bpftrace, c_definitions, map, print.top, print.div);
   if (!res) {
     return res.takeError();
+  }
+
+  if (!map_info.is_scalar || map_info.value_type.IsHistTy() ||
+      map_info.value_type.IsLhistTy() || map_info.value_type.IsTSeriesTy()) {
+    out->map(map.name(), *res);
+    return OK();
+  }
+
+  auto emit_empty_scalar = [&](bool stats) -> Result<> {
+    auto scalar = format(bpftrace,
+                         c_definitions,
+                         map_info.value_type,
+                         OpaqueValue::alloc(map_info.value_type.GetSize()));
+
+    if (!scalar) {
+      return scalar.takeError();
+    }
+
+    if (stats) {
+      out->map(map.name(),
+               output::Value(output::Value::Stats(std::move(*scalar))));
+    } else {
+      out->map(map.name(), output::Value(std::move(*scalar)));
+    }
+    return OK();
+  };
+
+  if (auto *m = std::get_if<output::Value::OrderedMap>(&res->variant);
+      m && m->values.empty()) {
+    return emit_empty_scalar(false);
+  }
+
+  if (auto *stats = std::get_if<output::Value::Stats>(&res->variant)) {
+    if (auto *m = std::get_if<output::Value::OrderedMap>(&stats->value);
+        m && m->values.empty()) {
+      return emit_empty_scalar(true);
+    }
   }
 
   out->map(map.name(), *res);

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -579,6 +579,24 @@ PROG begin { @x[1] = 5; print(@x[1]); exit() }
 EXPECT 5
 TIMEOUT 1
 
+NAME print_empty_scalar_map
+PROG begin { print(@); } end { @ = 1 }
+EXPECT @: 0
+EXPECT @: 1
+TIMEOUT 1
+
+NAME print_empty_scalar_stats_map
+PROG begin { print(@); } end { @ = stats(1) }
+EXPECT @: { .count = 0, .average = 0, .total = 0 }
+EXPECT @: { .count = 1, .average = 1, .total = 1 }
+TIMEOUT 1
+
+NAME print_empty_scalar_record_map
+PROG begin { print(@); } end { @ = (a=1, b=(2, "hi")) }
+EXPECT @: { .a = 0, .b = (0, ) }
+EXPECT @: { .a = 1, .b = (2, hi) }
+TIMEOUT 1
+
 NAME print_map_item_tuple
 PROG begin { @x[1] = "hi"; print((1, 2, @x[1])); exit() }
 EXPECT (1, 2, hi)


### PR DESCRIPTION
Fixes #3006.

## Summary
- Print `0` for empty scalar maps instead of producing no output.
- Add text and JSON runtime coverage for this case.

## Testing
- Built successfully.
- Unit tests pass locally.
