### PR TITLE
Remove check for bpf_map_lookup_percpu_elem helper

### DIFF
--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -897,11 +897,6 @@ void TypeChecker::visit(MapAccess &acc)
   visit(acc.map);
   visit(acc.key);
 
-  if (type_map_.map_value_type(acc.map->ident).IsCastableMapTy() &&
-      !bpftrace_.feature_->has_helper_map_lookup_percpu_elem()) {
-    acc.addError() << "Missing required kernel feature: map_lookup_percpu_elem";
-  }
-
   // Validate map key type
   const auto &key_type = type_map_.type(acc.key);
   if (key_type.IsPtrTy() && key_type.IsCtxAccess()) {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -465,7 +465,6 @@ std::string BPFfeature::report()
     { "dpath", to_str(has_d_path()) },
     { "get_tai_ns", to_str(has_helper_ktime_get_tai_ns()) },
     { "get_func_ip", to_str(has_helper_get_func_ip()) },
-    { "lookup_percpu_elem", to_str(has_helper_map_lookup_percpu_elem()) },
     { "loop", to_str(has_helper_loop()) }
   };
 

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -66,7 +66,6 @@ public:
 
   DEFINE_HELPER_TEST(ktime_get_tai_ns, BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(get_func_ip, BPF_PROG_TYPE_KPROBE);
-  DEFINE_HELPER_TEST(map_lookup_percpu_elem, BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(loop, BPF_PROG_TYPE_KPROBE); // Added in 5.17.
 
   bool has_kfunc(std::string kfunc);

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -165,7 +165,6 @@ public:
     has_uprobe_multi_ = std::make_optional<bool>(has_features);
     has_ktime_get_tai_ns_ = std::make_optional<bool>(has_features);
     has_get_func_ip_ = std::make_optional<bool>(has_features);
-    has_map_lookup_percpu_elem_ = std::make_optional<bool>(has_features);
     has_loop_ = std::make_optional<bool>(has_features);
   };
 

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -323,7 +323,6 @@ TIMEOUT 1
 WILL_FAIL
 
 NAME print_per_cpu_map_vals
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @a = avg(5); @c = count(); @s = sum(5); @mn = min(1); @mx = max(-1); print((@a, @c, @s, @mn, @mx));  }
 EXPECT (5, 1, 5, 1, -1)
 TIMEOUT 3

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -164,7 +164,6 @@ class Runner(object):
         bpffeature["get_tai_ns"] = output.find("get_ktime_ns: yes") != -1
         bpffeature["get_func_ip"] = output.find("get_func_ip: yes") != -1
         bpffeature["jiffies64"] = output.find("jiffies64: yes") != -1
-        bpffeature["lookup_percpu_elem"] = output.find("lookup_percpu_elem: yes") != -1
         bpffeature["dwunwind"] = output.find("dwunwind (DWARF stack unwinding): yes") != -1
         bpffeature["blazesym"] = output.find("blazesym (advanced symbolization): yes") != -1
         return bpffeature

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -74,13 +74,11 @@ PROG begin { @map[0] = 0; $var1 = 123; $var2 = "abc"; for ($kv : @map) { print((
 EXPECT (123, abc)
 
 NAME map two keys with a per cpu aggregation
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @map[16,17] = count(); @map[16,17] = count(); @map[1,2] = count(); for ($kv : @map) { print($kv); }  }
 EXPECT ((16, 17), 2)
 EXPECT ((1, 2), 1)
 
 NAME map stack key with a per cpu aggregation
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @map[kstack(raw)] = count(); for ($kv : @map) { print($kv.1); }  }
 EXPECT 1
 

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -282,37 +282,30 @@ EXPECT stdin:1:37-41: WARNING: Can't lookup map element because it does not exis
 TIMEOUT 1
 
 NAME per_cpu_map_count_if
-REQUIRES_FEATURE lookup_percpu_elem
 PROG i:ms:1 { @ = count(); if (@ > 5) { printf("done\n"); exit(); }}
 EXPECT done
 
 NAME per_cpu_map_min_if
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @ = 10; } i:ms:1 { @--; @mn = min(@); if (@mn < 5) { printf("done\n");  }}
 EXPECT done
 
 NAME per_cpu_map_max_if
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @ = 1; } i:ms:1 { @++; @mx = max(@); if (@mx > 5) { printf("done\n");  }}
 EXPECT done
 
 NAME per_cpu_map_avg_if
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @ = avg(1); @ = avg(1); @ = avg(10); if (@ == 4) { printf("done\n");  }}
 EXPECT done
 
 NAME per_cpu_map_arithmetic
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @a = sum(10); @b = count(); $c = @a + @b; if ($c == 11) { printf("done\n"); } }
 EXPECT done
 
 NAME per_cpu_map_cast
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @a = count(); @b = sum(10); printf("%d-%d\n", (uint64)@a, (int64)@b); }
 EXPECT 1-10
 
 NAME per_cpu_map_as_map_key
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin {@a = count(); @b = sum(5); @c = min(1); @d = max(10); @e = avg(7); @[@a, @b, @c, @d, @e] = 1;  }
 EXPECT @[1, 5, 1, 10, 7]: 1
 

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -7,7 +7,6 @@ PROG begin { @=avg(-30); @=avg(-10);  }
 EXPECT @: -20
 
 NAME avg cast negative values
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @ = avg(-1); @ = avg(-1); @ = avg(-10); if (@ == -4) { printf("done\n");  }}
 EXPECT done
 

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -4839,48 +4839,6 @@ TEST_F(TypeCheckerTest, for_range_nested_range)
        "} } }");
 }
 
-TEST_F(TypeCheckerTest, castable_map_missing_feature)
-{
-  test("k:f {  @a = count(); }", NoFeatures::Enable);
-  test("k:f {  @a = count(); print(@a) }", NoFeatures::Enable);
-  test("k:f {  @a = count(); clear(@a) }", NoFeatures::Enable);
-  test("k:f {  @a = count(); zero(@a) }", NoFeatures::Enable);
-
-  test("begin { @a = count(); print((uint64)@a) }",
-       NoFeatures::Enable,
-       Error{ R"(
-stdin:1:37-39: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a = count(); print((uint64)@a) }
-                                    ~~
-)" });
-
-  test("begin { @a = count(); print((@a, 1)) }", NoFeatures::Enable, Error{ R"(
-stdin:1:30-32: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a = count(); print((@a, 1)) }
-                             ~~
-)" });
-
-  test("begin { @a[1] = count(); print(@a[1]) }", NoFeatures::Enable, Error{ R"(
-stdin:1:32-37: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a[1] = count(); print(@a[1]) }
-                               ~~~~~
-)" });
-
-  test("begin { @a = count(); $b = @a; }", NoFeatures::Enable, Error{ R"(
-stdin:1:28-30: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a = count(); $b = @a; }
-                           ~~
-)" });
-
-  test("begin { @a = count(); @b = (uint8)1; @b = @a; }",
-       NoFeatures::Enable,
-       Error{ R"(
-stdin:1:43-45: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a = count(); @b = (uint8)1; @b = @a; }
-                                          ~~
-)" });
-}
-
 TEST_F(TypeCheckerTest, for_loop_no_ctx_access)
 {
   test("kprobe:f { @map[0] = 1; for ($kv : @map) { ctx } }", Error{ R"(


### PR DESCRIPTION
Stacked PRs:
 * #5343
 * __->__#5342


--- --- ---

### Remove check for bpf_map_lookup_percpu_elem helper


This was added in kernel 5.19 which is below our min kernel version. We can
remove the check for it.

Signed-off-by: Jordan Rome <jordalgo@meta.com>