### PR TITLE
Fix func builtin for session probe return/exit branches (#5315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to
   - [#5288](https://github.com/bpftrace/bpftrace/pull/5288)
 - Fix large string allocations for casts
   - [#5286](https://github.com/bpftrace/bpftrace/pull/5286)
+- Fix `func` builtin for session probe return/exit branches
+  - [#5302](https://github.com/bpftrace/bpftrace/issues/5302)
 
 ## [0.26.1] 2026-06-02
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -430,6 +430,7 @@ private:
   uint64_t probe_count_ = 0;
   int next_probe_index_ = 1;
   bool inside_subprog_ = false;
+  bool in_session_return_branch_ = false;
 
   std::vector<Node *> scope_stack_;
   std::unordered_map<Node *, std::map<std::string, VariableLLVM>> variables_;
@@ -865,7 +866,7 @@ ScopedExpr CodegenLLVM::visit(Builtin &builtin)
     auto probe_type = probetype(current_attach_point_->provider);
     if (probe_type == ProbeType::fentry || probe_type == ProbeType::fexit ||
         probe_type == ProbeType::kretprobe ||
-        probe_type == ProbeType::uretprobe) {
+        probe_type == ProbeType::uretprobe || in_session_return_branch_) {
       value = b_.CreateGetFuncIp(ctx_, builtin.loc);
     } else {
       value = b_.CreateRegisterRead(ctx_, builtin.ident);
@@ -2576,7 +2577,18 @@ ScopedExpr CodegenLLVM::visit(IfExpr &if_expr)
              type_map_.type(&if_expr).IsVoidTy()) {
     // Type::none
     b_.SetInsertPoint(left_block);
+
+    bool prev_in_session_return = in_session_return_branch_;
+    if (auto *call = if_expr.cond.as<Call>()) {
+      if (call->func == "__session_is_return") {
+        in_session_return_branch_ = true;
+      }
+    }
+
     visit(if_expr.left);
+
+    in_session_return_branch_ = prev_in_session_return;
+
     if (!b_.HasTerminator()) {
       b_.CreateBr(lazy_done());
     }

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -293,6 +293,13 @@ EXPECT links: 1
 REQUIRES bpftool
 REQUIRES_FEATURE kprobe_session
 
+NAME kprobe_session_func
+RUN {{BPFTRACE}} -e 'kprobe:ksys_read { printf("entry func = %s\n", func); } kretprobe:ksys_read { printf("exit func = %s\n", func); exit(); }'
+AFTER ./testprogs/syscall read
+EXPECT entry func = ksys_read
+EXPECT exit func = ksys_read
+REQUIRES_FEATURE kprobe_session
+
 NAME uprobe
 PROG uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}
 EXPECT_REGEX arg0: [0-9]*


### PR DESCRIPTION
Stacked PRs:
 * __->__#5316


--- --- ---

### Fix func builtin for session probe return/exit branches (#5315)


Signed-off-by: animesh68 <animeshyt68@gmail.com>
(cherry picked from commit c5c5ecfda5709b06d7c49fdedf3eef79ca9e6862)
Signed-off-by: Jordan Rome <jordalgo@meta.com>