### PR TITLE
test: re-enabled usdt mountns test and bumped bcc minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ include_directories(SYSTEM ${KERNEL_INCLUDE_DIRS})
 find_package(ZLIB REQUIRED)
 include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
 
-find_package(LibBcc REQUIRED)
+find_package(LibBcc 0.13.0 REQUIRED)
 include_directories(SYSTEM ${LIBBCC_INCLUDE_DIRS})
 
 find_package(LibBpf REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ include_directories(SYSTEM ${KERNEL_INCLUDE_DIRS})
 find_package(ZLIB REQUIRED)
 include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
 
-find_package(LibBcc 0.13.0 REQUIRED)
+find_package(LibBcc REQUIRED)
 include_directories(SYSTEM ${LIBBCC_INCLUDE_DIRS})
 
 find_package(LibBpf REQUIRED)

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -190,14 +190,11 @@ RUN {{BPFTRACE}} -l 'usdt:*' -p {{BEFORE_PID}}
 EXPECT_REGEX ^usdt:.*/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe$
 BEFORE ./testprogs/mountns_wrapper usdt_test
 
-# TODO(dalehamel): re-enable this test
-# This test relies on the latest version of bcc (expected to be released as 0.13.0)
-# Once we build against this version with USDT fixes, we should re-enable this test.
+
 NAME usdt probes - attach to fully specified probe by pid in separate mountns
 RUN {{BPFTRACE}} -e 'usdt:/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT here
 BEFORE ./testprogs/mountns_wrapper usdt_test
-REQUIRES bash -c "exit 1"
 
 NAME usdt quoted probe name
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_quoted_probe:test:"\"probe1\"" { printf("%d\n", arg0); exit(); }' -p {{BEFORE_PID}}


### PR DESCRIPTION
Fixes issue #1638 
Bumped the minimum required bcc version to 0.13.0 in CMakeLists.txt.
Removed the exit 1 skip directive for "usdt probes - attach to fully specified probe by pid in separate mountn" in tests/runtime/usdt.


##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ x] The new behaviour is covered by tests
