### PR TITLE
Symbol: Unify .address and .start fields

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1571,7 +1571,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     }
     // Convert to pointer to match GetType() for pointer types
     // The pointee size info is preserved in type_map_ and used during deref
-    Value *addr = b_.getInt64(sym->address);
+    Value *addr = b_.getInt64(sym->v_addr);
     Value *ptr = b_.CreateIntToPtr(addr, b_.getPtrTy());
     return ScopedExpr(ptr);
   } else if (call.func == "cgroupid") {

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -246,7 +246,7 @@ Result<uint64_t> resolve_offset_uprobe(Probe &probe, bool safe_mode)
     }
 
     symbol = sym->name;
-    func_offset = probe.address - sym->start;
+    func_offset = probe.address - sym->v_addr;
   }
 
   auto symbols = util::resolve_symbols(probe.path, { symbol });

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1294,7 +1294,7 @@ static int sym_resolve_callback(const char *name,
 {
   auto *sym = static_cast<Symbol *>(payload);
   if (!strcmp(name, sym->name.c_str())) {
-    sym->address = addr;
+    sym->v_addr = addr;
     sym->size = size;
     return -1;
   }
@@ -1313,7 +1313,7 @@ Result<Symbol> BPFtrace::resolve_uname(const std::string &name,
 
   int err = bcc_elf_foreach_sym(
       path.c_str(), sym_resolve_callback, &option, &sym);
-  if (err < 0 || sym.address == 0) {
+  if (err < 0 || sym.v_addr == 0) {
     return make_error<util::SymbolError>("Could not resolve symbol: " + path +
                                          ":" + name);
   }

--- a/src/symbols/kernel.cpp
+++ b/src/symbols/kernel.cpp
@@ -197,7 +197,7 @@ static std::optional<std::string> find_vmlinux(
         continue;
       }
 
-      if (sym->start) {
+      if (sym->v_addr) {
         LOG(V1) << "vmlinux: using " << loc.path;
         return loc.path;
       }

--- a/src/util/symbols.cpp
+++ b/src/util/symbols.cpp
@@ -103,7 +103,7 @@ static int resolve_symbols_cb(const char *symname,
   auto *data = static_cast<struct resolve_symbols_data *>(p);
 
   if (data->names.contains(symname)) {
-    data->symbols.push_back({ .name = symname, .start = start, .size = size });
+    data->symbols.push_back({ .name = symname, .v_addr = start, .size = size });
   }
 
   return 0;
@@ -117,8 +117,8 @@ static int load_section_cb(uint64_t v_addr,
   auto *syms = static_cast<std::vector<Symbol> *>(p);
 
   for (auto &sym : *syms) {
-    if (sym.start >= v_addr && sym.start < (v_addr + mem_sz)) {
-      sym.file_offset = sym.start - v_addr + file_offset;
+    if (sym.v_addr >= v_addr && sym.v_addr < (v_addr + mem_sz)) {
+      sym.file_offset = sym.v_addr - v_addr + file_offset;
     }
   }
 
@@ -157,7 +157,7 @@ Result<std::vector<Symbol>> resolve_symbols(const std::string &path,
 Result<Symbol> resolve_symbol(const std::string &path, uint64_t address)
 {
   Symbol sym = {};
-  sym.address = address;
+  sym.v_addr = address;
 
   struct bcc_symbol_option option;
   memset(&option, 0, sizeof(option));
@@ -166,7 +166,7 @@ Result<Symbol> resolve_symbol(const std::string &path, uint64_t address)
 
   bcc_elf_foreach_sym(path.c_str(), sym_address_cb, &option, &sym);
 
-  if (!sym.start) {
+  if (!sym.size) {
     std::stringstream ss;
     ss << "0x" << std::hex << address;
     return make_error<SymbolError>("Could not resolve address: " + path + ":" +

--- a/src/util/symbols.h
+++ b/src/util/symbols.h
@@ -29,9 +29,8 @@ private:
 
 struct Symbol {
   std::string name;
-  uint64_t start;
+  uint64_t v_addr;
   uint64_t size;
-  uint64_t address;
   uint64_t file_offset;
 };
 
@@ -43,7 +42,7 @@ inline int sym_name_cb(const char *symname,
   auto *sym = static_cast<Symbol *>(p);
 
   if (sym->name == symname) {
-    sym->start = start;
+    sym->v_addr = start;
     sym->size = size;
     return -1;
   }
@@ -60,9 +59,9 @@ inline int sym_address_cb(const char *symname,
 
   // When size is 0, then [start, start + size) = [start, start) = ø.
   // So we need a special case when size=0, but address matches the symbol's
-  if (sym->address == start ||
-      (sym->address > start && sym->address < (start + size))) {
-    sym->start = start;
+  if (sym->v_addr == start ||
+      (sym->v_addr > start && sym->v_addr < (start + size))) {
+    sym->v_addr = start;
     sym->size = size;
     sym->name = symname;
     return -1;

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -93,11 +93,11 @@ public:
       return make_error<util::SymbolError>("Could not resolve symbol: " + path +
                                            ":" + name);
     } else if (name[0] >= 'A' && name[0] <= 'z') {
-      sym.address = 12345;
+      sym.v_addr = 12345;
       sym.size = 4;
     } else {
       auto fields = util::split_string(name, '_');
-      sym.address = std::stoull(fields.at(0));
+      sym.v_addr = std::stoull(fields.at(0));
       sym.size = std::stoull(fields.at(1));
     }
     return sym;


### PR DESCRIPTION
Stacked PRs:
 * #5274
 * __->__#5273


--- --- ---

### Symbol: Unify .address and .start fields


The fields have the same semantics - they both hold the virtual address
of a symbol in ELF. Unify them to a new field .v_addr (virtual address),
which is common in the ELF world.

The only exception is when resolving symbol by address. Here,
sym.address was used as the "input" address to find (possibly in the
middle of the symbol) while sym.start was used as the found beginning of
the symbol. We can use sym.v_addr for both but need to update the
following check to `if (!sym.name)` since sym.v_addr is now always set.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
