### PR TITLE
CI: Use fetch-depth 0 for Binary workflow

### DIFF
--- a/.github/workflows/binary.yml
+++ b/.github/workflows/binary.yml
@@ -30,6 +30,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
+        fetch-depth: 0
     - uses: DeterminateSystems/nix-installer-action@v17
       with:
         determinate: true


### PR DESCRIPTION
Recently, we started getting the following failure for the Binary CI workflows on pull requests:

    nix build .?submodules=1#appimage
    cp ./result bpftrace
    shell: /usr/bin/bash -e {0}
    env:
      DETSYS_BACKTRACE_COLLECTOR: e5e28c06-d6d6-410e-90e3-e02e8d09333f
      DETERMINATE_NIX_KVM: 1
      MAGIC_NIX_CACHE_DAEMONDIR: /home/runner/work/_temp/magic-nix-cache-fb9be037-81ea-40cc-962c-57e0c180f2dd
    error:
         … while fetching the input 'git+file:///home/runner/work/bpftrace/bpftrace?shallow=1&submodules=1'

         … while fetching the input 'git+file:///home/runner/work/bpftrace/bpftrace/libbpf?submodules=1'

         error: '/home/runner/work/bpftrace/bpftrace/libbpf' is a shallow Git repository, so 'revCount' is not available
    Error: Process completed with exit code 1.

Interestingly, it only happens on pull requests. The reason seems to be that the checkout action by default performs shallow clones on submodules. Set fetch-depth to 0 to perform full clone.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
