### PR TITLE
CI: Add release as an input of Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
         description: 'Skip uploading artifacts (for testing the workflow)'
         type: boolean
         default: true
+      release:
+        description: 'Target release (tag) to upload artifacts to'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build-upload:
@@ -46,4 +51,4 @@ jobs:
       if: ${{ !inputs.dry_run }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload ${{ github.ref_name }} ./assets/*
+      run: gh release upload ${{ input.release || github.ref_name }} ./assets/*


### PR DESCRIPTION
The Release workflow has the workflow_dispatch event enabled, which means that it can br triggered manually. This was originally meant for testing but could be also useful for the case when the workflow fails, so that we can rerun it without crafting another release.

The problem is that github.ref_name will be empty when the workflow is triggered manually and therefore the assets won't be uploaded to the correct release. Fix this by adding a new "release" input parameter, which allows to specify the target tag for asset upload.

Now, we can also trigger the workflow if there are additional commits in the release branch (e.g. commits fixing the Release workflow).

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
