### PR TITLE
Preserve struct name and size converting BTF types

### DIFF
--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -1657,7 +1657,8 @@ void TypeRuleCollector::visit(For &f)
               ctx_idents.push_back(var.ident);
             }
 
-            return CreateCStruct(Struct::CreateRecord(ctx_types, ctx_idents));
+            return CreateCStruct("",
+                                 Struct::CreateRecord(ctx_types, ctx_idents));
           },
       });
     }
@@ -1668,7 +1669,7 @@ void TypeRuleCollector::visit(For &f)
   std::vector<SizedType> ctx_types;
   std::vector<std::string_view> ctx_idents;
   resolver_.set_type(
-      &f, CreateCStruct(Struct::CreateRecord(ctx_types, ctx_idents)));
+      &f, CreateCStruct("", Struct::CreateRecord(ctx_types, ctx_idents)));
 }
 
 void TypeRuleCollector::visit(Identifier &identifier)

--- a/src/btf/compat.cpp
+++ b/src/btf/compat.cpp
@@ -61,6 +61,8 @@ Result<SizedType> getCompatType(const Array &type, CompatTypeCache &type_cache)
 
 Result<SizedType> asRecord(
     uint32_t type_id,
+    const std::string &name,
+    size_t size,
     std::vector<std::pair<std::string, FieldInfo>> &&fields,
     CompatTypeCache &type_cache)
 {
@@ -71,6 +73,7 @@ Result<SizedType> asRecord(
 
   // The record start empty, and we construct below.
   auto s = bpftrace::Struct::CreateRecord({}, {});
+  s->size = static_cast<int>(size);
   type_cache.emplace(type_id, std::shared_ptr<bpftrace::Struct>(s));
 
   // We can only generate a type based on the offsets.
@@ -89,7 +92,7 @@ Result<SizedType> asRecord(
         .bitfield = std::nullopt,
     });
   }
-  return CreateCStruct(std::move(s));
+  return CreateCStruct(name, std::move(s));
 }
 
 Result<SizedType> getCompatType(const Struct &type, CompatTypeCache &type_cache)
@@ -98,7 +101,16 @@ Result<SizedType> getCompatType(const Struct &type, CompatTypeCache &type_cache)
   if (!f) {
     return f.takeError();
   }
-  return asRecord(type.type_id(), std::move(*f), type_cache);
+  auto sz = type.size();
+  if (!sz) {
+    return sz.takeError();
+  }
+  auto name = type.name();
+  return asRecord(type.type_id(),
+                  name.empty() ? name : "struct " + name,
+                  *sz,
+                  std::move(*f),
+                  type_cache);
 }
 
 Result<SizedType> getCompatType(const Union &type, CompatTypeCache &type_cache)
@@ -107,7 +119,16 @@ Result<SizedType> getCompatType(const Union &type, CompatTypeCache &type_cache)
   if (!f) {
     return f.takeError();
   }
-  return asRecord(type.type_id(), std::move(*f), type_cache);
+  auto sz = type.size();
+  if (!sz) {
+    return sz.takeError();
+  }
+  auto name = type.name();
+  return asRecord(type.type_id(),
+                  name.empty() ? name : "union " + name,
+                  *sz,
+                  std::move(*f),
+                  type_cache);
 }
 
 Result<SizedType> getCompatType(const Enum &type,

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -448,11 +448,14 @@ SizedType CreateCStruct(const std::string &name)
   return ty;
 }
 
-SizedType CreateCStruct(std::shared_ptr<Struct> &&record)
+SizedType CreateCStruct(const std::string &name,
+                        std::shared_ptr<Struct> &&record)
 {
-  // A local anonymous record.
+  // A local record, owned by the type rather than the `StructManager`. It is
+  // anonymous unless a name is given.
   assert(record);
   auto ty = SizedType(Type::c_type, record->size);
+  ty.name_ = name;
   ty.inner_struct_ = std::move(record);
   return ty;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -584,7 +584,8 @@ public:
 
   friend SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as);
   friend SizedType CreateCStruct(const std::string &name);
-  friend SizedType CreateCStruct(std::shared_ptr<Struct> &&record);
+  friend SizedType CreateCStruct(const std::string &name,
+                                 std::shared_ptr<Struct> &&record);
   friend SizedType CreateCStruct(const std::string &name,
                                  std::weak_ptr<Struct> record);
   friend SizedType CreateInteger(size_t bits, bool is_signed);
@@ -616,7 +617,8 @@ SizedType CreatePointer(const SizedType &pointee_type,
                         AddrSpace as = AddrSpace::none);
 
 SizedType CreateCStruct(const std::string &name);
-SizedType CreateCStruct(std::shared_ptr<Struct> &&record);
+SizedType CreateCStruct(const std::string &name,
+                        std::shared_ptr<Struct> &&record);
 SizedType CreateCStruct(const std::string &name, std::weak_ptr<Struct> record);
 SizedType CreateTuple(std::shared_ptr<Struct> &&tuple);
 SizedType CreateRecord(std::shared_ptr<Struct> &&record);

--- a/tests/btf.cpp
+++ b/tests/btf.cpp
@@ -2,6 +2,7 @@
 #include <unordered_set>
 
 #include "btf/btf.h"
+#include "btf/compat.h"
 #include "btf/helpers.h"
 #include "data/data_source_btf.h"
 #include "gtest/gtest.h"
@@ -9,6 +10,9 @@
 namespace bpftrace::test::btf {
 
 using namespace bpftrace::btf;
+
+// Disambiguate from `bpftrace::Struct`, which `compat.h` brings into scope.
+using bpftrace::btf::Struct;
 
 static std::string to_str(const AnyType &type)
 {
@@ -547,6 +551,43 @@ TEST(btf, helper_functions)
   EXPECT_EQ(retrieved_info->nr_elements, 100);
   EXPECT_TRUE(retrieved_info->key.is<Integer>());
   EXPECT_TRUE(retrieved_info->value.is<Integer>());
+}
+
+TEST(btf, compat_record_name_and_size)
+{
+  auto btf = Types::parse(reinterpret_cast<const char *>(btf_data),
+                          sizeof(btf_data));
+  ASSERT_TRUE(bool(btf));
+
+  auto task_struct = btf->lookup<Struct>("task_struct");
+  ASSERT_TRUE(bool(task_struct));
+
+  auto ty = getCompatType(*task_struct);
+  ASSERT_TRUE(bool(ty));
+
+  EXPECT_TRUE(ty->IsCTypeTy());
+  EXPECT_EQ(ty->GetName(), "struct task_struct");
+  EXPECT_EQ(ty->GetSize(), sizeof(int *));
+  EXPECT_EQ(ty->GetFieldCount(), 2);
+}
+
+TEST(btf, compat_anonymous_record)
+{
+  Types btf;
+  auto int32 = btf.add<Integer>("int32", 4, 1);
+  ASSERT_TRUE(bool(int32));
+  std::vector<std::pair<std::string, ValueType>> fields = {
+    { "a", ValueType(*int32) }
+  };
+  auto anon = btf.add<Struct>("", fields);
+  ASSERT_TRUE(bool(anon));
+
+  auto ty = getCompatType(*anon);
+  ASSERT_TRUE(bool(ty));
+
+  EXPECT_TRUE(ty->IsCTypeTy());
+  EXPECT_TRUE(ty->GetName().empty());
+  EXPECT_EQ(ty->GetSize(), 4);
 }
 
 } // namespace bpftrace::test::btf


### PR DESCRIPTION
Stacked PRs:
 * #5321
 * #5322
 * __->__#5320


--- --- ---

### Preserve struct name and size converting BTF types


getCompatType() built records via the anonymous CreateCStruct overload and
never set their size. A struct imported from an object's BTF therefore
compared unequal to the same struct resolved through the StructManager,
since SizedType orders c_types by name and then size, and the imported side
carried neither.

Nothing had hit this because no standard library function took a pointer to
a named struct. Passing one produced the unhelpful diagnostic
"Expected  * for argument", with the name rendered empty.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>