### PR TITLE
build: simplify libbpf UAPI header include path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ and this project adheres to
   - [#5272](https://github.com/bpftrace/bpftrace/pull/5272)
 - Print zero values for empty scalar maps
   - [#5239](https://github.com/bpftrace/bpftrace/pull/5239)
-- Fix to use vendored BPF UAPI headers across entire codebase to prevent build failures and inconsistencies
-  - [#5277](https://github.com/bpftrace/bpftrace/pull/5277)
+- Prefer vendored libbpf BPF UAPI headers over system ones
+  - [#5288](https://github.com/bpftrace/bpftrace/pull/5288)
 - Fix large string allocations for casts
   - [#5286](https://github.com/bpftrace/bpftrace/pull/5286)
 #### Security

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,10 +95,7 @@ if(USE_SYSTEM_LIBBPF)
   include_directories(SYSTEM ${LIBBPF_INCLUDE_DIRS})
   message(WARNING "Using system libbpf, please ensure that the version is greater than or equal to the submodule")
 else()
-  include_directories(BEFORE SYSTEM
-    ${LIBBPF_INCLUDE_DIRS}
-    ${CMAKE_SOURCE_DIR}/libbpf/include/uapi
-    ${CMAKE_SOURCE_DIR}/libbpf/include)
+  include_directories(BEFORE SYSTEM ${LIBBPF_INCLUDE_DIRS})
 endif()
 
 find_package(LibElf REQUIRED)


### PR DESCRIPTION
Stacked PRs:
 * __->__#5288


--- --- ---

### build: simplify libbpf UAPI header include path


Instead of adding `libbpf/include` and `libbpf/include/uapi` which holds
libbpf's private build shims, not UAPI headers just include
`LIBBPF_INCLUDE_DIRS` before the system ones if the submodule exists.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>