### PR TITLE
tests/self: migrate signed integer runtime tests

### DIFF
--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -16,11 +16,6 @@ PROG begin { @ = -11;  }
 EXPECT @: -11
 TIMEOUT 1
 
-NAME sum negative maps
-PROG begin { @ = -11; @+=@; exit() }
-EXPECT @: -22
-TIMEOUT 1
-
 NAME Comparison should print as 0 or 1
 PROG struct x { uint64_t x; }; begin { $a = (*(struct x*)0).x; printf("%d %d\n", $a > 0, $a < 1);  }
 EXPECT 0 1
@@ -29,31 +24,6 @@ TIMEOUT 1
 NAME sum with negative value
 PROG begin { @=sum(10); @=sum(-20);  }
 EXPECT @: -10
-TIMEOUT 1
-
-NAME cast negative to unsigned
-PROG begin { printf("%lu\n", (uint64)(-4095)); }
-EXPECT 18446744073709547521
-TIMEOUT 1
-
-NAME subtraction produces negative
-PROG begin { $a = (uint8)1 - 2; printf("%d\n", $a); }
-EXPECT -1
-TIMEOUT 1
-
-NAME decrement map below zero
-PROG begin { @x = 0; --@x; printf("%d\n", @x); }
-EXPECT -1
-TIMEOUT 1
-
-NAME increment then decrement map below zero
-PROG begin { @x = 0; ++@x; --@x; --@x; printf("%d\n", @x); }
-EXPECT -1
-TIMEOUT 1
-
-NAME uint64 subtraction stays unsigned with cast
-PROG begin { $a = (uint64)((uint64)5 - (uint64)3); printf("%lu\n", $a); }
-EXPECT 2
 TIMEOUT 1
 
 NAME uint64 subtraction underflow with cast

--- a/tests/self/signed_ints.bt
+++ b/tests/self/signed_ints.bt
@@ -1,0 +1,71 @@
+config = {
+  unstable_typeinfo = enable;
+}
+
+test:sum_negative_maps
+{
+  @sum_negative_maps = -11;
+
+  @sum_negative_maps += @sum_negative_maps;
+
+  if (@sum_negative_maps != -22) {
+    return 1;
+  }
+}
+
+test:cast_negative_to_unsigned
+{
+  $a = (uint64)(-4095);
+
+  if ($a != 18446744073709547521) {
+    return 1;
+  }
+}
+
+test:subtraction_produces_negative
+{
+  $a = (uint8)1 - 2;
+
+  if ($a != -1) {
+    return 1;
+  }
+
+  if (sizeof($a) != 8) {
+    return 1;
+  }
+}
+
+test:decrement_map_below_zero
+{
+  @decrement_map_below_zero = 0;
+  --@decrement_map_below_zero;
+
+  if (@decrement_map_below_zero != -1) {
+    return 1;
+  }
+}
+
+test:increment_then_decrement_map_below_zero
+{
+  @increment_then_decrement_map_below_zero = 0;
+  ++@increment_then_decrement_map_below_zero;
+  --@increment_then_decrement_map_below_zero;
+  --@increment_then_decrement_map_below_zero;
+
+  if (@increment_then_decrement_map_below_zero != -1) {
+    return 1;
+  }
+}
+
+test:uint64_subtraction_stays_unsigned_with_cast
+{
+  $a = (uint64)((uint64)5 - (uint64)3);
+
+  if ($a != 2) {
+    return 1;
+  }
+
+  if (typeinfo($a).full_type != "uint64") {
+    return 1;
+  }
+}


### PR DESCRIPTION
Migrate signed integer runtime tests that can directly assert their results to self-tests.

Runtime tests that specifically cover formatted output remain in the runtime test suite.

The migrated tests cover:

- arithmetic on negative map values
- casting a negative value to `uint64`
- signed subtraction results
- decrementing map values below zero
- preserving an unsigned result with an explicit cast

## Question

The `uint64 subtraction stays unsigned with cast` test preserves the original expression:

  ```bpftrace
  (uint64)((uint64)5 - (uint64)3)

This produces the following pre-existing warning because the subtraction converts its uint64 operands to int64:

WARNING: Expression of type: uint64 being cast to type: int64.
This may cause unexpected results. Use an explicit cast to suppress this warning.

The warning is also produced when the original runtime test program is run directly, although it is not displayed by the runtime test runner.

Explicitly casting both operands to int64 would suppress the warning, but would no longer test the original implicit type-resolution path.

Would it be preferable to keep this case as a self-test with the warning, or leave this particular case as a runtime test?