### PR TITLE
Fix recursive BTF compat types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to
   - [#5288](https://github.com/bpftrace/bpftrace/pull/5288)
 - Fix large string allocations for casts
   - [#5286](https://github.com/bpftrace/bpftrace/pull/5286)
+- Fix recursive BTF compat types
+  - [#5322](https://github.com/bpftrace/bpftrace/pull/5322)
 
 ## [0.26.1] 2026-06-02
 

--- a/src/ast/passes/types/cast_creator.cpp
+++ b/src/ast/passes/types/cast_creator.cpp
@@ -484,7 +484,8 @@ void CastCreator::visit(Call &call)
     }
 
     for (size_t i = 0; i < argument_types->size(); i++) {
-      auto compat_arg_type = getCompatType(argument_types->at(i).second);
+      auto compat_arg_type = getCompatType(argument_types->at(i).second,
+                                           bpftrace_.structs);
       if (!compat_arg_type) {
         consumeError(compat_arg_type.takeError());
         continue;

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -590,7 +590,7 @@ void TypeChecker::visit(Call &call)
     for (size_t i = 0; i < argument_types->size(); i++) {
       const auto &[name, type] = argument_types->at(i);
       const auto &varg_type = type_map_.type(call.vargs[i]);
-      auto compat_arg_type = getCompatType(type);
+      auto compat_arg_type = getCompatType(type, bpftrace_.structs);
       if (!compat_arg_type) {
         // If the required type is a **pointer**, and the provided type is
         // a **pointer**, then we let it slide. Just assume the user knows

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -1298,7 +1298,8 @@ void TypeRuleCollector::visit(Call &call)
                         << btf_return_type.takeError();
         return;
       }
-      auto compat_return_type = getCompatType(*btf_return_type);
+      auto compat_return_type = getCompatType(*btf_return_type,
+                                              bpftrace_.structs);
       if (!compat_return_type) {
         call.addError() << "Unable to convert return type: "
                         << compat_return_type.takeError();

--- a/src/btf/compat.cpp
+++ b/src/btf/compat.cpp
@@ -59,6 +59,27 @@ Result<SizedType> getCompatType(const Array &type, CompatTypeCache &type_cache)
   return CreateArray(type.element_count(), *ty);
 }
 
+// We can only generate the fields based on the offsets.
+static Result<bpftrace::Fields> resolveFields(
+    std::vector<std::pair<std::string, FieldInfo>> &&fields,
+    CompatTypeCache &type_cache)
+{
+  bpftrace::Fields resolved;
+  for (const auto &[name, info] : fields) {
+    auto ft = getCompatType(info.type, type_cache);
+    if (!ft) {
+      return ft.takeError();
+    }
+    resolved.emplace_back(Field{
+        .name = name,
+        .type = *ft,
+        .offset = static_cast<ssize_t>(info.bit_offset / 8),
+        .bitfield = std::nullopt,
+    });
+  }
+  return resolved;
+}
+
 Result<SizedType> asRecord(
     uint32_t type_id,
     const std::string &name,
@@ -66,33 +87,53 @@ Result<SizedType> asRecord(
     std::vector<std::pair<std::string, FieldInfo>> &&fields,
     CompatTypeCache &type_cache)
 {
-  auto it = type_cache.find(type_id);
-  if (it != type_cache.end()) {
-    return CreateRecord(std::shared_ptr<bpftrace::Struct>(it->second));
-  }
+  // While this record's fields are being resolved, the cache holds a null
+  // entry for it. Since this function recurses this null entry is used to
+  // determine if we're also dealing with a recursive type.
+  auto [it, first_visit] = type_cache.records.try_emplace(type_id, nullptr);
 
-  // The record start empty, and we construct below.
-  auto s = bpftrace::Struct::CreateRecord({}, {});
-  s->size = static_cast<int>(size);
-  type_cache.emplace(type_id, std::shared_ptr<bpftrace::Struct>(s));
-
-  // We can only generate a type based on the offsets.
-  std::vector<std::string_view> idents;
-  std::vector<FieldInfo> infos;
-  std::vector<SizedType> types;
-  for (const auto &[name, info] : fields) {
-    auto ft = getCompatType(info.type, type_cache);
-    if (!ft) {
-      return ft.takeError();
+  if (!name.empty()) {
+    auto record = type_cache.structs.LookupOrAdd(name, size).lock();
+    if (first_visit && !record->HasFields()) {
+      auto resolved = resolveFields(std::move(fields), type_cache);
+      if (!resolved) {
+        type_cache.records.erase(it);
+        return resolved.takeError();
+      }
+      // Another BTF type with the same name may have filled in this record
+      // while its fields were being resolved; don't clobber it.
+      if (!record->HasFields()) {
+        record->fields = std::move(*resolved);
+      }
     }
-    s->fields.emplace_back(Field{
-        .name = name,
-        .type = *ft,
-        .offset = static_cast<ssize_t>(info.bit_offset / 8),
-        .bitfield = std::nullopt,
-    });
+    return CreateCStruct(name, std::weak_ptr<bpftrace::Struct>(record));
   }
-  return CreateCStruct(name, std::move(s));
+
+  // Anonymous records have no name to share them under, so they are owned by
+  // the type that refers to them.
+  auto make_record = [size](bpftrace::Fields &&fields) {
+    auto record = bpftrace::Struct::CreateRecord({}, {});
+    record->size = static_cast<int>(size);
+    record->fields = std::move(fields);
+    return record;
+  };
+
+  if (!first_visit) {
+    if (it->second) {
+      return CreateCStruct(name, std::shared_ptr<bpftrace::Struct>(it->second));
+    }
+    // This type is still being resolved. We need to break the recursion cycle
+    // by returning an empty record of the right size.
+    return CreateCStruct(name, make_record({}));
+  }
+
+  auto resolved = resolveFields(std::move(fields), type_cache);
+  if (!resolved) {
+    type_cache.records.erase(it);
+    return resolved.takeError();
+  }
+  it->second = make_record(std::move(*resolved));
+  return CreateCStruct(name, std::shared_ptr<bpftrace::Struct>(it->second));
 }
 
 Result<SizedType> getCompatType(const Struct &type, CompatTypeCache &type_cache)

--- a/src/btf/compat.h
+++ b/src/btf/compat.h
@@ -4,6 +4,10 @@
 #include "types.h"
 #include "util/result.h"
 
+namespace bpftrace {
+class StructManager;
+} // namespace bpftrace
+
 namespace bpftrace::btf {
 
 class CompatTypeError : public ErrorInfo<CompatTypeError> {
@@ -26,9 +30,18 @@ private:
   std::string msg_;
 };
 
-// For struct resolution, this indicates the set of structs
-// that have already been resolved for the purposes of cycles.
-using CompatTypeCache = std::map<uint32_t, std::shared_ptr<bpftrace::Struct>>;
+using BtfTypeId = uint32_t;
+
+// The state for a single conversion.
+//
+// Named records are owned by the `StructManager` and referred to weakly, which
+// is how a type that refers back to itself is represented without forming a
+// reference cycle. Anonymous records have no name to share them under, so they
+// are owned by the type instead.
+struct CompatTypeCache {
+  StructManager &structs;
+  std::map<BtfTypeId, std::shared_ptr<bpftrace::Struct>> records;
+};
 
 template <typename T>
 struct compatTypeFor {
@@ -88,9 +101,9 @@ Result<SizedType> getCompatType(const T &type, CompatTypeCache &type_cache)
 }
 
 template <typename T>
-Result<SizedType> getCompatType(const T &type)
+Result<SizedType> getCompatType(const T &type, StructManager &structs)
 {
-  CompatTypeCache type_cache; // Empty initial cache.
+  CompatTypeCache type_cache{ .structs = structs, .records = {} };
   return getCompatType(type, type_cache);
 }
 

--- a/src/stdlib/test/test.bpf.c
+++ b/src/stdlib/test/test.bpf.c
@@ -1,3 +1,13 @@
+#define __KERNEL__
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
 // __always_true is a built-in test function to validate C interop is working
 // as expected.
 int __always_true() { return 1; }
+
+// __test_get_current_task is a built-in test function to validate that a
+// pointer to a named struct can be returned across the C interop boundary.
+struct task_struct *__test_get_current_task() {
+  return bpf_get_current_task_btf();
+}

--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -138,33 +138,33 @@ TEST_F(attachpoint_parser_dwarf, uprobe)
   std::string bin = std::string(bin_);
   std::string ap = "uprobe:" + bin;
 
-  test(ap + "@data_source.c:195 { 1 }");
-  test(ap + "@data_source.c:195:1 { 1 }");
-  test(ap + "@data/data_source.c:195 { 1 }");
-  test(ap + "@data/data_source.c:195:1 { 1 }");
-  test(ap + "@data_source.c:195 / 1 / { 1 }");
-  test(ap + "@data/data_source.c:195 / 1 / { 1 }");
-  test("begin { @x = 1; } " + ap + "@data/data_source.c:195 / @x / { @x/1; }");
-  test("begin { @x = 1; } " + ap + "@data/data_source.c:195 /@x/ { @x/1; }");
+  test(ap + "@data_source.c:202 { 1 }");
+  test(ap + "@data_source.c:202:1 { 1 }");
+  test(ap + "@data/data_source.c:202 { 1 }");
+  test(ap + "@data/data_source.c:202:1 { 1 }");
+  test(ap + "@data_source.c:202 / 1 / { 1 }");
+  test(ap + "@data/data_source.c:202 / 1 / { 1 }");
+  test("begin { @x = 1; } " + ap + "@data/data_source.c:202 / @x / { @x/1; }");
+  test("begin { @x = 1; } " + ap + "@data/data_source.c:202 /@x/ { @x/1; }");
   test("begin { @data_source = 1; } " + ap +
-       "@data_source.c:195 /@data_source/ { @data_source/1; }");
+       "@data_source.c:202 /@data_source/ { @data_source/1; }");
   test("begin { @data = 1; } " + ap +
-       "@data/data_source.c:195 /@data/ { @data/1; }");
+       "@data/data_source.c:202 /@data/ { @data/1; }");
 
   // Quoted arguments
-  test(ap + R"(@"data_source.c":195 { 1 })");
-  test(ap + R"(@data_source.c:"195" { 1 })");
-  test(ap + R"(@"data_source.c":"195" { 1 })");
-  test(ap + R"(@"data_source.c":"195":"1" { 1 })");
-  test(ap + R"(@data/"data_source.c":195 { 1 })");
-  test(ap + R"(@"data/data_source.c":195 { 1 })");
-  test(R"(uprobe:")" + bin + R"("@data_source.c:195 { 1 })");
-  test(R"(uprobe:")" + bin + R"("@"data_source.c":195 { 1 })");
-  test(R"(uprobe:")" + bin + R"("@"data/data_source.c":195 { 1 })");
+  test(ap + R"(@"data_source.c":202 { 1 })");
+  test(ap + R"(@data_source.c:"202" { 1 })");
+  test(ap + R"(@"data_source.c":"202" { 1 })");
+  test(ap + R"(@"data_source.c":"202":"1" { 1 })");
+  test(ap + R"(@data/"data_source.c":202 { 1 })");
+  test(ap + R"(@"data/data_source.c":202 { 1 })");
+  test(R"(uprobe:")" + bin + R"("@data_source.c:202 { 1 })");
+  test(R"(uprobe:")" + bin + R"("@"data_source.c":202 { 1 })");
+  test(R"(uprobe:")" + bin + R"("@"data/data_source.c":202 { 1 })");
 
-  test_error("uretprobe:" + bin + "@data_source.c:195 { 1 }",
+  test_error("uretprobe:" + bin + "@data_source.c:202 { 1 }",
              R"(Source code location not allowed)");
-  test_error("uprobe:*@data_source.c:195 { 1 }",
+  test_error("uprobe:*@data_source.c:202 { 1 }",
              R"(Cannot use wildcards with source code location)");
   test_error(
       ap + "@ { 1 }",
@@ -176,16 +176,16 @@ TEST_F(attachpoint_parser_dwarf, uprobe)
       ap + "@data_source.c: { 1 }",
       R"(Invalid uprobe arguments, expected format: uprobe:TARGET@FILE:LINE[:COL])");
   test_error(
-      ap + "@:195 { 1 }",
+      ap + "@:202 { 1 }",
       R"(ERROR: Invalid uprobe arguments, expected format: uprobe:TARGET@FILE:LINE[:COL])");
   test_error(
-      ap + "@data_source.c:195:1:2:3 { 1 }",
+      ap + "@data_source.c:202:1:2:3 { 1 }",
       R"(Invalid uprobe arguments, expected format: uprobe:TARGET@FILE:LINE[:COL])");
   test_error(ap + "@data_source.c:invalid { 1 }", R"(Invalid line number: )");
-  test_error(ap + "@data_source.c:195:invalid { 1 }",
+  test_error(ap + "@data_source.c:202:invalid { 1 }",
              R"(Invalid column number: )");
-  test_error(ap + "@data_source.c:195: { 1 }", R"(Invalid column number: )");
-  test_error(ap + "@invalid.c:195 { 1 }",
+  test_error(ap + "@data_source.c:202: { 1 }", R"(Invalid column number: )");
+  test_error(ap + "@invalid.c:202 { 1 }",
              R"(No compilation unit matches invalid.c)");
   test_error(
       "uprobe:no_dwarf@main.c:123 { 1 }",

--- a/tests/btf.cpp
+++ b/tests/btf.cpp
@@ -5,6 +5,7 @@
 #include "btf/compat.h"
 #include "btf/helpers.h"
 #include "data/data_source_btf.h"
+#include "struct.h"
 #include "gtest/gtest.h"
 
 namespace bpftrace::test::btf {
@@ -562,13 +563,70 @@ TEST(btf, compat_record_name_and_size)
   auto task_struct = btf->lookup<Struct>("task_struct");
   ASSERT_TRUE(bool(task_struct));
 
-  auto ty = getCompatType(*task_struct);
+  bpftrace::StructManager structs;
+  auto ty = getCompatType(*task_struct, structs);
   ASSERT_TRUE(bool(ty));
 
   EXPECT_TRUE(ty->IsCTypeTy());
   EXPECT_EQ(ty->GetName(), "struct task_struct");
   EXPECT_EQ(ty->GetSize(), sizeof(int *));
   EXPECT_EQ(ty->GetFieldCount(), 2);
+  EXPECT_EQ(ty->GetStruct(), structs.Lookup("struct task_struct").lock());
+}
+
+TEST(btf, compat_record_reuses_resolved_struct)
+{
+  auto btf = Types::parse(reinterpret_cast<const char *>(btf_data),
+                          sizeof(btf_data));
+  ASSERT_TRUE(bool(btf));
+
+  auto task_struct = btf->lookup<Struct>("task_struct");
+  ASSERT_TRUE(bool(task_struct));
+
+  // A record that has already been resolved elsewhere, e.g. from the kernel's
+  // BTF, is used as-is rather than being resolved again.
+  bpftrace::StructManager structs;
+  auto record = structs.Add("struct task_struct", 8).lock();
+  record->AddField("resolved_elsewhere", CreateInt32(), 0);
+
+  auto ty = getCompatType(*task_struct, structs);
+  ASSERT_TRUE(bool(ty));
+  ASSERT_EQ(ty->GetFieldCount(), 1);
+  EXPECT_EQ(ty->GetField(0).name, "resolved_elsewhere");
+}
+
+TEST(btf, compat_recursive_record)
+{
+  auto btf = Types::parse(reinterpret_cast<const char *>(btf_data),
+                          sizeof(btf_data));
+  ASSERT_TRUE(bool(btf));
+
+  auto foo = btf->lookup<Struct>("FooRecursive");
+  ASSERT_TRUE(bool(foo));
+
+  std::weak_ptr<const bpftrace::Struct> record;
+  {
+    bpftrace::StructManager structs;
+    auto ty = getCompatType(*foo, structs);
+    ASSERT_TRUE(bool(ty));
+    EXPECT_EQ(ty->GetName(), "struct FooRecursive");
+    EXPECT_EQ(ty->GetFieldCount(), 2);
+
+    const auto &next = ty->GetField("next").type;
+    ASSERT_TRUE(next.IsPtrTy());
+    const auto &pointee = next.GetPointeeTy();
+    EXPECT_EQ(pointee.GetName(), "struct FooRecursive");
+    EXPECT_EQ(pointee.GetStruct(), ty->GetStruct());
+    EXPECT_TRUE(pointee.HasField("a"));
+    EXPECT_TRUE(pointee.GetField("next").type.GetPointeeTy().HasField("a"));
+
+    EXPECT_TRUE(structs.Has("struct FooRecursive"));
+
+    record = ty->GetStruct();
+    EXPECT_FALSE(record.expired());
+  }
+
+  EXPECT_TRUE(record.expired());
 }
 
 TEST(btf, compat_anonymous_record)
@@ -582,12 +640,15 @@ TEST(btf, compat_anonymous_record)
   auto anon = btf.add<Struct>("", fields);
   ASSERT_TRUE(bool(anon));
 
-  auto ty = getCompatType(*anon);
+  bpftrace::StructManager structs;
+  auto ty = getCompatType(*anon, structs);
   ASSERT_TRUE(bool(ty));
 
   EXPECT_TRUE(ty->IsCTypeTy());
   EXPECT_TRUE(ty->GetName().empty());
   EXPECT_EQ(ty->GetSize(), 4);
+
+  EXPECT_FALSE(structs.Has(""));
 }
 
 } // namespace bpftrace::test::btf

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -42,6 +42,13 @@ struct Foo4 {
   unsigned int d : 20;
 };
 
+struct FooRecursive {
+  int a;
+  struct FooRecursive *next;
+};
+
+struct FooRecursive foo_recursive;
+
 enum FooEnum {
   VALUE
 };

--- a/tests/runtime/interop
+++ b/tests/runtime/interop
@@ -1,3 +1,8 @@
 NAME interop return types
 PROG import "stdlib/test"; begin { print(__always_true()); exit(); }
 EXPECT 1
+
+NAME interop struct pointer return type
+PROG import "stdlib/test"; begin { $t = __test_get_current_task(); printf("%d %d %d\n", $t->pid == tid, $t->tgid == pid, $t->parent->pid == curtask->parent->pid); exit(); }
+EXPECT 1 1 1
+REQUIRES_FEATURE btf

--- a/tests/type_system.cpp
+++ b/tests/type_system.cpp
@@ -80,6 +80,8 @@ TEST(TypeSystemTest, basic)
     "const struct bpf_map",
     "struct sock",
     "struct sock*",
+    "struct FooRecursive",
+    "struct FooRecursive*",
     "const struct bpf_map*",
     "struct ArrayWithCompoundData*",
     "struct Arrays*",


### PR DESCRIPTION
Stacked PRs:
 * #5328
 * #5321
 * __->__#5322


--- --- ---

### Fix recursive BTF compat types


This fixes an issue where we weren't correctly resolving BTF types that
were self-referential e.g. `struct task_struct`.

Named records are now owned by the `StructManager` and referred to
weakly, which is how records resolved from the kernel's BTF are already
represented. A type that refers back to itself finds the same record, so
its fields stay reachable at any depth, and the record is not kept alive
by a reference cycle through its own fields. Anonymous records have no
name to share them under, so they are still owned by the type.

Added unit tests and a runtime test.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>