### PR TITLE
stdlib: migrate uid, gid, and username

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1714,19 +1714,6 @@ CallInst *IRBuilderBPF::CreateGetCurrentCgroupId(const Location &loc)
                           loc);
 }
 
-CallInst *IRBuilderBPF::CreateGetUidGid(const Location &loc)
-{
-  // u64 bpf_get_current_uid_gid(void)
-  // Return: current_gid << 32 | current_uid
-  FunctionType *getuidgid_func_type = FunctionType::get(getInt64Ty(), false);
-  return CreateHelperCall(BPF_FUNC_get_current_uid_gid,
-                          getuidgid_func_type,
-                          {},
-                          true,
-                          "get_uid_gid",
-                          loc);
-}
-
 CallInst *IRBuilderBPF::CreateGetCpuId(const Location &loc)
 {
   // u32 bpf_get_smp_processor_id(void)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -112,7 +112,6 @@ public:
   Value *CreateGetNs(TimestampMode ts, const Location &loc);
   CallInst *CreateJiffies64(const Location &loc);
   CallInst *CreateGetCurrentCgroupId(const Location &loc);
-  CallInst *CreateGetUidGid(const Location &loc);
   CallInst *CreateGetCpuId(const Location &loc);
   CallInst *CreateGetCurrentTask(const Location &loc);
   CallInst *CreateGetRandom(const Location &loc);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -810,17 +810,6 @@ ScopedExpr CodegenLLVM::visit(Builtin &builtin)
     return ScopedExpr(b_.CreateGetTid(builtin.loc, false));
   } else if (builtin.ident == "__builtin_cgroup") {
     return ScopedExpr(b_.CreateGetCurrentCgroupId(builtin.loc));
-  } else if (builtin.ident == "__builtin_uid" ||
-             builtin.ident == "__builtin_gid" ||
-             builtin.ident == "__builtin_username") {
-    Value *uidgid = b_.CreateGetUidGid(builtin.loc);
-    if (builtin.ident == "__builtin_uid" ||
-        builtin.ident == "__builtin_username") {
-      return ScopedExpr(b_.CreateAnd(uidgid, 0xffffffff));
-    } else if (builtin.ident == "__builtin_gid") {
-      return ScopedExpr(b_.CreateLShr(uidgid, 32));
-    }
-    __builtin_unreachable();
   } else if (builtin.ident == "__builtin_usermode") {
     if (arch::Host::Machine == arch::Machine::X86_64) {
       auto cs_offset = arch::Host::register_to_pt_regs_offset("cs");

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -215,7 +215,7 @@ static bool IsValidVarDeclType(const SizedType &ty)
     case Type::ksym_t:
     case Type::usym_t:
     case Type::inet:
-    case Type::username:
+    case Type::username_t:
     case Type::string:
     case Type::buffer:
     case Type::pointer:
@@ -962,6 +962,10 @@ void TypeChecker::visit(Cast &cast)
     if (ty.GetSize() < rhs.GetSize()) {
       logError();
     }
+    return;
+  }
+
+  if (ty.IsUsernameTy() && rhs.IsIntegerTy()) {
     return;
   }
 

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -44,13 +44,10 @@ std::unordered_map<std::string, SizedType (*)()> SIMPLE_BUILTIN_TYPES = {
   { "nsecs", CreateUInt64 },
   { "__builtin_elapsed", CreateUInt64 },
   { "__builtin_cgroup", CreateUInt64 },
-  { "__builtin_uid", CreateUInt64 },
-  { "__builtin_gid", CreateUInt64 },
   { "__builtin_cpu", CreateUInt64 },
   { "__builtin_rand", CreateUInt64 },
   { "__builtin_jiffies", CreateUInt64 },
   { "__builtin_ncpus", CreateUInt64 },
-  { "__builtin_username", CreateUsername },
   { "__builtin_usermode", CreateUInt8 },
   { "__builtin_cpid", CreateUInt64 },
 };

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3324,15 +3324,12 @@ bool Parser::is_builtin(std::string_view name)
     "__builtin_dw_ustack",
     "__builtin_elapsed",
     "__builtin_func",
-    "__builtin_gid",
     "__builtin_jiffies",
     "__builtin_ncpus",
     "__builtin_probe",
     "__builtin_rand",
     "__builtin_retval",
-    "__builtin_uid",
     "__builtin_usermode",
-    "__builtin_username",
   };
   if (builtins.contains(name)) {
     return true;

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -420,7 +420,8 @@ macro func()
 // This utilizes the BPF helper `get_current_uid_gid`
 macro gid()
 {
-  __builtin_gid
+    import "stdlib/process/process.bpf.c";
+  __get_current_uid_gid() >> 32
 }
 
 // :variant boolean has_key(map m, mapkey k)
@@ -1455,7 +1456,8 @@ macro uaddr(sym)
 // This utilizes the BPF helper `get_current_uid_gid`
 macro uid()
 {
-  __builtin_uid
+  import "stdlib/process/process.bpf.c";
+  __get_current_uid_gid() & 0xffffffff
 }
 
 // :function uptr
@@ -1480,7 +1482,7 @@ macro usermode()
 // Often this is just "root"
 macro username()
 {
-  __builtin_username
+  (username_t)(uid)
 }
 
 // :function ustack

--- a/src/stdlib/process/process.bpf.c
+++ b/src/stdlib/process/process.bpf.c
@@ -13,3 +13,7 @@ long __signal_process(__u32 sig) {
 long __signal_thread(__u32 sig) {
     return bpf_send_signal_thread(sig);
 }
+
+unsigned long long __get_current_uid_gid() {
+    return bpf_get_current_uid_gid();
+}

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -108,7 +108,7 @@ std::string typestr(const SizedType &type)
     case Type::timestamp:
     case Type::ksym_t:
     case Type::usym_t:
-    case Type::username:
+    case Type::username_t:
     case Type::timestamp_mode:
     case Type::cgroup_path_t:
     case Type::hist_t:
@@ -320,7 +320,7 @@ std::string typestr(Type t)
     case Type::string:   return "string";   break;
     case Type::ksym_t:     return "ksym_t";     break;
     case Type::usym_t:     return "usym_t";     break;
-    case Type::username: return "username"; break;
+    case Type::username_t: return "username_t"; break;
     case Type::inet:     return "inet";     break;
     case Type::array:    return "array";    break;
     case Type::buffer:   return "buffer";   break;
@@ -511,7 +511,7 @@ SizedType CreateStats(bool is_signed)
 
 SizedType CreateUsername()
 {
-  return { Type::username, 8 };
+  return { Type::username_t, 8 };
 }
 
 SizedType CreateInet(size_t size)
@@ -619,6 +619,7 @@ std::optional<SizedType> ident_to_builtin_type(const std::string &name)
     { "string", CreateString(0) },
     { "buffer", CreateBuffer(0) },
     { "inet", CreateInet(0) },
+    { "username_t", CreateUsername() },
   };
   auto it = types.find(name);
   if (it != types.end())

--- a/src/types.h
+++ b/src/types.h
@@ -49,7 +49,7 @@ enum class Type : uint8_t {
   string,
   ksym_t,
   usym_t,
-  username,
+  username_t,
   inet,
   array,
   buffer,
@@ -493,7 +493,7 @@ public:
   };
   bool IsUsernameTy() const
   {
-    return type_ == Type::username;
+    return type_ == Type::username_t;
   };
   bool IsInetTy() const
   {

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -111,7 +111,7 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
       return bpftrace.resolve_inet(value.bitcast<uint64_t>(),
                                    value.slice(8).data());
     }
-    case Type::username: {
+    case Type::username_t: {
       return bpftrace.resolve_uid(value.bitcast<uint64_t>());
     }
     case Type::buffer: {

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -168,18 +168,6 @@ TEST(Parser, builtin_variables)
        Program().WithProbe(Probe(
            { "kprobe:f" }, { ExprStatement(Builtin("__builtin_cgroup")) })));
 
-  test("kprobe:f { __builtin_uid }",
-       Program().WithProbe(
-           Probe({ "kprobe:f" }, { ExprStatement(Builtin("__builtin_uid")) })));
-
-  test("kprobe:f { __builtin_username }",
-       Program().WithProbe(Probe(
-           { "kprobe:f" }, { ExprStatement(Builtin("__builtin_username")) })));
-
-  test("kprobe:f { __builtin_gid }",
-       Program().WithProbe(
-           Probe({ "kprobe:f" }, { ExprStatement(Builtin("__builtin_gid")) })));
-
   test("kprobe:f { nsecs }",
        Program().WithProbe(
            Probe({ "kprobe:f" }, { ExprStatement(Builtin("nsecs")) })));
@@ -734,13 +722,13 @@ TEST(Parser, map_key)
                                 Tuple({ Map("@a"), Map("@b"), Map("@c") }),
                                 Integer(1)) })));
 
-  test("kprobe:sys_read { @x[pid] = 1; @x[tid,__builtin_uid,arg9] = 1; }",
+  test("kprobe:sys_read { @x[pid] = 1; @x[tid,__builtin_probe,arg9] = 1; }",
        Program().WithProbe(
            Probe({ "kprobe:sys_read" },
                  { AssignMapStatement(Map("@x"), Builtin("pid"), Integer(1)),
                    AssignMapStatement(Map("@x"),
                                       Tuple({ Builtin("tid"),
-                                              Builtin("__builtin_uid"),
+                                              Builtin("__builtin_probe"),
                                               Builtin("arg9") }),
                                       Integer(1)) })));
 }
@@ -1555,28 +1543,9 @@ TEST(Parser, wildcard_func)
                                  { ExprStatement(Integer(1)) })));
 
   std::string keywords[] = {
-    "arg0",
-    "args",
-    "errorf",
-    "warnf",
-    "func",
-    "__builtin_gid"
-    "__builtin_rand",
-    "uid",
-    "avg",
-    "cat",
-    "exit",
-    "kaddr",
-    "min",
-    "printf",
-    "usym",
-    "kstack",
-    "ustack",
-    "bpftrace",
-    "perf",
-    "raw",
-    "uprobe",
-    "kprobe",
+    "arg0",   "args",   "errorf",   "warnf", "func", "__builtin_rand", "uid",
+    "avg",    "cat",    "exit",     "kaddr", "min",  "printf",         "usym",
+    "kstack", "ustack", "bpftrace", "perf",  "raw",  "uprobe",         "kprobe",
   };
   for (auto kw : keywords) {
     test("usdt:/my/program:" + kw + "*c*d { 1; }",

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -156,10 +156,6 @@ PROG k:vfs_read { if (__builtin_func == func() && __builtin_func == func) { prin
 EXPECT vfs_read
 AFTER ./testprogs/syscall read
 
-NAME builtin wrapper gid
-PROG begin { if (__builtin_gid == gid() && __builtin_gid == gid) { print(gid); } }
-EXPECT_REGEX [0-9][0-9]*
-
 NAME builtin wrapper jiffies
 PROG begin { if (__builtin_jiffies == jiffies() && __builtin_jiffies == jiffies) { printf("SUCCESS %llu\n", jiffies);} }
 EXPECT_REGEX SUCCESS [0-9]+
@@ -188,18 +184,10 @@ PROG kretprobe:vfs_read { if (__builtin_retval == retval() && __builtin_retval =
 EXPECT_REGEX SUCCESS .*
 AFTER ./testprogs/syscall read
 
-NAME builtin wrapper uid
-PROG begin { if (__builtin_uid == uid() && __builtin_uid == uid) { printf("SUCCESS %d\n", uid); } }
-EXPECT_REGEX SUCCESS [0-9]+
-
 NAME builtin wrapper usermode
 PROG begin { if (__builtin_usermode == usermode() && __builtin_usermode == usermode) { printf("SUCCESS %d\n", usermode); } }
 EXPECT_REGEX SUCCESS 1
 ARCH x86_64
-
-NAME builtin wrapper username
-PROG begin { if (__builtin_username == username() && __builtin_username == username) { printf("SUCCESS %s\n", username); } }
-EXPECT_REGEX SUCCESS .*
 
 NAME user macros override stdlib
 PROG macro cpu() { "hi" } begin { printf(cpu()); }

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -234,9 +234,6 @@ TEST_F(TypeCheckerTest, builtin_variables)
   test("kprobe:f { pid }");
   test("kprobe:f { tid }");
   test("kprobe:f { cgroup }");
-  test("kprobe:f { uid }");
-  test("kprobe:f { username }");
-  test("kprobe:f { gid }");
   test("kprobe:f { nsecs }");
   test("kprobe:f { elapsed }");
   test("kprobe:f { cpu }");
@@ -2409,6 +2406,15 @@ TEST_F(TypeCheckerTest, cast_string)
   test("kprobe:f { $a = (string[2])\"hello\"; }", Error{});
   test("kprobe:f { $a = (string[2])5; }", Error{});
   test("kprobe:f { $a = (string)5; }", Error{});
+}
+
+TEST_F(TypeCheckerTest, cast_username)
+{
+  test("kprobe:f { $a = (username_t)1000; }");
+  test("kprobe:f { $a = (username_t)pid; }");
+
+  // Errors
+  test("kprobe:f { $a = (username_t)comm; }", Error{});
 }
 
 TEST_F(TypeCheckerTest, cast_same_type)

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -76,7 +76,7 @@ TEST(types, to_str)
   EXPECT_EQ(to_str(CreateTimestamp()), "timestamp");
   EXPECT_EQ(to_str(CreateKSym()), "ksym_t");
   EXPECT_EQ(to_str(CreateUSym()), "usym_t");
-  EXPECT_EQ(to_str(CreateUsername()), "username");
+  EXPECT_EQ(to_str(CreateUsername()), "username_t");
   EXPECT_EQ(to_str(CreateTimestampMode()), "timestamp_mode");
   EXPECT_EQ(to_str(CreateCgroupPath()), "cgroup_path_t");
   EXPECT_EQ(to_str(CreateHist()), "hist_t");


### PR DESCRIPTION
Stacked PRs:
 * #5246
 * #5245
 * #5244
 * #5243
 * __->__#5242


--- --- ---

### stdlib: migrate uid, gid, and username


The only trickyness here was supporting a cast to `username_t` so that we
print a string for the uid instead of an int.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>