### PR TITLE
Use std::string_view where possible

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -17,7 +17,7 @@
 namespace bpftrace::ast {
 
 namespace {
-std::string probeReadHelperName(bpf_func_id id)
+std::string_view probeReadHelperName(bpf_func_id id)
 {
   switch (id) {
     case BPF_FUNC_probe_read:

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -90,20 +90,8 @@ bpf_prog_type progtype(ProbeType t)
   return {}; // unreached
 }
 
-std::string progtypeName(bpf_prog_type t)
-{
-  switch (t) {
-      // clang-format off
-    case BPF_PROG_TYPE_KPROBE:     return "BPF_PROG_TYPE_KPROBE";     break;
-    case BPF_PROG_TYPE_TRACEPOINT: return "BPF_PROG_TYPE_TRACEPOINT"; break;
-    case BPF_PROG_TYPE_PERF_EVENT: return "BPF_PROG_TYPE_PERF_EVENT"; break;
-    case BPF_PROG_TYPE_TRACING:    return "BPF_PROG_TYPE_TRACING";    break;
-    // clang-format on
-    default:
-      LOG(BUG) << "invalid program type: " << t;
-  }
-}
-
+// eventprefix is always used as std::string
+// NOLINTNEXTLINE(modernize-use-string-view)
 std::string eventprefix(ProbeType t)
 {
   return is_return_type(t) ? "r_" : "p_";

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -14,7 +14,7 @@ namespace bpftrace {
 
 bool is_return_type(ProbeType t);
 bpf_prog_type progtype(ProbeType t);
-std::string progtypeName(bpf_prog_type t);
+std::string_view progtypeName(bpf_prog_type t);
 
 class AttachError : public ErrorInfo<AttachError> {
 public:

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -4,7 +4,7 @@
 
 namespace bpftrace {
 
-static std::string logtype_str(LogType t)
+static std::string_view logtype_str(LogType t)
 {
   switch (t) {
       // clang-format off
@@ -67,8 +67,7 @@ void Log::take_input(LogType type,
   if (source_location) {
     out << *source_location << ": ";
   }
-  const std::string& typestr = logtype_str(type);
-  out << typestr << msg << color_end << std::endl;
+  out << logtype_str(type) << msg << color_end << std::endl;
 
   if (source_context) {
     for (const auto& s : *source_context) {

--- a/src/probe_types.cpp
+++ b/src/probe_types.cpp
@@ -43,6 +43,9 @@ std::string expand_probe_name(const std::string &orig_name)
   return expanded_name;
 }
 
+// probetypeName is often used in string concatenations so do not use
+// string_view to avoid extra casts
+// NOLINTNEXTLINE(modernize-use-string-view)
 std::string probetypeName(ProbeType t)
 {
   // clang-format off

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -280,7 +280,7 @@ bool SizedType::IsStack() const
   return type_ == Type::ustack_t || type_ == Type::kstack_t;
 }
 
-std::string addrspacestr(AddrSpace as)
+std::string_view addrspacestr(AddrSpace as)
 {
   switch (as) {
     case AddrSpace::kernel:

--- a/src/types.h
+++ b/src/types.h
@@ -661,7 +661,7 @@ std::optional<SizedType> get_promoted_record(const SizedType &currentType,
 std::optional<SizedType> get_promoted_type(const SizedType &currentType,
                                            const SizedType &newType);
 
-std::string addrspacestr(AddrSpace as);
+std::string_view addrspacestr(AddrSpace as);
 std::string typestr(Type t);
 std::string typestr(const SizedType &type);
 std::ostream &operator<<(std::ostream &os, const SizedType &type);


### PR DESCRIPTION
Stacked PRs:
 * #5299
 * #5298
 * __->__#5297
 * #5296
 * #5295


--- --- ---

### Use std::string_view where possible


Replace std::string by std::string_view where it makes sense to decrease
the number of string allocations. In some places, leaving std::string
leads to cleaner code so just add hints for Clang-Tidy to ignore those
parts.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>