### PR TITLE
Allow access to individual fields of stats_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- Allow access to individual fields (.count, .total, .avg) of `stats_t` created by `stats()`
+  - [#5227](https://github.com/bpftrace/bpftrace/issues/5227)
 - stdlib: Add `abs_path` and `cwd`.
   - [#5276](https://github.com/bpftrace/bpftrace/pull/5276)
 - Add `kprobe` support for source location attachpoints.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1934,6 +1934,14 @@ kprobe:vfs_read {
 @
 ```
 
+Individual fields of a `stats_t` map can also be accessed synchronously using `.count`, `.total`, and `.avg`:
+
+```
+interval:s:1 {
+  printf("Count: %d, Total: %d, Avg: %d\n", @bytes["bash"].count, @bytes["bash"].total, @bytes["bash"].avg);
+}
+```
+
 ### sum
 
 * `sum_t sum(int64 n)`

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -816,7 +816,8 @@ Value *IRBuilderBPF::CreateMapLookupElem(const std::string &map_name,
 Value *IRBuilderBPF::CreatePerCpuMapAggElems(Map &map,
                                              Value *key,
                                              const SizedType &type,
-                                             const Location &loc)
+                                             const Location &loc,
+                                             std::string_view field)
 {
   // int ret = 0;
   // int i = 0;
@@ -833,6 +834,10 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Map &map,
   //   i++;
   // }
   // return ret;
+
+  if (!field.empty() && !type.IsStatsTy()) {
+    LOG(BUG) << "field specified for non-stats_t map type: " << type;
+  }
 
   const std::string &map_name = map.ident;
 
@@ -887,7 +892,7 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Map &map,
 
   if (type.IsMinTy() || type.IsMaxTy()) {
     createPerCpuMinMax(val_1, val_2, call, type);
-  } else if (type.IsAvgTy()) {
+  } else if (type.IsAvgTy() || type.IsStatsTy()) {
     createPerCpuAvg(val_1, val_2, call, type);
   } else if (type.IsSumTy() || type.IsCountTy()) {
     createPerCpuSum(val_1, call, type);
@@ -934,7 +939,11 @@ Value *IRBuilderBPF::CreatePerCpuMapAggElems(Map &map,
 
   Value *ret_reg;
 
-  if (type.IsAvgTy()) {
+  if (field == "count") {
+    ret_reg = CreateLoad(getInt64Ty(), val_2);
+  } else if (field == "total") {
+    ret_reg = CreateLoad(getInt64Ty(), val_1);
+  } else if (type.IsAvgTy() || field == "avg") {
     AllocaInst *ret = CreateAllocaBPF(getInt64Ty(), "ret");
     // BPF doesn't yet support a signed division so we have to check if
     // the value is negative, flip it, do an unsigned division, and then

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -65,7 +65,8 @@ public:
   Value *CreatePerCpuMapAggElems(Map &map,
                                  Value *key,
                                  const SizedType &type,
-                                 const Location &loc);
+                                 const Location &loc,
+                                 std::string_view field = "");
   void CreateMapUpdateElem(const std::string &map_ident,
                            Value *key,
                            Value *val,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2641,6 +2641,18 @@ ScopedExpr CodegenLLVM::visit(IfExpr &if_expr)
 ScopedExpr CodegenLLVM::visit(FieldAccess &acc)
 {
   const SizedType &type = type_map_.type(acc.expr);
+
+  if (type.IsStatsTy()) {
+    auto *map_acc = acc.expr.as<MapAccess>();
+    if (!map_acc) {
+      LOG(BUG) << "stats_t field access expression must be a MapAccess node";
+    }
+    auto scoped_key = getMapKey(*map_acc->map, map_acc->key);
+    Value *val = b_.CreatePerCpuMapAggElems(
+        *map_acc->map, scoped_key.value(), type, acc.loc, acc.field);
+    return ScopedExpr(val, std::move(scoped_key));
+  }
+
   auto scoped_arg = visit(acc.expr);
 
   assert(type.IsRecordTy() || type.IsCTypeTy());

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -40,6 +40,7 @@ public:
   void visit(Builtin &builtin);
   void visit(Call &call);
   void visit(Cast &cast);
+  void visit(FieldAccess &acc);
   void visit(Map &map);
   void visit(MapAccess &acc);
   void visit(MapDeclStatement &decl);
@@ -254,7 +255,7 @@ void ResourceAnalyser::visit(Call &call)
     resources_.join_args_id_map[&call] = resources_.join_args.size();
     resources_.join_args.push_back(delim);
   } else if (call.func == "count" || call.func == "sum" || call.func == "min" ||
-             call.func == "max" || call.func == "avg") {
+             call.func == "max" || call.func == "avg" || call.func == "stats") {
     resources_.global_vars.add_known(bpftrace::globalvars::NUM_CPUS);
   } else if (call.func == "hist") {
     Map *map = call.vargs.at(0).as<Map>();
@@ -445,6 +446,16 @@ void ResourceAnalyser::visit(Cast &cast)
     const auto max_strlen = bpftrace_.config_->pad_max_strlen();
     if (exceeds_stack_limit(max_strlen))
       resources_.str_buffers++;
+  }
+}
+
+void ResourceAnalyser::visit(FieldAccess &acc)
+{
+  Visitor<ResourceAnalyser>::visit(acc);
+
+  const auto &type = type_map_.type(acc.expr);
+  if (type.IsStatsTy()) {
+    resources_.global_vars.add_known(bpftrace::globalvars::NUM_CPUS);
   }
 }
 

--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -873,6 +873,14 @@ void TypeChecker::visit(FieldAccess &acc)
     type = type.GetPointeeTy();
   }
 
+  if (type.IsStatsTy()) {
+    if (acc.field != "count" && acc.field != "total" && acc.field != "avg") {
+      acc.addError() << "Invalid stats_t field '" << acc.field
+                     << "'. Valid fields are: count, total, avg.";
+    }
+    return;
+  }
+
   if (!type.IsCTypeTy() && !type.IsTupleTy() && !type.IsRecordTy()) {
     return;
   }

--- a/src/ast/passes/types/type_resolver.cpp
+++ b/src/ast/passes/types/type_resolver.cpp
@@ -587,8 +587,7 @@ bool TypeRuleCollector::check_offsetof_type(Offsetof &offof, SizedType c_type)
   // Check if all sub-fields are present.
   for (const auto &field : offof.field) {
     if (!c_type.IsCTypeTy()) {
-      offof.addError() << "'" << c_type << "' "
-                       << "is not a C type.";
+      offof.addError() << "'" << c_type << "' " << "is not a C type.";
       return false;
     } else if (!bpftrace_.structs.Has(c_type.GetName())) {
       offof.addError() << "'" << c_type.GetName() << "' does not exist.";
@@ -1472,6 +1471,10 @@ void TypeRuleCollector::visit(FieldAccess &acc)
         }
 
         SizedType result_type = CreateNone();
+
+        if (expr_type.IsStatsTy()) {
+          return expr_type.IsSigned() ? CreateInt64() : CreateUInt64();
+        }
 
         if (!expr_type.IsCTypeTy() && !expr_type.IsRecordTy()) {
           acc.addError() << "Can not access field '" << acc.field

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -365,6 +365,16 @@ NAME stats
 PROG begin { @stats = stats(1); @stats = stats(2); @stats = stats(3); }
 EXPECT @stats: { .count = 3, .average = 2, .total = 6 }
 
+NAME stats_field_access
+PROG begin { @stats = stats(4); @stats = stats(8); printf("%d %d %d\n", @stats.count, @stats.total, @stats.avg); }
+EXPECT @stats: { .count = 2, .average = 6, .total = 12 }
+EXPECT 2 12 6
+
+NAME stats_field_access_keyed
+PROG begin { @stats[10] = stats(4); @stats[10] = stats(8); printf("%d %d %d\n", @stats[10].count, @stats[10].total, @stats[10].avg); }
+EXPECT @stats[10]: { .count = 2, .average = 6, .total = 12 }
+EXPECT 2 12 6
+
 NAME hist
 PROG begin { @=hist(-1); @=hist(2); @=hist(3); @=hist(7); @=hist(20); }
 EXPECT_FILE runtime/outputs/hist.txt

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -780,6 +780,14 @@ TEST_F(TypeCheckerTest, call_stats)
   test("kprobe:f { @[stats(123)] = 1; }", Error{});
   test("kprobe:f { if(stats(1)) { 123 } }", Error{});
   test("kprobe:f { stats(1) ? 0 : 1; }", Error{});
+  test("kprobe:f { @x = stats(123); $c = @x.count; $t = @x.total; $a = "
+       "@x.avg; }");
+  test("kprobe:f { @x[1] = stats(123); $c = @x[1].count; }");
+  test("kprobe:f { @x = stats(123); $foo = @x.foo; }", Error{ R"(
+stdin:1:36-42: ERROR: Invalid stats_t field 'foo'. Valid fields are: count, total, avg.
+kprobe:f { @x = stats(123); $foo = @x.foo; }
+                                   ~~~~~~
+)" });
 }
 
 TEST_F(TypeCheckerTest, call_delete)


### PR DESCRIPTION
Allow accessing .count, .total, .average, and .avg fields on stats_t map values created by stats().
Closes #5227

### Description

This PR enables access to individual fields (`.count`, `.total`, `.average`, and `.avg`) on `stats_t` map values created by `stats()`, resolving issue #5227.

Previously, attempting to access individual fields on a `stats()` map (such as `@mystats.count` or `@mystats.total`) resulted in a type checker error. Users were forced to split `stats()` into separate `count()`, `sum()`, and `avg()` map assignments if they needed to read specific fields.

#### Example Usage

```bpftrace
BEGIN {
  @mystats = stats(4);
}

interval:1ms {
  printf(
    "Stats fields: %d %d %d %d\n",
    @mystats.count,
    @mystats.total,
    @mystats.average,
    @mystats.avg
  );
  exit();
}

