### PR TITLE
Formatter: fix array access in a type context

### DIFF
--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -455,14 +455,58 @@ Buffer Formatter::visit(Call& call)
   }
 }
 
+static bool is_array_access_ident(const Expression& expr)
+{
+  const auto* arr = expr.as<ArrayAccess>();
+  if (arr == nullptr) {
+    return false;
+  }
+  const Expression* base = &arr->expr;
+  while (const auto* inner = base->as<ArrayAccess>()) {
+    base = &inner->expr;
+  }
+  return base->is<Identifier>();
+}
+
+// Check if the expression used as a type-context argument (e.g. to `typeinfo`,
+// `typeof`, `sizeof`, `offsetof`) is an array access on a bare identifier. If
+// so, we need to make sure to wrap this expression in parens to ensure that it
+// re-parses as an expression instead of as a ParsedType (Kind::Array). For
+// example these two parse differently: `typeof(ident[0])` and
+// `typeof((ident[0]))`. The first is a parsed as a type (an array of type
+// `ident` with 0 elements) while the second is parsed as an ArrayAccess
+// expression of the ident `ident`. This is important because in the second case
+// `ident` could be a macro (with no arguments) that gets expanded, while the
+// former cannot.
+Buffer Formatter::format_expr_as_type(Expression& expr, size_t max_width)
+{
+  auto buffer = format(expr, metadata, max_width, true);
+  if (is_array_access_ident(expr)) {
+    return Buffer().text("(").append(std::move(buffer)).text(")");
+  }
+  return buffer;
+}
+
+Buffer Formatter::format_type_arg(ExprOrType& record, size_t max_width)
+{
+  return std::visit(
+      [&](auto& v) -> Buffer {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, Expression>) {
+          return format_expr_as_type(v, max_width);
+        } else {
+          return format(v, metadata, max_width, true);
+        }
+      },
+      record);
+}
+
 Buffer Formatter::visit(Sizeof& szof)
 {
   // N.B. Does not support splitting.
   return Buffer()
       .text("sizeof(")
-      .append(std::visit(
-          [&](auto& v) { return format(v, metadata, max_width - 8, true); },
-          szof.type_of->record))
+      .append(format_type_arg(szof.type_of->record, max_width - 8))
       .text(")");
 }
 
@@ -476,10 +520,9 @@ Buffer Formatter::visit(Offsetof& ofof)
     }
     fields = fields.text(ofof.field[i]);
   }
-  auto expr = format(ofof.type_of->record, metadata, max_width);
   return Buffer()
       .text("offsetof(")
-      .append(std::move(expr))
+      .append(format_type_arg(ofof.type_of->record, max_width))
       .text(", ")
       .append(std::move(fields))
       .text(")");
@@ -489,8 +532,7 @@ Buffer Formatter::visit(Typeof& typeof)
 {
   if (std::holds_alternative<Expression>(typeof.record)) {
     return Buffer().text("typeof(").append(
-        format(
-            std::get<Expression>(typeof.record), metadata, max_width - 8, true)
+        format_expr_as_type(std::get<Expression>(typeof.record), max_width - 8)
             .text(")"));
   } else {
     // Prefer the simpler form for direct types.
@@ -524,19 +566,10 @@ Buffer Formatter::visit(TypeArg& type_arg)
 
 Buffer Formatter::visit(Typeinfo& typeinfo)
 {
-  if (std::holds_alternative<Expression>(typeinfo.typeof->record)) {
-    // Omit the `typeof` for `typeinfo`.
-    return Buffer()
-        .text("typeinfo(")
-        .append(format(typeinfo.typeof->record, metadata, max_width - 10, true))
-        .text(")");
-  } else {
-    // Use the default representation.
-    return Buffer()
-        .text("typeinfo(")
-        .append(format(typeinfo.typeof, metadata, max_width - 10, true))
-        .text(")");
-  }
+  return Buffer()
+      .text("typeinfo(")
+      .append(format_type_arg(typeinfo.typeof->record, max_width - 10))
+      .text(")");
 }
 
 Buffer Formatter::visit(MapDeclStatement& decl)

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -134,6 +134,9 @@ private:
     return Formatter(mode, metadata, max_width, bare, type_map).visit(value);
   }
 
+  Buffer format_expr_as_type(Expression &expr, size_t max_width);
+  Buffer format_type_arg(ExprOrType &record, size_t max_width);
+
   template <typename U>
   Buffer format_list(std::vector<U> &exprs,
                      const std::string &sep,

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -18,10 +18,10 @@ macro assert_str(exp)
   if comptime (!is_str(exp)) {
     if comptime is_array(exp) {
       // wrap exp in parens to force it to be evaluated as an expression
-      static_assert(typeinfo((exp)[0]) == typeinfo(int8),
+      static_assert(typeinfo((exp[0])) == typeinfo(int8),
                     "string-like arrays must contain a char-like type");
     } else if comptime is_ptr(exp) {
-      static_assert(typeinfo((exp)[0]) == typeinfo(int8),
+      static_assert(typeinfo((exp[0])) == typeinfo(int8),
                     "string-like pointers must point to a char-like type");
     } else {
       fail("string-like values must be either strings, arrays or pointers");
@@ -85,7 +85,7 @@ macro strcap(exp)
   if comptime is_str(exp) {
     sizeof(exp)
   } else if comptime is_array(exp) {
-    sizeof(exp) / sizeof((exp)[0])
+    sizeof(exp) / sizeof((exp[0]))
   } else {
     strlen(exp) // Pointer, so pass by value.
   }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -14,6 +14,7 @@
 
 namespace bpftrace::test::parser {
 
+using bpftrace::test::ArrayAccess;
 using bpftrace::test::AssignMapStatement;
 using bpftrace::test::AssignScalarMapStatement;
 using bpftrace::test::AssignVarStatement;
@@ -25,6 +26,7 @@ using bpftrace::test::Cast;
 using bpftrace::test::CStatement;
 using bpftrace::test::ExprStatement;
 using bpftrace::test::FieldAccess;
+using bpftrace::test::Identifier;
 using bpftrace::test::Integer;
 using bpftrace::test::Map;
 using bpftrace::test::MapAddr;
@@ -36,9 +38,11 @@ using bpftrace::test::PositionalParameterCount;
 using bpftrace::test::Probe;
 using bpftrace::test::Program;
 
+using bpftrace::test::Sizeof;
 using bpftrace::test::String;
 using bpftrace::test::Tuple;
 using bpftrace::test::TypeArg;
+using bpftrace::test::Typeinfo;
 using bpftrace::test::Typeof;
 using bpftrace::test::Unop;
 using bpftrace::test::Variable;
@@ -2042,6 +2046,42 @@ TEST(Parser, typeinfo_macro_call)
        Program().WithProbe(
            Probe({ "kprobe:sys_read" },
                  { ExprStatement(Typeinfo(Typeof(Call("mymacro", {})))) })));
+}
+
+TEST(Parser, array_access_in_type_context)
+{
+  // `(exp)[0]` or `(exp[0]) is parsed as an Array Access expression on the bare
+  // identifier `exp`, while the unparenthesized `exp[0]` is parsed as the array
+  // type `exp[0]`. The formatter must keep the parens so the reparsed output
+  // stays an expression.
+  auto exp_index = [] { return ArrayAccess(Identifier("exp"), Integer(0)); };
+  auto exp_array_type = [] {
+    return ParsedType(ast::ParsedType::Kind::Array)
+        .WithArraySize(0)
+        .WithInner(ParsedType(ast::ParsedType::Kind::Identifier, "exp"));
+  };
+  auto check = [](const std::string &src, const auto &expr) {
+    test(src,
+         Program().WithProbe(
+             Probe({ "kprobe:sys_read" }, { ExprStatement(expr) })));
+  };
+
+  // With parens: parsed as an expression. Both paren placements are
+  // equivalent.
+  check("kprobe:sys_read { typeinfo((exp)[0]); }",
+        Typeinfo(Typeof(exp_index())));
+  check("kprobe:sys_read { typeinfo((exp[0])); }",
+        Typeinfo(Typeof(exp_index())));
+  check("kprobe:sys_read { sizeof((exp)[0]); }", Sizeof(exp_index()));
+  check("kprobe:sys_read { offsetof((exp)[0], field); }",
+        Offsetof(exp_index(), { "field" }));
+
+  // Without parens: parsed as the array type instead.
+  check("kprobe:sys_read { typeinfo(exp[0]); }",
+        Typeinfo(Typeof(exp_array_type())));
+  check("kprobe:sys_read { sizeof(exp[0]); }", Sizeof(exp_array_type()));
+  check("kprobe:sys_read { offsetof(exp[0], field); }",
+        Offsetof(exp_array_type(), { "field" }));
 }
 
 TEST(Parser, typeof_unknown_type)


### PR DESCRIPTION
Stacked PRs:
 * #5256
 * #5253
 * #5255
 * #5252
 * #5250
 * __->__#5248


--- --- ---

### Formatter: fix array access in a type context


We need to maintain the parens for an array access on an ident in a type
context e.g. `sizeof((ident[0])` or `sizeof((ident)[0])` to prevent it
being re-parsed as a ParsedType. In the latter example, we format it as the
first example so there is also an update to strings.bt to use this
canonical formatting.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>