### PR TITLE
Nix: bump naersk to fix crates.io 403s when building blazesym

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769799857,
-        "narHash": "sha256-88IFXZ7Sa1vxbz5pty0Io5qEaMQMMUPMonLa3Ls/ss4=",
+        "lastModified": 1782220280,
+        "narHash": "sha256-thLTFbp9D5Qknmh8q/v4FRpLGphUSijT3E86cbLYTXo=",
         "owner": "nix-community",
         "repo": "naersk",
-        "rev": "9d4ed44d8b8cecdceb1d6fd76e74123d90ae6339",
+        "rev": "9aa07bb0256d300219b30622d2454e85f7f3667e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Stacked PRs:
 * __->__#5313


--- --- ---

### Nix: bump naersk to fix crates.io 403s when building blazesym


crates.io rejects requests whose User-Agent starts with "curl/", which is
what nixpkgs' fetchurl sends, so every crate not already in a binary cache
failed with HTTP 403 when building blazesym.

naersk 0e8c8c2 ("Use static.crates.io to download crates") switched the
default download URL to https://static.crates.io/crates, which has no
User-Agent filtering. flake.nix already tracks naersk/master, so only the
lock was stale. This bumps 9d4ed44 (2026-01-30) -> 9aa07bb (2026-06-23);
all other inputs are untouched.

Refs: https://github.com/nix-community/naersk/issues/390