### PR TITLE
Add probefunc builtin

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1082,6 +1082,14 @@ Name of the fully expanded probe
 For example: `kprobe:do_nanosleep`
 
 
+### probefunc
+- `string probefunc()`
+- `string probefunc`
+
+Name of the probe function.
+Note: `begin` and `end` probes have empty function.
+
+
 ### probetype
 - `string probetype()`
 - `string probetype`

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -190,21 +190,20 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
     return ast_.make_node<String>(node.loc, ss.str());
   } else if (ident == "__builtin_safe_mode") {
     return ast_.make_node<Boolean>(node.loc, bpftrace_.safe_mode_);
-  } else if (ident == "__builtin_probe") {
+  } else if (ident == "__builtin_probe" || ident == "__builtin_probetype" ||
+             ident == "__builtin_probefunc") {
     if (check_probe()) {
+      std::string name;
+      if (ident == "__builtin_probe") {
+        name = probe->attach_points.front()->name();
+      } else if (ident == "__builtin_probefunc") {
+        name = probe->attach_points.front()->func;
+      } else if (ident == "__builtin_probetype") {
+        name = probetypeName(probetype(probe->attach_points.front()->provider));
+      }
       return ast_.make_node<String>(node.loc,
-                                    probe->attach_points.empty()
-                                        ? "none"
-                                        : probe->attach_points.front()->name());
-    }
-  } else if (ident == "__builtin_probetype") {
-    if (check_probe()) {
-      return ast_.make_node<String>(
-          node.loc,
-          probe->attach_points.empty()
-              ? "none"
-              : probetypeName(
-                    probetype(probe->attach_points.front()->provider)));
+                                    probe->attach_points.empty() ? "none"
+                                                                 : name);
     }
   } else if (ident == "__builtin_elf_is_exe") {
     if (check_probe()) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3326,6 +3326,7 @@ bool Parser::is_builtin(std::string_view name)
     "__builtin_func",
     "__builtin_ncpus",
     "__builtin_probe",
+    "__builtin_probefunc",
     "__builtin_retval",
     "__builtin_usermode",
   };

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -1131,6 +1131,14 @@ macro probetype()
   __builtin_probetype
 }
 
+// :variant string probefunc()
+// Name of the probe function.
+// Note: `begin` and `end` probes have empty function.
+macro probefunc()
+{
+  __builtin_probefunc
+}
+
 // :function pton
 // :variant char addr[4] pton(const string *addr_v4)
 // :variant char addr[16] pton(const string *addr_v6)

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -161,6 +161,11 @@ NAME builtin wrapper probetype
 PROG begin { if (__builtin_probetype == probetype() && __builtin_probetype == probetype) { print(probetype); } exit(); }
 EXPECT special
 
+NAME builtin wrapper probefunc
+PROG k:do_nanosleep { if (__builtin_probefunc == probefunc() && __builtin_probefunc == probefunc) { print(probefunc); } exit(); }
+EXPECT do_nanosleep
+AFTER ./testprogs/syscall nanosleep 1e8
+
 NAME builtin wrapper retval
 PROG kretprobe:vfs_read { if (__builtin_retval == retval() && __builtin_retval == retval) { printf("SUCCESS %d\n", retval); exit(); } }
 EXPECT_REGEX SUCCESS .*


### PR DESCRIPTION
Add __builtin_probefunc and implement stdlib probefunc, this is particularly useful in the following scenarios.

When I need to track a series of kprobes, I need to perform independent statistics for each observation point, so I need to add an @map. The key of this @map needs to distinguish different kprobes.

Think about printk-ringbuffer:

    kprobe:prb_commit,
    kprobe:prb_read,
    kprobe:prb_reserve
    {
      @start[/*KEY*/, tid] = nsecs;
    }
    kretprobe:prb_commit,
    kretprobe:prb_read,
    kretprobe:prb_reserve
    / has_key(@start, (/*KEY*/, tid)) /
    {
       $cost = (nsecs - @start[/*KEY*/, tid]) / 1000;
       // Do more things
    }

In the example above, I need a key that allows kprobe:prb_commit and kretprobe:prb_commit to match, meaning their key values are the same.

`probe` won't work because it includes `probetype`, and `func/__builtin_func` also won't work because they currently handle `kprobe` and `kretprobe` inconsistently. Therefore, this commit added `__builtin_probefunc/probefunc` to resolve this issue.
