### PR TITLE
Warn on low log space in verbose mode

### DIFF
--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -278,17 +278,20 @@ Result<> BpfBytecode::load_progs(const RequiredResources &resources,
 
       std::stringstream errmsg;
       errmsg << "Error loading BPF program for " << name
-             << ". Error code: " << res << ".";
+             << ". Error code: " << res << " ("
+             << strerror(res < 0 ? -res : res) << ").";
       if (bt_verbose) {
         errmsg << std::endl
                << "Kernel error log: " << std::endl
                << log << std::endl;
-        if (is_log_trimmed(log)) {
+        if (res == -ENOSPC || is_log_trimmed(log)) {
           LOG(WARNING, errmsg)
               << "Kernel log seems to be trimmed. This may be due to buffer "
                  "not being big enough, try increasing the BPFTRACE_LOG_SIZE "
                  "environment variable beyond the current value of "
-              << log_bufs[name].size() << " bytes";
+              << log_bufs[name].size()
+              << " bytes. Or, add the configuration "
+                 "`config = { log_size = N; }` to the script.";
         }
       } else {
         errmsg << " Use -v for full kernel error log.";

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -161,7 +161,7 @@ EXPECT_REGEX ^([0-9]+\.[0-9]+ ?)+.*$
 NAME log size too small
 ENV BPFTRACE_LOG_SIZE=2
 RUN {{BPFTRACE}} -v -e 'begin { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
-EXPECT ERROR: Error loading BPF program for begin_1. Error code: -28.
+EXPECT ERROR: Error loading BPF program for begin_1. Error code: -28 (No space left on device).
 EXPECT_REGEX ^WARNING: Kernel log seems to be trimmed.*
 WILL_FAIL
 


### PR DESCRIPTION
Prompt a message when there is insufficient log space in verbose mode. This will let the user know what may have happened and allow them to make adjustments.

Normally, logging is not used by default (log_level=0). However, in verbose mode, enabling logging may cause failure (ENOSPC). This can cause the same command or script to succeed in non-verbose mode but fail in verbbose mode, which can confuse users.

For example:

    $ sudo ./str_concat.bt # success
    $ sudo ./str_concat.bt -v # failed (Users will be very confused)
    ....
    ERROR: Error loading BPF program for begin_1. Error code: -28.
    Kernel error log:
    processed 87034 insns (limit 1000000) max_states_per_insn 4 total_states 2811 peak_states 136 mark_read 31

If the error is ENOSPC, prompt the user to set a larger log space:

    $ sudo ./str_concat.bt -v # failed (but give some advice)
    ....
    ERROR: Error loading BPF program for begin_1. Error code: -28 (No space left on device).
    Kernel error log:
    processed 87034 insns (limit 1000000) max_states_per_insn 4 total_states 2811 peak_states 136 mark_read 31

    Increasing the log buf size might solve this problem.  `config = {log_size = 10000000; }`, or set the environment variable `BPFTRACE_LOG_SIZE=10000000 `.

Example code:

    // str_concat.bpf.c
    #define __KERNEL__
    #include <asm/errno.h>
    #include <asm/posix_types.h>
    #include <linux/errno.h>
    #include <linux/types.h>
    #include <stddef.h>

    #include <bpf/bpf_helpers.h>

    extern int bpf_strnlen(const char *s__ign, size_t count) __ksym __weak;

    long __bpf_strnlen(const char *ptr, size_t max_size)
    {
      if (bpf_strnlen) {
        return bpf_strnlen(ptr, max_size);
      }
      long sz = 0;
      for (size_t i = 0; i < max_size; ++i) {
        if (ptr[i] == 0) {
          break;
        }
        ++sz;
      }
      return sz;
    }

    // see https://github.com/bpftrace/bpftrace/pull/5231
    size_t __bpf_str_concat(char *dst, size_t dst_sz, const char *src,
                            size_t src_sz)
    {
      __u32 i, j;
      size_t dst_len = __bpf_strnlen(dst, dst_sz);

      // Provide sufficient conditions for the BPF Verifier
      for (i = dst_len, j = 0; i < dst_sz - 1 && j < src_sz - 1 && src[j] != '\0';
           j++, i++)
        dst[i] = src[j];

      dst[i % dst_sz] = '\0';

      return j;
    }

    // str_concat.bt
    macro str_concat($s1, $s2) {
      import "str_concat.bpf.c";

      let $new : string[1024];

      assert_str($s1);
      assert_str($s2);

      let $new_sz = strcap($new);
      let $s1_sz = strcap($s1);
      let $s2_sz = strcap($s2);

      __bpf_str_concat((int8 *)&$new, (uint64)$new_sz, (int8 *)&$s1,
                       (uint64)$s1_sz);
      __bpf_str_concat((int8 *)&$new, (uint64)$new_sz, (int8 *)&$s2,
                       (uint64)$s2_sz);

      $new
    }

    macro str_concat($s1, s2) {
      let $s2 = s2;
      str_concat($s1, $s2)
    }

    macro str_concat(s1, $s2) {
      let $s1 = s1;
      str_concat($s1, $s2)
    }

    macro str_concat(s1, s2) {
      let $s1 = s1;
      let $s2 = s2;
      str_concat($s1, $s2)
    }

    BEGIN
    {
      let $s1 : string[32];
      $s1 = "hello";

      $new = str_concat($s1, " world");
      $new = str_concat($new, " Rong Tao");
      $new = str_concat("INFO: ", $new);

      printf("%s\n", $new);

      $new2 = str_concat("Hello", " World");
      printf("%s\n", $new2);
      exit();
    }


