### PR TITLE
Remove has_iter feature check

### DIFF
--- a/src/ast/passes/types/type_checker.cpp
+++ b/src/ast/passes/types/type_checker.cpp
@@ -897,11 +897,6 @@ void TypeChecker::visit(MapAccess &acc)
   visit(acc.map);
   visit(acc.key);
 
-  if (type_map_.map_value_type(acc.map->ident).IsCastableMapTy() &&
-      !bpftrace_.feature_->has_helper_map_lookup_percpu_elem()) {
-    acc.addError() << "Missing required kernel feature: map_lookup_percpu_elem";
-  }
-
   // Validate map key type
   const auto &key_type = type_map_.type(acc.key);
   if (key_type.IsPtrTy() && key_type.IsCtxAccess()) {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -51,8 +51,7 @@ static bool try_load_(const char* name,
                       size_t insns_cnt,
                       int loglevel,
                       char* logbuf,
-                      size_t logbuf_size,
-                      int* outfd = nullptr)
+                      size_t logbuf_size)
 {
   const KernelVersionMethod methods[] = { KernelVersionMethod::vDSO,
                                           KernelVersionMethod::UTS,
@@ -82,11 +81,7 @@ static bool try_load_(const char* name,
 
     int ret = bpf_prog_load(prog_type, name, "GPL", insns, insns_cnt, &opts);
     if (ret >= 0) {
-      if (outfd)
-        *outfd = ret;
-      else
-        close(ret);
-
+      close(ret);
       return true;
     }
   }
@@ -98,8 +93,7 @@ bool BPFfeature::try_load(enum bpf_prog_type prog_type,
                           struct bpf_insn* insns,
                           size_t len,
                           const char* name,
-                          std::optional<bpf_attach_type> attach_type,
-                          int* outfd)
+                          std::optional<bpf_attach_type> attach_type)
 {
   constexpr int log_size = 4096;
   char logbuf[log_size] = {};
@@ -116,16 +110,8 @@ bool BPFfeature::try_load(enum bpf_prog_type prog_type,
       return false;
   }
 
-  return try_load_(name,
-                   prog_type,
-                   attach_type,
-                   btf_id,
-                   insns,
-                   len,
-                   0,
-                   logbuf,
-                   log_size,
-                   outfd);
+  return try_load_(
+      name, prog_type, attach_type, btf_id, insns, len, 0, logbuf, log_size);
 }
 
 bool BPFfeature::try_load_btf(const void* btf_data, size_t btf_size)
@@ -237,16 +223,6 @@ bool BPFfeature::has_kfunc(std::string kfunc)
     btf_id = btf_.get_btf_id(kfunc, "vmlinux");
   }
   return btf_id > 0;
-}
-
-bool BPFfeature::detect_prog_type(enum bpf_prog_type prog_type,
-                                  const char* name,
-                                  std::optional<bpf_attach_type> attach_type,
-                                  int* outfd)
-{
-  struct bpf_insn insns[] = { BPF_MOV64_IMM(BPF_REG_0, 0), BPF_EXIT_INSN() };
-  return try_load(
-      prog_type, insns, ARRAY_SIZE(insns), name, attach_type, outfd);
 }
 
 bool BPFfeature::has_btf()
@@ -478,7 +454,6 @@ std::string BPFfeature::report()
     { "kprobe_multi", to_str(has_kprobe_multi()) },
     { "uprobe_multi", to_str(has_uprobe_multi()) },
     { "kprobe_session", to_str(has_kprobe_session()) },
-    { "iter", to_str(has_iter("task")) }
   };
 
   buf << "Kernel helpers" << std::endl;
@@ -494,14 +469,6 @@ std::string BPFfeature::report()
   buf << std::endl;
 
   return buf.str();
-}
-
-bool BPFfeature::has_iter(std::string name)
-{
-  auto tracing_name = "bpf_iter_" + name;
-  return detect_prog_type(BPF_PROG_TYPE_TRACING,
-                          tracing_name.c_str(),
-                          BPF_TRACE_ITER);
 }
 
 } // namespace bpftrace

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -465,7 +465,6 @@ std::string BPFfeature::report()
     { "dpath", to_str(has_d_path()) },
     { "get_tai_ns", to_str(has_helper_ktime_get_tai_ns()) },
     { "get_func_ip", to_str(has_helper_get_func_ip()) },
-    { "lookup_percpu_elem", to_str(has_helper_map_lookup_percpu_elem()) },
     { "loop", to_str(has_helper_loop()) }
   };
 

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -60,7 +60,6 @@ public:
   bool has_kprobe_multi();
   bool has_kprobe_session();
   bool has_uprobe_multi();
-  virtual bool has_iter(std::string name);
 
   std::string report();
 
@@ -81,17 +80,12 @@ protected:
 
 private:
   bool detect_helper(bpf_func_id func_id, bpf_prog_type prog_type);
-  bool detect_prog_type(bpf_prog_type prog_type,
-                        const char* name,
-                        std::optional<bpf_attach_type> attach_type,
-                        int* outfd = nullptr);
 
   bool try_load(bpf_prog_type prog_type,
                 struct bpf_insn* insns,
                 size_t len,
                 const char* name = nullptr,
-                std::optional<bpf_attach_type> attach_type = std::nullopt,
-                int* outfd = nullptr);
+                std::optional<bpf_attach_type> attach_type = std::nullopt);
   bool try_load_btf(const void* btf_data, size_t btf_size);
 
   BPFnofeature no_feature_;

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -66,7 +66,6 @@ public:
 
   DEFINE_HELPER_TEST(ktime_get_tai_ns, BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(get_func_ip, BPF_PROG_TYPE_KPROBE);
-  DEFINE_HELPER_TEST(map_lookup_percpu_elem, BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(loop, BPF_PROG_TYPE_KPROBE); // Added in 5.17.
 
   bool has_kfunc(std::string kfunc);

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -224,13 +224,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
       std::string ret;
       auto iters = bpftrace_->btf_->get_all_iters();
       for (const auto& iter : iters) {
-        // second check
-        if (bpftrace_->feature_->has_iter(iter))
-          ret += iter + "\n";
-        else
-          LOG(WARNING) << "The kernel contains bpf_iter__" << iter
-                       << " struct but does not support loading an iterator"
-                          " program against it. Please report this bug.";
+        ret += iter + "\n";
       }
       symbol_stream = std::make_unique<std::istringstream>(ret);
       break;

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -165,7 +165,6 @@ public:
     has_uprobe_multi_ = std::make_optional<bool>(has_features);
     has_ktime_get_tai_ns_ = std::make_optional<bool>(has_features);
     has_get_func_ip_ = std::make_optional<bool>(has_features);
-    has_map_lookup_percpu_elem_ = std::make_optional<bool>(has_features);
     has_loop_ = std::make_optional<bool>(has_features);
   };
 

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -158,7 +158,6 @@ class MockBPFfeature : public BPFfeature {
 public:
   MockBPFfeature(bool has_features = true) : BPFfeature(bpf_nofeature, btf_obj)
   {
-    has_features_ = has_features;
     has_d_path_ = std::make_optional<bool>(has_features);
     has_kprobe_multi_ = std::make_optional<bool>(has_features);
     has_kprobe_session_ = std::make_optional<bool>(has_features);
@@ -167,13 +166,6 @@ public:
     has_get_func_ip_ = std::make_optional<bool>(has_features);
     has_loop_ = std::make_optional<bool>(has_features);
   };
-
-  bool has_iter(std::string name __attribute__((unused))) override
-  {
-    return has_features_;
-  }
-
-  bool has_features_;
 };
 
 class MockChildProc : public util::ChildProc {

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -323,7 +323,6 @@ TIMEOUT 1
 WILL_FAIL
 
 NAME print_per_cpu_map_vals
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @a = avg(5); @c = count(); @s = sum(5); @mn = min(1); @mx = max(-1); print((@a, @c, @s, @mn, @mx));  }
 EXPECT (5, 1, 5, 1, -1)
 TIMEOUT 3

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -702,22 +702,18 @@ EXPECT @[1]: 05:04:03:02:01:02
 NAME iter:task
 PROG iter:task { printf("comm: %s\n", ctx.task.comm); exit(); }
 EXPECT comm: bpftrace
-REQUIRES_FEATURE iter
 
 NAME iter:task_file
 PROG iter:task_file { printf("comm: %s\n", ctx.task.comm); exit(); }
 EXPECT comm: bpftrace
-REQUIRES_FEATURE iter
 
 NAME iter:task_vma
 PROG iter:task_vma { printf("comm: %s\n", ctx.task.comm); exit(); }
 EXPECT comm: bpftrace
-REQUIRES_FEATURE iter
 
 NAME iter printf multiple values
 PROG iter:task { printf("%s: %d\n", "hello", 0); exit(); }
 EXPECT hello: 0
-REQUIRES_FEATURE iter
 
 NAME cgroup_path
 PROG begin { print(cgroup_path(cgroup & ((1 << 32) - 1)));  }

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -164,7 +164,6 @@ class Runner(object):
         bpffeature["get_tai_ns"] = output.find("get_ktime_ns: yes") != -1
         bpffeature["get_func_ip"] = output.find("get_func_ip: yes") != -1
         bpffeature["jiffies64"] = output.find("jiffies64: yes") != -1
-        bpffeature["lookup_percpu_elem"] = output.find("lookup_percpu_elem: yes") != -1
         bpffeature["dwunwind"] = output.find("dwunwind (DWARF stack unwinding): yes") != -1
         bpffeature["blazesym"] = output.find("blazesym (advanced symbolization): yes") != -1
         return bpffeature

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -153,7 +153,6 @@ class Runner(object):
         bpffeature["fentry"] = output.find("fentry: yes") != -1
         bpffeature["dpath"] = output.find("dpath: yes") != -1
         bpffeature["signal"] = output.find("send_signal: yes") != -1
-        bpffeature["iter"] = output.find("iter: yes") != -1
         bpffeature["libpath_resolv"] = output.find("bcc library path resolution: yes") != -1
         bpffeature["dwarf"] = output.find("libdw (DWARF support): yes") != -1
         bpffeature["kprobe_multi"] = output.find("kprobe_multi: yes") != -1

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -74,13 +74,11 @@ PROG begin { @map[0] = 0; $var1 = 123; $var2 = "abc"; for ($kv : @map) { print((
 EXPECT (123, abc)
 
 NAME map two keys with a per cpu aggregation
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @map[16,17] = count(); @map[16,17] = count(); @map[1,2] = count(); for ($kv : @map) { print($kv); }  }
 EXPECT ((16, 17), 2)
 EXPECT ((1, 2), 1)
 
 NAME map stack key with a per cpu aggregation
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @map[kstack(raw)] = count(); for ($kv : @map) { print($kv.1); }  }
 EXPECT 1
 

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -282,37 +282,30 @@ EXPECT stdin:1:37-41: WARNING: Can't lookup map element because it does not exis
 TIMEOUT 1
 
 NAME per_cpu_map_count_if
-REQUIRES_FEATURE lookup_percpu_elem
 PROG i:ms:1 { @ = count(); if (@ > 5) { printf("done\n"); exit(); }}
 EXPECT done
 
 NAME per_cpu_map_min_if
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @ = 10; } i:ms:1 { @--; @mn = min(@); if (@mn < 5) { printf("done\n");  }}
 EXPECT done
 
 NAME per_cpu_map_max_if
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @ = 1; } i:ms:1 { @++; @mx = max(@); if (@mx > 5) { printf("done\n");  }}
 EXPECT done
 
 NAME per_cpu_map_avg_if
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @ = avg(1); @ = avg(1); @ = avg(10); if (@ == 4) { printf("done\n");  }}
 EXPECT done
 
 NAME per_cpu_map_arithmetic
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @a = sum(10); @b = count(); $c = @a + @b; if ($c == 11) { printf("done\n"); } }
 EXPECT done
 
 NAME per_cpu_map_cast
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @a = count(); @b = sum(10); printf("%d-%d\n", (uint64)@a, (int64)@b); }
 EXPECT 1-10
 
 NAME per_cpu_map_as_map_key
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin {@a = count(); @b = sum(5); @c = min(1); @d = max(10); @e = avg(7); @[@a, @b, @c, @d, @e] = 1;  }
 EXPECT @[1, 5, 1, 10, 7]: 1
 

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -7,7 +7,6 @@ PROG begin { @=avg(-30); @=avg(-10);  }
 EXPECT @: -20
 
 NAME avg cast negative values
-REQUIRES_FEATURE lookup_percpu_elem
 PROG begin { @ = avg(-1); @ = avg(-1); @ = avg(-10); if (@ == -4) { printf("done\n");  }}
 EXPECT done
 

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -4839,48 +4839,6 @@ TEST_F(TypeCheckerTest, for_range_nested_range)
        "} } }");
 }
 
-TEST_F(TypeCheckerTest, castable_map_missing_feature)
-{
-  test("k:f {  @a = count(); }", NoFeatures::Enable);
-  test("k:f {  @a = count(); print(@a) }", NoFeatures::Enable);
-  test("k:f {  @a = count(); clear(@a) }", NoFeatures::Enable);
-  test("k:f {  @a = count(); zero(@a) }", NoFeatures::Enable);
-
-  test("begin { @a = count(); print((uint64)@a) }",
-       NoFeatures::Enable,
-       Error{ R"(
-stdin:1:37-39: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a = count(); print((uint64)@a) }
-                                    ~~
-)" });
-
-  test("begin { @a = count(); print((@a, 1)) }", NoFeatures::Enable, Error{ R"(
-stdin:1:30-32: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a = count(); print((@a, 1)) }
-                             ~~
-)" });
-
-  test("begin { @a[1] = count(); print(@a[1]) }", NoFeatures::Enable, Error{ R"(
-stdin:1:32-37: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a[1] = count(); print(@a[1]) }
-                               ~~~~~
-)" });
-
-  test("begin { @a = count(); $b = @a; }", NoFeatures::Enable, Error{ R"(
-stdin:1:28-30: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a = count(); $b = @a; }
-                           ~~
-)" });
-
-  test("begin { @a = count(); @b = (uint8)1; @b = @a; }",
-       NoFeatures::Enable,
-       Error{ R"(
-stdin:1:43-45: ERROR: Missing required kernel feature: map_lookup_percpu_elem
-begin { @a = count(); @b = (uint8)1; @b = @a; }
-                                          ~~
-)" });
-}
-
 TEST_F(TypeCheckerTest, for_loop_no_ctx_access)
 {
   test("kprobe:f { @map[0] = 1; for ($kv : @map) { ctx } }", Error{ R"(


### PR DESCRIPTION
Stacked PRs:
 * __->__#5343
 * #5342


--- --- ---

### Remove has_iter feature check


This was added back in kernel 5.8 which is way below our min kernel
version.

Signed-off-by: Jordan Rome <jordalgo@meta.com>