### PR TITLE
Ensure that string allocation and usage are consistent in size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Ensure that string allocation and usage are consistent in size.
+  - [#5279](https://github.com/bpftrace/bpftrace/pull/5279)
 - Fix crash caused by debug locations leaking between generated functions
   - [#5278](https://github.com/bpftrace/bpftrace/pull/5278)
 - Fix address space handling for map and variable addresses

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -587,10 +587,9 @@ CallInst *IRBuilderBPF::createPerCpuMapLookup(const std::string &map_name,
 }
 
 Value *IRBuilderBPF::CreateGetStrAllocation(const std::string &name,
-                                            const Location &loc,
-                                            uint64_t pad)
+                                            const Location &loc)
 {
-  const auto max_strlen = bpftrace_.config_->max_strlen + pad;
+  const auto max_strlen = bpftrace_.config_->pad_max_strlen();
   const auto str_type = CreateArray(max_strlen, CreateInt8());
   return createAllocation(bpftrace::globalvars::GET_STR_BUFFER,
                           GetType(str_type),

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -132,9 +132,7 @@ public:
   CallInst *CreatePerCpuPtr(Value *var, Value *cpu, const Location &loc);
   CallInst *CreateThisCpuPtr(Value *var, const Location &loc);
   CallInst *CreateGetSocketCookie(Value *var, const Location &loc);
-  Value *CreateGetStrAllocation(const std::string &name,
-                                const Location &loc,
-                                uint64_t pad = 0);
+  Value *CreateGetStrAllocation(const std::string &name, const Location &loc);
   Value *CreateGetFmtStringArgsAllocation(StructType *struct_type,
                                           const std::string &name,
                                           const Location &loc);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1406,7 +1406,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
 
     return ScopedExpr();
   } else if (call.func == "str") {
-    const auto max_strlen = bpftrace_.config_->max_strlen;
+    const auto max_strlen = bpftrace_.config_->pad_max_strlen();
     // Largest read we'll allow = our global string buffer size
     Value *strlen = b_.getInt64(max_strlen);
     if (call.vargs.size() > 1) {
@@ -1426,24 +1426,12 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       strlen = b_.CreateSelect(Cmp, proposed_strlen, strlen, "str.min.select");
     }
 
-    // Note that the successful copying of the string will always include the
-    // NULL byte, so we explicitly poison the string value up front. This
-    // allows the conversion to know when the string has been truncated. We
-    // have added an extra byte to the kernel copy to account for this.
-    // Anything copied out of this will be copied as a str[N] type that may
-    // omit the NUL byte (which indicates that it has been truncated).
-    uint64_t padding = 0;
-    Value *readlen = strlen;
-    if (max_strlen < 1024) {
-      padding = 1;
-      readlen = b_.CreateAdd(readlen, b_.getInt64(padding));
-    }
-    Value *buf = b_.CreateGetStrAllocation("str", call.loc, padding);
-    b_.CreateMemsetBPF(buf, b_.getInt8(0xff), max_strlen + padding);
+    Value *buf = b_.CreateGetStrAllocation("str", call.loc);
+    b_.CreateMemsetBPF(buf, b_.getInt8(0xff), max_strlen);
     auto &arg0 = call.vargs.front();
     auto scoped_expr = visit(call.vargs.front());
     b_.CreateProbeReadStr(buf,
-                          readlen,
+                          strlen,
                           scoped_expr.value(),
                           type_map_.type(arg0).GetAS(),
                           call.loc);

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -391,7 +391,7 @@ void ResourceAnalyser::visit(Call &call)
   }
 
   if (call.func == "str" || call.func == "buf" || call.func == "path") {
-    const auto max_strlen = bpftrace_.config_->max_strlen;
+    const auto max_strlen = bpftrace_.config_->pad_max_strlen();
     if (exceeds_stack_limit(max_strlen))
       resources_.str_buffers++;
   }
@@ -456,7 +456,7 @@ void ResourceAnalyser::visit(Map &map)
                                            it->second.value,
                                            it->second.description);
     if (std::holds_alternative<std::string>(it->second.value)) {
-      const auto max_strlen = bpftrace_.config_->max_strlen;
+      const auto max_strlen = bpftrace_.config_->pad_max_strlen();
       if (exceeds_stack_limit(max_strlen))
         resources_.str_buffers++;
     }
@@ -567,7 +567,7 @@ void ResourceAnalyser::visit(IfExpr &if_expr)
   // blow it up. So we need a scratch buffer for it.
 
   if (type_map_.type(&if_expr).IsStringTy()) {
-    const auto max_strlen = bpftrace_.config_->max_strlen;
+    const auto max_strlen = bpftrace_.config_->pad_max_strlen();
     if (exceeds_stack_limit(max_strlen))
       resources_.str_buffers++;
   }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -439,4 +439,13 @@ std::string Config::get_license_str(CompatibleBPFLicense license)
   return "";
 }
 
+uint64_t Config::pad_max_strlen() const
+{
+  // Note that the successful copying of a string will always include the
+  // NULL byte, so we always add an extra byte to detect truncation.
+  // Anything copied out of this will be copied as a str[N] type that may
+  // omit the NUL byte (which indicates that it has been truncated).
+  return max_strlen < 1024 ? max_strlen + 1 : max_strlen;
+}
+
 } // namespace bpftrace

--- a/src/config.h
+++ b/src/config.h
@@ -87,6 +87,8 @@ public:
 
   // Initialized in the constructor.
   UserSymbolCacheType user_symbol_cache_type;
+
+  uint64_t pad_max_strlen() const;
 };
 
 // Specific key has been renamed, must be handled by caller. This may be

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -245,7 +245,7 @@ SizedType GlobalVars::get_sized_type(const std::string &global_var_name,
 
   if (global_var_name == GET_STR_BUFFER) {
     assert(resources.str_buffers > 0);
-    const auto max_strlen = bpftrace_config.max_strlen;
+    const auto max_strlen = bpftrace_config.pad_max_strlen();
     return make_rw_type(resources.str_buffers,
                         CreateArray(max_strlen, CreateInt8()));
   }

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -247,7 +247,7 @@ SizedType GlobalVars::get_sized_type(const std::string &global_var_name,
     assert(resources.str_buffers > 0);
     const auto max_strlen = bpftrace_config.max_strlen;
     return make_rw_type(resources.str_buffers,
-                        CreateArray(max_strlen, CreateInt8()));
+                        CreateArray(max_strlen + 1, CreateInt8()));
   }
 
   if (global_var_name == READ_MAP_VALUE_BUFFER) {

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -182,3 +182,13 @@ NAME debug location does not leak across probes
 PROG begin { $pid = curtask->pid; } end { $pid = curtask->pid; }
 EXPECT Attached 2 probes
 TIMEOUT 1
+
+NAME config max_strlen and on_stack_limit
+PROG config = { max_strlen = 8; on_stack_limit = 8 } t:syscalls:sys_enter_execve { print(str(args.filename)); exit(); }
+AFTER ./testprogs/syscall execve ./testprogs/true &>/dev/null
+EXPECT_REGEX /.......\.\.
+
+NAME config max_strlen with 8 cpus
+RUN printf '0-7\n' > /tmp/fake_possible && unshare -m bash -c 'mount --bind /tmp/fake_possible /sys/devices/system/cpu/possible && exec {{BPFTRACE}} -e "config = { max_strlen = 8; } t:syscalls:sys_enter_execve { print(str(args.filename)); exit(); }"'
+AFTER ./testprogs/syscall execve ./testprogs/true &>/dev/null
+EXPECT_REGEX /.......\.\.


### PR DESCRIPTION
Since [1] defaults to adding 1 ('\0') to the length of strings less than 1024, this causes the bpf verifier to complain. We can solve this problem by simply adding 1 to the string length by default.

[1] commit 3049bbf4170f ("printf: use `OpaqueValue` for formatting")
    https://github.com/bpftrace/bpftrace/blob/master/src/ast/passes/codegen_llvm.cpp#L1437C1-L1442C69

```c
    if (max_strlen < 1024) {
      padding = 1;
      readlen = b_.CreateAdd(readlen, b_.getInt64(padding));
    }
    Value *buf = b_.CreateGetStrAllocation("str", call.loc, padding);
    b_.CreateMemsetBPF(buf, b_.getInt8(0xff), max_strlen + padding);
```

codegen 'str(args.filename)' pseudocode:

    buf = CreateGetStrAllocation() {
            createAllocation() {
              createScratchBuffer() {
                get_sized_type() {
                  /* actually allocate max_strlen */
                }
              }
            }
          };
    CreateMemsetBPF(buf, ..., max_strlen + padding); // invalid access

Example:

    config = { max_strlen = 64; }
    tracepoint:syscalls:sys_enter_openat
    {
      str(args.filename);
    }

on centos stream 10, 6.12.0-233.el10.x86_64, llvm 22.1.1:

    ERROR: Error loading BPF program for tracepoint_syscalls_sys_enter_openat_1. Error code: -13 (Permission denied).
    Kernel error log:
    0: R1=ctx() R10=fp0
    ;  @ bpftrace.bpf.o:0
    0: (bf) r6 = r1                       ; R1=ctx() R6=ctx()
    1: (18) r1 = 0xffffce058085a000       ; R1=map_value(map=26a28e50.rodata,ks=4,vs=8)
    3: (79) r7 = *(u64 *)(r1 +0)          ; R1=map_value(map=26a28e50.rodata,ks=4,vs=8) R7=7
    4: (85) call bpf_get_smp_processor_id#8       ; R0=scalar(smin=smin32=0,smax=umax=smax32=umax32=7,var_off=(0x0; 0x7))
    5: (5f) r7 &= r0                      ; R0=scalar(smin=smin32=0,smax=umax=smax32=umax32=7,var_off=(0x0; 0x7)) R7=scalar(smin=smin32=0,smax=umax=smax32=umax32=7,var_off=(0x0; 0x7))
    6: (67) r7 <<= 6                      ; R7=scalar(smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0))
    7: (18) r1 = 0xffffce058088a000       ; R1=map_value(map=.data.get_str_b,ks=4,vs=512)
    9: (0f) r1 += r7                      ; R1=map_value(map=.data.get_str_b,ks=4,vs=512,smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0)) R7=scalar(smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0))
    10: (b7) r2 = -1                      ; R2=-1
    11: (7b) *(u64 *)(r1 +0) = r2         ; R1=map_value(map=.data.get_str_b,ks=4,vs=512,smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0)) R2=-1
    12: (7b) *(u64 *)(r1 +8) = r2         ; R1=map_value(map=.data.get_str_b,ks=4,vs=512,smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0)) R2=-1
    13: (7b) *(u64 *)(r1 +16) = r2        ; R1=map_value(map=.data.get_str_b,ks=4,vs=512,smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0)) R2=-1
    14: (7b) *(u64 *)(r1 +24) = r2        ; R1=map_value(map=.data.get_str_b,ks=4,vs=512,smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0)) R2=-1
    15: (7b) *(u64 *)(r1 +32) = r2        ; R1=map_value(map=.data.get_str_b,ks=4,vs=512,smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0)) R2=-1
    16: (7b) *(u64 *)(r1 +40) = r2        ; R1=map_value(map=.data.get_str_b,ks=4,vs=512,smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0)) R2=-1
    17: (7b) *(u64 *)(r1 +48) = r2        ; R1=map_value(map=.data.get_str_b,ks=4,vs=512,smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0)) R2=-1
    18: (7b) *(u64 *)(r1 +56) = r2        ; R1=map_value(map=.data.get_str_b,ks=4,vs=512,smin=smin32=0,smax=umax=smax32=umax32=448,var_off=(0x0; 0x1c0)) R2=-1
    19: (73) *(u8 *)(r1 +64) = r2
    invalid access to map value, value_size=512 off=512 size=1
    R1 max value is outside of the allowed memory range
    processed 18 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0
