### PR TITLE
tests: Fix capturing stderr

### DIFF
--- a/tests/async_action.cpp
+++ b/tests/async_action.cpp
@@ -171,6 +171,8 @@ TEST_F(AsyncActionTest, time_invalid_format)
   testing::internal::CaptureStderr();
 
   auto out = handlers.time(OpaqueValue::from(time_event));
+  testing::internal::GetCapturedStderr();
+
   ASSERT_FALSE(bool(out));
   EXPECT_THAT(llvm::toString(out.takeError()),
               testing::HasSubstr("strftime returned"));


### PR DESCRIPTION
The `AsyncActionTest.time_invalid_format` test captures stderr by running GoogleTest's `CaptureStderr()`, however, it never stops capturing. This causes a failure later in `LogStreamBug` tests. The reason is that these tests call `EXPECT_DEATH`, which also calls `CaptureStderr()`, however, since stderr is already being captured, it crashes.

Fix the issue by calling `GetCapturedStderr()` from the `AsyncActionTest`.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
