### PR TITLE
Fix mismatch between size_t and unsigned long on armhf

### DIFF
--- a/src/dwarf/dwunwind_table.cpp
+++ b/src/dwarf/dwunwind_table.cpp
@@ -331,7 +331,8 @@ std::vector<uint8_t> dwunwind_build_table(
 
     auto diff = static_cast<signed long>(buf.size()) -
                 static_cast<signed long>(max_size);
-    auto adj = std::max(static_cast<size_t>(labs(diff) / 2.6), 1UL);
+    auto adj = std::max(static_cast<size_t>(labs(diff) / 2.6),
+                        static_cast<size_t>(1));
     if (buf.size() > max_size) {
       right = n - 1;
       n = std::max(n - adj, left);


### PR DESCRIPTION
On armhf, a `size_t` does not have the same size as an `unsigned long`. We get this error when compiling:

```
cd /build/reproducible-path/bpftrace-0.26.1/obj-arm-linux-gnueabihf/src && /usr/bin/arm-linux-gnueabihf-g++ -DHAVE_BFD_DISASM -DHAVE_LIBDW -DHAVE_NAME_TO_HANDLE_AT=1 -DKERNEL_HEADERS_DIR=\"\" -DLIBBFD_INIT_DISASM_INFO_FOUR_ARGS_SIGNATURE -I/build/reproducible-path/bpftrace-0.26.1/src -I/build/reproducible-path/bpftrace-0.26.1/obj-arm-linux-gnueabihf/src -I/build/reproducible-path/bpftrace-0.26.1/obj-arm-linux-gnueabihf -isystem /usr/lib/llvm-21/include -g -O2 -ffile-prefix-map=/build/reproducible-path/bpftrace-0.26.1=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64 -Wdate-time -D_FORTIFY_SOURCE=2 -std=c++20   -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -DEXPERIMENTAL_KEY_INSTRUCTIONS -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -Wall -Wextra -Werror=undef -Wpointer-arith -Wcast-align -Wwrite-strings -Wcast-qual -Wunreachable-code -Wdisabled-optimization -Wno-missing-field-initializers -MD -MT src/CMakeFiles/runtime.dir/bfd-disasm.cpp.o -MF CMakeFiles/runtime.dir/bfd-disasm.cpp.o.d -o CMakeFiles/runtime.dir/bfd-disasm.cpp.o -c /build/reproducible-path/bpftrace-0.26.1/src/bfd-disasm.cpp
/build/reproducible-path/bpftrace-0.26.1/src/dwarf/dwunwind_table.cpp: In function ‘std::vector<unsigned char> dwunwind_build_table(const std::vector<std::pair<long long unsigned int, long long unsigned int> >&, size_t, size_t, size_t&)’:
/build/reproducible-path/bpftrace-0.26.1/src/dwarf/dwunwind_table.cpp:334:24: error: no matching function for call to ‘max(size_t, long unsigned int)’
  334 |     auto adj = std::max(static_cast<size_t>(labs(diff) / 2.6), 1UL);
      |                ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Cast 1 to `size_t` to workaround this issue.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests

I have only tested compilation as I didn't have root access to a true armhf box.