### PR TITLE
stdlib: support std_concat()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- stdlib: add `str_concat()`.
+  - [#5265](https://github.com/bpftrace/bpftrace/pull/5265)
 - Add reg("pc") as an alias for the instruction pointer
   - [#5272](https://github.com/bpftrace/bpftrace/pull/5272)
 - Publish arm64/aarch64 release artifacts alongside x86_64.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1301,6 +1301,14 @@ In case the string is longer than the specified length only `length - 1` bytes a
 bpftrace will automatically use the `kernel` or `user` variant of `probe_read_{kernel,user}_str` based on the address space of `data`, see [Address-spaces](./language.md#address-spaces) for more information.
 
 
+### str_concat
+- `string str_concat(string s1, string s2)`
+
+Concatenate two strings into a new string.
+Returns the new string.
+
+
+
 ### strcap
 - `int64 strcap(string exp)`
 - `int64 strcap(int8 exp[])`

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -127,6 +127,41 @@ macro strstr(haystack, needle)
   strstr($haystack, needle)
 }
 
+// Concatenate two strings into a new string.
+// Returns the new string.
+//
+// :variant string str_concat(string s1, string s2)
+macro str_concat($s1, $s2) {
+  import "stdlib/strings/strings.bpf.c";
+
+  let $new : string[1024];
+
+  assert_str($s1);
+  assert_str($s2);
+
+  let $new_sz = strcap($new);
+
+  __bpf_str_concat((int8 *)&$new, (uint64)$new_sz, (int8 *)&$s1);
+  __bpf_str_concat((int8 *)&$new, (uint64)$new_sz, (int8 *)&$s2);
+
+  $new
+}
+
+macro str_concat($s1, s2) {
+  let $s2 = s2;
+  str_concat($s1, $s2)
+}
+
+macro str_concat(s1, $s2) {
+  let $s1 = s1;
+  str_concat($s1, $s2)
+}
+
+macro str_concat(s1, s2) {
+  let $s1 = s1;
+  str_concat($s1, s2)
+}
+
 // :variant bool strcontains(string haystack, string needle)
 // Compares whether the string haystack contains the string needle.
 //

--- a/src/stdlib/strings/strings.bpf.c
+++ b/src/stdlib/strings/strings.bpf.c
@@ -12,19 +12,46 @@
 
 extern int bpf_strnlen(const char *s__ign, size_t count) __ksym __weak;
 
+struct strnlen_ctx {
+  const char *str;
+  __u32 sz;
+};
+
+static int strnlen_cb(__u32 index, void *data)
+{
+  struct strnlen_ctx *ctx = data;
+  if (index >= ctx->sz) {
+    return 1;
+  }
+  char ch;
+  bpf_probe_read_kernel(&ch, sizeof(char), (void *)(ctx->str + index));
+  if (ch == '\0') {
+    // terminate the bpf_loop()
+    return 1;
+  }
+  return 0;
+}
+
 long __bpf_strnlen(const char *ptr, size_t max_size)
 {
   if (bpf_strnlen) {
     return bpf_strnlen(ptr, max_size);
   }
-  long sz = 0;
-  for (size_t i = 0; i < max_size; ++i) {
-    if (ptr[i] == 0) {
-      break;
-    }
-    ++sz;
+  // To allow the external interface function __bpf_strnlen to be called by
+  // other functions in strings.bpf.c and to solve the problem of
+  // `The sequence of xxxx jumps is too complex`, bpf_loop() first is used
+  // instead of a for loop.
+  // TODO: use bpf_for() macro instead of bpf_loop() since linux >= v6.4
+  struct strnlen_ctx ctx = {
+    .str = ptr,
+    .sz = max_size,
+  };
+  int len = bpf_loop(max_size, strnlen_cb, &ctx, 0);
+  if (len <= 0) {
+    return len;
   }
-  return sz;
+  // The string length does not include the null terminator '\0'.
+  return (len == max_size && ptr[len - 1] != '\0') ? len : len - 1;
 }
 
 extern int bpf_strnstr(const char *s1__ign,
@@ -65,6 +92,14 @@ int __bpf_strnstr(const char *haystack,
     }
   }
   return -1;
+}
+
+long __bpf_str_concat(char *dst, size_t dst_sz, const char *src)
+{
+  long dst_len = __bpf_strnlen(dst, dst_sz);
+  if (dst_len < 0 || dst_len >= dst_sz)
+    return 0;
+  return bpf_probe_read_kernel_str(dst + dst_len, dst_sz - dst_len, src);
 }
 
 int __strerror(int errno, err_str *out) {

--- a/tests/self/strings.bt
+++ b/tests/self/strings.bt
@@ -1,0 +1,14 @@
+test:str_contat
+{
+  $log = "log";
+  $filename = "system.journal";
+
+  $path = str_concat("var", "/");
+  $path = str_concat("/", $path);
+  $path = str_concat($path, "log/");
+  $path = str_concat($path, $filename);
+
+  if ($path != "/var/log/system.journal") {
+    return 1;
+  }
+}


### PR DESCRIPTION
Support stdlib `str_concat()`, see PR: [stdlib: support get current working directory](https://github.com/bpftrace/bpftrace/pull/5231)

This PR contains two separate commits (non-squash merge is better):

1. Assembles `bpffeature` into `cflags` and passes it to the stdlib C compiler. This is to allow stdlib C to determine if `bpf-helper` is available;

2. Adds the `bpf_concat()` function to concatenate a string and return a new string; also, if `bpf_loop()` is supported, stdlib C's `__bpf_strnlen()` will replace the `for` loop with `bpf_loop`.

Usage:

        $new = str_concat("hello", " world");
        $new = str_concat($new, "!!!");
        $new = str_concat("INFO: ", $new);
    
        printf("%s\n", $new);
    
        INFO: hello world!!!

