### PR TITLE
formatter: fix blocks following assignments

### DIFF
--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -80,7 +80,7 @@ Buffer::Buffer() : state(std::make_unique<BufferState>())
 
 Buffer::~Buffer() = default;
 
-Buffer&& Buffer::append(Buffer&& other, size_t indent)
+Buffer&& Buffer::append(Buffer&& other, size_t indent, bool align)
 {
   if (other.lines() == 0) {
     return std::move(*this);
@@ -105,6 +105,14 @@ Buffer&& Buffer::append(Buffer&& other, size_t indent)
     //     line3
     //   );
     //
+    // When align is false, continuation lines are preserved verbatim (keeping
+    // their own base-relative indentation) rather than aligned to the current
+    // column. This is appropriate for block bodies following assignments, but
+    // wrong for call arguments, e.g.
+    // let $a = {
+    //   let $b = 1;
+    //   $b
+    // };
     size_t col = state->lines.back().columns();
     if (indent > 0) {
       state->lines.emplace_back();
@@ -112,7 +120,7 @@ Buffer&& Buffer::append(Buffer&& other, size_t indent)
     }
     for (size_t i = 0; i < other.state->lines.size(); i++) {
       auto& line = other.state->lines[i];
-      if (col != 0 && state->lines.back().segments.empty()) {
+      if (align && col != 0 && state->lines.back().segments.empty()) {
         state->lines.back().segments.emplace_back(Text(std::string(col, ' ')));
       }
       state->lines.back().segments.insert(
@@ -870,10 +878,12 @@ Buffer Formatter::visit(AssignScalarMapStatement& assignment)
   Buffer expr;
 
   // Is this a compound operator?
+  Expression* rhs = &assignment.expr;
   auto* binop = assignment.expr.as<Binop>();
   if (binop && binop->left.is<Map>() &&
       *binop->left.as<Map>() == *assignment.map) {
     ops = opstr(*binop) + "=";
+    rhs = &binop->right;
     expr = format(binop->right,
                   metadata,
                   max_width - (map.width() + 2 + ops.size()),
@@ -886,13 +896,10 @@ Buffer Formatter::visit(AssignScalarMapStatement& assignment)
                   true);
   }
 
-  return Buffer()
-      .append(std::move(map))
-      .text(" ")
-      .text(ops)
-      .text(" ")
-      .append(std::move(expr))
-      .text(";");
+  auto buffer = Buffer().append(std::move(map)).text(" ").text(ops).text(" ");
+  bool align = !(rhs->is<BlockExpr>() || rhs->is<IfExpr>());
+
+  return buffer.append(std::move(expr), 0, align).text(";");
 }
 
 Buffer Formatter::visit(AssignMapStatement& assignment)
@@ -902,10 +909,12 @@ Buffer Formatter::visit(AssignMapStatement& assignment)
   Buffer expr;
 
   // Is this a compound operator?
+  Expression* rhs = &assignment.expr;
   auto* binop = assignment.expr.as<Binop>();
   if (binop && binop->left.is<MapAccess>() &&
       *binop->left.as<MapAccess>() == *assignment.map_access) {
     ops = opstr(*binop) + "=";
+    rhs = &binop->right;
     expr = format(binop->right,
                   metadata,
                   max_width - (map.width() + 2 + ops.size()),
@@ -918,13 +927,10 @@ Buffer Formatter::visit(AssignMapStatement& assignment)
                   true);
   }
 
-  return Buffer()
-      .append(std::move(map))
-      .text(" ")
-      .text(ops)
-      .text(" ")
-      .append(std::move(expr))
-      .text(";");
+  auto buffer = Buffer().append(std::move(map)).text(" ").text(ops).text(" ");
+  bool align = !(rhs->is<BlockExpr>() || rhs->is<IfExpr>());
+
+  return buffer.append(std::move(expr), 0, align).text(";");
 }
 
 Buffer Formatter::visit(AssignVarStatement& assignment)
@@ -935,10 +941,12 @@ Buffer Formatter::visit(AssignVarStatement& assignment)
 
   // Is this a compound operator?
   std::string ops;
+  Expression* rhs = &assignment.expr;
   auto* binop = assignment.expr.as<Binop>();
   if (binop && binop->left.is<Variable>() &&
       *binop->left.as<Variable>() == *assignment.var()) {
     ops = opstr(*binop) + "=";
+    rhs = &binop->right;
     expr = format(binop->right,
                   metadata,
                   max_width - (var.width() + 2 + ops.size()),
@@ -951,13 +959,10 @@ Buffer Formatter::visit(AssignVarStatement& assignment)
                   true);
   }
 
-  return Buffer()
-      .append(std::move(var))
-      .text(" ")
-      .text(ops)
-      .text(" ")
-      .append(std::move(expr))
-      .text(";");
+  auto buffer = Buffer().append(std::move(var)).text(" ").text(ops).text(" ");
+  bool align = !(rhs->is<BlockExpr>() || rhs->is<IfExpr>());
+
+  return buffer.append(std::move(expr), 0, align).text(";");
 }
 
 Buffer Formatter::visit(AssignConfigVarStatement& assignment)

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -22,7 +22,9 @@ public:
   Buffer(const Buffer &) = delete;
   Buffer &operator=(const Buffer &) = delete;
 
-  [[nodiscard]] Buffer &&append(Buffer &&other, size_t indent = 0);
+  [[nodiscard]] Buffer &&append(Buffer &&other,
+                                size_t indent = 0,
+                                bool align = true);
   [[nodiscard]] Buffer &&text(std::string str);
   [[nodiscard]] Buffer &&metadata(
       MetadataIndex metadata,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -913,6 +913,85 @@ int main(int argc, char* argv[])
   auto config = std::make_unique<Config>(!args.cmd_str.empty());
   BPFtrace bpftrace(args.no_feature, std::move(config));
 
+  // This is our primary program AST context. Initially it is empty, i.e.
+  // there is no filename set or source file. The way we set it up depends on
+  // the mode of execution below, and we expect that it will be reinitialized.
+  ast::ASTContext ast;
+
+  if (!args.filename.empty()) {
+    std::stringstream buf;
+
+    if (args.filename == "-") {
+      std::string line;
+      while (std::getline(std::cin, line)) {
+        // Note we may add an extra newline if the input doesn't end in a new
+        // line. This should not matter because bpftrace (the language) is not
+        // whitespace sensitive.
+        buf << line << std::endl;
+      }
+
+      ast = ast::ASTContext("stdin", buf.str());
+    } else {
+      std::ifstream file(args.filename);
+      if (file.fail()) {
+        LOG(ERROR) << "failed to open file '" << args.filename
+                   << "': " << std::strerror(errno);
+        exit(1);
+      }
+
+      buf << file.rdbuf();
+      ast = ast::ASTContext(args.filename, buf.str());
+    }
+  } else {
+    // Script is provided as a command line argument.
+    ast = ast::ASTContext("stdin", args.script);
+  }
+
+  // Formatting is a purely local operation: we parse the source and print it
+  // back out, without loading any BPF. Handle it before check_privileges() and
+  // any kernel symbol loading so that it can be run as an unprivileged user.
+  if (args.mode == Mode::FORMAT) {
+    // For formatting, we parse the full file, but don't apply any other passes
+    // or use any other diagnostics. It only matters whether the parse itself
+    // was successful, and then we emit the formatted source code.
+    ast::PassManager pm;
+    pm.put(ast);
+    pm.put(bpftrace);
+    pm.add(CreateParsePass(bt_debug.contains(DebugStage::Parse)));
+    auto ok = pm.run();
+    if (!ok) {
+      std::cerr << ok.takeError() << "\n";
+      return 2;
+    }
+    if (!ast.diagnostics().ok()) {
+      // We didn't successfully parse the file, so can't format it.
+      ast.diagnostics().emit(std::cerr);
+      return 1;
+    }
+    if (!args.output_file.empty()) {
+      // To make this operation safe, we open a temporary file next to the
+      // intented output file, and atomically rename when completed.
+      auto file = util::TempFile::create(args.output_file + ".XXXXXX");
+      if (!file) {
+        LOG(ERROR) << "unable to create temporary file: " << file.takeError();
+        return 1;
+      }
+      std::ofstream out(file->path());
+      if (out.fail()) {
+        LOG(ERROR) << "failed to open file '" << file->path()
+                   << "': " << std::strerror(errno);
+        return 1;
+      }
+      ast::Printer printer(ast, out, ast::FormatMode::Full);
+      printer.visit(ast.root);
+      std::filesystem::rename(file->path(), args.output_file);
+    } else {
+      ast::Printer printer(ast, std::cout, ast::FormatMode::Full);
+      printer.visit(ast.root);
+    }
+    return 0; // All done.
+  }
+
   check_privileges();
 
   // Create function info objects for probe matching and pass state.
@@ -960,86 +1039,10 @@ int main(int argc, char* argv[])
     bpftrace.child_ = std::move(*child);
   }
 
-  // This is our primary program AST context. Initially it is empty, i.e.
-  // there is no filename set or source file. The way we set it up depends on
-  // the mode of execution below, and we expect that it will be reinitialized.
-  ast::ASTContext ast;
-
   // Listing probes when there is no program.
   if (args.listing && args.script.empty() && args.filename.empty()) {
     list_probes(bpftrace, args.search, *kernel_func_info, user_func_info);
     return 0;
-  }
-
-  if (!args.filename.empty()) {
-    std::stringstream buf;
-
-    if (args.filename == "-") {
-      std::string line;
-      while (std::getline(std::cin, line)) {
-        // Note we may add an extra newline if the input doesn't end in a new
-        // line. This should not matter because bpftrace (the language) is not
-        // whitespace sensitive.
-        buf << line << std::endl;
-      }
-
-      ast = ast::ASTContext("stdin", buf.str());
-    } else {
-      std::ifstream file(args.filename);
-      if (file.fail()) {
-        LOG(ERROR) << "failed to open file '" << args.filename
-                   << "': " << std::strerror(errno);
-        exit(1);
-      }
-
-      buf << file.rdbuf();
-      ast = ast::ASTContext(args.filename, buf.str());
-    }
-  } else {
-    // Script is provided as a command line argument.
-    ast = ast::ASTContext("stdin", args.script);
-  }
-
-  if (args.mode == Mode::FORMAT) {
-    // For formatting, we parse the full file, but don't apply any other passes
-    // or use any other diagnostics. It only matters whether the parse itself
-    // was successful, and then we emit the formatted source code.
-    ast::PassManager pm;
-    pm.put(ast);
-    pm.put(bpftrace);
-    pm.add(CreateParsePass(bt_debug.contains(DebugStage::Parse)));
-    auto ok = pm.run();
-    if (!ok) {
-      std::cerr << ok.takeError() << "\n";
-      return 2;
-    }
-    if (!ast.diagnostics().ok()) {
-      // We didn't successfully parse the file, so can't format it.
-      ast.diagnostics().emit(std::cerr);
-      return 1;
-    }
-    if (!args.output_file.empty()) {
-      // To make this operation safe, we open a temporary file next to the
-      // intented output file, and atomically rename when completed.
-      auto file = util::TempFile::create(args.output_file + ".XXXXXX");
-      if (!file) {
-        LOG(ERROR) << "unable to create temporary file: " << file.takeError();
-        return 1;
-      }
-      std::ofstream out(file->path());
-      if (out.fail()) {
-        LOG(ERROR) << "failed to open file '" << file->path()
-                   << "': " << std::strerror(errno);
-        return 1;
-      }
-      ast::Printer printer(ast, out, ast::FormatMode::Full);
-      printer.visit(ast.root);
-      std::filesystem::rename(file->path(), args.output_file);
-    } else {
-      ast::Printer printer(ast, std::cout, ast::FormatMode::Full);
-      printer.visit(ast.root);
-    }
-    return 0; // All done.
   }
 
   for (const auto& param : args.params) {

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -232,25 +232,25 @@ EXPECT WARNING: It appears that 'non_existent_file.bt' is a filename but the fil
 TIMEOUT 1
 
 NAME pid fails validation with leading non-number
-RUN {{BPFTRACE}} -p a1111 file.bt
+RUN {{BPFTRACE}} -p a1111 -e 'begin { print(1); }'
 EXPECT ERROR: Failed to parse pid: invalid integer: a1111
 TIMEOUT 1
 WILL_FAIL
 
 NAME pid fails validation with non-number in between
-RUN {{BPFTRACE}} -p 111a1 file.bt
+RUN {{BPFTRACE}} -p 111a1 -e 'begin { print(1); }'
 EXPECT ERROR: Failed to parse pid: invalid trailing bytes: 111a1
 TIMEOUT 1
 WILL_FAIL
 
 NAME pid fails validation with non-numeric argument
-RUN {{BPFTRACE}} -p not_a_pid file.bt
+RUN {{BPFTRACE}} -p not_a_pid -e 'begin { print(1); }'
 EXPECT ERROR: Failed to parse pid: invalid integer: not_a_pid
 TIMEOUT 1
 WILL_FAIL
 
 NAME pid outside of valid pid range
-RUN {{BPFTRACE}} -p 5000000 file.bt
+RUN {{BPFTRACE}} -p 5000000 -e 'begin { print(1); }'
 EXPECT ERROR: Pid out of range: 5000000
 TIMEOUT 1
 WILL_FAIL


### PR DESCRIPTION
Stacked PRs:
 * #5256
 * #5253
 * __->__#5255


--- --- ---

### formatter: fix blocks following assignments


block line indentation should be relative to the initial statement if
following an assignment e.g.
```
let $a = {
  let $b = 1;
  $b
};
```
And not:
```
let $a = {
           let $b = 1;
           $b
         };
```

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>