### PR TITLE
stdlib: support get current working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- stdlib: Add `abs_path` and `cwd`.
+  - [#5276](https://github.com/bpftrace/bpftrace/pull/5276)
 #### Changed
 #### Deprecated
 #### Removed

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -13,6 +13,23 @@ Basically all functions or macros that don't have arguments or have default argu
 
 ## Helpers
 
+### abs_path
+- `string abs_path(string path, uint64 max_path_depth);`
+
+Returns the absolute path for the passed relative path or filename.
+
+If the first string parameter is empty, the returned string will be empty.
+
+Example:
+```
+tracepoint:syscalls:sys_enter_openat {
+  print(abs_path(str(args.filename), 32));
+}
+```
+
+see also `cwd`.
+
+
 ### assert
 - `void assert(bool condition, string message)`
 
@@ -211,6 +228,14 @@ This utilizes the BPF helper `raw_smp_processor_id`
 Pointer to `struct task_struct` of the current task
 
 This utilizes the BPF helper `get_current_task`
+
+
+### cwd
+- `string cwd();`
+- `string cwd;`
+- `string cwd(max_path_depth);`
+
+Get the current working directory.
 
 
 ### default_str_length

--- a/src/stdlib/path.bt
+++ b/src/stdlib/path.bt
@@ -1,0 +1,92 @@
+// Path helpers.
+
+// :variant string cwd();
+// :variant string cwd(max_path_depth);
+//
+// Get the current working directory.
+macro cwd(max_path_depth)
+{
+  let $path : string[1024] = "";
+
+  $fs = curtask->fs;
+  $dentry = $fs->pwd.dentry;
+  $vfsmnt = $fs->pwd.mnt;
+  $mnt = (struct mount *)(((int64)$vfsmnt) - offsetof(struct mount, mnt));
+  $mnt_root = $vfsmnt.mnt_root;
+
+  for $j : ((uint64)0)..((uint64)max_path_depth) {
+
+    $d_name = str($dentry.d_name.name);
+    $parent_dentry = $dentry.d_parent;
+
+    if ($dentry == $parent_dentry || $dentry == $mnt_root) {
+      $mnt_parent = $mnt.mnt_parent;
+
+      // Real root directory
+      if ($mnt == $mnt_parent) {
+        break;
+      }
+
+      $dentry = $mnt.mnt_mountpoint;
+      $mnt = $mnt_parent;
+      $mnt_root = $mnt.mnt.mnt_root;
+      continue;
+    }
+
+    // Sometimes, $d_name will be equal to "/" or start with "/", such as in a
+    // mount point directory.
+    // If the $path is empty, and it is the first loop iteration, it means to
+    // get the current working directory. In this case, no extra slash is
+    // needed.
+    if ($d_name[0] != "/"[0] && !($path == "" && $j == 0)) {
+      $path = str_concat("/", $path);
+    }
+    $path = str_concat($d_name, $path);
+
+    $dentry = $parent_dentry;
+  }
+
+  // Normally, the root directory will be missing a '/'.
+  if ($path[0] != "/"[0]) {
+    $path = str_concat("/", $path);
+  }
+
+  $path
+}
+
+macro cwd()
+{
+  cwd(32)
+}
+
+// :variant string abs_path(string path, uint64 max_path_depth);
+//
+// Returns the absolute path for the passed relative path or filename.
+//
+// If the first string parameter is empty, the returned string will be empty.
+//
+// Example:
+// ```
+// tracepoint:syscalls:sys_enter_openat {
+//   print(abs_path(str(args.filename), 32));
+// }
+// ```
+//
+// see also `cwd`.
+macro abs_path(path, max_path_depth)
+{
+  assert_str(path);
+
+  if (path[0] == "/"[0] || path == "") {
+    path
+  } else {
+    let $abspath : string[1024] = "";
+    let $cwd : string[1024] = "";
+
+    $cwd = cwd(max_path_depth);
+    $abspath = str_concat($cwd, "/");
+    $abspath = str_concat($abspath, path);
+
+    $abspath
+  }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -138,6 +138,7 @@ not known until test time. The following runtime variables are available for the
 
 * `{{BPFTRACE}}`: Path to bpftrace executable
 * `{{BEFORE_PID}}`: Process ID of the process in the first `BEFORE` directive
+* `{{CWD}}`: Current working directory
 
 ### Test programs
 

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -3,6 +3,7 @@
 from collections import namedtuple
 import os
 import platform
+import re
 import sys
 from runner import Runner
 
@@ -21,7 +22,8 @@ class InvalidFieldError(Exception):
 
 class Expect:
   def __init__(self, expect, mode):
-    self.expect = expect
+    real_expect = re.sub("{{CWD}}", os.getcwd(), expect)
+    self.expect = real_expect
     self.mode = mode
 
 # Remember to update tests/README.md if adding a new directive!

--- a/tests/runtime/stdlib
+++ b/tests/runtime/stdlib
@@ -76,3 +76,15 @@ PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:n_func { $n = (int
 EXPECT { .m = 2, .n = 3 }
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
+
+NAME abs_path
+PROG begin { print(abs_path("a.out", 32)); }
+EXPECT {{CWD}}/a.out
+
+NAME abs_path pass absolute path
+PROG begin { print(abs_path("/etc/passwd", 32)); }
+EXPECT /etc/passwd
+
+NAME cwd
+PROG begin { print(cwd); }
+EXPECT {{CWD}}

--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -35,6 +35,7 @@
 //
 // 08-Sep-2018	Brendan Gregg	Created this.
 // 16-Sep-2025	Rong Tao	Support fullpath of file.
+// 29-Jul-2026	Rong Tao	Use stdlib abs_path() to get the absolute path.
 
 config = {
   missing_probes = warn;
@@ -69,65 +70,11 @@ tracepoint:syscalls:sys_enter_openat2
   @filename[tid] = args.filename;
 }
 
-macro getcwd(@paths)
-{
-  $dentry = curtask.fs.pwd.dentry;
-  $vfsmnt = curtask.fs.pwd.mnt;
-  $mnt = (struct mount*)(((uint64)$vfsmnt) - offsetof(struct mount, mnt));
-  $mnt_root = $vfsmnt.mnt_root;
-
-  for $j : ((uint64)0)..((uint64)max_path_depth) {
-
-    @paths[tid, $j] = str($dentry.d_name.name);
-    $parent_dentry = $dentry.d_parent;
-
-    if ($dentry == $parent_dentry || $dentry == $mnt_root) {
-      $mnt_parent = (struct mount*)$mnt.mnt_parent;
-
-      // Real root directory
-
-      if ($mnt == $mnt_parent) {
-        break;
-      }
-
-      $dentry = $mnt.mnt_mountpoint;
-      $mnt = $mnt_parent;
-      $mnt_root = $mnt.mnt.mnt_root;
-      continue;
-    }
-
-    $dentry = $parent_dentry;
-  }
-}
-
-macro printcwd(@paths)
-{
-  for $j : ((uint64)0)..((uint64)max_path_depth) {
-    let $key = (tid, (uint64)((max_path_depth() - $j) - 1));
-    let $name = @paths[$key];
-    // If it is a mount point, there will be a '/', because
-    // the '/' will be added below, so just skip this '/'.
-    //
-    // And, if @paths don't have the $key, just skip the
-    // empty string.
-    if ($name == "/" || $name == "") {
-      continue;
-    }
-    printf("/%s", $name);
-    delete(@paths, $key);
-  }
-  printf("/");
-}
-
-macro sys_exit(ret, @filename, @paths)
+macro sys_exit(ret, $file)
 {
   $ret = ret;
   $fd = ($ret >= 0) ? $ret : (-1);
   $errno = ($ret >= 0) ? 0 : (-$ret);
-
-  getcwd(@paths);
-
-  $path = str(@filename[tid]);
 
   printf("%-6d %-16s %4d", pid, comm, $fd);
 
@@ -138,11 +85,11 @@ macro sys_exit(ret, @filename, @paths)
   }
 
   // Skip display cwd if path start with '/'.
-  if ($path[0] != "/"[0]) {
-    printcwd(@paths);
+  if ($file[0] != "/"[0]) {
+    printf("%s\n", abs_path($file, max_path_depth));
+  } else {
+    printf("%s\n", $file);
   }
-  printf("%s\n", str(@filename[tid]));
-  delete(@filename, tid);
 }
 
 tracepoint:syscalls:sys_exit_open,
@@ -150,11 +97,12 @@ tracepoint:syscalls:sys_exit_openat,
 tracepoint:syscalls:sys_exit_openat2
 /@filename[tid]/
 {
-  sys_exit(args.ret, @filename, @paths);
+  $file = str(@filename[tid]);
+  sys_exit(args.ret, $file);
+  delete(@filename, tid);
 }
 
 END
 {
   clear(@filename);
-  clear(@paths);
 }


### PR DESCRIPTION
In PR [1], opensnoop.bt support full-path of file, this PR moves the functionality to retrieve absolute paths to stdlib. Also, instead of using @map to store each level of the path, it uses the string concatenate `str_concat()` [2] to assemble an absolute path.

Add stdlib function:

    fs_root();
    abspath($path, max_path_depth);

[1] https://github.com/bpftrace/bpftrace/pull/4601
    commit 89ac7c69f7c5 ("tools/opensnoop: support full path (#4601)")
[2] https://github.com/bpftrace/bpftrace/pull/5265
    commit f57772cbfa99 ("stdlib: add str_concat() to concatenate two strings (#5265)")
