### PR TITLE
Feat config builtin clean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
   - [#5234](https://github.com/bpftrace/bpftrace/pull/5234)
 - stdlib: add `container_of` mirroring the libbpf macro
   - [#5236](https://github.com/bpftrace/bpftrace/pull/5236)
+- stdlib: add `config` to read bpftrace configuration variables
+ -  [#5241](https://github.com/bpftrace/bpftrace/pull/5241)
 #### Changed
 - List structure with module name in verbose mode
   - [#5212](https://github.com/bpftrace/bpftrace/pull/5212)
@@ -23,8 +25,6 @@ and this project adheres to
   - [#5208](https://github.com/bpftrace/bpftrace/pull/5208)
 - Release assets are now suffixed with the architecture
   - [#5213](https://github.com/bpftrace/bpftrace/pull/5213)
-- stdlib: add `config` to read bpftrace configuration variables
- -  [#5241](https://github.com/bpftrace/bpftrace/pull/5241)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to
   - [#5208](https://github.com/bpftrace/bpftrace/pull/5208)
 - Release assets are now suffixed with the architecture
   - [#5213](https://github.com/bpftrace/bpftrace/pull/5213)
-- Added config builtin to read bpftrace configuration settings
+- stdlib: add `config` to read bpftrace configuration variables
  -  [#5241](https://github.com/bpftrace/bpftrace/pull/5241)
 #### Deprecated
 #### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   - [#5208](https://github.com/bpftrace/bpftrace/pull/5208)
 - Release assets are now suffixed with the architecture
   - [#5213](https://github.com/bpftrace/bpftrace/pull/5213)
+- Added config builtin to read bpftrace configuration settings
+ -  [#5241](https://github.com/bpftrace/bpftrace/pull/5241)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -135,6 +135,25 @@ BEGIN {
 ```
 
 
+### clear
+- `void clear(map m)`
+
+**async**
+
+Clear all keys/values from map `m`.
+
+```
+interval:ms:100 {
+  @[rand % 10] = count();
+}
+
+interval:s:10 {
+  print(@);
+  clear(@);
+}
+```
+
+
 ### comm
 - `string comm()`
 - `string comm`
@@ -143,6 +162,18 @@ BEGIN {
 Name of the current thread or the process with the specified PID
 
 This utilizes the BPF helper `get_current_comm`
+
+
+### config
+- `Record config()`
+- `Record config`
+
+Returns a `Record` containing the current `bpftrace` configuration settings. [List of config variables](./language.md#config-variables)
+
+```
+printf("max_strlen: %d, stack_mode: %s\n", config.max_strlen, config.stack_mode);
+}
+```
 
 
 ### container_of

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -135,25 +135,6 @@ BEGIN {
 ```
 
 
-### clear
-- `void clear(map m)`
-
-**async**
-
-Clear all keys/values from map `m`.
-
-```
-interval:ms:100 {
-  @[rand % 10] = count();
-}
-
-interval:s:10 {
-  print(@);
-  clear(@);
-}
-```
-
-
 ### comm
 - `string comm()`
 - `string comm`
@@ -163,17 +144,6 @@ Name of the current thread or the process with the specified PID
 
 This utilizes the BPF helper `get_current_comm`
 
-### config
-- `Record config()`
-- `Record config`
-
-Returns a `Record` containing the current `bpftrace` configuration settings.
-Example : 
-BEGIN {
-	$c = config;
-	printf("max_strlen: %d, stack_mode: %s\n", $c.max_strlen, $c.stack_mode);
-	exit();
-}
 
 ### container_of
 - `Container* container_of(Member* ptr, Type type, Identifier member)`

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -163,6 +163,17 @@ Name of the current thread or the process with the specified PID
 
 This utilizes the BPF helper `get_current_comm`
 
+### config
+- `Record config()`
+- `Record config`
+
+Returns a `Record` containing the current `bpftrace` configuration settings.
+Example : 
+BEGIN {
+	$c = config;
+	printf("max_strlen: %d, stack_mode: %s\n", $c.max_strlen, $c.stack_mode);
+	exit();
+}
 
 ### container_of
 - `Container* container_of(Member* ptr, Type type, Identifier member)`

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -104,7 +104,63 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
       return ast_.make_node<Integer>(
           node.loc, util::file_ino(probe->attach_points.front()->target));
     }
-  }
+  } else if (ident == "__builtin_elf_ino") {
+      if (check_probe()) {
+        return ast_.make_node<Integer>(
+            node.loc, util::file_ino(probe->attach_points.front()->target));
+      }
+    } else if (ident == "config") {
+        std::vector<std::pair<std::string, Expression>> args;
+        auto &cfg = bpftrace_.config_;
+    
+        auto add_bool = [&](const char* key, bool val) {
+          args.emplace_back(key, ast_.make_node<Boolean>(node.loc, val));
+        };
+        auto add_int = [&](const char* key, uint64_t val) {
+          args.emplace_back(key, ast_.make_node<Integer>(node.loc, val));
+        };
+        auto add_str = [&](const char* key, const std::string& val) {
+          args.emplace_back(key, ast_.make_node<String>(node.loc, val));
+        };
+    
+        // Booleans
+        add_bool("cpp_demangle", cfg->cpp_demangle);
+        add_bool("lazy_symbolication", cfg->lazy_symbolication);
+        add_bool("print_maps_on_exit", cfg->print_maps_on_exit);
+        add_bool("use_blazesym", cfg->use_blazesym);
+        add_bool("show_debug_info", cfg->show_debug_info);
+    
+        // Integers
+        add_int("log_size", cfg->log_size);
+        add_int("max_bpf_progs", cfg->max_bpf_progs);
+        add_int("max_cat_bytes", cfg->max_cat_bytes);
+        add_int("max_map_keys", cfg->max_map_keys);
+        add_int("max_probes", cfg->max_probes);
+        add_int("max_strlen", cfg->max_strlen);
+        add_int("on_stack_limit", cfg->on_stack_limit);
+        add_int("perf_rb_pages", cfg->perf_rb_pages);
+    
+        // Strings
+        add_str("str_trunc_trailer", cfg->str_trunc_trailer);
+    
+        // Enums -> Strings
+        auto unstable_str = [](ConfigUnstable u) {
+          return u == ConfigUnstable::enable ? "enable" : (u == ConfigUnstable::warn ? "warn" : "error");
+        };
+        add_str("unstable_import_statement", unstable_str(cfg->unstable_import_statement));
+        add_str("unstable_tseries", unstable_str(cfg->unstable_tseries));
+        add_str("unstable_typeinfo", unstable_str(cfg->unstable_typeinfo));
+        add_str("unstable_dw_ustack", unstable_str(cfg->unstable_dw_ustack));
+    
+        auto missing_str = [](ConfigMissingProbes m) {
+          return m == ConfigMissingProbes::ignore ? "ignore" : (m == ConfigMissingProbes::warn ? "warn" : "error");
+        };
+        add_str("missing_probes", missing_str(cfg->missing_probes));
+    
+        add_str("stack_mode", cfg->stack_mode == StackMode::bpftrace ? "bpftrace" : "perf");
+		add_str("license", bpftrace::Config::get_license_str(cfg->license));    
+        return make_record(ast_, node.loc, std::move(args));
+      }
 
   return std::nullopt;
 }

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -104,12 +104,7 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
       return ast_.make_node<Integer>(
           node.loc, util::file_ino(probe->attach_points.front()->target));
     }
-  } else if (ident == "__builtin_elf_ino") {
-      if (check_probe()) {
-        return ast_.make_node<Integer>(
-            node.loc, util::file_ino(probe->attach_points.front()->target));
-      }
-    } else if (ident == "config") {
+  } else if (ident == "config") {
         std::vector<std::pair<std::string, Expression>> args;
         auto &cfg = bpftrace_.config_;
     

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -104,7 +104,7 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
       return ast_.make_node<Integer>(
           node.loc, util::file_ino(probe->attach_points.front()->target));
     }
-  } else if (ident == "config") {
+  } else if (ident == "__builtin_config") {
     std::vector<std::pair<std::string, Expression>> args;
     auto &cfg = bpftrace_.config_;
 
@@ -140,25 +140,40 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
 
     // Enums -> Strings
     auto unstable_str = [](ConfigUnstable u) {
-      return u == ConfigUnstable::enable
-                 ? "enable"
-                 : (u == ConfigUnstable::warn ? "warn" : "error");
+      switch (u) {
+        case ConfigUnstable::enable:
+          return "enable";
+        case ConfigUnstable::warn:
+          return "warn";
+        case ConfigUnstable::error:
+          return "error";
+      }
+      return "error";
     };
+
     add_str("unstable_import_statement",
             unstable_str(cfg->unstable_import_statement));
     add_str("unstable_tseries", unstable_str(cfg->unstable_tseries));
     add_str("unstable_typeinfo", unstable_str(cfg->unstable_typeinfo));
     add_str("unstable_dw_ustack", unstable_str(cfg->unstable_dw_ustack));
 
-    auto missing_str = [](ConfigMissingProbes m) {
-      return m == ConfigMissingProbes::ignore
-                 ? "ignore"
-                 : (m == ConfigMissingProbes::warn ? "warn" : "error");
-    };
-    add_str("missing_probes", missing_str(cfg->missing_probes));
+    std::string missing_str;
+    switch (cfg->missing_probes) {
+      case ConfigMissingProbes::ignore:
+        missing_str = "ignore";
+        break;
+      case ConfigMissingProbes::warn:
+        missing_str = "warn";
+        break;
+      case ConfigMissingProbes::error:
+        missing_str = "error";
+        break;
+    }
 
-    add_str("stack_mode",
-            cfg->stack_mode == StackMode::bpftrace ? "bpftrace" : "perf");
+    add_str("missing_probes", missing_str);
+
+    add_str("stack_mode", STACK_MODE_NAME_MAP.at(cfg->stack_mode));
+
     add_str("license", bpftrace::Config::get_license_str(cfg->license));
     return make_record(ast_, node.loc, std::move(args));
   }

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -105,57 +105,63 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
           node.loc, util::file_ino(probe->attach_points.front()->target));
     }
   } else if (ident == "config") {
-        std::vector<std::pair<std::string, Expression>> args;
-        auto &cfg = bpftrace_.config_;
-    
-        auto add_bool = [&](const char* key, bool val) {
-          args.emplace_back(key, ast_.make_node<Boolean>(node.loc, val));
-        };
-        auto add_int = [&](const char* key, uint64_t val) {
-          args.emplace_back(key, ast_.make_node<Integer>(node.loc, val));
-        };
-        auto add_str = [&](const char* key, const std::string& val) {
-          args.emplace_back(key, ast_.make_node<String>(node.loc, val));
-        };
-    
-        // Booleans
-        add_bool("cpp_demangle", cfg->cpp_demangle);
-        add_bool("lazy_symbolication", cfg->lazy_symbolication);
-        add_bool("print_maps_on_exit", cfg->print_maps_on_exit);
-        add_bool("use_blazesym", cfg->use_blazesym);
-        add_bool("show_debug_info", cfg->show_debug_info);
-    
-        // Integers
-        add_int("log_size", cfg->log_size);
-        add_int("max_bpf_progs", cfg->max_bpf_progs);
-        add_int("max_cat_bytes", cfg->max_cat_bytes);
-        add_int("max_map_keys", cfg->max_map_keys);
-        add_int("max_probes", cfg->max_probes);
-        add_int("max_strlen", cfg->max_strlen);
-        add_int("on_stack_limit", cfg->on_stack_limit);
-        add_int("perf_rb_pages", cfg->perf_rb_pages);
-    
-        // Strings
-        add_str("str_trunc_trailer", cfg->str_trunc_trailer);
-    
-        // Enums -> Strings
-        auto unstable_str = [](ConfigUnstable u) {
-          return u == ConfigUnstable::enable ? "enable" : (u == ConfigUnstable::warn ? "warn" : "error");
-        };
-        add_str("unstable_import_statement", unstable_str(cfg->unstable_import_statement));
-        add_str("unstable_tseries", unstable_str(cfg->unstable_tseries));
-        add_str("unstable_typeinfo", unstable_str(cfg->unstable_typeinfo));
-        add_str("unstable_dw_ustack", unstable_str(cfg->unstable_dw_ustack));
-    
-        auto missing_str = [](ConfigMissingProbes m) {
-          return m == ConfigMissingProbes::ignore ? "ignore" : (m == ConfigMissingProbes::warn ? "warn" : "error");
-        };
-        add_str("missing_probes", missing_str(cfg->missing_probes));
-    
-        add_str("stack_mode", cfg->stack_mode == StackMode::bpftrace ? "bpftrace" : "perf");
-		add_str("license", bpftrace::Config::get_license_str(cfg->license));    
-        return make_record(ast_, node.loc, std::move(args));
-      }
+    std::vector<std::pair<std::string, Expression>> args;
+    auto &cfg = bpftrace_.config_;
+
+    auto add_bool = [&](const char *key, bool val) {
+      args.emplace_back(key, ast_.make_node<Boolean>(node.loc, val));
+    };
+    auto add_int = [&](const char *key, uint64_t val) {
+      args.emplace_back(key, ast_.make_node<Integer>(node.loc, val));
+    };
+    auto add_str = [&](const char *key, const std::string &val) {
+      args.emplace_back(key, ast_.make_node<String>(node.loc, val));
+    };
+
+    // Booleans
+    add_bool("cpp_demangle", cfg->cpp_demangle);
+    add_bool("lazy_symbolication", cfg->lazy_symbolication);
+    add_bool("print_maps_on_exit", cfg->print_maps_on_exit);
+    add_bool("use_blazesym", cfg->use_blazesym);
+    add_bool("show_debug_info", cfg->show_debug_info);
+
+    // Integers
+    add_int("log_size", cfg->log_size);
+    add_int("max_bpf_progs", cfg->max_bpf_progs);
+    add_int("max_cat_bytes", cfg->max_cat_bytes);
+    add_int("max_map_keys", cfg->max_map_keys);
+    add_int("max_probes", cfg->max_probes);
+    add_int("max_strlen", cfg->max_strlen);
+    add_int("on_stack_limit", cfg->on_stack_limit);
+    add_int("perf_rb_pages", cfg->perf_rb_pages);
+
+    // Strings
+    add_str("str_trunc_trailer", cfg->str_trunc_trailer);
+
+    // Enums -> Strings
+    auto unstable_str = [](ConfigUnstable u) {
+      return u == ConfigUnstable::enable
+                 ? "enable"
+                 : (u == ConfigUnstable::warn ? "warn" : "error");
+    };
+    add_str("unstable_import_statement",
+            unstable_str(cfg->unstable_import_statement));
+    add_str("unstable_tseries", unstable_str(cfg->unstable_tseries));
+    add_str("unstable_typeinfo", unstable_str(cfg->unstable_typeinfo));
+    add_str("unstable_dw_ustack", unstable_str(cfg->unstable_dw_ustack));
+
+    auto missing_str = [](ConfigMissingProbes m) {
+      return m == ConfigMissingProbes::ignore
+                 ? "ignore"
+                 : (m == ConfigMissingProbes::warn ? "warn" : "error");
+    };
+    add_str("missing_probes", missing_str(cfg->missing_probes));
+
+    add_str("stack_mode",
+            cfg->stack_mode == StackMode::bpftrace ? "bpftrace" : "perf");
+    add_str("license", bpftrace::Config::get_license_str(cfg->license));
+    return make_record(ast_, node.loc, std::move(args));
+  }
 
   return std::nullopt;
 }

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -117,6 +117,22 @@ macro cgroup()
 // :function clear
 // :variant void clear(map m)
 //
+
+// :variant Record config()
+// :variant Record config
+//
+// Returns a `Record` containing the current `bpftrace` configuration settings.
+//
+// ```
+// BEGIN {
+//   $c = config;
+//   printf("max_strlen: %d, stack_mode: %s\n", $c.max_strlen, $c.stack_mode);
+//   exit();
+// }
+// ```
+
+
+//
 // **async**
 //
 // Clear all keys/values from map `m`.

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -117,22 +117,6 @@ macro cgroup()
 // :function clear
 // :variant void clear(map m)
 //
-
-// :variant Record config()
-// :variant Record config
-//
-// Returns a `Record` containing the current `bpftrace` configuration settings.
-//
-// ```
-// BEGIN {
-//   $c = config;
-//   printf("max_strlen: %d, stack_mode: %s\n", $c.max_strlen, $c.stack_mode);
-//   exit();
-// }
-// ```
-
-
-//
 // **async**
 //
 // Clear all keys/values from map `m`.
@@ -147,6 +131,19 @@ macro cgroup()
 //   clear(@);
 // }
 // ```
+
+// :variant Record config()
+//
+// Returns a `Record` containing the current `bpftrace` configuration settings. [List of config variables](./language.md#config-variables)
+//
+// ```
+// printf("max_strlen: %d, stack_mode: %s\n", config.max_strlen, config.stack_mode);
+// }
+// ```
+macro config()
+{
+  __builtin_config
+}
 
 // :variant string comm()
 // :variant string comm(uint32 pid)

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -298,6 +298,6 @@ ARCH aarch64
 WILL_FAIL
 
 NAME config builtin reads integer, string, and boolean
-RUN {{BPFTRACE}} -e 'BEGIN { $c = config; printf("%d %s %d\n", $c.max_strlen, $c.stack_mode, $c.cpp_demangle); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%d %s %d\n", config().max_strlen, config().stack_mode, config().cpp_demangle); exit(); }'
 EXPECT 1024 bpftrace 1
 TIMEOUT 5

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -296,3 +296,8 @@ PROG i:1ms { print(usermode); exit(); }
 EXPECT_REGEX .*ERROR: 'usermode' builtin is only supported on x86_64.*
 ARCH aarch64
 WILL_FAIL
+
+NAME config builtin reads integer, string, and boolean
+RUN {{BPFTRACE}} -e 'BEGIN { $c = config; printf("%d %s %d\n", $c.max_strlen, $c.stack_mode, $c.cpp_demangle); exit(); }'
+EXPECT 1024 bpftrace 1
+TIMEOUT 5

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -217,3 +217,7 @@ EXPECT 2
 NAME user macros don't poison stdlib builtin calls
 PROG macro fail(x) { x } begin { print(strlen("hi")); }
 EXPECT 2
+
+NAME builtin wrapper config
+PROG BEGIN { if (config().max_strlen == __builtin_config.max_strlen) { printf("match"); } exit(); }
+EXPECT match


### PR DESCRIPTION
Resolves #5079 
Added a config builtin for access to bpftrace configuration settings. I also added a test and documentation.

##### Checklist

- [ x ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ x ] The new behaviour is covered by tests
