### PR TITLE
AttachedProbe: Factor out symbol resolution

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -330,56 +330,11 @@ Result<uint64_t> resolve_offset_uprobe(Probe &probe, bool safe_mode)
   return offset;
 }
 
-struct bcc_sym_cb_data {
-  std::vector<std::string> &syms;
-  std::set<uint64_t> &offsets;
-};
-
-static int bcc_sym_cb(const char *symname,
-                      uint64_t start,
-                      uint64_t /*unused*/,
-                      void *p)
-{
-  auto *data = static_cast<struct bcc_sym_cb_data *>(p);
-  std::vector<std::string> &syms = data->syms;
-
-  if (std::ranges::binary_search(syms, symname)) {
-    data->offsets.insert(start);
-  }
-
-  return 0;
-}
-
-struct addr_offset {
-  uint64_t addr;
-  uint64_t offset;
-};
-
-static int bcc_load_cb(uint64_t v_addr,
-                       uint64_t mem_sz,
-                       uint64_t file_offset,
-                       void *p)
-{
-  auto *addrs = static_cast<std::vector<struct addr_offset> *>(p);
-
-  for (auto &a : *addrs) {
-    if (a.addr >= v_addr && a.addr < (v_addr + mem_sz)) {
-      a.offset = a.addr - v_addr + file_offset;
-    }
-  }
-
-  return 0;
-}
-
 Result<std::vector<unsigned long>> resolve_offsets_uprobe_multi(
     Probe &probe,
     std::vector<std::string> &syms)
 {
-  std::vector<unsigned long> offsets;
-  struct bcc_symbol_option option = {};
-  int err;
-
-  // Parse symbols names into syms vector
+  std::set<std::string> names;
   for (const std::string &func : probe.funcs) {
     auto pos = func.find(':');
 
@@ -387,46 +342,19 @@ Result<std::vector<unsigned long>> resolve_offsets_uprobe_multi(
       return make_error<AttachError>("Error resolving probe: " + probe.name);
     }
 
-    syms.push_back(func.substr(pos + 1));
+    auto name = func.substr(pos + 1);
+    syms.push_back(name);
+    names.insert(std::move(name));
   }
 
-  std::ranges::sort(syms);
-
-  option.use_debug_file = 1;
-  option.use_symbol_type = BCC_SYM_ALL_TYPES ^ (1 << STT_NOTYPE);
-
-  std::vector<struct addr_offset> addrs;
-  std::set<uint64_t> set;
-  struct bcc_sym_cb_data data = {
-    .syms = syms,
-    .offsets = set,
-  };
-
-  // Resolve symbols into addresses
-  err = bcc_elf_foreach_sym(probe.path.c_str(), bcc_sym_cb, &option, &data);
-  if (err) {
-    return make_error<AttachError>("Failed to list symbols for probe: " +
-                                   probe.name);
+  auto symbols = util::resolve_symbols(probe.path, names);
+  if (!symbols) {
+    return make_error<AttachError>(llvm::toString(symbols.takeError()));
   }
 
-  for (auto a : set) {
-    struct addr_offset addr = {
-      .addr = a,
-      .offset = 0x0,
-    };
-
-    addrs.push_back(addr);
-  }
-
-  // Translate addresses into offsets
-  err = bcc_elf_foreach_load_section(probe.path.c_str(), bcc_load_cb, &addrs);
-  if (err) {
-    return make_error<AttachError>(
-        "Failed to resolve symbols offsets for probe: " + probe.name);
-  }
-
-  for (auto a : addrs) {
-    offsets.push_back(a.offset);
+  std::vector<unsigned long> offsets;
+  for (const auto &sym : *symbols) {
+    offsets.push_back(sym.file_offset);
   }
 
   return offsets;

--- a/src/util/symbols.cpp
+++ b/src/util/symbols.cpp
@@ -20,6 +20,8 @@
 
 namespace bpftrace::util {
 
+char SymbolError::ID;
+
 std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
     const std::string &elf_file)
 {
@@ -85,6 +87,70 @@ std::tuple<std::string, std::string, std::string> split_addrrange_symbol_module(
            symbol.substr(idx1 + strlen("\t"), idx2 - idx1 - strlen("\t")),
            symbol.substr(idx2 + strlen(" ["),
                          symbol.length() - idx2 - strlen(" []")) };
+}
+
+struct resolve_symbols_data {
+  const std::set<std::string> &names;
+  std::vector<symbol> &symbols;
+};
+
+static int resolve_symbols_cb(const char *symname,
+                              uint64_t start,
+                              uint64_t size,
+                              void *p)
+{
+  auto *data = static_cast<struct resolve_symbols_data *>(p);
+
+  if (data->names.contains(symname)) {
+    data->symbols.push_back({ .name = symname, .start = start, .size = size });
+  }
+
+  return 0;
+}
+
+static int load_section_cb(uint64_t v_addr,
+                           uint64_t mem_sz,
+                           uint64_t file_offset,
+                           void *p)
+{
+  auto *syms = static_cast<std::vector<symbol> *>(p);
+
+  for (auto &sym : *syms) {
+    if (sym.start >= v_addr && sym.start < (v_addr + mem_sz)) {
+      sym.file_offset = sym.start - v_addr + file_offset;
+    }
+  }
+
+  return 0;
+}
+
+Result<std::vector<symbol>> resolve_symbols(const std::string &path,
+                                            const std::set<std::string> &names)
+{
+  std::vector<symbol> symbols;
+  struct bcc_symbol_option option;
+  memset(&option, 0, sizeof(option));
+  option.use_debug_file = 1;
+  option.use_symbol_type = BCC_SYM_ALL_TYPES ^ (1 << STT_NOTYPE);
+
+  struct resolve_symbols_data data = {
+    .names = names,
+    .symbols = symbols,
+  };
+
+  int err = bcc_elf_foreach_sym(
+      path.c_str(), resolve_symbols_cb, &option, &data);
+  if (err) {
+    return make_error<SymbolError>("Failed to list symbols in " + path);
+  }
+
+  err = bcc_elf_foreach_load_section(path.c_str(), load_section_cb, &symbols);
+  if (err) {
+    return make_error<SymbolError>("Failed to resolve symbol offsets in " +
+                                   path);
+  }
+
+  return symbols;
 }
 
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name)

--- a/src/util/symbols.h
+++ b/src/util/symbols.h
@@ -2,15 +2,37 @@
 
 #include <cstdint>
 #include <map>
+#include <set>
 #include <string>
+#include <vector>
+
+#include "util/result.h"
 
 namespace bpftrace::util {
+
+class SymbolError : public ErrorInfo<SymbolError> {
+public:
+  SymbolError(std::string msg) : msg_(std::move(msg)) {};
+  static char ID;
+  void log(llvm::raw_ostream &OS) const override
+  {
+    OS << msg_;
+  }
+  const std::string &msg() const
+  {
+    return msg_;
+  }
+
+private:
+  std::string msg_;
+};
 
 struct symbol {
   std::string name;
   uint64_t start;
   uint64_t size;
   uint64_t address;
+  uint64_t file_offset;
 };
 
 inline int sym_name_cb(const char *symname,
@@ -61,6 +83,9 @@ struct elf_symbol {
 // address inside a range using std::map::lower_bound.
 std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
     const std::string &elf_file);
+
+Result<std::vector<symbol>> resolve_symbols(const std::string &path,
+                                            const std::set<std::string> &names);
 
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
 


### PR DESCRIPTION
Stacked PRs:
 * #5270
 * #5269
 * #5268
 * __->__#5267


--- --- ---

### AttachedProbe: Factor out symbol resolution


Userspace symbol resolution is done in multiple places in AttachedProbe.
In an attempt to unify these, factor out the most reasonable
implementation, which is currently in resolve_offsets_uprobe_multi, into
a separate function. Move the function to src/util/symbols.h, where it
logically belongs.

The function accepts a set of symbol names to resolve (this was
previously a vector, which was then sorted, so a set should be more
efficient) and for each symbol, resolves its size, virtual address
(start) and ELF file offset. This is done in 2 steps:
1. Iterate the ELF symbol table (using bcc_elf_foreach_sym) to do
   name->{size,start} resolution.
2. Iterate the ELF load sections (using bcc_elf_foreach_load_section) to
   do address->offset resolution.

For now, resolve_offsets_uprobe_multi does some redundant set/vector
manipulation but that will go away in the following commit.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>