### PR TITLE
Convert util::symbol and its usages to C++ style

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1562,14 +1562,12 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     return ScopedExpr(b_.CreatePtrToInt(percpu_ptr, b_.getInt64Ty()));
   } else if (call.func == "__builtin_uaddr") {
     auto name = call.vargs.at(0).as<String>()->value;
-    struct symbol sym = {};
-    int err = bpftrace_.resolve_uname(name,
-                                      &sym,
-                                      current_attach_point_->target);
-    if (err < 0 || sym.address == 0)
-      call.addError() << "Could not resolve symbol: "
-                      << current_attach_point_->target << ":" << name;
-    return ScopedExpr(b_.getInt64(sym.address));
+    auto sym = bpftrace_.resolve_uname(name, current_attach_point_->target);
+    if (!sym) {
+      call.addError() << sym.takeError();
+      return ScopedExpr(b_.getInt64(0));
+    }
+    return ScopedExpr(b_.getInt64(sym->address));
   } else if (call.func == "cgroupid") {
     uint64_t cgroupid;
     auto path = call.vargs.at(0).as<String>()->value;

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -1151,28 +1151,24 @@ void TypeRuleCollector::visit(Call &call)
       if (probe == nullptr)
         return;
 
-      struct symbol sym = {};
+      size_t pointee_size = 64;
 
       if (!call.vargs.empty() && call.vargs.at(0).is<String>()) {
         auto name = call.vargs.at(0).as<String>()->value;
         const auto &target = probe->attach_points[0]->target;
 
-        int err = bpftrace_.resolve_uname(name, &sym, target);
-        if (err < 0 || sym.address == 0) {
-          call.addError() << "Could not resolve symbol: " << target << ":"
-                          << name;
+        auto sym = bpftrace_.resolve_uname(name, target);
+        if (sym) {
+          switch (sym->size) {
+            case 1:
+            case 2:
+            case 4:
+              pointee_size = sym->size * 8;
+              break;
+          }
+        } else {
+          call.addError() << sym.takeError();
         }
-      }
-
-      size_t pointee_size = 0;
-      switch (sym.size) {
-        case 1:
-        case 2:
-        case 4:
-          pointee_size = sym.size * 8;
-          break;
-        default:
-          pointee_size = 64;
       }
 
       return_type = CreatePointer(CreateInt(pointee_size), AddrSpace::user);

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -150,7 +150,7 @@ Result<uint64_t> resolve_offset_kprobe(Probe &probe)
   // kernel. This function is only called for sym+offset kprobes.
   assert(is_symbol_kprobe);
 
-  struct symbol sym = {};
+  Symbol sym = {};
   sym.name = probe.attach_point;
 
   auto path = symbols::find_vmlinux(&sym);
@@ -249,7 +249,7 @@ Result<> check_alignment(Probe &probe,
 Result<uint64_t> resolve_offset_uprobe(Probe &probe, bool safe_mode)
 {
   struct bcc_symbol_option option = {};
-  struct symbol sym = {};
+  Symbol sym = {};
   std::string &symbol = probe.attach_point;
   uint64_t func_offset = probe.func_offset;
 
@@ -330,9 +330,7 @@ Result<uint64_t> resolve_offset_uprobe(Probe &probe, bool safe_mode)
   return offset;
 }
 
-Result<std::vector<unsigned long>> resolve_offsets_uprobe_multi(
-    Probe &probe,
-    std::vector<std::string> &syms)
+Result<std::vector<Symbol>> resolve_offsets_uprobe_multi(Probe &probe)
 {
   std::set<std::string> names;
   for (const std::string &func : probe.funcs) {
@@ -342,9 +340,7 @@ Result<std::vector<unsigned long>> resolve_offsets_uprobe_multi(
       return make_error<AttachError>("Error resolving probe: " + probe.name);
     }
 
-    auto name = func.substr(pos + 1);
-    syms.push_back(name);
-    names.insert(std::move(name));
+    names.insert(func.substr(pos + 1));
   }
 
   auto symbols = util::resolve_symbols(probe.path, names);
@@ -352,12 +348,7 @@ Result<std::vector<unsigned long>> resolve_offsets_uprobe_multi(
     return make_error<AttachError>(llvm::toString(symbols.takeError()));
   }
 
-  std::vector<unsigned long> offsets;
-  for (const auto &sym : *symbols) {
-    offsets.push_back(sym.file_offset);
-  }
-
-  return offsets;
+  return symbols;
 }
 
 class AttachedKprobeProbe : public AttachedProbe {
@@ -631,20 +622,21 @@ size_t AttachedMultiUprobeProbe::probe_count() const
 Result<std::unique_ptr<AttachedMultiUprobeProbe>> AttachedMultiUprobeProbe::
     make(Probe &probe, const BpfProgram &prog, std::optional<int> pid)
 {
-  std::vector<std::string> syms;
-  unsigned int i;
+  auto symbols = resolve_offsets_uprobe_multi(probe);
+  if (!symbols) {
+    return symbols.takeError();
+  }
 
-  // Resolve probe_.funcs into offsets and syms vector
-  auto offset_res = resolve_offsets_uprobe_multi(probe, syms);
-  if (!offset_res) {
-    return offset_res.takeError();
+  std::vector<unsigned long> offsets;
+  for (const auto &sym : *symbols) {
+    offsets.push_back(sym.file_offset);
   }
 
   // Attach uprobe through uprobe_multi link
   DECLARE_LIBBPF_OPTS(bpf_link_create_opts, opts);
   opts.uprobe_multi.path = probe.path.c_str();
-  opts.uprobe_multi.offsets = offset_res->data();
-  opts.uprobe_multi.cnt = offset_res->size();
+  opts.uprobe_multi.offsets = offsets.data();
+  opts.uprobe_multi.cnt = offsets.size();
   opts.uprobe_multi.flags = probe.type == ProbeType::uretprobe
                                 ? BPF_F_UPROBE_MULTI_RETURN
                                 : 0;
@@ -654,8 +646,8 @@ Result<std::unique_ptr<AttachedMultiUprobeProbe>> AttachedMultiUprobeProbe::
 
   if (bt_verbose) {
     LOG(V1) << "Attaching to " << probe.funcs.size() << " functions";
-    for (i = 0; i < syms.size(); i++) {
-      LOG(V1) << probe.path << ":" << syms[i];
+    for (const auto &sym : *symbols) {
+      LOG(V1) << probe.path << ":" << sym.name;
     }
   }
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1292,7 +1292,7 @@ static int sym_resolve_callback(const char *name,
                                 uint64_t size,
                                 void *payload)
 {
-  auto *sym = static_cast<struct symbol *>(payload);
+  auto *sym = static_cast<Symbol *>(payload);
   if (!strcmp(name, sym->name.c_str())) {
     sym->address = addr;
     sym->size = size;
@@ -1301,17 +1301,24 @@ static int sym_resolve_callback(const char *name,
   return 0;
 }
 
-int BPFtrace::resolve_uname(const std::string &name,
-                            struct symbol *sym,
-                            const std::string &path) const
+Result<Symbol> BPFtrace::resolve_uname(const std::string &name,
+                                       const std::string &path) const
 {
-  sym->name = name;
+  Symbol sym = {};
+  sym.name = name;
   struct bcc_symbol_option option;
   memset(&option, 0, sizeof(option));
   option.use_symbol_type = (1 << STT_OBJECT | 1 << STT_FUNC |
                             1 << STT_GNU_IFUNC);
 
-  return bcc_elf_foreach_sym(path.c_str(), sym_resolve_callback, &option, sym);
+  int err = bcc_elf_foreach_sym(
+      path.c_str(), sym_resolve_callback, &option, &sym);
+  if (err < 0 || sym.address == 0) {
+    return make_error<util::SymbolError>("Could not resolve symbol: " + path +
+                                         ":" + name);
+  }
+
+  return sym;
 }
 
 std::string BPFtrace::resolve_mac_address(const char *mac_addr) const

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -40,7 +40,7 @@
 
 namespace bpftrace {
 
-using util::symbol;
+using util::Symbol;
 
 const int timeout_ms = 100;
 
@@ -148,9 +148,8 @@ public:
                           uint64_t timestamp_ns,
                           uint64_t *nsecs);
   uint64_t resolve_kname(const std::string &name) const;
-  virtual int resolve_uname(const std::string &name,
-                            struct symbol *sym,
-                            const std::string &path) const;
+  virtual Result<Symbol> resolve_uname(const std::string &name,
+                                       const std::string &path) const;
   std::string resolve_mac_address(const char *mac_addr) const;
   std::string resolve_cgroup_path(uint64_t cgroup_path_id,
                                   uint64_t cgroup_id) const;

--- a/src/symbols/kernel.cpp
+++ b/src/symbols/kernel.cpp
@@ -170,7 +170,7 @@ const struct vmlinux_location vmlinux_locs[] = {
 
 static std::optional<std::string> find_vmlinux(
     struct vmlinux_location const *locs,
-    struct util::symbol *sym)
+    util::Symbol *sym)
 {
   for (size_t i = 0; !locs[i].path.empty(); ++i) {
     const auto &loc = locs[i];
@@ -209,7 +209,7 @@ static std::optional<std::string> find_vmlinux(
 
 // find vmlinux file.
 // if sym is not null, check vmlinux contains the given symbol information
-std::optional<std::string> find_vmlinux(struct util::symbol *sym)
+std::optional<std::string> find_vmlinux(util::Symbol *sym)
 {
   const char *path = std::getenv("BPFTRACE_VMLINUX");
   if (path != nullptr) {

--- a/src/symbols/kernel.h
+++ b/src/symbols/kernel.h
@@ -17,7 +17,7 @@ namespace bpftrace::symbols {
 enum KernelVersionMethod { vDSO, UTS, File, None };
 uint32_t kernel_version(KernelVersionMethod method);
 
-std::optional<std::string> find_vmlinux(struct util::symbol *sym = nullptr);
+std::optional<std::string> find_vmlinux(util::Symbol *sym = nullptr);
 
 using FunctionSet = std::set<std::string>;
 using ModuleSet = std::set<std::string>;

--- a/src/util/symbols.cpp
+++ b/src/util/symbols.cpp
@@ -91,7 +91,7 @@ std::tuple<std::string, std::string, std::string> split_addrrange_symbol_module(
 
 struct resolve_symbols_data {
   const std::set<std::string> &names;
-  std::vector<symbol> &symbols;
+  std::vector<Symbol> &symbols;
 };
 
 static int resolve_symbols_cb(const char *symname,
@@ -113,7 +113,7 @@ static int load_section_cb(uint64_t v_addr,
                            uint64_t file_offset,
                            void *p)
 {
-  auto *syms = static_cast<std::vector<symbol> *>(p);
+  auto *syms = static_cast<std::vector<Symbol> *>(p);
 
   for (auto &sym : *syms) {
     if (sym.start >= v_addr && sym.start < (v_addr + mem_sz)) {
@@ -124,10 +124,10 @@ static int load_section_cb(uint64_t v_addr,
   return 0;
 }
 
-Result<std::vector<symbol>> resolve_symbols(const std::string &path,
+Result<std::vector<Symbol>> resolve_symbols(const std::string &path,
                                             const std::set<std::string> &names)
 {
-  std::vector<symbol> symbols;
+  std::vector<Symbol> symbols;
   struct bcc_symbol_option option;
   memset(&option, 0, sizeof(option));
   option.use_debug_file = 1;

--- a/src/util/symbols.h
+++ b/src/util/symbols.h
@@ -27,7 +27,7 @@ private:
   std::string msg_;
 };
 
-struct symbol {
+struct Symbol {
   std::string name;
   uint64_t start;
   uint64_t size;
@@ -40,7 +40,7 @@ inline int sym_name_cb(const char *symname,
                        uint64_t size,
                        void *p)
 {
-  auto *sym = static_cast<struct symbol *>(p);
+  auto *sym = static_cast<Symbol *>(p);
 
   if (sym->name == symname) {
     sym->start = start;
@@ -56,7 +56,7 @@ inline int sym_address_cb(const char *symname,
                           uint64_t size,
                           void *p)
 {
-  auto *sym = static_cast<struct symbol *>(p);
+  auto *sym = static_cast<Symbol *>(p);
 
   // When size is 0, then [start, start + size) = [start, start) = ø.
   // So we need a special case when size=0, but address matches the symbol's
@@ -84,7 +84,7 @@ struct elf_symbol {
 std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
     const std::string &elf_file);
 
-Result<std::vector<symbol>> resolve_symbols(const std::string &path,
+Result<std::vector<Symbol>> resolve_symbols(const std::string &path,
                                             const std::set<std::string> &names);
 
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name);

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -83,23 +83,24 @@ public:
     return resources.benchmark_probes;
   }
 
-  int resolve_uname(const std::string &name,
-                    struct symbol *sym,
-                    const std::string &path) const override
+  Result<Symbol> resolve_uname(const std::string &name,
+                               const std::string &path) const override
   {
     (void)path;
-    sym->name = name;
+    Symbol sym = {};
+    sym.name = name;
     if (name == "cpp_mangled(int)") {
-      return -1;
+      return make_error<util::SymbolError>("Could not resolve symbol: " + path +
+                                           ":" + name);
     } else if (name[0] >= 'A' && name[0] <= 'z') {
-      sym->address = 12345;
-      sym->size = 4;
+      sym.address = 12345;
+      sym.size = 4;
     } else {
       auto fields = util::split_string(name, '_');
-      sym->address = std::stoull(fields.at(0));
-      sym->size = std::stoull(fields.at(1));
+      sym.address = std::stoull(fields.at(0));
+      sym.size = std::stoull(fields.at(1));
     }
-    return 0;
+    return sym;
   }
 
   Result<uint64_t> get_buffer_pages(


### PR DESCRIPTION
Stacked PRs:
 * #5274
 * #5273
 * #5270
 * #5269
 * __->__#5268


--- --- ---

### Convert util::symbol and its usages to C++ style


util::symbol is used in a very C-like style - it is passed to functions
via reference and the functions fill its contents.

Modernize it by:
1. Renaming the struct to `Symbol` since that is what we prefer for
   public data classes.
2. Refactoring `resolve_uname()` and `resolve_offsets_uprobe_multi()` to
   return `Symbol` and `std::vector<Symbol>`, respectively, wrapped in
   `Result<>`.

This aligns the code with modern C++ patterns and simplifies the call
sites.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
