### PR TITLE
Error for strings larger than max_str_len

### DIFF
--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -14,6 +14,118 @@ namespace bpftrace::ast {
 
 namespace {
 
+class ConfigBuiltins
+    : public Visitor<ConfigBuiltins, std::optional<Expression>> {
+public:
+  ConfigBuiltins(ASTContext &ast, BPFtrace &bpftrace)
+      : ast_(ast), bpftrace_(bpftrace)
+  {
+  }
+
+  using Visitor<ConfigBuiltins, std::optional<Expression>>::visit;
+
+  std::optional<Expression> visit(Expression &expr)
+  {
+    auto replacement =
+        Visitor<ConfigBuiltins, std::optional<Expression>>::visit(expr.value);
+    if (replacement) {
+      expr.value = replacement->value;
+    }
+    return std::nullopt;
+  }
+
+  std::optional<Expression> visit(Builtin &builtin)
+  {
+    if (builtin.ident == "__builtin_config") {
+      return expand_config(builtin.loc);
+    }
+
+    return std::nullopt;
+  }
+
+  std::optional<Expression> visit(Identifier &identifier)
+  {
+    if (identifier.ident == "__builtin_config") {
+      return expand_config(identifier.loc);
+    }
+
+    return std::nullopt;
+  }
+
+private:
+  std::optional<Expression> expand_config(const Location &loc)
+  {
+    std::vector<std::pair<std::string, Expression>> args;
+    auto &cfg = bpftrace_.config_;
+
+    auto add_bool = [&](const char *key, bool val) {
+      args.emplace_back(key, ast_.make_node<Boolean>(loc, val));
+    };
+    auto add_int = [&](const char *key, uint64_t val) {
+      args.emplace_back(key, ast_.make_node<Integer>(loc, val));
+    };
+    auto add_str = [&](const char *key, const std::string &val) {
+      args.emplace_back(key, ast_.make_node<String>(loc, val));
+    };
+
+    add_bool("cpp_demangle", cfg->cpp_demangle);
+    add_bool("lazy_symbolication", cfg->lazy_symbolication);
+    add_bool("print_maps_on_exit", cfg->print_maps_on_exit);
+    add_bool("use_blazesym", cfg->use_blazesym);
+    add_bool("show_debug_info", cfg->show_debug_info);
+
+    add_int("log_size", cfg->log_size);
+    add_int("max_bpf_progs", cfg->max_bpf_progs);
+    add_int("max_cat_bytes", cfg->max_cat_bytes);
+    add_int("max_map_keys", cfg->max_map_keys);
+    add_int("max_probes", cfg->max_probes);
+    add_int("max_strlen", cfg->max_strlen);
+    add_int("on_stack_limit", cfg->on_stack_limit);
+    add_int("perf_rb_pages", cfg->perf_rb_pages);
+
+    add_str("str_trunc_trailer", cfg->str_trunc_trailer);
+
+    auto unstable_str = [](ConfigUnstable u) {
+      switch (u) {
+        case ConfigUnstable::enable:
+          return "enable";
+        case ConfigUnstable::warn:
+          return "warn";
+        case ConfigUnstable::error:
+          return "error";
+      }
+      return "error";
+    };
+
+    add_str("unstable_import_statement",
+            unstable_str(cfg->unstable_import_statement));
+    add_str("unstable_tseries", unstable_str(cfg->unstable_tseries));
+    add_str("unstable_typeinfo", unstable_str(cfg->unstable_typeinfo));
+    add_str("unstable_dw_ustack", unstable_str(cfg->unstable_dw_ustack));
+
+    std::string missing_str;
+    switch (cfg->missing_probes) {
+      case ConfigMissingProbes::ignore:
+        missing_str = "ignore";
+        break;
+      case ConfigMissingProbes::warn:
+        missing_str = "warn";
+        break;
+      case ConfigMissingProbes::error:
+        missing_str = "error";
+        break;
+    }
+
+    add_str("missing_probes", missing_str);
+    add_str("stack_mode", STACK_MODE_NAME_MAP.at(cfg->stack_mode));
+    add_str("license", bpftrace::Config::get_license_str(cfg->license));
+    return make_record(ast_, loc, std::move(args));
+  }
+
+  ASTContext &ast_;
+  BPFtrace &bpftrace_;
+};
+
 class Builtins : public Visitor<Builtins, std::optional<Expression>> {
 public:
   explicit Builtins(ASTContext &ast, BPFtrace &bpftrace, bool has_child = true)
@@ -22,8 +134,8 @@ public:
   using Visitor<Builtins, std::optional<Expression>>::visit;
   std::optional<Expression> visit(Builtin &builtin);
   std::optional<Expression> visit(Call &call);
-  std::optional<Expression> visit(Identifier &identifier);
   std::optional<Expression> visit(Expression &expression);
+  std::optional<Expression> visit(Identifier &identifier);
   std::optional<Expression> visit(For &f);
   std::optional<Expression> visit(Probe &probe);
   std::optional<Expression> check(const std::string &ident, Node &node);
@@ -104,78 +216,6 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
       return ast_.make_node<Integer>(
           node.loc, util::file_ino(probe->attach_points.front()->target));
     }
-  } else if (ident == "__builtin_config") {
-    std::vector<std::pair<std::string, Expression>> args;
-    auto &cfg = bpftrace_.config_;
-
-    auto add_bool = [&](const char *key, bool val) {
-      args.emplace_back(key, ast_.make_node<Boolean>(node.loc, val));
-    };
-    auto add_int = [&](const char *key, uint64_t val) {
-      args.emplace_back(key, ast_.make_node<Integer>(node.loc, val));
-    };
-    auto add_str = [&](const char *key, const std::string &val) {
-      args.emplace_back(key, ast_.make_node<String>(node.loc, val));
-    };
-
-    // Booleans
-    add_bool("cpp_demangle", cfg->cpp_demangle);
-    add_bool("lazy_symbolication", cfg->lazy_symbolication);
-    add_bool("print_maps_on_exit", cfg->print_maps_on_exit);
-    add_bool("use_blazesym", cfg->use_blazesym);
-    add_bool("show_debug_info", cfg->show_debug_info);
-
-    // Integers
-    add_int("log_size", cfg->log_size);
-    add_int("max_bpf_progs", cfg->max_bpf_progs);
-    add_int("max_cat_bytes", cfg->max_cat_bytes);
-    add_int("max_map_keys", cfg->max_map_keys);
-    add_int("max_probes", cfg->max_probes);
-    add_int("max_strlen", cfg->max_strlen);
-    add_int("on_stack_limit", cfg->on_stack_limit);
-    add_int("perf_rb_pages", cfg->perf_rb_pages);
-
-    // Strings
-    add_str("str_trunc_trailer", cfg->str_trunc_trailer);
-
-    // Enums -> Strings
-    auto unstable_str = [](ConfigUnstable u) {
-      switch (u) {
-        case ConfigUnstable::enable:
-          return "enable";
-        case ConfigUnstable::warn:
-          return "warn";
-        case ConfigUnstable::error:
-          return "error";
-      }
-      return "error";
-    };
-
-    add_str("unstable_import_statement",
-            unstable_str(cfg->unstable_import_statement));
-    add_str("unstable_tseries", unstable_str(cfg->unstable_tseries));
-    add_str("unstable_typeinfo", unstable_str(cfg->unstable_typeinfo));
-    add_str("unstable_dw_ustack", unstable_str(cfg->unstable_dw_ustack));
-
-    std::string missing_str;
-    switch (cfg->missing_probes) {
-      case ConfigMissingProbes::ignore:
-        missing_str = "ignore";
-        break;
-      case ConfigMissingProbes::warn:
-        missing_str = "warn";
-        break;
-      case ConfigMissingProbes::error:
-        missing_str = "error";
-        break;
-    }
-
-    add_str("missing_probes", missing_str);
-
-    add_str("stack_mode", STACK_MODE_NAME_MAP.at(cfg->stack_mode));
-
-    add_str("license", bpftrace::Config::get_license_str(cfg->license));
-    return make_record(ast_, node.loc, std::move(args));
   }
 
   return std::nullopt;
@@ -369,6 +409,16 @@ Pass CreateBuiltinsPass()
   };
 
   return Pass::create("Builtins", fn);
+};
+
+Pass CreateConfigBuiltinsPass()
+{
+  auto fn = [&](ASTContext &ast, BPFtrace &bpftrace) {
+    ConfigBuiltins config_builtins(ast, bpftrace);
+    config_builtins.visit(ast.root);
+  };
+
+  return Pass::create("ConfigBuiltins", fn);
 };
 
 Pass CreatePreExpansionBuiltinsPass()

--- a/src/ast/passes/builtins.h
+++ b/src/ast/passes/builtins.h
@@ -8,6 +8,9 @@ namespace bpftrace::ast {
 // merges probes (e.g. session expansion merging kprobe + kretprobe).
 Pass CreatePreExpansionBuiltinsPass();
 
+// Expand builtins that must be available before literal folding.
+Pass CreateConfigBuiltinsPass();
+
 // Fill in the values of all intrinsics.
 Pass CreateBuiltinsPass();
 

--- a/src/ast/passes/parse_passes.h
+++ b/src/ast/passes/parse_passes.h
@@ -58,6 +58,8 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateArgsResolverPass());
   passes.emplace_back(CreateFieldAnalyserPass());
   passes.emplace_back(CreateClangParsePass(std::move(extra_flags)));
+  // separate pass so we can fold accesses to configs e.g. `config.max_strlen`
+  passes.emplace_back(CreateConfigBuiltinsPass());
   passes.emplace_back(CreateFoldLiteralsPass());
   passes.emplace_back(CreateBuiltinsPass());
   passes.emplace_back(CreateCMacroExpansionPass());

--- a/src/ast/passes/types/pre_type_check.cpp
+++ b/src/ast/passes/types/pre_type_check.cpp
@@ -670,9 +670,18 @@ void CallPreCheck::visit(Call &call)
     }
   } else if (call.func == "path") {
     if (call.vargs.size() == 2) {
-      if (!call.vargs.at(1).is<Integer>()) {
+      auto *size = call.vargs.at(1).as<Integer>();
+      if (!size) {
         call.addError() << call.func
                         << ": invalid size value, need non-negative literal";
+      } else {
+        const auto max_strlen = bpftrace_.config_->max_strlen;
+        if (size->value > max_strlen) {
+          auto &err = call.addError();
+          err << call.func << ": size is too long (over " << max_strlen
+              << " bytes): " << size->value;
+          err.addHint() << "Increase BPFTRACE_MAX_STRLEN.";
+        }
       }
     }
 

--- a/src/ast/passes/types/pre_type_check.cpp
+++ b/src/ast/passes/types/pre_type_check.cpp
@@ -709,12 +709,6 @@ void CallPreCheck::visit(Identifier &identifier)
           << "Invalid PID namespace mode: " << identifier.ident
           << " (expects: curr_ns or init)";
     }
-  } else if (func_ == "signal") {
-    if (identifier.ident != "current_pid" &&
-        identifier.ident != "current_tid") {
-      identifier.addError() << "Invalid signal target: " << identifier.ident
-                            << " (expects: current_pid or current_tid)";
-    }
   }
 }
 

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -83,6 +83,7 @@ private:
                                size_t index,
                                const arg_type_spec &spec);
   [[nodiscard]] bool check_call(Call &call);
+  bool check_string_size(Node &node, const SizedType &ty);
 
   bool check_arg(Call &call,
                  Type type,
@@ -953,6 +954,10 @@ void TypeChecker::visit(Cast &cast)
     return;
   }
 
+  if (!check_string_size(cast, ty)) {
+    return;
+  }
+
   if (ty == rhs) {
     cast.addWarning() << "Unnecessary cast: expression is already of type "
                       << rhs;
@@ -1118,6 +1123,8 @@ void TypeChecker::visit(VarDeclStatement &decl)
     if (!ty.IsNoneTy()) {
       if (!IsValidVarDeclType(ty)) {
         decl.typeof->addError() << "Invalid variable declaration type: " << ty;
+      } else {
+        check_string_size(*decl.typeof, ty);
       }
     } else {
       // We couldn't resolve that specific type by now.
@@ -1142,6 +1149,8 @@ void TypeChecker::visit(Subprog &subprog)
   for (SubprogArg *arg : subprog.args) {
     if (type_map_.type(arg->typeof).IsNoneTy()) {
       arg->addError() << "Unable to resolve argument type.";
+    } else {
+      check_string_size(*arg->typeof, type_map_.type(arg->typeof));
     }
   }
 
@@ -1153,7 +1162,22 @@ void TypeChecker::visit(Subprog &subprog)
   if (type_map_.type(subprog.return_type).IsNoneTy()) {
     subprog.return_type->addError()
         << "Unable to resolve suitable return type.";
+  } else {
+    check_string_size(*subprog.return_type,
+                      type_map_.type(subprog.return_type));
   }
+}
+
+bool TypeChecker::check_string_size(Node &node, const SizedType &ty)
+{
+  const auto max_strlen = bpftrace_.config_->max_strlen;
+  if (!ty.IsStringTy() || ty.GetSize() <= max_strlen) {
+    return true;
+  }
+  auto &err = node.addError();
+  err << "String type is too long (over " << max_strlen << " bytes): " << ty;
+  err.addHint() << "Increase BPFTRACE_MAX_STRLEN.";
+  return false;
 }
 
 void TypeChecker::visit(Program &program)

--- a/tests/pre_type_check.cpp
+++ b/tests/pre_type_check.cpp
@@ -40,6 +40,7 @@ void test(const std::string &input,
                 .add(ast::CreateMacroExpansionPass())
                 .add(ast::CreateParseAttachpointsPass())
                 .add(ast::CreateProbeAndApExpansionPass())
+                .add(ast::CreateConfigBuiltinsPass())
                 .add(ast::CreateFoldLiteralsPass())
                 .add(ast::CreateBuiltinsPass())
                 .add(ast::CreateMapSugarPass())

--- a/tests/pre_type_check.cpp
+++ b/tests/pre_type_check.cpp
@@ -4,9 +4,12 @@
 #include "ast/passes/ap_probe_expansion.h"
 #include "ast/passes/attachpoint_passes.h"
 #include "ast/passes/builtins.h"
+#include "ast/passes/config_analyser.h"
 #include "ast/passes/fold_literals.h"
+#include "ast/passes/import_scripts.h"
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
+#include "ast/passes/resolve_imports.h"
 #include "ast/passes/types/pre_type_check.h"
 #include "mocks.h"
 #include "parser.h"
@@ -37,6 +40,9 @@ void test(const std::string &input,
                 .put(bpftrace)
                 .put(get_mock_function_info())
                 .add(CreateParsePass())
+                .add(ast::CreateConfigPass())
+                .add(ast::CreateResolveRootImportsPass())
+                .add(ast::CreateImportInternalScriptsPass())
                 .add(ast::CreateMacroExpansionPass())
                 .add(ast::CreateParseAttachpointsPass())
                 .add(ast::CreateProbeAndApExpansionPass())
@@ -521,12 +527,15 @@ TEST(CallPreCheck, debugf)
 TEST(CallPreCheck, path)
 {
   test("fentry:f { path(\"adf\", 1); }");
+  test("fentry:f { path(\"adf\", config.max_strlen); }");
 
   // Errors
   test(R"(fentry:f { path("adf", "Na"); })",
        "path: invalid size value, need non-negative literal");
   test("fentry:f { path(\"adf\", -1); }",
        "path: invalid size value, need non-negative literal");
+  test("fentry:f { path(\"adf\", config.max_strlen + 1); }",
+       "path: size is too long");
 }
 
 TEST(CallPreCheck, strncmp)

--- a/tests/pre_type_check.cpp
+++ b/tests/pre_type_check.cpp
@@ -537,16 +537,6 @@ TEST(CallPreCheck, strncmp)
        "Builtin strncmp requires a non-negative literal");
 }
 
-TEST(CallPreCheck, signal)
-{
-  test(R"(begin { signal(current_pid) })");
-  test(R"(begin { signal(current_tid) })");
-
-  // Errors
-  test(R"(begin { signal(bob) })",
-       "Invalid signal target: bob (expects: current_pid or current_tid)");
-}
-
 TEST(CallPreCheck, pid_tid)
 {
   test("begin { $i = tid(); }");
@@ -593,14 +583,11 @@ TEST(CallPreCheck, raw_map_arg_funcs)
 {
   test("kprobe:f { @x[1,2] = count(); clear(@x); }");
   test("kprobe:f { @x[1,2] = count(); zero(@x); }");
-  test("kprobe:f { @x[1,2] = count(); len(@x); }");
 
   // Errors
   test("kprobe:f { @x[1,2] = count(); clear(@x[3,4]); }",
        "expects a map argument");
   test("kprobe:f { @x[1,2] = count(); zero(@x[3,4]); }",
-       "expects a map argument");
-  test("kprobe:f { @x[1,2] = count(); len(@x[3,4]); }",
        "expects a map argument");
 }
 

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -2406,6 +2406,42 @@ TEST_F(TypeCheckerTest, cast_string)
   test("kprobe:f { $a = (string)5; }", Error{});
 }
 
+TEST_F(TypeCheckerTest, string_too_long)
+{
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->config_->max_strlen = 64;
+
+  test("kprobe:f { $a = (string[64])\"hello\"; }", Mock{ *bpftrace });
+
+  test("kprobe:f { $a = (string[65])\"hello\"; }",
+       Mock{ *bpftrace },
+       Error{ R"_(
+stdin:1:17-29: ERROR: String type is too long (over 64 bytes): string[65]
+kprobe:f { $a = (string[65])"hello"; }
+                ~~~~~~~~~~~~
+)_" });
+
+  test("kprobe:f { let $a : string[64]; }", Mock{ *bpftrace });
+  test("fn f($s : string[64]): void { print($s); }", Mock{ *bpftrace });
+  test("fn f(): string[64] { return \"hello\"; }", Mock{ *bpftrace });
+
+  test("kprobe:f { let $a : string[65]; }", Mock{ *bpftrace }, Error{ R"(
+stdin:1:21-31: ERROR: String type is too long (over 64 bytes): string[65]
+kprobe:f { let $a : string[65]; }
+                    ~~~~~~~~~~
+)" });
+
+  test("fn f($s : string[65]): void { print($s); }",
+       Mock{ *bpftrace },
+       Error{ "String type is too long (over 64 bytes): string[65]" });
+  test("fn f(): string[65] { return \"hello\"; }",
+       Mock{ *bpftrace },
+       Error{ "String type is too long (over 64 bytes): string[65]" });
+
+  // No allocation
+  test("kprobe:f { $a = sizeof(string[65]); }", Mock{ *bpftrace });
+}
+
 TEST_F(TypeCheckerTest, cast_username)
 {
   test("kprobe:f { $a = (username_t)1000; }");


### PR DESCRIPTION
Stacked PRs:
 * #5287
 * #5286
 * __->__#5285
 * #5284
 * #5283


--- --- ---

### Error for strings larger than max_str_len


In cases where we are casting, setting variable type declarations, or using
the `path` builtin, make sure to check the string size against the config
max_strlen like we do for string literals and other string functions.

Signed-off-by: Jordan Rome <jordalgo@meta.com>