### PR TITLE
Unify userspace symbol resolution

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1,9 +1,6 @@
 #include "bpfbytecode.h"
 #include "types_format.h"
 #include <arpa/inet.h>
-#include <bcc/bcc_elf.h>
-#include <bcc/bcc_syms.h>
-#include <bcc/perf_reader.h>
 #include <bpf/bpf.h>
 #include <bpf/libbpf.h>
 #include <cassert>
@@ -1287,38 +1284,18 @@ uint64_t BPFtrace::resolve_kname(const std::string &name) const
   return addr;
 }
 
-static int sym_resolve_callback(const char *name,
-                                uint64_t addr,
-                                uint64_t size,
-                                void *payload)
-{
-  auto *sym = static_cast<Symbol *>(payload);
-  if (!strcmp(name, sym->name.c_str())) {
-    sym->v_addr = addr;
-    sym->size = size;
-    return -1;
-  }
-  return 0;
-}
-
 Result<Symbol> BPFtrace::resolve_uname(const std::string &name,
                                        const std::string &path) const
 {
-  Symbol sym = {};
-  sym.name = name;
-  struct bcc_symbol_option option;
-  memset(&option, 0, sizeof(option));
-  option.use_symbol_type = (1 << STT_OBJECT | 1 << STT_FUNC |
-                            1 << STT_GNU_IFUNC);
-
-  int err = bcc_elf_foreach_sym(
-      path.c_str(), sym_resolve_callback, &option, &sym);
-  if (err < 0 || sym.v_addr == 0) {
+  auto symbols = util::resolve_symbols(path, { name }, false);
+  if (!symbols) {
+    return symbols.takeError();
+  }
+  if (symbols->empty()) {
     return make_error<util::SymbolError>("Could not resolve symbol: " + path +
                                          ":" + name);
   }
-
-  return sym;
+  return symbols->front();
 }
 
 std::string BPFtrace::resolve_mac_address(const char *mac_addr) const

--- a/src/util/symbols.cpp
+++ b/src/util/symbols.cpp
@@ -126,13 +126,15 @@ static int load_section_cb(uint64_t v_addr,
 }
 
 Result<std::vector<Symbol>> resolve_symbols(const std::string &path,
-                                            const std::set<std::string> &names)
+                                            const std::set<std::string> &names,
+                                            bool resolve_offsets)
 {
   std::vector<Symbol> symbols;
   struct bcc_symbol_option option;
   memset(&option, 0, sizeof(option));
   option.use_debug_file = 1;
-  option.use_symbol_type = BCC_SYM_ALL_TYPES ^ (1 << STT_NOTYPE);
+  option.use_symbol_type = (1 << STT_FUNC | 1 << STT_GNU_IFUNC |
+                            1 << STT_OBJECT);
 
   struct resolve_symbols_data data = {
     .names = names,
@@ -145,10 +147,12 @@ Result<std::vector<Symbol>> resolve_symbols(const std::string &path,
     return make_error<SymbolError>("Failed to list symbols in " + path);
   }
 
-  err = bcc_elf_foreach_load_section(path.c_str(), load_section_cb, &symbols);
-  if (err) {
-    return make_error<SymbolError>("Failed to resolve symbol offsets in " +
-                                   path);
+  if (resolve_offsets) {
+    err = bcc_elf_foreach_load_section(path.c_str(), load_section_cb, &symbols);
+    if (err) {
+      return make_error<SymbolError>("Failed to resolve symbol offsets in " +
+                                     path);
+    }
   }
 
   return symbols;
@@ -162,7 +166,8 @@ Result<Symbol> resolve_symbol(const std::string &path, uint64_t address)
   struct bcc_symbol_option option;
   memset(&option, 0, sizeof(option));
   option.use_debug_file = 1;
-  option.use_symbol_type = BCC_SYM_ALL_TYPES ^ (1 << STT_NOTYPE);
+  option.use_symbol_type = (1 << STT_FUNC | 1 << STT_GNU_IFUNC |
+                            1 << STT_OBJECT);
 
   bcc_elf_foreach_sym(path.c_str(), sym_address_cb, &option, &sym);
 

--- a/src/util/symbols.h
+++ b/src/util/symbols.h
@@ -84,7 +84,8 @@ std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
     const std::string &elf_file);
 
 Result<std::vector<Symbol>> resolve_symbols(const std::string &path,
-                                            const std::set<std::string> &names);
+                                            const std::set<std::string> &names,
+                                            bool resolve_offsets = true);
 
 Result<Symbol> resolve_symbol(const std::string &path, uint64_t address);
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#5274
 * #5273


--- --- ---

### Unify userspace symbol resolution


We have two functions for userspace symbol resolution -
BPFtrace::resolve_uname() and util::resolve_symbols(). Both do the same
resolution via bcc_elf_foreach_sym(). Unify them by letting
BPFtrace::resolve_uname() call util::resolve_symbols(). We do not drop
BPFtrace::resolve_uname() completely because it is virtual and
overridden by tests.

There are two slight differences between the functions:

1. BPFtrace::resolve_uname() uses

        (1 << STT_OBJECT | 1 << STT_FUNC | 1 << STT_GNU_IFUNC)

   as the searched symbol type while util::resolve_symbols() uses

        BCC_SYM_ALL_TYPES ^ (1 << STT_NOTYPE)

   The former is better here since we generally don't want to search for
   things like sections, etc. We should be fine with functions and
   objects everywhere. While at it, also update the same in
   util::resolve_symbol() used for resolution by address.

2. util::resolve_symbols() also resolves ELF file symbol offsets by
   iterating load segments. This is unnecessary for resolve_uname() so
   add an extra argument to util::resolve_symbols() to allow disabling
   the resolution.

This also allows removing all BCC includes from bpftrace.cpp.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
