### PR TITLE
build: prefer vendored libbpf UAPI headers over system ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to
   - [#5272](https://github.com/bpftrace/bpftrace/pull/5272)
 - Print zero values for empty scalar maps
   - [#5239](https://github.com/bpftrace/bpftrace/pull/5239)
+- Fix to use vendored BPF UAPI headers across entire codebase to prevent build failures and inconsistencies
+  - [#5277](https://github.com/bpftrace/bpftrace/pull/5277)
 #### Security
 #### Docs
 #### Tools

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,14 @@ find_package(LibBcc REQUIRED)
 include_directories(SYSTEM ${LIBBCC_INCLUDE_DIRS})
 
 find_package(LibBpf REQUIRED)
-include_directories(SYSTEM ${LIBBPF_INCLUDE_DIRS})
 if(USE_SYSTEM_LIBBPF)
+  include_directories(SYSTEM ${LIBBPF_INCLUDE_DIRS})
   message(WARNING "Using system libbpf, please ensure that the version is greater than or equal to the submodule")
+else()
+  include_directories(BEFORE SYSTEM
+    ${LIBBPF_INCLUDE_DIRS}
+    ${CMAKE_SOURCE_DIR}/libbpf/include/uapi
+    ${CMAKE_SOURCE_DIR}/libbpf/include)
 endif()
 
 find_package(LibElf REQUIRED)


### PR DESCRIPTION
bpftrace vendors the kernel UAPI headers via the libbpf submodule, but runtime sources write #include <linux/bpf.h>, which resolves to the system copy instead. On systems whose UAPI headers predate BPF_TRACE_KPROBE_SESSION (added in kernel commit 535a3692ba72, "bpf: Add support for kprobe session attach", v6.10) this breaks the build.

When building against the vendored libbpf, put its include/uapi directory ahead of the system paths on the include search path so all <linux/...> UAPI includes resolve to the vendored copies, keeping the build independent of the headers installed on the host. Using SYSTEM directories also keeps clang-tidy from linting the vendored headers.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
