### PR TITLE
Auto-include headers for imported C

### DIFF
--- a/src/ast/passes/resolve_imports.cpp
+++ b/src/ast/passes/resolve_imports.cpp
@@ -422,6 +422,22 @@ Result<OK> Imports::import_any(Node &node,
   return OK();
 }
 
+Result<OK> Imports::import_cwd_c_headers(Node &node)
+{
+  auto cwd = std::filesystem::current_path();
+  for (const auto &entry : std::filesystem::recursive_directory_iterator(cwd)) {
+    if (std::filesystem::is_regular_file(entry.status()) &&
+        entry.path().extension() == ".h") {
+      auto ok = import_c(
+          node, entry.path().filename().string(), entry.path(), c_headers);
+      if (!ok) {
+        return ok.takeError();
+      }
+    }
+  }
+  return OK();
+}
+
 void ResolveStatementImports::visit(StatementImport &imp)
 {
   static std::string import_error =
@@ -563,6 +579,11 @@ Pass CreateResolveRootImportsPass(std::vector<std::string> &&import_paths)
                           if (!ok) {
                             return ok.takeError();
                           }
+                        }
+
+                        auto hdr = imports.import_cwd_c_headers(*ast.root);
+                        if (!hdr) {
+                          return hdr.takeError();
                         }
 
                         return imports;

--- a/src/ast/passes/resolve_imports.h
+++ b/src/ast/passes/resolve_imports.h
@@ -88,6 +88,8 @@ public:
                            const std::string &macro_name,
                            const std::vector<std::filesystem::path> &paths);
 
+  Result<OK> import_cwd_c_headers(Node &node);
+
   void mark_external_stdlib_override()
   {
     has_external_stdlib_override_ = true;


### PR DESCRIPTION
When using import to include C code in a bpftrace script, if this C code depends on header files in the current directory, we also need to import the header files in the bpftrace script; otherwise, the header files won't exist in llvm::vfs::InMemoryFileSystem, as shown in the example below:

    // a.bpf.h
    #pragma once
    #define ONE 1

    // a.bpf.c
    #include "a.bpf.h"
    int one(void) {
      return ONE;
    }

    // a.bt
    import "a.bpf.c";
    begin {
      printf("%d\n", one());
    }

Then, run script:

    $ sudo ./a.bt
    1 error generated.
    /home/rongtao/Git/tst-linux/bpf/bpftrace/samples/import/a.bt:3:1-17: ERROR: failed to build
    import "a.bpf.c";
    ~~~~~~~~~~~~~~~~
    HINT: a.bpf.c:1:10: fatal error: 'a.bpf.h' file not found
        1 | #include "a.bpf.h"
          |          ^~~~~~~~~

We have to import "a.bpf.h" to fix this issue. But actually, a.bpf.c has already included a.bpf.h, so we should avoid letting import bring it in again.

This submission automatically adds all .h files in the current directory to clang's virtual file system, so they can be #include'd directly in .c files without any extra import steps.

