### PR TITLE
Create a separate pass for the config builtin

### DIFF
--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -14,6 +14,118 @@ namespace bpftrace::ast {
 
 namespace {
 
+class ConfigBuiltins
+    : public Visitor<ConfigBuiltins, std::optional<Expression>> {
+public:
+  ConfigBuiltins(ASTContext &ast, BPFtrace &bpftrace)
+      : ast_(ast), bpftrace_(bpftrace)
+  {
+  }
+
+  using Visitor<ConfigBuiltins, std::optional<Expression>>::visit;
+
+  std::optional<Expression> visit(Expression &expr)
+  {
+    auto replacement =
+        Visitor<ConfigBuiltins, std::optional<Expression>>::visit(expr.value);
+    if (replacement) {
+      expr.value = replacement->value;
+    }
+    return std::nullopt;
+  }
+
+  std::optional<Expression> visit(Builtin &builtin)
+  {
+    if (builtin.ident == "__builtin_config") {
+      return expand_config(builtin.loc);
+    }
+
+    return std::nullopt;
+  }
+
+  std::optional<Expression> visit(Identifier &identifier)
+  {
+    if (identifier.ident == "__builtin_config") {
+      return expand_config(identifier.loc);
+    }
+
+    return std::nullopt;
+  }
+
+private:
+  std::optional<Expression> expand_config(const Location &loc)
+  {
+    std::vector<std::pair<std::string, Expression>> args;
+    auto &cfg = bpftrace_.config_;
+
+    auto add_bool = [&](const char *key, bool val) {
+      args.emplace_back(key, ast_.make_node<Boolean>(loc, val));
+    };
+    auto add_int = [&](const char *key, uint64_t val) {
+      args.emplace_back(key, ast_.make_node<Integer>(loc, val));
+    };
+    auto add_str = [&](const char *key, const std::string &val) {
+      args.emplace_back(key, ast_.make_node<String>(loc, val));
+    };
+
+    add_bool("cpp_demangle", cfg->cpp_demangle);
+    add_bool("lazy_symbolication", cfg->lazy_symbolication);
+    add_bool("print_maps_on_exit", cfg->print_maps_on_exit);
+    add_bool("use_blazesym", cfg->use_blazesym);
+    add_bool("show_debug_info", cfg->show_debug_info);
+
+    add_int("log_size", cfg->log_size);
+    add_int("max_bpf_progs", cfg->max_bpf_progs);
+    add_int("max_cat_bytes", cfg->max_cat_bytes);
+    add_int("max_map_keys", cfg->max_map_keys);
+    add_int("max_probes", cfg->max_probes);
+    add_int("max_strlen", cfg->max_strlen);
+    add_int("on_stack_limit", cfg->on_stack_limit);
+    add_int("perf_rb_pages", cfg->perf_rb_pages);
+
+    add_str("str_trunc_trailer", cfg->str_trunc_trailer);
+
+    auto unstable_str = [](ConfigUnstable u) {
+      switch (u) {
+        case ConfigUnstable::enable:
+          return "enable";
+        case ConfigUnstable::warn:
+          return "warn";
+        case ConfigUnstable::error:
+          return "error";
+      }
+      return "error";
+    };
+
+    add_str("unstable_import_statement",
+            unstable_str(cfg->unstable_import_statement));
+    add_str("unstable_tseries", unstable_str(cfg->unstable_tseries));
+    add_str("unstable_typeinfo", unstable_str(cfg->unstable_typeinfo));
+    add_str("unstable_dw_ustack", unstable_str(cfg->unstable_dw_ustack));
+
+    std::string missing_str;
+    switch (cfg->missing_probes) {
+      case ConfigMissingProbes::ignore:
+        missing_str = "ignore";
+        break;
+      case ConfigMissingProbes::warn:
+        missing_str = "warn";
+        break;
+      case ConfigMissingProbes::error:
+        missing_str = "error";
+        break;
+    }
+
+    add_str("missing_probes", missing_str);
+    add_str("stack_mode", STACK_MODE_NAME_MAP.at(cfg->stack_mode));
+    add_str("license", bpftrace::Config::get_license_str(cfg->license));
+    return make_record(ast_, loc, std::move(args));
+  }
+
+  ASTContext &ast_;
+  BPFtrace &bpftrace_;
+};
+
 class Builtins : public Visitor<Builtins, std::optional<Expression>> {
 public:
   explicit Builtins(ASTContext &ast, BPFtrace &bpftrace, bool has_child = true)
@@ -22,8 +134,8 @@ public:
   using Visitor<Builtins, std::optional<Expression>>::visit;
   std::optional<Expression> visit(Builtin &builtin);
   std::optional<Expression> visit(Call &call);
-  std::optional<Expression> visit(Identifier &identifier);
   std::optional<Expression> visit(Expression &expression);
+  std::optional<Expression> visit(Identifier &identifier);
   std::optional<Expression> visit(For &f);
   std::optional<Expression> visit(Probe &probe);
   std::optional<Expression> check(const std::string &ident, Node &node);
@@ -104,78 +216,6 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
       return ast_.make_node<Integer>(
           node.loc, util::file_ino(probe->attach_points.front()->target));
     }
-  } else if (ident == "__builtin_config") {
-    std::vector<std::pair<std::string, Expression>> args;
-    auto &cfg = bpftrace_.config_;
-
-    auto add_bool = [&](const char *key, bool val) {
-      args.emplace_back(key, ast_.make_node<Boolean>(node.loc, val));
-    };
-    auto add_int = [&](const char *key, uint64_t val) {
-      args.emplace_back(key, ast_.make_node<Integer>(node.loc, val));
-    };
-    auto add_str = [&](const char *key, const std::string &val) {
-      args.emplace_back(key, ast_.make_node<String>(node.loc, val));
-    };
-
-    // Booleans
-    add_bool("cpp_demangle", cfg->cpp_demangle);
-    add_bool("lazy_symbolication", cfg->lazy_symbolication);
-    add_bool("print_maps_on_exit", cfg->print_maps_on_exit);
-    add_bool("use_blazesym", cfg->use_blazesym);
-    add_bool("show_debug_info", cfg->show_debug_info);
-
-    // Integers
-    add_int("log_size", cfg->log_size);
-    add_int("max_bpf_progs", cfg->max_bpf_progs);
-    add_int("max_cat_bytes", cfg->max_cat_bytes);
-    add_int("max_map_keys", cfg->max_map_keys);
-    add_int("max_probes", cfg->max_probes);
-    add_int("max_strlen", cfg->max_strlen);
-    add_int("on_stack_limit", cfg->on_stack_limit);
-    add_int("perf_rb_pages", cfg->perf_rb_pages);
-
-    // Strings
-    add_str("str_trunc_trailer", cfg->str_trunc_trailer);
-
-    // Enums -> Strings
-    auto unstable_str = [](ConfigUnstable u) {
-      switch (u) {
-        case ConfigUnstable::enable:
-          return "enable";
-        case ConfigUnstable::warn:
-          return "warn";
-        case ConfigUnstable::error:
-          return "error";
-      }
-      return "error";
-    };
-
-    add_str("unstable_import_statement",
-            unstable_str(cfg->unstable_import_statement));
-    add_str("unstable_tseries", unstable_str(cfg->unstable_tseries));
-    add_str("unstable_typeinfo", unstable_str(cfg->unstable_typeinfo));
-    add_str("unstable_dw_ustack", unstable_str(cfg->unstable_dw_ustack));
-
-    std::string missing_str;
-    switch (cfg->missing_probes) {
-      case ConfigMissingProbes::ignore:
-        missing_str = "ignore";
-        break;
-      case ConfigMissingProbes::warn:
-        missing_str = "warn";
-        break;
-      case ConfigMissingProbes::error:
-        missing_str = "error";
-        break;
-    }
-
-    add_str("missing_probes", missing_str);
-
-    add_str("stack_mode", STACK_MODE_NAME_MAP.at(cfg->stack_mode));
-
-    add_str("license", bpftrace::Config::get_license_str(cfg->license));
-    return make_record(ast_, node.loc, std::move(args));
   }
 
   return std::nullopt;
@@ -369,6 +409,16 @@ Pass CreateBuiltinsPass()
   };
 
   return Pass::create("Builtins", fn);
+};
+
+Pass CreateConfigBuiltinsPass()
+{
+  auto fn = [&](ASTContext &ast, BPFtrace &bpftrace) {
+    ConfigBuiltins config_builtins(ast, bpftrace);
+    config_builtins.visit(ast.root);
+  };
+
+  return Pass::create("ConfigBuiltins", fn);
 };
 
 Pass CreatePreExpansionBuiltinsPass()

--- a/src/ast/passes/builtins.h
+++ b/src/ast/passes/builtins.h
@@ -8,6 +8,9 @@ namespace bpftrace::ast {
 // merges probes (e.g. session expansion merging kprobe + kretprobe).
 Pass CreatePreExpansionBuiltinsPass();
 
+// Expand builtins that must be available before literal folding.
+Pass CreateConfigBuiltinsPass();
+
 // Fill in the values of all intrinsics.
 Pass CreateBuiltinsPass();
 

--- a/src/ast/passes/parse_passes.h
+++ b/src/ast/passes/parse_passes.h
@@ -58,6 +58,8 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateArgsResolverPass());
   passes.emplace_back(CreateFieldAnalyserPass());
   passes.emplace_back(CreateClangParsePass(std::move(extra_flags)));
+  // separate pass so we can fold accesses to configs e.g. `config.max_strlen`
+  passes.emplace_back(CreateConfigBuiltinsPass());
   passes.emplace_back(CreateFoldLiteralsPass());
   passes.emplace_back(CreateBuiltinsPass());
   passes.emplace_back(CreateCMacroExpansionPass());

--- a/src/ast/passes/types/pre_type_check.cpp
+++ b/src/ast/passes/types/pre_type_check.cpp
@@ -709,12 +709,6 @@ void CallPreCheck::visit(Identifier &identifier)
           << "Invalid PID namespace mode: " << identifier.ident
           << " (expects: curr_ns or init)";
     }
-  } else if (func_ == "signal") {
-    if (identifier.ident != "current_pid" &&
-        identifier.ident != "current_tid") {
-      identifier.addError() << "Invalid signal target: " << identifier.ident
-                            << " (expects: current_pid or current_tid)";
-    }
   }
 }
 

--- a/tests/pre_type_check.cpp
+++ b/tests/pre_type_check.cpp
@@ -40,6 +40,7 @@ void test(const std::string &input,
                 .add(ast::CreateMacroExpansionPass())
                 .add(ast::CreateParseAttachpointsPass())
                 .add(ast::CreateProbeAndApExpansionPass())
+                .add(ast::CreateConfigBuiltinsPass())
                 .add(ast::CreateFoldLiteralsPass())
                 .add(ast::CreateBuiltinsPass())
                 .add(ast::CreateMapSugarPass())

--- a/tests/pre_type_check.cpp
+++ b/tests/pre_type_check.cpp
@@ -537,16 +537,6 @@ TEST(CallPreCheck, strncmp)
        "Builtin strncmp requires a non-negative literal");
 }
 
-TEST(CallPreCheck, signal)
-{
-  test(R"(begin { signal(current_pid) })");
-  test(R"(begin { signal(current_tid) })");
-
-  // Errors
-  test(R"(begin { signal(bob) })",
-       "Invalid signal target: bob (expects: current_pid or current_tid)");
-}
-
 TEST(CallPreCheck, pid_tid)
 {
   test("begin { $i = tid(); }");
@@ -593,14 +583,11 @@ TEST(CallPreCheck, raw_map_arg_funcs)
 {
   test("kprobe:f { @x[1,2] = count(); clear(@x); }");
   test("kprobe:f { @x[1,2] = count(); zero(@x); }");
-  test("kprobe:f { @x[1,2] = count(); len(@x); }");
 
   // Errors
   test("kprobe:f { @x[1,2] = count(); clear(@x[3,4]); }",
        "expects a map argument");
   test("kprobe:f { @x[1,2] = count(); zero(@x[3,4]); }",
-       "expects a map argument");
-  test("kprobe:f { @x[1,2] = count(); len(@x[3,4]); }",
        "expects a map argument");
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #5287
 * #5286
 * #5285
 * __->__#5284
 * #5283


--- --- ---

### Create a separate pass for the config builtin


This is so we can fold access in the following pass e.g.
`config.max_strlen`.

Signed-off-by: Jordan Rome <jordalgo@meta.com>