### PR TITLE
Fix segfault from debug locations leaking between generated functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix crash caused by debug locations leaking between generated functions
+  - [#5278](https://github.com/bpftrace/bpftrace/pull/5278)
 - Fix address space handling for map and variable addresses
   - [#5272](https://github.com/bpftrace/bpftrace/pull/5272)
 - Fix uaddr() to preserve pointer type for correct dereference size

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -220,16 +220,43 @@ IRBuilderBPF::IRBuilderBPF(LLVMContext &context,
                          &module_);
 }
 
+void IRBuilderBPF::SetInsertPoint(BasicBlock *bb)
+{
+  IRBuilder<>::SetInsertPoint(bb);
+  SetCurrentDebugLocation(llvm::DebugLoc());
+}
+
+void IRBuilderBPF::SetInsertPoint(Instruction *inst)
+{
+  IRBuilder<>::SetInsertPoint(inst);
+  SetCurrentDebugLocation(llvm::DebugLoc());
+}
+
+void IRBuilderBPF::SetInsertPoint(BasicBlock *bb, BasicBlock::iterator ip)
+{
+  IRBuilder<>::SetInsertPoint(bb, ip);
+  SetCurrentDebugLocation(llvm::DebugLoc());
+}
+
+void IRBuilderBPF::SetInsertPoint(BasicBlock::iterator ip)
+{
+  IRBuilder<>::SetInsertPoint(ip);
+  SetCurrentDebugLocation(llvm::DebugLoc());
+}
+
+void IRBuilderBPF::restoreIP(InsertPoint ip)
+{
+  IRBuilder<>::restoreIP(ip);
+  SetCurrentDebugLocation(llvm::DebugLoc());
+}
+
 void IRBuilderBPF::hoist(const std::function<void()> &functor)
 {
   llvm::Function *parent = GetInsertBlock()->getParent();
   BasicBlock &entry_block = parent->getEntryBlock();
 
   auto ip = saveIP();
-  if (entry_block.empty())
-    SetInsertPoint(&entry_block);
-  else
-    SetInsertPoint(&entry_block.front());
+  SetInsertPoint(&entry_block, entry_block.begin());
 
   functor();
   restoreIP(ip);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -28,6 +28,19 @@ public:
   // this wrapper guards against calling lifetime.end on non-alloca values.
   void CreateLifetimeEnd(Value *val);
 
+  // The builder must never carry a debug location: we attach locations to
+  // individual instructions instead. Several IRBuilder::SetInsertPoint
+  // overloads copy the !dbg of the instruction they land on, which then sticks
+  // to everything emitted afterwards, which can cause leaking and segfaults if
+  // a location outlives the function it came from. These wrappers clear it so
+  // no insertion point change can carry a location along.
+  // https://github.com/bpftrace/bpftrace/pull/5278
+  void SetInsertPoint(BasicBlock *bb);
+  void SetInsertPoint(Instruction *inst);
+  void SetInsertPoint(BasicBlock *bb, BasicBlock::iterator ip);
+  void SetInsertPoint(BasicBlock::iterator ip);
+  void restoreIP(InsertPoint ip);
+
   AllocaInst *CreateAllocaBPF(llvm::Type *ty, const std::string &name = "");
   AllocaInst *CreateAllocaBPF(const SizedType &stype,
                               const std::string &name = "");

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2128,13 +2128,8 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     }
 
     auto *inst = b_.CreateCall(func, arg_values, call.func);
-    return ScopedExpr(inst, [this, inst, &call] {
-      // We set the debug location on the call instructions only after the
-      // scoped expression is no longer used. Otherwise the instruction emitter
-      // seems to use this location for everything, which results in problems.
-      inst->setDebugLoc(
-          debug_.createDebugLocation(llvm_ctx_, scope_, call.loc));
-    });
+    inst->setDebugLoc(debug_.createDebugLocation(llvm_ctx_, scope_, call.loc));
+    return ScopedExpr(inst);
   }
 }
 
@@ -4892,12 +4887,8 @@ ScopedExpr CodegenLLVM::createExternFuncCall(
   }
 
   auto *inst = b_.CreateCall(func, arg_values, name);
-  return ScopedExpr(inst, [this, inst, loc] {
-    // We set the debug location on the call instructions only after the
-    // scoped expression is no longer used. Otherwise the instruction emitter
-    // seems to use this location for everything, which results in problems.
-    inst->setDebugLoc(debug_.createDebugLocation(llvm_ctx_, scope_, loc));
-  });
+  inst->setDebugLoc(debug_.createDebugLocation(llvm_ctx_, scope_, loc));
+  return ScopedExpr(inst);
 }
 
 /// This should emit

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -177,3 +177,8 @@ AFTER ./testprogs/syscall read
 EXPECT Attached 1 probe
 TIMEOUT 1
 REQUIRES_FEATURE kprobe_session
+
+NAME debug location does not leak across probes
+PROG begin { $pid = curtask->pid; } end { $pid = curtask->pid; }
+EXPECT Attached 2 probes
+TIMEOUT 1


### PR DESCRIPTION
Stacked PRs:
 * __->__#5278


--- --- ---

### Fix segfault from debug locations leaking between generated functions


Bug:
IRBuilder::SetInsertPoint(Instruction *) copies that instruction's !dbg
into the builder's current debug location, and nothing clears it again:
SetInsertPoint(BasicBlock *) leaves it alone and restoreIP() only
re-copies from wherever it lands. hoist() moves the insert point to the
front of the entry block to place allocas there, so once that first
instruction carries a !dbg -- codegen attaches one to the calls it emits
-- the location is sticky for the rest of code generation.

Codegen emits one LLVM function per probe and per for-loop callback into
a single module, so the stale location outlives the function it came
from, and instructions in the next function end up tagged with a
DILocation whose scope belongs to the previous function's DISubprogram.
DWARF emission finds no parent DIE for that entity and dereferences
null:

  llvm::DIE::getUnitDie()
  llvm::DwarfDebug::finishEntityDefinitions()
  llvm::DwarfDebug::finalizeModuleInfo()
  llvm::DwarfDebug::endModule()
  llvm::AsmPrinter::doFinalization()

This makes

  bpftrace -e 'begin { $pid = curtask->pid; } end { $pid = curtask->pid; }'

segfault before attaching. Under --verify-llvm-ir, which every runtime
test runs with, the same program fails verification instead, with "!dbg
attachment points at wrong subprogram for function".

Fix:
Shadow every SetInsertPoint overload and restoreIP in IRBuilderBPF and
clear the debug location after each cursor move. The builder is never
meant to carry one -- bpftrace attaches locations to individual call
instructions instead -- so clearing is enough and no save/restore is
needed.

Wrapping all of the overloads rather than only the ones that copy a !dbg
today keeps the invariant from depending on which overloads LLVM chooses
to copy from, and on which ones bpftrace happens to call. It is also the
only way to shadow them at all without a using-declaration that would
re-expose the unwrapped ones to overload resolution. The redundant
clears are free: they run at compile time, not in the BPF program.

hoist() also switches to the two-argument SetInsertPoint, which drops
the empty-block special case since begin() == end() there.

This lets visit(Call &) and createExternFuncCall() set the debug
location on the call directly again. Deferring it until the ScopedExpr
was destroyed was aimed at this same bug: it shrank the window in which
the entry block's first instruction had a !dbg for hoist() to pick up,
but never closed it.

Co-authored-by: Shakeel Butt <shakeel.butt@linux.dev>

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>