### PR TITLE
Clang-Tidy: Disable some verbose checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -32,7 +32,10 @@ Checks:
   - -readability-isolate-declaration
   - -readability-magic-numbers
   - -readability-make-member-function-const
+  - -readability-redundant-lambda-parameter-list
+  - -readability-redundant-nested-if
   - -readability-suspicious-call-argument
+  - -readability-trailing-comma
 
 CheckOptions:
   # gcc and llvm did not introduce <format> when supporting C++20, so using


### PR DESCRIPTION
Stacked PRs:
 * #5299
 * #5298
 * #5297
 * #5296
 * __->__#5295


--- --- ---

### Clang-Tidy: Disable some verbose checks


Some new checks introduced by Clang-Tidy 23 generate a lot of warnings
and fixing them would not contribute to better code base (on the
contrary - sometimes implementing the suggestions would make the code
less readable). Disable such checks.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>