### PR TITLE
Fixes for s390

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to
 - Release assets are now suffixed with the architecture
   - [#5213](https://github.com/bpftrace/bpftrace/pull/5213)
 #### Fixed
+- Propagate address space for sized variable declarations
+  - [#5294](https://github.com/bpftrace/bpftrace/pull/5294)
 - Ensure that string allocation and usage are consistent in size.
   - [#5279](https://github.com/bpftrace/bpftrace/pull/5279)
 - Fix crash caused by debug locations leaking between generated functions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to
 - Release assets are now suffixed with the architecture
   - [#5213](https://github.com/bpftrace/bpftrace/pull/5213)
 #### Fixed
+- Fix session probes support for kernel version 7.0
+  - [#5294](https://github.com/bpftrace/bpftrace/pull/5294)
 - Propagate address space for sized variable declarations
   - [#5294](https://github.com/bpftrace/bpftrace/pull/5294)
 - Ensure that string allocation and usage are consistent in size.

--- a/src/ast/passes/ap_probe_expansion.cpp
+++ b/src/ast/passes/ap_probe_expansion.cpp
@@ -212,11 +212,25 @@ void SessionExpander::visit(Probe &probe)
       return;
 
     AttachPointList attach_points = probe.attach_points;
+
+    auto *ctx_builtin = ast_.make_node<Builtin>(probe.block->loc, "ctx");
+    auto *void_type = ast_.make_node<ParsedType>(probe.block->loc,
+                                                 ParsedType::Kind::Identifier,
+                                                 "void");
+    auto *void_ptr_type = ast_.make_node<ParsedType>(probe.block->loc,
+                                                     void_type);
+    auto *typeof_node = ast_.make_node<Typeof>(probe.block->loc, void_ptr_type);
+    auto *ctx_cast = ast_.make_node<Cast>(probe.block->loc,
+                                          typeof_node,
+                                          ctx_builtin);
+    ExpressionList call_args;
+    call_args.emplace_back(ctx_cast);
+
     auto *expr = ast_.make_node<IfExpr>(
         probe.block->loc,
         ast_.make_node<Call>(probe.block->loc,
                              "__session_is_return",
-                             ExpressionList{}),
+                             call_args),
         retprobe->block,
         probe.block);
     auto *stmt = ast_.make_node<ExprStatement>(probe.block->loc, expr);

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -750,11 +750,27 @@ void TypeRuleCollector::visit(AssignVarStatement &assignment)
 
   // Ignore the RHS to determine the type of this variable and issue errors
   // later if the RHS type is not compatible or doesn't fit into this sized
-  // declaration type
+  // declaration type. For sized declarations, propagate addrspace from RHS if
+  // LHS has none.
   if (sized_decl_vars_.contains(scoped_var)) {
+    resolver_.add_type_rule({
+        .output = scoped_var,
+        .inputs = { &assignment.expr.node(), scoped_var },
+        .resolve = [this](const std::vector<SizedType> &inputs) -> SizedType {
+          auto var_type = inputs[1];         // $x's declared type
+          const auto &expr_type = inputs[0]; // rhs type
+          if (var_type.GetAS() == AddrSpace::none &&
+              expr_type.GetAS() != AddrSpace::none) {
+            var_type.SetAS(expr_type.GetAS());
+          }
+          return var_type;
+        },
+    });
     return;
   }
 
+  // For unsized declarations (e.g., begin { let $x; $x = ...; }), infer type
+  // from RHS
   resolver_.add_type_rule({
       .output = scoped_var,
       .inputs = { &assignment.expr.node() },

--- a/src/stdlib/base.bpf.c
+++ b/src/stdlib/base.bpf.c
@@ -4,15 +4,24 @@
 
 #include <bpf/bpf_helpers.h>
 
-extern _Bool bpf_session_is_return(void) __ksym __weak;
+// Kernel v7.0+ signature with ctx parameter.
+// The ___with_ctx suffix is stripped by libbpf, mapping to kernel symbol "bpf_session_is_return"
+extern _Bool bpf_session_is_return___with_ctx(void *ctx) __ksym __weak;
+
+// Kernel < v7.0 signature without ctx parameter.
+// The ___no_ctx suffix is stripped by libbpf, mapping to kernel symbol "bpf_session_is_return"
+extern _Bool bpf_session_is_return___no_ctx(void) __ksym __weak;
 
 // Try to limit the functions that get added in this file
 // as these will always be imported/compiled by every script
 
-_Bool __session_is_return() {
-    if (bpf_session_is_return) {
-        return bpf_session_is_return();
-    }
+// Always called with ctx. If the kernel exposes the newer ctx aware kfunc,
+// use it. otherwise fall back to the no arg variant.
+_Bool __session_is_return(void *ctx) {
+    if (bpf_session_is_return___with_ctx)
+        return bpf_session_is_return___with_ctx(ctx);
+    if (bpf_session_is_return___no_ctx)
+        return bpf_session_is_return___no_ctx();
     return 0;
 }
 

--- a/tests/ap_probe_expansion.cpp
+++ b/tests/ap_probe_expansion.cpp
@@ -68,12 +68,14 @@ TEST(ap_probe_expansion, session_ast)
        {},
        Program().WithProbe(Probe(
            { "kprobe:sys_*" },
-           { ExprStatement(
-               If(Call("__session_is_return", {}),
-                  Block({ AssignScalarMapStatement(Map("@exit"), Integer(1)) },
-                        None()),
-                  Block({ AssignScalarMapStatement(Map("@entry"), Integer(1)) },
-                        None()))) })),
+           { ExprStatement(If(
+               Call("__session_is_return",
+                    { Cast(Typeof(ParsedType(ast::ParsedType::Kind::Pointer)),
+                           Builtin("ctx")) }),
+               Block({ AssignScalarMapStatement(Map("@exit"), Integer(1)) },
+                     None()),
+               Block({ AssignScalarMapStatement(Map("@entry"), Integer(1)) },
+                     None()))) })),
        true);
 }
 
@@ -179,12 +181,14 @@ TEST(ap_probe_expansion, kprobe_multi_exact)
        { { "sys_read" } },
        Program().WithProbe(Probe(
            { "kprobe:sys_read" },
-           { ExprStatement(
-               If(Call("__session_is_return", {}),
-                  Block({ AssignScalarMapStatement(Map("@exit"), Integer(1)) },
-                        None()),
-                  Block({ AssignScalarMapStatement(Map("@entry"), Integer(1)) },
-                        None()))) })),
+           { ExprStatement(If(
+               Call("__session_is_return",
+                    { Cast(Typeof(ParsedType(ast::ParsedType::Kind::Pointer)),
+                           Builtin("ctx")) }),
+               Block({ AssignScalarMapStatement(Map("@exit"), Integer(1)) },
+                     None()),
+               Block({ AssignScalarMapStatement(Map("@entry"), Integer(1)) },
+                     None()))) })),
        true);
 }
 

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -158,14 +158,19 @@ RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, pr
 EXPECT_REGEX ^\d+ usdt:.*/testprogs/usdt_test:tracetest.?:testprobe.?$
 BEFORE ./testprogs/usdt_test
 
+# The same probe can be registered more than once through different vmas
+# mapping the same file offset (e.g. an executable text mapping and a RELRO
+# mapping), causing the semaphore to be incremented more than once. Accept any
+# positive value.
+# Ref: https://lore.kernel.org/all/20260805131904.1127416-1-sumanthk@linux.ibm.com/
 NAME usdt probes - attach to probe with semaphore
 RUN {{BPFTRACE}} -e 'usdt:*:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
-EXPECT USDT semaphore: 1
+EXPECT_REGEX USDT semaphore: [1-9]\d*$
 BEFORE ./testprogs/usdt_semaphore_test
 
 NAME usdt probes - file based semaphore activation
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' --usdt-file-activation
-EXPECT USDT semaphore: 1
+EXPECT_REGEX USDT semaphore: [1-9]\d*$
 BEFORE ./testprogs/usdt_semaphore_test
 
 NAME usdt probes - file based semaphore activation no process, kernel usdt semaphore
@@ -174,7 +179,7 @@ EXPECT Attached 1 probe
 
 NAME usdt probes - file based semaphore activation
 PROG usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }
-EXPECT USDT semaphore: 1
+EXPECT_REGEX USDT semaphore: [1-9]\d*$
 BEFORE ./testprogs/usdt_semaphore_test
 
 NAME usdt probes - file based semaphore activation multi process

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -114,6 +114,10 @@ NAME variable declaration with builtin
 PROG begin { let $f: struct task_struct *; $f = curtask; print($f.pid); }
 EXPECT_REGEX [0-9]+
 
+NAME variable declaration with typeof and builtin
+PROG begin { $a = (struct task_struct *)0; let $f: typeof($a); $f = curtask; print($f.pid); }
+EXPECT_REGEX [0-9]+
+
 NAME variable declaration not initialized
 PROG begin { let $a; if ($a) { $a = 1; } @b = $a; }
 EXPECT @b: 0

--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -154,19 +154,26 @@ list(APPEND testprogtargets ${EXTERNAL_DEBUG_DIR}/dwo/uprobe_test-split)
 
 # Build a binary with split debuginfo and bundle the .dwo files into a DWARF Package (.dwp)
 # archive; to verify parsing of the packaged format.
-find_program(LLVM_DWP llvm-dwp REQUIRED)
-add_custom_command(
-  OUTPUT
+#
+# Disable llvm-dwp tests on s390 and with LLVM versions earlier than 23,
+# due to failures when using the -gsplit-dwarf flag. The issue is caused
+# by an endianness bug in llvm-dwp.
+# https://github.com/llvm/llvm-project/pull/203424
+if(NOT (CMAKE_SYSTEM_PROCESSOR MATCHES "s390x" AND LLVM_VERSION_MAJOR LESS 23))
+  find_program(LLVM_DWP llvm-dwp REQUIRED)
+  add_custom_command(
+    OUTPUT
+      ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split
+      ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split.dwp
+    COMMAND ${CMAKE_C_COMPILER} -g -O0 -gsplit-dwarf ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c -o ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split
+    COMMAND ${LLVM_DWP} -e ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split -o ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split.dwp
+    COMMAND ${CMAKE_COMMAND} -E rm -f ${EXTERNAL_DEBUG_DIR}/dwp/*.dwo
+    DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c
+  )
+  list(APPEND testprogtargets
     ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split
-    ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split.dwp
-  COMMAND ${CMAKE_C_COMPILER} -g -O0 -gsplit-dwarf ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c -o ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split
-  COMMAND ${LLVM_DWP} -e ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split -o ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split.dwp
-  COMMAND ${CMAKE_COMMAND} -E rm -f ${EXTERNAL_DEBUG_DIR}/dwp/*.dwo
-  DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/uprobe_test.c
-)
-list(APPEND testprogtargets
-  ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split
-  ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split.dwp)
+    ${EXTERNAL_DEBUG_DIR}/dwp/uprobe_test-split.dwp)
+endif()
 
 add_custom_target(testprogs ALL DEPENDS ${testprogtargets})
 


### PR DESCRIPTION
Hi,

I have worked on the following fixes for s390:

Patch 1: Propagates the address space for sized variable declarations.
Patch 2: Adds runtime detection for bpf_session_is_return(), enables session probes on newer kernels, and maintains compatibility with older kernels.
Patch 3: Disables the llvm-dwp tests on s390 until the recent s390 llvm-dwp fix is available. If it is not disabled, it causes build failures.
Patch 4: Fixes USDT semaphore test failures on s390.

Thank you

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
