### PR TITLE
tests: implement CI arm testing and fix runtime test failures on arm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       run: nix develop --command git clang-format --diff origin/master --extensions cpp,h
 
   build_test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.env.RUNS_ON || 'ubuntu-latest' }}
     # For flakehub cache
     permissions:
       id-token: write
@@ -63,6 +63,11 @@ jobs:
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm22
           TOOLS_TEST_DISABLE: runqlen.bt
+        - NAME: LLVM 22 Release (arm64)
+          CMAKE_BUILD_TYPE: Release
+          NIX_TARGET: .#bpftrace-llvm22
+          TOOLS_TEST_DISABLE: runqlen.bt
+          RUNS_ON: ubuntu-24.04-arm
         - NAME: LLVM 22 Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm22

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -476,13 +476,21 @@ ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM
 PROG config = { show_debug_info=0 } uprobe:./testprogs/uprobe_symres_exited_process:test { print(ustack); exit(); }
 EXPECT_REGEX ^\s+test\+[0-9]+\s+test2\+[0-9]+\s+main\+[0-9]+
 AFTER ./testprogs/disable_aslr ./testprogs/uprobe_symres_exited_process
+ARCH x86_64
 # The stack output expects prologue to be skipped on uprobes. See kernel:
 # cfa7f3d2c526 ("perf,x86: avoid missing caller address in stack traces captured in uprobe")
 MIN_KERNEL 6.12
 
+NAME ustack_elf_symtable
+ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM
+PROG config = { show_debug_info=0 } uprobe:./testprogs/uprobe_symres_exited_process:test { print(ustack); exit(); }
+EXPECT_REGEX ^\s+test\+[0-9]+\s+main\+[0-9]+
+AFTER ./testprogs/disable_aslr ./testprogs/uprobe_symres_exited_process
+ARCH aarch64
+
 NAME ustack_with_inlined_funcs
 RUN {{BPFTRACE}} -e 'config = { show_debug_info=1 } usdt:./testprogs/usdt_inlined:tracetest:testprobe { if (arg1 == 100) { printf("%s\n", ustack()); exit(); } }' -c ./testprogs/usdt_inlined
-EXPECT_REGEX ^\s*\[inlined\] myclock@[\w\/]+.c:[0-9]+\s+\[inlined\] mywrapper_inlined@[\w\/]+.c:[0-9]+\s+mywrapper\+[0-9]+@[\w\/]+.c:[0-9]+\s+loop\+[0-9]+@[\w\/]+.c:[0-9]+\s+main\+[0-9]+@[\w\/]+.c:[0-9]+\s+_end\+[0-9]+\s+_end\+[0-9]+\s+_start\+[0-9]+$
+EXPECT_REGEX ^\s*\[inlined\] myclock@[\w\/]+.c:[0-9]+\s+\[inlined\] mywrapper_inlined@[\w\/]+.c:[0-9]+\s+mywrapper\+[0-9]+@[\w\/]+.c:[0-9]+\s+loop\+[0-9]+@[\w\/]+.c:[0-9]+\s+main\+[0-9]+@[\w\/]+.c:[0-9]+\s+(_bss_end__|_end)\+[0-9]+\s+(_bss_end__|_end)\+[0-9]+\s+_start\+[0-9]+$
 TIMEOUT 1
 
 # This outputs 4 frames because the limit refers to instruction pointers which may resolve to multiple inlined symbols

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -658,13 +658,13 @@ NAME path
 RUN {{BPFTRACE}} -ve 'fentry:security_file_open { if (!strncmp(path(args.file.f_path), "/tmp/bpftrace_runtime_test_syscall_gen_open_temp", 49)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath
-AFTER TMPDIR=/tmp ./testprogs/syscall open
+AFTER TMPDIR=/tmp ./testprogs/syscall openat
 
 NAME path_with_optional_size
 RUN {{BPFTRACE}} -ve 'fentry:security_file_open { $p = path(args.file.f_path, 48);  if ( sizeof($p) == 48 && !strncmp($p, "tmp/bpftrace_runtime_test_syscall_gen_open_temp", 48)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath
-AFTER TMPDIR=/tmp ./testprogs/syscall open
+AFTER TMPDIR=/tmp ./testprogs/syscall openat
 
 # The extra prints are here to confirm that we report on the correct helper, not
 # just the first or the last one.

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -87,6 +87,15 @@ EXPECT_REGEX ^0x[0-9A-Fa-f]+$
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
+ARCH x86_64
+
+NAME uprobe source location - attach probe to source line
+PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:22 { printf("0x%lx\n", reg("pc")); exit(); }
+EXPECT_REGEX ^0x[0-9A-Fa-f]+$
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+ARCH aarch64
 
 NAME uprobe source location - source line to address validation
 PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:22 { @a = reg("ip"); }
@@ -95,6 +104,16 @@ EXPECT_REGEX ^0x[0-9A-Fa-f]+ == 0x[0-9A-Fa-f]+$
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
+ARCH x86_64
+
+NAME uprobe source location - source line to address validation
+PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:22 { @a = reg("pc"); }
+     uprobe:./testprogs/uprobe_test:uprobeFunction1 { @b = reg("pc"); if (@b == @a) { printf("0x%lx == 0x%lx\n", @a, @b); exit(); } }
+EXPECT_REGEX ^0x[0-9A-Fa-f]+ == 0x[0-9A-Fa-f]+$
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+ARCH aarch64
 
 NAME uprobe source location - attach multiple probes
 PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:34 { @a=1; }

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -206,9 +206,16 @@ AFTER ./testprogs/syscall nanosleep  1e8
 NAME positional ustack
 RUN {{BPFTRACE}} -e 'config = { show_debug_info=0 } u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack($1)); exit(); }' 1
 EXPECT_REGEX .*uprobeFunction1\+[0-9]+\n\s+spin\+[0-9]+\n\s+main\+[0-9]+\n(?s:.*)\n\n\n\s+uprobeFunction1\+[0-9]+
+ARCH x86_64
 # The stack output expects prologue to be skipped on uprobes. See kernel:
 # cfa7f3d2c526 ("perf,x86: avoid missing caller address in stack traces captured in uprobe")
 MIN_KERNEL 6.12
+AFTER ./testprogs/uprobe_loop
+
+NAME positional ustack
+RUN {{BPFTRACE}} -e 'config = { show_debug_info=0 } u:./testprogs/uprobe_loop:uprobeFunction1 { printf("%s\n%s\n", ustack(), ustack($1)); exit(); }' 1
+EXPECT_REGEX .*uprobeFunction1\+[0-9]+\n\s+main\+[0-9]+\n(?s:.*)\n\n\n\s+uprobeFunction1\+[0-9]+ 
+ARCH aarch64
 AFTER ./testprogs/uprobe_loop
 
 NAME lhist can be cleared

--- a/tests/runtime/pid_namespace
+++ b/tests/runtime/pid_namespace
@@ -22,9 +22,16 @@ RUN unshare --fork --pid --mount-proc bash -c "(./testprogs/uprobe_loop &) && {{
 EXPECT_REGEX         uprobeFunction1\+\d+$
                      spin\+\d+$
                      main\+\d+$
+ARCH x86_64
 # The stack output expects prologue to be skipped on uprobes. See kernel:
 # cfa7f3d2c526 ("perf,x86: avoid missing caller address in stack traces captured in uprobe")
 MIN_KERNEL 6.12
+
+NAME ustack_inside
+RUN unshare --fork --pid --mount-proc bash -c "(./testprogs/uprobe_loop &) && {{BPFTRACE}} -e 'config = { show_debug_info=0 } uprobe:./testprogs/uprobe_loop:uprobeFunction1 { print(ustack); exit(); }'"
+EXPECT_REGEX         uprobeFunction1\+\d+$
+                     main\+\d+$
+ARCH aarch64
 
 # Target inside a PID namespace, bpftrace outside
 # This test assumes we're starting in the init-namespace, which
@@ -36,6 +43,15 @@ AFTER unshare --fork --pid --mount-proc bash -c ./testprogs/uprobe_loop
 EXPECT_REGEX         uprobeFunction1\+\d+$
                      spin\+\d+$
                      main\+\d+$
+ARCH x86_64
 # See above
 MIN_KERNEL 6.12
+REQUIRES [ "$(stat -Lc %i /proc/1/ns/pid)" -eq "$((0xeffffffc))" ]
+
+NAME ustack_outside
+RUN {{BPFTRACE}} -e 'config = { show_debug_info=0 } uprobe:./testprogs/uprobe_loop:uprobeFunction1 { print(ustack); exit(); }'
+AFTER unshare --fork --pid --mount-proc bash -c ./testprogs/uprobe_loop
+EXPECT_REGEX         uprobeFunction1\+\d+$
+                     main\+\d+$
+ARCH aarch64
 REQUIRES [ "$(stat -Lc %i /proc/1/ns/pid)" -eq "$((0xeffffffc))" ]

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -578,6 +578,13 @@ NAME rawtracepoint_order
 RUN {{BPFTRACE}} runtime/scripts/rawtracepoint_order.bt
 EXPECT_REGEX (first)+ second
 AFTER ./testprogs/syscall nanosleep 233;
+ARCH x86_64
+
+NAME rawtracepoint_order
+RUN {{BPFTRACE}} runtime/scripts/rawtracepoint_order_aarch64.bt
+EXPECT_REGEX (first)+ second
+AFTER ./testprogs/syscall nanosleep 233;
+ARCH aarch64
 
 NAME usdt_order
 RUN {{BPFTRACE}} runtime/scripts/usdt_order.bt

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -218,7 +218,7 @@ WILL_FAIL
 
 NAME kprobe_offset_module_error
 RUN {{BPFTRACE}} -e 'kprobe:nf_tables_newtable+0x1 { printf("hit\n"); exit(); }'
-EXPECT ERROR: Unable to attach probe: kprobe:nf_tables_newtable+0x1. If this is expected, set the 'missing_probes' config variable to 'warn'.
+EXPECT ERROR: Unable to attach probe: kprobe:nf_tables_newtable+1. If this is expected, set the 'missing_probes' config variable to 'warn'.
 ARCH aarch64|ppc64le|ppc64
 REQUIRES lsmod | grep '^nf_tables'
 WILL_FAIL
@@ -719,3 +719,7 @@ TIMEOUT 1
 NAME uprobe_zip_archive
 RUN {{BPFTRACE}} -e 'uprobe:"./testprogs/archive.zip!/true":main {} begin { exit() }'
 EXPECT_REGEX Attached 2 probes
+ARCH x86_64
+# ZIP alignment is not guaranteed, on aarch64 the uprobe offset
+# is not 4-byte aligned, failing the kernel's IS_ALIGNED check, 
+# run this test on x86_64 only

--- a/tests/runtime/scripts/rawtracepoint_order_aarch64.bt
+++ b/tests/runtime/scripts/rawtracepoint_order_aarch64.bt
@@ -1,0 +1,14 @@
+// Check comm and arg1(syscall_id) to make sure these are the nanosleeps we issued
+
+rawtracepoint:sys_enter
+/comm == "syscall" && arg1 == 0x65/
+{
+  printf("first");
+}
+
+rawtracepoint:sys_enter
+/comm == "syscall" && arg1 == 0x65/
+{
+  printf(" second\n");
+  exit();
+}

--- a/tests/runtime/strcontains
+++ b/tests/runtime/strcontains
@@ -2,7 +2,7 @@ NAME path
 PROG fentry:security_file_open { if (strcontains(path(args.file.f_path, 128), "tmp")) { printf("OK\n"); exit(); } }
 EXPECT OK
 REQUIRES_FEATURE dpath
-AFTER TMPDIR=/tmp ./testprogs/syscall open
+AFTER TMPDIR=/tmp ./testprogs/syscall openat
 
 NAME literals
 PROG begin { if (strcontains("abc", "a")) { printf("OK\n");  } }


### PR DESCRIPTION
Fix runtime test failures on aarch64

This PR fixes runtime test failures found when bringing up the new
aarch64 CI job.

uprobe prologue skip (4 tests)

ustack_elf_symtable, positional ustack, ustack_inside, and
ustack_outside all expect stack frames (test2, spin) that only
appear when the kernel's x86-specific uprobe prologue fix is active
(cfa7f3d2c526). On aarch64 these frames are absent, so add
aarch64 variants with the correct expected output.

DWARF source location (2 tests)

The uprobe source location tests use reg("ip") which is x86_64-only.
Add aarch64 variants using reg("pc").

symbol names (1 test)

ustack_with_inlined_funcs expects _end in the stack trace but
aarch64 uses __bss__end. Update the regex to accept both.

kprobe_offset_module_error (1 test)

The expected error message uses +0x1 but bpftrace prints +1. 
I think the std::to_string in the name construction is converting the hex
value to decimal. Fix the expected output to match.
Alternatively I think  we could change the source to format with 
std::format as hex instead, let me know if that's preferred.

uprobe_zip_archive (1 test)

Skip on aarch64. ZIP does not guarantee alignment of entry data within
the archive. When archive.zip is created the ELF data for true
lands at offset 0x3e in the file, so the main symbol ends up at
0x3e + 0x64c = 0x68a, which is not 4-byte aligned. This gets passed to
uprobe_register() which fails on:

` IS_ALIGNED(offset, UPROBE_SWBP_INSN_SIZE)`

where UPROBE_SWBP_INSN_SIZE is 4 on aarch64 (vs 1 on x86_64).

To verify, I copied the file with a two character longer filename to
push the data offset to 0x40, making the final offset 0x68c (4-byte
aligned), and the probe attached successfully:

```
[DEBUG] libbpf: elf: symbol address match for main of truest
in ./tests/testprogs/archive_aligned.zip: 0x40 + 0x64c = 0x68c

./src/bpftrace -e 'uprobe:"./tests/testprogs/archive_aligned.zip!/truest":main {} BEGIN { exit() }'
Attached 2 probes
```

I've simply skipped this test on aarch64 for now, but it may be worth
rewriting the test to ensure 4-byte alignment. 
Let me know what you think.

path tests (3 tests)

path, path_with_optional_size, and strcontains.path use
AFTER ./testprogs/syscall open, but aarch64 does not define
SYS_open, it only has openat. The testprog silently fails and no
file is opened, so the probe never matches and the test times out.

Changed the AFTER commands to use openat which works on both
architectures.

rawtracepoint_order (1 test)

The test script hardcodes the x86 nanosleep syscall number (0x23).
On aarch64 nanosleep is syscall 101 (0x65), so the filter never
matches and the test timesout. Add an aarch64 variant with the 
correct syscall number.

  ##### Checklist
  
  - [x] Language changes are updated in docs/language.md, docs/stdlib.md, or man/adoc/bpftrace.adoc
  - [x] User-visible and non-trivial changes updated in CHANGELOG.md
  - [x] The new behaviour is covered by tests

