### PR TITLE
ci: update checkout and setup-python to current majors

### DIFF
--- a/.github/workflows/stdlib-docs.yml
+++ b/.github/workflows/stdlib-docs.yml
@@ -18,9 +18,9 @@ jobs:
   check-stdlib-docs:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Generate stdlib documentation


### PR DESCRIPTION
Updates the stdlib docs workflow to current action majors.

Changes:
- actions/checkout v2 -> v7
- actions/setup-python v4 -> v7

Validation:
- actionlint 1.7.12 passes on the updated workflow
- python-version '3.x' is resolved by setup-python itself, no removed inputs are used (v7 dropped pip-install, which this workflow does not use)

Scope: .github/workflows/stdlib-docs.yml only.

Note: this PR comes from a fork. If workflow runs show action_required, they need a maintainer approval click; I will not retry-push to force it.

Commit author katsugtgz, unsigned.
