### PR TITLE
tests: Migrate strcontains runtime tests to self tests

### DIFF
--- a/tests/runtime/strcontains
+++ b/tests/runtime/strcontains
@@ -4,11 +4,6 @@ EXPECT OK
 REQUIRES_FEATURE dpath
 AFTER TMPDIR=/tmp ./testprogs/syscall openat
 
-NAME literals
-PROG begin { if (strcontains("abc", "a")) { printf("OK\n");  } }
-EXPECT OK
-TIMEOUT 1
-
 NAME no literals
 # Clamping is done to not blow verifier complexity limits
 PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/true" / { print(strcontains(str(args.argv[1], 32), str(args.argv[2], 32))); exit(); }
@@ -21,95 +16,6 @@ PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/tr
 AFTER ./testprogs/true zztest test
 EXPECT true
 
-NAME basic substring match
-PROG begin { print(strcontains("hello-test-world", "test"));  }
-EXPECT true
-TIMEOUT 1
-
-NAME substring at end
-PROG begin { print(strcontains("hello-test-world", "world"));  }
-EXPECT true
-TIMEOUT 1
-
-NAME substring at beginning
-PROG begin { print(strcontains("hello-test-world", "hello"));  }
-EXPECT true
-TIMEOUT 1
-
-NAME no match
-PROG begin { print(strcontains("hello-test-world", "not-there"));  }
-EXPECT false
-TIMEOUT 1
-
-NAME empty haystack, empty needle
-PROG begin { print(strcontains("", ""));  }
-EXPECT true
-TIMEOUT 1
-
-NAME non-empty haystack, empty needle
-PROG begin { print(strcontains("hello", ""));  }
-EXPECT true
-TIMEOUT 1
-
-NAME empty haystack, non-empty needle
-PROG begin { print(strcontains("", "test"));  }
-EXPECT false
-TIMEOUT 1
-
-NAME exact match
-PROG begin { print(strcontains("hello", "hello"));  }
-EXPECT true
-TIMEOUT 1
-
-NAME needle longer than haystack
-PROG begin { print(strcontains("hello", "hello-longer"));  }
-EXPECT false
-TIMEOUT 1
-
-NAME case sensitivity check
-PROG begin { print(strcontains("Hello World", "hello"));  }
-EXPECT false
-TIMEOUT 1
-
-NAME multiple occurrences
-PROG begin { print(strcontains("test-test-test", "test"));  }
-EXPECT true
-TIMEOUT 1
-
-NAME overlapping potential matches
-PROG begin { print(strcontains("ababac", "abac"));  }
-EXPECT true
-TIMEOUT 1
-
-NAME special characters
-PROG begin { print(strcontains("hello\tworld", "\two"));  }
-EXPECT true
-TIMEOUT 1
-
-NAME null terminator inside haystack
-PROG begin { $str = "hello\0world"; print(strcontains($str, "world"));  }
-EXPECT false
-TIMEOUT 1
-
-NAME content after null terminator
-PROG begin { $str = "hello\0test"; print(strcontains($str, "test"));  }
-EXPECT false
-TIMEOUT 1
-
-NAME null character in needle
-PROG begin { $needle = "wo\0rld"; print(strcontains("hello world", $needle));  }
-EXPECT true
-TIMEOUT 1
-
-NAME null character in both
-PROG begin { $haystack = "hello\0world"; $needle = "wo\0rld"; print(strcontains($haystack, $needle));  }
-EXPECT false
-TIMEOUT 1
-
-NAME indexing
-PROG begin { $a = "foo"; printf("%c is the first letter", $a[0]); }
-EXPECT f is the first letter
-
 # This test just ensures that the probe passes verification. There are no
 # guardrails here, if the read comes from proberead then we expect zero, but if
 # it points to BPF memory then it may be legitimate but random.
@@ -121,11 +27,3 @@ NAME types
 PROG BEGIN { strcontains("foo", 1) }
 EXPECT_REGEX .* ERROR:.*
 WILL_FAIL
-
-NAME variable not present
-PROG BEGIN { $a = "bar"; print(strcontains("foo", $a)) }
-EXPECT false
-
-NAME variable present
-PROG BEGIN { $a = "bar"; print(strcontains("foobar", $a)) }
-EXPECT true

--- a/tests/self/strcontains.bt
+++ b/tests/self/strcontains.bt
@@ -1,0 +1,152 @@
+test:literals
+{
+  if (!strcontains("abc", "a")) {
+    return 1;
+  }
+}
+
+test:basic_substring_match
+{
+  if (!strcontains("hello-test-world", "test")) {
+    return 1;
+  }
+}
+
+test:substring_at_end
+{
+  if (!strcontains("hello-test-world", "world")) {
+    return 1;
+  }
+}
+
+test:substring_at_beginning
+{
+  if (!strcontains("hello-test-world", "hello")) {
+    return 1;
+  }
+}
+
+test:no_match
+{
+  if (strcontains("hello-test-world", "not-there")) {
+    return 1;
+  }
+}
+
+test:empty_haystack_empty_needle
+{
+  if (!strcontains("", "")) {
+    return 1;
+  }
+}
+
+test:non_empty_haystack_empty_needle
+{
+  if (!strcontains("hello", "")) {
+    return 1;
+  }
+}
+
+test:empty_haystack_non_empty_needle
+{
+  if (strcontains("", "test")) {
+    return 1;
+  }
+}
+
+test:exact_match
+{
+  if (!strcontains("hello", "hello")) {
+    return 1;
+  }
+}
+
+test:needle_longer_than_haystack
+{
+  if (strcontains("hello", "hello-longer")) {
+    return 1;
+  }
+}
+
+test:case_sensitivity_check
+{
+  if (strcontains("Hello World", "hello")) {
+    return 1;
+  }
+}
+
+test:multiple_occurrences
+{
+  if (!strcontains("test-test-test", "test")) {
+    return 1;
+  }
+}
+
+test:overlapping_potential_matches
+{
+  if (!strcontains("ababac", "abac")) {
+    return 1;
+  }
+}
+
+test:special_characters
+{
+  if (!strcontains("hello\tworld", "\two")) {
+    return 1;
+  }
+}
+
+test:null_terminator_inside_haystack
+{
+  $str = "hello\0world";
+
+  if (strcontains($str, "world")) {
+    return 1;
+  }
+}
+
+test:null_character_in_needle
+{
+  $needle = "wo\0rld";
+
+  if (!strcontains("hello world", $needle)) {
+    return 1;
+  }
+}
+
+test:null_character_in_both
+{
+  $haystack = "hello\0world";
+  $needle = "wo\0rld";
+
+  if (strcontains($haystack, $needle)) {
+    return 1;
+  }
+}
+
+test:indexing
+{
+  $a = "foo";
+
+  if ($a[0] != "f"[0]) {
+    return 1;
+  }
+}
+
+test:variable_not_present
+{
+  $a = "bar";
+
+  if (strcontains("foo", $a)) {
+    return 1;
+  }
+}
+
+test:variable_present
+{
+  $a = "bar";
+
+  if (!strcontains("foobar", $a)) {
+    return 1;
+  }
+}

--- a/tests/self/strcontains.bt
+++ b/tests/self/strcontains.bt
@@ -1,0 +1,161 @@
+test:literals
+{
+  if (!strcontains("abc", "a")) {
+    return 1;
+  }
+}
+
+test:basic_substring_match
+{
+  if (!strcontains("hello-test-world", "test")) {
+    return 1;
+  }
+}
+
+test:substring_at_end
+{
+  if (!strcontains("hello-test-world", "world")) {
+    return 1;
+  }
+}
+
+test:substring_at_beginning
+{
+  if (!strcontains("hello-test-world", "hello")) {
+    return 1;
+  }
+}
+
+test:no_match
+{
+  if (strcontains("hello-test-world", "not-there")) {
+    return 1;
+  }
+}
+
+test:empty_haystack_empty_needle
+{
+  if (!strcontains("", "")) {
+    return 1;
+  }
+}
+
+test:non_empty_haystack_empty_needle
+{
+  if (!strcontains("hello", "")) {
+    return 1;
+  }
+}
+
+test:empty_haystack_non_empty_needle
+{
+  if (strcontains("", "test")) {
+    return 1;
+  }
+}
+
+test:exact_match
+{
+  if (!strcontains("hello", "hello")) {
+    return 1;
+  }
+}
+
+test:needle_longer_than_haystack
+{
+  if (strcontains("hello", "hello-longer")) {
+    return 1;
+  }
+}
+
+test:case_sensitivity_check
+{
+  if (strcontains("Hello World", "hello")) {
+    return 1;
+  }
+}
+
+test:multiple_occurrences
+{
+  if (!strcontains("test-test-test", "test")) {
+    return 1;
+  }
+}
+
+test:overlapping_potential_matches
+{
+  if (!strcontains("ababac", "abac")) {
+    return 1;
+  }
+}
+
+test:special_characters
+{
+  if (!strcontains("hello\tworld", "\two")) {
+    return 1;
+  }
+}
+
+test:null_terminator_inside_haystack
+{
+  $str = "hello\0world";
+
+  if (strcontains($str, "world")) {
+    return 1;
+  }
+}
+
+test:content_after_null_teminator
+{
+  $str = "hello\0test";
+
+  if (strcontains($str, "test")) {
+    return 1;
+  }
+}
+
+test:null_character_in_needle
+{
+  $needle = "wo\0rld";
+
+  if (!strcontains("hello world", $needle)) {
+    return 1;
+  }
+}
+
+test:null_character_in_both
+{
+  $haystack = "hello\0world";
+  $needle = "wo\0rld";
+
+  if (strcontains($haystack, $needle)) {
+    return 1;
+  }
+}
+
+test:indexing
+{
+  $a = "foo";
+
+  if ($a[0] != "f"[0]) {
+    return 1;
+  }
+}
+
+test:variable_not_present
+{
+  $a = "bar";
+
+  if (strcontains("foo", $a)) {
+    return 1;
+  }
+}
+
+test:variable_present
+{
+  $a = "bar";
+
+  if (!strcontains("foobar", $a)) {
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary

- Migrate kernel-independent `strcontains()` runtime tests to self tests
- Cover literal, variable, empty-string, null-character, and substring matching vehavior in the new self test

## Testing
- `nix debelop -c make -C build -j$(nproc)`
- `sudo ./build/src/bpftrace --test tests/self/strcontains.bt`
- `nix develop -c sudo --preserve-env=PATH,PYTHONPATH ./build/tests/runtime-tests./sh --fileter='^strcontains'`