### PR TITLE
Implement some Clang-Tidy suggestions

### DIFF
--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -30,7 +30,7 @@ inline bool inBpfMemory(const SizedType &type)
 
 inline AddrSpace find_addrspace_stack(const SizedType &ty)
 {
-  return (shouldBeInBpfMemoryAlready(ty)) ? AddrSpace::kernel : ty.GetAS();
+  return shouldBeInBpfMemoryAlready(ty) ? AddrSpace::kernel : ty.GetAS();
 }
 
 // This applies to both map keys and map values

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -1425,7 +1425,7 @@ Buffer Formatter::visit(NamedArgument& named_arg)
 {
   Buffer elem;
   // -1 for the equals
-  size_t width = max_width - (named_arg.name.size()) - 1;
+  size_t width = max_width - named_arg.name.size() - 1;
   auto elem_buf = format(named_arg.expr, metadata, width);
   elem = Buffer().text(named_arg.name).text("=").append(std::move(elem_buf));
   return elem;

--- a/src/ast/passes/types/pre_type_check.cpp
+++ b/src/ast/passes/types/pre_type_check.cpp
@@ -700,7 +700,7 @@ void CallPreCheck::visit(Call &call)
   } else if (call.func == "pid" || call.func == "tid") {
     if (call.vargs.size() == 1) {
       auto &arg = call.vargs.at(0);
-      if (!(arg.as<Identifier>())) {
+      if (!arg.as<Identifier>()) {
         call.addError() << call.func
                         << "() only supports curr_ns and init as the argument";
       }

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -14,7 +14,7 @@ protected:                                                                     \
   std::optional<bool> has_##name##_;                                           \
                                                                                \
 public:                                                                        \
-  bool has_helper_##name(void)                                                 \
+  bool has_helper_##name()                                                     \
   {                                                                            \
     if (!has_##name##_.has_value())                                            \
       has_##name##_ = std::make_optional<bool>(                                \

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -145,7 +145,7 @@ void update_global_vars_rodata(
           break;
         }
         case GlobalVarConfig::opt_string: {
-          auto *var = reinterpret_cast<char *>(global_vars_buf + offset);
+          auto *var = global_vars_buf + offset;
           const auto &val = std::get<std::string>(it->second);
           strncpy(var, val.c_str(), val.size() + 1);
           break;

--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -474,27 +474,22 @@ void JsonOutput::attached_probes(uint64_t num_probes)
 
 void JsonOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
 {
-  switch (info.error_id) {
-    case RuntimeErrorId::HELPER_ERROR: {
-      out_ << R"({"type": "helper_error")";
-      out_ << R"(, "msg": )";
-      JsonEmitter<std::string>::emit(out_, strerror(-retcode));
-      out_ << R"(, "helper": )";
-      std::stringstream ss;
-      ss << info.func_id;
-      JsonEmitter<std::string>::emit(out_, ss.str());
-      out_ << R"(, "retcode": )";
-      JsonEmitter<int64_t>::emit(out_, retcode);
-      break;
-    }
-    default: {
-      out_ << R"({"type": "runtime_error")";
-      out_ << R"(, "msg": )";
-      std::stringstream ss;
-      ss << info;
-      JsonEmitter<std::string>::emit(out_, ss.str());
-      break;
-    }
+  if (info.error_id == RuntimeErrorId::HELPER_ERROR) {
+    out_ << R"({"type": "helper_error")";
+    out_ << R"(, "msg": )";
+    JsonEmitter<std::string>::emit(out_, strerror(-retcode));
+    out_ << R"(, "helper": )";
+    std::stringstream ss;
+    ss << info.func_id;
+    JsonEmitter<std::string>::emit(out_, ss.str());
+    out_ << R"(, "retcode": )";
+    JsonEmitter<int64_t>::emit(out_, retcode);
+  } else {
+    out_ << R"({"type": "runtime_error")";
+    out_ << R"(, "msg": )";
+    std::stringstream ss;
+    ss << info;
+    JsonEmitter<std::string>::emit(out_, ss.str());
   }
 
   // Json only prints the top level location

--- a/src/output/text.cpp
+++ b/src/output/text.cpp
@@ -609,43 +609,37 @@ void TextOutput::attached_probes(uint64_t num_probes)
 
 void TextOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
 {
-  switch (info.error_id) {
-    case RuntimeErrorId::HELPER_ERROR: {
-      std::string msg;
-      if (info.func_id == BPF_FUNC_map_update_elem && retcode == -E2BIG) {
-        msg = "Map full; can't update element. Try increasing max_map_keys "
-              "config "
-              "or manually setting the max entries in a map declaration e.g. "
-              "`let "
-              "@a = hash(5000)`";
-      } else if (info.func_id == BPF_FUNC_map_delete_elem &&
-                 retcode == -ENOENT) {
-        msg = "Can't delete map element because it does not exist.";
-      }
-      // bpftrace sets the return code to 0 for map_lookup_elem failures
-      // which is why we're not also checking the retcode
-      else if (info.func_id == BPF_FUNC_map_lookup_elem) {
-        msg = "Can't lookup map element because it does not exist.";
-      } else {
-        msg = strerror(-retcode);
-      }
+  if (info.error_id == RuntimeErrorId::HELPER_ERROR) {
+    std::string msg;
+    if (info.func_id == BPF_FUNC_map_update_elem && retcode == -E2BIG) {
+      msg = "Map full; can't update element. Try increasing max_map_keys "
+            "config "
+            "or manually setting the max entries in a map declaration e.g. "
+            "`let "
+            "@a = hash(5000)`";
+    } else if (info.func_id == BPF_FUNC_map_delete_elem && retcode == -ENOENT) {
+      msg = "Can't delete map element because it does not exist.";
+    }
+    // bpftrace sets the return code to 0 for map_lookup_elem failures
+    // which is why we're not also checking the retcode
+    else if (info.func_id == BPF_FUNC_map_lookup_elem) {
+      msg = "Can't lookup map element because it does not exist.";
+    } else {
+      msg = strerror(-retcode);
+    }
 
-      LOG(WARNING,
-          std::string(info.locations.begin()->source_location),
-          std::vector(info.locations.begin()->source_context),
-          err_)
-          << msg << "\nAdditional Info - helper: " << info.func_id
-          << ", retcode: " << retcode;
-      break;
-    }
-    default: {
-      LOG(WARNING,
-          std::string(info.locations.begin()->source_location),
-          std::vector(info.locations.begin()->source_context),
-          err_)
-          << info;
-      break;
-    }
+    LOG(WARNING,
+        std::string(info.locations.begin()->source_location),
+        std::vector(info.locations.begin()->source_context),
+        err_)
+        << msg << "\nAdditional Info - helper: " << info.func_id
+        << ", retcode: " << retcode;
+  } else {
+    LOG(WARNING,
+        std::string(info.locations.begin()->source_location),
+        std::vector(info.locations.begin()->source_context),
+        err_)
+        << info;
   }
 
   // Print the chain

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -75,7 +75,7 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
       auto num_frames = value.bitcast<uint64_t>(0);
       auto limit = type.stack_type.limit;
       constexpr size_t stack_offset = sizeof(uint64_t);
-      auto len = static_cast<size_t>(type.stack_type.elem_size() * limit);
+      auto len = type.stack_type.elem_size() * limit;
       const auto raw_stack = value.slice(stack_offset, len);
 
       return bpftrace.get_stack(
@@ -89,7 +89,7 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
       auto limit = type.stack_type.limit;
       constexpr size_t stack_offset = sizeof(uint64_t) * 2;
 
-      auto len = static_cast<size_t>(type.stack_type.elem_size() * limit);
+      auto len = type.stack_type.elem_size() * limit;
       const auto raw_stack = value.slice(stack_offset, len);
 
       if (type.stack_type.mode == StackMode::build_id) {


### PR DESCRIPTION
Stacked PRs:
 * #5299
 * #5298
 * #5297
 * __->__#5296
 * #5295


--- --- ---

### Implement some Clang-Tidy suggestions


Clang-Tidy 23 suggested some improvements to the codebase:
- remove unnecessary parentheses
- remove unnecessary typecasts
- replace switch with one case by if/else
- replace `(void)` by `()`

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>