### PR TITLE
Fix formatting of MAC address bytes with the high bit set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
 #### Fixed
 - Fix `func` builtin for session probe return/exit branches
   - [#5302](https://github.com/bpftrace/bpftrace/issues/5302)
+- Fix formatting of MAC address bytes with the high bit set
+  - [#5326](https://github.com/bpftrace/bpftrace/issues/5326)
 #### Security
 #### Docs
 #### Tools

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1302,15 +1302,16 @@ std::string BPFtrace::resolve_mac_address(const char *mac_addr) const
 {
   const size_t SIZE = 18;
   char addr[SIZE];
+  const auto *bytes = reinterpret_cast<const unsigned char *>(mac_addr);
   snprintf(addr,
            SIZE,
            "%02X:%02X:%02X:%02X:%02X:%02X",
-           mac_addr[0],
-           mac_addr[1],
-           mac_addr[2],
-           mac_addr[3],
-           mac_addr[4],
-           mac_addr[5]);
+           static_cast<unsigned int>(bytes[0]),
+           static_cast<unsigned int>(bytes[1]),
+           static_cast<unsigned int>(bytes[2]),
+           static_cast<unsigned int>(bytes[3]),
+           static_cast<unsigned int>(bytes[4]),
+           static_cast<unsigned int>(bytes[5]));
   return addr;
 }
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -784,6 +784,16 @@ TEST(bpftrace, resolve_timestamp)
       "1736725827.000000");
 }
 
+TEST(bpftrace, resolve_mac_address)
+{
+  const unsigned char mac_addr[] = { 0x80, 0xFF, 0x03, 0xA5, 0x01, 0xFE };
+  BPFtrace bpftrace;
+
+  EXPECT_EQ(bpftrace.resolve_mac_address(
+                reinterpret_cast<const char *>(mac_addr)),
+            "80:FF:03:A5:01:FE");
+}
+
 static std::set<std::string> list_modules(std::string_view ap)
 {
   ast::ASTContext ast("stdin", ap.data());


### PR DESCRIPTION


`macaddr()` can format MAC addresses incorrectly when any byte has its high bit set.

`BPFtrace::resolve_mac_address()` currently passes `char` values directly to `%X`. On platforms where `char` is signed, values such as `0x80` are promoted to negative integers and may be formatted as `FFFFFF80`.

Because the output buffer is sized for the canonical 17-character MAC format, this can also truncate the remaining MAC bytes.

This change reads the six MAC bytes as unsigned bytes and passes them to `snprintf()` as `unsigned int` values.

A regression test now covers:

    80:FF:03:A5:01:FE



Checklist:

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests