### PR TITLE
pre_type_check fix ups

### DIFF
--- a/src/ast/passes/types/pre_type_check.cpp
+++ b/src/ast/passes/types/pre_type_check.cpp
@@ -709,12 +709,6 @@ void CallPreCheck::visit(Identifier &identifier)
           << "Invalid PID namespace mode: " << identifier.ident
           << " (expects: curr_ns or init)";
     }
-  } else if (func_ == "signal") {
-    if (identifier.ident != "current_pid" &&
-        identifier.ident != "current_tid") {
-      identifier.addError() << "Invalid signal target: " << identifier.ident
-                            << " (expects: current_pid or current_tid)";
-    }
   }
 }
 

--- a/tests/pre_type_check.cpp
+++ b/tests/pre_type_check.cpp
@@ -537,16 +537,6 @@ TEST(CallPreCheck, strncmp)
        "Builtin strncmp requires a non-negative literal");
 }
 
-TEST(CallPreCheck, signal)
-{
-  test(R"(begin { signal(current_pid) })");
-  test(R"(begin { signal(current_tid) })");
-
-  // Errors
-  test(R"(begin { signal(bob) })",
-       "Invalid signal target: bob (expects: current_pid or current_tid)");
-}
-
 TEST(CallPreCheck, pid_tid)
 {
   test("begin { $i = tid(); }");
@@ -593,14 +583,11 @@ TEST(CallPreCheck, raw_map_arg_funcs)
 {
   test("kprobe:f { @x[1,2] = count(); clear(@x); }");
   test("kprobe:f { @x[1,2] = count(); zero(@x); }");
-  test("kprobe:f { @x[1,2] = count(); len(@x); }");
 
   // Errors
   test("kprobe:f { @x[1,2] = count(); clear(@x[3,4]); }",
        "expects a map argument");
   test("kprobe:f { @x[1,2] = count(); zero(@x[3,4]); }",
-       "expects a map argument");
-  test("kprobe:f { @x[1,2] = count(); len(@x[3,4]); }",
        "expects a map argument");
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #5287
 * #5286
 * #5285
 * #5284
 * __->__#5283


--- --- ---

### pre_type_check fix ups


Signal is now a macro that gets expanded so these pre_type_check paths
don't even get hit.

Also remove the 'len' check in the tests as it's also a macro that gets
expanded.

Signed-off-by: Jordan Rome <jordalgo@meta.com>