### PR TITLE
IRBuilderBPF: Fix HasTerminator on LLVM 23

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -2512,7 +2512,13 @@ llvm::Value *IRBuilderBPF::CreateCheckedBinop(Binop &binop,
 bool IRBuilderBPF::HasTerminator()
 {
   BasicBlock *current_block = GetInsertBlock();
-  return current_block && current_block->getTerminator();
+  if (!current_block)
+    return false;
+#if LLVM_VERSION_MAJOR >= 23
+  if (!current_block->hasTerminator())
+    return false;
+#endif
+  return current_block->getTerminator();
 }
 
 } // namespace bpftrace::ast


### PR DESCRIPTION
Stacked PRs:
 * #5299
 * __->__#5298
 * #5297
 * #5296
 * #5295


--- --- ---

### IRBuilderBPF: Fix HasTerminator on LLVM 23


LLVM 23 changed the implementation of BasicBlock::getTerminator(), which
now doesn't check that a basic block actually has a terminator and
should only be called after a successful BasicBlock::hasTerminator()
check. Add the check to IRBuilderBPF::HasTerminator() for LLVM 23.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>