### PR TITLE
Hint at --unsafe when address-based uprobe fails on stripped binary

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -222,7 +222,10 @@ Result<uint64_t> resolve_offset_uprobe(Probe &probe, bool safe_mode)
 
     if (!sym) {
       if (safe_mode) {
-        return make_error<AttachError>(llvm::toString(sym.takeError()));
+        consumeError(sym.takeError());
+        return make_error<AttachError>(
+            "Could not determine instruction boundary for " + probe.name +
+            " (binary appears stripped)." + std::string{ hint_unsafe });
       } else {
         consumeError(sym.takeError());
         LOG(WARNING) << "Could not determine instruction boundary for "

--- a/tests/attached_probe.cpp
+++ b/tests/attached_probe.cpp
@@ -1,8 +1,13 @@
 #include "attached_probe.h"
 #include "mocks.h"
+#include "llvm/Support/Error.h"
 #include "gtest/gtest.h"
 
-namespace bpftrace::test {
+namespace bpftrace {
+
+Result<uint64_t> resolve_offset_uprobe(Probe &probe, bool safe_mode);
+
+namespace test {
 
 TEST(attached_probe, kprobe_empty_name_and_zero_address)
 {
@@ -20,4 +25,20 @@ TEST(attached_probe, kprobe_empty_name_and_zero_address)
   EXPECT_TRUE(!result);
 }
 
-} // namespace bpftrace::test
+TEST(attached_probe, resolve_offset_uprobe_unresolvable_address_hints_unsafe)
+{
+  Probe probe;
+  probe.type = ProbeType::uprobe;
+  probe.path = "/nonexistent-binary-for-bpftrace-test";
+  probe.attach_point = "";
+  probe.address = 0x1000;
+  probe.name = "uprobe:" + probe.path + ":0x1000";
+
+  auto result = resolve_offset_uprobe(probe, /*safe_mode=*/true);
+  ASSERT_TRUE(!result);
+  auto msg = llvm::toString(result.takeError());
+  EXPECT_NE(msg.find("--unsafe"), std::string::npos) << msg;
+}
+
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -322,7 +322,7 @@ WILL_FAIL
 
 NAME uprobe_address_fail_resolve
 PROG uprobe:/bin/bash:10 { printf("arg0: %d\n", arg0); exit();}
-EXPECT ERROR: Could not resolve address: /bin/bash:0xa
+EXPECT ERROR: Could not determine instruction boundary for uprobe:/bin/bash:10 (binary appears stripped).
 WILL_FAIL
 
 NAME uprobe_library


### PR DESCRIPTION
## Summary
- When attaching an address-based uprobe (no symbol name given, e.g. `uprobe:./a.out:0x1149`) against a stripped binary in safe mode, `resolve_offset_uprobe()` forwarded the raw "Could not resolve address" error without explaining *why* it failed or how to work around it.
- Every other safe-mode `AttachError` in `attached_probe.cpp` already appends a hint to use `--unsafe`; this path was inconsistent with the rest of the file. Fix brings it in line, using the same wording already used in the non-safe-mode warning path a few lines below ("binary appears stripped").

Fixes #5144

## Test plan
- [x] Added a unit test (`tests/attached_probe.cpp`) exercising `resolve_offset_uprobe()` directly with a non-resolvable address in safe mode, asserting the returned error mentions `--unsafe`.
- [ ] `./build/tests/bpftrace_test --gtest_filter='attached_probe.*'` (not run locally — no build environment available in this session; relying on CI)
- [ ] `git clang-format` (not run locally for the same reason; please flag if formatting needs adjustment)