### PR TITLE
kprobe: Add support for attaching kprobes via source location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 #### Added
 - stdlib: Add `abs_path` and `cwd`.
   - [#5276](https://github.com/bpftrace/bpftrace/pull/5276)
+- Add `kprobe` support for source location attachpoints.
+  - [#5308](https://github.com/bpftrace/bpftrace/pull/5308)
 #### Changed
 #### Deprecated
 #### Removed

--- a/docker/Dockerfile.static
+++ b/docker/Dockerfile.static
@@ -31,6 +31,7 @@ RUN apk add --update \
   llvm18-dev \
   llvm18-gtest \
   llvm18-static \
+  musl-fts-dev \
   musl-obstack-dev \
   openssl-dev \
   pahole \

--- a/docs/language.md
+++ b/docs/language.md
@@ -1343,6 +1343,7 @@ fexit:fget {
 * `kprobe[:module]:fn`
 * `kprobe[:module]:fn+offset`
 * `kprobe:addr`
+* `kprobe@file:line[:col]`
 * `kretprobe[:module]:fn`
 * `kretprobe:addr`
 
@@ -1426,6 +1427,20 @@ kretprobe:d_lookup
 {
 	printf("%-8d %-6d %-16s M %s\n", elapsed / 1e6, pid, comm,
 	    str(@fname[tid]));
+}
+```
+
+If DWARF debugging symbols are available for the kernel and/or kernel modules,
+`kprobe` can be attached via a `file:line[:col]` source location. The file path
+may be absolute or relative, and
+`line:col` must refer to a valid statement in that file. This is useful for
+probing inside a function body.
+
+```
+kprobe@fs/open.c:1077
+{
+  printf("0x%lx\n", reg("ip"));
+  exit();
 }
 ```
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -178,6 +178,16 @@ if (LIBDW_FOUND)
 
     set(LIBDW_LIBS LIBBZ2 LIBELF LIBLZMA)
 
+    # Some libc implementations, such as musl, provide fts(3) in a separate
+    # library. libdwfl's kernel module helpers use these symbols, so propagate
+    # the optional static library when it is available.
+    find_library(LIBFTS_LIBRARIES NAMES fts)
+    if (LIBFTS_LIBRARIES)
+      add_library(LIBFTS STATIC IMPORTED)
+      set_property(TARGET LIBFTS PROPERTY IMPORTED_LOCATION ${LIBFTS_LIBRARIES})
+      set(LIBDW_LIBS ${LIBDW_LIBS} LIBFTS)
+    endif()
+
     if (${LIBEBL_FOUND})
       # libebl is not necessary on some systems (e.g. Alpine)
       add_library(LIBEBL STATIC IMPORTED)

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -39,8 +39,12 @@ private:
 void AttachPointChecker::visit(AttachPoint &ap)
 {
   if (ap.provider == "kprobe" || ap.provider == "kretprobe") {
-    if (ap.func.empty() && ap.address == 0)
-      ap.addError() << "kprobes should be attached to a function or an address";
+    if (ap.func.empty() && ap.address == 0 &&
+        (ap.source_file.empty() || ap.line_num == 0)) {
+      ap.addError()
+          << "kprobes should be attached to a function, address, or source "
+             "file and line";
+    }
     // Warn if user tries to attach to a non-traceable function
     if (bpftrace_.config_->missing_probes != ConfigMissingProbes::ignore &&
         !util::has_wildcard(ap.func) && !ap.func.empty() &&
@@ -641,14 +645,67 @@ AttachPointParser::State AttachPointParser::benchmark_parser()
   return OK;
 }
 
-AttachPointParser::State AttachPointParser::kprobe_parser(bool allow_offset)
+AttachPointParser::State AttachPointParser::kprobe_parser(bool allow_offset,
+                                                          bool allow_src_loc)
 {
   auto num_parts = parts_.size();
-  if (num_parts != 2 && num_parts != 3) {
+  // kprobe attached by source code location (kprobe@source_file:line[:col])
+  const bool source_location = num_parts > 1 && parts_[1] == "@";
+  if (!source_location && num_parts != 2 && num_parts != 3) {
     if (ap_->ignore_invalid)
       return SKIP;
 
     return argument_count_error(1, 2);
+  }
+
+  if (source_location) {
+    if (!allow_src_loc) {
+      errs_ << "Source code location not allowed" << std::endl;
+      return INVALID;
+    }
+
+    if ((parts_.size() != 4 && parts_.size() != 5) ||
+        (parts_[2].empty() || parts_[3].empty())) {
+      errs_ << "Invalid kprobe arguments, "
+            << "expected format: kprobe@FILE:LINE[:COL]" << std::endl;
+      return INVALID;
+    }
+
+    ap_->source_file = parts_[2];
+
+    auto line = util::to_uint(parts_[3]);
+    if (!line) {
+      errs_ << "Invalid line number: " << line.takeError() << std::endl;
+      return INVALID;
+    }
+    ap_->line_num = *line;
+
+    if (parts_.size() == 5) {
+      auto col = util::to_uint(parts_[4]);
+      if (!col) {
+        errs_ << "Invalid column number: " << col.takeError() << std::endl;
+        return INVALID;
+      }
+      ap_->col_num = *col;
+    }
+
+    Dwarf *dwarf = bpftrace_.get_kernel_dwarf();
+    if (dwarf) {
+      auto address = dwarf->line_to_addr(ap_->source_file,
+                                         ap_->line_num,
+                                         ap_->col_num);
+      if (!address) {
+        errs_ << address.takeError() << std::endl;
+        return INVALID;
+      }
+      ap_->address = *address;
+
+      return OK;
+    }
+
+    errs_ << "No DWARF debug info found for kernel, cannot attach "
+          << "by source code location." << std::endl;
+    return INVALID;
   }
 
   auto func_idx = 1;
@@ -709,7 +766,7 @@ AttachPointParser::State AttachPointParser::kprobe_parser(bool allow_offset)
 
 AttachPointParser::State AttachPointParser::kretprobe_parser()
 {
-  return kprobe_parser(false);
+  return kprobe_parser(false, false);
 }
 
 AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,

--- a/src/ast/passes/attachpoint_passes.h
+++ b/src/ast/passes/attachpoint_passes.h
@@ -62,7 +62,7 @@ private:
   State special_parser();
   State test_parser();
   State benchmark_parser();
-  State kprobe_parser(bool allow_offset = true);
+  State kprobe_parser(bool allow_offset = true, bool allow_src_loc = true);
   State kretprobe_parser();
   State uprobe_parser(bool allow_offset = true, bool allow_src_loc = true);
   State uretprobe_parser();

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1480,6 +1480,13 @@ Result<uint64_t> BPFtrace::get_buffer_pages_per_cpu() const
   return get_buffer_pages(true);
 }
 
+Dwarf *BPFtrace::get_kernel_dwarf()
+{
+  if (!kernel_dwarf_)
+    kernel_dwarf_ = Dwarf::GetFromKernel(this, debuginfo_path_);
+  return kernel_dwarf_.get();
+}
+
 Dwarf *BPFtrace::get_dwarf(const std::string &filename)
 {
   auto dwarf = dwarves_.find(filename);
@@ -1495,10 +1502,13 @@ Dwarf *BPFtrace::get_dwarf(const std::string &filename)
 Dwarf *BPFtrace::get_dwarf(const ast::AttachPoint &attachpoint)
 {
   auto probe_type = probetype(attachpoint.provider);
-  if (probe_type != ProbeType::uprobe && probe_type != ProbeType::uretprobe)
-    return nullptr;
+  if (probe_type == ProbeType::uprobe || probe_type == ProbeType::uretprobe)
+    return get_dwarf(attachpoint.target);
+  if ((probe_type == ProbeType::kprobe || probe_type == ProbeType::kretprobe) &&
+      !attachpoint.source_file.empty())
+    return get_kernel_dwarf();
 
-  return get_dwarf(attachpoint.target);
+  return nullptr;
 }
 
 int BPFtrace::create_pcaps()

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -44,6 +44,9 @@ using util::Symbol;
 
 const int timeout_ms = 100;
 
+constexpr auto default_debuginfo_paths =
+    ":.debug:/usr/lib/debug:/lib/debug/boot";
+
 enum class DebugStage;
 
 // globals
@@ -171,6 +174,7 @@ public:
   bool write_pcaps(uint64_t id, uint64_t ns, const OpaqueValue &pkt);
   void parse_module_btf(const std::set<std::string> &modules);
   bool has_btf_data() const;
+  Dwarf *get_kernel_dwarf();
   Dwarf *get_dwarf(const std::string &filename);
   Dwarf *get_dwarf(const ast::AttachPoint &attachpoint);
   std::set<std::string> list_modules(const ast::ASTContext &ctx,
@@ -265,6 +269,7 @@ private:
   uint64_t event_loss_count_ = 0;
 
   std::unordered_map<std::string, std::unique_ptr<Dwarf>> dwarves_;
+  std::unique_ptr<Dwarf> kernel_dwarf_;
 };
 
 } // namespace bpftrace

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -28,20 +28,37 @@ struct FuncInfo {
   Dwarf_Die die;
 };
 
+static int kernel_module_section_address(Dwfl_Module *mod,
+                                         void **userdata,
+                                         const char *modname,
+                                         Dwarf_Addr base,
+                                         const char *secname,
+                                         Elf32_Word shndx,
+                                         const GElf_Shdr *shdr,
+                                         Dwarf_Addr *addr);
+
 Dwarf::Dwarf(BPFtrace *bpftrace,
-             const std::string &file_path,
-             std::string debuginfo_path)
+             std::string file_path,
+             std::string debuginfo_path,
+             bool is_kernel)
     : bpftrace_(bpftrace),
-      file_path_(file_path),
-      debuginfo_path_(std::move(debuginfo_path))
+      file_path_(std::move(file_path)),
+      debuginfo_path_(std::move(debuginfo_path)),
+      is_kernel_(is_kernel)
 {
   debuginfo_path_cstr_ = debuginfo_path_.c_str();
-  callbacks.find_debuginfo = dwfl_standard_find_debuginfo;
-  callbacks.section_address = dwfl_offline_section_address;
+  if (is_kernel_) {
+    callbacks.find_elf = dwfl_linux_kernel_find_elf;
+    callbacks.find_debuginfo = dwfl_standard_find_debuginfo;
+    // Wrapper callback preventing libdw from mistakenly failing due to a
+    // missing __versions section in /sys/module/<name>/sections at runtime.
+    callbacks.section_address = kernel_module_section_address;
+  } else {
+    callbacks.find_debuginfo = dwfl_standard_find_debuginfo;
+    callbacks.section_address = dwfl_offline_section_address;
+  }
   callbacks.debuginfo_path = const_cast<char **>(&debuginfo_path_cstr_);
   dwfl = dwfl_begin(&callbacks);
-  dwfl_report_offline(dwfl, file_path.c_str(), file_path.c_str(), -1);
-  dwfl_report_end(dwfl, nullptr, nullptr);
 }
 
 static bool debug_alt_link_missing(::Dwarf *dwarf)
@@ -56,7 +73,15 @@ std::unique_ptr<Dwarf> Dwarf::GetFromBinary(BPFtrace *bpftrace,
                                             const std::string &file_path,
                                             const std::string &debuginfo_path)
 {
-  std::unique_ptr<Dwarf> dwarf(new Dwarf(bpftrace, file_path, debuginfo_path));
+  std::unique_ptr<Dwarf> dwarf(
+      new Dwarf(bpftrace, file_path, debuginfo_path, false));
+  if (!dwarf->dwfl ||
+      !dwfl_report_offline(
+          dwarf->dwfl, file_path.c_str(), file_path.c_str(), -1) ||
+      dwfl_report_end(dwarf->dwfl, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+
   Dwarf_Addr bias;
   Dwarf_Die *cudie = dwfl_nextcu(dwarf->dwfl, nullptr, &bias);
   if (cudie == nullptr)
@@ -68,22 +93,65 @@ std::unique_ptr<Dwarf> Dwarf::GetFromBinary(BPFtrace *bpftrace,
   // data from crashing the runtime.
   Dwfl_Module *mod = dwfl_cumodule(cudie);
   ::Dwarf *dw = dwfl_module_getdwarf(mod, &bias);
-  if (debug_alt_link_missing(dw)) {
+  if (dw && debug_alt_link_missing(dw)) {
     return nullptr;
   }
 
   return dwarf;
 }
 
+static int kernel_module_section_address(Dwfl_Module *mod,
+                                         void **userdata,
+                                         const char *modname,
+                                         Dwarf_Addr base,
+                                         const char *secname,
+                                         Elf32_Word shndx,
+                                         const GElf_Shdr *shdr,
+                                         Dwarf_Addr *addr)
+{
+  const std::string_view section(secname);
+
+  // Older libdwfl versions fail for module sections intentionally absent from
+  // /sys/module/<name>/sections. See elfutils Bugzilla 34030, fixed upstream:
+  // https://sourceware.org/bugzilla/show_bug.cgi?id=34030
+  // A zero-sized section has no runtime contents or address to resolve.
+  if ((shdr != nullptr && shdr->sh_size == 0) || section == "__versions" ||
+      section == ".data..percpu") {
+    *addr = static_cast<Dwarf_Addr>(-1L);
+    return DWARF_CB_OK;
+  }
+
+  return dwfl_linux_kernel_module_section_address(
+      mod, userdata, modname, base, secname, shndx, shdr, addr);
+}
+
+std::unique_ptr<Dwarf> Dwarf::GetFromKernel(BPFtrace *bpftrace,
+                                            const std::string &debuginfo_path)
+{
+  std::unique_ptr<Dwarf> dwarf(new Dwarf(bpftrace, "", debuginfo_path, true));
+  if (!dwarf->dwfl || dwfl_linux_kernel_report_kernel(dwarf->dwfl) != 0 ||
+      dwfl_linux_kernel_report_modules(dwarf->dwfl) != 0 ||
+      dwfl_report_end(dwarf->dwfl, nullptr, nullptr) != 0) {
+    return nullptr;
+  }
+
+  Dwarf_Addr bias;
+
+  if (dwfl_nextcu(dwarf->dwfl, nullptr, &bias) == nullptr)
+    return nullptr;
+
+  return dwarf;
+}
+
 Dwarf::~Dwarf()
 {
-  dwfl_end(dwfl);
+  if (dwfl)
+    dwfl_end(dwfl);
 }
 
 bool Dwarf::next_cu_info(CuInfo *cu_info) const
 {
-  Dwarf_Addr cubias;
-  cu_info->cudie = dwfl_nextcu(dwfl, cu_info->cudie, &cubias);
+  cu_info->cudie = dwfl_nextcu(dwfl, cu_info->cudie, &cu_info->mod_bias);
   if (cu_info->cudie == nullptr)
     return false;
 
@@ -610,7 +678,8 @@ Result<uint64_t> Dwarf::line_to_addr(const std::string &source_file,
         (col_num == 0 || col_num == static_cast<size_t>(linecol))) {
       Dwarf_Addr addr;
       if (dwarf_lineaddr(line, &addr) == 0) {
-        return addr;
+        // Add KASLR offset if in kernel mode
+        return is_kernel_ ? addr + cu->mod_bias : addr;
       }
     }
   }

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -54,6 +54,10 @@ public:
       const std::string &file_path,
       const std::string &debuginfo_path);
 
+  static std::unique_ptr<Dwarf> GetFromKernel(
+      BPFtrace *bpftrace,
+      const std::string &debuginfo_path);
+
   std::vector<std::string> get_function_params(
       const std::string &function) const;
   std::shared_ptr<Struct> resolve_args(const std::string &function);
@@ -82,6 +86,8 @@ private:
     // automatically resolves references between the skeleton and split CU.
     std::optional<Dwarf_Die> split_cudie;
 
+    Dwarf_Addr mod_bias = 0;
+
     // Returns split CU DIE if present (skeleton CU), otherwise cudie.
     Dwarf_Die *cu_die()
     {
@@ -92,9 +98,13 @@ private:
     std::optional<std::filesystem::path> source_path;
   };
 
+  // The DWFL setup is shared by offline binaries and the running kernel.
+  // Kernel mode reports the kernel and loaded modules instead of an offline
+  // file and applies the module load bias to addresses.
   Dwarf(BPFtrace *bpftrace,
-        const std::string &file_path,
-        std::string debuginfo_path);
+        std::string file_path,
+        std::string debuginfo_path,
+        bool is_kernel);
 
   bool next_cu_info(CuInfo *cu_info) const;
   std::vector<Dwarf_Die> function_param_dies(const std::string &function) const;
@@ -122,7 +132,7 @@ private:
   static std::vector<std::filesystem::path> get_cu_src_paths(Dwarf_Die *cudie);
 
   Dwfl *dwfl = nullptr;
-  Dwfl_Callbacks callbacks;
+  Dwfl_Callbacks callbacks = {};
 
   BPFtrace *bpftrace_;
   std::string file_path_;
@@ -136,6 +146,7 @@ private:
   // char** to Dwfl_Callbacks.
   std::string debuginfo_path_;
   const char *debuginfo_path_cstr_;
+  bool is_kernel_ = false;
 };
 
 } // namespace bpftrace
@@ -153,6 +164,14 @@ public:
   static std::unique_ptr<Dwarf> GetFromBinary(BPFtrace *bpftrace
                                               __attribute__((unused)),
                                               const std::string &file_path_
+                                              __attribute__((unused)),
+                                              const std::string &debuginfo_path
+                                              __attribute__((unused)))
+  {
+    return nullptr;
+  }
+
+  static std::unique_ptr<Dwarf> GetFromKernel(BPFtrace *bpftrace
                                               __attribute__((unused)),
                                               const std::string &debuginfo_path
                                               __attribute__((unused)))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,8 +110,6 @@ enum Options {
 
 constexpr auto FULL_SEARCH = "*:*";
 
-constexpr auto DEFAULT_DEBUG_INFO_PATHS = ":.debug:/usr/lib/debug";
-
 } // namespace
 
 void usage(std::ostream& out)
@@ -1013,7 +1011,7 @@ int main(int argc, char* argv[])
   bpftrace.run_tests_ = args.mode == Mode::BPF_TEST;
   bpftrace.run_benchmarks_ = args.mode == Mode::BPF_BENCHMARK;
   bpftrace.probe_filter_ = args.probe_filter;
-  bpftrace.debuginfo_path_ = args.debuginfo_path + DEFAULT_DEBUG_INFO_PATHS;
+  bpftrace.debuginfo_path_ = args.debuginfo_path + default_debuginfo_paths;
 
   if (!args.pid_str.empty()) {
     auto pid = parse_pid(args.pid_str);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -735,12 +735,13 @@ AttachPoint *Parser::parse_attach_point()
       break;
     }
 
-    // '/' could be a predicate start or part of a path. It's a path
-    // component if we've seen a ':' in the raw text (paths appear after
-    // the provider separator, e.g. uprobe:/my/program:func).
-    if (c == '/' && !raw.empty() && raw.find(':') == std::string::npos) {
-      // No ':' seen yet — this '/' can't be a path, it's a predicate but check
-      // it's not a comment.
+    // '/' can start a predicate or be part of a path. A ':' identifies
+    // path-bearing attachpoints while '@' identifies source-location kprobes.
+    // Therefore, a slash after kprobe@ must remain part of the source path.
+    if (c == '/' && !raw.empty() && raw.find(':') == std::string::npos &&
+        raw.find('@') == std::string::npos) {
+      // No ':' or '@' has appeared, so this '/' is a predicate delimiter
+      // unless it starts a comment.
       char next = peek(1);
       if (next != '/' && next != '*') {
         break;

--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -104,6 +104,26 @@ TEST(attachpoint_parser, uprobe_lang)
   test_uprobe_lang("uprobe:cpp:main { 1 }", "cpp");
 }
 
+TEST(attachpoint_parser, kprobe_src_loc)
+{
+  test_error("kprobe@fs/open.c:1077 { 1 }",
+             "No DWARF debug info found for kernel, cannot attach by source "
+             "code location.");
+  test_error(
+      "kprobe@fs/open.c: { 1 }",
+      R"(Invalid kprobe arguments, expected format: kprobe@FILE:LINE[:COL])");
+  test_error(
+      "kprobe@fs/open.c:1077:1:2 { 1 }",
+      R"(Invalid kprobe arguments, expected format: kprobe@FILE:LINE[:COL])");
+  test_error("kprobe@fs/open.c:invalid { 1 }",
+             R"(Invalid line number: invalid integer: invalid)");
+  test_error("kprobe@fs/open.c:1077:invalid { 1 }",
+             R"(Invalid column number: invalid integer: invalid)");
+  test_error("kprobe@fs/open.c:1077: { 1 }", R"(Invalid column number:)");
+  test_error("kretprobe@fs/open.c:1077 { 1 }",
+             R"(Source code location not allowed)");
+}
+
 #ifdef HAVE_LIBDW
 
 class attachpoint_parser_dwarf : public test_dwarf {};


### PR DESCRIPTION
1. Preserve Marek's original source-location kprobe implementation and authorship.
2. Resolve source-line kprobes against the live kernel and currently loaded modules, including the parser fix for paths such as `kprobe@drivers/net/loopback.c:74`.
3. Fix Alpine/musl static linking of the libdwfl kernel-module helpers by adding and propagating the optional `libfts` dependency.

test log：
sudo  \
timeout --signal=INT --kill-after=3 30 \
./bpftrace \
--unsafe \
-e 'kprobe@fs/open.c:1390 {
printf("UBUNTU_LINE_HIT pid=%d comm=%s\n", pid, comm);
exit();
}'

Attached 1 probe
UBUNTU_LINE_HIT pid=500 comm=systemd-journal
