### PR TITLE
tests/self: strings.bt: fix typo

### DIFF
--- a/tests/self/strings.bt
+++ b/tests/self/strings.bt
@@ -1,4 +1,4 @@
-test:str_contat
+test:str_concat
 {
   $log = "log";
   $filename = "system.journal";


### PR DESCRIPTION
str_contat should be str_concat.

Fixes: f57772cbfa99 ("stdlib: add str_concat() to concatenate two strings (#5265)")
