### PR TITLE
Add quote-aware splitting for child command (-c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -272,6 +272,8 @@ and this project adheres to
   - [#5022](https://github.com/bpftrace/bpftrace/pull/5022)
 - Fix handling of void ptr and function ptr BTF types
   - [#5042](https://github.com/bpftrace/bpftrace/pull/5042)
+- Fix command splitting with quotes and escapes for child command (`-c`)
+  - [#5301](https://github.com/bpftrace/bpftrace/pull/5301)
 #### Security
 #### Docs
 #### Tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
 #### Fixed
 - Fix `func` builtin for session probe return/exit branches
   - [#5302](https://github.com/bpftrace/bpftrace/issues/5302)
+- Fix command splitting with quotes and escapes for child command (`-c`)
+  - [#5301](https://github.com/bpftrace/bpftrace/pull/5301)
 #### Security
 #### Docs
 #### Tools
@@ -272,8 +274,6 @@ and this project adheres to
   - [#5022](https://github.com/bpftrace/bpftrace/pull/5022)
 - Fix handling of void ptr and function ptr BTF types
   - [#5042](https://github.com/bpftrace/bpftrace/pull/5042)
-- Fix command splitting with quotes and escapes for child command (`-c`)
-  - [#5301](https://github.com/bpftrace/bpftrace/pull/5301)
 #### Security
 #### Docs
 #### Tools

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -73,9 +73,10 @@ The child process runs with the same privileges as bpftrace itself (usually root
 
 The command is split into arguments without invoking a shell. Single and double
 quotes group words into a single argument and are stripped; a backslash escapes
-the following character (outside quotes, and inside double quotes for `"`, `\\`,
-'$', '`' and newline only). '\$' and '\*' are passed through verbatim without
-shell expansion. An unclosed quote or a trailing backslash is an error.
+the following character (outside quotes, and inside double quotes for `"`, `\`,
+`$`, ``` and newline only). The command is executed directly, so variables (such
+as `$HOME`) and wildcards are not expanded. An unclosed quote or a trailing
+backslash is an error.
 
 Unless otherwise specified, bpftrace does not perform any implicit filtering. Therefore, if you are only interested in
 events in _COMMAND_, you may want to filter based on the child PID. The child PID is available to programs as the 'cpid' builtin.

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -71,6 +71,12 @@ If used, 'USDT' probes will only be attached to the child process.
 To avoid a race condition when using 'USDTs', the child is stopped after 'execve' using 'ptrace(2)' and continued when all 'USDT' probes are attached.
 The child process runs with the same privileges as bpftrace itself (usually root).
 
+The command is split into arguments without invoking a shell. Single and double
+quotes group words into a single argument and are stripped; a backslash escapes
+the following character (outside quotes, and inside double quotes for `"`, `\\`,
+'$', '`' and newline only). '\$' and '\*' are passed through verbatim without
+shell expansion. An unclosed quote or a trailing backslash is an error.
+
 Unless otherwise specified, bpftrace does not perform any implicit filtering. Therefore, if you are only interested in
 events in _COMMAND_, you may want to filter based on the child PID. The child PID is available to programs as the 'cpid' builtin.
 For example, you could add the predicate `/pid == cpid/` to probes with userspace context.

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -200,7 +200,7 @@ struct PerfEventContext {
   PerfEventContext(BPFtrace &b,
                    async_action::AsyncHandlers &handlers,
                    output::Output &o)
-      : bpftrace(b), handlers(handlers), output(o) {};
+      : bpftrace(b), handlers(handlers), output(o){};
   BPFtrace &bpftrace;
   async_action::AsyncHandlers &handlers;
   output::Output &output;
@@ -1417,7 +1417,8 @@ int BPFtrace::resume_tracee(pid_t tracee_pid)
 
 const std::optional<struct stat> &BPFtrace::get_pidns_self_stat() const
 {
-  static std::optional<struct stat> pidns = []() -> std::optional<struct stat> {
+  static std::optional<struct stat> pidns = []() -> std::optional<struct stat>
+  {
     struct stat s;
     if (::stat("/proc/self/ns/pid", &s)) {
       if (errno == ENOENT)
@@ -1427,7 +1428,8 @@ const std::optional<struct stat> &BPFtrace::get_pidns_self_stat() const
           std::strerror(errno));
     }
     return s;
-  }();
+  }
+  ();
 
   return pidns;
 }

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1050,9 +1050,13 @@ std::optional<std::string> BPFtrace::get_watchpoint_binary_path() const
   if (child_) {
     // We can ignore all error checking here b/c child.cpp:validate_cmd() has
     // already done it
-    auto args = util::split_string_quotes(cmd_, ' ', /* remove_empty */ true);
-    assert(!args.empty());
-    return util::resolve_binary_path(args[0]).front();
+    auto args = util::split_string_quotes(cmd_);
+    if (!args) {
+      LOG(ERROR) << "Bad child command. Error: " << args.takeError();
+      return std::nullopt;
+    }
+    assert(!args->empty());
+    return util::resolve_binary_path((*args)[0]).front();
   } else if (pid().has_value()) {
     return "/proc/" + std::to_string(pid().value_or(0)) + "/exe";
   } else {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1048,8 +1048,6 @@ void BPFtrace::poll_event_loss(output::Output &out)
 std::optional<std::string> BPFtrace::get_watchpoint_binary_path() const
 {
   if (child_) {
-    // We can ignore all error checking here b/c child.cpp:validate_cmd() has
-    // already done it
     auto args = util::split_string_quotes(cmd_);
     if (!args) {
       LOG(ERROR) << "Bad child command. Error: " << args.takeError();

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1050,7 +1050,7 @@ std::optional<std::string> BPFtrace::get_watchpoint_binary_path() const
   if (child_) {
     // We can ignore all error checking here b/c child.cpp:validate_cmd() has
     // already done it
-    auto args = util::split_string(cmd_, ' ', /* remove_empty */ true);
+    auto args = util::split_string_quotes(cmd_, ' ', /* remove_empty */ true);
     assert(!args.empty());
     return util::resolve_binary_path(args[0]).front();
   } else if (pid().has_value()) {

--- a/src/util/proc.cpp
+++ b/src/util/proc.cpp
@@ -26,7 +26,7 @@ namespace bpftrace::util {
 namespace {
 class ProcImpl : public Proc {
 public:
-  ProcImpl(pid_t pid, util::FD pidfd) : pid_(pid), pidfd_(std::move(pidfd)) {};
+  ProcImpl(pid_t pid, util::FD pidfd) : pid_(pid), pidfd_(std::move(pidfd)){};
 
   bool is_alive() override;
   pid_t pid() override
@@ -52,7 +52,7 @@ public:
       : child_pid_(child_pid),
         pidfd_(std::move(pidfd)),
         command_fd_(std::move(command_fd)),
-        result_fd_(std::move(result_fd)) {};
+        result_fd_(std::move(result_fd)){};
 
   // Parse command and fork a child process. The child is run with the same
   // permissions and environment variables as bpftrace.

--- a/src/util/proc.cpp
+++ b/src/util/proc.cpp
@@ -526,13 +526,16 @@ Result<std::unique_ptr<ChildProc>> create_child(const std::string& cmd,
   }
 
   // Construct our arguments for the child.
-  auto args = util::split_string_quotes(cmd, ' ');
-  auto binary = extract_binary(args);
+  auto args = util::split_string_quotes(cmd);
+  if (!args) {
+    return args.takeError();
+  }
+  auto binary = extract_binary(*args);
   if (!binary) {
     return binary.takeError();
   }
   std::vector<char*> argv;
-  for (auto& arg : args) {
+  for (auto& arg : *args) {
     argv.push_back(const_cast<char*>(arg.c_str()));
   }
   argv.push_back(nullptr);

--- a/src/util/proc.cpp
+++ b/src/util/proc.cpp
@@ -526,7 +526,7 @@ Result<std::unique_ptr<ChildProc>> create_child(const std::string& cmd,
   }
 
   // Construct our arguments for the child.
-  auto args = util::split_string(cmd, ' ');
+  auto args = util::split_string_quotes(cmd, ' ');
   auto binary = extract_binary(args);
   if (!binary) {
     return binary.takeError();

--- a/src/util/strings.cpp
+++ b/src/util/strings.cpp
@@ -22,6 +22,63 @@ std::vector<std::string> split_string(const std::string &str,
   return elems;
 }
 
+std::vector<std::string> split_string_quotes(const std::string &str,
+                                             char delimiter,
+                                             bool remove_empty)
+{
+  std::vector<std::string> elems;
+  if (str.empty())
+    return elems;
+
+  std::string value;
+  char quote = '\0';
+  bool escaped = false;
+  bool quoted = false; // current token contains a quoted section
+
+  for (char c : str) {
+    if (escaped) {
+      // Backslash escapes the next character: keep it verbatim and
+      // don't treat it as a quote or delimiter.
+      value += c;
+      escaped = false;
+    } else if (c == '\\') {
+      // Keep the backslash itself and escape the following character.
+      value += c;
+      escaped = true;
+    } else if (quote != '\0') {
+      if (c == quote) {
+        quote = '\0';
+      } else {
+        value += c;
+      }
+    } else if (c == '\'' || c == '"') {
+      quote = c;
+      quoted = true;
+    } else if (c == delimiter) {
+      // An explicitly quoted empty argument is kept even when
+      // remove_empty is set: it is a real argument, not a gap.
+      if (!remove_empty || !value.empty() || quoted) {
+        elems.push_back(value);
+        value.clear();
+        quoted = false;
+      }
+    } else {
+      value += c;
+    }
+  }
+
+  // Flush the final token. An unclosed quote is kept verbatim (the
+  // opening quote char is prepended) so we never silently drop input.
+  if (quote != '\0') {
+    value = std::string(1, quote) + value;
+  }
+  if (!remove_empty || !value.empty() || quoted) {
+    elems.push_back(value);
+  }
+
+  return elems;
+}
+
 /// Erase prefix up to the first colon (:) from str and return the prefix
 std::string erase_prefix(std::string &str)
 {

--- a/src/util/strings.cpp
+++ b/src/util/strings.cpp
@@ -70,7 +70,7 @@ Result<std::vector<std::string>> split_string_quotes(const std::string &str)
           i += 2;
         } else {
           return make_error<SystemError>(
-              "Trailing backslash in command string: " + str);
+              "Trailing backslash in command string: " + str, 0);
         }
       } else if (std::isspace(static_cast<unsigned char>(c))) {
         if (has_token) {
@@ -88,7 +88,8 @@ Result<std::vector<std::string>> split_string_quotes(const std::string &str)
   }
 
   if (in_quotes) {
-    return make_error<SystemError>("Unclosed quote in command string: " + str);
+    return make_error<SystemError>("Unclosed quote in command string: " + str,
+                                   0);
   }
 
   if (has_token) {

--- a/src/util/strings.cpp
+++ b/src/util/strings.cpp
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include <sstream>
 
+#include "util/result.h"
 #include "util/strings.h"
 
 namespace bpftrace::util {
@@ -22,61 +23,71 @@ std::vector<std::string> split_string(const std::string &str,
   return elems;
 }
 
-std::vector<std::string> split_string_quotes(const std::string &str,
-                                             char delimiter,
-                                             bool remove_empty)
+Result<std::vector<std::string>> split_string_quotes(const std::string &str)
 {
-  std::vector<std::string> elems;
-  if (str.empty())
-    return elems;
+  std::vector<std::string> args;
+  std::string current;
+  bool in_quotes = false;
+  char quote_char = '\0';
+  bool has_token = false;
 
-  std::string value;
-  char quote = '\0';
-  bool escaped = false;
-  bool quoted = false; // current token contains a quoted section
+  for (size_t i = 0; i < str.size(); ++i) {
+    char c = str[i];
 
-  for (char c : str) {
-    if (escaped) {
-      // Backslash escapes the next character: keep it verbatim and
-      // don't treat it as a quote or delimiter.
-      value += c;
-      escaped = false;
-    } else if (c == '\\') {
-      // Keep the backslash itself and escape the following character.
-      value += c;
-      escaped = true;
-    } else if (quote != '\0') {
-      if (c == quote) {
-        quote = '\0';
+    if (in_quotes) {
+      if (c == quote_char) {
+        // Closing quote
+        in_quotes = false;
+        quote_char = '\0';
+      } else if (quote_char == '"' && c == '\\' && i + 1 < str.size()) {
+        char next = str[i + 1];
+        // POSIX rule: inside double quotes, \ only escapes ", \, $, `, and \n
+        if (next == '"' || next == '\\' || next == '$' || next == '`' ||
+            next == '\n') {
+          current += next;
+          i++;
+        } else {
+          current += c;
+        }
       } else {
-        value += c;
-      }
-    } else if (c == '\'' || c == '"') {
-      quote = c;
-      quoted = true;
-    } else if (c == delimiter) {
-      // An explicitly quoted empty argument is kept even when
-      // remove_empty is set: it is a real argument, not a gap.
-      if (!remove_empty || !value.empty() || quoted) {
-        elems.push_back(value);
-        value.clear();
-        quoted = false;
+        current += c;
       }
     } else {
-      value += c;
+      if (c == '\'' || c == '"') {
+        in_quotes = true;
+        quote_char = c;
+        has_token = true;
+      } else if (c == '\\') {
+        // Outside quotes: backslash escapes the following character
+        if (i + 1 < str.size()) {
+          current += str[++i];
+          has_token = true;
+        } else {
+          return make_error<SystemError>(
+              "Trailing backslash in command string: " + str);
+        }
+      } else if (std::isspace(static_cast<unsigned char>(c))) {
+        if (has_token) {
+          args.push_back(std::move(current));
+          current.clear();
+          has_token = false;
+        }
+      } else {
+        current += c;
+        has_token = true;
+      }
     }
   }
 
-  // Flush the final token. An unclosed quote is kept verbatim (the
-  // opening quote char is prepended) so we never silently drop input.
-  if (quote != '\0') {
-    value = std::string(1, quote) + value;
-  }
-  if (!remove_empty || !value.empty() || quoted) {
-    elems.push_back(value);
+  if (in_quotes) {
+    return make_error<SystemError>("Unclosed quote in command string: " + str);
   }
 
-  return elems;
+  if (has_token) {
+    args.push_back(std::move(current));
+  }
+
+  return args;
 }
 
 /// Erase prefix up to the first colon (:) from str and return the prefix

--- a/src/util/strings.cpp
+++ b/src/util/strings.cpp
@@ -31,7 +31,8 @@ Result<std::vector<std::string>> split_string_quotes(const std::string &str)
   char quote_char = '\0';
   bool has_token = false;
 
-  for (size_t i = 0; i < str.size(); ++i) {
+  size_t i = 0;
+  while (i < str.size()) {
     char c = str[i];
 
     if (in_quotes) {
@@ -39,29 +40,34 @@ Result<std::vector<std::string>> split_string_quotes(const std::string &str)
         // Closing quote
         in_quotes = false;
         quote_char = '\0';
+        i++;
       } else if (quote_char == '"' && c == '\\' && i + 1 < str.size()) {
         char next = str[i + 1];
         // POSIX rule: inside double quotes, \ only escapes ", \, $, `, and \n
         if (next == '"' || next == '\\' || next == '$' || next == '`' ||
             next == '\n') {
           current += next;
-          i++;
+          i += 2;
         } else {
           current += c;
+          i++;
         }
       } else {
         current += c;
+        i++;
       }
     } else {
       if (c == '\'' || c == '"') {
         in_quotes = true;
         quote_char = c;
         has_token = true;
+        i++;
       } else if (c == '\\') {
         // Outside quotes: backslash escapes the following character
         if (i + 1 < str.size()) {
-          current += str[++i];
+          current += str[i + 1];
           has_token = true;
+          i += 2;
         } else {
           return make_error<SystemError>(
               "Trailing backslash in command string: " + str);
@@ -72,9 +78,11 @@ Result<std::vector<std::string>> split_string_quotes(const std::string &str)
           current.clear();
           has_token = false;
         }
+        i++;
       } else {
         current += c;
         has_token = true;
+        i++;
       }
     }
   }

--- a/src/util/strings.h
+++ b/src/util/strings.h
@@ -38,7 +38,8 @@ std::vector<std::string> split_string(const std::string &str,
 // - Unquoted backslashes escape the next character.
 // - Whitespace outside quotes separates arguments.
 //
-// Returns SystemError if there are unclosed quotes or trailing escape backslashes.
+// Returns SystemError if there are unclosed quotes or trailing escape
+// backslashes.
 Result<std::vector<std::string>> split_string_quotes(const std::string &str);
 
 std::string str_join(const std::vector<std::string> &list,

--- a/src/util/strings.h
+++ b/src/util/strings.h
@@ -28,6 +28,9 @@ inline std::string &trim(std::string &s)
 std::vector<std::string> split_string(const std::string &str,
                                       char delimiter,
                                       bool remove_empty = false);
+std::vector<std::string> split_string_quotes(const std::string &str,
+                                             char delimiter,
+                                             bool remove_empty = false);
 
 std::string str_join(const std::vector<std::string> &list,
                      const std::string &delim);

--- a/src/util/strings.h
+++ b/src/util/strings.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include "util/result.h"
+
 namespace bpftrace::util {
 
 // trim from end of string (right)
@@ -28,9 +30,16 @@ inline std::string &trim(std::string &s)
 std::vector<std::string> split_string(const std::string &str,
                                       char delimiter,
                                       bool remove_empty = false);
-std::vector<std::string> split_string_quotes(const std::string &str,
-                                             char delimiter,
-                                             bool remove_empty = false);
+
+// Splits a command string into arguments according to POSIX shell quote and
+// escape rules:
+// - Double quotes allow \ escapes for ", \, $, `, and newline.
+// - Single quotes preserve literal contents verbatim (no \ escaping).
+// - Unquoted backslashes escape the next character.
+// - Whitespace outside quotes separates arguments.
+//
+// Returns SystemError if there are unclosed quotes or trailing escape backslashes.
+Result<std::vector<std::string>> split_string_quotes(const std::string &str);
 
 std::string str_join(const std::vector<std::string> &list,
                      const std::string &delim);

--- a/tests/runtime/child
+++ b/tests/runtime/child
@@ -1,15 +1,15 @@
 NAME child command splits double-quoted args
-RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c "echo 'hello world'"
-EXPECT echo|hello world
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c "/bin/echo 'hello world'"
+EXPECT /bin/echo|hello world
 
 NAME child command splits single-quoted args
-RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c 'echo "hello world"'
-EXPECT echo|hello world
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c '/bin/echo "hello world"'
+EXPECT /bin/echo|hello world
 
 NAME child command backslash escapes space
-RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c "echo a\ b"
-EXPECT echo|a b
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c "/bin/echo a\ b"
+EXPECT /bin/echo|a b
 
 NAME child command trailing space does not add empty arg
-RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c "sleep 5 "
-EXPECT sleep|5
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c "/bin/sleep 5 "
+EXPECT /bin/sleep|5

--- a/tests/runtime/child
+++ b/tests/runtime/child
@@ -1,0 +1,15 @@
+NAME child command splits double-quoted args
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c "echo 'hello world'"
+EXPECT echo|hello world
+
+NAME child command splits single-quoted args
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c 'echo "hello world"'
+EXPECT echo|hello world
+
+NAME child command backslash escapes space
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c "echo a\ b"
+EXPECT echo|a b
+
+NAME child command trailing space does not add empty arg
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_execve /pid == cpid/ { join(args.argv, "|"); exit(); }' -c "sleep 5 "
+EXPECT sleep|5

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -111,7 +111,7 @@ EXPECT {"type": "syscall", "data": "a b c\n"}
 
 NAME join_delim
 RUN {{BPFTRACE}} --unsafe -f json -e 'tracepoint:syscalls:sys_enter_execve { join(args.argv, ","); }' -c "./testprogs/syscall execve /bin/echo 'A'"
-EXPECT {"type": "join", "data": "/bin/echo,'A'"}
+EXPECT {"type": "join", "data": "/bin/echo,A"}
 
 NAME cat
 RUN {{BPFTRACE}} -f json -e 'begin { cat("/proc/uptime");  }'

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -109,9 +109,20 @@ TEST(utils, split_string_quotes)
   EXPECT_EQ(*split_string_quotes("echo $HOME *"), tokens_echo_verbatim);
 
   // Error handling on unterminated quotes / trailing backslash
-  EXPECT_FALSE(split_string_quotes("echo 'unterminated"));
-  EXPECT_FALSE(split_string_quotes("echo \"unterminated"));
-  EXPECT_FALSE(split_string_quotes("echo trailing\\"));
+  auto unclosed_single = split_string_quotes("echo 'unterminated");
+  EXPECT_FALSE(unclosed_single);
+  EXPECT_THAT(llvm::toString(unclosed_single.takeError()),
+              testing::HasSubstr("Unclosed quote in command string"));
+
+  auto unclosed_double = split_string_quotes("echo \"unterminated");
+  EXPECT_FALSE(unclosed_double);
+  EXPECT_THAT(llvm::toString(unclosed_double.takeError()),
+              testing::HasSubstr("Unclosed quote in command string"));
+
+  auto trailing_backslash = split_string_quotes("echo trailing\\");
+  EXPECT_FALSE(trailing_backslash);
+  EXPECT_THAT(llvm::toString(trailing_backslash.takeError()),
+              testing::HasSubstr("Trailing backslash in command string"));
 }
 
 TEST(utils, split_addrrange_symbol_module)

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -64,42 +64,54 @@ TEST(utils, split_string_quotes)
   std::vector<std::string> tokens_echo_hello_world_q = { "echo",
                                                          "hello world" };
   std::vector<std::string> tokens_echo_mixed = { "echo", "a'b", "c\"d" };
-  std::vector<std::string> tokens_echo_backslash = { "echo", "a\\ b" };
+  std::vector<std::string> tokens_echo_backslash = { "echo", "a b" };
   std::vector<std::string> tokens_echo_verbatim = { "echo", "$HOME", "*" };
   std::vector<std::string> tokens_empty_arg = { "echo", "" };
 
-  // Plain splitting without quotes behaves like split_string.
-  EXPECT_EQ(split_string_quotes("echo hello world", ' '),
-            tokens_echo_hello_world);
-  EXPECT_EQ(split_string_quotes("", ' '), tokens_empty);
+  // Plain splitting without quotes
+  EXPECT_EQ(*split_string_quotes("echo hello world"), tokens_echo_hello_world);
+  EXPECT_EQ(*split_string_quotes(""), tokens_empty);
+  EXPECT_EQ(*split_string_quotes("   "), tokens_empty);
 
-  // Quotes group tokens; the quotes themselves are stripped.
-  EXPECT_EQ(split_string_quotes("echo \"hello world\"", ' '),
+  // Quotes group tokens; quotes themselves are stripped
+  EXPECT_EQ(*split_string_quotes("echo \"hello world\""),
             tokens_echo_hello_world_q);
-  EXPECT_EQ(split_string_quotes("echo 'hello world'", ' '),
+  EXPECT_EQ(*split_string_quotes("echo 'hello world'"),
             tokens_echo_hello_world_q);
 
-  // A quote inside the other quote type is an ordinary character.
-  EXPECT_EQ(split_string_quotes("echo \"a'b\" 'c\"d'", ' '), tokens_echo_mixed);
+  // Quotes inside the other quote type
+  EXPECT_EQ(*split_string_quotes("echo \"a'b\" 'c\"d'"), tokens_echo_mixed);
 
-  // Backslash is kept verbatim and escapes the following character, so
-  // the space does not split the token.
-  EXPECT_EQ(split_string_quotes("echo a\\ b", ' '), tokens_echo_backslash);
+  // Unquoted backslash escapes space, but backslash is stripped
+  EXPECT_EQ(*split_string_quotes("echo a\\ b"), tokens_echo_backslash);
 
-  // $ and * are passed through without expansion.
-  EXPECT_EQ(split_string_quotes("echo $HOME *", ' '), tokens_echo_verbatim);
+  // Single quotes do NOT interpret backslashes
+  EXPECT_EQ(*split_string_quotes("echo 'a\\ b'"),
+            std::vector<std::string>({ "echo", "a\\ b" }));
 
-  // Empty quoted arguments are preserved even with remove_empty: they
-  // are explicit empty arguments, not gaps between delimiters.
-  EXPECT_EQ(split_string_quotes("echo \"\"", ' '), tokens_empty_arg);
-  EXPECT_EQ(split_string_quotes("echo \"\"", ' ', true), tokens_empty_arg);
-  // ...while plain gaps between delimiters are dropped with remove_empty.
-  EXPECT_EQ(split_string_quotes("echo   a", ' ', true),
-            std::vector<std::string>({ "echo", "a" }));
+  // Double quotes only escape ", \, $, `, \n
+  EXPECT_EQ(*split_string_quotes("echo \"a\\\"b\""),
+            std::vector<std::string>({ "echo", "a\"b" }));
+  EXPECT_EQ(*split_string_quotes("echo \"a\\t\""),
+            std::vector<std::string>({ "echo", "a\\t" }));
 
-  // An unclosed quote is kept verbatim rather than silently dropped.
-  EXPECT_EQ(split_string_quotes("echo \"abc", ' '),
-            std::vector<std::string>({ "echo", "\"abc" }));
+  // Trailing whitespace should not produce an empty token
+  EXPECT_EQ(*split_string_quotes("sleep 5 "),
+            std::vector<std::string>({ "sleep", "5" }));
+  EXPECT_EQ(*split_string_quotes("  sleep   5   "),
+            std::vector<std::string>({ "sleep", "5" }));
+
+  // Explicit empty quotes produce an empty token
+  EXPECT_EQ(*split_string_quotes("echo \"\""), tokens_empty_arg);
+  EXPECT_EQ(*split_string_quotes("echo ''"), tokens_empty_arg);
+
+  // Shell variables/globs are preserved verbatim (no expansion)
+  EXPECT_EQ(*split_string_quotes("echo $HOME *"), tokens_echo_verbatim);
+
+  // Error handling on unterminated quotes / trailing backslash
+  EXPECT_FALSE(split_string_quotes("echo 'unterminated"));
+  EXPECT_FALSE(split_string_quotes("echo \"unterminated"));
+  EXPECT_FALSE(split_string_quotes("echo trailing\\"));
 }
 
 TEST(utils, split_addrrange_symbol_module)

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -55,6 +55,53 @@ TEST(utils, split_string)
   EXPECT_EQ(split_string("foo-bar", '-'), tokens_foo_bar);
 }
 
+TEST(utils, split_string_quotes)
+{
+  std::vector<std::string> tokens_empty = {};
+  std::vector<std::string> tokens_echo_hello_world = { "echo",
+                                                       "hello",
+                                                       "world" };
+  std::vector<std::string> tokens_echo_hello_world_q = { "echo",
+                                                         "hello world" };
+  std::vector<std::string> tokens_echo_mixed = { "echo", "a'b", "c\"d" };
+  std::vector<std::string> tokens_echo_backslash = { "echo", "a\\ b" };
+  std::vector<std::string> tokens_echo_verbatim = { "echo", "$HOME", "*" };
+  std::vector<std::string> tokens_empty_arg = { "echo", "" };
+
+  // Plain splitting without quotes behaves like split_string.
+  EXPECT_EQ(split_string_quotes("echo hello world", ' '),
+            tokens_echo_hello_world);
+  EXPECT_EQ(split_string_quotes("", ' '), tokens_empty);
+
+  // Quotes group tokens; the quotes themselves are stripped.
+  EXPECT_EQ(split_string_quotes("echo \"hello world\"", ' '),
+            tokens_echo_hello_world_q);
+  EXPECT_EQ(split_string_quotes("echo 'hello world'", ' '),
+            tokens_echo_hello_world_q);
+
+  // A quote inside the other quote type is an ordinary character.
+  EXPECT_EQ(split_string_quotes("echo \"a'b\" 'c\"d'", ' '), tokens_echo_mixed);
+
+  // Backslash is kept verbatim and escapes the following character, so
+  // the space does not split the token.
+  EXPECT_EQ(split_string_quotes("echo a\\ b", ' '), tokens_echo_backslash);
+
+  // $ and * are passed through without expansion.
+  EXPECT_EQ(split_string_quotes("echo $HOME *", ' '), tokens_echo_verbatim);
+
+  // Empty quoted arguments are preserved even with remove_empty: they
+  // are explicit empty arguments, not gaps between delimiters.
+  EXPECT_EQ(split_string_quotes("echo \"\"", ' '), tokens_empty_arg);
+  EXPECT_EQ(split_string_quotes("echo \"\"", ' ', true), tokens_empty_arg);
+  // ...while plain gaps between delimiters are dropped with remove_empty.
+  EXPECT_EQ(split_string_quotes("echo   a", ' ', true),
+            std::vector<std::string>({ "echo", "a" }));
+
+  // An unclosed quote is kept verbatim rather than silently dropped.
+  EXPECT_EQ(split_string_quotes("echo \"abc", ' '),
+            std::vector<std::string>({ "echo", "\"abc" }));
+}
+
 TEST(utils, split_addrrange_symbol_module)
 {
   std::tuple<std::string, std::string, std::string> tokens_ar_sym = {


### PR DESCRIPTION
## What

Make `-c` child command parsing quote-aware: single and double quotes group tokens into one argument (quotes stripped), backslash escapes the next character verbatim, and `$`/`*` pass through without shell expansion. An explicitly quoted empty argument (`""`) is preserved.

Fixes #5119

## Why

`-c "echo \"hello world\""` currently splits on spaces and passes `"hello` and `world"` as separate args. This makes quoted commands (very common: `-c "kill -TERM $PID"`, `-c "echo a b"`) behave unexpectedly compared to a shell-like split.

## How

- `src/util/strings.{cpp,h}`: new `split_string_quotes()` — single-pass state machine tracking quote/escape state.
- `src/util/proc.cpp` (`create_child`): use the new splitter for the argument vector.
- `src/bpftrace.cpp` (`get_watchpoint_binary_path`): same splitter so watchpoint binary resolution agrees with how the command is parsed.
- `tests/utils.cpp`: unit tests covering plain split, quote grouping (single/double), nested-other-quote chars, backslash escaping, `$`/`*` verbatim, and empty quoted args.

## Behavior notes

- Kept non-shell on purpose: no variable expansion, no globbing — just quote-aware splitting, matching the discussion in #5119 (re @ZhangYet).
- Unclosed quote: the opening quote char is prepended and the token kept verbatim, so input is never silently dropped.
- `remove_empty` semantics: a quoted empty arg is a real arg, kept even when `remove_empty=true`.