### PR TITLE
test/self: migrate integer cast runtime tests

### DIFF
--- a/tests/runtime/intcast
+++ b/tests/runtime/intcast
@@ -7,27 +7,3 @@ NAME Sum casted retval
 PROG ur:./testprogs/uprobe_negative_retval:function1 { @=stats((int32)retval); exit();} ur:./testprogs/uprobe_negative_retval:main { exit() }
 AFTER ./testprogs/uprobe_negative_retval
 EXPECT @: { .count = 221, .average = -10, .total = -2210 }
-
-NAME Casting ints
-PROG begin{printf("Values: %d %d\n", (uint8) -10, (uint16) 131087); exit(); }
-EXPECT Values: 246 15
-
-NAME Implicit truncation of ints
-PROG begin{ $a = (int16)0; $a = 2; $b = (int8)3; $b = -100; print(($a, $b)); exit(); }
-EXPECT (2, -100)
-
-NAME Binop on 32bit int
-PROG begin { $x = (uint32)5; $x += (uint32)1; print($x); exit() }
-EXPECT 6
-
-NAME Binop on 16bit int
-PROG begin { $x = (uint16)0xFF; $x &= (uint16)0xF; print($x); exit() }
-EXPECT 15
-
-NAME Binop on 8bit int
-PROG begin { $x = (uint8)0xF; $x |= (uint8)0xF0; print($x); exit() }
-EXPECT 255
-
-NAME Binop promotion
-PROG begin { $x = (uint32)0; $x = (uint32)5 + (uint16)1; print($x); exit() }
-EXPECT 6

--- a/tests/self/intcast.bt
+++ b/tests/self/intcast.bt
@@ -1,0 +1,78 @@
+test:casting_ints
+{
+  $a = (uint8)(-10);
+  $b = (uint16)131087;
+
+  if ($a != 246) {
+    return 1;
+  }
+
+  if ($b != 15) {
+    return 1;
+  }
+}
+
+test:binop_on_32bit_int
+{
+  $x = (uint32)5;
+  $x += (uint32)1;
+
+  if ($x != 6) {
+    return 1;
+  }
+
+  let $y: uint32 = 0xffffffff;
+  $y = (uint32)($y + 1);
+
+  if ($y != 0) {
+    return 1;
+  }
+}
+
+test:binop_on_16bit_int
+{
+  $x = (uint16)0xFF;
+  $x &= (uint16)0xF;
+
+  if ($x != 15) {
+    return 1;
+  }
+
+  let $y: uint16 = 0xffff;
+  $y = (uint16)($y + 1);
+
+  if ($y != 0) {
+    return 1;
+  }
+}
+
+test:binop_on_8bit_int
+{
+  $x = (uint8)0xF;
+  $x |= (uint8)0xF0;
+
+  if ($x != 255) {
+    return 1;
+  }
+
+  let $y: uint8 = 0xff;
+  $y = (uint8)($y + 1);
+
+  if ($y != 0) {
+    return 1;
+  }
+}
+
+test:binop_promotion
+{
+  $x = (uint32)0;
+  $x = (uint32)5 + (uint16)1;
+
+  if ($x != 6) {
+    return 1;
+  }
+
+  if (sizeof($x) != 8) {
+    return 1;
+  }
+}


### PR DESCRIPTION
Migrate integer cast tests that only validate expression results from the runtime test suite to self tests.

The following coverage is migrated:

- integer casts and truncation
- implicit truncation of scratch variables
- binary operations on 8-, 16-, and 32-bit integers
- binary operation type promotion

The retval-based tests remain in the runtime suite because they exercise uretprobe return values and aggregation behavior using an external test program.