### PR TITLE
Add support for open-coded iterators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
   - [#5276](https://github.com/bpftrace/bpftrace/pull/5276)
 - Add `kprobe` support for source location attachpoints.
   - [#5308](https://github.com/bpftrace/bpftrace/pull/5308)
+- Add open-coded iterators to `for` loops: `iter_task`, `iter_threads`,
+  `iter_task_threads` and `iter_task_vma`.
 #### Changed
 #### Deprecated
 #### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,8 @@ and this project adheres to
   - [#5288](https://github.com/bpftrace/bpftrace/pull/5288)
 - Fix large string allocations for casts
   - [#5286](https://github.com/bpftrace/bpftrace/pull/5286)
+- Fix recursive BTF compat types
+  - [#5322](https://github.com/bpftrace/bpftrace/pull/5322)
 
 ## [0.26.1] 2026-06-02
 

--- a/docs/language.md
+++ b/docs/language.md
@@ -636,7 +636,7 @@ Strings support the following escape sequences:
 
 ### For
 
-`for` loops can be used to iterate over elements in a map, or over a range of integers, provided as two unary expressions separated by `..`.
+`for` loops can be used to iterate over elements in a map, over a range of integers, provided as two unary expressions separated by `..`, or over specific kernel objects using an iterator.
 
 ```
 for ($kv : @map) {
@@ -646,6 +646,12 @@ for ($kv : @map) {
 
 ```
 for ($i : start..end) {
+  block;
+}
+```
+
+```
+for ($task : iter_task()) {
   block;
 }
 ```
@@ -693,7 +699,35 @@ for ($i : 0..$a) {
 }
 ```
 
-Both `for` loops support the following control flow statements:
+#### Iterators
+
+Iterators walk a set of kernel objects, and the loop variable is a pointer to the current object.
+These are implemented using [open coded iterators](https://docs.kernel.org/bpf/bpf_iterators.html#open-coded-bpf-iterators) and require kernel 6.7 or later.
+
+| iterator | yields | |
+| --- | --- | --- |
+| `iter_task()` | `struct task_struct *` | every process |
+| `iter_threads()` | `struct task_struct *` | every thread |
+| `iter_task_threads(task)` | `struct task_struct *` | the threads of `task` |
+| `iter_task_vma(task[, addr])` | `struct vm_area_struct *` | the memory mappings of `task`, optionally starting at `addr` |
+
+```
+interval:s:10 {
+  for ($task : iter_task()) {
+    printf("%-6d %s\n", $task->pid, $task->comm);
+  }
+}
+```
+
+```
+tracepoint:syscalls:sys_enter_execve {
+  for ($vma : iter_task_vma(curtask)) {
+    printf("%lx-%lx\n", $vma->vm_start, $vma->vm_end);
+  }
+}
+```
+
+All three `for` loops support the following control flow statements:
 
 |     |     |
 | --- | --- |
@@ -1194,6 +1228,7 @@ interval:1s { print(@syscalls); clear(@syscalls); }
 
 These are eBPF iterator probes that allow iteration over kernel objects.
 Iterator probe can’t be mixed with any other probe, not even another iterator.
+However, some of these iterators are available in `for` loops, which can be used within most probes.
 Each iterator probe provides a set of fields that could be accessed with the
 ctx pointer. Users can display the set of available fields for each iterator via
 -lv options as described below.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -222,12 +222,12 @@ This utilizes the BPF helper `raw_smp_processor_id`
 
 
 ### curtask
-- `uint64 curtask()`
-- `uint64 curtask`
+- `struct task_struct * curtask()`
+- `struct task_struct * curtask`
 
 Pointer to `struct task_struct` of the current task
 
-This utilizes the BPF helper `get_current_task`
+This utilizes the BPF helper `bpf_get_current_task_btf`
 
 
 ### cwd

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,6 +10,7 @@ add_compile_options($<$<BOOL:${BUILD_UBSAN}>:-fsanitize=undefined>)
 add_library(required_resources required_resources.cpp)
 
 add_library(compiler_core STATIC
+  bpf_iters.cpp
   functions.cpp
   struct.cpp
   types.cpp

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1601,7 +1601,7 @@ public:
   Expression end;
 };
 
-class Iterable : public VariantNode<Map, Range> {
+class Iterable : public VariantNode<Map, Range, Call> {
 public:
   using VariantNode::VariantNode;
   Iterable() : Iterable(static_cast<Map *>(nullptr)) {};

--- a/src/ast/codegen_helper.cpp
+++ b/src/ast/codegen_helper.cpp
@@ -1,6 +1,70 @@
 #include "codegen_helper.h"
 
+#include "ast/visitor.h"
+
 namespace bpftrace::ast {
+
+namespace {
+
+class IterLoopVarCollector : public Visitor<IterLoopVarCollector> {
+public:
+  using Visitor<IterLoopVarCollector>::visit;
+
+  void visit(For &f)
+  {
+    bool outer = in_iter_loop_;
+    in_iter_loop_ = in_iter_loop_ || f.iterable.is<Call>();
+    Visitor<IterLoopVarCollector>::visit(f);
+    in_iter_loop_ = outer;
+  }
+
+  void visit(AssignVarStatement &assignment)
+  {
+    if (in_iter_loop_) {
+      idents_.insert(assignment.var()->ident);
+    }
+    Visitor<IterLoopVarCollector>::visit(assignment);
+  }
+
+  void visit(Unop &unop)
+  {
+    if (in_iter_loop_ && is_inc_dec(unop.op)) {
+      if (auto *var = unop.expr.as<Variable>()) {
+        idents_.insert(var->ident);
+      }
+    }
+    Visitor<IterLoopVarCollector>::visit(unop);
+  }
+
+  std::unordered_set<std::string> take()
+  {
+    return std::move(idents_);
+  }
+
+private:
+  static bool is_inc_dec(Operator op)
+  {
+    return op == Operator::PRE_INCREMENT || op == Operator::POST_INCREMENT ||
+           op == Operator::PRE_DECREMENT || op == Operator::POST_DECREMENT;
+  }
+
+  std::unordered_set<std::string> idents_;
+  bool in_iter_loop_ = false;
+};
+
+} // namespace
+
+template <typename T>
+  requires std::same_as<T, Probe> || std::same_as<T, Subprog>
+std::unordered_set<std::string> collectIterLoopVars(T &node)
+{
+  IterLoopVarCollector collector;
+  collector.visit(node);
+  return collector.take();
+}
+
+template std::unordered_set<std::string> collectIterLoopVars(Probe &);
+template std::unordered_set<std::string> collectIterLoopVars(Subprog &);
 
 bool needMapAllocation(const SizedType &src, const SizedType &dst)
 {

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <concepts>
+#include <string>
+#include <unordered_set>
+
 #include "ast/ast.h"
 #include "types.h"
 
@@ -35,5 +39,9 @@ inline AddrSpace find_addrspace_stack(const SizedType &ty)
 
 // This applies to both map keys and map values
 bool needMapAllocation(const SizedType &src, const SizedType &dst);
+
+template <typename T>
+  requires std::same_as<T, Probe> || std::same_as<T, Subprog>
+std::unordered_set<std::string> collectIterLoopVars(T &node);
 
 } // namespace bpftrace::ast

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -20,10 +20,18 @@ DILocalScope *DIBuilderBPF::createFunctionDebugInfo(llvm::Function &func,
                                                     const Struct &args,
                                                     bool is_declaration)
 {
+  return createFunctionDebugInfo(func, GetType(ret_type), args, is_declaration);
+}
+
+DILocalScope *DIBuilderBPF::createFunctionDebugInfo(llvm::Function &func,
+                                                    DIType *ret_type,
+                                                    const Struct &args,
+                                                    bool is_declaration)
+{
   // Return type should be at index 0
   SmallVector<Metadata *> types;
   types.reserve(args.fields.size() + 1);
-  types.push_back(GetType(ret_type));
+  types.push_back(ret_type);
   for (const auto &arg : args.fields)
     types.push_back(GetType(arg.type));
 

--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -19,6 +19,10 @@ public:
                                         const SizedType &ret_type,
                                         const Struct &args,
                                         bool is_declaration = false);
+  DILocalScope *createFunctionDebugInfo(llvm::Function &func,
+                                        DIType *ret_type,
+                                        const Struct &args,
+                                        bool is_declaration = false);
   DILocalScope *createProbeDebugInfo(llvm::Function &probe_func);
 
   DIType *getInt8Ty();

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1718,6 +1718,18 @@ llvm::Type *IRBuilderBPF::BpfPidnsInfoType()
                        false);
 }
 
+CallInst *IRBuilderBPF::CreateGetCurrentTask(const Location &loc)
+{
+  // struct task_struct *bpf_get_current_task_btf(void)
+  FunctionType *fn_type = FunctionType::get(getPtrTy(), false);
+  return CreateHelperCall(BPF_FUNC_get_current_task_btf,
+                          fn_type,
+                          {},
+                          true,
+                          "get_current_task_btf",
+                          loc);
+}
+
 CallInst *IRBuilderBPF::CreateGetCpuId(const Location &loc)
 {
   // u32 bpf_get_smp_processor_id(void)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -662,21 +662,22 @@ Value *IRBuilderBPF::CreateWriteMapValueAllocation(const SizedType &value_type,
 
 Value *IRBuilderBPF::CreateVariableAllocationInit(const SizedType &value_type,
                                                   const std::string &name,
-                                                  const Location &loc)
+                                                  const Location &loc,
+                                                  bool force_scratch)
 {
   // Hoist variable declaration and initialization to entry point of
   // probe/subprogram. While we technically do not need this as variables
   // are properly scoped, it eases debugging and is consistent with previous
   // stack-only variable implementation.
   Value *alloc;
-  hoist([this, &value_type, &name, &loc, &alloc] {
-    alloc = createAllocation(bpftrace::globalvars::VARIABLE_BUFFER,
-                             GetType(value_type),
-                             name,
-                             loc,
-                             [](AsyncIds &async_ids) {
-                               return async_ids.variable();
-                             });
+  hoist([this, &value_type, &name, &loc, &alloc, force_scratch] {
+    alloc = createAllocation(
+        bpftrace::globalvars::VARIABLE_BUFFER,
+        GetType(value_type),
+        name,
+        loc,
+        [](AsyncIds &async_ids) { return async_ids.variable(); },
+        force_scratch);
     CreateAllocationInit(value_type, alloc);
   });
   return alloc;
@@ -700,11 +701,12 @@ Value *IRBuilderBPF::createAllocation(
     llvm::Type *obj_type,
     const std::string &name,
     const Location &loc,
-    std::optional<std::function<size_t(AsyncIds &)>> gen_async_id_cb)
+    std::optional<std::function<size_t(AsyncIds &)>> gen_async_id_cb,
+    bool force_scratch)
 {
   const auto obj_size = module_.getDataLayout().getTypeAllocSize(obj_type);
   const auto on_stack_limit = bpftrace_.config_->on_stack_limit;
-  if (obj_size > on_stack_limit) {
+  if (force_scratch || obj_size > on_stack_limit) {
     return createScratchBuffer(global_var_name,
                                loc,
                                gen_async_id_cb ? (*gen_async_id_cb)(async_ids_)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -123,6 +123,7 @@ public:
                                const Location &loc,
                                MDNode *metadata);
   Value *CreateGetNs(TimestampMode ts, const Location &loc);
+  CallInst *CreateGetCurrentTask(const Location &loc);
   CallInst *CreateGetCpuId(const Location &loc);
   CallInst *CreateGetStack(Value *ctx,
                            Value *buf,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -149,7 +149,8 @@ public:
                                        const Location &loc);
   Value *CreateVariableAllocationInit(const SizedType &value_type,
                                       const std::string &name,
-                                      const Location &loc);
+                                      const Location &loc,
+                                      bool force_scratch = false);
   Value *CreateMapKeyAllocation(const SizedType &value_type,
                                 const std::string &name,
                                 const Location &loc);
@@ -300,7 +301,8 @@ private:
                           const std::string &name,
                           const Location &loc,
                           std::optional<std::function<size_t(AsyncIds &)>>
-                              gen_async_id_cb = std::nullopt);
+                              gen_async_id_cb = std::nullopt,
+                          bool force_scratch = false);
   void CreateAllocationInit(const SizedType &stype, Value *alloc);
   Value *createScratchBuffer(std::string_view global_var_name,
                              const Location &loc,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -834,6 +834,8 @@ ScopedExpr CodegenLLVM::visit(Builtin &builtin)
   } else if (builtin.ident == "__builtin_cpu") {
     Value *cpu = b_.CreateGetCpuId(builtin.loc);
     return ScopedExpr(b_.CreateZExt(cpu, b_.getInt64Ty()));
+  } else if (builtin.ident == "__builtin_curtask") {
+    return ScopedExpr(b_.CreateGetCurrentTask(builtin.loc));
   } else if (builtin.ident == "__builtin_ncpus") {
     return ScopedExpr(b_.CreateLoad(b_.getInt64Ty(),
                                     module_->getGlobalVariable(std::string(

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -48,6 +48,7 @@
 #include "ast/passes/types/type_map.h"
 #include "ast/visitor.h"
 #include "async_action.h"
+#include "bpf_iters.h"
 #include "bpfmap.h"
 #include "bpftrace.h"
 #include "config.h"
@@ -237,6 +238,7 @@ public:
   ScopedExpr visit(While &while_block);
   ScopedExpr visit(For &f, Map &map);
   ScopedExpr visit(For &f, Range &range);
+  ScopedExpr visit(For &f, Call &iter);
   ScopedExpr visit(For &f);
   ScopedExpr visit(Jump &jump);
   ScopedExpr visit(Probe &probe);
@@ -383,6 +385,12 @@ private:
       llvm::Type *ctx_t,
       std::function<llvm::Value *(llvm::Function *)> decl);
 
+  llvm::Function *createKfuncDecl(const std::string &name,
+                                  llvm::Type *ret,
+                                  ArrayRef<llvm::Type *> args,
+                                  DIType *debug_ret,
+                                  const Struct &debug_args);
+
   llvm::Function *createForEachMapCallback(const For &f,
                                            const Map &map,
                                            llvm::Type *ctx_t);
@@ -434,6 +442,7 @@ private:
 
   std::vector<Node *> scope_stack_;
   std::unordered_map<Node *, std::map<std::string, VariableLLVM>> variables_;
+  std::unordered_set<std::string> iter_loop_vars_;
 
   std::unordered_map<std::string, bpf_map_type> map_types_;
 
@@ -3124,7 +3133,8 @@ void CodegenLLVM::maybeAllocVariable(const std::string &var_ident,
     alloca_type = CreatePointer(pointee_type, var_type.GetAS());
   }
 
-  auto *val = b_.CreateVariableAllocationInit(alloca_type, var_ident, loc);
+  auto *val = b_.CreateVariableAllocationInit(
+      alloca_type, var_ident, loc, iter_loop_vars_.contains(var_ident));
   variables_[scope_stack_.back()][var_ident] = VariableLLVM{
     .value = val, .type = b_.GetType(alloca_type)
   };
@@ -3387,6 +3397,7 @@ void CodegenLLVM::add_probe(AttachPoint &ap,
 
 ScopedExpr CodegenLLVM::visit(Subprog &subprog)
 {
+  iter_loop_vars_ = collectIterLoopVars(subprog);
   scope_stack_.push_back(&subprog);
   std::vector<llvm::Type *> arg_types;
   // First argument is for passing ctx pointer for output, rest are proper
@@ -3499,6 +3510,7 @@ ScopedExpr CodegenLLVM::visit(Probe &probe)
   // can restore it for the next pass (printf_id_, time_id_).
   async_ids_.create_reset_ids();
   assert(probe.attach_points.size() == 1);
+  iter_loop_vars_ = collectIterLoopVars(probe);
   current_attach_point_ = probe.attach_points.at(0);
   probe.set_index(getNextIndexForProbe());
 
@@ -4781,6 +4793,150 @@ ScopedExpr CodegenLLVM::visit(For &f, Range &range)
 
   // Execute the loop.
   b_.CreateForRange(iters, cb, ctx, f.loc);
+  return ScopedExpr();
+}
+
+llvm::Function *CodegenLLVM::createKfuncDecl(const std::string &name,
+                                             llvm::Type *ret,
+                                             ArrayRef<llvm::Type *> args,
+                                             DIType *debug_ret,
+                                             const Struct &debug_args)
+{
+  if (auto *existing = module_->getFunction(name)) {
+    return existing;
+  }
+
+  FunctionType *func_type = FunctionType::get(ret, args, false);
+  auto *fn = llvm::Function::Create(
+      func_type,
+      llvm::Function::LinkageTypes::ExternalWeakLinkage,
+      name,
+      module_.get());
+  fn->setDSOLocal(true);
+  fn->setSection(".ksyms");
+
+  debug_.createFunctionDebugInfo(*fn,
+                                 debug_ret,
+                                 debug_args,
+                                 /*is_declaration=*/true);
+  return fn;
+}
+
+ScopedExpr CodegenLLVM::visit(For &f, Call &it)
+{
+  const auto *info = find_bpf_iter(it.func);
+
+  // Declare the bpf_iter_<kind>_{new,next,destroy} trio. Several bpftrace
+  // iterators may share one trio, so these are cached per module.
+  //
+  // This flow mimics this bpf.c code:
+  // struct bpf_iter_task task_it;
+  // bpf_iter_task_new(&task_it, NULL, FLAGS);
+  //
+  // while ((task = bpf_iter_task_next(&task_it))) {
+  //   body
+  // }
+  //
+  // bpf_iter_task_destroy(&task_it);
+  const std::string state_type_name = "__compat_" + info->kfunc;
+  auto state_type = CreateCStruct(
+      state_type_name,
+      bpftrace_.structs.LookupOrAdd(state_type_name, info->iter_size));
+  auto ptr_to_state = CreatePointer(state_type);
+  auto yielded = CreatePointer(bpftrace_.btf_->get_stype(info->yields),
+                               AddrSpace::kernel);
+  auto start_arg = CreatePointer(
+      bpftrace_.btf_->get_stype("struct task_struct"), AddrSpace::kernel);
+  auto last_arg = info->flags ? CreateUInt32() : CreateUInt64();
+
+  Struct new_args;
+  new_args.AddField("it", ptr_to_state);
+  new_args.AddField("start", start_arg);
+  new_args.AddField(info->flags ? "flags" : "addr", last_arg);
+  auto *new_fn = createKfuncDecl(
+      info->kfunc + "_new",
+      b_.getInt32Ty(),
+      { b_.getPtrTy(), b_.getPtrTy(), b_.GetType(last_arg) },
+      debug_.GetType(CreateInt32()),
+      new_args);
+
+  Struct iter_only_args;
+  iter_only_args.AddField("it", ptr_to_state);
+  auto *next_fn = createKfuncDecl(info->kfunc + "_next",
+                                  b_.getPtrTy(),
+                                  { b_.getPtrTy() },
+                                  debug_.GetType(yielded),
+                                  iter_only_args);
+  auto *destroy_fn = createKfuncDecl(info->kfunc + "_destroy",
+                                     b_.getVoidTy(),
+                                     { b_.getPtrTy() },
+                                     nullptr,
+                                     iter_only_args);
+
+  llvm::Function *parent = b_.GetInsertBlock()->getParent();
+  BasicBlock *iter_cond = BasicBlock::Create(module_->getContext(),
+                                             "iter_cond",
+                                             parent);
+  BasicBlock *iter_body = BasicBlock::Create(module_->getContext(),
+                                             "iter_body",
+                                             parent);
+  BasicBlock *iter_destroy = BasicBlock::Create(module_->getContext(),
+                                                "iter_destroy",
+                                                parent);
+  BasicBlock *iter_end = BasicBlock::Create(module_->getContext(),
+                                            "iter_end",
+                                            parent);
+
+  auto *state = b_.CreateAllocaBPF(b_.GetType(state_type), "iter_state");
+  state->setAlignment(Align(8));
+  auto *decl_type = b_.GetType(type_map_.type(f.decl));
+  auto *decl = b_.CreateAllocaBPF(decl_type, f.decl->ident);
+  variables_[scope_stack_.back()][f.decl->ident] = VariableLLVM{
+    .value = decl, .type = decl_type
+  };
+
+  std::vector<ScopedExpr> scoped_args;
+  Value *start = b_.GetNull();
+  Value *last = nullptr;
+  for (size_t i = 0; i < it.vargs.size(); i++) {
+    scoped_args.emplace_back(visit(it.vargs.at(i)));
+    auto *value = scoped_args.back().value();
+    if (i == 0) {
+      start = value;
+    } else {
+      last = b_.CreateIntCast(value, b_.getInt64Ty(), false);
+    }
+  }
+
+  if (info->flags) {
+    last = b_.getInt32(static_cast<uint32_t>(*info->flags));
+  } else if (last == nullptr) {
+    last = b_.getInt64(0);
+  }
+
+  auto *rc = b_.CreateCall(new_fn, { state, start, last }, "iter_new");
+  b_.CreateCondBr(b_.CreateICmpNE(rc, b_.getInt32(0), "iter_new_failed"),
+                  iter_destroy,
+                  iter_cond);
+
+  b_.SetInsertPoint(iter_cond);
+  auto *elem = b_.CreateCall(next_fn, { state }, "iter_next");
+  b_.CreateCondBr(b_.CreateIsNotNull(elem, "iter_more"),
+                  iter_body,
+                  iter_destroy);
+
+  loops_.emplace_back([&] { return iter_cond; }, [&] { return iter_destroy; });
+  b_.SetInsertPoint(iter_body);
+  b_.CreateStore(elem, decl);
+  visit(f.block);
+  loops_.pop_back();
+
+  b_.SetInsertPoint(iter_destroy);
+  b_.CreateCall(destroy_fn, { state });
+  b_.CreateBr(iter_end);
+
+  b_.SetInsertPoint(iter_end);
+  variables_[scope_stack_.back()].erase(f.decl->ident);
   return ScopedExpr();
 }
 

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -81,6 +81,8 @@ void FieldAnalyser::visit(Builtin &builtin)
     // make them resolved and available
     if (probe_type_ == ProbeType::iter)
       builtin_type = "struct bpf_iter__" + attach_func_;
+  } else if (builtin.ident == "__builtin_curtask") {
+    builtin_type = "struct task_struct";
   } else if (builtin.ident == "args") {
     if (!probe_)
       return;

--- a/src/ast/passes/portability_analyser.cpp
+++ b/src/ast/passes/portability_analyser.cpp
@@ -17,6 +17,7 @@ class PortabilityAnalyser : public Visitor<PortabilityAnalyser> {
 public:
   using Visitor<PortabilityAnalyser>::visit;
   void visit(PositionalParameter &param);
+  void visit(Builtin &builtin);
   void visit(Call &call);
   void visit(Cast &cast);
 };
@@ -54,13 +55,16 @@ void PortabilityAnalyser::visit(Call &call)
       call.func == "cgroupid") {
     call.addError() << "AOT does not yet support " << call.func << "()";
   }
+}
 
-  // `curtask` is implemented via the `bpf_get_current_task` helper, which
+void PortabilityAnalyser::visit(Builtin &builtin)
+{
+  // `curtask` is implemented via the `bpf_get_current_task_btf` helper, which
   // returns a `struct task_struct *`. This struct is unstable across kernel
   // versions and configurations. This makes it inherently unportable. We must
   // block it until we support field access relocations.
-  if (call.func == "__get_current_task") {
-    call.addError() << "AOT does not yet support accessing `curtask`";
+  if (builtin.ident == "__builtin_curtask") {
+    builtin.addError() << "AOT does not yet support accessing `curtask`";
   }
 }
 

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -76,6 +76,9 @@ private:
 
   // Current probe we're analysing
   Probe *probe_{ nullptr };
+  // All variables inside an open-coded iterator get promoted to a scratch map
+  // to prevent verifier errors
+  std::unordered_set<std::string> iter_loop_vars_;
   std::unordered_map<std::string, std::pair<bpf_map_type, int>> map_decls_;
 
   int next_map_id_ = 0;
@@ -148,12 +151,14 @@ RequiredResources ResourceAnalyser::resources()
 void ResourceAnalyser::visit(Probe &probe)
 {
   probe_ = &probe;
+  iter_loop_vars_ = collectIterLoopVars(probe);
   Visitor<ResourceAnalyser>::visit(probe);
 }
 
 void ResourceAnalyser::visit(Subprog &subprog)
 {
   probe_ = nullptr;
+  iter_loop_vars_ = collectIterLoopVars(subprog);
   Visitor<ResourceAnalyser>::visit(subprog);
 }
 
@@ -595,7 +600,8 @@ void ResourceAnalyser::update_variable_info(Variable &var)
   // we would need to track scopes like TypeChecker and CodegenLLVM
   // and duplicate scope tracking in a third module.
   const auto &ty = type_map_.type(&var);
-  if (exceeds_stack_limit(ty.GetSize())) {
+  if (exceeds_stack_limit(ty.GetSize()) ||
+      iter_loop_vars_.contains(var.ident)) {
     resources_.variable_buffers++;
     resources_.max_variable_size = std::max(resources_.max_variable_size,
                                             ty.GetSize());

--- a/src/ast/passes/types/cast_creator.cpp
+++ b/src/ast/passes/types/cast_creator.cpp
@@ -484,7 +484,8 @@ void CastCreator::visit(Call &call)
     }
 
     for (size_t i = 0; i < argument_types->size(); i++) {
-      auto compat_arg_type = getCompatType(argument_types->at(i).second);
+      auto compat_arg_type = getCompatType(argument_types->at(i).second,
+                                           bpftrace_.structs);
       if (!compat_arg_type) {
         consumeError(compat_arg_type.takeError());
         continue;

--- a/src/ast/passes/types/pre_type_check.cpp
+++ b/src/ast/passes/types/pre_type_check.cpp
@@ -11,6 +11,7 @@
 #include "ast/helpers.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/visitor.h"
+#include "bpf_iters.h"
 #include "bpfmap.h"
 #include "bpftrace.h"
 #include "format_string.h"
@@ -298,6 +299,10 @@ const std::map<std::string, nargs_spec> CALL_NARGS = {
   { "exit",           { .min_args=0, .max_args=1 } },
   { "fail",           { .min_args=1, .max_args=128 } },
   { "hist",           { .min_args=3, .max_args=4 } },
+  { "iter_task",      { .min_args=0, .max_args=0 } },
+  { "iter_task_threads", { .min_args=1, .max_args=1 } },
+  { "iter_task_vma",  { .min_args=1, .max_args=2 } },
+  { "iter_threads",   { .min_args=0, .max_args=0 } },
   { "join",           { .min_args=1, .max_args=2 } },
   { "kaddr",          { .min_args=1, .max_args=1 } },
   { "kptr",           { .min_args=1, .max_args=1 } },
@@ -386,6 +391,7 @@ public:
   using Visitor<CallPreCheck>::visit;
 
   void visit(Call &call);
+  void visit(For &f);
   void visit(Identifier &identifier);
   void visit(Probe &probe);
   void visit(String &string);
@@ -719,6 +725,31 @@ void CallPreCheck::visit(Identifier &identifier)
           << " (expects: curr_ns or init)";
     }
   }
+}
+
+void CallPreCheck::visit(For &f)
+{
+  visit(f.decl);
+  if (auto *call = f.iterable.as<Call>()) {
+    const auto *info = find_bpf_iter(call->func);
+    if (info == nullptr) {
+      auto &err = call->addError();
+      err << call->func << "() is not a valid iterator";
+      auto &hint = err.addHint();
+      hint << "Valid iterators are: ";
+      size_t i = 0;
+      for (const auto &iter : BPF_ITER_LIST) {
+        hint << iter.name;
+        if (i++ != BPF_ITER_LIST.size() - 1) {
+          hint << ", ";
+        }
+      }
+      return;
+    }
+  }
+
+  visit(f.iterable);
+  visit(f.block);
 }
 
 void CallPreCheck::visit(Probe &probe)

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -590,7 +590,7 @@ void TypeChecker::visit(Call &call)
     for (size_t i = 0; i < argument_types->size(); i++) {
       const auto &[name, type] = argument_types->at(i);
       const auto &varg_type = type_map_.type(call.vargs[i]);
-      auto compat_arg_type = getCompatType(type);
+      auto compat_arg_type = getCompatType(type, bpftrace_.structs);
       if (!compat_arg_type) {
         // If the required type is a **pointer**, and the provided type is
         // a **pointer**, then we let it slide. Just assume the user knows

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -11,6 +11,7 @@
 #include "ast/passes/types/type_checker.h"
 #include "ast/passes/types/type_map.h"
 #include "ast/passes/types/type_system.h"
+#include "bpf_iters.h"
 #include "bpftrace.h"
 #include "btf/compat.h"
 #include "config.h"
@@ -552,6 +553,33 @@ void TypeChecker::visit(Call &call)
       FormatString fs(call.vargs[0].as<String>()->value);
       call.addError() << fs.format(args);
     }
+  } else if (call.func == "iter_task" || call.func == "iter_threads") {
+    // OK
+  } else if (call.func == "iter_task_threads" || call.func == "iter_task_vma") {
+    auto logError = [&]<typename T>(T name) {
+      call.addError() << call.func
+                      << "() only supports 'struct task_struct *' as the "
+                         "first argument ("
+                      << name << " provided)";
+    };
+
+    const auto &task = type_map_.type(call.vargs.at(0));
+    if (!task.IsPtrTy() || !task.GetPointeeTy().IsCTypeTy()) {
+      logError(task.GetTy());
+    } else if (!task.GetPointeeTy().IsCompatible(
+                   CreateCStruct("struct task_struct"))) {
+      logError("'" + task.GetPointeeTy().GetName() + " *'");
+    }
+
+    if (call.func == "iter_task_vma" && call.vargs.size() == 2) {
+      const auto &addr = type_map_.type(call.vargs.at(1));
+      if (!addr.IsIntTy()) {
+        call.addError() << call.func
+                        << "() only supports an integer as the second "
+                           "argument ("
+                        << addr.GetTy() << " provided)";
+      }
+    }
   } else {
     // Check here if this corresponds to an external function. We convert the
     // external type metadata into the internal `SizedType` representation and
@@ -848,18 +876,29 @@ void TypeChecker::visit(For &f)
 
   visit(f.iterable);
 
+  if (auto *it = f.iterable.as<Call>()) {
+    const auto *info = find_bpf_iter(it->func);
+    if (!bpftrace_.feature_->has_kfunc(info->kfunc + "_new")) {
+      it->addError() << "Missing required kernel feature: " << info->kfunc
+                     << " (open-coded iterators require kernel 6.7 or later)";
+    }
+  }
+
   loop_depth_++;
   visit(f.block);
   loop_depth_--;
 
-  // Currently, we do not pass BPF context to the callback so disable builtins
-  // which require ctx access.
-  CollectNodes<Builtin> builtins;
-  builtins.visit(f.block);
-  for (Builtin &builtin : builtins.nodes()) {
-    if (type_map_.type(&builtin).IsCtxAccess()) {
-      builtin.addError() << "'" << builtin.ident
-                         << "' builtin is not allowed in a for-loop";
+  // Loops lowered to a callback do not receive the BPF context, so builtins
+  // which require ctx access are unavailable there. Open-coded iterators are
+  // lowered inline and keep the enclosing probe's context.
+  if (!f.iterable.is<Call>()) {
+    CollectNodes<Builtin> builtins;
+    builtins.visit(f.block);
+    for (Builtin &builtin : builtins.nodes()) {
+      if (type_map_.type(&builtin).IsCtxAccess()) {
+        builtin.addError() << "'" << builtin.ident
+                           << "' builtin is not allowed in a for-loop";
+      }
     }
   }
 }

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -833,6 +833,15 @@ void TypeRuleCollector::visit(Builtin &builtin)
       default:
         break;
     }
+  } else if (builtin.ident == "__builtin_curtask") {
+    auto record = bpftrace_.structs.Lookup("struct task_struct");
+    if (record.expired()) {
+      builtin.addError() << "Cannot resolve \"struct task_struct\"; kernel BTF "
+                            "may be unavailable";
+    } else {
+      builtin_type = CreatePointer(CreateCStruct("struct task_struct", record),
+                                   AddrSpace::kernel);
+    }
   } else if (builtin.ident == "__builtin_retval") {
     auto *probe = get_probe(builtin, builtin.ident);
     if (probe == nullptr)

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -1298,7 +1298,8 @@ void TypeRuleCollector::visit(Call &call)
                         << btf_return_type.takeError();
         return;
       }
-      auto compat_return_type = getCompatType(*btf_return_type);
+      auto compat_return_type = getCompatType(*btf_return_type,
+                                              bpftrace_.structs);
       if (!compat_return_type) {
         call.addError() << "Unable to convert return type: "
                         << compat_return_type.takeError();

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -15,6 +15,7 @@
 #include "ast/passes/types/type_map.h"
 #include "ast/passes/types/type_system.h"
 #include "ast/visitor.h"
+#include "bpf_iters.h"
 #include "bpftrace.h"
 #include "btf/compat.h"
 #include "config.h"
@@ -1638,13 +1639,27 @@ void TypeRuleCollector::visit(For &f)
           return get_range_type(inputs[0], inputs[1], range);
         },
     });
+  } else if (auto *it = f.iterable.as<Call>()) {
+    for (auto &varg : it->vargs) {
+      visit(varg);
+    }
+    const auto *info = find_bpf_iter(it->func);
+    auto yielded = bpftrace_.btf_->get_stype(info->yields);
+    if (yielded.IsNoneTy()) {
+      it->addError() << "Cannot resolve \"" << info->yields << "\" required by "
+                     << it->func << "(); kernel BTF may be unavailable";
+    } else {
+      resolver_.set_type(scoped_var, CreatePointer(yielded, AddrSpace::kernel));
+    }
   }
 
   visit(f.block);
 
   scope_stack_.pop_back();
 
-  {
+  // Open-coded iterators are lowered to an inline loop rather than a callback,
+  // so outer variables are used directly and need no context struct.
+  if (!f.iterable.is<Call>()) {
     std::vector<TypeVariable> ctx_inputs;
     for (Variable &var : collector.nodes()) {
       ctx_inputs.emplace_back(&var);

--- a/src/bpf_iters.cpp
+++ b/src/bpf_iters.cpp
@@ -1,0 +1,39 @@
+#include "bpf_iters.h"
+
+#include <algorithm>
+
+namespace bpftrace {
+
+const std::vector<BpfIterItem> BPF_ITER_LIST = {
+  { .name = "iter_task",
+    .kfunc = "bpf_iter_task",
+    .iter_size = 24,
+    .yields = "struct task_struct",
+    .flags = TaskIterFlags::all_procs },
+  { .name = "iter_threads",
+    .kfunc = "bpf_iter_task",
+    .iter_size = 24,
+    .yields = "struct task_struct",
+    .flags = TaskIterFlags::all_threads },
+  { .name = "iter_task_threads",
+    .kfunc = "bpf_iter_task",
+    .iter_size = 24,
+    .yields = "struct task_struct",
+    .flags = TaskIterFlags::proc_threads },
+  { .name = "iter_task_vma",
+    .kfunc = "bpf_iter_task_vma",
+    .iter_size = 8,
+    .yields = "struct vm_area_struct",
+    .flags = std::nullopt },
+};
+
+const BpfIterItem *find_bpf_iter(std::string_view name)
+{
+  auto it = std::ranges::find(BPF_ITER_LIST, name, &BpfIterItem::name);
+  if (it == BPF_ITER_LIST.end()) {
+    return nullptr;
+  }
+  return &*it;
+}
+
+} // namespace bpftrace

--- a/src/bpf_iters.h
+++ b/src/bpf_iters.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace bpftrace {
+
+enum class TaskIterFlags : uint32_t {
+  all_procs = 0,
+  all_threads = 1,
+  proc_threads = 2,
+};
+
+struct BpfIterItem {
+  std::string name;
+  std::string kfunc;
+  size_t iter_size;
+  std::string yields;
+  std::optional<TaskIterFlags> flags;
+};
+
+extern const std::vector<BpfIterItem> BPF_ITER_LIST;
+
+const BpfIterItem *find_bpf_iter(std::string_view name);
+
+} // namespace bpftrace

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -201,6 +201,19 @@ static bool is_stack_size_error(std::string_view log)
   return util::wildcard_match(log, tokens, true, true);
 }
 
+// Linux 6.17 - 6.18 abort with a verifier bug when an open-coded iterator
+// loop that unconditionally breaks is nested inside another for loop. The
+// break leaves the iterator's next() call without a back-edge, so the kernel
+// assigns it no SCC, but re-entering the enclosing loop's callback still makes
+// is_state_visited() record a backedge against that missing SCC.
+static bool is_iter_backedge_error(std::string_view log)
+{
+  static const std::vector<std::string> tokens = {
+    "add backedge", "no SCC in verification path"
+  };
+  return util::wildcard_match(log, tokens, true, true);
+}
+
 Result<> BpfBytecode::load_progs(const RequiredResources &resources,
                                  const BTF &btf,
                                  BPFfeature &feature,
@@ -274,6 +287,14 @@ Result<> BpfBytecode::load_progs(const RequiredResources &resources,
             "Stack size is too large. Trying moving some scratch variables "
             "into maps or try setting a lower on_stack_limit (e.g. `config = { "
             "on_stack_limit=16 }`)");
+      }
+
+      if (is_iter_backedge_error(log)) {
+        return make_error<BpfLoadError>(
+            "Hit a known kernel verifier bug (Linux 6.17 - 6.18) affecting an "
+            "iterator loop that unconditionally breaks inside another for "
+            "loop. Try making the break conditional (e.g. `if (...) { break; "
+            "}`) or moving the iterator loop out of the enclosing for loop.");
       }
 
       std::stringstream errmsg;

--- a/src/btf/compat.cpp
+++ b/src/btf/compat.cpp
@@ -59,6 +59,27 @@ Result<SizedType> getCompatType(const Array &type, CompatTypeCache &type_cache)
   return CreateArray(type.element_count(), *ty);
 }
 
+// We can only generate the fields based on the offsets.
+static Result<bpftrace::Fields> resolveFields(
+    std::vector<std::pair<std::string, FieldInfo>> &&fields,
+    CompatTypeCache &type_cache)
+{
+  bpftrace::Fields resolved;
+  for (const auto &[name, info] : fields) {
+    auto ft = getCompatType(info.type, type_cache);
+    if (!ft) {
+      return ft.takeError();
+    }
+    resolved.emplace_back(Field{
+        .name = name,
+        .type = *ft,
+        .offset = static_cast<ssize_t>(info.bit_offset / 8),
+        .bitfield = std::nullopt,
+    });
+  }
+  return resolved;
+}
+
 Result<SizedType> asRecord(
     uint32_t type_id,
     const std::string &name,
@@ -66,33 +87,53 @@ Result<SizedType> asRecord(
     std::vector<std::pair<std::string, FieldInfo>> &&fields,
     CompatTypeCache &type_cache)
 {
-  auto it = type_cache.find(type_id);
-  if (it != type_cache.end()) {
-    return CreateRecord(std::shared_ptr<bpftrace::Struct>(it->second));
-  }
+  // While this record's fields are being resolved, the cache holds a null
+  // entry for it. Since this function recurses this null entry is used to
+  // determine if we're also dealing with a recursive type.
+  auto [it, first_visit] = type_cache.records.try_emplace(type_id, nullptr);
 
-  // The record start empty, and we construct below.
-  auto s = bpftrace::Struct::CreateRecord({}, {});
-  s->size = static_cast<int>(size);
-  type_cache.emplace(type_id, std::shared_ptr<bpftrace::Struct>(s));
-
-  // We can only generate a type based on the offsets.
-  std::vector<std::string_view> idents;
-  std::vector<FieldInfo> infos;
-  std::vector<SizedType> types;
-  for (const auto &[name, info] : fields) {
-    auto ft = getCompatType(info.type, type_cache);
-    if (!ft) {
-      return ft.takeError();
+  if (!name.empty()) {
+    auto record = type_cache.structs.LookupOrAdd(name, size).lock();
+    if (first_visit && !record->HasFields()) {
+      auto resolved = resolveFields(std::move(fields), type_cache);
+      if (!resolved) {
+        type_cache.records.erase(it);
+        return resolved.takeError();
+      }
+      // Another BTF type with the same name may have filled in this record
+      // while its fields were being resolved; don't clobber it.
+      if (!record->HasFields()) {
+        record->fields = std::move(*resolved);
+      }
     }
-    s->fields.emplace_back(Field{
-        .name = name,
-        .type = *ft,
-        .offset = static_cast<ssize_t>(info.bit_offset / 8),
-        .bitfield = std::nullopt,
-    });
+    return CreateCStruct(name, std::weak_ptr<bpftrace::Struct>(record));
   }
-  return CreateCStruct(name, std::move(s));
+
+  // Anonymous records have no name to share them under, so they are owned by
+  // the type that refers to them.
+  auto make_record = [size](bpftrace::Fields &&fields) {
+    auto record = bpftrace::Struct::CreateRecord({}, {});
+    record->size = static_cast<int>(size);
+    record->fields = std::move(fields);
+    return record;
+  };
+
+  if (!first_visit) {
+    if (it->second) {
+      return CreateCStruct(name, std::shared_ptr<bpftrace::Struct>(it->second));
+    }
+    // This type is still being resolved. We need to break the recursion cycle
+    // by returning an empty record of the right size.
+    return CreateCStruct(name, make_record({}));
+  }
+
+  auto resolved = resolveFields(std::move(fields), type_cache);
+  if (!resolved) {
+    type_cache.records.erase(it);
+    return resolved.takeError();
+  }
+  it->second = make_record(std::move(*resolved));
+  return CreateCStruct(name, std::shared_ptr<bpftrace::Struct>(it->second));
 }
 
 Result<SizedType> getCompatType(const Struct &type, CompatTypeCache &type_cache)

--- a/src/btf/compat.h
+++ b/src/btf/compat.h
@@ -4,6 +4,10 @@
 #include "types.h"
 #include "util/result.h"
 
+namespace bpftrace {
+class StructManager;
+} // namespace bpftrace
+
 namespace bpftrace::btf {
 
 class CompatTypeError : public ErrorInfo<CompatTypeError> {
@@ -26,9 +30,18 @@ private:
   std::string msg_;
 };
 
-// For struct resolution, this indicates the set of structs
-// that have already been resolved for the purposes of cycles.
-using CompatTypeCache = std::map<uint32_t, std::shared_ptr<bpftrace::Struct>>;
+using BtfTypeId = uint32_t;
+
+// The state for a single conversion.
+//
+// Named records are owned by the `StructManager` and referred to weakly, which
+// is how a type that refers back to itself is represented without forming a
+// reference cycle. Anonymous records have no name to share them under, so they
+// are owned by the type instead.
+struct CompatTypeCache {
+  StructManager &structs;
+  std::map<BtfTypeId, std::shared_ptr<bpftrace::Struct>> records;
+};
 
 template <typename T>
 struct compatTypeFor {
@@ -88,9 +101,9 @@ Result<SizedType> getCompatType(const T &type, CompatTypeCache &type_cache)
 }
 
 template <typename T>
-Result<SizedType> getCompatType(const T &type)
+Result<SizedType> getCompatType(const T &type, StructManager &structs)
 {
-  CompatTypeCache type_cache; // Empty initial cache.
+  CompatTypeCache type_cache{ .structs = structs, .records = {} };
   return getCompatType(type, type_cache);
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1170,7 +1170,7 @@ Statement Parser::parse_for()
     return { f };
   }
 
-  // Must be a map.
+  // Must be a map or an open-coded iterator.
   if (has_open_paren && !expect(')')) {
     skip_to_block_end();
     auto *none = make_none();
@@ -1178,9 +1178,16 @@ Statement Parser::parse_for()
     return { es };
   }
 
+  if (auto *call = first.as<Call>()) {
+    auto *block = parse_block(false);
+    auto loc = make_loc(begin_line, begin_col, line_, col_);
+    auto *f = ctx_.make_node<For>(loc, var, call, block);
+    return { f };
+  }
+
   auto *map_ptr = first.as<Map>();
   if (!map_ptr) {
-    error("expected map or range in for loop");
+    error("expected map, range, or iterator in for loop");
     skip_to_block_end();
     auto *none = make_none();
     auto *es = ctx_.make_node<ExprStatement>(none->loc, Expression(none));

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -3324,6 +3324,7 @@ bool Parser::is_builtin(std::string_view name)
     "__builtin_config",
     "__builtin_cpid",
     "__builtin_cpu",
+    "__builtin_curtask",
     "__builtin_dw_ustack",
     "__builtin_elapsed",
     "__builtin_elf_ino",

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -221,14 +221,13 @@ macro cpu()
   __builtin_cpu
 }
 
-// :variant uint64 curtask()
+// :variant struct task_struct * curtask()
 // Pointer to `struct task_struct` of the current task
 //
-// This utilizes the BPF helper `get_current_task`
+// This utilizes the BPF helper `bpf_get_current_task_btf`
 macro curtask()
 {
-  import "stdlib/process/process.bpf.c";
-  kptr((struct task_struct*)__get_current_task())
+  __builtin_curtask
 }
 
 // :variant bool delete(map m, mapkey k)
@@ -1473,7 +1472,7 @@ macro uaddr(sym)
   // libraries. Among them, PIE and dynamic libraries need to correct the
   // symbol address according to the actual load address.
   if comptime (!elf_is_exe) {
-    $offset = __bpf_task_map_file_min_addr((uint64)elf_info);
+    $offset = __bpf_task_map_file_min_addr(curtask, (uint64)elf_info);
     // Recast to the original pointer type to preserve dereference size.
     $addr = (typeof($addr))((uint64)$addr + $offset);
   }

--- a/src/stdlib/process/process.bpf.c
+++ b/src/stdlib/process/process.bpf.c
@@ -21,7 +21,3 @@ unsigned long long __get_current_uid_gid() {
 unsigned long long __get_cgroup() {
     return bpf_get_current_cgroup_id();
 }
-
-unsigned long long __get_current_task() {
-    return bpf_get_current_task();
-}

--- a/src/stdlib/task/vma.bpf.c
+++ b/src/stdlib/task/vma.bpf.c
@@ -19,7 +19,9 @@ extern struct vm_area_struct *bpf_iter_task_vma_next(
 extern void bpf_iter_task_vma_destroy(
     struct __compat_bpf_iter_task_vma *it) __ksym __weak;
 
-unsigned long __bpf_task_map_file_min_addr(unsigned long ino)
+unsigned long __bpf_task_map_file_min_addr(
+    struct task_struct *task __arg_trusted,
+    unsigned long ino)
 {
   // linux >= 6.7
   if (!bpf_iter_task_vma_new || !bpf_iter_task_vma_destroy ||
@@ -28,10 +30,9 @@ unsigned long __bpf_task_map_file_min_addr(unsigned long ino)
 
   struct __compat_bpf_iter_task_vma vma_it;
   struct vm_area_struct *vma;
-  struct task_struct *cur_task = bpf_get_current_task_btf();
   unsigned long off = 0;
 
-  if (bpf_iter_task_vma_new(&vma_it, cur_task, 0)) {
+  if (bpf_iter_task_vma_new(&vma_it, task, 0)) {
     bpf_iter_task_vma_destroy(&vma_it);
     return 0;
   }

--- a/src/stdlib/test/test.bpf.c
+++ b/src/stdlib/test/test.bpf.c
@@ -1,3 +1,13 @@
+#define __KERNEL__
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+
 // __always_true is a built-in test function to validate C interop is working
 // as expected.
 int __always_true() { return 1; }
+
+// __test_get_current_task is a built-in test function to validate that a
+// pointer to a named struct can be returned across the C interop boundary.
+struct task_struct *__test_get_current_task() {
+  return bpf_get_current_task_btf();
+}

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -1000,6 +1000,15 @@ public:
       return MatchWith(node, range_matcher, *node.iterable.as<ast::Range>());
     });
   }
+
+  ForMatcher& WithIterCall(const Matcher<const ast::Call&>& call_matcher)
+  {
+    return Where([call_matcher](const ast::For& node) {
+      if (!node.iterable.is<ast::Call>())
+        return false;
+      return MatchWith(node, call_matcher, *node.iterable.as<ast::Call>());
+    });
+  }
 };
 
 inline ForMatcher For(
@@ -1017,6 +1026,15 @@ inline ForMatcher For(
     const std::vector<Matcher<const ast::Statement&>>& statements)
 {
   return ForMatcher().WithVariable(var).WithRange(range).WithStatements(
+      statements);
+}
+
+inline ForMatcher For(
+    const Matcher<const ast::Variable&>& var,
+    const Matcher<const ast::Call&>& iter,
+    const std::vector<Matcher<const ast::Statement&>>& statements)
+{
+  return ForMatcher().WithVariable(var).WithIterCall(iter).WithStatements(
       statements);
 }
 

--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -138,33 +138,33 @@ TEST_F(attachpoint_parser_dwarf, uprobe)
   std::string bin = std::string(bin_);
   std::string ap = "uprobe:" + bin;
 
-  test(ap + "@data_source.c:195 { 1 }");
-  test(ap + "@data_source.c:195:1 { 1 }");
-  test(ap + "@data/data_source.c:195 { 1 }");
-  test(ap + "@data/data_source.c:195:1 { 1 }");
-  test(ap + "@data_source.c:195 / 1 / { 1 }");
-  test(ap + "@data/data_source.c:195 / 1 / { 1 }");
-  test("begin { @x = 1; } " + ap + "@data/data_source.c:195 / @x / { @x/1; }");
-  test("begin { @x = 1; } " + ap + "@data/data_source.c:195 /@x/ { @x/1; }");
+  test(ap + "@data_source.c:202 { 1 }");
+  test(ap + "@data_source.c:202:1 { 1 }");
+  test(ap + "@data/data_source.c:202 { 1 }");
+  test(ap + "@data/data_source.c:202:1 { 1 }");
+  test(ap + "@data_source.c:202 / 1 / { 1 }");
+  test(ap + "@data/data_source.c:202 / 1 / { 1 }");
+  test("begin { @x = 1; } " + ap + "@data/data_source.c:202 / @x / { @x/1; }");
+  test("begin { @x = 1; } " + ap + "@data/data_source.c:202 /@x/ { @x/1; }");
   test("begin { @data_source = 1; } " + ap +
-       "@data_source.c:195 /@data_source/ { @data_source/1; }");
+       "@data_source.c:202 /@data_source/ { @data_source/1; }");
   test("begin { @data = 1; } " + ap +
-       "@data/data_source.c:195 /@data/ { @data/1; }");
+       "@data/data_source.c:202 /@data/ { @data/1; }");
 
   // Quoted arguments
-  test(ap + R"(@"data_source.c":195 { 1 })");
-  test(ap + R"(@data_source.c:"195" { 1 })");
-  test(ap + R"(@"data_source.c":"195" { 1 })");
-  test(ap + R"(@"data_source.c":"195":"1" { 1 })");
-  test(ap + R"(@data/"data_source.c":195 { 1 })");
-  test(ap + R"(@"data/data_source.c":195 { 1 })");
-  test(R"(uprobe:")" + bin + R"("@data_source.c:195 { 1 })");
-  test(R"(uprobe:")" + bin + R"("@"data_source.c":195 { 1 })");
-  test(R"(uprobe:")" + bin + R"("@"data/data_source.c":195 { 1 })");
+  test(ap + R"(@"data_source.c":202 { 1 })");
+  test(ap + R"(@data_source.c:"202" { 1 })");
+  test(ap + R"(@"data_source.c":"202" { 1 })");
+  test(ap + R"(@"data_source.c":"202":"1" { 1 })");
+  test(ap + R"(@data/"data_source.c":202 { 1 })");
+  test(ap + R"(@"data/data_source.c":202 { 1 })");
+  test(R"(uprobe:")" + bin + R"("@data_source.c:202 { 1 })");
+  test(R"(uprobe:")" + bin + R"("@"data_source.c":202 { 1 })");
+  test(R"(uprobe:")" + bin + R"("@"data/data_source.c":202 { 1 })");
 
-  test_error("uretprobe:" + bin + "@data_source.c:195 { 1 }",
+  test_error("uretprobe:" + bin + "@data_source.c:202 { 1 }",
              R"(Source code location not allowed)");
-  test_error("uprobe:*@data_source.c:195 { 1 }",
+  test_error("uprobe:*@data_source.c:202 { 1 }",
              R"(Cannot use wildcards with source code location)");
   test_error(
       ap + "@ { 1 }",
@@ -176,16 +176,16 @@ TEST_F(attachpoint_parser_dwarf, uprobe)
       ap + "@data_source.c: { 1 }",
       R"(Invalid uprobe arguments, expected format: uprobe:TARGET@FILE:LINE[:COL])");
   test_error(
-      ap + "@:195 { 1 }",
+      ap + "@:202 { 1 }",
       R"(ERROR: Invalid uprobe arguments, expected format: uprobe:TARGET@FILE:LINE[:COL])");
   test_error(
-      ap + "@data_source.c:195:1:2:3 { 1 }",
+      ap + "@data_source.c:202:1:2:3 { 1 }",
       R"(Invalid uprobe arguments, expected format: uprobe:TARGET@FILE:LINE[:COL])");
   test_error(ap + "@data_source.c:invalid { 1 }", R"(Invalid line number: )");
-  test_error(ap + "@data_source.c:195:invalid { 1 }",
+  test_error(ap + "@data_source.c:202:invalid { 1 }",
              R"(Invalid column number: )");
-  test_error(ap + "@data_source.c:195: { 1 }", R"(Invalid column number: )");
-  test_error(ap + "@invalid.c:195 { 1 }",
+  test_error(ap + "@data_source.c:202: { 1 }", R"(Invalid column number: )");
+  test_error(ap + "@invalid.c:202 { 1 }",
              R"(No compilation unit matches invalid.c)");
   test_error(
       "uprobe:no_dwarf@main.c:123 { 1 }",

--- a/tests/btf.cpp
+++ b/tests/btf.cpp
@@ -5,6 +5,7 @@
 #include "btf/compat.h"
 #include "btf/helpers.h"
 #include "data/data_source_btf.h"
+#include "struct.h"
 #include "gtest/gtest.h"
 
 namespace bpftrace::test::btf {
@@ -562,13 +563,70 @@ TEST(btf, compat_record_name_and_size)
   auto task_struct = btf->lookup<Struct>("task_struct");
   ASSERT_TRUE(bool(task_struct));
 
-  auto ty = getCompatType(*task_struct);
+  bpftrace::StructManager structs;
+  auto ty = getCompatType(*task_struct, structs);
   ASSERT_TRUE(bool(ty));
 
   EXPECT_TRUE(ty->IsCTypeTy());
   EXPECT_EQ(ty->GetName(), "struct task_struct");
   EXPECT_EQ(ty->GetSize(), sizeof(int *));
   EXPECT_EQ(ty->GetFieldCount(), 2);
+  EXPECT_EQ(ty->GetStruct(), structs.Lookup("struct task_struct").lock());
+}
+
+TEST(btf, compat_record_reuses_resolved_struct)
+{
+  auto btf = Types::parse(reinterpret_cast<const char *>(btf_data),
+                          sizeof(btf_data));
+  ASSERT_TRUE(bool(btf));
+
+  auto task_struct = btf->lookup<Struct>("task_struct");
+  ASSERT_TRUE(bool(task_struct));
+
+  // A record that has already been resolved elsewhere, e.g. from the kernel's
+  // BTF, is used as-is rather than being resolved again.
+  bpftrace::StructManager structs;
+  auto record = structs.Add("struct task_struct", 8).lock();
+  record->AddField("resolved_elsewhere", CreateInt32(), 0);
+
+  auto ty = getCompatType(*task_struct, structs);
+  ASSERT_TRUE(bool(ty));
+  ASSERT_EQ(ty->GetFieldCount(), 1);
+  EXPECT_EQ(ty->GetField(0).name, "resolved_elsewhere");
+}
+
+TEST(btf, compat_recursive_record)
+{
+  auto btf = Types::parse(reinterpret_cast<const char *>(btf_data),
+                          sizeof(btf_data));
+  ASSERT_TRUE(bool(btf));
+
+  auto foo = btf->lookup<Struct>("FooRecursive");
+  ASSERT_TRUE(bool(foo));
+
+  std::weak_ptr<const bpftrace::Struct> record;
+  {
+    bpftrace::StructManager structs;
+    auto ty = getCompatType(*foo, structs);
+    ASSERT_TRUE(bool(ty));
+    EXPECT_EQ(ty->GetName(), "struct FooRecursive");
+    EXPECT_EQ(ty->GetFieldCount(), 2);
+
+    const auto &next = ty->GetField("next").type;
+    ASSERT_TRUE(next.IsPtrTy());
+    const auto &pointee = next.GetPointeeTy();
+    EXPECT_EQ(pointee.GetName(), "struct FooRecursive");
+    EXPECT_EQ(pointee.GetStruct(), ty->GetStruct());
+    EXPECT_TRUE(pointee.HasField("a"));
+    EXPECT_TRUE(pointee.GetField("next").type.GetPointeeTy().HasField("a"));
+
+    EXPECT_TRUE(structs.Has("struct FooRecursive"));
+
+    record = ty->GetStruct();
+    EXPECT_FALSE(record.expired());
+  }
+
+  EXPECT_TRUE(record.expired());
 }
 
 TEST(btf, compat_anonymous_record)
@@ -582,12 +640,15 @@ TEST(btf, compat_anonymous_record)
   auto anon = btf.add<Struct>("", fields);
   ASSERT_TRUE(bool(anon));
 
-  auto ty = getCompatType(*anon);
+  bpftrace::StructManager structs;
+  auto ty = getCompatType(*anon, structs);
   ASSERT_TRUE(bool(ty));
 
   EXPECT_TRUE(ty->IsCTypeTy());
   EXPECT_TRUE(ty->GetName().empty());
   EXPECT_EQ(ty->GetSize(), 4);
+
+  EXPECT_FALSE(structs.Has(""));
 }
 
 } // namespace bpftrace::test::btf

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -42,6 +42,13 @@ struct Foo4 {
   unsigned int d : 20;
 };
 
+struct FooRecursive {
+  int a;
+  struct FooRecursive *next;
+};
+
+struct FooRecursive foo_recursive;
+
 enum FooEnum {
   VALUE
 };

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -3309,6 +3309,53 @@ begin { for ($i : ..10) { print($i) } }
 )");
 }
 
+TEST(Parser, for_iter)
+{
+  test("begin { for ($t : iter_task()) { print($t) } }",
+       Program().WithProbe(Probe(
+           { "begin" },
+           { For(Variable("$t"),
+                 Call("iter_task", {}),
+                 { ExprStatement(Call("print", { Variable("$t") })) }) })));
+
+  test("begin { for ($t : iter_threads()) { print($t) } }",
+       Program().WithProbe(Probe(
+           { "begin" },
+           { For(Variable("$t"),
+                 Call("iter_threads", {}),
+                 { ExprStatement(Call("print", { Variable("$t") })) }) })));
+
+  test("begin { for ($v : iter_task_vma(curtask)) { print($v) } }",
+       Program().WithProbe(Probe(
+           { "begin" },
+           { For(Variable("$v"),
+                 Call("iter_task_vma", { Identifier("curtask") }),
+                 { ExprStatement(Call("print", { Variable("$v") })) }) })));
+
+  test(
+      "begin { for ($v : iter_task_vma(curtask, 4096)) { print($v) } }",
+      Program().WithProbe(Probe(
+          { "begin" },
+          { For(Variable("$v"),
+                Call("iter_task_vma", { Identifier("curtask"), Integer(4096) }),
+                { ExprStatement(Call("print", { Variable("$v") })) }) })));
+
+  // Any call parses as an iterator; the name is validated during pre type
+  // checking, not here.
+  test("begin { for ($x : str($y)) { print($x) } }",
+       Program().WithProbe(Probe(
+           { "begin" },
+           { For(Variable("$x"),
+                 Call("str", { Variable("$y") }),
+                 { ExprStatement(Call("print", { Variable("$x") })) }) })));
+
+  test_parse_failure("begin { for ($x : 1) { print($x) } }", R"(
+stdin:1:22-23: ERROR: syntax: expected map, range, or iterator in for loop
+begin { for ($x : 1) { print($x) } }
+                     ~
+)");
+}
+
 TEST(Parser, variable_declarations)
 {
   // N.B. we check that the variable decl is defined, and also that is does not

--- a/tests/pre_type_check.cpp
+++ b/tests/pre_type_check.cpp
@@ -601,6 +601,32 @@ TEST(CallPreCheck, raw_map_arg_funcs)
        "expects a map argument");
 }
 
+TEST(CallPreCheck, open_coded_iter_nargs)
+{
+  test("begin { for ($t : iter_task()) { print($t) } }");
+  test("begin { for ($t : iter_task_threads(curtask)) { print($t) } }");
+  test("begin { for ($v : iter_task_vma(curtask)) { print($v) } }");
+  test("begin { for ($v : iter_task_vma(curtask, 4096)) { print($v) } }");
+
+  // Errors
+  test("begin { for ($t : iter_task(curtask)) { print($t) } }",
+       "iter_task() requires no arguments (1 provided)");
+  test("begin { for ($t : iter_task_threads()) { print($t) } }",
+       "iter_task_threads() requires one argument (0 provided)");
+  test("begin { for ($v : iter_task_vma()) { print($v) } }",
+       "iter_task_vma() requires at least one argument (0 provided)");
+  test("begin { for ($v : iter_task_vma(curtask, 4096, 1)) { print($v) } }",
+       "iter_task_vma() takes up to 2 arguments (3 provided)");
+}
+
+TEST(CallPreCheck, open_coded_iter_unknown)
+{
+  test("begin { for ($x : str($y)) { print($x) } }",
+       "str() is not a valid iterator");
+  test("begin { for ($x : no_such_iter()) { print($x) } }",
+       "no_such_iter() is not a valid iterator");
+}
+
 TEST(MapPreCheck, no_meta_map_assignments)
 {
   test("begin { let $b : typeof({ @a = 1; 1 }) = 1; }",

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -155,3 +155,63 @@ EXPECT true
 NAME external function call range
 PROG begin { @map[1] = 1; $x = 1; for ($i : 0..1) { print(has_key(@map, $x)); }  }
 EXPECT true
+
+NAME iter_task finds init
+PROG begin { for ($t : iter_task()) { if ($t->pid == 1) { print("found"); } } }
+EXPECT found
+MIN_KERNEL 6.7
+
+NAME iter_task with break
+PROG begin { $n = 0; for ($t : iter_task()) { $n++; if ($n == 2) { break; } } print($n); }
+EXPECT 2
+MIN_KERNEL 6.7
+
+NAME iter_task with continue
+PROG begin { $seen = 0; for ($t : iter_task()) { if ($t->pid != 1) { continue; } $seen = 1; } print($seen); }
+EXPECT 1
+MIN_KERNEL 6.7
+
+NAME iter_task with return
+PROG begin { for ($t : iter_task()) { if ($t->pid == 1) { return; } } print("end"); }
+EXPECT_NONE end
+MIN_KERNEL 6.7
+
+NAME iter_task writes map
+PROG begin { for ($t : iter_task()) { if ($t->pid == 1) { @[$t->pid] = 1; } } print(@); }
+EXPECT @[1]: 1
+MIN_KERNEL 6.7
+
+NAME iter_threads ran
+PROG begin { $seen = 0; for ($t : iter_threads()) { $seen = 1; } print($seen); }
+EXPECT 1
+MIN_KERNEL 6.7
+
+# This would trigger a verifier error if inner variables weren't put into per-cpu scratch maps
+NAME iter_threads external variable
+PROG begin { $seen = 0; for ($t : iter_threads()) { $seen++; } if ($seen > 1) { print($seen); } }
+EXPECT_REGEX [0-9]+
+MIN_KERNEL 6.7
+
+NAME iter_task_threads ran
+PROG begin { $seen = 0; for ($t : iter_task_threads(curtask)) { $seen = 1; } print($seen); }
+EXPECT 1
+MIN_KERNEL 6.7
+
+NAME iter_task_vma ran
+PROG begin { $seen = 0; for ($v : iter_task_vma(curtask)) { $seen = 1; } print($seen); }
+EXPECT 1
+MIN_KERNEL 6.7
+
+NAME iter nested in range
+PROG begin { $n = 0; for ($i : 0..2) { for ($t : iter_task()) { $n++; if ($n > 0) { break; } } } print($n); }
+EXPECT 2
+MIN_KERNEL 6.7
+
+# An unconditional break leaves bpf_iter_task_next with no back-edge, so the
+# kernel assigns it no SCC, yet re-entering the bpf_loop callback still makes
+# is_state_visited() record a backedge for it. Kernels 6.17 - 6.18 abort with
+# "verifier bug: add backedge: no SCC in verification path".
+NAME iter nested in range with unconditional break
+PROG begin { $n = 0; for ($i : 0..2) { for ($t : iter_task()) { $n++; break; } } print($n); }
+EXPECT 2
+MIN_KERNEL 7.1

--- a/tests/runtime/interop
+++ b/tests/runtime/interop
@@ -1,3 +1,8 @@
 NAME interop return types
 PROG import "stdlib/test"; begin { print(__always_true()); exit(); }
 EXPECT 1
+
+NAME interop struct pointer return type
+PROG import "stdlib/test"; begin { $t = __test_get_current_task(); printf("%d %d %d\n", $t->pid == tid, $t->tgid == pid, $t->parent->pid == curtask->parent->pid); exit(); }
+EXPECT 1 1 1
+REQUIRES_FEATURE btf

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -4441,6 +4441,20 @@ fentry:func_1 { $ret = socket_cookie(args.foo1); }
 )" });
 }
 
+TEST_F(TypeCheckerBTFTest, open_coded_iter_args)
+{
+  test("begin { for ($t : iter_task_threads(1)) { print($t) } }",
+       Error{ "iter_task_threads() only supports 'struct task_struct *' as "
+              "the first argument (int provided)" });
+  test(
+      "fentry:func_1 { for ($t : iter_task_threads(args.foo1)) { print($t) } }",
+      Error{ "iter_task_threads() only supports 'struct task_struct *' as "
+             "the first argument ('struct Foo1 *' provided)" });
+  test("begin { for ($v : iter_task_vma(curtask, \"x\")) { print($v) } }",
+       Error{ "iter_task_vma() only supports an integer as the second "
+              "argument (string provided)" });
+}
+
 TEST_F(TypeCheckerBTFTest, rawtracepoint)
 {
   test("rawtracepoint:event_rt { args.first_real_arg }");

--- a/tests/type_system.cpp
+++ b/tests/type_system.cpp
@@ -80,6 +80,8 @@ TEST(TypeSystemTest, basic)
     "const struct bpf_map",
     "struct sock",
     "struct sock*",
+    "struct FooRecursive",
+    "struct FooRecursive*",
     "const struct bpf_map*",
     "struct ArrayWithCompoundData*",
     "struct Arrays*",


### PR DESCRIPTION
Stacked PRs:
 * __->__#5328
 * #5321
 * #5322


--- --- ---

### Add support for open-coded iterators


The syntax is integrated with `for` loops e.g.
```
for ($t : iter_task()) {
}
```

Specifically:
- iter_task
- iter_threads
- iter_task_threads
- iter_task_vma

We can add more open coded iterators as needed.

Note on the implementation: all scratch variables assigned inside a iter
loop are automatically placed inside of per-cpu scratch maps because
modifying and referencing these variables outside of the loop can trigger a
verifier error because they can produce a distinct state on every loop
iteration and it never converges. As scratch map values they are opaque to
the verifier and it reaches a fixpoint immediately.

Signed-off-by: Jordan Rome <jordalgo@meta.com>
Signed-off-by: Jordan Rome <jordalgo@meta.com>