### PR TITLE
[0.27.x] CI: Add release as an input of Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ on:
         description: 'Skip uploading artifacts (for testing the workflow)'
         type: boolean
         default: true
+      release:
+        description: 'Target release (tag) to upload artifacts to'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   build-upload:
@@ -47,4 +52,4 @@ jobs:
       if: ${{ !inputs.dry_run }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload ${{ github.ref_name }} ./assets/*
+      run: gh release upload ${{ input.release || github.ref_name }} ./assets/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,4 @@ jobs:
       if: ${{ !inputs.dry_run }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh release upload ${{ input.release || github.ref_name }} ./assets/*
+      run: gh release upload ${{ inputs.release || github.ref_name }} ./assets/*


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

Need to backport these to the release branch such that the new input parameter can be used when triggering the Release job manually for the branch.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
