### PR TITLE
CI: Use fetch-depth 0 for Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         submodules: true
+        fetch-depth: 0
     - uses: DeterminateSystems/nix-installer-action@v17
       with:
         determinate: true


### PR DESCRIPTION
Similarly to dc9d708e ("CI: Use fetch-depth 0 for Binary workflow (#5304)"), we need to set fetch-depth to 0 to perform full libbpf clone and avoid CI failures.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
