### PR TITLE
Fix string buffer allocation for casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to
   - [#5239](https://github.com/bpftrace/bpftrace/pull/5239)
 - Fix to use vendored BPF UAPI headers across entire codebase to prevent build failures and inconsistencies
   - [#5277](https://github.com/bpftrace/bpftrace/pull/5277)
+- Fix large string allocations for casts
+  - [#5286](https://github.com/bpftrace/bpftrace/pull/5286)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2928,12 +2928,15 @@ ScopedExpr CodegenLLVM::visit(Cast &cast)
     }
     return scoped_expr;
   } else if (ty.IsStringTy()) {
-    auto *v = b_.CreateAllocaBPF(ty);
-    b_.CreateMemsetBPF(v, b_.getInt8(0), ty.GetSize());
-    b_.CreateMemcpyBPF(v,
+    auto *buf = b_.CreateGetStrAllocation("cast", cast.loc);
+    const auto max_strlen = bpftrace_.config_->max_strlen;
+    b_.CreateMemsetBPF(buf, b_.getInt8(0), max_strlen);
+    b_.CreateMemcpyBPF(buf,
                        scoped_expr.value(),
                        type_map_.type(cast.expr).GetSize());
-    return ScopedExpr(v, [this, v] { b_.CreateLifetimeEnd(v); });
+    if (dyn_cast<AllocaInst>(buf))
+      return ScopedExpr(buf, [this, buf]() { b_.CreateLifetimeEnd(buf); });
+    return ScopedExpr(buf);
   } else {
     // FIXME(amscanne): The existing behavior is to simply pass the existing
     // expression back up when it is neither an integer nor an array.

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -39,6 +39,7 @@ public:
   void visit(Subprog &subprog);
   void visit(Builtin &builtin);
   void visit(Call &call);
+  void visit(Cast &cast);
   void visit(Map &map);
   void visit(MapAccess &acc);
   void visit(MapDeclStatement &decl);
@@ -431,6 +432,19 @@ void ResourceAnalyser::visit(Call &call)
     // mark probe as using usym, so that the symbol table can be pre-loaded
     // and symbols resolved even when unavailable at resolution time
     resources_.probes_using_usym.insert(probe_);
+  }
+}
+
+void ResourceAnalyser::visit(Cast &cast)
+{
+  Visitor<ResourceAnalyser>::visit(cast);
+
+  const auto &ty = type_map_.type(&cast);
+
+  if (ty.IsStringTy()) {
+    const auto max_strlen = bpftrace_.config_->pad_max_strlen();
+    if (exceeds_stack_limit(max_strlen))
+      resources_.str_buffers++;
   }
 }
 

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -192,3 +192,8 @@ NAME config max_strlen with 8 cpus
 RUN printf '0-7\n' > /tmp/fake_possible && unshare -m bash -c 'mount --bind /tmp/fake_possible /sys/devices/system/cpu/possible && exec {{BPFTRACE}} -e "config = { max_strlen = 8; } t:syscalls:sys_enter_execve { print(str(args.filename)); exit(); }"'
 AFTER ./testprogs/syscall execve ./testprogs/true &>/dev/null
 EXPECT_REGEX /.......\.\.
+
+NAME large string cast
+PROG begin { let $a = (string[1024])"hi"; print($a); }
+EXPECT hi
+TIMEOUT 1


### PR DESCRIPTION
Stacked PRs:
 * #5287
 * __->__#5286


--- --- ---

### Fix string buffer allocation for casts


When casting to a large string we need to make sure to check if it needs a
global string buffer.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>