### PR TITLE
Remove useless structure Probe::need_expansion field

### DIFF
--- a/src/probe_types.h
+++ b/src/probe_types.h
@@ -107,7 +107,6 @@ struct Probe {
   std::string path;         // file path if used
   std::string attach_point; // probe name (last component)
   std::string name;         // full probe name
-  bool need_expansion;
   std::string pin;  // pin file for iterator probes
   std::string ns;   // for USDT probes, if provider namespace not from path
   uint64_t loc = 0; // for USDT probes


### PR DESCRIPTION
Probe::need_expansion is not used in anywhere.

Probe::need_expansion is not used in anywhere. If compile bpftrace with `-DBUILD_ASAN=ON -DBUILD_UBSAN=ON`:
    
        $ sudo bpftrace -e 'begin {}'
        /home/rongtao/Git/bpftrace/bpftrace/src/probe_types.h:105:8:
        runtime error: load of value 188, which is not a valid value for type 'bool'
    
This error comes from UBSan's bool type check: bool in memory can only be
0 or 1, but you loaded 188 (0xbc) here. This usually means that there is
an uninitialized bool member in the Probe structure/class in
src/probe_types.h, which was then read or copied.